### PR TITLE
Fix ArrayBufferView interface

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -1668,9 +1668,9 @@ export class Compiler extends DiagnosticEmitter {
 
     var bufferAddress32 = i64_low(bufferSegment.offset) + runtimeHeaderSize;
     assert(!program.options.isWasm64); // TODO
-    assert(arrayInstance.writeField("buffer", bufferAddress32, buf, runtimeHeaderSize));
+    assert(arrayInstance.writeField("data", bufferAddress32, buf, runtimeHeaderSize));
     assert(arrayInstance.writeField("dataStart", bufferAddress32, buf, runtimeHeaderSize));
-    assert(arrayInstance.writeField("byteLength", bufferLength, buf, runtimeHeaderSize));
+    assert(arrayInstance.writeField("dataLength", bufferLength, buf, runtimeHeaderSize));
     assert(arrayInstance.writeField("length_", arrayLength, buf, runtimeHeaderSize));
 
     return this.addMemorySegment(buf);

--- a/std/assembly/array.ts
+++ b/std/assembly/array.ts
@@ -9,18 +9,18 @@ import { E_INDEXOUTOFRANGE, E_INVALIDLENGTH, E_EMPTYARRAY, E_HOLEYARRAY } from "
 
 /** Ensures that the given array has _at least_ the specified backing size. */
 function ensureSize(array: usize, minSize: usize, alignLog2: u32): void {
-  var oldCapacity = changetype<ArrayBufferView>(array).byteLength;
+  var oldCapacity = changetype<ArrayBufferView>(array).dataLength;
   if (minSize > <usize>oldCapacity >>> alignLog2) {
     if (minSize > BLOCK_MAXSIZE >>> alignLog2) throw new RangeError(E_INVALIDLENGTH);
-    let oldData = changetype<usize>(changetype<ArrayBufferView>(array).buffer);
+    let oldData = changetype<usize>(changetype<ArrayBufferView>(array).data);
     let newCapacity = minSize << alignLog2;
     let newData = __realloc(oldData, newCapacity); // keeps RC
     memory.fill(newData + oldCapacity, 0, newCapacity - oldCapacity);
     if (newData !== oldData) { // oldData has been free'd
-      store<usize>(array, newData, offsetof<ArrayBufferView>("buffer"));
+      store<usize>(array, newData, offsetof<ArrayBufferView>("data"));
       store<usize>(array, newData, offsetof<ArrayBufferView>("dataStart"));
     }
-    store<u32>(array, newCapacity, offsetof<ArrayBufferView>("byteLength"));
+    store<i32>(array, newCapacity, offsetof<ArrayBufferView>("dataLength"));
   }
 }
 
@@ -49,8 +49,13 @@ export class Array<T> extends ArrayBufferView {
   }
 
   constructor(length: i32 = 0) {
-    super(length, alignof<T>());
+    super();
+    super.alloc(length, alignof<T>());
     this.length_ = length;
+  }
+
+  get buffer(): ArrayBuffer {
+    return this.data;
   }
 
   get length(): i32 {
@@ -498,6 +503,6 @@ export class Array<T> extends ArrayBufferView {
         cur += sizeof<usize>();
       }
     }
-    // automatically visits ArrayBufferView (.buffer) next
+    // automatically visits ArrayBufferView (.data) next
   }
 }

--- a/std/assembly/arraybuffer.ts
+++ b/std/assembly/arraybuffer.ts
@@ -6,26 +6,17 @@ import { E_INVALIDLENGTH } from "./util/error";
 
 export abstract class ArrayBufferView {
 
-  readonly buffer: ArrayBuffer;
-  @unsafe readonly dataStart: usize;
-  readonly byteLength: i32;
+  @unsafe data: ArrayBuffer;
+  @unsafe dataStart: usize;
+  @unsafe dataLength: i32;
 
-  get byteOffset(): i32 {
-    return <i32>(this.dataStart - changetype<usize>(this.buffer));
-  }
-
-  get length(): i32 {
-    ERROR("missing implementation: subclasses must implement ArrayBufferView#length");
-    return unreachable();
-  }
-
-  protected constructor(length: i32, alignLog2: i32) {
+  @unsafe protected alloc(length: i32, alignLog2: i32): void {
     if (<u32>length > <u32>BLOCK_MAXSIZE >>> alignLog2) throw new RangeError(E_INVALIDLENGTH);
-    var buffer = __alloc(length = length << alignLog2, idof<ArrayBuffer>());
-    memory.fill(buffer, 0, <usize>length);
-    this.buffer = changetype<ArrayBuffer>(buffer); // retains
-    this.dataStart = buffer;
-    this.byteLength = length;
+    var data = __alloc(length = length << alignLog2, idof<ArrayBuffer>());
+    memory.fill(data, 0, <usize>length);
+    this.data = changetype<ArrayBuffer>(data); // retains
+    this.dataStart = data;
+    this.dataLength = length;
   }
 }
 

--- a/std/assembly/atomics.ts
+++ b/std/assembly/atomics.ts
@@ -8,7 +8,7 @@ export namespace Atomics {
   export function load<T extends ArrayBufferView>(array: T, index: i32): valueof<T> {
     if (index < 0 || (index << alignof<valueof<T>>()) >= array.byteLength) throw new RangeError(E_INDEXOUTOFRANGE);
     return atomic.load<valueof<T>>(
-      changetype<usize>(array.buffer) + (index << alignof<valueof<T>>()) + array.byteOffset
+      changetype<usize>(array.data) + (index << alignof<valueof<T>>()) + array.byteOffset
     );
   }
 
@@ -17,7 +17,7 @@ export namespace Atomics {
   export function store<T extends ArrayBufferView>(array: T, index: i32, value: valueof<T>): void {
     if (index < 0 || (index << alignof<valueof<T>>()) >= array.byteLength) throw new RangeError(E_INDEXOUTOFRANGE);
     atomic.store<valueof<T>>(
-      changetype<usize>(array.buffer) + (index << alignof<valueof<T>>()) + array.byteOffset,
+      changetype<usize>(array.data) + (index << alignof<valueof<T>>()) + array.byteOffset,
       value
     );
   }
@@ -27,7 +27,7 @@ export namespace Atomics {
   export function add<T extends ArrayBufferView>(array: T, index: i32, value: valueof<T>): valueof<T> {
     if (index < 0 || (index << alignof<valueof<T>>()) >= array.byteLength) throw new RangeError(E_INDEXOUTOFRANGE);
     return atomic.add<valueof<T>>(
-      changetype<usize>(array.buffer) + (index << alignof<valueof<T>>()) + array.byteOffset,
+      changetype<usize>(array.data) + (index << alignof<valueof<T>>()) + array.byteOffset,
       value
     );
   }
@@ -37,7 +37,7 @@ export namespace Atomics {
   export function sub<T extends ArrayBufferView>(array: T, index: i32, value: valueof<T>): valueof<T> {
     if (index < 0 || (index << alignof<valueof<T>>()) >= array.byteLength) throw new RangeError(E_INDEXOUTOFRANGE);
     return atomic.sub<valueof<T>>(
-      changetype<usize>(array.buffer) + (index << alignof<valueof<T>>()) + array.byteOffset,
+      changetype<usize>(array.data) + (index << alignof<valueof<T>>()) + array.byteOffset,
       value
     );
   }
@@ -47,7 +47,7 @@ export namespace Atomics {
   export function and<T extends ArrayBufferView>(array: T, index: i32, value: valueof<T>): valueof<T> {
     if (index < 0 || (index << alignof<valueof<T>>()) >= array.byteLength) throw new RangeError(E_INDEXOUTOFRANGE);
     return atomic.and<valueof<T>>(
-      changetype<usize>(array.buffer) + (index << alignof<valueof<T>>()) + array.byteOffset,
+      changetype<usize>(array.data) + (index << alignof<valueof<T>>()) + array.byteOffset,
       value
     );
   }
@@ -57,7 +57,7 @@ export namespace Atomics {
   export function or<T extends ArrayBufferView>(array: T, index: i32, value: valueof<T>): valueof<T> {
     if (index < 0 || (index << alignof<valueof<T>>()) >= array.byteLength) throw new RangeError(E_INDEXOUTOFRANGE);
     return atomic.or<valueof<T>>(
-      changetype<usize>(array.buffer) + (index << alignof<valueof<T>>()) + array.byteOffset,
+      changetype<usize>(array.data) + (index << alignof<valueof<T>>()) + array.byteOffset,
       value
     );
   }
@@ -67,7 +67,7 @@ export namespace Atomics {
   export function xor<T extends ArrayBufferView>(array: T, index: i32, value: valueof<T>): valueof<T> {
     if (index < 0 || (index << alignof<valueof<T>>()) >= array.byteLength) throw new RangeError(E_INDEXOUTOFRANGE);
     return atomic.xor<valueof<T>>(
-      changetype<usize>(array.buffer) + (index << alignof<valueof<T>>()) + array.byteOffset,
+      changetype<usize>(array.data) + (index << alignof<valueof<T>>()) + array.byteOffset,
       value
     );
   }
@@ -77,7 +77,7 @@ export namespace Atomics {
   export function exchange<T extends ArrayBufferView>(array: T, index: i32, value: valueof<T>): valueof<T> {
     if (index < 0 || (index << alignof<valueof<T>>()) >= array.byteLength) throw new RangeError(E_INDEXOUTOFRANGE);
     return atomic.xchg<valueof<T>>(
-      changetype<usize>(array.buffer) + (index << alignof<valueof<T>>()) + array.byteOffset,
+      changetype<usize>(array.data) + (index << alignof<valueof<T>>()) + array.byteOffset,
       value
     );
   }
@@ -92,7 +92,7 @@ export namespace Atomics {
   ): valueof<T> {
     if (index < 0 || (index << alignof<valueof<T>>()) >= array.byteLength) throw new RangeError(E_INDEXOUTOFRANGE);
     return atomic.cmpxchg<valueof<T>>(
-      changetype<usize>(array.buffer) + (index << alignof<valueof<T>>()) + array.byteOffset,
+      changetype<usize>(array.data) + (index << alignof<valueof<T>>()) + array.byteOffset,
       expectedValue,
       replacementValue
     );
@@ -101,14 +101,14 @@ export namespace Atomics {
   // @ts-ignore: decorator
   @inline
   export function wait<T extends ArrayBufferView>(array: T, value: valueof<T>, timeout: i64 = -1): AtomicWaitResult {
-    return atomic.wait<valueof<T>>(changetype<usize>(array.buffer) + array.byteOffset, value, timeout);
+    return atomic.wait<valueof<T>>(changetype<usize>(array.data) + array.byteOffset, value, timeout);
   }
 
   // @ts-ignore: decorator
   @inline
   export function notify<T extends ArrayBufferView>(array: T, index: i32, count: i32 = -1): i32 {
     if (index < 0 || (index << alignof<valueof<T>>()) >= array.byteLength) throw new RangeError(E_INDEXOUTOFRANGE);
-    return atomic.notify(changetype<usize>(array.buffer) + (index << alignof<valueof<T>>()) + array.byteOffset, count);
+    return atomic.notify(changetype<usize>(array.data) + (index << alignof<valueof<T>>()) + array.byteOffset, count);
   }
 
   export function isLockFree(size: usize): bool {

--- a/std/assembly/rt.ts
+++ b/std/assembly/rt.ts
@@ -41,9 +41,9 @@ export function __allocArray(length: i32, alignLog2: usize, id: u32, data: usize
   var array = __alloc(offsetof<i32[]>(), id);
   var bufferSize = <usize>length << alignLog2;
   var buffer = __alloc(bufferSize, idof<ArrayBuffer>());
-  store<usize>(array, __retain(buffer), offsetof<ArrayBufferView>("buffer"));
+  store<usize>(array, __retain(buffer), offsetof<ArrayBufferView>("data"));
   store<usize>(array, buffer, offsetof<ArrayBufferView>("dataStart"));
-  store<u32>(array, bufferSize, offsetof<ArrayBufferView>("byteLength"));
+  store<i32>(array, bufferSize, offsetof<ArrayBufferView>("dataLength"));
   store<i32>(array, length, offsetof<i32[]>("length_"));
   if (data) memory.copy(buffer, data, bufferSize);
   return array;

--- a/std/assembly/typedarray.ts
+++ b/std/assembly/typedarray.ts
@@ -3,6 +3,7 @@ import { E_INDEXOUTOFRANGE, E_INVALIDLENGTH, E_NOTIMPLEMENTED } from "./util/err
 import { joinIntegerArray, joinFloatArray } from "./util/string";
 import { idof } from "./builtins";
 import { ArrayBufferView } from "./arraybuffer";
+import { BLOCK_MAXSIZE } from "./rt/common";
 
 export class Int8Array extends ArrayBufferView {
   [key: number]: i8;
@@ -12,16 +13,29 @@ export class Int8Array extends ArrayBufferView {
   static readonly BYTES_PER_ELEMENT: usize = sizeof<i8>();
 
   constructor(length: i32) {
-    super(length, alignof<i8>());
+    super();
+    super.alloc(length, alignof<i8>());
+  }
+
+  get buffer(): ArrayBuffer {
+    return this.data;
+  }
+
+  get byteOffset(): i32 {
+    return <i32>(this.dataStart - changetype<usize>(this.data));
+  }
+
+  get byteLength(): i32 {
+    return this.dataLength;
   }
 
   get length(): i32 {
-    return this.byteLength;
+    return this.dataLength;
   }
 
   @operator("[]")
   private __get(index: i32): i8 {
-    if (<u32>index >= <u32>this.byteLength) throw new RangeError(E_INDEXOUTOFRANGE);
+    if (<u32>index >= <u32>this.dataLength) throw new RangeError(E_INDEXOUTOFRANGE);
     return load<i8>(this.dataStart + <usize>index);
   }
 
@@ -32,7 +46,7 @@ export class Int8Array extends ArrayBufferView {
 
   @operator("[]=")
   private __set(index: i32, value: native<i8>): void {
-    if (<u32>index >= <u32>this.byteLength) throw new RangeError(E_INDEXOUTOFRANGE);
+    if (<u32>index >= <u32>this.dataLength) throw new RangeError(E_INDEXOUTOFRANGE);
     store<i8>(this.dataStart + <usize>index, value);
   }
 
@@ -140,16 +154,29 @@ export class Uint8Array extends ArrayBufferView {
   static readonly BYTES_PER_ELEMENT: usize = sizeof<u8>();
 
   constructor(length: i32) {
-    super(length, alignof<u8>());
+    super();
+    super.alloc(length, alignof<u8>());
+  }
+
+  get buffer(): ArrayBuffer {
+    return this.data;
+  }
+
+  get byteOffset(): i32 {
+    return <i32>(this.dataStart - changetype<usize>(this.data));
+  }
+
+  get byteLength(): i32 {
+    return this.dataLength;
   }
 
   get length(): i32 {
-    return this.byteLength;
+    return this.dataLength;
   }
 
   @operator("[]")
   private __get(index: i32): u8 {
-    if (<u32>index >= <u32>this.byteLength) throw new RangeError(E_INDEXOUTOFRANGE);
+    if (<u32>index >= <u32>this.dataLength) throw new RangeError(E_INDEXOUTOFRANGE);
     return load<u8>(this.dataStart + <usize>index);
   }
 
@@ -160,7 +187,7 @@ export class Uint8Array extends ArrayBufferView {
 
   @operator("[]=")
   private __set(index: i32, value: native<u8>): void {
-    if (<u32>index >= <u32>this.byteLength) throw new RangeError(E_INDEXOUTOFRANGE);
+    if (<u32>index >= <u32>this.dataLength) throw new RangeError(E_INDEXOUTOFRANGE);
     store<u8>(this.dataStart + <usize>index, value);
   }
 
@@ -268,16 +295,29 @@ export class Uint8ClampedArray extends ArrayBufferView {
   static readonly BYTES_PER_ELEMENT: usize = sizeof<u8>();
 
   constructor(length: i32) {
-    super(length, alignof<u8>());
+    super();
+    super.alloc(length, alignof<u8>());
+  }
+
+  get buffer(): ArrayBuffer {
+    return this.data;
+  }
+
+  get byteOffset(): i32 {
+    return <i32>(this.dataStart - changetype<usize>(this.data));
+  }
+
+  get byteLength(): i32 {
+    return this.dataLength;
   }
 
   get length(): i32 {
-    return this.byteLength;
+    return this.dataLength;
   }
 
   @operator("[]")
   private __get(index: i32): u8 {
-    if (<u32>index >= <u32>this.byteLength) throw new RangeError(E_INDEXOUTOFRANGE);
+    if (<u32>index >= <u32>this.dataLength) throw new RangeError(E_INDEXOUTOFRANGE);
     return load<u8>(this.dataStart + <usize>index);
   }
 
@@ -288,7 +328,7 @@ export class Uint8ClampedArray extends ArrayBufferView {
 
   @operator("[]=")
   private __set(index: i32, value: native<u8>): void {
-    if (<u32>index >= <u32>this.byteLength) throw new RangeError(E_INDEXOUTOFRANGE);
+    if (<u32>index >= <u32>this.dataLength) throw new RangeError(E_INDEXOUTOFRANGE);
     store<u8>(this.dataStart + <usize>index, ~(<i32>value >> 31) & (((255 - value) >> 31) | value));
   }
 
@@ -396,16 +436,29 @@ export class Int16Array extends ArrayBufferView {
   static readonly BYTES_PER_ELEMENT: usize = sizeof<i16>();
 
   constructor(length: i32) {
-    super(length, alignof<i16>());
+    super();
+    super.alloc(length, alignof<i16>());
+  }
+
+  get buffer(): ArrayBuffer {
+    return this.data;
+  }
+
+  get byteOffset(): i32 {
+    return <i32>(this.dataStart - changetype<usize>(this.data));
+  }
+
+  get byteLength(): i32 {
+    return this.dataLength;
   }
 
   get length(): i32 {
-    return this.byteLength >>> alignof<i16>();
+    return this.dataLength >>> alignof<i16>();
   }
 
   @operator("[]")
   private __get(index: i32): i16 {
-    if (<u32>index >= <u32>this.byteLength >>> alignof<i16>()) throw new RangeError(E_INDEXOUTOFRANGE);
+    if (<u32>index >= <u32>this.dataLength >>> alignof<i16>()) throw new RangeError(E_INDEXOUTOFRANGE);
     return load<i16>(this.dataStart + (<usize>index << alignof<i16>()));
   }
 
@@ -416,7 +469,7 @@ export class Int16Array extends ArrayBufferView {
 
   @operator("[]=")
   private __set(index: i32, value: native<i16>): void {
-    if (<u32>index >= <u32>this.byteLength >>> alignof<i16>()) throw new RangeError(E_INDEXOUTOFRANGE);
+    if (<u32>index >= <u32>this.dataLength >>> alignof<i16>()) throw new RangeError(E_INDEXOUTOFRANGE);
     store<i16>(this.dataStart + (<usize>index << alignof<i16>()), value);
   }
 
@@ -524,16 +577,29 @@ export class Uint16Array extends ArrayBufferView {
   static readonly BYTES_PER_ELEMENT: usize = sizeof<u16>();
 
   constructor(length: i32) {
-    super(length, alignof<u16>());
+    super();
+    super.alloc(length, alignof<u16>());
+  }
+
+  get buffer(): ArrayBuffer {
+    return this.data;
+  }
+
+  get byteOffset(): i32 {
+    return <i32>(this.dataStart - changetype<usize>(this.data));
+  }
+
+  get byteLength(): i32 {
+    return this.dataLength;
   }
 
   get length(): i32 {
-    return this.byteLength >>> alignof<u16>();
+    return this.dataLength >>> alignof<u16>();
   }
 
   @operator("[]")
   private __get(index: i32): u16 {
-    if (<u32>index >= <u32>this.byteLength >>> alignof<u16>()) throw new RangeError(E_INDEXOUTOFRANGE);
+    if (<u32>index >= <u32>this.dataLength >>> alignof<u16>()) throw new RangeError(E_INDEXOUTOFRANGE);
     return load<u16>(this.dataStart + (<usize>index << alignof<u16>()));
   }
 
@@ -544,7 +610,7 @@ export class Uint16Array extends ArrayBufferView {
 
   @operator("[]=")
   private __set(index: i32, value: native<u16>): void {
-    if (<u32>index >= <u32>this.byteLength >>> alignof<u16>()) throw new RangeError(E_INDEXOUTOFRANGE);
+    if (<u32>index >= <u32>this.dataLength >>> alignof<u16>()) throw new RangeError(E_INDEXOUTOFRANGE);
     store<u16>(this.dataStart + (<usize>index << alignof<u16>()), value);
   }
 
@@ -652,16 +718,29 @@ export class Int32Array extends ArrayBufferView {
   static readonly BYTES_PER_ELEMENT: usize = sizeof<i32>();
 
   constructor(length: i32) {
-    super(length, alignof<i32>());
+    super();
+    super.alloc(length, alignof<i32>());
+  }
+
+  get buffer(): ArrayBuffer {
+    return this.data;
+  }
+
+  get byteOffset(): i32 {
+    return <i32>(this.dataStart - changetype<usize>(this.data));
+  }
+
+  get byteLength(): i32 {
+    return this.dataLength;
   }
 
   get length(): i32 {
-    return this.byteLength >>> alignof<i32>();
+    return this.dataLength >>> alignof<i32>();
   }
 
   @operator("[]")
   private __get(index: i32): i32 {
-    if (<u32>index >= <u32>this.byteLength >>> alignof<i32>()) throw new RangeError(E_INDEXOUTOFRANGE);
+    if (<u32>index >= <u32>this.dataLength >>> alignof<i32>()) throw new RangeError(E_INDEXOUTOFRANGE);
     return load<i32>(this.dataStart + (<usize>index << alignof<i32>()));
   }
 
@@ -672,7 +751,7 @@ export class Int32Array extends ArrayBufferView {
 
   @operator("[]=")
   private __set(index: i32, value: i32): void {
-    if (<u32>index >= <u32>this.byteLength >>> alignof<i32>()) throw new RangeError(E_INDEXOUTOFRANGE);
+    if (<u32>index >= <u32>this.dataLength >>> alignof<i32>()) throw new RangeError(E_INDEXOUTOFRANGE);
     store<i32>(this.dataStart + (<usize>index << alignof<i32>()), value);
   }
 
@@ -780,16 +859,29 @@ export class Uint32Array extends ArrayBufferView {
   static readonly BYTES_PER_ELEMENT: usize = sizeof<u32>();
 
   constructor(length: i32) {
-    super(length, alignof<u32>());
+    super();
+    super.alloc(length, alignof<u32>());
+  }
+
+  get buffer(): ArrayBuffer {
+    return this.data;
+  }
+
+  get byteOffset(): i32 {
+    return <i32>(this.dataStart - changetype<usize>(this.data));
+  }
+
+  get byteLength(): i32 {
+    return this.dataLength;
   }
 
   get length(): i32 {
-    return this.byteLength >>> alignof<u32>();
+    return this.dataLength >>> alignof<u32>();
   }
 
   @operator("[]")
   private __get(index: i32): u32 {
-    if (<u32>index >= <u32>this.byteLength >>> alignof<u32>()) throw new RangeError(E_INDEXOUTOFRANGE);
+    if (<u32>index >= <u32>this.dataLength >>> alignof<u32>()) throw new RangeError(E_INDEXOUTOFRANGE);
     return load<u32>(this.dataStart + (<usize>index << alignof<u32>()));
   }
 
@@ -800,7 +892,7 @@ export class Uint32Array extends ArrayBufferView {
 
   @operator("[]=")
   private __set(index: i32, value: u32): void {
-    if (<u32>index >= <u32>this.byteLength >>> alignof<u32>()) throw new RangeError(E_INDEXOUTOFRANGE);
+    if (<u32>index >= <u32>this.dataLength >>> alignof<u32>()) throw new RangeError(E_INDEXOUTOFRANGE);
     store<u32>(this.dataStart + (<usize>index << alignof<u32>()), value);
   }
 
@@ -908,16 +1000,29 @@ export class Int64Array extends ArrayBufferView {
   static readonly BYTES_PER_ELEMENT: usize = sizeof<i64>();
 
   constructor(length: i32) {
-    super(length, alignof<i64>());
+    super();
+    super.alloc(length, alignof<i64>());
+  }
+
+  get buffer(): ArrayBuffer {
+    return this.data;
+  }
+
+  get byteOffset(): i32 {
+    return <i32>(this.dataStart - changetype<usize>(this.data));
+  }
+
+  get byteLength(): i32 {
+    return this.dataLength;
   }
 
   get length(): i32 {
-    return this.byteLength >>> alignof<i64>();
+    return this.dataLength >>> alignof<i64>();
   }
 
   @operator("[]")
   private __get(index: i32): i64 {
-    if (<u32>index >= <u32>this.byteLength >>> alignof<i64>()) throw new RangeError(E_INDEXOUTOFRANGE);
+    if (<u32>index >= <u32>this.dataLength >>> alignof<i64>()) throw new RangeError(E_INDEXOUTOFRANGE);
     return load<i64>(this.dataStart + (<usize>index << alignof<i64>()));
   }
 
@@ -928,7 +1033,7 @@ export class Int64Array extends ArrayBufferView {
 
   @operator("[]=")
   private __set(index: i32, value: i64): void {
-    if (<u32>index >= <u32>this.byteLength >>> alignof<i64>()) throw new RangeError(E_INDEXOUTOFRANGE);
+    if (<u32>index >= <u32>this.dataLength >>> alignof<i64>()) throw new RangeError(E_INDEXOUTOFRANGE);
     store<i64>(this.dataStart + (<usize>index << alignof<i64>()), value);
   }
 
@@ -1036,16 +1141,29 @@ export class Uint64Array extends ArrayBufferView {
   static readonly BYTES_PER_ELEMENT: usize = sizeof<u64>();
 
   constructor(length: i32) {
-    super(length, alignof<u64>());
+    super();
+    super.alloc(length, alignof<u64>());
+  }
+
+  get buffer(): ArrayBuffer {
+    return this.data;
+  }
+
+  get byteOffset(): i32 {
+    return <i32>(this.dataStart - changetype<usize>(this.data));
+  }
+
+  get byteLength(): i32 {
+    return this.dataLength;
   }
 
   get length(): i32 {
-    return this.byteLength >>> alignof<u64>();
+    return this.dataLength >>> alignof<u64>();
   }
 
   @operator("[]")
   private __get(index: i32): u64 {
-    if (<u32>index >= <u32>this.byteLength >>> alignof<u64>()) throw new RangeError(E_INDEXOUTOFRANGE);
+    if (<u32>index >= <u32>this.dataLength >>> alignof<u64>()) throw new RangeError(E_INDEXOUTOFRANGE);
     return load<u64>(this.dataStart + (<usize>index << alignof<u64>()));
   }
 
@@ -1056,7 +1174,7 @@ export class Uint64Array extends ArrayBufferView {
 
   @operator("[]=")
   private __set(index: i32, value: u64): void {
-    if (<u32>index >= <u32>this.byteLength >>> alignof<u64>()) throw new RangeError(E_INDEXOUTOFRANGE);
+    if (<u32>index >= <u32>this.dataLength >>> alignof<u64>()) throw new RangeError(E_INDEXOUTOFRANGE);
     store<u64>(this.dataStart + (<usize>index << alignof<u64>()), value);
   }
 
@@ -1164,16 +1282,29 @@ export class Float32Array extends ArrayBufferView {
   static readonly BYTES_PER_ELEMENT: usize = sizeof<f32>();
 
   constructor(length: i32) {
-    super(length, alignof<f32>());
+    super();
+    super.alloc(length, alignof<f32>());
+  }
+
+  get buffer(): ArrayBuffer {
+    return this.data;
+  }
+
+  get byteOffset(): i32 {
+    return <i32>(this.dataStart - changetype<usize>(this.data));
+  }
+
+  get byteLength(): i32 {
+    return this.dataLength;
   }
 
   get length(): i32 {
-    return this.byteLength >>> alignof<f32>();
+    return this.dataLength >>> alignof<f32>();
   }
 
   @operator("[]")
   private __get(index: i32): f32 {
-    if (<u32>index >= <u32>this.byteLength >>> alignof<f32>()) throw new RangeError(E_INDEXOUTOFRANGE);
+    if (<u32>index >= <u32>this.dataLength >>> alignof<f32>()) throw new RangeError(E_INDEXOUTOFRANGE);
     return load<f32>(this.dataStart + (<usize>index << alignof<f32>()));
   }
 
@@ -1184,7 +1315,7 @@ export class Float32Array extends ArrayBufferView {
 
   @operator("[]=")
   private __set(index: i32, value: f32): void {
-    if (<u32>index >= <u32>this.byteLength >>> alignof<f32>()) throw new RangeError(E_INDEXOUTOFRANGE);
+    if (<u32>index >= <u32>this.dataLength >>> alignof<f32>()) throw new RangeError(E_INDEXOUTOFRANGE);
     store<f32>(this.dataStart + (<usize>index << alignof<f32>()), value);
   }
 
@@ -1292,16 +1423,29 @@ export class Float64Array extends ArrayBufferView {
   static readonly BYTES_PER_ELEMENT: usize = sizeof<f64>();
 
   constructor(length: i32) {
-    super(length, alignof<f64>());
+    super();
+    super.alloc(length, alignof<f64>());
+  }
+
+  get buffer(): ArrayBuffer {
+    return this.data;
+  }
+
+  get byteOffset(): i32 {
+    return <i32>(this.dataStart - changetype<usize>(this.data));
+  }
+
+  get byteLength(): i32 {
+    return this.dataLength;
   }
 
   get length(): i32 {
-    return this.byteLength >>> alignof<f64>();
+    return this.dataLength >>> alignof<f64>();
   }
 
   @operator("[]")
   private __get(index: i32): f64 {
-    if (<u32>index >= <u32>this.byteLength >>> alignof<f64>()) throw new RangeError(E_INDEXOUTOFRANGE);
+    if (<u32>index >= <u32>this.dataLength >>> alignof<f64>()) throw new RangeError(E_INDEXOUTOFRANGE);
     return load<f64>(this.dataStart + (<usize>index << alignof<f64>()));
   }
 
@@ -1312,7 +1456,7 @@ export class Float64Array extends ArrayBufferView {
 
   @operator("[]=")
   private __set(index: i32, value: f64): void {
-    if (<u32>index >= <u32>this.byteLength >>> alignof<f64>()) throw new RangeError(E_INDEXOUTOFRANGE);
+    if (<u32>index >= <u32>this.dataLength >>> alignof<f64>()) throw new RangeError(E_INDEXOUTOFRANGE);
     store<f64>(this.dataStart + (<usize>index << alignof<f64>()), value);
   }
 
@@ -1489,9 +1633,9 @@ function SUBARRAY<TArray extends ArrayBufferView, T>(
   end   = max(end, begin);
 
   var out = __alloc(offsetof<TArray>(), idof<TArray>());
-  store<usize>(out, __retain(changetype<usize>(array.buffer)), offsetof<TArray>("buffer"));
+  store<usize>(out, __retain(changetype<usize>(array.data)), offsetof<TArray>("data"));
   store<usize>(out, array.dataStart + (<usize>begin << alignof<T>()), offsetof<TArray>("dataStart"));
-  store<u32>(out, (end - begin) << alignof<T>(), offsetof<TArray>("byteLength"));
+  store<i32>(out, (end - begin) << alignof<T>(), offsetof<TArray>("dataLength"));
   return changetype<TArray>(out); // retains
 }
 
@@ -1566,9 +1710,9 @@ function MAP<TArray extends ArrayBufferView, T>(
       fn(load<T>(dataStart + (<usize>i << alignof<T>())), i, array)
     );
   }
-  store<usize>(out, __retain(buffer), offsetof<TArray>("buffer"));
+  store<usize>(out, __retain(buffer), offsetof<TArray>("data"));
   store<usize>(out, buffer, offsetof<TArray>("dataStart"));
-  store<u32>(out, byteLength, offsetof<TArray>("byteLength"));
+  store<i32>(out, byteLength, offsetof<TArray>("dataLength"));
   return changetype<TArray>(out); // retains
 }
 
@@ -1595,9 +1739,9 @@ function FILTER<TArray extends ArrayBufferView, T>(
   // shrink output buffer
   var byteLength = j << alignof<T>();
   var data = __realloc(buffer, byteLength);
-  store<usize>(out, __retain(data), offsetof<TArray>("buffer"));
-  store<u32>(out, byteLength, offsetof<TArray>("byteLength"));
+  store<usize>(out, __retain(data), offsetof<TArray>("data"));
   store<usize>(out, data, offsetof<TArray>("dataStart"));
+  store<i32>(out, byteLength, offsetof<TArray>("dataLength"));
   return changetype<TArray>(out); // retains
 }
 
@@ -1756,9 +1900,9 @@ function WRAP<TArray extends ArrayBufferView, T>(buffer: ArrayBuffer, byteOffset
     }
   }
   var out = __alloc(offsetof<TArray>(), idof<TArray>());
-  store<usize>(out, __retain(changetype<usize>(buffer)), offsetof<TArray>("buffer"));
-  store<u32>(out, byteLength, offsetof<TArray>("byteLength"));
+  store<usize>(out, __retain(changetype<usize>(buffer)), offsetof<TArray>("data"));
   store<usize>(out, changetype<usize>(buffer) + <usize>byteOffset, offsetof<TArray>("dataStart"));
+  store<i32>(out, byteLength, offsetof<TArray>("dataLength"));
   return changetype<TArray>(out); // retains
 }
 
@@ -1780,7 +1924,7 @@ function SET<TArray extends ArrayBufferView, T, UArray extends ArrayBufferView, 
     memory.copy(
       target.dataStart + (<usize>offset << alignof<T>()),
       source.dataStart,
-      source.byteLength
+      source.dataLength
     );
   } else {
     let targetDataStart = target.dataStart + (<usize>offset << alignof<T>());

--- a/tests/compiler/assert-nonnull.optimized.wat
+++ b/tests/compiler/assert-nonnull.optimized.wat
@@ -80,7 +80,7 @@
   if
    i32.const 96
    i32.const 160
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -92,7 +92,7 @@
   if
    i32.const 208
    i32.const 160
-   i32.const 97
+   i32.const 102
    i32.const 39
    call $~lib/builtins/abort
    unreachable
@@ -121,7 +121,7 @@
   if
    i32.const 96
    i32.const 160
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/assert-nonnull.untouched.wat
+++ b/tests/compiler/assert-nonnull.untouched.wat
@@ -122,7 +122,7 @@
   if
    i32.const 96
    i32.const 160
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -138,7 +138,7 @@
    call $~lib/rt/stub/__release
    i32.const 208
    i32.const 160
-   i32.const 97
+   i32.const 102
    i32.const 39
    call $~lib/builtins/abort
    unreachable
@@ -188,7 +188,7 @@
   if
    i32.const 96
    i32.const 160
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/builtins.optimized.wat
+++ b/tests/compiler/builtins.optimized.wat
@@ -604,9 +604,9 @@
   i32.const 5
   f64.const 0
   f64.const 0
-  f64.const 12
-  f64.const 23
-  f64.const 23
+  f64.const 10
+  f64.const 25
+  f64.const 25
   call $~lib/builtins/trace
   i32.const 208
   i32.const 208

--- a/tests/compiler/builtins.untouched.wat
+++ b/tests/compiler/builtins.untouched.wat
@@ -1561,11 +1561,11 @@
   local.set $0
   i32.const 0
   local.set $1
-  i32.const 12
+  i32.const 10
   local.set $6
-  i32.const 23
+  i32.const 25
   local.set $7
-  i32.const 23
+  i32.const 25
   local.set $8
   i32.const 128
   i32.const 5
@@ -1605,7 +1605,7 @@
    unreachable
   end
   local.get $6
-  i32.const 12
+  i32.const 10
   i32.eq
   i32.eqz
   if

--- a/tests/compiler/infer-array.optimized.wat
+++ b/tests/compiler/infer-array.optimized.wat
@@ -332,7 +332,7 @@
   if
    i32.const 64
    i32.const 128
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -351,7 +351,7 @@
   if
    i32.const 64
    i32.const 128
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/infer-array.untouched.wat
+++ b/tests/compiler/infer-array.untouched.wat
@@ -1444,7 +1444,7 @@
   if
    i32.const 64
    i32.const 128
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -1476,7 +1476,7 @@
   if
    i32.const 64
    i32.const 128
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -1505,7 +1505,7 @@
   if
    i32.const 64
    i32.const 128
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -1534,7 +1534,7 @@
   if
    i32.const 64
    i32.const 128
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -1576,7 +1576,7 @@
   if
    i32.const 64
    i32.const 128
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -1606,7 +1606,7 @@
   if
    i32.const 64
    i32.const 128
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -1635,7 +1635,7 @@
   if
    i32.const 64
    i32.const 128
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -1665,7 +1665,7 @@
   if
    i32.const 64
    i32.const 128
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -1681,7 +1681,7 @@
    call $~lib/rt/stub/__release
    i32.const 640
    i32.const 128
-   i32.const 97
+   i32.const 102
    i32.const 39
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-access.optimized.wat
+++ b/tests/compiler/resolve-access.optimized.wat
@@ -313,7 +313,7 @@
   if
    i32.const 64
    i32.const 128
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-access.untouched.wat
+++ b/tests/compiler/resolve-access.untouched.wat
@@ -1439,7 +1439,7 @@
   if
    i32.const 64
    i32.const 128
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-elementaccess.optimized.wat
+++ b/tests/compiler/resolve-elementaccess.optimized.wat
@@ -132,7 +132,27 @@
   i32.store offset=12
   local.get $3
  )
- (func $~lib/memory/memory.fill (; 3 ;) (param $0 i32)
+ (func $~lib/arraybuffer/ArrayBufferView#constructor (; 3 ;) (param $0 i32) (result i32)
+  local.get $0
+  i32.eqz
+  if
+   i32.const 12
+   i32.const 2
+   call $~lib/rt/stub/__alloc
+   local.set $0
+  end
+  local.get $0
+  i32.const 0
+  i32.store
+  local.get $0
+  i32.const 0
+  i32.store offset=4
+  local.get $0
+  i32.const 0
+  i32.store offset=8
+  local.get $0
+ )
+ (func $~lib/memory/memory.fill (; 4 ;) (param $0 i32)
   (local $1 i32)
   local.get $0
   i32.const 0
@@ -176,30 +196,13 @@
   i32.const 0
   i32.store8
  )
- (func $~lib/arraybuffer/ArrayBufferView#constructor (; 4 ;) (param $0 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBufferView#alloc (; 5 ;) (param $0 i32)
   (local $1 i32)
   i32.const 8
   i32.const 0
   call $~lib/rt/stub/__alloc
   local.tee $1
   call $~lib/memory/memory.fill
-  local.get $0
-  i32.eqz
-  if
-   i32.const 12
-   i32.const 2
-   call $~lib/rt/stub/__alloc
-   local.set $0
-  end
-  local.get $0
-  i32.const 0
-  i32.store
-  local.get $0
-  i32.const 0
-  i32.store offset=4
-  local.get $0
-  i32.const 0
-  i32.store offset=8
   local.get $0
   i32.load
   drop
@@ -212,9 +215,8 @@
   local.get $0
   i32.const 8
   i32.store offset=8
-  local.get $0
  )
- (func $~lib/typedarray/Float32Array#__set (; 5 ;) (param $0 i32) (param $1 i32) (param $2 f32)
+ (func $~lib/typedarray/Float32Array#__set (; 6 ;) (param $0 i32) (param $1 i32) (param $2 f32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -224,7 +226,7 @@
   if
    i32.const 144
    i32.const 208
-   i32.const 1187
+   i32.const 1318
    i32.const 63
    call $~lib/builtins/abort
    unreachable
@@ -238,7 +240,7 @@
   local.get $2
   f32.store
  )
- (func $~lib/typedarray/Float32Array#__get (; 6 ;) (param $0 i32) (param $1 i32) (result f32)
+ (func $~lib/typedarray/Float32Array#__get (; 7 ;) (param $0 i32) (param $1 i32) (result f32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -248,7 +250,7 @@
   if
    i32.const 144
    i32.const 208
-   i32.const 1176
+   i32.const 1307
    i32.const 63
    call $~lib/builtins/abort
    unreachable
@@ -261,7 +263,7 @@
   i32.add
   f32.load
  )
- (func $~lib/util/number/decimalCount32 (; 7 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/decimalCount32 (; 8 ;) (param $0 i32) (result i32)
   i32.const 1
   i32.const 2
   local.get $0
@@ -309,7 +311,7 @@
   i32.lt_u
   select
  )
- (func $~lib/util/number/genDigits (; 8 ;) (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (param $6 i32) (result i32)
+ (func $~lib/util/number/genDigits (; 9 ;) (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (param $6 i32) (result i32)
   (local $7 i32)
   (local $8 i32)
   (local $9 i64)
@@ -703,7 +705,7 @@
    local.get $6
   end
  )
- (func $~lib/memory/memory.copy (; 9 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/memory/memory.copy (; 10 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   block $~lib/util/memory/memmove|inlined.0
@@ -876,7 +878,7 @@
    end
   end
  )
- (func $~lib/util/number/utoa_simple<u32> (; 10 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/number/utoa_simple<u32> (; 11 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   loop $do-continue|0
    local.get $1
@@ -900,7 +902,7 @@
    br_if $do-continue|0
   end
  )
- (func $~lib/util/number/prettify (; 11 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/prettify (; 12 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   i32.eqz
@@ -1145,7 +1147,7 @@
    end
   end
  )
- (func $~lib/util/number/dtoa_core (; 12 ;) (param $0 i32) (param $1 f64) (result i32)
+ (func $~lib/util/number/dtoa_core (; 13 ;) (param $0 i32) (param $1 f64) (result i32)
   (local $2 i64)
   (local $3 i32)
   (local $4 i64)
@@ -1433,7 +1435,7 @@
   local.get $10
   i32.add
  )
- (func $~lib/string/String#get:length (; 13 ;) (param $0 i32) (result i32)
+ (func $~lib/string/String#get:length (; 14 ;) (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub
@@ -1441,7 +1443,7 @@
   i32.const 1
   i32.shr_u
  )
- (func $~lib/string/String#substring (; 14 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String#substring (; 15 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1513,7 +1515,7 @@
   call $~lib/memory/memory.copy
   local.get $2
  )
- (func $~lib/rt/stub/__free (; 15 ;) (param $0 i32)
+ (func $~lib/rt/stub/__free (; 16 ;) (param $0 i32)
   (local $1 i32)
   local.get $0
   i32.const 15
@@ -1557,7 +1559,7 @@
    global.set $~lib/rt/stub/offset
   end
  )
- (func $~lib/util/number/dtoa (; 16 ;) (param $0 f64) (result i32)
+ (func $~lib/util/number/dtoa (; 17 ;) (param $0 f64) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -1607,12 +1609,12 @@
   local.get $1
   call $~lib/rt/stub/__free
  )
- (func $~lib/number/F32#toString (; 17 ;) (param $0 f32) (result i32)
+ (func $~lib/number/F32#toString (; 18 ;) (param $0 f32) (result i32)
   local.get $0
   f64.promote_f32
   call $~lib/util/number/dtoa
  )
- (func $~lib/util/string/compareImpl (; 18 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/compareImpl (; 19 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -1688,7 +1690,7 @@
   end
   i32.const 0
  )
- (func $~lib/string/String.__eq (; 19 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__eq (; 20 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -1720,7 +1722,7 @@
   end
   i32.const 0
  )
- (func $start:resolve-elementaccess (; 20 ;)
+ (func $start:resolve-elementaccess (; 21 ;)
   (local $0 i32)
   i32.const 1696
   global.set $~lib/rt/stub/startOffset
@@ -1730,6 +1732,9 @@
   i32.const 3
   call $~lib/rt/stub/__alloc
   call $~lib/arraybuffer/ArrayBufferView#constructor
+  local.tee $0
+  call $~lib/arraybuffer/ArrayBufferView#alloc
+  local.get $0
   global.set $resolve-elementaccess/arr
   global.get $resolve-elementaccess/arr
   i32.const 0
@@ -1815,7 +1820,7 @@
    unreachable
   end
  )
- (func $~start (; 21 ;)
+ (func $~start (; 22 ;)
   call $start:resolve-elementaccess
  )
 )

--- a/tests/compiler/resolve-elementaccess.untouched.wat
+++ b/tests/compiler/resolve-elementaccess.untouched.wat
@@ -1,10 +1,10 @@
 (module
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
+ (type $i32_=>_i32 (func (param i32) (result i32)))
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_=>_none (func (param i32)))
- (type $i32_=>_i32 (func (param i32) (result i32)))
- (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (type $none_=>_none (func))
+ (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $i32_i32_f32_=>_none (func (param i32 i32 f32)))
  (type $i32_i32_i32_i32_i32_=>_i32 (func (param i32 i32 i32 i32 i32) (result i32)))
@@ -159,7 +159,31 @@
   i32.store offset=12
   local.get $2
  )
- (func $~lib/memory/memory.fill (; 3 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/rt/stub/__retain (; 3 ;) (param $0 i32) (result i32)
+  local.get $0
+ )
+ (func $~lib/arraybuffer/ArrayBufferView#constructor (; 4 ;) (param $0 i32) (result i32)
+  local.get $0
+  i32.eqz
+  if
+   i32.const 12
+   i32.const 2
+   call $~lib/rt/stub/__alloc
+   call $~lib/rt/stub/__retain
+   local.set $0
+  end
+  local.get $0
+  i32.const 0
+  i32.store
+  local.get $0
+  i32.const 0
+  i32.store offset=4
+  local.get $0
+  i32.const 0
+  i32.store offset=8
+  local.get $0
+ )
+ (func $~lib/memory/memory.fill (; 5 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -423,13 +447,10 @@
    end
   end
  )
- (func $~lib/rt/stub/__retain (; 4 ;) (param $0 i32) (result i32)
-  local.get $0
- )
- (func $~lib/rt/stub/__release (; 5 ;) (param $0 i32)
+ (func $~lib/rt/stub/__release (; 6 ;) (param $0 i32)
   nop
  )
- (func $~lib/arraybuffer/ArrayBufferView#constructor (; 6 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBufferView#alloc (; 7 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -442,7 +463,7 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 23
+   i32.const 14
    i32.const 56
    call $~lib/builtins/abort
    unreachable
@@ -458,24 +479,6 @@
   i32.const 0
   local.get $1
   call $~lib/memory/memory.fill
-  local.get $0
-  i32.eqz
-  if
-   i32.const 12
-   i32.const 2
-   call $~lib/rt/stub/__alloc
-   call $~lib/rt/stub/__retain
-   local.set $0
-  end
-  local.get $0
-  i32.const 0
-  i32.store
-  local.get $0
-  i32.const 0
-  i32.store offset=4
-  local.get $0
-  i32.const 0
-  i32.store offset=8
   local.get $0
   local.tee $4
   local.get $3
@@ -499,9 +502,8 @@
   local.get $0
   local.get $1
   i32.store offset=8
-  local.get $0
  )
- (func $~lib/typedarray/Float32Array#constructor (; 7 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#constructor (; 8 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   if (result i32)
    local.get $0
@@ -511,13 +513,15 @@
    call $~lib/rt/stub/__alloc
    call $~lib/rt/stub/__retain
   end
-  local.get $1
-  i32.const 2
   call $~lib/arraybuffer/ArrayBufferView#constructor
   local.set $0
   local.get $0
+  local.get $1
+  i32.const 2
+  call $~lib/arraybuffer/ArrayBufferView#alloc
+  local.get $0
  )
- (func $~lib/typedarray/Float32Array#__set (; 8 ;) (param $0 i32) (param $1 i32) (param $2 f32)
+ (func $~lib/typedarray/Float32Array#__set (; 9 ;) (param $0 i32) (param $1 i32) (param $2 f32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -527,7 +531,7 @@
   if
    i32.const 144
    i32.const 208
-   i32.const 1187
+   i32.const 1318
    i32.const 63
    call $~lib/builtins/abort
    unreachable
@@ -541,7 +545,7 @@
   local.get $2
   f32.store
  )
- (func $~lib/typedarray/Float32Array#__get (; 9 ;) (param $0 i32) (param $1 i32) (result f32)
+ (func $~lib/typedarray/Float32Array#__get (; 10 ;) (param $0 i32) (param $1 i32) (result f32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -551,7 +555,7 @@
   if
    i32.const 144
    i32.const 208
-   i32.const 1176
+   i32.const 1307
    i32.const 63
    call $~lib/builtins/abort
    unreachable
@@ -564,7 +568,7 @@
   i32.add
   f32.load
  )
- (func $~lib/array/Array<u64>#__unchecked_get (; 10 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $~lib/array/Array<u64>#__unchecked_get (; 11 ;) (param $0 i32) (param $1 i32) (result i64)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -573,7 +577,7 @@
   i32.add
   i64.load
  )
- (func $~lib/array/Array<i16>#__unchecked_get (; 11 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i16>#__unchecked_get (; 12 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -582,7 +586,7 @@
   i32.add
   i32.load16_s
  )
- (func $~lib/util/number/decimalCount32 (; 12 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/decimalCount32 (; 13 ;) (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   i32.const 100000
@@ -648,7 +652,7 @@
   end
   unreachable
  )
- (func $~lib/util/number/genDigits (; 13 ;) (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (param $6 i32) (result i32)
+ (func $~lib/util/number/genDigits (; 14 ;) (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (param $6 i32) (result i32)
   (local $7 i32)
   (local $8 i64)
   (local $9 i64)
@@ -1155,7 +1159,7 @@
   end
   local.get $15
  )
- (func $~lib/util/memory/memcpy (; 14 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/memory/memcpy (; 15 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2179,7 +2183,7 @@
    i32.store8
   end
  )
- (func $~lib/memory/memory.copy (; 15 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/memory/memory.copy (; 16 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2399,7 +2403,7 @@
    end
   end
  )
- (func $~lib/util/number/utoa32_lut (; 16 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/number/utoa32_lut (; 17 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2543,7 +2547,7 @@
    i32.store16
   end
  )
- (func $~lib/util/number/prettify (; 17 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/prettify (; 18 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2860,7 +2864,7 @@
   end
   unreachable
  )
- (func $~lib/util/number/dtoa_core (; 18 ;) (param $0 i32) (param $1 f64) (result i32)
+ (func $~lib/util/number/dtoa_core (; 19 ;) (param $0 i32) (param $1 f64) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3282,7 +3286,7 @@
   local.get $2
   i32.add
  )
- (func $~lib/string/String#get:length (; 19 ;) (param $0 i32) (result i32)
+ (func $~lib/string/String#get:length (; 20 ;) (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub
@@ -3290,7 +3294,7 @@
   i32.const 1
   i32.shr_u
  )
- (func $~lib/string/String#substring (; 20 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/string/String#substring (; 21 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3397,7 +3401,7 @@
   local.get $11
   call $~lib/rt/stub/__retain
  )
- (func $~lib/rt/stub/__free (; 21 ;) (param $0 i32)
+ (func $~lib/rt/stub/__free (; 22 ;) (param $0 i32)
   (local $1 i32)
   local.get $0
   i32.const 0
@@ -3447,7 +3451,7 @@
    global.set $~lib/rt/stub/offset
   end
  )
- (func $~lib/util/number/dtoa (; 22 ;) (param $0 f64) (result i32)
+ (func $~lib/util/number/dtoa (; 23 ;) (param $0 f64) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -3508,12 +3512,12 @@
   call $~lib/rt/stub/__free
   local.get $3
  )
- (func $~lib/number/F32#toString (; 23 ;) (param $0 f32) (result i32)
+ (func $~lib/number/F32#toString (; 24 ;) (param $0 f32) (result i32)
   local.get $0
   f64.promote_f32
   call $~lib/util/number/dtoa
  )
- (func $~lib/util/string/compareImpl (; 24 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
+ (func $~lib/util/string/compareImpl (; 25 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
@@ -3635,7 +3639,7 @@
   call $~lib/rt/stub/__release
   local.get $7
  )
- (func $~lib/string/String.__eq (; 25 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__eq (; 26 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -3708,7 +3712,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $start:resolve-elementaccess (; 26 ;)
+ (func $start:resolve-elementaccess (; 27 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -3822,7 +3826,7 @@
   local.get $2
   call $~lib/rt/stub/__release
  )
- (func $~start (; 27 ;)
+ (func $~start (; 28 ;)
   call $start:resolve-elementaccess
  )
 )

--- a/tests/compiler/retain-release-sanity.optimized.wat
+++ b/tests/compiler/retain-release-sanity.optimized.wat
@@ -2,12 +2,12 @@
  (type $i32_=>_none (func (param i32)))
  (type $i32_i32_=>_none (func (param i32 i32)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_none (func))
+ (type $none_=>_i32 (func (result i32)))
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
- (type $none_=>_i32 (func (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (import "rtrace" "onalloc" (func $~lib/rt/rtrace/onalloc (param i32)))
  (import "rtrace" "onincrement" (func $~lib/rt/rtrace/onincrement (param i32)))
@@ -15,11 +15,11 @@
  (import "rtrace" "onfree" (func $~lib/rt/rtrace/onfree (param i32)))
  (import "rtrace" "ondecrement" (func $~lib/rt/rtrace/ondecrement (param i32)))
  (memory $0 1)
- (data (i32.const 16) "\1c\00\00\00\01\00\00\00\01\00\00\00\1c\00\00\00I\00n\00v\00a\00l\00i\00d\00 \00l\00e\00n\00g\00t\00h")
- (data (i32.const 64) "&\00\00\00\01\00\00\00\01\00\00\00&\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00b\00u\00f\00f\00e\00r\00.\00t\00s")
- (data (i32.const 128) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s")
- (data (i32.const 176) "(\00\00\00\01\00\00\00\01\00\00\00(\00\00\00a\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e")
- (data (i32.const 240) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00p\00u\00r\00e\00.\00t\00s")
+ (data (i32.const 16) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s")
+ (data (i32.const 64) "(\00\00\00\01\00\00\00\01\00\00\00(\00\00\00a\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e")
+ (data (i32.const 128) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00p\00u\00r\00e\00.\00t\00s")
+ (data (i32.const 176) "\1c\00\00\00\01\00\00\00\01\00\00\00\1c\00\00\00I\00n\00v\00a\00l\00i\00d\00 \00l\00e\00n\00g\00t\00h")
+ (data (i32.const 224) "&\00\00\00\01\00\00\00\01\00\00\00&\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00b\00u\00f\00f\00e\00r\00.\00t\00s")
  (data (i32.const 288) "\1a\00\00\00\01\00\00\00\01\00\00\00\1a\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00.\00t\00s")
  (data (i32.const 336) "\1c\00\00\00\01\00\00\00\01\00\00\00\1c\00\00\00A\00r\00r\00a\00y\00 \00i\00s\00 \00e\00m\00p\00t\00y")
  (data (i32.const 388) "\01\00\00\00\01")
@@ -50,7 +50,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 277
    i32.const 13
    call $~lib/builtins/abort
@@ -72,7 +72,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 279
    i32.const 13
    call $~lib/builtins/abort
@@ -117,7 +117,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 292
    i32.const 13
    call $~lib/builtins/abort
@@ -214,7 +214,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 205
    i32.const 13
    call $~lib/builtins/abort
@@ -228,7 +228,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 207
    i32.const 13
    call $~lib/builtins/abort
@@ -301,7 +301,7 @@
    i32.eqz
    if
     i32.const 0
-    i32.const 144
+    i32.const 32
     i32.const 228
     i32.const 15
     call $~lib/builtins/abort
@@ -356,7 +356,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 243
    i32.const 13
    call $~lib/builtins/abort
@@ -371,7 +371,7 @@
   i32.ne
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 244
    i32.const 13
    call $~lib/builtins/abort
@@ -421,7 +421,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 260
    i32.const 13
    call $~lib/builtins/abort
@@ -507,7 +507,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 386
    i32.const 4
    call $~lib/builtins/abort
@@ -524,7 +524,7 @@
    i32.lt_u
    if
     i32.const 0
-    i32.const 144
+    i32.const 32
     i32.const 396
     i32.const 15
     call $~lib/builtins/abort
@@ -552,7 +552,7 @@
    i32.lt_u
    if
     i32.const 0
-    i32.const 144
+    i32.const 32
     i32.const 408
     i32.const 4
     call $~lib/builtins/abort
@@ -692,8 +692,8 @@
   i32.const 1073741808
   i32.ge_u
   if
-   i32.const 192
-   i32.const 144
+   i32.const 80
+   i32.const 32
    i32.const 457
    i32.const 29
    call $~lib/builtins/abort
@@ -768,7 +768,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 338
    i32.const 13
    call $~lib/builtins/abort
@@ -820,7 +820,7 @@
     i32.eqz
     if
      i32.const 0
-     i32.const 144
+     i32.const 32
      i32.const 351
      i32.const 17
      call $~lib/builtins/abort
@@ -915,7 +915,7 @@
   i32.and
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 365
    i32.const 13
    call $~lib/builtins/abort
@@ -986,7 +986,7 @@
   global.get $~lib/rt/tlsf/collectLock
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 490
    i32.const 13
    call $~lib/builtins/abort
@@ -1021,7 +1021,7 @@
     i32.eqz
     if
      i32.const 0
-     i32.const 144
+     i32.const 32
      i32.const 502
      i32.const 19
      call $~lib/builtins/abort
@@ -1037,7 +1037,7 @@
   i32.lt_u
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 510
    i32.const 13
    call $~lib/builtins/abort
@@ -1071,7 +1071,81 @@
   i32.const 16
   i32.add
  )
- (func $~lib/memory/memory.fill (; 16 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/pure/increment (; 16 ;) (param $0 i32)
+  (local $1 i32)
+  local.get $0
+  i32.load offset=4
+  local.tee $1
+  i32.const -268435456
+  i32.and
+  local.get $1
+  i32.const 1
+  i32.add
+  i32.const -268435456
+  i32.and
+  i32.ne
+  if
+   i32.const 0
+   i32.const 144
+   i32.const 109
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  local.get $1
+  i32.const 1
+  i32.add
+  i32.store offset=4
+  local.get $0
+  call $~lib/rt/rtrace/onincrement
+  local.get $0
+  i32.load
+  i32.const 1
+  i32.and
+  if
+   i32.const 0
+   i32.const 144
+   i32.const 112
+   i32.const 13
+   call $~lib/builtins/abort
+   unreachable
+  end
+ )
+ (func $~lib/rt/pure/__retain (; 17 ;) (param $0 i32) (result i32)
+  local.get $0
+  i32.const 708
+  i32.gt_u
+  if
+   local.get $0
+   i32.const 16
+   i32.sub
+   call $~lib/rt/pure/increment
+  end
+  local.get $0
+ )
+ (func $~lib/arraybuffer/ArrayBufferView#constructor (; 18 ;) (param $0 i32) (result i32)
+  local.get $0
+  i32.eqz
+  if
+   i32.const 12
+   i32.const 2
+   call $~lib/rt/tlsf/__alloc
+   call $~lib/rt/pure/__retain
+   local.set $0
+  end
+  local.get $0
+  i32.const 0
+  i32.store
+  local.get $0
+  i32.const 0
+  i32.store offset=4
+  local.get $0
+  i32.const 0
+  i32.store offset=8
+  local.get $0
+ )
+ (func $~lib/memory/memory.fill (; 19 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   block $~lib/util/memory/memset|inlined.0
    local.get $1
@@ -1282,60 +1356,7 @@
    end
   end
  )
- (func $~lib/rt/pure/increment (; 17 ;) (param $0 i32)
-  (local $1 i32)
-  local.get $0
-  i32.load offset=4
-  local.tee $1
-  i32.const -268435456
-  i32.and
-  local.get $1
-  i32.const 1
-  i32.add
-  i32.const -268435456
-  i32.and
-  i32.ne
-  if
-   i32.const 0
-   i32.const 256
-   i32.const 109
-   i32.const 2
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $0
-  local.get $1
-  i32.const 1
-  i32.add
-  i32.store offset=4
-  local.get $0
-  call $~lib/rt/rtrace/onincrement
-  local.get $0
-  i32.load
-  i32.const 1
-  i32.and
-  if
-   i32.const 0
-   i32.const 256
-   i32.const 112
-   i32.const 13
-   call $~lib/builtins/abort
-   unreachable
-  end
- )
- (func $~lib/rt/pure/__retain (; 18 ;) (param $0 i32) (result i32)
-  local.get $0
-  i32.const 708
-  i32.gt_u
-  if
-   local.get $0
-   i32.const 16
-   i32.sub
-   call $~lib/rt/pure/increment
-  end
-  local.get $0
- )
- (func $~lib/rt/pure/__release (; 19 ;) (param $0 i32)
+ (func $~lib/rt/pure/__release (; 20 ;) (param $0 i32)
   local.get $0
   i32.const 708
   i32.gt_u
@@ -1346,7 +1367,7 @@
    call $~lib/rt/pure/decrement
   end
  )
- (func $~lib/arraybuffer/ArrayBufferView#constructor (; 20 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBufferView#alloc (; 21 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1354,9 +1375,9 @@
   i32.const 268435452
   i32.gt_u
   if
-   i32.const 32
-   i32.const 80
-   i32.const 23
+   i32.const 192
+   i32.const 240
+   i32.const 14
    i32.const 56
    call $~lib/builtins/abort
    unreachable
@@ -1370,24 +1391,6 @@
   local.tee $3
   local.get $2
   call $~lib/memory/memory.fill
-  local.get $0
-  i32.eqz
-  if
-   i32.const 12
-   i32.const 2
-   call $~lib/rt/tlsf/__alloc
-   call $~lib/rt/pure/__retain
-   local.set $0
-  end
-  local.get $0
-  i32.const 0
-  i32.store
-  local.get $0
-  i32.const 0
-  i32.store offset=4
-  local.get $0
-  i32.const 0
-  i32.store offset=8
   local.get $3
   local.tee $1
   local.get $0
@@ -1410,9 +1413,26 @@
   local.get $0
   local.get $2
   i32.store offset=8
+ )
+ (func $~lib/array/Array<i32>#constructor (; 22 ;) (result i32)
+  (local $0 i32)
+  i32.const 16
+  i32.const 3
+  call $~lib/rt/tlsf/__alloc
+  call $~lib/rt/pure/__retain
+  call $~lib/arraybuffer/ArrayBufferView#constructor
+  local.tee $0
+  i32.const 0
+  i32.store offset=12
+  local.get $0
+  i32.const 3
+  call $~lib/arraybuffer/ArrayBufferView#alloc
+  local.get $0
+  i32.const 3
+  i32.store offset=12
   local.get $0
  )
- (func $~lib/rt/tlsf/checkUsedBlock (; 21 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/tlsf/checkUsedBlock (; 23 ;) (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   i32.const 16
@@ -1446,7 +1466,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 570
    i32.const 2
    call $~lib/builtins/abort
@@ -1454,7 +1474,7 @@
   end
   local.get $1
  )
- (func $~lib/memory/memory.copy (; 22 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/memory/memory.copy (; 24 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   block $~lib/util/memory/memmove|inlined.0
@@ -1627,7 +1647,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/freeBlock (; 23 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/freeBlock (; 25 ;) (param $0 i32) (param $1 i32)
   local.get $1
   local.get $1
   i32.load
@@ -1640,7 +1660,7 @@
   local.get $1
   call $~lib/rt/rtrace/onfree
  )
- (func $~lib/rt/tlsf/reallocateBlock (; 24 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/reallocateBlock (; 26 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1743,7 +1763,7 @@
   end
   local.get $3
  )
- (func $~lib/array/ensureSize (; 25 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/ensureSize (; 27 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1759,7 +1779,7 @@
    i32.const 268435452
    i32.gt_u
    if
-    i32.const 32
+    i32.const 192
     i32.const 304
     i32.const 14
     i32.const 47
@@ -1802,7 +1822,7 @@
    i32.store offset=8
   end
  )
- (func $~lib/array/Array<i32>#push (; 26 ;) (param $0 i32)
+ (func $~lib/array/Array<i32>#push (; 28 ;) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -1825,7 +1845,7 @@
   local.get $2
   i32.store offset=12
  )
- (func $~lib/array/Array<i32>#pop (; 27 ;) (param $0 i32)
+ (func $~lib/array/Array<i32>#pop (; 29 ;) (param $0 i32)
   (local $1 i32)
   local.get $0
   i32.load offset=12
@@ -1835,7 +1855,7 @@
   if
    i32.const 352
    i32.const 304
-   i32.const 288
+   i32.const 293
    i32.const 20
    call $~lib/builtins/abort
    unreachable
@@ -1855,7 +1875,43 @@
   local.get $1
   i32.store offset=12
  )
- (func $~lib/array/Array<~lib/string/String>#push (; 28 ;) (param $0 i32)
+ (func $~lib/array/Array<~lib/array/Array<~lib/string/String>>#constructor (; 30 ;) (result i32)
+  (local $0 i32)
+  i32.const 16
+  i32.const 5
+  call $~lib/rt/tlsf/__alloc
+  call $~lib/rt/pure/__retain
+  call $~lib/arraybuffer/ArrayBufferView#constructor
+  local.tee $0
+  i32.const 0
+  i32.store offset=12
+  local.get $0
+  i32.const 0
+  call $~lib/arraybuffer/ArrayBufferView#alloc
+  local.get $0
+  i32.const 0
+  i32.store offset=12
+  local.get $0
+ )
+ (func $~lib/array/Array<~lib/string/String>#constructor (; 31 ;) (result i32)
+  (local $0 i32)
+  i32.const 16
+  i32.const 4
+  call $~lib/rt/tlsf/__alloc
+  call $~lib/rt/pure/__retain
+  call $~lib/arraybuffer/ArrayBufferView#constructor
+  local.tee $0
+  i32.const 0
+  i32.store offset=12
+  local.get $0
+  i32.const 0
+  call $~lib/arraybuffer/ArrayBufferView#alloc
+  local.get $0
+  i32.const 0
+  i32.store offset=12
+  local.get $0
+ )
+ (func $~lib/array/Array<~lib/string/String>#push (; 32 ;) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -1878,7 +1934,7 @@
   local.get $2
   i32.store offset=12
  )
- (func $~lib/string/String#get:length (; 29 ;) (param $0 i32) (result i32)
+ (func $~lib/string/String#get:length (; 33 ;) (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub
@@ -1886,7 +1942,7 @@
   i32.const 1
   i32.shr_u
  )
- (func $~lib/string/String#concat (; 30 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String#concat (; 34 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1945,7 +2001,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/string/String.__concat (; 31 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__concat (; 35 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.const 480
   local.get $0
@@ -1953,74 +2009,42 @@
   local.get $1
   call $~lib/string/String#concat
  )
- (func $start:retain-release-sanity (; 32 ;)
+ (func $start:retain-release-sanity (; 36 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
-  i32.const 16
-  i32.const 3
-  call $~lib/rt/tlsf/__alloc
-  call $~lib/rt/pure/__retain
-  i32.const 3
-  call $~lib/arraybuffer/ArrayBufferView#constructor
-  local.tee $0
-  i32.const 0
-  i32.store offset=12
-  local.get $0
-  i32.const 3
-  i32.store offset=12
-  local.get $0
+  call $~lib/array/Array<i32>#constructor
+  local.tee $1
   call $~lib/array/Array<i32>#push
-  local.get $0
+  local.get $1
   call $~lib/array/Array<i32>#push
-  local.get $0
+  local.get $1
   call $~lib/array/Array<i32>#pop
-  local.get $0
+  local.get $1
   call $~lib/rt/pure/__release
-  i32.const 16
-  i32.const 5
-  call $~lib/rt/tlsf/__alloc
-  call $~lib/rt/pure/__retain
-  i32.const 0
-  call $~lib/arraybuffer/ArrayBufferView#constructor
-  local.tee $0
-  i32.const 0
-  i32.store offset=12
-  local.get $0
-  i32.const 0
-  i32.store offset=12
+  call $~lib/array/Array<~lib/array/Array<~lib/string/String>>#constructor
   loop $for-loop|0
    local.get $2
    i32.const 10
    i32.lt_s
    if
-    i32.const 16
-    i32.const 4
-    call $~lib/rt/tlsf/__alloc
-    call $~lib/rt/pure/__retain
+    call $~lib/array/Array<~lib/string/String>#constructor
+    local.set $3
     i32.const 0
-    call $~lib/arraybuffer/ArrayBufferView#constructor
-    local.tee $3
-    i32.const 0
-    i32.store offset=12
-    local.get $3
-    i32.const 0
-    i32.store offset=12
-    i32.const 0
-    local.set $1
+    local.set $0
     loop $for-loop|1
-     local.get $1
+     local.get $0
      i32.const 10
      i32.lt_s
      if
       local.get $3
       call $~lib/array/Array<~lib/string/String>#push
-      local.get $1
+      local.get $0
       i32.const 1
       i32.add
-      local.set $1
+      local.set $0
       br $for-loop|1
      end
     end
@@ -2033,7 +2057,6 @@
     br $for-loop|0
    end
   end
-  local.get $0
   call $~lib/rt/pure/__release
   i32.const 416
   i32.const 448
@@ -2048,10 +2071,10 @@
   i32.const 6
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
-  local.tee $0
+  local.tee $1
   i32.const 0
   i32.store
-  local.get $0
+  local.get $1
   i32.const 4
   i32.const 7
   call $~lib/rt/tlsf/__alloc
@@ -2060,118 +2083,118 @@
   i32.const 0
   i32.store
   local.get $3
-  local.set $1
+  local.set $0
   local.get $3
-  local.get $0
+  local.get $1
   i32.load
   local.tee $2
   i32.ne
   if
-   local.get $1
+   local.get $0
    call $~lib/rt/pure/__retain
-   local.set $1
+   local.set $0
    local.get $2
    call $~lib/rt/pure/__release
   end
-  local.get $1
-  i32.store
   local.get $0
-  local.set $1
+  i32.store
+  local.get $1
+  local.set $0
   local.get $3
   local.set $2
   local.get $3
-  local.get $0
+  local.get $1
   i32.load
   local.tee $4
-  i32.ne
-  if
-   local.get $2
-   call $~lib/rt/pure/__retain
-   local.set $2
-   local.get $4
-   call $~lib/rt/pure/__release
-  end
-  local.get $1
-  local.get $2
-  i32.store
-  local.get $3
-  local.set $2
-  local.get $0
-  local.get $3
-  i32.load
-  local.tee $4
-  i32.ne
-  if
-   local.get $1
-   call $~lib/rt/pure/__retain
-   local.set $1
-   local.get $4
-   call $~lib/rt/pure/__release
-  end
-  local.get $2
-  local.get $1
-  i32.store
-  local.get $0
-  local.set $1
-  local.get $0
-  local.get $2
-  i32.load
-  local.tee $4
-  i32.ne
-  if
-   local.get $1
-   call $~lib/rt/pure/__retain
-   local.set $1
-   local.get $4
-   call $~lib/rt/pure/__release
-  end
-  local.get $2
-  local.get $1
-  i32.store
-  local.get $2
-  local.set $1
-  local.get $0
-  local.set $2
-  local.get $3
-  local.get $0
-  i32.load
-  local.tee $4
-  i32.ne
-  if
-   local.get $1
-   call $~lib/rt/pure/__retain
-   local.set $1
-   local.get $4
-   call $~lib/rt/pure/__release
-  end
-  local.get $2
-  local.get $1
-  i32.store
-  local.get $0
-  local.get $3
-  i32.load
-  local.tee $1
   i32.ne
   if
    local.get $2
    call $~lib/rt/pure/__retain
    local.set $2
-   local.get $1
+   local.get $4
+   call $~lib/rt/pure/__release
+  end
+  local.get $0
+  local.get $2
+  i32.store
+  local.get $3
+  local.set $2
+  local.get $1
+  local.get $3
+  i32.load
+  local.tee $4
+  i32.ne
+  if
+   local.get $0
+   call $~lib/rt/pure/__retain
+   local.set $0
+   local.get $4
+   call $~lib/rt/pure/__release
+  end
+  local.get $2
+  local.get $0
+  i32.store
+  local.get $1
+  local.set $0
+  local.get $1
+  local.get $2
+  i32.load
+  local.tee $4
+  i32.ne
+  if
+   local.get $0
+   call $~lib/rt/pure/__retain
+   local.set $0
+   local.get $4
+   call $~lib/rt/pure/__release
+  end
+  local.get $2
+  local.get $0
+  i32.store
+  local.get $2
+  local.set $0
+  local.get $1
+  local.set $2
+  local.get $3
+  local.get $1
+  i32.load
+  local.tee $4
+  i32.ne
+  if
+   local.get $0
+   call $~lib/rt/pure/__retain
+   local.set $0
+   local.get $4
+   call $~lib/rt/pure/__release
+  end
+  local.get $2
+  local.get $0
+  i32.store
+  local.get $1
+  local.get $3
+  i32.load
+  local.tee $0
+  i32.ne
+  if
+   local.get $2
+   call $~lib/rt/pure/__retain
+   local.set $2
+   local.get $0
    call $~lib/rt/pure/__release
   end
   local.get $3
   local.get $2
   i32.store
-  local.get $0
+  local.get $1
   call $~lib/rt/pure/__release
   local.get $3
   call $~lib/rt/pure/__release
   call $~lib/rt/pure/__collect
  )
- (func $~start (; 33 ;)
+ (func $~start (; 37 ;)
   call $start:retain-release-sanity
  )
- (func $~lib/rt/pure/markGray (; 34 ;) (param $0 i32)
+ (func $~lib/rt/pure/markGray (; 38 ;) (param $0 i32)
   (local $1 i32)
   local.get $0
   i32.load offset=4
@@ -2195,7 +2218,7 @@
    call $~lib/rt/__visit_members
   end
  )
- (func $~lib/rt/pure/scanBlack (; 35 ;) (param $0 i32)
+ (func $~lib/rt/pure/scanBlack (; 39 ;) (param $0 i32)
   local.get $0
   local.get $0
   i32.load offset=4
@@ -2208,7 +2231,7 @@
   i32.const 4
   call $~lib/rt/__visit_members
  )
- (func $~lib/rt/pure/scan (; 36 ;) (param $0 i32)
+ (func $~lib/rt/pure/scan (; 40 ;) (param $0 i32)
   (local $1 i32)
   local.get $0
   i32.load offset=4
@@ -2242,7 +2265,7 @@
    end
   end
  )
- (func $~lib/rt/pure/collectWhite (; 37 ;) (param $0 i32)
+ (func $~lib/rt/pure/collectWhite (; 41 ;) (param $0 i32)
   (local $1 i32)
   local.get $0
   i32.load offset=4
@@ -2275,7 +2298,7 @@
    call $~lib/rt/tlsf/freeBlock
   end
  )
- (func $~lib/rt/pure/__collect (; 38 ;)
+ (func $~lib/rt/pure/__collect (; 42 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -2396,7 +2419,7 @@
   local.get $5
   global.set $~lib/rt/pure/CUR
  )
- (func $~lib/rt/__typeinfo (; 39 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/__typeinfo (; 43 ;) (param $0 i32) (result i32)
   local.get $0
   i32.const 640
   i32.load
@@ -2416,7 +2439,7 @@
   i32.add
   i32.load
  )
- (func $~lib/rt/pure/growRoots (; 40 ;)
+ (func $~lib/rt/pure/growRoots (; 44 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -2467,7 +2490,7 @@
   i32.add
   global.set $~lib/rt/pure/END
  )
- (func $~lib/rt/pure/appendRoot (; 41 ;) (param $0 i32)
+ (func $~lib/rt/pure/appendRoot (; 45 ;) (param $0 i32)
   (local $1 i32)
   global.get $~lib/rt/pure/CUR
   local.tee $1
@@ -2486,7 +2509,7 @@
   i32.add
   global.set $~lib/rt/pure/CUR
  )
- (func $~lib/rt/pure/decrement (; 42 ;) (param $0 i32)
+ (func $~lib/rt/pure/decrement (; 46 ;) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -2503,7 +2526,7 @@
   i32.and
   if
    i32.const 0
-   i32.const 256
+   i32.const 144
    i32.const 122
    i32.const 13
    call $~lib/builtins/abort
@@ -2536,7 +2559,7 @@
    i32.le_u
    if
     i32.const 0
-    i32.const 256
+    i32.const 144
     i32.const 136
     i32.const 15
     call $~lib/builtins/abort
@@ -2576,7 +2599,7 @@
    end
   end
  )
- (func $~lib/rt/pure/__visit (; 43 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/pure/__visit (; 47 ;) (param $0 i32) (param $1 i32)
   local.get $0
   i32.const 708
   i32.lt_u
@@ -2614,7 +2637,7 @@
        i32.le_u
        if
         i32.const 0
-        i32.const 256
+        i32.const 144
         i32.const 79
         i32.const 19
         call $~lib/builtins/abort
@@ -2647,7 +2670,7 @@
      i32.ne
      if
       i32.const 0
-      i32.const 256
+      i32.const 144
       i32.const 90
       i32.const 8
       call $~lib/builtins/abort
@@ -2672,14 +2695,14 @@
     br $break|0
    end
    i32.const 0
-   i32.const 256
+   i32.const 144
    i32.const 101
    i32.const 26
    call $~lib/builtins/abort
    unreachable
   end
  )
- (func $~lib/array/Array<~lib/string/String>#__visit_impl (; 44 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<~lib/string/String>#__visit_impl (; 48 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -2712,7 +2735,7 @@
    end
   end
  )
- (func $~lib/rt/__visit_members (; 45 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/__visit_members (; 49 ;) (param $0 i32) (param $1 i32)
   block $block$4$break
    block $switch$1$default
     block $switch$1$case$7

--- a/tests/compiler/retain-release-sanity.untouched.wat
+++ b/tests/compiler/retain-release-sanity.untouched.wat
@@ -15,11 +15,11 @@
  (import "rtrace" "onfree" (func $~lib/rt/rtrace/onfree (param i32)))
  (import "rtrace" "ondecrement" (func $~lib/rt/rtrace/ondecrement (param i32)))
  (memory $0 1)
- (data (i32.const 16) "\1c\00\00\00\01\00\00\00\01\00\00\00\1c\00\00\00I\00n\00v\00a\00l\00i\00d\00 \00l\00e\00n\00g\00t\00h\00")
- (data (i32.const 64) "&\00\00\00\01\00\00\00\01\00\00\00&\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00b\00u\00f\00f\00e\00r\00.\00t\00s\00")
- (data (i32.const 128) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s\00")
- (data (i32.const 176) "(\00\00\00\01\00\00\00\01\00\00\00(\00\00\00a\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e\00")
- (data (i32.const 240) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00p\00u\00r\00e\00.\00t\00s\00")
+ (data (i32.const 16) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s\00")
+ (data (i32.const 64) "(\00\00\00\01\00\00\00\01\00\00\00(\00\00\00a\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e\00")
+ (data (i32.const 128) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00p\00u\00r\00e\00.\00t\00s\00")
+ (data (i32.const 176) "\1c\00\00\00\01\00\00\00\01\00\00\00\1c\00\00\00I\00n\00v\00a\00l\00i\00d\00 \00l\00e\00n\00g\00t\00h\00")
+ (data (i32.const 224) "&\00\00\00\01\00\00\00\01\00\00\00&\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00b\00u\00f\00f\00e\00r\00.\00t\00s\00")
  (data (i32.const 288) "\1a\00\00\00\01\00\00\00\01\00\00\00\1a\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00.\00t\00s\00")
  (data (i32.const 336) "\1c\00\00\00\01\00\00\00\01\00\00\00\1c\00\00\00A\00r\00r\00a\00y\00 \00i\00s\00 \00e\00m\00p\00t\00y\00")
  (data (i32.const 384) "\00\00\00\00\01\00\00\00\01\00\00\00\00\00\00\00")
@@ -62,7 +62,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 277
    i32.const 13
    call $~lib/builtins/abort
@@ -87,7 +87,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 279
    i32.const 13
    call $~lib/builtins/abort
@@ -139,7 +139,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 292
    i32.const 13
    call $~lib/builtins/abort
@@ -269,7 +269,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 205
    i32.const 13
    call $~lib/builtins/abort
@@ -284,7 +284,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 207
    i32.const 13
    call $~lib/builtins/abort
@@ -377,7 +377,7 @@
    i32.eqz
    if
     i32.const 0
-    i32.const 144
+    i32.const 32
     i32.const 228
     i32.const 15
     call $~lib/builtins/abort
@@ -440,7 +440,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 243
    i32.const 13
    call $~lib/builtins/abort
@@ -456,7 +456,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 244
    i32.const 13
    call $~lib/builtins/abort
@@ -513,7 +513,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 260
    i32.const 13
    call $~lib/builtins/abort
@@ -632,7 +632,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 386
    i32.const 4
    call $~lib/builtins/abort
@@ -655,7 +655,7 @@
    i32.eqz
    if
     i32.const 0
-    i32.const 144
+    i32.const 32
     i32.const 396
     i32.const 15
     call $~lib/builtins/abort
@@ -686,7 +686,7 @@
    i32.eqz
    if
     i32.const 0
-    i32.const 144
+    i32.const 32
     i32.const 408
     i32.const 4
     call $~lib/builtins/abort
@@ -907,8 +907,8 @@
   i32.const 1073741808
   i32.ge_u
   if
-   i32.const 192
-   i32.const 144
+   i32.const 80
+   i32.const 32
    i32.const 457
    i32.const 29
    call $~lib/builtins/abort
@@ -1002,7 +1002,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 338
    i32.const 13
    call $~lib/builtins/abort
@@ -1065,7 +1065,7 @@
     i32.eqz
     if
      i32.const 0
-     i32.const 144
+     i32.const 32
      i32.const 351
      i32.const 17
      call $~lib/builtins/abort
@@ -1210,7 +1210,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 365
    i32.const 13
    call $~lib/builtins/abort
@@ -1299,7 +1299,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 490
    i32.const 13
    call $~lib/builtins/abort
@@ -1340,7 +1340,7 @@
      i32.eqz
      if
       i32.const 0
-      i32.const 144
+      i32.const 32
       i32.const 502
       i32.const 19
       call $~lib/builtins/abort
@@ -1359,7 +1359,7 @@
     i32.eqz
     if
      i32.const 0
-     i32.const 144
+     i32.const 32
      i32.const 507
      i32.const 17
      call $~lib/builtins/abort
@@ -1376,7 +1376,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 510
    i32.const 13
    call $~lib/builtins/abort
@@ -1410,7 +1410,85 @@
   i32.const 16
   i32.add
  )
- (func $~lib/memory/memory.fill (; 16 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/rt/pure/increment (; 16 ;) (param $0 i32)
+  (local $1 i32)
+  local.get $0
+  i32.load offset=4
+  local.set $1
+  local.get $1
+  i32.const -268435456
+  i32.and
+  local.get $1
+  i32.const 1
+  i32.add
+  i32.const -268435456
+  i32.and
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 144
+   i32.const 109
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  local.get $1
+  i32.const 1
+  i32.add
+  i32.store offset=4
+  local.get $0
+  call $~lib/rt/rtrace/onincrement
+  local.get $0
+  i32.load
+  i32.const 1
+  i32.and
+  i32.eqz
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 144
+   i32.const 112
+   i32.const 13
+   call $~lib/builtins/abort
+   unreachable
+  end
+ )
+ (func $~lib/rt/pure/__retain (; 17 ;) (param $0 i32) (result i32)
+  local.get $0
+  global.get $~lib/heap/__heap_base
+  i32.gt_u
+  if
+   local.get $0
+   i32.const 16
+   i32.sub
+   call $~lib/rt/pure/increment
+  end
+  local.get $0
+ )
+ (func $~lib/arraybuffer/ArrayBufferView#constructor (; 18 ;) (param $0 i32) (result i32)
+  local.get $0
+  i32.eqz
+  if
+   i32.const 12
+   i32.const 2
+   call $~lib/rt/tlsf/__alloc
+   call $~lib/rt/pure/__retain
+   local.set $0
+  end
+  local.get $0
+  i32.const 0
+  i32.store
+  local.get $0
+  i32.const 0
+  i32.store offset=4
+  local.get $0
+  i32.const 0
+  i32.store offset=8
+  local.get $0
+ )
+ (func $~lib/memory/memory.fill (; 19 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1674,64 +1752,7 @@
    end
   end
  )
- (func $~lib/rt/pure/increment (; 17 ;) (param $0 i32)
-  (local $1 i32)
-  local.get $0
-  i32.load offset=4
-  local.set $1
-  local.get $1
-  i32.const -268435456
-  i32.and
-  local.get $1
-  i32.const 1
-  i32.add
-  i32.const -268435456
-  i32.and
-  i32.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 256
-   i32.const 109
-   i32.const 2
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $0
-  local.get $1
-  i32.const 1
-  i32.add
-  i32.store offset=4
-  local.get $0
-  call $~lib/rt/rtrace/onincrement
-  local.get $0
-  i32.load
-  i32.const 1
-  i32.and
-  i32.eqz
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 256
-   i32.const 112
-   i32.const 13
-   call $~lib/builtins/abort
-   unreachable
-  end
- )
- (func $~lib/rt/pure/__retain (; 18 ;) (param $0 i32) (result i32)
-  local.get $0
-  global.get $~lib/heap/__heap_base
-  i32.gt_u
-  if
-   local.get $0
-   i32.const 16
-   i32.sub
-   call $~lib/rt/pure/increment
-  end
-  local.get $0
- )
- (func $~lib/rt/pure/__release (; 19 ;) (param $0 i32)
+ (func $~lib/rt/pure/__release (; 20 ;) (param $0 i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.gt_u
@@ -1742,7 +1763,7 @@
    call $~lib/rt/pure/decrement
   end
  )
- (func $~lib/arraybuffer/ArrayBufferView#constructor (; 20 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBufferView#alloc (; 21 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1753,9 +1774,9 @@
   i32.shr_u
   i32.gt_u
   if
-   i32.const 32
-   i32.const 80
-   i32.const 23
+   i32.const 192
+   i32.const 240
+   i32.const 14
    i32.const 56
    call $~lib/builtins/abort
    unreachable
@@ -1771,24 +1792,6 @@
   i32.const 0
   local.get $1
   call $~lib/memory/memory.fill
-  local.get $0
-  i32.eqz
-  if
-   i32.const 12
-   i32.const 2
-   call $~lib/rt/tlsf/__alloc
-   call $~lib/rt/pure/__retain
-   local.set $0
-  end
-  local.get $0
-  i32.const 0
-  i32.store
-  local.get $0
-  i32.const 0
-  i32.store offset=4
-  local.get $0
-  i32.const 0
-  i32.store offset=8
   local.get $0
   local.tee $4
   local.get $3
@@ -1812,9 +1815,8 @@
   local.get $0
   local.get $1
   i32.store offset=8
-  local.get $0
  )
- (func $~lib/array/Array<i32>#constructor (; 21 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#constructor (; 22 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   if (result i32)
    local.get $0
@@ -1824,8 +1826,6 @@
    call $~lib/rt/tlsf/__alloc
    call $~lib/rt/pure/__retain
   end
-  local.get $1
-  i32.const 2
   call $~lib/arraybuffer/ArrayBufferView#constructor
   local.set $0
   local.get $0
@@ -1833,10 +1833,14 @@
   i32.store offset=12
   local.get $0
   local.get $1
+  i32.const 2
+  call $~lib/arraybuffer/ArrayBufferView#alloc
+  local.get $0
+  local.get $1
   i32.store offset=12
   local.get $0
  )
- (func $~lib/rt/tlsf/checkUsedBlock (; 22 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/tlsf/checkUsedBlock (; 23 ;) (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   i32.const 16
@@ -1874,7 +1878,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 570
    i32.const 2
    call $~lib/builtins/abort
@@ -1882,7 +1886,7 @@
   end
   local.get $1
  )
- (func $~lib/util/memory/memcpy (; 23 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/memory/memcpy (; 24 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2906,7 +2910,7 @@
    i32.store8
   end
  )
- (func $~lib/memory/memory.copy (; 24 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/memory/memory.copy (; 25 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3126,7 +3130,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/freeBlock (; 25 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/freeBlock (; 26 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $1
   i32.load
@@ -3142,7 +3146,7 @@
   local.get $1
   call $~lib/rt/rtrace/onfree
  )
- (func $~lib/rt/tlsf/reallocateBlock (; 26 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/reallocateBlock (; 27 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3261,7 +3265,7 @@
   end
   local.get $8
  )
- (func $~lib/rt/tlsf/__realloc (; 27 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/__realloc (; 28 ;) (param $0 i32) (param $1 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
   local.get $0
   call $~lib/rt/tlsf/checkUsedBlock
@@ -3270,7 +3274,7 @@
   i32.const 16
   i32.add
  )
- (func $~lib/array/ensureSize (; 28 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/ensureSize (; 29 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3290,7 +3294,7 @@
    i32.shr_u
    i32.gt_u
    if
-    i32.const 32
+    i32.const 192
     i32.const 304
     i32.const 14
     i32.const 47
@@ -3332,7 +3336,7 @@
    i32.store offset=8
   end
  )
- (func $~lib/array/Array<i32>#push (; 29 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#push (; 30 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -3359,7 +3363,7 @@
   i32.store offset=12
   local.get $3
  )
- (func $~lib/array/Array<i32>#pop (; 30 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<i32>#pop (; 31 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -3371,7 +3375,7 @@
   if
    i32.const 352
    i32.const 304
-   i32.const 288
+   i32.const 293
    i32.const 20
    call $~lib/builtins/abort
    unreachable
@@ -3392,7 +3396,7 @@
   i32.store offset=12
   local.get $2
  )
- (func $~lib/array/Array<~lib/array/Array<~lib/string/String>>#constructor (; 31 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<~lib/string/String>>#constructor (; 32 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   if (result i32)
    local.get $0
@@ -3402,8 +3406,6 @@
    call $~lib/rt/tlsf/__alloc
    call $~lib/rt/pure/__retain
   end
-  local.get $1
-  i32.const 2
   call $~lib/arraybuffer/ArrayBufferView#constructor
   local.set $0
   local.get $0
@@ -3411,10 +3413,14 @@
   i32.store offset=12
   local.get $0
   local.get $1
+  i32.const 2
+  call $~lib/arraybuffer/ArrayBufferView#alloc
+  local.get $0
+  local.get $1
   i32.store offset=12
   local.get $0
  )
- (func $~lib/array/Array<~lib/string/String>#constructor (; 32 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/string/String>#constructor (; 33 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   if (result i32)
    local.get $0
@@ -3424,8 +3430,6 @@
    call $~lib/rt/tlsf/__alloc
    call $~lib/rt/pure/__retain
   end
-  local.get $1
-  i32.const 2
   call $~lib/arraybuffer/ArrayBufferView#constructor
   local.set $0
   local.get $0
@@ -3433,10 +3437,14 @@
   i32.store offset=12
   local.get $0
   local.get $1
+  i32.const 2
+  call $~lib/arraybuffer/ArrayBufferView#alloc
+  local.get $0
+  local.get $1
   i32.store offset=12
   local.get $0
  )
- (func $~lib/array/Array<~lib/string/String>#push (; 33 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/string/String>#push (; 34 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3472,7 +3480,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/string/String#get:length (; 34 ;) (param $0 i32) (result i32)
+ (func $~lib/string/String#get:length (; 35 ;) (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub
@@ -3480,7 +3488,7 @@
   i32.const 1
   i32.shr_u
  )
- (func $~lib/string/String#concat (; 35 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String#concat (; 36 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3556,7 +3564,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/string/String.__concat (; 36 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__concat (; 37 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -3579,7 +3587,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $retain-release-sanity/A#constructor (; 37 ;) (param $0 i32) (result i32)
+ (func $retain-release-sanity/A#constructor (; 38 ;) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -3594,7 +3602,7 @@
   i32.store
   local.get $0
  )
- (func $retain-release-sanity/B#constructor (; 38 ;) (param $0 i32) (result i32)
+ (func $retain-release-sanity/B#constructor (; 39 ;) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -3609,7 +3617,7 @@
   i32.store
   local.get $0
  )
- (func $start:retain-release-sanity (; 39 ;)
+ (func $start:retain-release-sanity (; 40 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -3816,10 +3824,10 @@
   call $~lib/rt/pure/__release
   call $~lib/rt/pure/__collect
  )
- (func $~start (; 40 ;)
+ (func $~start (; 41 ;)
   call $start:retain-release-sanity
  )
- (func $~lib/rt/pure/markGray (; 41 ;) (param $0 i32)
+ (func $~lib/rt/pure/markGray (; 42 ;) (param $0 i32)
   (local $1 i32)
   local.get $0
   i32.load offset=4
@@ -3846,7 +3854,7 @@
    call $~lib/rt/__visit_members
   end
  )
- (func $~lib/rt/pure/scanBlack (; 42 ;) (param $0 i32)
+ (func $~lib/rt/pure/scanBlack (; 43 ;) (param $0 i32)
   local.get $0
   local.get $0
   i32.load offset=4
@@ -3863,7 +3871,7 @@
   i32.const 4
   call $~lib/rt/__visit_members
  )
- (func $~lib/rt/pure/scan (; 43 ;) (param $0 i32)
+ (func $~lib/rt/pure/scan (; 44 ;) (param $0 i32)
   (local $1 i32)
   local.get $0
   i32.load offset=4
@@ -3900,7 +3908,7 @@
    end
   end
  )
- (func $~lib/rt/pure/collectWhite (; 44 ;) (param $0 i32)
+ (func $~lib/rt/pure/collectWhite (; 45 ;) (param $0 i32)
   (local $1 i32)
   local.get $0
   i32.load offset=4
@@ -3938,7 +3946,7 @@
    call $~lib/rt/tlsf/freeBlock
   end
  )
- (func $~lib/rt/pure/__collect (; 45 ;)
+ (func $~lib/rt/pure/__collect (; 46 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -4079,7 +4087,7 @@
   local.get $0
   global.set $~lib/rt/pure/CUR
  )
- (func $~lib/rt/__typeinfo (; 46 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/__typeinfo (; 47 ;) (param $0 i32) (result i32)
   (local $1 i32)
   global.get $~lib/rt/__rtti_base
   local.set $1
@@ -4104,13 +4112,13 @@
   i32.add
   i32.load
  )
- (func $~lib/rt/tlsf/__free (; 47 ;) (param $0 i32)
+ (func $~lib/rt/tlsf/__free (; 48 ;) (param $0 i32)
   call $~lib/rt/tlsf/maybeInitialize
   local.get $0
   call $~lib/rt/tlsf/checkUsedBlock
   call $~lib/rt/tlsf/freeBlock
  )
- (func $~lib/rt/pure/growRoots (; 48 ;)
+ (func $~lib/rt/pure/growRoots (; 49 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -4168,7 +4176,7 @@
   i32.add
   global.set $~lib/rt/pure/END
  )
- (func $~lib/rt/pure/appendRoot (; 49 ;) (param $0 i32)
+ (func $~lib/rt/pure/appendRoot (; 50 ;) (param $0 i32)
   (local $1 i32)
   global.get $~lib/rt/pure/CUR
   local.set $1
@@ -4188,7 +4196,7 @@
   i32.add
   global.set $~lib/rt/pure/CUR
  )
- (func $~lib/rt/pure/decrement (; 50 ;) (param $0 i32)
+ (func $~lib/rt/pure/decrement (; 51 ;) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -4208,7 +4216,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 256
+   i32.const 144
    i32.const 122
    i32.const 13
    call $~lib/builtins/abort
@@ -4247,7 +4255,7 @@
    i32.eqz
    if
     i32.const 0
-    i32.const 256
+    i32.const 144
     i32.const 136
     i32.const 15
     call $~lib/builtins/abort
@@ -4292,7 +4300,7 @@
    end
   end
  )
- (func $~lib/rt/pure/__visit (; 51 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/pure/__visit (; 52 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -4349,7 +4357,7 @@
        i32.eqz
        if
         i32.const 0
-        i32.const 256
+        i32.const 144
         i32.const 79
         i32.const 19
         call $~lib/builtins/abort
@@ -4384,7 +4392,7 @@
      i32.eqz
      if
       i32.const 0
-      i32.const 256
+      i32.const 144
       i32.const 90
       i32.const 8
       call $~lib/builtins/abort
@@ -4414,7 +4422,7 @@
    i32.eqz
    if
     i32.const 0
-    i32.const 256
+    i32.const 144
     i32.const 101
     i32.const 26
     call $~lib/builtins/abort
@@ -4422,10 +4430,10 @@
    end
   end
  )
- (func $~lib/array/Array<i32>#__visit_impl (; 52 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i32>#__visit_impl (; 53 ;) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/array/Array<~lib/string/String>#__visit_impl (; 53 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<~lib/string/String>#__visit_impl (; 54 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4464,7 +4472,7 @@
    end
   end
  )
- (func $~lib/array/Array<~lib/array/Array<~lib/string/String>>#__visit_impl (; 54 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<~lib/array/Array<~lib/string/String>>#__visit_impl (; 55 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4503,7 +4511,7 @@
    end
   end
  )
- (func $~lib/rt/__visit_members (; 55 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/__visit_members (; 56 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   block $block$4$break
    block $switch$1$default

--- a/tests/compiler/std/array-access.optimized.wat
+++ b/tests/compiler/std/array-access.optimized.wat
@@ -24,7 +24,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -41,7 +41,7 @@
   if
    i32.const 144
    i32.const 96
-   i32.const 97
+   i32.const 102
    i32.const 39
    call $~lib/builtins/abort
    unreachable
@@ -56,7 +56,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array-access.untouched.wat
+++ b/tests/compiler/std/array-access.untouched.wat
@@ -45,7 +45,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -61,7 +61,7 @@
    call $~lib/rt/stub/__release
    i32.const 144
    i32.const 96
-   i32.const 97
+   i32.const 102
    i32.const 39
    call $~lib/builtins/abort
    unreachable
@@ -86,7 +86,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -135,7 +135,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -151,7 +151,7 @@
    call $~lib/rt/stub/__release
    i32.const 144
    i32.const 96
-   i32.const 97
+   i32.const 102
    i32.const 39
    call $~lib/builtins/abort
    unreachable
@@ -420,7 +420,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -436,7 +436,7 @@
    call $~lib/rt/stub/__release
    i32.const 144
    i32.const 96
-   i32.const 97
+   i32.const 102
    i32.const 39
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array-literal.optimized.wat
+++ b/tests/compiler/std/array-literal.optimized.wat
@@ -43,7 +43,7 @@
   if
    i32.const 160
    i32.const 224
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -62,7 +62,7 @@
   if
    i32.const 160
    i32.const 224
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array-literal.untouched.wat
+++ b/tests/compiler/std/array-literal.untouched.wat
@@ -65,7 +65,7 @@
   if
    i32.const 160
    i32.const 224
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -98,7 +98,7 @@
   if
    i32.const 160
    i32.const 224
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array.optimized.wat
+++ b/tests/compiler/std/array.optimized.wat
@@ -2,9 +2,9 @@
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
+ (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
  (type $i32_=>_none (func (param i32)))
  (type $i32_i32_=>_none (func (param i32 i32)))
- (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
  (type $i32_i32_i32_i32_=>_i32 (func (param i32 i32 i32 i32) (result i32)))
  (type $none_=>_i32 (func (result i32)))
  (type $i64_=>_i32 (func (param i64) (result i32)))
@@ -32,11 +32,11 @@
  (import "Math" "random" (func $~lib/bindings/Math/random (result f64)))
  (import "rtrace" "ondecrement" (func $~lib/rt/rtrace/ondecrement (param i32)))
  (memory $0 1)
- (data (i32.const 16) "\1c\00\00\00\01\00\00\00\01\00\00\00\1c\00\00\00I\00n\00v\00a\00l\00i\00d\00 \00l\00e\00n\00g\00t\00h")
- (data (i32.const 64) "&\00\00\00\01\00\00\00\01\00\00\00&\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00b\00u\00f\00f\00e\00r\00.\00t\00s")
- (data (i32.const 128) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s")
- (data (i32.const 176) "(\00\00\00\01\00\00\00\01\00\00\00(\00\00\00a\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e")
- (data (i32.const 240) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00p\00u\00r\00e\00.\00t\00s")
+ (data (i32.const 16) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s")
+ (data (i32.const 64) "(\00\00\00\01\00\00\00\01\00\00\00(\00\00\00a\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e")
+ (data (i32.const 128) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00p\00u\00r\00e\00.\00t\00s")
+ (data (i32.const 176) "\1c\00\00\00\01\00\00\00\01\00\00\00\1c\00\00\00I\00n\00v\00a\00l\00i\00d\00 \00l\00e\00n\00g\00t\00h")
+ (data (i32.const 224) "&\00\00\00\01\00\00\00\01\00\00\00&\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00b\00u\00f\00f\00e\00r\00.\00t\00s")
  (data (i32.const 288) "\18\00\00\00\01\00\00\00\01\00\00\00\18\00\00\00s\00t\00d\00/\00a\00r\00r\00a\00y\00.\00t\00s")
  (data (i32.const 336) "\06\00\00\00\01\00\00\00\01\00\00\00\06\00\00\00a\00b\00c")
  (data (i32.const 368) "\05\00\00\00\01\00\00\00\00\00\00\00\05\00\00\00\01\02\03\04\05")
@@ -253,7 +253,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 277
    i32.const 13
    call $~lib/builtins/abort
@@ -275,7 +275,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 279
    i32.const 13
    call $~lib/builtins/abort
@@ -320,7 +320,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 292
    i32.const 13
    call $~lib/builtins/abort
@@ -417,7 +417,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 205
    i32.const 13
    call $~lib/builtins/abort
@@ -431,7 +431,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 207
    i32.const 13
    call $~lib/builtins/abort
@@ -504,7 +504,7 @@
    i32.eqz
    if
     i32.const 0
-    i32.const 144
+    i32.const 32
     i32.const 228
     i32.const 15
     call $~lib/builtins/abort
@@ -559,7 +559,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 243
    i32.const 13
    call $~lib/builtins/abort
@@ -574,7 +574,7 @@
   i32.ne
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 244
    i32.const 13
    call $~lib/builtins/abort
@@ -624,7 +624,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 260
    i32.const 13
    call $~lib/builtins/abort
@@ -710,7 +710,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 386
    i32.const 4
    call $~lib/builtins/abort
@@ -727,7 +727,7 @@
    i32.lt_u
    if
     i32.const 0
-    i32.const 144
+    i32.const 32
     i32.const 396
     i32.const 15
     call $~lib/builtins/abort
@@ -755,7 +755,7 @@
    i32.lt_u
    if
     i32.const 0
-    i32.const 144
+    i32.const 32
     i32.const 408
     i32.const 4
     call $~lib/builtins/abort
@@ -895,8 +895,8 @@
   i32.const 1073741808
   i32.ge_u
   if
-   i32.const 192
-   i32.const 144
+   i32.const 80
+   i32.const 32
    i32.const 457
    i32.const 29
    call $~lib/builtins/abort
@@ -971,7 +971,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 338
    i32.const 13
    call $~lib/builtins/abort
@@ -1023,7 +1023,7 @@
     i32.eqz
     if
      i32.const 0
-     i32.const 144
+     i32.const 32
      i32.const 351
      i32.const 17
      call $~lib/builtins/abort
@@ -1118,7 +1118,7 @@
   i32.and
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 365
    i32.const 13
    call $~lib/builtins/abort
@@ -1189,7 +1189,7 @@
   global.get $~lib/rt/tlsf/collectLock
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 490
    i32.const 13
    call $~lib/builtins/abort
@@ -1223,7 +1223,7 @@
     i32.eqz
     if
      i32.const 0
-     i32.const 144
+     i32.const 32
      i32.const 502
      i32.const 19
      call $~lib/builtins/abort
@@ -1239,7 +1239,7 @@
   i32.lt_u
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 510
    i32.const 13
    call $~lib/builtins/abort
@@ -1273,7 +1273,81 @@
   i32.const 16
   i32.add
  )
- (func $~lib/memory/memory.fill (; 17 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/rt/pure/increment (; 17 ;) (param $0 i32)
+  (local $1 i32)
+  local.get $0
+  i32.load offset=4
+  local.tee $1
+  i32.const -268435456
+  i32.and
+  local.get $1
+  i32.const 1
+  i32.add
+  i32.const -268435456
+  i32.and
+  i32.ne
+  if
+   i32.const 0
+   i32.const 144
+   i32.const 109
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  local.get $1
+  i32.const 1
+  i32.add
+  i32.store offset=4
+  local.get $0
+  call $~lib/rt/rtrace/onincrement
+  local.get $0
+  i32.load
+  i32.const 1
+  i32.and
+  if
+   i32.const 0
+   i32.const 144
+   i32.const 112
+   i32.const 13
+   call $~lib/builtins/abort
+   unreachable
+  end
+ )
+ (func $~lib/rt/pure/__retain (; 18 ;) (param $0 i32) (result i32)
+  local.get $0
+  i32.const 8388
+  i32.gt_u
+  if
+   local.get $0
+   i32.const 16
+   i32.sub
+   call $~lib/rt/pure/increment
+  end
+  local.get $0
+ )
+ (func $~lib/arraybuffer/ArrayBufferView#constructor (; 19 ;) (param $0 i32) (result i32)
+  local.get $0
+  i32.eqz
+  if
+   i32.const 12
+   i32.const 2
+   call $~lib/rt/tlsf/__alloc
+   call $~lib/rt/pure/__retain
+   local.set $0
+  end
+  local.get $0
+  i32.const 0
+  i32.store
+  local.get $0
+  i32.const 0
+  i32.store offset=4
+  local.get $0
+  i32.const 0
+  i32.store offset=8
+  local.get $0
+ )
+ (func $~lib/memory/memory.fill (; 20 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i64)
   block $~lib/util/memory/memset|inlined.0
@@ -1498,60 +1572,7 @@
    end
   end
  )
- (func $~lib/rt/pure/increment (; 18 ;) (param $0 i32)
-  (local $1 i32)
-  local.get $0
-  i32.load offset=4
-  local.tee $1
-  i32.const -268435456
-  i32.and
-  local.get $1
-  i32.const 1
-  i32.add
-  i32.const -268435456
-  i32.and
-  i32.ne
-  if
-   i32.const 0
-   i32.const 256
-   i32.const 109
-   i32.const 2
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $0
-  local.get $1
-  i32.const 1
-  i32.add
-  i32.store offset=4
-  local.get $0
-  call $~lib/rt/rtrace/onincrement
-  local.get $0
-  i32.load
-  i32.const 1
-  i32.and
-  if
-   i32.const 0
-   i32.const 256
-   i32.const 112
-   i32.const 13
-   call $~lib/builtins/abort
-   unreachable
-  end
- )
- (func $~lib/rt/pure/__retain (; 19 ;) (param $0 i32) (result i32)
-  local.get $0
-  i32.const 8388
-  i32.gt_u
-  if
-   local.get $0
-   i32.const 16
-   i32.sub
-   call $~lib/rt/pure/increment
-  end
-  local.get $0
- )
- (func $~lib/rt/pure/__release (; 20 ;) (param $0 i32)
+ (func $~lib/rt/pure/__release (; 21 ;) (param $0 i32)
   local.get $0
   i32.const 8388
   i32.gt_u
@@ -1562,7 +1583,7 @@
    call $~lib/rt/pure/decrement
   end
  )
- (func $~lib/arraybuffer/ArrayBufferView#constructor (; 21 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBufferView#alloc (; 22 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $1
@@ -1571,9 +1592,9 @@
   i32.shr_u
   i32.gt_u
   if
-   i32.const 32
-   i32.const 80
-   i32.const 23
+   i32.const 192
+   i32.const 240
+   i32.const 14
    i32.const 56
    call $~lib/builtins/abort
    unreachable
@@ -1588,24 +1609,6 @@
   i32.const 0
   local.get $3
   call $~lib/memory/memory.fill
-  local.get $0
-  i32.eqz
-  if
-   i32.const 12
-   i32.const 2
-   call $~lib/rt/tlsf/__alloc
-   call $~lib/rt/pure/__retain
-   local.set $0
-  end
-  local.get $0
-  i32.const 0
-  i32.store
-  local.get $0
-  i32.const 0
-  i32.store offset=4
-  local.get $0
-  i32.const 0
-  i32.store offset=8
   local.get $2
   local.set $1
   local.get $2
@@ -1629,31 +1632,32 @@
   local.get $0
   local.get $3
   i32.store offset=8
-  local.get $0
  )
- (func $~lib/array/Array<i32>#constructor (; 22 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<i32>#constructor (; 23 ;) (param $0 i32) (result i32)
   (local $1 i32)
   i32.const 16
   i32.const 3
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
-  local.get $0
-  i32.const 2
   call $~lib/arraybuffer/ArrayBufferView#constructor
   local.tee $1
   i32.const 0
   i32.store offset=12
   local.get $1
   local.get $0
+  i32.const 2
+  call $~lib/arraybuffer/ArrayBufferView#alloc
+  local.get $1
+  local.get $0
   i32.store offset=12
   local.get $1
  )
- (func $~lib/array/Array.isArray<~lib/array/Array<i32> | null> (; 23 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array.isArray<~lib/array/Array<i32> | null> (; 24 ;) (param $0 i32) (result i32)
   local.get $0
   i32.const 0
   i32.ne
  )
- (func $std/array/Ref#constructor (; 24 ;) (param $0 i32) (result i32)
+ (func $std/array/Ref#constructor (; 25 ;) (param $0 i32) (result i32)
   (local $1 i32)
   i32.const 4
   i32.const 4
@@ -1664,7 +1668,7 @@
   i32.store
   local.get $1
  )
- (func $~lib/memory/memory.copy (; 25 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/memory/memory.copy (; 26 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   block $~lib/util/memory/memmove|inlined.0
@@ -1837,7 +1841,7 @@
    end
   end
  )
- (func $~lib/rt/__allocArray (; 26 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $~lib/rt/__allocArray (; 27 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   i32.const 16
   local.get $2
@@ -1870,7 +1874,7 @@
   end
   local.get $2
  )
- (func $~lib/array/Array<u8>#fill (; 27 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $~lib/array/Array<u8>#fill (; 28 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   (local $5 i32)
   local.get $0
@@ -1937,7 +1941,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/array/Array<u8>#__get (; 28 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u8>#__get (; 29 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -1945,7 +1949,7 @@
   if
    i32.const 448
    i32.const 512
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -1956,7 +1960,7 @@
   i32.add
   i32.load8_u
  )
- (func $std/array/isArraysEqual<u8> (; 29 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/array/isArraysEqual<u8> (; 30 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -2001,7 +2005,7 @@
   end
   i32.const 1
  )
- (func $~lib/array/Array<u32>#fill (; 30 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $~lib/array/Array<u32>#fill (; 31 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   (local $5 i32)
   local.get $0
@@ -2076,7 +2080,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/array/Array<u32>#__get (; 31 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u32>#__get (; 32 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -2084,7 +2088,7 @@
   if
    i32.const 448
    i32.const 512
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -2097,7 +2101,7 @@
   i32.add
   i32.load
  )
- (func $std/array/isArraysEqual<u32> (; 32 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/array/isArraysEqual<u32> (; 33 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   i32.eqz
@@ -2145,7 +2149,7 @@
   end
   i32.const 1
  )
- (func $std/array/internalCapacity<i32> (; 33 ;) (param $0 i32) (result i32)
+ (func $std/array/internalCapacity<i32> (; 34 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load
   i32.const 16
@@ -2154,7 +2158,7 @@
   i32.const 2
   i32.shr_s
  )
- (func $~lib/rt/tlsf/checkUsedBlock (; 34 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/tlsf/checkUsedBlock (; 35 ;) (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   i32.const 16
@@ -2188,7 +2192,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 570
    i32.const 2
    call $~lib/builtins/abort
@@ -2196,7 +2200,7 @@
   end
   local.get $1
  )
- (func $~lib/rt/tlsf/freeBlock (; 35 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/freeBlock (; 36 ;) (param $0 i32) (param $1 i32)
   local.get $1
   local.get $1
   i32.load
@@ -2209,7 +2213,7 @@
   local.get $1
   call $~lib/rt/rtrace/onfree
  )
- (func $~lib/rt/tlsf/reallocateBlock (; 36 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/reallocateBlock (; 37 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2312,7 +2316,7 @@
   end
   local.get $3
  )
- (func $~lib/array/ensureSize (; 37 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/ensureSize (; 38 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2328,7 +2332,7 @@
    i32.const 268435452
    i32.gt_u
    if
-    i32.const 32
+    i32.const 192
     i32.const 512
     i32.const 14
     i32.const 47
@@ -2372,7 +2376,7 @@
    i32.store offset=8
   end
  )
- (func $~lib/array/Array<i32>#push (; 38 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i32>#push (; 39 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -2395,7 +2399,7 @@
   local.get $3
   i32.store offset=12
  )
- (func $~lib/array/Array<i32>#pop (; 39 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<i32>#pop (; 40 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -2406,7 +2410,7 @@
   if
    i32.const 976
    i32.const 512
-   i32.const 288
+   i32.const 293
    i32.const 20
    call $~lib/builtins/abort
    unreachable
@@ -2425,7 +2429,7 @@
   local.get $1
   i32.store offset=12
  )
- (func $~lib/array/Array<std/array/Ref>#set:length (; 40 ;) (param $0 i32)
+ (func $~lib/array/Array<std/array/Ref>#set:length (; 41 ;) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -2463,7 +2467,7 @@
   i32.const 0
   i32.store offset=12
  )
- (func $~lib/array/Array<i32>#concat (; 41 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#concat (; 42 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2482,9 +2486,9 @@
   i32.const 268435452
   i32.gt_u
   if
-   i32.const 32
+   i32.const 192
    i32.const 512
-   i32.const 218
+   i32.const 223
    i32.const 59
    call $~lib/builtins/abort
    unreachable
@@ -2516,7 +2520,7 @@
   call $~lib/memory/memory.copy
   local.get $2
  )
- (func $~lib/array/Array<i32>#copyWithin (; 42 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $~lib/array/Array<i32>#copyWithin (; 43 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   (local $5 i32)
   local.get $3
@@ -2620,7 +2624,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/array/Array<i32>#unshift (; 43 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i32>#unshift (; 44 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -2649,7 +2653,7 @@
   local.get $2
   i32.store offset=12
  )
- (func $~lib/array/Array<i32>#shift (; 44 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<i32>#shift (; 45 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -2662,7 +2666,7 @@
   if
    i32.const 976
    i32.const 512
-   i32.const 349
+   i32.const 354
    i32.const 20
    call $~lib/builtins/abort
    unreachable
@@ -2692,7 +2696,7 @@
   local.get $1
   i32.store offset=12
  )
- (func $~lib/array/Array<i32>#reverse (; 45 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<i32>#reverse (; 46 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -2742,7 +2746,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/array/Array<i32>#indexOf (; 46 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/array/Array<i32>#indexOf (; 47 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $0
   i32.load offset=12
@@ -2802,7 +2806,7 @@
   end
   i32.const -1
  )
- (func $~lib/array/Array<f32>#indexOf (; 47 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<f32>#indexOf (; 48 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -2848,7 +2852,7 @@
   end
   i32.const -1
  )
- (func $~lib/array/Array<f64>#indexOf (; 48 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<f64>#indexOf (; 49 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -2894,7 +2898,7 @@
   end
   i32.const -1
  )
- (func $~lib/array/Array<i32>#includes (; 49 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/array/Array<i32>#includes (; 50 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   local.get $1
   local.get $2
@@ -2902,7 +2906,7 @@
   i32.const 0
   i32.ge_s
  )
- (func $~lib/array/Array<f32>#includes (; 50 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<f32>#includes (; 51 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 f32)
@@ -2957,7 +2961,7 @@
   end
   i32.const 0
  )
- (func $~lib/array/Array<f64>#includes (; 51 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<f64>#includes (; 52 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 f64)
@@ -3012,7 +3016,7 @@
   end
   i32.const 0
  )
- (func $~lib/array/Array<i32>#splice (; 52 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/array/Array<i32>#splice (; 53 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3102,7 +3106,7 @@
   i32.store offset=12
   local.get $4
  )
- (func $~lib/array/Array<std/array/Ref>#splice (; 53 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<std/array/Ref>#splice (; 54 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3193,7 +3197,7 @@
   i32.store offset=12
   local.get $4
  )
- (func $~lib/array/Array<std/array/Ref>#__unchecked_get (; 54 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<std/array/Ref>#__unchecked_get (; 55 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -3203,7 +3207,7 @@
   i32.load
   call $~lib/rt/pure/__retain
  )
- (func $~lib/array/Array<std/array/Ref>#__get (; 55 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<std/array/Ref>#__get (; 56 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -3211,7 +3215,7 @@
   if
    i32.const 448
    i32.const 512
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -3226,14 +3230,14 @@
    call $~lib/rt/pure/__release
    i32.const 3920
    i32.const 512
-   i32.const 97
+   i32.const 102
    i32.const 39
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
  )
- (func $~lib/array/Array<std/array/Ref | null>#splice (; 56 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<std/array/Ref | null>#splice (; 57 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -3311,7 +3315,7 @@
   i32.store offset=12
   local.get $4
  )
- (func $~lib/array/Array<std/array/Ref | null>#__get (; 57 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<std/array/Ref | null>#__get (; 58 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -3319,7 +3323,7 @@
   if
    i32.const 448
    i32.const 512
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -3328,7 +3332,7 @@
   local.get $1
   call $~lib/array/Array<std/array/Ref>#__unchecked_get
  )
- (func $~lib/array/Array<i32>#__set (; 58 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<i32>#__set (; 59 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $1
   local.get $0
@@ -3341,7 +3345,7 @@
    if
     i32.const 448
     i32.const 512
-    i32.const 109
+    i32.const 114
     i32.const 21
     call $~lib/builtins/abort
     unreachable
@@ -3365,15 +3369,15 @@
   local.get $2
   i32.store
  )
- (func $start:std/array~anonymous|0 (; 59 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|0 (; 60 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.eqz
  )
- (func $~setArgumentsLength (; 60 ;) (param $0 i32)
+ (func $~setArgumentsLength (; 61 ;) (param $0 i32)
   local.get $0
   global.set $~argumentsLength
  )
- (func $~lib/array/Array<i32>#findIndex (; 61 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#findIndex (; 62 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3418,17 +3422,17 @@
   end
   i32.const -1
  )
- (func $start:std/array~anonymous|1 (; 62 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|1 (; 63 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 1
   i32.eq
  )
- (func $start:std/array~anonymous|2 (; 63 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|2 (; 64 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 100
   i32.eq
  )
- (func $start:std/array~anonymous|3 (; 64 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|3 (; 65 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $2
   i32.const 100
   call $~lib/array/Array<i32>#push
@@ -3436,7 +3440,7 @@
   i32.const 100
   i32.eq
  )
- (func $start:std/array~anonymous|5 (; 65 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|5 (; 66 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $2
   call $~lib/array/Array<i32>#pop
   drop
@@ -3444,12 +3448,12 @@
   i32.const 100
   i32.eq
  )
- (func $start:std/array~anonymous|6 (; 66 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|6 (; 67 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 0
   i32.ge_s
  )
- (func $~lib/array/Array<i32>#every (; 67 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#every (; 68 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3495,12 +3499,12 @@
   end
   i32.const 1
  )
- (func $start:std/array~anonymous|7 (; 68 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|7 (; 69 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 0
   i32.le_s
  )
- (func $start:std/array~anonymous|8 (; 69 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|8 (; 70 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $2
   i32.const 100
   call $~lib/array/Array<i32>#push
@@ -3508,12 +3512,12 @@
   i32.const 10
   i32.lt_s
  )
- (func $start:std/array~anonymous|9 (; 70 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|9 (; 71 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 10
   i32.lt_s
  )
- (func $start:std/array~anonymous|10 (; 71 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|10 (; 72 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $2
   call $~lib/array/Array<i32>#pop
   drop
@@ -3521,12 +3525,12 @@
   i32.const 3
   i32.lt_s
  )
- (func $start:std/array~anonymous|11 (; 72 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|11 (; 73 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 3
   i32.ge_s
  )
- (func $~lib/array/Array<i32>#some (; 73 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#some (; 74 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3571,12 +3575,12 @@
   end
   i32.const 0
  )
- (func $start:std/array~anonymous|12 (; 74 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|12 (; 75 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const -1
   i32.le_s
  )
- (func $start:std/array~anonymous|13 (; 75 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|13 (; 76 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $2
   i32.const 100
   call $~lib/array/Array<i32>#push
@@ -3584,12 +3588,12 @@
   i32.const 10
   i32.gt_s
  )
- (func $start:std/array~anonymous|14 (; 76 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|14 (; 77 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 10
   i32.gt_s
  )
- (func $start:std/array~anonymous|15 (; 77 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|15 (; 78 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $2
   call $~lib/array/Array<i32>#pop
   drop
@@ -3597,13 +3601,13 @@
   i32.const 3
   i32.gt_s
  )
- (func $start:std/array~anonymous|16 (; 78 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $start:std/array~anonymous|16 (; 79 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $0
   global.get $std/array/i
   i32.add
   global.set $std/array/i
  )
- (func $~lib/array/Array<i32>#forEach (; 79 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i32>#forEach (; 80 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3643,7 +3647,7 @@
    end
   end
  )
- (func $start:std/array~anonymous|17 (; 80 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $start:std/array~anonymous|17 (; 81 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $2
   i32.const 100
   call $~lib/array/Array<i32>#push
@@ -3652,7 +3656,7 @@
   i32.add
   global.set $std/array/i
  )
- (func $start:std/array~anonymous|19 (; 81 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $start:std/array~anonymous|19 (; 82 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $2
   call $~lib/array/Array<i32>#pop
   drop
@@ -3661,7 +3665,7 @@
   i32.add
   global.set $std/array/i
  )
- (func $start:std/array~anonymous|20 (; 82 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $start:std/array~anonymous|20 (; 83 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $1
   i32.eqz
@@ -3747,18 +3751,18 @@
    if
     i32.const 0
     i32.const 304
-    i32.const 619
+    i32.const 620
     i32.const 6
     call $~lib/builtins/abort
     unreachable
    end
   end
  )
- (func $start:std/array~anonymous|21 (; 83 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result f32)
+ (func $start:std/array~anonymous|21 (; 84 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result f32)
   local.get $0
   f32.convert_i32_s
  )
- (func $~lib/array/Array<i32>#map<f32> (; 84 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<i32>#map<f32> (; 85 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -3814,7 +3818,7 @@
   end
   local.get $4
  )
- (func $~lib/array/Array<f32>#__get (; 85 ;) (param $0 i32) (param $1 i32) (result f32)
+ (func $~lib/array/Array<f32>#__get (; 86 ;) (param $0 i32) (param $1 i32) (result f32)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -3822,7 +3826,7 @@
   if
    i32.const 448
    i32.const 512
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -3835,7 +3839,7 @@
   i32.add
   f32.load
  )
- (func $start:std/array~anonymous|22 (; 86 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|22 (; 87 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $2
   i32.const 100
   call $~lib/array/Array<i32>#push
@@ -3845,7 +3849,7 @@
   global.set $std/array/i
   local.get $0
  )
- (func $~lib/array/Array<i32>#map<i32> (; 87 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#map<i32> (; 88 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3904,14 +3908,14 @@
   end
   local.get $5
  )
- (func $start:std/array~anonymous|23 (; 88 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|23 (; 89 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   global.get $std/array/i
   i32.add
   global.set $std/array/i
   local.get $0
  )
- (func $start:std/array~anonymous|24 (; 89 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|24 (; 90 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $2
   call $~lib/array/Array<i32>#pop
   drop
@@ -3921,12 +3925,12 @@
   global.set $std/array/i
   local.get $0
  )
- (func $start:std/array~anonymous|25 (; 90 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|25 (; 91 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 2
   i32.ge_s
  )
- (func $~lib/array/Array<i32>#filter (; 91 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#filter (; 92 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3982,7 +3986,7 @@
   end
   local.get $4
  )
- (func $start:std/array~anonymous|26 (; 92 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|26 (; 93 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $2
   i32.const 100
   call $~lib/array/Array<i32>#push
@@ -3994,7 +3998,7 @@
   i32.const 2
   i32.ge_s
  )
- (func $start:std/array~anonymous|27 (; 93 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|27 (; 94 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   global.get $std/array/i
   i32.add
@@ -4003,7 +4007,7 @@
   i32.const 2
   i32.ge_s
  )
- (func $start:std/array~anonymous|28 (; 94 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|28 (; 95 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $2
   call $~lib/array/Array<i32>#pop
   drop
@@ -4015,12 +4019,12 @@
   i32.const 2
   i32.ge_s
  )
- (func $start:std/array~anonymous|29 (; 95 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|29 (; 96 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   local.get $0
   local.get $1
   i32.add
  )
- (func $~lib/array/Array<i32>#reduce<i32> (; 96 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/array/Array<i32>#reduce<i32> (; 97 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -4063,7 +4067,7 @@
   end
   local.get $2
  )
- (func $start:std/array~anonymous|31 (; 97 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|31 (; 98 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   i32.const 1
   local.get $1
   i32.const 2
@@ -4071,7 +4075,7 @@
   local.get $0
   select
  )
- (func $start:std/array~anonymous|32 (; 98 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|32 (; 99 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   i32.const 1
   local.get $1
   i32.const 100
@@ -4079,7 +4083,7 @@
   local.get $0
   select
  )
- (func $start:std/array~anonymous|33 (; 99 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|33 (; 100 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   local.get $3
   i32.const 1
   call $~lib/array/Array<i32>#push
@@ -4087,7 +4091,7 @@
   local.get $1
   i32.add
  )
- (func $start:std/array~anonymous|35 (; 100 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|35 (; 101 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   local.get $3
   call $~lib/array/Array<i32>#pop
   drop
@@ -4095,7 +4099,7 @@
   local.get $1
   i32.add
  )
- (func $~lib/array/Array<i32>#reduceRight<i32> (; 101 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/array/Array<i32>#reduceRight<i32> (; 102 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $0
   i32.load offset=12
@@ -4131,7 +4135,7 @@
   end
   local.get $2
  )
- (func $~lib/math/murmurHash3 (; 102 ;) (param $0 i64) (result i64)
+ (func $~lib/math/murmurHash3 (; 103 ;) (param $0 i64) (result i64)
   local.get $0
   local.get $0
   i64.const 33
@@ -4152,7 +4156,7 @@
   i64.shr_u
   i64.xor
  )
- (func $~lib/math/splitMix32 (; 103 ;) (param $0 i32) (result i32)
+ (func $~lib/math/splitMix32 (; 104 ;) (param $0 i32) (result i32)
   local.get $0
   i32.const 1831565813
   i32.add
@@ -4184,7 +4188,7 @@
   i32.shr_u
   i32.xor
  )
- (func $~lib/math/NativeMath.seedRandom (; 104 ;) (param $0 i64)
+ (func $~lib/math/NativeMath.seedRandom (; 105 ;) (param $0 i64)
   i32.const 1
   global.set $~lib/math/random_seeded
   local.get $0
@@ -4228,7 +4232,7 @@
    unreachable
   end
  )
- (func $~lib/util/sort/insertionSort<f32> (; 105 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/util/sort/insertionSort<f32> (; 106 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 f32)
@@ -4306,13 +4310,13 @@
    end
   end
  )
- (func $~lib/rt/tlsf/__free (; 106 ;) (param $0 i32)
+ (func $~lib/rt/tlsf/__free (; 107 ;) (param $0 i32)
   call $~lib/rt/tlsf/maybeInitialize
   local.get $0
   call $~lib/rt/tlsf/checkUsedBlock
   call $~lib/rt/tlsf/freeBlock
  )
- (func $~lib/util/sort/weakHeapSort<f32> (; 107 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/util/sort/weakHeapSort<f32> (; 108 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 f32)
@@ -4569,7 +4573,7 @@
   local.get $4
   f32.store
  )
- (func $~lib/array/Array<f32>#sort (; 108 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<f32>#sort (; 109 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 f32)
@@ -4631,7 +4635,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/sort/COMPARATOR<f32>~anonymous|0 (; 109 ;) (param $0 f32) (param $1 f32) (result i32)
+ (func $~lib/util/sort/COMPARATOR<f32>~anonymous|0 (; 110 ;) (param $0 f32) (param $1 f32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -4660,7 +4664,7 @@
   i32.lt_s
   i32.sub
  )
- (func $std/array/isArraysEqual<f32> (; 110 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/array/isArraysEqual<f32> (; 111 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 f32)
   (local $4 i32)
@@ -4725,7 +4729,7 @@
   end
   i32.const 1
  )
- (func $~lib/util/sort/insertionSort<f64> (; 111 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/util/sort/insertionSort<f64> (; 112 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 f64)
@@ -4803,7 +4807,7 @@
    end
   end
  )
- (func $~lib/util/sort/weakHeapSort<f64> (; 112 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/util/sort/weakHeapSort<f64> (; 113 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 f64)
@@ -5060,7 +5064,7 @@
   local.get $4
   f64.store
  )
- (func $~lib/array/Array<f64>#sort (; 113 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<f64>#sort (; 114 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 f64)
@@ -5122,7 +5126,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/sort/COMPARATOR<f64>~anonymous|0 (; 114 ;) (param $0 f64) (param $1 f64) (result i32)
+ (func $~lib/util/sort/COMPARATOR<f64>~anonymous|0 (; 115 ;) (param $0 f64) (param $1 f64) (result i32)
   (local $2 i64)
   (local $3 i64)
   local.get $0
@@ -5151,7 +5155,7 @@
   i64.lt_s
   i32.sub
  )
- (func $~lib/array/Array<f64>#__get (; 115 ;) (param $0 i32) (param $1 i32) (result f64)
+ (func $~lib/array/Array<f64>#__get (; 116 ;) (param $0 i32) (param $1 i32) (result f64)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -5159,7 +5163,7 @@
   if
    i32.const 448
    i32.const 512
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -5172,7 +5176,7 @@
   i32.add
   f64.load
  )
- (func $std/array/isArraysEqual<f64> (; 116 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/array/isArraysEqual<f64> (; 117 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 f64)
   (local $4 i32)
@@ -5237,7 +5241,7 @@
   end
   i32.const 1
  )
- (func $~lib/util/sort/insertionSort<i32> (; 117 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/sort/insertionSort<i32> (; 118 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -5316,7 +5320,7 @@
    end
   end
  )
- (func $~lib/util/sort/weakHeapSort<i32> (; 118 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/sort/weakHeapSort<i32> (; 119 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -5575,7 +5579,7 @@
   local.get $1
   i32.store
  )
- (func $~lib/array/Array<i32>#sort (; 119 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#sort (; 120 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5639,12 +5643,12 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/sort/COMPARATOR<i32>~anonymous|0 (; 120 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/sort/COMPARATOR<i32>~anonymous|0 (; 121 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.sub
  )
- (func $~lib/util/sort/COMPARATOR<u32>~anonymous|0 (; 121 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/sort/COMPARATOR<u32>~anonymous|0 (; 122 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.gt_u
@@ -5653,7 +5657,7 @@
   i32.lt_u
   i32.sub
  )
- (func $std/array/createReverseOrderedArray (; 122 ;) (param $0 i32) (result i32)
+ (func $std/array/createReverseOrderedArray (; 123 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -5681,7 +5685,7 @@
   end
   local.get $2
  )
- (func $~lib/math/NativeMath.random (; 123 ;) (result f64)
+ (func $~lib/math/NativeMath.random (; 124 ;) (result f64)
   (local $0 i64)
   (local $1 i64)
   global.get $~lib/math/random_seeded
@@ -5725,7 +5729,7 @@
   f64.const 1
   f64.sub
  )
- (func $std/array/createRandomOrderedArray (; 124 ;) (param $0 i32) (result i32)
+ (func $std/array/createRandomOrderedArray (; 125 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -5753,7 +5757,7 @@
   end
   local.get $2
  )
- (func $std/array/isSorted<i32> (; 125 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/array/isSorted<i32> (; 126 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   i32.const 1
@@ -5793,7 +5797,7 @@
   end
   i32.const 1
  )
- (func $std/array/assertSorted<i32> (; 126 ;) (param $0 i32) (param $1 i32)
+ (func $std/array/assertSorted<i32> (; 127 ;) (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
   call $~lib/array/Array<i32>#sort
@@ -5804,7 +5808,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 881
+   i32.const 882
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -5812,17 +5816,36 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $std/array/assertSortedDefault<i32> (; 127 ;) (param $0 i32)
+ (func $std/array/assertSortedDefault<i32> (; 128 ;) (param $0 i32)
   local.get $0
   i32.const 48
   call $std/array/assertSorted<i32>
  )
- (func $start:std/array~anonymous|44 (; 128 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $start:std/array~anonymous|44 (; 129 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.sub
  )
- (func $~lib/array/Array<~lib/array/Array<i32>>#__unchecked_set (; 129 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<~lib/array/Array<i32>>#constructor (; 130 ;) (result i32)
+  (local $0 i32)
+  i32.const 16
+  i32.const 12
+  call $~lib/rt/tlsf/__alloc
+  call $~lib/rt/pure/__retain
+  call $~lib/arraybuffer/ArrayBufferView#constructor
+  local.tee $0
+  i32.const 0
+  i32.store offset=12
+  local.get $0
+  i32.const 2
+  i32.const 2
+  call $~lib/arraybuffer/ArrayBufferView#alloc
+  local.get $0
+  i32.const 2
+  i32.store offset=12
+  local.get $0
+ )
+ (func $~lib/array/Array<~lib/array/Array<i32>>#__unchecked_set (; 131 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -5843,7 +5866,7 @@
    call $~lib/rt/pure/__release
   end
  )
- (func $~lib/array/Array<~lib/array/Array<i32>>#__set (; 130 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<~lib/array/Array<i32>>#__set (; 132 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $1
   local.get $0
@@ -5856,7 +5879,7 @@
    if
     i32.const 448
     i32.const 512
-    i32.const 109
+    i32.const 114
     i32.const 21
     call $~lib/builtins/abort
     unreachable
@@ -5876,23 +5899,12 @@
   local.get $2
   call $~lib/array/Array<~lib/array/Array<i32>>#__unchecked_set
  )
- (func $std/array/createReverseOrderedNestedArray (; 131 ;) (result i32)
+ (func $std/array/createReverseOrderedNestedArray (; 133 ;) (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
-  i32.const 16
-  i32.const 12
-  call $~lib/rt/tlsf/__alloc
-  call $~lib/rt/pure/__retain
-  i32.const 2
-  i32.const 2
-  call $~lib/arraybuffer/ArrayBufferView#constructor
-  local.tee $1
-  i32.const 0
-  i32.store offset=12
-  local.get $1
-  i32.const 2
-  i32.store offset=12
+  call $~lib/array/Array<~lib/array/Array<i32>>#constructor
+  local.set $1
   loop $for-loop|0
    local.get $0
    i32.const 2
@@ -5921,7 +5933,7 @@
   end
   local.get $1
  )
- (func $start:std/array~anonymous|47 (; 132 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $start:std/array~anonymous|47 (; 134 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.const 0
   call $~lib/array/Array<u32>#__get
@@ -5930,7 +5942,7 @@
   call $~lib/array/Array<u32>#__get
   i32.sub
  )
- (func $~lib/array/Array<~lib/array/Array<i32>>#sort (; 133 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<i32>>#sort (; 135 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5984,7 +5996,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $std/array/isSorted<~lib/array/Array<i32>> (; 134 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/array/isSorted<~lib/array/Array<i32>> (; 136 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6036,7 +6048,7 @@
   end
   i32.const 1
  )
- (func $std/array/assertSorted<~lib/array/Array<i32>> (; 135 ;) (param $0 i32) (param $1 i32)
+ (func $std/array/assertSorted<~lib/array/Array<i32>> (; 137 ;) (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
   call $~lib/array/Array<~lib/array/Array<i32>>#sort
@@ -6047,7 +6059,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 881
+   i32.const 882
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -6055,23 +6067,31 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $std/array/createReverseOrderedElementsArray (; 136 ;) (result i32)
+ (func $~lib/array/Array<std/array/Proxy<i32>>#constructor (; 138 ;) (result i32)
   (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
   i32.const 16
   i32.const 14
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
-  i32.const 512
-  i32.const 2
   call $~lib/arraybuffer/ArrayBufferView#constructor
-  local.tee $1
+  local.tee $0
   i32.const 0
   i32.store offset=12
-  local.get $1
+  local.get $0
+  i32.const 512
+  i32.const 2
+  call $~lib/arraybuffer/ArrayBufferView#alloc
+  local.get $0
   i32.const 512
   i32.store offset=12
+  local.get $0
+ )
+ (func $std/array/createReverseOrderedElementsArray (; 139 ;) (result i32)
+  (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  call $~lib/array/Array<std/array/Proxy<i32>>#constructor
+  local.set $1
   loop $for-loop|0
    local.get $0
    i32.const 512
@@ -6101,14 +6121,14 @@
   end
   local.get $1
  )
- (func $start:std/array~anonymous|48 (; 137 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $start:std/array~anonymous|48 (; 140 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load
   local.get $1
   i32.load
   i32.sub
  )
- (func $std/array/isSorted<~lib/string/String | null> (; 138 ;) (param $0 i32) (result i32)
+ (func $std/array/isSorted<~lib/string/String | null> (; 141 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -6159,7 +6179,7 @@
   end
   i32.const 1
  )
- (func $std/array/assertSorted<~lib/string/String | null> (; 139 ;) (param $0 i32)
+ (func $std/array/assertSorted<~lib/string/String | null> (; 142 ;) (param $0 i32)
   local.get $0
   i32.const 55
   call $~lib/array/Array<~lib/array/Array<i32>>#sort
@@ -6169,7 +6189,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 881
+   i32.const 882
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -6177,7 +6197,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/string/String#get:length (; 140 ;) (param $0 i32) (result i32)
+ (func $~lib/string/String#get:length (; 143 ;) (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub
@@ -6185,7 +6205,7 @@
   i32.const 1
   i32.shr_u
  )
- (func $~lib/util/string/compareImpl (; 141 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/compareImpl (; 144 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -6261,7 +6281,7 @@
   end
   i32.const 0
  )
- (func $~lib/util/sort/COMPARATOR<~lib/string/String | null>~anonymous|0 (; 142 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/sort/COMPARATOR<~lib/string/String | null>~anonymous|0 (; 145 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   i32.const 1
@@ -6315,7 +6335,7 @@
   select
   call $~lib/util/string/compareImpl
  )
- (func $~lib/string/String.__eq (; 143 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__eq (; 146 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -6349,7 +6369,7 @@
   call $~lib/util/string/compareImpl
   i32.eqz
  )
- (func $std/array/isArraysEqual<~lib/string/String | null> (; 144 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/array/isArraysEqual<~lib/string/String | null> (; 147 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6407,7 +6427,26 @@
   end
   i32.const 1
  )
- (func $~lib/string/String#charAt (; 145 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<~lib/string/String>#constructor (; 148 ;) (result i32)
+  (local $0 i32)
+  i32.const 16
+  i32.const 16
+  call $~lib/rt/tlsf/__alloc
+  call $~lib/rt/pure/__retain
+  call $~lib/arraybuffer/ArrayBufferView#constructor
+  local.tee $0
+  i32.const 0
+  i32.store offset=12
+  local.get $0
+  i32.const 400
+  i32.const 2
+  call $~lib/arraybuffer/ArrayBufferView#alloc
+  local.get $0
+  i32.const 400
+  i32.store offset=12
+  local.get $0
+ )
+ (func $~lib/string/String#charAt (; 149 ;) (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   i32.const 4080
@@ -6431,7 +6470,7 @@
   local.get $1
   call $~lib/rt/pure/__retain
  )
- (func $~lib/string/String#concat (; 146 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String#concat (; 150 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6490,7 +6529,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/string/String.__concat (; 147 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__concat (; 151 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.const 5232
   local.get $0
@@ -6498,7 +6537,7 @@
   local.get $1
   call $~lib/string/String#concat
  )
- (func $std/array/createRandomString (; 148 ;) (param $0 i32) (result i32)
+ (func $std/array/createRandomString (; 152 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -6547,30 +6586,19 @@
   end
   local.get $1
  )
- (func $std/array/createRandomStringArray (; 149 ;) (result i32)
+ (func $std/array/createRandomStringArray (; 153 ;) (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
-  i32.const 16
-  i32.const 16
-  call $~lib/rt/tlsf/__alloc
-  call $~lib/rt/pure/__retain
-  i32.const 400
-  i32.const 2
-  call $~lib/arraybuffer/ArrayBufferView#constructor
-  local.tee $0
-  i32.const 0
-  i32.store offset=12
-  local.get $0
-  i32.const 400
-  i32.store offset=12
+  call $~lib/array/Array<~lib/string/String>#constructor
+  local.set $1
   loop $for-loop|0
-   local.get $1
+   local.get $0
    i32.const 400
    i32.lt_s
    if
-    local.get $0
     local.get $1
+    local.get $0
     call $~lib/math/NativeMath.random
     f64.const 32
     f64.mul
@@ -6580,16 +6608,16 @@
     call $~lib/array/Array<~lib/array/Array<i32>>#__set
     local.get $2
     call $~lib/rt/pure/__release
-    local.get $1
+    local.get $0
     i32.const 1
     i32.add
-    local.set $1
+    local.set $0
     br $for-loop|0
    end
   end
-  local.get $0
+  local.get $1
  )
- (func $~lib/string/String#substring (; 150 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String#substring (; 154 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6663,7 +6691,7 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/string/joinBooleanArray (; 151 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/joinBooleanArray (; 155 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6803,7 +6831,7 @@
   end
   local.get $3
  )
- (func $~lib/util/number/decimalCount32 (; 152 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/decimalCount32 (; 156 ;) (param $0 i32) (result i32)
   i32.const 1
   i32.const 2
   local.get $0
@@ -6851,7 +6879,7 @@
   i32.lt_u
   select
  )
- (func $~lib/util/number/utoa_simple<u32> (; 153 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/number/utoa_simple<u32> (; 157 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   loop $do-continue|0
    local.get $1
@@ -6875,7 +6903,7 @@
    br_if $do-continue|0
   end
  )
- (func $~lib/util/number/itoa32 (; 154 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/itoa32 (; 158 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -6917,7 +6945,7 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/itoa_stream<i32> (; 155 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_stream<i32> (; 159 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   local.get $1
   i32.const 1
@@ -6959,7 +6987,7 @@
   end
   local.get $2
  )
- (func $~lib/util/string/joinIntegerArray<i32> (; 156 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<i32> (; 160 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -7066,7 +7094,7 @@
   end
   local.get $3
  )
- (func $~lib/array/Array<i32>#join (; 157 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#join (; 161 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $0
@@ -7074,7 +7102,7 @@
   local.get $1
   call $~lib/util/string/joinIntegerArray<i32>
  )
- (func $~lib/util/number/utoa32 (; 158 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/utoa32 (; 162 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -7097,7 +7125,7 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/itoa_stream<u32> (; 159 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_stream<u32> (; 163 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   local.get $1
   i32.const 1
@@ -7121,7 +7149,7 @@
   call $~lib/util/number/utoa_simple<u32>
   local.get $0
  )
- (func $~lib/util/string/joinIntegerArray<u32> (; 160 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<u32> (; 164 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -7228,7 +7256,7 @@
   end
   local.get $3
  )
- (func $~lib/array/Array<u32>#join (; 161 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u32>#join (; 165 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $0
@@ -7236,7 +7264,7 @@
   local.get $1
   call $~lib/util/string/joinIntegerArray<u32>
  )
- (func $~lib/util/number/genDigits (; 162 ;) (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (param $6 i32) (result i32)
+ (func $~lib/util/number/genDigits (; 166 ;) (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (param $6 i32) (result i32)
   (local $7 i32)
   (local $8 i32)
   (local $9 i64)
@@ -7630,7 +7658,7 @@
    local.get $6
   end
  )
- (func $~lib/util/number/prettify (; 163 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/prettify (; 167 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   i32.eqz
@@ -7875,7 +7903,7 @@
    end
   end
  )
- (func $~lib/util/number/dtoa_core (; 164 ;) (param $0 i32) (param $1 f64) (result i32)
+ (func $~lib/util/number/dtoa_core (; 168 ;) (param $0 i32) (param $1 f64) (result i32)
   (local $2 i64)
   (local $3 i32)
   (local $4 i64)
@@ -8163,7 +8191,7 @@
   local.get $10
   i32.add
  )
- (func $~lib/util/number/dtoa (; 165 ;) (param $0 f64) (result i32)
+ (func $~lib/util/number/dtoa (; 169 ;) (param $0 f64) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -8215,7 +8243,7 @@
   local.get $1
   call $~lib/rt/tlsf/__free
  )
- (func $~lib/util/number/dtoa_stream (; 166 ;) (param $0 i32) (param $1 i32) (param $2 f64) (result i32)
+ (func $~lib/util/number/dtoa_stream (; 170 ;) (param $0 i32) (param $1 i32) (param $2 f64) (result i32)
   (local $3 i32)
   local.get $0
   local.get $1
@@ -8286,7 +8314,7 @@
   local.get $2
   call $~lib/util/number/dtoa_core
  )
- (func $~lib/util/string/joinFloatArray<f64> (; 167 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/joinFloatArray<f64> (; 171 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -8393,7 +8421,7 @@
   end
   local.get $2
  )
- (func $~lib/util/string/joinReferenceArray<~lib/string/String | null> (; 168 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinReferenceArray<~lib/string/String | null> (; 172 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -8561,7 +8589,7 @@
   call $~lib/rt/pure/__release
   local.get $1
  )
- (func $~lib/array/Array<~lib/string/String | null>#join (; 169 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/string/String | null>#join (; 173 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $0
@@ -8569,7 +8597,7 @@
   local.get $1
   call $~lib/util/string/joinReferenceArray<~lib/string/String | null>
  )
- (func $~lib/util/string/joinReferenceArray<std/array/Ref | null> (; 170 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/joinReferenceArray<std/array/Ref | null> (; 174 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -8721,19 +8749,19 @@
   call $~lib/rt/pure/__release
   local.get $1
  )
- (func $~lib/array/Array<std/array/Ref | null>#join (; 171 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<std/array/Ref | null>#join (; 175 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $0
   i32.load offset=12
   call $~lib/util/string/joinReferenceArray<std/array/Ref | null>
  )
- (func $~lib/array/Array<i32>#toString (; 172 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<i32>#toString (; 176 ;) (param $0 i32) (result i32)
   local.get $0
   i32.const 5360
   call $~lib/array/Array<i32>#join
  )
- (func $~lib/util/number/itoa_stream<i8> (; 173 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_stream<i8> (; 177 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $0
   local.get $1
@@ -8788,7 +8816,7 @@
   end
   local.get $2
  )
- (func $~lib/util/string/joinIntegerArray<i8> (; 174 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<i8> (; 178 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -8891,7 +8919,7 @@
   end
   local.get $2
  )
- (func $~lib/util/number/itoa_stream<u16> (; 175 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_stream<u16> (; 179 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   local.get $1
   i32.const 1
@@ -8921,7 +8949,7 @@
   call $~lib/util/number/utoa_simple<u32>
   local.get $1
  )
- (func $~lib/util/string/joinIntegerArray<u16> (; 176 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<u16> (; 180 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9028,7 +9056,7 @@
   end
   local.get $2
  )
- (func $~lib/util/number/decimalCount64 (; 177 ;) (param $0 i64) (result i32)
+ (func $~lib/util/number/decimalCount64 (; 181 ;) (param $0 i64) (result i32)
   i32.const 10
   i32.const 11
   i32.const 12
@@ -9081,7 +9109,7 @@
   i64.lt_u
   select
  )
- (func $~lib/util/number/utoa_simple<u64> (; 178 ;) (param $0 i32) (param $1 i64) (param $2 i32)
+ (func $~lib/util/number/utoa_simple<u64> (; 182 ;) (param $0 i32) (param $1 i64) (param $2 i32)
   (local $3 i64)
   loop $do-continue|0
    local.get $1
@@ -9108,7 +9136,7 @@
    br_if $do-continue|0
   end
  )
- (func $~lib/util/number/utoa64 (; 179 ;) (param $0 i64) (result i32)
+ (func $~lib/util/number/utoa64 (; 183 ;) (param $0 i64) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -9151,7 +9179,7 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/itoa_stream<u64> (; 180 ;) (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
+ (func $~lib/util/number/itoa_stream<u64> (; 184 ;) (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
   (local $3 i32)
   local.get $0
   local.get $1
@@ -9191,7 +9219,7 @@
   end
   local.get $1
  )
- (func $~lib/util/string/joinIntegerArray<u64> (; 181 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<u64> (; 185 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9298,7 +9326,7 @@
   end
   local.get $2
  )
- (func $~lib/util/number/itoa64 (; 182 ;) (param $0 i64) (result i32)
+ (func $~lib/util/number/itoa64 (; 186 ;) (param $0 i64) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -9362,7 +9390,7 @@
   local.get $3
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/itoa_stream<i64> (; 183 ;) (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
+ (func $~lib/util/number/itoa_stream<i64> (; 187 ;) (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -9423,7 +9451,7 @@
   end
   local.get $3
  )
- (func $~lib/util/string/joinIntegerArray<i64> (; 184 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<i64> (; 188 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9530,12 +9558,12 @@
   end
   local.get $2
  )
- (func $~lib/array/Array<~lib/string/String | null>#toString (; 185 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<~lib/string/String | null>#toString (; 189 ;) (param $0 i32) (result i32)
   local.get $0
   i32.const 5360
   call $~lib/array/Array<~lib/string/String | null>#join
  )
- (func $~lib/util/string/joinReferenceArray<~lib/array/Array<i32>> (; 186 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/joinReferenceArray<~lib/array/Array<i32>> (; 190 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9699,7 +9727,7 @@
   call $~lib/rt/pure/__release
   local.get $1
  )
- (func $~lib/util/number/itoa_stream<u8> (; 187 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_stream<u8> (; 191 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   local.get $1
   i32.const 1
@@ -9729,7 +9757,7 @@
   call $~lib/util/number/utoa_simple<u32>
   local.get $1
  )
- (func $~lib/util/string/joinIntegerArray<u8> (; 188 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<u8> (; 192 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9832,14 +9860,14 @@
   end
   local.get $2
  )
- (func $~lib/array/Array<u8>#toString (; 189 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<u8>#toString (; 193 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $0
   i32.load offset=12
   call $~lib/util/string/joinIntegerArray<u8>
  )
- (func $~lib/util/string/joinReferenceArray<~lib/array/Array<u8>> (; 190 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/joinReferenceArray<~lib/array/Array<u8>> (; 194 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10003,12 +10031,12 @@
   call $~lib/rt/pure/__release
   local.get $1
  )
- (func $~lib/array/Array<u32>#toString (; 191 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<u32>#toString (; 195 ;) (param $0 i32) (result i32)
   local.get $0
   i32.const 5360
   call $~lib/array/Array<u32>#join
  )
- (func $~lib/util/string/joinReferenceArray<~lib/array/Array<u32>> (; 192 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/joinReferenceArray<~lib/array/Array<u32>> (; 196 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10172,14 +10200,14 @@
   call $~lib/rt/pure/__release
   local.get $1
  )
- (func $~lib/array/Array<~lib/array/Array<u32>>#toString (; 193 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<u32>>#toString (; 197 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $0
   i32.load offset=12
   call $~lib/util/string/joinReferenceArray<~lib/array/Array<u32>>
  )
- (func $~lib/util/string/joinReferenceArray<~lib/array/Array<~lib/array/Array<u32>>> (; 194 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/joinReferenceArray<~lib/array/Array<~lib/array/Array<u32>>> (; 198 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10343,7 +10371,7 @@
   call $~lib/rt/pure/__release
   local.get $1
  )
- (func $start:std/array (; 195 ;)
+ (func $start:std/array (; 199 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -10415,7 +10443,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 40
+   i32.const 41
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -10426,17 +10454,18 @@
   i32.const 5
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
+  call $~lib/arraybuffer/ArrayBufferView#constructor
+  local.tee $1
   i32.const 1
   i32.const 0
-  call $~lib/arraybuffer/ArrayBufferView#constructor
-  local.set $1
+  call $~lib/arraybuffer/ArrayBufferView#alloc
   global.get $std/array/arr
   call $~lib/array/Array.isArray<~lib/array/Array<i32> | null>
   i32.eqz
   if
    i32.const 0
    i32.const 304
-   i32.const 46
+   i32.const 47
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -10469,7 +10498,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 54
+   i32.const 55
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -10493,7 +10522,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 57
+   i32.const 58
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -10517,7 +10546,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 60
+   i32.const 61
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -10541,7 +10570,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 63
+   i32.const 64
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -10565,7 +10594,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 66
+   i32.const 67
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -10608,7 +10637,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 73
+   i32.const 74
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -10633,7 +10662,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 76
+   i32.const 77
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -10658,7 +10687,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 79
+   i32.const 80
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -10683,7 +10712,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 82
+   i32.const 83
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -10708,7 +10737,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 85
+   i32.const 86
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -10730,7 +10759,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 91
+   i32.const 92
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -10740,7 +10769,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 92
+   i32.const 93
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -10756,25 +10785,13 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 96
-   i32.const 2
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $std/array/arr
-  i32.load offset=12
-  i32.const 1
-  i32.ne
-  if
-   i32.const 0
-   i32.const 304
    i32.const 97
    i32.const 2
    call $~lib/builtins/abort
    unreachable
   end
   global.get $std/array/arr
-  call $std/array/internalCapacity<i32>
+  i32.load offset=12
   i32.const 1
   i32.ne
   if
@@ -10786,19 +10803,21 @@
    unreachable
   end
   global.get $std/array/arr
-  call $~lib/array/Array<i32>#pop
-  i32.const 42
+  call $std/array/internalCapacity<i32>
+  i32.const 1
   i32.ne
   if
    i32.const 0
    i32.const 304
-   i32.const 102
+   i32.const 99
    i32.const 2
    call $~lib/builtins/abort
    unreachable
   end
   global.get $std/array/arr
-  i32.load offset=12
+  call $~lib/array/Array<i32>#pop
+  i32.const 42
+  i32.ne
   if
    i32.const 0
    i32.const 304
@@ -10808,9 +10827,7 @@
    unreachable
   end
   global.get $std/array/arr
-  call $std/array/internalCapacity<i32>
-  i32.const 1
-  i32.ne
+  i32.load offset=12
   if
    i32.const 0
    i32.const 304
@@ -10820,22 +10837,22 @@
    unreachable
   end
   global.get $std/array/arr
-  i32.const 43
-  call $~lib/array/Array<i32>#push
-  global.get $std/array/arr
-  i32.load offset=12
+  call $std/array/internalCapacity<i32>
   i32.const 1
   i32.ne
   if
    i32.const 0
    i32.const 304
-   i32.const 108
+   i32.const 105
    i32.const 2
    call $~lib/builtins/abort
    unreachable
   end
   global.get $std/array/arr
-  call $std/array/internalCapacity<i32>
+  i32.const 43
+  call $~lib/array/Array<i32>#push
+  global.get $std/array/arr
+  i32.load offset=12
   i32.const 1
   i32.ne
   if
@@ -10847,9 +10864,8 @@
    unreachable
   end
   global.get $std/array/arr
-  i32.const 0
-  call $~lib/array/Array<u32>#__get
-  i32.const 43
+  call $std/array/internalCapacity<i32>
+  i32.const 1
   i32.ne
   if
    i32.const 0
@@ -10860,22 +10876,23 @@
    unreachable
   end
   global.get $std/array/arr
-  i32.const 44
-  call $~lib/array/Array<i32>#push
-  global.get $std/array/arr
-  i32.load offset=12
-  i32.const 2
+  i32.const 0
+  call $~lib/array/Array<u32>#__get
+  i32.const 43
   i32.ne
   if
    i32.const 0
    i32.const 304
-   i32.const 114
+   i32.const 111
    i32.const 2
    call $~lib/builtins/abort
    unreachable
   end
   global.get $std/array/arr
-  call $std/array/internalCapacity<i32>
+  i32.const 44
+  call $~lib/array/Array<i32>#push
+  global.get $std/array/arr
+  i32.load offset=12
   i32.const 2
   i32.ne
   if
@@ -10887,6 +10904,18 @@
    unreachable
   end
   global.get $std/array/arr
+  call $std/array/internalCapacity<i32>
+  i32.const 2
+  i32.ne
+  if
+   i32.const 0
+   i32.const 304
+   i32.const 116
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $std/array/arr
   i32.const 0
   call $~lib/array/Array<u32>#__get
   i32.const 43
@@ -10894,7 +10923,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 116
+   i32.const 117
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -10907,7 +10936,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 117
+   i32.const 118
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -10922,7 +10951,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 121
+   i32.const 122
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -10934,7 +10963,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 122
+   i32.const 123
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -10947,7 +10976,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 123
+   i32.const 124
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -10960,7 +10989,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 124
+   i32.const 125
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -10973,7 +11002,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 125
+   i32.const 126
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -11005,7 +11034,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 133
+   i32.const 134
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -11030,7 +11059,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 142
+   i32.const 143
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -11042,7 +11071,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 143
+   i32.const 144
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -11054,7 +11083,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 144
+   i32.const 145
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -11076,7 +11105,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 147
+   i32.const 148
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -11089,7 +11118,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 149
+   i32.const 150
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -11102,7 +11131,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 150
+   i32.const 151
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -11115,7 +11144,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 151
+   i32.const 152
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -11139,7 +11168,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 158
+   i32.const 159
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -11151,7 +11180,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 159
+   i32.const 160
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -11163,7 +11192,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 160
+   i32.const 161
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -11176,7 +11205,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 161
+   i32.const 162
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -11189,7 +11218,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 162
+   i32.const 163
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -11202,7 +11231,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 163
+   i32.const 164
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -11215,7 +11244,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 164
+   i32.const 165
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -11228,7 +11257,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 165
+   i32.const 166
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -11243,7 +11272,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 168
+   i32.const 169
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -11259,7 +11288,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 176
+   i32.const 177
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -11277,7 +11306,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 178
+   i32.const 179
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -11287,7 +11316,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 179
+   i32.const 180
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -11325,7 +11354,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 186
+   i32.const 187
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -11358,7 +11387,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 188
+   i32.const 189
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -11390,7 +11419,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 190
+   i32.const 191
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -11422,7 +11451,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 192
+   i32.const 193
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -11454,7 +11483,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 194
+   i32.const 195
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -11486,7 +11515,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 196
+   i32.const 197
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -11518,7 +11547,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 198
+   i32.const 199
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -11550,7 +11579,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 200
+   i32.const 201
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -11582,7 +11611,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 202
+   i32.const 203
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -11614,7 +11643,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 204
+   i32.const 205
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -11646,7 +11675,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 206
+   i32.const 207
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -11679,7 +11708,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 208
+   i32.const 209
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -11744,7 +11773,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 216
+   i32.const 217
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -11756,7 +11785,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 217
+   i32.const 218
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -11769,7 +11798,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 218
+   i32.const 219
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -11782,7 +11811,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 219
+   i32.const 220
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -11795,7 +11824,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 220
+   i32.const 221
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -11808,7 +11837,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 221
+   i32.const 222
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -11823,7 +11852,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 225
+   i32.const 226
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -11835,7 +11864,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 226
+   i32.const 227
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -11848,7 +11877,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 227
+   i32.const 228
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -11861,7 +11890,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 228
+   i32.const 229
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -11874,7 +11903,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 229
+   i32.const 230
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -11887,7 +11916,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 230
+   i32.const 231
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -11900,7 +11929,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 231
+   i32.const 232
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -11914,7 +11943,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 240
+   i32.const 241
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -11926,7 +11955,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 241
+   i32.const 242
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -11938,7 +11967,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 242
+   i32.const 243
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -11951,7 +11980,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 243
+   i32.const 244
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -11964,7 +11993,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 244
+   i32.const 245
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -11977,7 +12006,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 245
+   i32.const 246
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -11990,7 +12019,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 246
+   i32.const 247
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -12004,7 +12033,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 250
+   i32.const 251
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -12016,7 +12045,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 251
+   i32.const 252
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -12028,7 +12057,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 252
+   i32.const 253
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -12041,7 +12070,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 253
+   i32.const 254
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -12054,7 +12083,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 254
+   i32.const 255
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -12067,7 +12096,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 255
+   i32.const 256
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -12082,7 +12111,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 263
+   i32.const 264
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -12094,7 +12123,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 264
+   i32.const 265
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -12107,7 +12136,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 265
+   i32.const 266
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -12120,7 +12149,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 266
+   i32.const 267
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -12133,7 +12162,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 267
+   i32.const 268
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -12153,7 +12182,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 277
+   i32.const 278
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -12169,7 +12198,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 280
+   i32.const 281
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -12185,7 +12214,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 283
+   i32.const 284
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -12201,7 +12230,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 286
+   i32.const 287
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -12217,7 +12246,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 289
+   i32.const 290
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -12233,7 +12262,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 292
+   i32.const 293
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -12249,7 +12278,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 295
+   i32.const 296
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -12265,7 +12294,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 298
+   i32.const 299
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -12281,7 +12310,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 301
+   i32.const 302
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -12297,7 +12326,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 304
+   i32.const 305
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -12315,7 +12344,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 306
+   i32.const 307
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -12333,7 +12362,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 307
+   i32.const 308
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -12351,7 +12380,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 314
+   i32.const 315
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -12365,7 +12394,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 317
+   i32.const 318
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -12377,7 +12406,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 320
+   i32.const 321
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -12389,7 +12418,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 323
+   i32.const 324
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -12403,7 +12432,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 326
+   i32.const 327
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -12417,7 +12446,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 329
+   i32.const 330
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -12431,7 +12460,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 332
+   i32.const 333
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -12445,7 +12474,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 335
+   i32.const 336
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -12459,7 +12488,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 338
+   i32.const 339
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -12473,7 +12502,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 341
+   i32.const 342
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -12490,7 +12519,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 343
+   i32.const 344
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -12507,7 +12536,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 344
+   i32.const 345
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -12524,7 +12553,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 348
+   i32.const 349
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -12536,7 +12565,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 349
+   i32.const 350
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -12549,7 +12578,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 350
+   i32.const 351
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -12562,7 +12591,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 351
+   i32.const 352
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -12595,7 +12624,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 358
+   i32.const 359
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -12614,7 +12643,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 359
+   i32.const 360
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -12646,7 +12675,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 362
+   i32.const 363
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -12665,7 +12694,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 363
+   i32.const 364
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -12697,7 +12726,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 366
+   i32.const 367
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -12716,7 +12745,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 367
+   i32.const 368
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -12747,7 +12776,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 370
+   i32.const 371
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -12766,7 +12795,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 371
+   i32.const 372
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -12797,7 +12826,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 374
+   i32.const 375
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -12816,7 +12845,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 375
+   i32.const 376
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -12847,7 +12876,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 378
+   i32.const 379
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -12866,7 +12895,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 379
+   i32.const 380
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -12897,7 +12926,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 382
+   i32.const 383
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -12916,7 +12945,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 383
+   i32.const 384
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -12947,7 +12976,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 386
+   i32.const 387
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -12966,7 +12995,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 387
+   i32.const 388
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -12997,7 +13026,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 390
+   i32.const 391
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -13016,7 +13045,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 391
+   i32.const 392
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -13047,7 +13076,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 394
+   i32.const 395
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -13066,7 +13095,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 395
+   i32.const 396
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -13097,7 +13126,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 398
+   i32.const 399
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -13116,7 +13145,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 399
+   i32.const 400
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -13147,7 +13176,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 402
+   i32.const 403
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -13166,7 +13195,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 403
+   i32.const 404
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -13198,7 +13227,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 406
+   i32.const 407
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -13217,7 +13246,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 407
+   i32.const 408
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -13249,7 +13278,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 410
+   i32.const 411
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -13268,7 +13297,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 411
+   i32.const 412
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -13287,7 +13316,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 415
+   i32.const 416
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -13297,7 +13326,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 416
+   i32.const 417
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -13355,7 +13384,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 421
+   i32.const 422
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -13370,7 +13399,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 422
+   i32.const 423
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -13385,7 +13414,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 423
+   i32.const 424
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -13397,7 +13426,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 425
+   i32.const 426
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -13412,7 +13441,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 426
+   i32.const 427
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -13427,7 +13456,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 427
+   i32.const 428
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -13442,7 +13471,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 428
+   i32.const 429
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -13479,7 +13508,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 433
+   i32.const 434
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -13493,7 +13522,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 434
+   i32.const 435
    i32.const 9
    call $~lib/builtins/abort
    unreachable
@@ -13504,7 +13533,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 434
+   i32.const 435
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -13516,7 +13545,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 436
+   i32.const 437
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -13528,7 +13557,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 437
+   i32.const 438
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -13542,7 +13571,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 438
+   i32.const 439
    i32.const 9
    call $~lib/builtins/abort
    unreachable
@@ -13553,7 +13582,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 438
+   i32.const 439
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -13698,7 +13727,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 451
+   i32.const 452
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -13713,7 +13742,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 454
+   i32.const 455
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -13728,7 +13757,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 457
+   i32.const 458
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -13743,7 +13772,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 465
+   i32.const 466
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -13755,7 +13784,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 466
+   i32.const 467
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -13770,7 +13799,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 468
+   i32.const 469
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -13797,7 +13826,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 481
+   i32.const 482
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -13809,7 +13838,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 482
+   i32.const 483
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -13828,7 +13857,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 492
+   i32.const 493
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -13839,7 +13868,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 495
+   i32.const 496
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -13852,7 +13881,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 503
+   i32.const 504
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -13864,7 +13893,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 504
+   i32.const 505
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -13875,7 +13904,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 506
+   i32.const 507
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -13900,7 +13929,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 519
+   i32.const 520
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -13912,7 +13941,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 520
+   i32.const 521
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -13931,7 +13960,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 530
+   i32.const 531
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -13942,7 +13971,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 533
+   i32.const 534
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -13953,7 +13982,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 541
+   i32.const 542
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -13965,7 +13994,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 542
+   i32.const 543
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -13978,7 +14007,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 544
+   i32.const 545
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -14001,7 +14030,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 557
+   i32.const 558
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -14013,7 +14042,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 558
+   i32.const 559
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -14035,7 +14064,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 569
+   i32.const 570
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -14051,7 +14080,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 578
+   i32.const 579
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -14063,7 +14092,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 579
+   i32.const 580
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -14079,7 +14108,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 582
+   i32.const 583
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -14107,7 +14136,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 596
+   i32.const 597
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -14119,7 +14148,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 597
+   i32.const 598
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -14140,7 +14169,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 622
+   i32.const 623
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -14183,7 +14212,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 636
+   i32.const 637
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -14199,7 +14228,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 637
+   i32.const 638
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -14216,7 +14245,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 646
+   i32.const 647
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -14228,7 +14257,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 647
+   i32.const 648
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -14245,7 +14274,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 654
+   i32.const 655
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -14274,7 +14303,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 669
+   i32.const 670
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -14286,7 +14315,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 670
+   i32.const 671
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -14309,7 +14338,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 680
+   i32.const 681
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -14326,7 +14355,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 689
+   i32.const 690
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -14338,7 +14367,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 690
+   i32.const 691
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -14355,7 +14384,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 697
+   i32.const 698
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -14384,7 +14413,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 712
+   i32.const 713
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -14396,7 +14425,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 713
+   i32.const 714
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -14420,7 +14449,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 723
+   i32.const 724
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -14436,7 +14465,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 727
+   i32.const 728
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -14452,7 +14481,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 730
+   i32.const 731
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -14464,7 +14493,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 733
+   i32.const 734
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -14480,7 +14509,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 741
+   i32.const 742
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -14492,7 +14521,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 742
+   i32.const 743
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -14508,7 +14537,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 744
+   i32.const 745
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -14536,7 +14565,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 757
+   i32.const 758
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -14548,7 +14577,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 758
+   i32.const 759
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -14570,7 +14599,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 768
+   i32.const 769
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -14586,7 +14615,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 772
+   i32.const 773
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -14602,7 +14631,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 775
+   i32.const 776
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -14614,7 +14643,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 778
+   i32.const 779
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -14630,7 +14659,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 786
+   i32.const 787
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -14642,7 +14671,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 787
+   i32.const 788
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -14658,7 +14687,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 789
+   i32.const 790
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -14686,7 +14715,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 802
+   i32.const 803
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -14696,7 +14725,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 803
+   i32.const 804
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -14741,7 +14770,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 892
+   i32.const 893
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -14771,7 +14800,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 896
+   i32.const 897
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -14803,7 +14832,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 900
+   i32.const 901
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -14835,7 +14864,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 904
+   i32.const 905
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -14908,7 +14937,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 924
+   i32.const 925
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -14929,7 +14958,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 927
+   i32.const 928
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -14944,7 +14973,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 930
+   i32.const 931
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -14959,7 +14988,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 933
+   i32.const 934
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -14974,7 +15003,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 936
+   i32.const 937
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -14989,7 +15018,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 939
+   i32.const 940
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -15004,7 +15033,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 942
+   i32.const 943
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -15110,7 +15139,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 979
+   i32.const 980
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -15147,7 +15176,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 988
+   i32.const 989
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -15168,7 +15197,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 989
+   i32.const 990
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -15189,7 +15218,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 990
+   i32.const 991
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -15210,7 +15239,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 991
+   i32.const 992
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -15235,7 +15264,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 992
+   i32.const 993
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -15256,7 +15285,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 993
+   i32.const 994
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -15293,7 +15322,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 995
+   i32.const 996
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -15327,7 +15356,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 998
+   i32.const 999
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -15408,7 +15437,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 1008
+   i32.const 1009
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -15422,7 +15451,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 1009
+   i32.const 1010
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -15436,7 +15465,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 1010
+   i32.const 1011
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -15450,7 +15479,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 1011
+   i32.const 1012
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -15474,7 +15503,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 1013
+   i32.const 1014
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -15499,7 +15528,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 1014
+   i32.const 1015
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -15524,7 +15553,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 1015
+   i32.const 1016
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -15549,7 +15578,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 1016
+   i32.const 1017
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -15569,7 +15598,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 1020
+   i32.const 1021
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -15589,7 +15618,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 1021
+   i32.const 1022
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -15636,7 +15665,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 1024
+   i32.const 1025
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -15683,7 +15712,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 1027
+   i32.const 1028
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -15730,7 +15759,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 1030
+   i32.const 1031
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -15809,7 +15838,7 @@
   local.get $3
   call $~lib/rt/pure/__release
  )
- (func $~start (; 196 ;)
+ (func $~start (; 200 ;)
   global.get $~started
   if
    return
@@ -15819,7 +15848,7 @@
   end
   call $start:std/array
  )
- (func $~lib/rt/pure/decrement (; 197 ;) (param $0 i32)
+ (func $~lib/rt/pure/decrement (; 201 ;) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -15836,7 +15865,7 @@
   i32.and
   if
    i32.const 0
-   i32.const 256
+   i32.const 144
    i32.const 122
    i32.const 13
    call $~lib/builtins/abort
@@ -15855,7 +15884,7 @@
    i32.and
    if
     i32.const 0
-    i32.const 256
+    i32.const 144
     i32.const 126
     i32.const 17
     call $~lib/builtins/abort
@@ -15870,7 +15899,7 @@
    i32.le_u
    if
     i32.const 0
-    i32.const 256
+    i32.const 144
     i32.const 136
     i32.const 15
     call $~lib/builtins/abort
@@ -15887,7 +15916,7 @@
    i32.store offset=4
   end
  )
- (func $~lib/rt/pure/__visit (; 198 ;) (param $0 i32)
+ (func $~lib/rt/pure/__visit (; 202 ;) (param $0 i32)
   local.get $0
   i32.const 8388
   i32.lt_u
@@ -15899,7 +15928,7 @@
   i32.sub
   call $~lib/rt/pure/decrement
  )
- (func $~lib/array/Array<std/array/Ref>#__visit_impl (; 199 ;) (param $0 i32)
+ (func $~lib/array/Array<std/array/Ref>#__visit_impl (; 203 ;) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -15931,7 +15960,7 @@
    end
   end
  )
- (func $~lib/rt/__visit_members (; 200 ;) (param $0 i32)
+ (func $~lib/rt/__visit_members (; 204 ;) (param $0 i32)
   block $block$4$break
    block $switch$1$default
     block $switch$1$case$27

--- a/tests/compiler/std/array.ts
+++ b/tests/compiler/std/array.ts
@@ -1,3 +1,4 @@
+import { ArrayBufferView } from "arraybuffer";
 import { Array } from "array";
 import { COMPARATOR } from "util/sort";
 
@@ -5,7 +6,7 @@ import { COMPARATOR } from "util/sort";
 function internalCapacity<T>(array: Array<T>): i32 {
   // the memory region used by the backing buffer might still be larger in that the ArrayBuffer
   // pre-allocates a power of 2 sized buffer itself and reuses it as long as it isn't exceeded.
-  var buffer: ArrayBuffer = array.buffer;
+  var buffer = changetype<ArrayBufferView>(array).data;
   return buffer.byteLength >> alignof<T>();
 }
 

--- a/tests/compiler/std/array.untouched.wat
+++ b/tests/compiler/std/array.untouched.wat
@@ -36,11 +36,11 @@
  (import "Math" "random" (func $~lib/bindings/Math/random (result f64)))
  (import "rtrace" "ondecrement" (func $~lib/rt/rtrace/ondecrement (param i32)))
  (memory $0 1)
- (data (i32.const 16) "\1c\00\00\00\01\00\00\00\01\00\00\00\1c\00\00\00I\00n\00v\00a\00l\00i\00d\00 \00l\00e\00n\00g\00t\00h\00")
- (data (i32.const 64) "&\00\00\00\01\00\00\00\01\00\00\00&\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00b\00u\00f\00f\00e\00r\00.\00t\00s\00")
- (data (i32.const 128) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s\00")
- (data (i32.const 176) "(\00\00\00\01\00\00\00\01\00\00\00(\00\00\00a\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e\00")
- (data (i32.const 240) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00p\00u\00r\00e\00.\00t\00s\00")
+ (data (i32.const 16) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s\00")
+ (data (i32.const 64) "(\00\00\00\01\00\00\00\01\00\00\00(\00\00\00a\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e\00")
+ (data (i32.const 128) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00p\00u\00r\00e\00.\00t\00s\00")
+ (data (i32.const 176) "\1c\00\00\00\01\00\00\00\01\00\00\00\1c\00\00\00I\00n\00v\00a\00l\00i\00d\00 \00l\00e\00n\00g\00t\00h\00")
+ (data (i32.const 224) "&\00\00\00\01\00\00\00\01\00\00\00&\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00b\00u\00f\00f\00e\00r\00.\00t\00s\00")
  (data (i32.const 288) "\18\00\00\00\01\00\00\00\01\00\00\00\18\00\00\00s\00t\00d\00/\00a\00r\00r\00a\00y\00.\00t\00s\00")
  (data (i32.const 336) "\06\00\00\00\01\00\00\00\01\00\00\00\06\00\00\00a\00b\00c\00")
  (data (i32.const 368) "\05\00\00\00\01\00\00\00\00\00\00\00\05\00\00\00\01\02\03\04\05")
@@ -267,7 +267,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 277
    i32.const 13
    call $~lib/builtins/abort
@@ -292,7 +292,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 279
    i32.const 13
    call $~lib/builtins/abort
@@ -344,7 +344,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 292
    i32.const 13
    call $~lib/builtins/abort
@@ -474,7 +474,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 205
    i32.const 13
    call $~lib/builtins/abort
@@ -489,7 +489,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 207
    i32.const 13
    call $~lib/builtins/abort
@@ -582,7 +582,7 @@
    i32.eqz
    if
     i32.const 0
-    i32.const 144
+    i32.const 32
     i32.const 228
     i32.const 15
     call $~lib/builtins/abort
@@ -645,7 +645,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 243
    i32.const 13
    call $~lib/builtins/abort
@@ -661,7 +661,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 244
    i32.const 13
    call $~lib/builtins/abort
@@ -718,7 +718,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 260
    i32.const 13
    call $~lib/builtins/abort
@@ -837,7 +837,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 386
    i32.const 4
    call $~lib/builtins/abort
@@ -860,7 +860,7 @@
    i32.eqz
    if
     i32.const 0
-    i32.const 144
+    i32.const 32
     i32.const 396
     i32.const 15
     call $~lib/builtins/abort
@@ -891,7 +891,7 @@
    i32.eqz
    if
     i32.const 0
-    i32.const 144
+    i32.const 32
     i32.const 408
     i32.const 4
     call $~lib/builtins/abort
@@ -1112,8 +1112,8 @@
   i32.const 1073741808
   i32.ge_u
   if
-   i32.const 192
-   i32.const 144
+   i32.const 80
+   i32.const 32
    i32.const 457
    i32.const 29
    call $~lib/builtins/abort
@@ -1207,7 +1207,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 338
    i32.const 13
    call $~lib/builtins/abort
@@ -1270,7 +1270,7 @@
     i32.eqz
     if
      i32.const 0
-     i32.const 144
+     i32.const 32
      i32.const 351
      i32.const 17
      call $~lib/builtins/abort
@@ -1415,7 +1415,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 365
    i32.const 13
    call $~lib/builtins/abort
@@ -1504,7 +1504,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 490
    i32.const 13
    call $~lib/builtins/abort
@@ -1545,7 +1545,7 @@
      i32.eqz
      if
       i32.const 0
-      i32.const 144
+      i32.const 32
       i32.const 502
       i32.const 19
       call $~lib/builtins/abort
@@ -1564,7 +1564,7 @@
     i32.eqz
     if
      i32.const 0
-     i32.const 144
+     i32.const 32
      i32.const 507
      i32.const 17
      call $~lib/builtins/abort
@@ -1581,7 +1581,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 510
    i32.const 13
    call $~lib/builtins/abort
@@ -1615,7 +1615,85 @@
   i32.const 16
   i32.add
  )
- (func $~lib/memory/memory.fill (; 17 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/rt/pure/increment (; 17 ;) (param $0 i32)
+  (local $1 i32)
+  local.get $0
+  i32.load offset=4
+  local.set $1
+  local.get $1
+  i32.const -268435456
+  i32.and
+  local.get $1
+  i32.const 1
+  i32.add
+  i32.const -268435456
+  i32.and
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 144
+   i32.const 109
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  local.get $1
+  i32.const 1
+  i32.add
+  i32.store offset=4
+  local.get $0
+  call $~lib/rt/rtrace/onincrement
+  local.get $0
+  i32.load
+  i32.const 1
+  i32.and
+  i32.eqz
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 144
+   i32.const 112
+   i32.const 13
+   call $~lib/builtins/abort
+   unreachable
+  end
+ )
+ (func $~lib/rt/pure/__retain (; 18 ;) (param $0 i32) (result i32)
+  local.get $0
+  global.get $~lib/heap/__heap_base
+  i32.gt_u
+  if
+   local.get $0
+   i32.const 16
+   i32.sub
+   call $~lib/rt/pure/increment
+  end
+  local.get $0
+ )
+ (func $~lib/arraybuffer/ArrayBufferView#constructor (; 19 ;) (param $0 i32) (result i32)
+  local.get $0
+  i32.eqz
+  if
+   i32.const 12
+   i32.const 2
+   call $~lib/rt/tlsf/__alloc
+   call $~lib/rt/pure/__retain
+   local.set $0
+  end
+  local.get $0
+  i32.const 0
+  i32.store
+  local.get $0
+  i32.const 0
+  i32.store offset=4
+  local.get $0
+  i32.const 0
+  i32.store offset=8
+  local.get $0
+ )
+ (func $~lib/memory/memory.fill (; 20 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1879,64 +1957,7 @@
    end
   end
  )
- (func $~lib/rt/pure/increment (; 18 ;) (param $0 i32)
-  (local $1 i32)
-  local.get $0
-  i32.load offset=4
-  local.set $1
-  local.get $1
-  i32.const -268435456
-  i32.and
-  local.get $1
-  i32.const 1
-  i32.add
-  i32.const -268435456
-  i32.and
-  i32.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 256
-   i32.const 109
-   i32.const 2
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $0
-  local.get $1
-  i32.const 1
-  i32.add
-  i32.store offset=4
-  local.get $0
-  call $~lib/rt/rtrace/onincrement
-  local.get $0
-  i32.load
-  i32.const 1
-  i32.and
-  i32.eqz
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 256
-   i32.const 112
-   i32.const 13
-   call $~lib/builtins/abort
-   unreachable
-  end
- )
- (func $~lib/rt/pure/__retain (; 19 ;) (param $0 i32) (result i32)
-  local.get $0
-  global.get $~lib/heap/__heap_base
-  i32.gt_u
-  if
-   local.get $0
-   i32.const 16
-   i32.sub
-   call $~lib/rt/pure/increment
-  end
-  local.get $0
- )
- (func $~lib/rt/pure/__release (; 20 ;) (param $0 i32)
+ (func $~lib/rt/pure/__release (; 21 ;) (param $0 i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.gt_u
@@ -1947,7 +1968,7 @@
    call $~lib/rt/pure/decrement
   end
  )
- (func $~lib/arraybuffer/ArrayBufferView#constructor (; 21 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBufferView#alloc (; 22 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1958,9 +1979,9 @@
   i32.shr_u
   i32.gt_u
   if
-   i32.const 32
-   i32.const 80
-   i32.const 23
+   i32.const 192
+   i32.const 240
+   i32.const 14
    i32.const 56
    call $~lib/builtins/abort
    unreachable
@@ -1976,24 +1997,6 @@
   i32.const 0
   local.get $1
   call $~lib/memory/memory.fill
-  local.get $0
-  i32.eqz
-  if
-   i32.const 12
-   i32.const 2
-   call $~lib/rt/tlsf/__alloc
-   call $~lib/rt/pure/__retain
-   local.set $0
-  end
-  local.get $0
-  i32.const 0
-  i32.store
-  local.get $0
-  i32.const 0
-  i32.store offset=4
-  local.get $0
-  i32.const 0
-  i32.store offset=8
   local.get $0
   local.tee $4
   local.get $3
@@ -2017,9 +2020,8 @@
   local.get $0
   local.get $1
   i32.store offset=8
-  local.get $0
  )
- (func $~lib/array/Array<i32>#constructor (; 22 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#constructor (; 23 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   if (result i32)
    local.get $0
@@ -2029,8 +2031,6 @@
    call $~lib/rt/tlsf/__alloc
    call $~lib/rt/pure/__retain
   end
-  local.get $1
-  i32.const 2
   call $~lib/arraybuffer/ArrayBufferView#constructor
   local.set $0
   local.get $0
@@ -2038,10 +2038,14 @@
   i32.store offset=12
   local.get $0
   local.get $1
+  i32.const 2
+  call $~lib/arraybuffer/ArrayBufferView#alloc
+  local.get $0
+  local.get $1
   i32.store offset=12
   local.get $0
  )
- (func $~lib/array/Array.isArray<~lib/array/Array<i32> | null> (; 23 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array.isArray<~lib/array/Array<i32> | null> (; 24 ;) (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -2059,7 +2063,7 @@
   call $~lib/rt/pure/__release
   local.get $1
  )
- (func $std/array/Ref#constructor (; 24 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/array/Ref#constructor (; 25 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -2074,7 +2078,7 @@
   i32.store
   local.get $0
  )
- (func $~lib/array/Array.isArray<std/array/Ref> (; 25 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array.isArray<std/array/Ref> (; 26 ;) (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -2092,7 +2096,7 @@
   call $~lib/rt/pure/__release
   local.get $1
  )
- (func $~lib/typedarray/Uint8Array#constructor (; 26 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#constructor (; 27 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   if (result i32)
    local.get $0
@@ -2102,13 +2106,15 @@
    call $~lib/rt/tlsf/__alloc
    call $~lib/rt/pure/__retain
   end
-  local.get $1
-  i32.const 0
   call $~lib/arraybuffer/ArrayBufferView#constructor
   local.set $0
   local.get $0
+  local.get $1
+  i32.const 0
+  call $~lib/arraybuffer/ArrayBufferView#alloc
+  local.get $0
  )
- (func $~lib/array/Array.isArray<~lib/typedarray/Uint8Array> (; 27 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array.isArray<~lib/typedarray/Uint8Array> (; 28 ;) (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -2126,10 +2132,10 @@
   call $~lib/rt/pure/__release
   local.get $1
  )
- (func $~lib/array/Array.isArray<i32> (; 28 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array.isArray<i32> (; 29 ;) (param $0 i32) (result i32)
   i32.const 0
  )
- (func $~lib/array/Array.isArray<~lib/string/String> (; 29 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array.isArray<~lib/string/String> (; 30 ;) (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -2147,7 +2153,7 @@
   call $~lib/rt/pure/__release
   local.get $1
  )
- (func $~lib/array/Array.isArray<~lib/array/Array<i32>> (; 30 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array.isArray<~lib/array/Array<i32>> (; 31 ;) (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -2165,7 +2171,7 @@
   call $~lib/rt/pure/__release
   local.get $1
  )
- (func $~lib/util/memory/memcpy (; 31 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/memory/memcpy (; 32 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3189,7 +3195,7 @@
    i32.store8
   end
  )
- (func $~lib/memory/memory.copy (; 32 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/memory/memory.copy (; 33 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3409,7 +3415,7 @@
    end
   end
  )
- (func $~lib/rt/__allocArray (; 33 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $~lib/rt/__allocArray (; 34 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -3447,7 +3453,7 @@
   end
   local.get $4
  )
- (func $~lib/array/Array<u8>#fill (; 34 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $~lib/array/Array<u8>#fill (; 35 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -3524,11 +3530,11 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/array/Array<u8>#get:length (; 35 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<u8>#get:length (; 36 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<u8>#__unchecked_get (; 36 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u8>#__unchecked_get (; 37 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -3537,7 +3543,7 @@
   i32.add
   i32.load8_u
  )
- (func $~lib/array/Array<u8>#__get (; 37 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u8>#__get (; 38 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   local.get $0
@@ -3546,7 +3552,7 @@
   if
    i32.const 448
    i32.const 512
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -3557,7 +3563,7 @@
   local.set $2
   local.get $2
  )
- (func $std/array/isArraysEqual<u8> (; 38 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/array/isArraysEqual<u8> (; 39 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3642,7 +3648,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/array/Array<u32>#fill (; 39 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $~lib/array/Array<u32>#fill (; 40 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -3727,11 +3733,11 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/array/Array<u32>#get:length (; 40 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<u32>#get:length (; 41 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<u32>#__unchecked_get (; 41 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u32>#__unchecked_get (; 42 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -3740,7 +3746,7 @@
   i32.add
   i32.load
  )
- (func $~lib/array/Array<u32>#__get (; 42 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u32>#__get (; 43 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   local.get $0
@@ -3749,7 +3755,7 @@
   if
    i32.const 448
    i32.const 512
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -3760,7 +3766,7 @@
   local.set $2
   local.get $2
  )
- (func $std/array/isArraysEqual<u32> (; 43 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/array/isArraysEqual<u32> (; 44 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3845,17 +3851,17 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/array/Array<i32>#get:length (; 44 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<i32>#get:length (; 45 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/arraybuffer/ArrayBuffer#get:byteLength (; 45 ;) (param $0 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBuffer#get:byteLength (; 46 ;) (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub
   i32.load offset=12
  )
- (func $std/array/internalCapacity<i32> (; 46 ;) (param $0 i32) (result i32)
+ (func $std/array/internalCapacity<i32> (; 47 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -3876,7 +3882,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/rt/tlsf/checkUsedBlock (; 47 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/tlsf/checkUsedBlock (; 48 ;) (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   i32.const 16
@@ -3914,7 +3920,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 570
    i32.const 2
    call $~lib/builtins/abort
@@ -3922,7 +3928,7 @@
   end
   local.get $1
  )
- (func $~lib/rt/tlsf/freeBlock (; 48 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/freeBlock (; 49 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $1
   i32.load
@@ -3938,7 +3944,7 @@
   local.get $1
   call $~lib/rt/rtrace/onfree
  )
- (func $~lib/rt/tlsf/reallocateBlock (; 49 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/reallocateBlock (; 50 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -4057,7 +4063,7 @@
   end
   local.get $8
  )
- (func $~lib/rt/tlsf/__realloc (; 50 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/__realloc (; 51 ;) (param $0 i32) (param $1 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
   local.get $0
   call $~lib/rt/tlsf/checkUsedBlock
@@ -4066,7 +4072,7 @@
   i32.const 16
   i32.add
  )
- (func $~lib/array/ensureSize (; 51 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/ensureSize (; 52 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -4086,7 +4092,7 @@
    i32.shr_u
    i32.gt_u
    if
-    i32.const 32
+    i32.const 192
     i32.const 512
     i32.const 14
     i32.const 47
@@ -4128,7 +4134,7 @@
    i32.store offset=8
   end
  )
- (func $~lib/array/Array<i32>#push (; 52 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#push (; 53 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -4155,7 +4161,7 @@
   i32.store offset=12
   local.get $3
  )
- (func $~lib/array/Array<i32>#__unchecked_get (; 53 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#__unchecked_get (; 54 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -4164,7 +4170,7 @@
   i32.add
   i32.load
  )
- (func $~lib/array/Array<i32>#__get (; 54 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#__get (; 55 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   local.get $0
@@ -4173,7 +4179,7 @@
   if
    i32.const 448
    i32.const 512
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -4184,7 +4190,7 @@
   local.set $2
   local.get $2
  )
- (func $~lib/array/Array<i32>#pop (; 55 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<i32>#pop (; 56 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -4196,7 +4202,7 @@
   if
    i32.const 976
    i32.const 512
-   i32.const 288
+   i32.const 293
    i32.const 20
    call $~lib/builtins/abort
    unreachable
@@ -4217,7 +4223,7 @@
   i32.store offset=12
   local.get $2
  )
- (func $~lib/array/Array<std/array/Ref>#set:length (; 56 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<std/array/Ref>#set:length (; 57 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4269,11 +4275,11 @@
   local.get $1
   i32.store offset=12
  )
- (func $~lib/array/Array<std/array/Ref>#get:length (; 57 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<std/array/Ref>#get:length (; 58 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<i32>#concat (; 58 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#concat (; 59 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4305,9 +4311,9 @@
   if
    local.get $1
    call $~lib/rt/pure/__release
-   i32.const 32
+   i32.const 192
    i32.const 512
-   i32.const 218
+   i32.const 223
    i32.const 59
    call $~lib/builtins/abort
    unreachable
@@ -4346,7 +4352,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $~lib/array/Array<i32>#copyWithin (; 59 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $~lib/array/Array<i32>#copyWithin (; 60 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -4475,7 +4481,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $std/array/isArraysEqual<i32> (; 60 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/array/isArraysEqual<i32> (; 61 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -4560,7 +4566,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/array/Array<i32>#unshift (; 61 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#unshift (; 62 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -4593,7 +4599,7 @@
   i32.store offset=12
   local.get $2
  )
- (func $~lib/array/Array<i32>#shift (; 62 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<i32>#shift (; 63 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -4607,7 +4613,7 @@
   if
    i32.const 976
    i32.const 512
-   i32.const 349
+   i32.const 354
    i32.const 20
    call $~lib/builtins/abort
    unreachable
@@ -4642,7 +4648,7 @@
   i32.store offset=12
   local.get $3
  )
- (func $~lib/array/Array<i32>#reverse (; 63 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<i32>#reverse (; 64 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -4697,7 +4703,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/array/Array<i32>#indexOf (; 64 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/array/Array<i32>#indexOf (; 65 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -4766,7 +4772,7 @@
   end
   i32.const -1
  )
- (func $~lib/array/Array<f32>#indexOf (; 65 ;) (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
+ (func $~lib/array/Array<f32>#indexOf (; 66 ;) (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -4835,7 +4841,7 @@
   end
   i32.const -1
  )
- (func $~lib/array/Array<f64>#indexOf (; 66 ;) (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
+ (func $~lib/array/Array<f64>#indexOf (; 67 ;) (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -4904,7 +4910,7 @@
   end
   i32.const -1
  )
- (func $~lib/array/Array<i32>#includes (; 67 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/array/Array<i32>#includes (; 68 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   local.get $1
   local.get $2
@@ -4913,7 +4919,7 @@
   i32.ge_s
   return
  )
- (func $~lib/array/Array<f32>#includes (; 68 ;) (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
+ (func $~lib/array/Array<f32>#includes (; 69 ;) (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -4996,7 +5002,7 @@
   i32.const 0
   return
  )
- (func $~lib/array/Array<f64>#includes (; 69 ;) (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
+ (func $~lib/array/Array<f64>#includes (; 70 ;) (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -5079,7 +5085,7 @@
   i32.const 0
   return
  )
- (func $~lib/array/Array<i32>#splice (; 70 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/array/Array<i32>#splice (; 71 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -5187,7 +5193,7 @@
   i32.store offset=12
   local.get $6
  )
- (func $~lib/array/Array<std/array/Ref>#splice (; 71 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/array/Array<std/array/Ref>#splice (; 72 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -5295,7 +5301,7 @@
   i32.store offset=12
   local.get $6
  )
- (func $~lib/array/Array<std/array/Ref>#__unchecked_get (; 72 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<std/array/Ref>#__unchecked_get (; 73 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -5305,7 +5311,7 @@
   i32.load
   call $~lib/rt/pure/__retain
  )
- (func $~lib/array/Array<std/array/Ref>#__get (; 73 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<std/array/Ref>#__get (; 74 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   local.get $0
@@ -5314,7 +5320,7 @@
   if
    i32.const 448
    i32.const 512
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -5330,14 +5336,14 @@
    call $~lib/rt/pure/__release
    i32.const 3920
    i32.const 512
-   i32.const 97
+   i32.const 102
    i32.const 39
    call $~lib/builtins/abort
    unreachable
   end
   local.get $2
  )
- (func $~lib/array/Array<std/array/Ref | null>#splice (; 74 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/array/Array<std/array/Ref | null>#splice (; 75 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -5445,11 +5451,11 @@
   i32.store offset=12
   local.get $6
  )
- (func $~lib/array/Array<std/array/Ref | null>#get:length (; 75 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<std/array/Ref | null>#get:length (; 76 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<std/array/Ref | null>#__unchecked_get (; 76 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<std/array/Ref | null>#__unchecked_get (; 77 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -5459,7 +5465,7 @@
   i32.load
   call $~lib/rt/pure/__retain
  )
- (func $~lib/array/Array<std/array/Ref | null>#__get (; 77 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<std/array/Ref | null>#__get (; 78 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   local.get $0
@@ -5468,7 +5474,7 @@
   if
    i32.const 448
    i32.const 512
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -5479,7 +5485,7 @@
   local.set $2
   local.get $2
  )
- (func $~lib/array/Array<i32>#__unchecked_set (; 78 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<i32>#__unchecked_set (; 79 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -5489,7 +5495,7 @@
   local.get $2
   i32.store
  )
- (func $~lib/array/Array<i32>#__set (; 79 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<i32>#__set (; 80 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -5501,7 +5507,7 @@
    if
     i32.const 448
     i32.const 512
-    i32.const 109
+    i32.const 114
     i32.const 21
     call $~lib/builtins/abort
     unreachable
@@ -5523,7 +5529,7 @@
   local.get $2
   call $~lib/array/Array<i32>#__unchecked_set
  )
- (func $start:std/array~anonymous|0 (; 80 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|0 (; 81 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -5536,11 +5542,11 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~setArgumentsLength (; 81 ;) (param $0 i32)
+ (func $~setArgumentsLength (; 82 ;) (param $0 i32)
   local.get $0
   global.set $~argumentsLength
  )
- (func $~lib/array/Array<i32>#findIndex (; 82 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#findIndex (; 83 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5591,7 +5597,7 @@
   end
   i32.const -1
  )
- (func $start:std/array~anonymous|1 (; 83 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|1 (; 84 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -5604,7 +5610,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $start:std/array~anonymous|2 (; 84 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|2 (; 85 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -5617,7 +5623,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $start:std/array~anonymous|3 (; 85 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|3 (; 86 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -5634,7 +5640,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $start:std/array~anonymous|4 (; 86 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|4 (; 87 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -5647,7 +5653,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $start:std/array~anonymous|5 (; 87 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|5 (; 88 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -5663,7 +5669,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $start:std/array~anonymous|6 (; 88 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|6 (; 89 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -5676,7 +5682,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/array/Array<i32>#every (; 89 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#every (; 90 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5728,7 +5734,7 @@
   end
   i32.const 1
  )
- (func $start:std/array~anonymous|7 (; 90 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|7 (; 91 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -5741,7 +5747,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $start:std/array~anonymous|8 (; 91 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|8 (; 92 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -5758,7 +5764,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $start:std/array~anonymous|9 (; 92 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|9 (; 93 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -5771,7 +5777,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $start:std/array~anonymous|10 (; 93 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|10 (; 94 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -5787,7 +5793,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $start:std/array~anonymous|11 (; 94 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|11 (; 95 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -5800,7 +5806,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/array/Array<i32>#some (; 95 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#some (; 96 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5851,7 +5857,7 @@
   end
   i32.const 0
  )
- (func $start:std/array~anonymous|12 (; 96 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|12 (; 97 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -5864,7 +5870,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $start:std/array~anonymous|13 (; 97 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|13 (; 98 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -5881,7 +5887,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $start:std/array~anonymous|14 (; 98 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|14 (; 99 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -5894,7 +5900,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $start:std/array~anonymous|15 (; 99 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|15 (; 100 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -5910,7 +5916,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $start:std/array~anonymous|16 (; 100 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $start:std/array~anonymous|16 (; 101 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $2
   call $~lib/rt/pure/__retain
   local.set $2
@@ -5921,7 +5927,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $~lib/array/Array<i32>#forEach (; 101 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i32>#forEach (; 102 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5967,7 +5973,7 @@
    end
   end
  )
- (func $start:std/array~anonymous|17 (; 102 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $start:std/array~anonymous|17 (; 103 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $2
   call $~lib/rt/pure/__retain
   local.set $2
@@ -5982,7 +5988,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $start:std/array~anonymous|18 (; 103 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $start:std/array~anonymous|18 (; 104 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $2
   call $~lib/rt/pure/__retain
   local.set $2
@@ -5993,7 +5999,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $start:std/array~anonymous|19 (; 104 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $start:std/array~anonymous|19 (; 105 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $2
   call $~lib/rt/pure/__retain
   local.set $2
@@ -6007,7 +6013,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $start:std/array~anonymous|20 (; 105 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $start:std/array~anonymous|20 (; 106 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $2
@@ -6111,7 +6117,7 @@
    if
     i32.const 0
     i32.const 304
-    i32.const 619
+    i32.const 620
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -6120,7 +6126,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $start:std/array~anonymous|21 (; 106 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result f32)
+ (func $start:std/array~anonymous|21 (; 107 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result f32)
   (local $3 f32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -6132,7 +6138,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/array/Array<i32>#map<f32> (; 107 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#map<f32> (; 108 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6200,11 +6206,11 @@
   end
   local.get $3
  )
- (func $~lib/array/Array<f32>#get:length (; 108 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<f32>#get:length (; 109 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<f32>#__unchecked_get (; 109 ;) (param $0 i32) (param $1 i32) (result f32)
+ (func $~lib/array/Array<f32>#__unchecked_get (; 110 ;) (param $0 i32) (param $1 i32) (result f32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -6213,7 +6219,7 @@
   i32.add
   f32.load
  )
- (func $~lib/array/Array<f32>#__get (; 110 ;) (param $0 i32) (param $1 i32) (result f32)
+ (func $~lib/array/Array<f32>#__get (; 111 ;) (param $0 i32) (param $1 i32) (result f32)
   (local $2 f32)
   local.get $1
   local.get $0
@@ -6222,7 +6228,7 @@
   if
    i32.const 448
    i32.const 512
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -6233,7 +6239,7 @@
   local.set $2
   local.get $2
  )
- (func $start:std/array~anonymous|22 (; 111 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|22 (; 112 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -6252,7 +6258,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/array/Array<i32>#map<i32> (; 112 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#map<i32> (; 113 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6319,7 +6325,7 @@
   end
   local.get $3
  )
- (func $start:std/array~anonymous|23 (; 113 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|23 (; 114 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -6334,7 +6340,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $start:std/array~anonymous|24 (; 114 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|24 (; 115 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -6352,7 +6358,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $start:std/array~anonymous|25 (; 115 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|25 (; 116 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -6365,7 +6371,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/array/Array<i32>#filter (; 116 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#filter (; 117 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6428,7 +6434,7 @@
   end
   local.get $2
  )
- (func $start:std/array~anonymous|26 (; 117 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|26 (; 118 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -6449,7 +6455,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $start:std/array~anonymous|27 (; 118 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|27 (; 119 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -6466,7 +6472,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $start:std/array~anonymous|28 (; 119 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|28 (; 120 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -6486,7 +6492,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $start:std/array~anonymous|29 (; 120 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|29 (; 121 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -6499,7 +6505,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/array/Array<i32>#reduce<i32> (; 121 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/array/Array<i32>#reduce<i32> (; 122 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -6551,7 +6557,7 @@
   end
   local.get $3
  )
- (func $start:std/array~anonymous|30 (; 122 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|30 (; 123 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -6564,7 +6570,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $start:std/array~anonymous|31 (; 123 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|31 (; 124 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -6582,7 +6588,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/array/Array<i32>#reduce<bool> (; 124 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/array/Array<i32>#reduce<bool> (; 125 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -6634,7 +6640,7 @@
   end
   local.get $3
  )
- (func $start:std/array~anonymous|32 (; 125 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|32 (; 126 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -6652,7 +6658,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $start:std/array~anonymous|33 (; 126 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|33 (; 127 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -6669,7 +6675,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $start:std/array~anonymous|34 (; 127 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|34 (; 128 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -6682,7 +6688,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $start:std/array~anonymous|35 (; 128 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|35 (; 129 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -6698,7 +6704,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $start:std/array~anonymous|36 (; 129 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|36 (; 130 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -6711,7 +6717,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/array/Array<i32>#reduceRight<i32> (; 130 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/array/Array<i32>#reduceRight<i32> (; 131 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -6753,7 +6759,7 @@
   end
   local.get $3
  )
- (func $start:std/array~anonymous|37 (; 131 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|37 (; 132 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -6766,7 +6772,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $start:std/array~anonymous|38 (; 132 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|38 (; 133 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -6784,7 +6790,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/array/Array<i32>#reduceRight<bool> (; 133 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/array/Array<i32>#reduceRight<bool> (; 134 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -6826,7 +6832,7 @@
   end
   local.get $3
  )
- (func $start:std/array~anonymous|39 (; 134 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|39 (; 135 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -6844,7 +6850,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $start:std/array~anonymous|40 (; 135 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|40 (; 136 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -6861,7 +6867,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $start:std/array~anonymous|41 (; 136 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|41 (; 137 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -6874,7 +6880,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $start:std/array~anonymous|42 (; 137 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|42 (; 138 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -6890,7 +6896,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/math/murmurHash3 (; 138 ;) (param $0 i64) (result i64)
+ (func $~lib/math/murmurHash3 (; 139 ;) (param $0 i64) (result i64)
   local.get $0
   local.get $0
   i64.const 33
@@ -6919,7 +6925,7 @@
   local.set $0
   local.get $0
  )
- (func $~lib/math/splitMix32 (; 139 ;) (param $0 i32) (result i32)
+ (func $~lib/math/splitMix32 (; 140 ;) (param $0 i32) (result i32)
   local.get $0
   i32.const 1831565813
   i32.add
@@ -6954,7 +6960,7 @@
   i32.shr_u
   i32.xor
  )
- (func $~lib/math/NativeMath.seedRandom (; 140 ;) (param $0 i64)
+ (func $~lib/math/NativeMath.seedRandom (; 141 ;) (param $0 i64)
   i32.const 1
   global.set $~lib/math/random_seeded
   local.get $0
@@ -7006,7 +7012,7 @@
    unreachable
   end
  )
- (func $~lib/util/sort/insertionSort<f32> (; 141 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/sort/insertionSort<f32> (; 142 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 f32)
@@ -7096,13 +7102,13 @@
    end
   end
  )
- (func $~lib/rt/tlsf/__free (; 142 ;) (param $0 i32)
+ (func $~lib/rt/tlsf/__free (; 143 ;) (param $0 i32)
   call $~lib/rt/tlsf/maybeInitialize
   local.get $0
   call $~lib/rt/tlsf/checkUsedBlock
   call $~lib/rt/tlsf/freeBlock
  )
- (func $~lib/util/sort/weakHeapSort<f32> (; 143 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/sort/weakHeapSort<f32> (; 144 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -7391,7 +7397,7 @@
   local.get $12
   f32.store
  )
- (func $~lib/array/Array<f32>#sort (; 144 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<f32>#sort (; 145 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 f32)
@@ -7466,7 +7472,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/sort/COMPARATOR<f32>~anonymous|0 (; 145 ;) (param $0 f32) (param $1 f32) (result i32)
+ (func $~lib/util/sort/COMPARATOR<f32>~anonymous|0 (; 146 ;) (param $0 f32) (param $1 f32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -7499,7 +7505,7 @@
   i32.lt_s
   i32.sub
  )
- (func $~lib/array/Array<f32>#sort|trampoline (; 146 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<f32>#sort|trampoline (; 147 ;) (param $0 i32) (param $1 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -7518,7 +7524,7 @@
   local.get $1
   call $~lib/array/Array<f32>#sort
  )
- (func $std/array/isArraysEqual<f32> (; 147 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/array/isArraysEqual<f32> (; 148 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 f32)
@@ -7625,7 +7631,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/util/sort/insertionSort<f64> (; 148 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/sort/insertionSort<f64> (; 149 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 f64)
@@ -7715,7 +7721,7 @@
    end
   end
  )
- (func $~lib/util/sort/weakHeapSort<f64> (; 149 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/sort/weakHeapSort<f64> (; 150 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -8004,7 +8010,7 @@
   local.get $12
   f64.store
  )
- (func $~lib/array/Array<f64>#sort (; 150 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<f64>#sort (; 151 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 f64)
@@ -8079,7 +8085,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/sort/COMPARATOR<f64>~anonymous|0 (; 151 ;) (param $0 f64) (param $1 f64) (result i32)
+ (func $~lib/util/sort/COMPARATOR<f64>~anonymous|0 (; 152 ;) (param $0 f64) (param $1 f64) (result i32)
   (local $2 i64)
   (local $3 i64)
   local.get $0
@@ -8112,7 +8118,7 @@
   i64.lt_s
   i32.sub
  )
- (func $~lib/array/Array<f64>#sort|trampoline (; 152 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<f64>#sort|trampoline (; 153 ;) (param $0 i32) (param $1 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -8131,11 +8137,11 @@
   local.get $1
   call $~lib/array/Array<f64>#sort
  )
- (func $~lib/array/Array<f64>#get:length (; 153 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<f64>#get:length (; 154 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<f64>#__unchecked_get (; 154 ;) (param $0 i32) (param $1 i32) (result f64)
+ (func $~lib/array/Array<f64>#__unchecked_get (; 155 ;) (param $0 i32) (param $1 i32) (result f64)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -8144,7 +8150,7 @@
   i32.add
   f64.load
  )
- (func $~lib/array/Array<f64>#__get (; 155 ;) (param $0 i32) (param $1 i32) (result f64)
+ (func $~lib/array/Array<f64>#__get (; 156 ;) (param $0 i32) (param $1 i32) (result f64)
   (local $2 f64)
   local.get $1
   local.get $0
@@ -8153,7 +8159,7 @@
   if
    i32.const 448
    i32.const 512
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -8164,7 +8170,7 @@
   local.set $2
   local.get $2
  )
- (func $std/array/isArraysEqual<f64> (; 156 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/array/isArraysEqual<f64> (; 157 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 f64)
@@ -8271,7 +8277,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/util/sort/insertionSort<i32> (; 157 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/sort/insertionSort<i32> (; 158 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -8361,7 +8367,7 @@
    end
   end
  )
- (func $~lib/util/sort/weakHeapSort<i32> (; 158 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/sort/weakHeapSort<i32> (; 159 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -8650,7 +8656,7 @@
   local.get $12
   i32.store
  )
- (func $~lib/array/Array<i32>#sort (; 159 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#sort (; 160 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -8723,12 +8729,12 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/sort/COMPARATOR<i32>~anonymous|0 (; 160 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/sort/COMPARATOR<i32>~anonymous|0 (; 161 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.sub
  )
- (func $~lib/array/Array<i32>#sort|trampoline (; 161 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#sort|trampoline (; 162 ;) (param $0 i32) (param $1 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -8747,7 +8753,7 @@
   local.get $1
   call $~lib/array/Array<i32>#sort
  )
- (func $~lib/util/sort/insertionSort<u32> (; 162 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/sort/insertionSort<u32> (; 163 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -8837,7 +8843,7 @@
    end
   end
  )
- (func $~lib/util/sort/weakHeapSort<u32> (; 163 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/sort/weakHeapSort<u32> (; 164 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -9126,7 +9132,7 @@
   local.get $12
   i32.store
  )
- (func $~lib/array/Array<u32>#sort (; 164 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u32>#sort (; 165 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9199,7 +9205,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/sort/COMPARATOR<u32>~anonymous|0 (; 165 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/sort/COMPARATOR<u32>~anonymous|0 (; 166 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.gt_u
@@ -9208,7 +9214,7 @@
   i32.lt_u
   i32.sub
  )
- (func $~lib/array/Array<u32>#sort|trampoline (; 166 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u32>#sort|trampoline (; 167 ;) (param $0 i32) (param $1 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -9227,7 +9233,7 @@
   local.get $1
   call $~lib/array/Array<u32>#sort
  )
- (func $std/array/createReverseOrderedArray (; 167 ;) (param $0 i32) (result i32)
+ (func $std/array/createReverseOrderedArray (; 168 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -9261,7 +9267,7 @@
   end
   local.get $1
  )
- (func $~lib/math/NativeMath.random (; 168 ;) (result f64)
+ (func $~lib/math/NativeMath.random (; 169 ;) (result f64)
   (local $0 i64)
   (local $1 i64)
   (local $2 i64)
@@ -9316,7 +9322,7 @@
   f64.const 1
   f64.sub
  )
- (func $std/array/createRandomOrderedArray (; 169 ;) (param $0 i32) (result i32)
+ (func $std/array/createRandomOrderedArray (; 170 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -9350,12 +9356,12 @@
   end
   local.get $1
  )
- (func $~lib/util/sort/COMPARATOR<i32>~anonymous|1 (; 170 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/sort/COMPARATOR<i32>~anonymous|1 (; 171 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.sub
  )
- (func $std/array/isSorted<i32> (; 171 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/array/isSorted<i32> (; 172 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9410,7 +9416,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $std/array/assertSorted<i32> (; 172 ;) (param $0 i32) (param $1 i32)
+ (func $std/array/assertSorted<i32> (; 173 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -9425,7 +9431,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 881
+   i32.const 882
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -9435,7 +9441,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $std/array/assertSortedDefault<i32> (; 173 ;) (param $0 i32)
+ (func $std/array/assertSortedDefault<i32> (; 174 ;) (param $0 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $0
@@ -9448,27 +9454,27 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $start:std/array~anonymous|43 (; 174 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $start:std/array~anonymous|43 (; 175 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.sub
  )
- (func $start:std/array~anonymous|44 (; 175 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $start:std/array~anonymous|44 (; 176 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.sub
  )
- (func $start:std/array~anonymous|45 (; 176 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $start:std/array~anonymous|45 (; 177 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.sub
  )
- (func $start:std/array~anonymous|46 (; 177 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $start:std/array~anonymous|46 (; 178 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.sub
  )
- (func $~lib/array/Array<~lib/array/Array<i32>>#constructor (; 178 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<i32>>#constructor (; 179 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   if (result i32)
    local.get $0
@@ -9478,8 +9484,6 @@
    call $~lib/rt/tlsf/__alloc
    call $~lib/rt/pure/__retain
   end
-  local.get $1
-  i32.const 2
   call $~lib/arraybuffer/ArrayBufferView#constructor
   local.set $0
   local.get $0
@@ -9487,10 +9491,14 @@
   i32.store offset=12
   local.get $0
   local.get $1
+  i32.const 2
+  call $~lib/arraybuffer/ArrayBufferView#alloc
+  local.get $0
+  local.get $1
   i32.store offset=12
   local.get $0
  )
- (func $~lib/array/Array<~lib/array/Array<i32>>#__unchecked_set (; 179 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<~lib/array/Array<i32>>#__unchecked_set (; 180 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $2
@@ -9520,7 +9528,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $~lib/array/Array<~lib/array/Array<i32>>#__set (; 180 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<~lib/array/Array<i32>>#__set (; 181 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $2
   call $~lib/rt/pure/__retain
   local.set $2
@@ -9537,7 +9545,7 @@
     call $~lib/rt/pure/__release
     i32.const 448
     i32.const 512
-    i32.const 109
+    i32.const 114
     i32.const 21
     call $~lib/builtins/abort
     unreachable
@@ -9561,7 +9569,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/array/createReverseOrderedNestedArray (; 181 ;) (param $0 i32) (result i32)
+ (func $std/array/createReverseOrderedNestedArray (; 182 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -9606,7 +9614,7 @@
   end
   local.get $1
  )
- (func $start:std/array~anonymous|47 (; 182 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $start:std/array~anonymous|47 (; 183 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -9628,7 +9636,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/util/sort/insertionSort<~lib/array/Array<i32>> (; 183 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/sort/insertionSort<~lib/array/Array<i32>> (; 184 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -9726,7 +9734,7 @@
    end
   end
  )
- (func $~lib/array/Array<~lib/array/Array<i32>>#sort (; 184 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<i32>>#sort (; 185 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9797,11 +9805,11 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/array/Array<~lib/array/Array<i32>>#get:length (; 185 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<i32>>#get:length (; 186 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<~lib/array/Array<i32>>#__unchecked_get (; 186 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<i32>>#__unchecked_get (; 187 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -9811,7 +9819,7 @@
   i32.load
   call $~lib/rt/pure/__retain
  )
- (func $~lib/array/Array<~lib/array/Array<i32>>#__get (; 187 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<i32>>#__get (; 188 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   local.get $0
@@ -9820,7 +9828,7 @@
   if
    i32.const 448
    i32.const 512
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -9836,14 +9844,14 @@
    call $~lib/rt/pure/__release
    i32.const 3920
    i32.const 512
-   i32.const 97
+   i32.const 102
    i32.const 39
    call $~lib/builtins/abort
    unreachable
   end
   local.get $2
  )
- (func $std/array/isSorted<~lib/array/Array<i32>> (; 188 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/array/isSorted<~lib/array/Array<i32>> (; 189 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9910,7 +9918,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $std/array/assertSorted<~lib/array/Array<i32>> (; 189 ;) (param $0 i32) (param $1 i32)
+ (func $std/array/assertSorted<~lib/array/Array<i32>> (; 190 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -9925,7 +9933,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 881
+   i32.const 882
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -9935,7 +9943,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/array/Array<std/array/Proxy<i32>>#constructor (; 190 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<std/array/Proxy<i32>>#constructor (; 191 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   if (result i32)
    local.get $0
@@ -9945,8 +9953,6 @@
    call $~lib/rt/tlsf/__alloc
    call $~lib/rt/pure/__retain
   end
-  local.get $1
-  i32.const 2
   call $~lib/arraybuffer/ArrayBufferView#constructor
   local.set $0
   local.get $0
@@ -9954,10 +9960,14 @@
   i32.store offset=12
   local.get $0
   local.get $1
+  i32.const 2
+  call $~lib/arraybuffer/ArrayBufferView#alloc
+  local.get $0
+  local.get $1
   i32.store offset=12
   local.get $0
  )
- (func $std/array/Proxy<i32>#constructor (; 191 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/array/Proxy<i32>#constructor (; 192 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -9972,7 +9982,7 @@
   i32.store
   local.get $0
  )
- (func $~lib/array/Array<std/array/Proxy<i32>>#__unchecked_set (; 192 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<std/array/Proxy<i32>>#__unchecked_set (; 193 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $2
@@ -10002,7 +10012,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $~lib/array/Array<std/array/Proxy<i32>>#__set (; 193 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<std/array/Proxy<i32>>#__set (; 194 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $2
   call $~lib/rt/pure/__retain
   local.set $2
@@ -10019,7 +10029,7 @@
     call $~lib/rt/pure/__release
     i32.const 448
     i32.const 512
-    i32.const 109
+    i32.const 114
     i32.const 21
     call $~lib/builtins/abort
     unreachable
@@ -10043,7 +10053,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/array/createReverseOrderedElementsArray (; 194 ;) (param $0 i32) (result i32)
+ (func $std/array/createReverseOrderedElementsArray (; 195 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -10083,7 +10093,7 @@
   end
   local.get $1
  )
- (func $start:std/array~anonymous|48 (; 195 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $start:std/array~anonymous|48 (; 196 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -10103,7 +10113,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/util/sort/insertionSort<std/array/Proxy<i32>> (; 196 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/sort/insertionSort<std/array/Proxy<i32>> (; 197 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -10201,7 +10211,7 @@
    end
   end
  )
- (func $~lib/array/Array<std/array/Proxy<i32>>#sort (; 197 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<std/array/Proxy<i32>>#sort (; 198 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10272,11 +10282,11 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/array/Array<std/array/Proxy<i32>>#get:length (; 198 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<std/array/Proxy<i32>>#get:length (; 199 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<std/array/Proxy<i32>>#__unchecked_get (; 199 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<std/array/Proxy<i32>>#__unchecked_get (; 200 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -10286,7 +10296,7 @@
   i32.load
   call $~lib/rt/pure/__retain
  )
- (func $~lib/array/Array<std/array/Proxy<i32>>#__get (; 200 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<std/array/Proxy<i32>>#__get (; 201 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   local.get $0
@@ -10295,7 +10305,7 @@
   if
    i32.const 448
    i32.const 512
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -10311,14 +10321,14 @@
    call $~lib/rt/pure/__release
    i32.const 3920
    i32.const 512
-   i32.const 97
+   i32.const 102
    i32.const 39
    call $~lib/builtins/abort
    unreachable
   end
   local.get $2
  )
- (func $std/array/isSorted<std/array/Proxy<i32>> (; 201 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/array/isSorted<std/array/Proxy<i32>> (; 202 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10385,7 +10395,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $std/array/assertSorted<std/array/Proxy<i32>> (; 202 ;) (param $0 i32) (param $1 i32)
+ (func $std/array/assertSorted<std/array/Proxy<i32>> (; 203 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -10400,7 +10410,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 881
+   i32.const 882
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -10410,7 +10420,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/util/sort/insertionSort<~lib/string/String | null> (; 203 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/sort/insertionSort<~lib/string/String | null> (; 204 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -10508,7 +10518,7 @@
    end
   end
  )
- (func $~lib/array/Array<~lib/string/String | null>#sort (; 204 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/string/String | null>#sort (; 205 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10579,11 +10589,11 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/array/Array<~lib/string/String | null>#get:length (; 205 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<~lib/string/String | null>#get:length (; 206 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<~lib/string/String | null>#__unchecked_get (; 206 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/string/String | null>#__unchecked_get (; 207 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -10593,7 +10603,7 @@
   i32.load
   call $~lib/rt/pure/__retain
  )
- (func $~lib/array/Array<~lib/string/String | null>#__get (; 207 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/string/String | null>#__get (; 208 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   local.get $0
@@ -10602,7 +10612,7 @@
   if
    i32.const 448
    i32.const 512
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -10613,7 +10623,7 @@
   local.set $2
   local.get $2
  )
- (func $std/array/isSorted<~lib/string/String | null> (; 208 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/array/isSorted<~lib/string/String | null> (; 209 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10680,7 +10690,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $std/array/assertSorted<~lib/string/String | null> (; 209 ;) (param $0 i32) (param $1 i32)
+ (func $std/array/assertSorted<~lib/string/String | null> (; 210 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -10695,7 +10705,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 881
+   i32.const 882
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -10705,7 +10715,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/string/String#get:length (; 210 ;) (param $0 i32) (result i32)
+ (func $~lib/string/String#get:length (; 211 ;) (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub
@@ -10713,7 +10723,7 @@
   i32.const 1
   i32.shr_u
  )
- (func $~lib/util/string/compareImpl (; 211 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
+ (func $~lib/util/string/compareImpl (; 212 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
@@ -10835,7 +10845,7 @@
   call $~lib/rt/pure/__release
   local.get $7
  )
- (func $~lib/util/sort/COMPARATOR<~lib/string/String | null>~anonymous|0 (; 212 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/sort/COMPARATOR<~lib/string/String | null>~anonymous|0 (; 213 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10941,7 +10951,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $std/array/assertSorted<~lib/string/String | null>|trampoline (; 213 ;) (param $0 i32) (param $1 i32)
+ (func $std/array/assertSorted<~lib/string/String | null>|trampoline (; 214 ;) (param $0 i32) (param $1 i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -10962,7 +10972,7 @@
   local.get $1
   call $std/array/assertSorted<~lib/string/String | null>
  )
- (func $~lib/string/String.__eq (; 214 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__eq (; 215 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -11035,7 +11045,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/string/String.__ne (; 215 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__ne (; 216 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -11054,7 +11064,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $std/array/isArraysEqual<~lib/string/String | null> (; 216 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/array/isArraysEqual<~lib/string/String | null> (; 217 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -11151,7 +11161,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/array/Array<~lib/string/String>#constructor (; 217 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/string/String>#constructor (; 218 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   if (result i32)
    local.get $0
@@ -11161,8 +11171,6 @@
    call $~lib/rt/tlsf/__alloc
    call $~lib/rt/pure/__retain
   end
-  local.get $1
-  i32.const 2
   call $~lib/arraybuffer/ArrayBufferView#constructor
   local.set $0
   local.get $0
@@ -11170,10 +11178,14 @@
   i32.store offset=12
   local.get $0
   local.get $1
+  i32.const 2
+  call $~lib/arraybuffer/ArrayBufferView#alloc
+  local.get $0
+  local.get $1
   i32.store offset=12
   local.get $0
  )
- (func $~lib/string/String#charAt (; 218 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String#charAt (; 219 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   local.get $0
@@ -11199,7 +11211,7 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~lib/string/String#concat (; 219 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String#concat (; 220 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -11275,7 +11287,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/string/String.__concat (; 220 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__concat (; 221 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -11298,7 +11310,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $std/array/createRandomString (; 221 ;) (param $0 i32) (result i32)
+ (func $std/array/createRandomString (; 222 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -11359,7 +11371,7 @@
   end
   local.get $1
  )
- (func $~lib/array/Array<~lib/string/String>#__unchecked_set (; 222 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<~lib/string/String>#__unchecked_set (; 223 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $2
@@ -11389,7 +11401,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $~lib/array/Array<~lib/string/String>#__set (; 223 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<~lib/string/String>#__set (; 224 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $2
   call $~lib/rt/pure/__retain
   local.set $2
@@ -11406,7 +11418,7 @@
     call $~lib/rt/pure/__release
     i32.const 448
     i32.const 512
-    i32.const 109
+    i32.const 114
     i32.const 21
     call $~lib/builtins/abort
     unreachable
@@ -11430,7 +11442,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/array/createRandomStringArray (; 224 ;) (param $0 i32) (result i32)
+ (func $std/array/createRandomStringArray (; 225 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -11468,7 +11480,7 @@
   end
   local.get $1
  )
- (func $~lib/util/sort/insertionSort<~lib/string/String> (; 225 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/sort/insertionSort<~lib/string/String> (; 226 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -11566,7 +11578,7 @@
    end
   end
  )
- (func $~lib/array/Array<~lib/string/String>#sort (; 226 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/string/String>#sort (; 227 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -11637,11 +11649,11 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/array/Array<~lib/string/String>#get:length (; 227 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<~lib/string/String>#get:length (; 228 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<~lib/string/String>#__unchecked_get (; 228 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/string/String>#__unchecked_get (; 229 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -11651,7 +11663,7 @@
   i32.load
   call $~lib/rt/pure/__retain
  )
- (func $~lib/array/Array<~lib/string/String>#__get (; 229 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/string/String>#__get (; 230 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   local.get $0
@@ -11660,7 +11672,7 @@
   if
    i32.const 448
    i32.const 512
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -11676,14 +11688,14 @@
    call $~lib/rt/pure/__release
    i32.const 3920
    i32.const 512
-   i32.const 97
+   i32.const 102
    i32.const 39
    call $~lib/builtins/abort
    unreachable
   end
   local.get $2
  )
- (func $std/array/isSorted<~lib/string/String> (; 230 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/array/isSorted<~lib/string/String> (; 231 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -11750,7 +11762,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $std/array/assertSorted<~lib/string/String> (; 231 ;) (param $0 i32) (param $1 i32)
+ (func $std/array/assertSorted<~lib/string/String> (; 232 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -11765,7 +11777,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 881
+   i32.const 882
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -11775,7 +11787,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/util/sort/COMPARATOR<~lib/string/String>~anonymous|0 (; 232 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/sort/COMPARATOR<~lib/string/String>~anonymous|0 (; 233 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -11881,7 +11893,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $std/array/assertSorted<~lib/string/String>|trampoline (; 233 ;) (param $0 i32) (param $1 i32)
+ (func $std/array/assertSorted<~lib/string/String>|trampoline (; 234 ;) (param $0 i32) (param $1 i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -11902,7 +11914,7 @@
   local.get $1
   call $std/array/assertSorted<~lib/string/String>
  )
- (func $~lib/string/String#substring (; 234 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/string/String#substring (; 235 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -12009,7 +12021,7 @@
   local.get $11
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/string/joinBooleanArray (; 235 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinBooleanArray (; 236 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -12184,7 +12196,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/array/Array<bool>#join (; 236 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<bool>#join (; 237 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -12207,7 +12219,7 @@
   local.get $4
   return
  )
- (func $~lib/util/number/decimalCount32 (; 237 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/decimalCount32 (; 238 ;) (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   i32.const 100000
@@ -12273,7 +12285,7 @@
   end
   unreachable
  )
- (func $~lib/util/number/utoa32_lut (; 238 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/number/utoa32_lut (; 239 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -12417,7 +12429,7 @@
    i32.store16
   end
  )
- (func $~lib/util/number/itoa32 (; 239 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/itoa32 (; 240 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -12471,12 +12483,12 @@
   local.get $3
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/itoa<i32> (; 240 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/itoa<i32> (; 241 ;) (param $0 i32) (result i32)
   local.get $0
   call $~lib/util/number/itoa32
   return
  )
- (func $~lib/util/number/itoa_stream<i32> (; 241 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_stream<i32> (; 242 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -12533,7 +12545,7 @@
   end
   local.get $3
  )
- (func $~lib/util/string/joinIntegerArray<i32> (; 242 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<i32> (; 243 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -12676,7 +12688,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/array/Array<i32>#join (; 243 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#join (; 244 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -12699,7 +12711,7 @@
   local.get $4
   return
  )
- (func $~lib/util/number/utoa32 (; 244 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/utoa32 (; 245 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -12733,12 +12745,12 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/itoa<u32> (; 245 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/itoa<u32> (; 246 ;) (param $0 i32) (result i32)
   local.get $0
   call $~lib/util/number/utoa32
   return
  )
- (func $~lib/util/number/itoa_stream<u32> (; 246 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_stream<u32> (; 247 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -12775,7 +12787,7 @@
   call $~lib/util/number/utoa32_lut
   local.get $3
  )
- (func $~lib/util/string/joinIntegerArray<u32> (; 247 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<u32> (; 248 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -12918,7 +12930,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/array/Array<u32>#join (; 248 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u32>#join (; 249 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -12941,7 +12953,7 @@
   local.get $4
   return
  )
- (func $~lib/array/Array<u64>#__unchecked_get (; 249 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $~lib/array/Array<u64>#__unchecked_get (; 250 ;) (param $0 i32) (param $1 i32) (result i64)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -12950,7 +12962,7 @@
   i32.add
   i64.load
  )
- (func $~lib/array/Array<i16>#__unchecked_get (; 250 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i16>#__unchecked_get (; 251 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -12959,7 +12971,7 @@
   i32.add
   i32.load16_s
  )
- (func $~lib/util/number/genDigits (; 251 ;) (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (param $6 i32) (result i32)
+ (func $~lib/util/number/genDigits (; 252 ;) (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (param $6 i32) (result i32)
   (local $7 i32)
   (local $8 i64)
   (local $9 i64)
@@ -13466,7 +13478,7 @@
   end
   local.get $15
  )
- (func $~lib/util/number/prettify (; 252 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/prettify (; 253 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -13783,7 +13795,7 @@
   end
   unreachable
  )
- (func $~lib/util/number/dtoa_core (; 253 ;) (param $0 i32) (param $1 f64) (result i32)
+ (func $~lib/util/number/dtoa_core (; 254 ;) (param $0 i32) (param $1 f64) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -14205,7 +14217,7 @@
   local.get $2
   i32.add
  )
- (func $~lib/util/number/dtoa (; 254 ;) (param $0 f64) (result i32)
+ (func $~lib/util/number/dtoa (; 255 ;) (param $0 f64) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -14266,7 +14278,7 @@
   call $~lib/rt/tlsf/__free
   local.get $3
  )
- (func $~lib/util/number/dtoa_stream (; 255 ;) (param $0 i32) (param $1 i32) (param $2 f64) (result i32)
+ (func $~lib/util/number/dtoa_stream (; 256 ;) (param $0 i32) (param $1 i32) (param $2 f64) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -14340,7 +14352,7 @@
   local.get $2
   call $~lib/util/number/dtoa_core
  )
- (func $~lib/util/string/joinFloatArray<f64> (; 256 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinFloatArray<f64> (; 257 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -14483,7 +14495,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/array/Array<f64>#join (; 257 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<f64>#join (; 258 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -14506,7 +14518,7 @@
   local.get $4
   return
  )
- (func $~lib/util/string/joinStringArray (; 258 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinStringArray (; 259 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -14735,7 +14747,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $~lib/array/Array<~lib/string/String | null>#join (; 259 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/string/String | null>#join (; 260 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -14758,10 +14770,10 @@
   local.get $4
   return
  )
- (func $std/array/Ref#toString (; 260 ;) (param $0 i32) (result i32)
+ (func $std/array/Ref#toString (; 261 ;) (param $0 i32) (result i32)
   i32.const 7648
  )
- (func $~lib/util/string/joinReferenceArray<std/array/Ref | null> (; 261 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinReferenceArray<std/array/Ref | null> (; 262 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -14972,7 +14984,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/array/Array<std/array/Ref | null>#join (; 262 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<std/array/Ref | null>#join (; 263 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -14995,7 +15007,7 @@
   local.get $4
   return
  )
- (func $~lib/util/string/joinReferenceArray<std/array/Ref> (; 263 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinReferenceArray<std/array/Ref> (; 264 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -15206,7 +15218,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/array/Array<std/array/Ref>#join (; 264 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<std/array/Ref>#join (; 265 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -15229,12 +15241,12 @@
   local.get $4
   return
  )
- (func $~lib/array/Array<i32>#toString (; 265 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<i32>#toString (; 266 ;) (param $0 i32) (result i32)
   local.get $0
   i32.const 5360
   call $~lib/array/Array<i32>#join
  )
- (func $~lib/util/number/itoa<i8> (; 266 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/itoa<i8> (; 267 ;) (param $0 i32) (result i32)
   local.get $0
   i32.const 24
   i32.shl
@@ -15243,7 +15255,7 @@
   call $~lib/util/number/itoa32
   return
  )
- (func $~lib/util/number/itoa_stream<i8> (; 267 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_stream<i8> (; 268 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -15316,7 +15328,7 @@
   end
   local.get $3
  )
- (func $~lib/util/string/joinIntegerArray<i8> (; 268 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<i8> (; 269 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -15459,7 +15471,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/array/Array<i8>#join (; 269 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i8>#join (; 270 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -15482,19 +15494,19 @@
   local.get $4
   return
  )
- (func $~lib/array/Array<i8>#toString (; 270 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<i8>#toString (; 271 ;) (param $0 i32) (result i32)
   local.get $0
   i32.const 5360
   call $~lib/array/Array<i8>#join
  )
- (func $~lib/util/number/itoa<u16> (; 271 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/itoa<u16> (; 272 ;) (param $0 i32) (result i32)
   local.get $0
   i32.const 65535
   i32.and
   call $~lib/util/number/utoa32
   return
  )
- (func $~lib/util/number/itoa_stream<u16> (; 272 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_stream<u16> (; 273 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -15537,7 +15549,7 @@
   call $~lib/util/number/utoa32_lut
   local.get $3
  )
- (func $~lib/util/string/joinIntegerArray<u16> (; 273 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<u16> (; 274 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -15680,7 +15692,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/array/Array<u16>#join (; 274 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u16>#join (; 275 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -15703,12 +15715,12 @@
   local.get $4
   return
  )
- (func $~lib/array/Array<u16>#toString (; 275 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<u16>#toString (; 276 ;) (param $0 i32) (result i32)
   local.get $0
   i32.const 5360
   call $~lib/array/Array<u16>#join
  )
- (func $~lib/util/number/decimalCount64 (; 276 ;) (param $0 i64) (result i32)
+ (func $~lib/util/number/decimalCount64 (; 277 ;) (param $0 i64) (result i32)
   (local $1 i32)
   local.get $0
   i64.const 1000000000000000
@@ -15781,7 +15793,7 @@
   end
   unreachable
  )
- (func $~lib/util/number/utoa64_lut (; 277 ;) (param $0 i32) (param $1 i64) (param $2 i32)
+ (func $~lib/util/number/utoa64_lut (; 278 ;) (param $0 i32) (param $1 i64) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i64)
@@ -15908,7 +15920,7 @@
   local.get $2
   call $~lib/util/number/utoa32_lut
  )
- (func $~lib/util/number/utoa64 (; 278 ;) (param $0 i64) (result i32)
+ (func $~lib/util/number/utoa64 (; 279 ;) (param $0 i64) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -15974,12 +15986,12 @@
   local.get $1
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/itoa<u64> (; 279 ;) (param $0 i64) (result i32)
+ (func $~lib/util/number/itoa<u64> (; 280 ;) (param $0 i64) (result i32)
   local.get $0
   call $~lib/util/number/utoa64
   return
  )
- (func $~lib/util/number/itoa_stream<u64> (; 280 ;) (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
+ (func $~lib/util/number/itoa_stream<u64> (; 281 ;) (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -16042,7 +16054,7 @@
   end
   local.get $3
  )
- (func $~lib/util/string/joinIntegerArray<u64> (; 281 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<u64> (; 282 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -16185,7 +16197,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/array/Array<u64>#join (; 282 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u64>#join (; 283 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -16208,12 +16220,12 @@
   local.get $4
   return
  )
- (func $~lib/array/Array<u64>#toString (; 283 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<u64>#toString (; 284 ;) (param $0 i32) (result i32)
   local.get $0
   i32.const 5360
   call $~lib/array/Array<u64>#join
  )
- (func $~lib/util/number/itoa64 (; 284 ;) (param $0 i64) (result i32)
+ (func $~lib/util/number/itoa64 (; 285 ;) (param $0 i64) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -16301,12 +16313,12 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/itoa<i64> (; 285 ;) (param $0 i64) (result i32)
+ (func $~lib/util/number/itoa<i64> (; 286 ;) (param $0 i64) (result i32)
   local.get $0
   call $~lib/util/number/itoa64
   return
  )
- (func $~lib/util/number/itoa_stream<i64> (; 286 ;) (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
+ (func $~lib/util/number/itoa_stream<i64> (; 287 ;) (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -16391,7 +16403,7 @@
   end
   local.get $3
  )
- (func $~lib/util/string/joinIntegerArray<i64> (; 287 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<i64> (; 288 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -16534,7 +16546,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/array/Array<i64>#join (; 288 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i64>#join (; 289 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -16557,17 +16569,17 @@
   local.get $4
   return
  )
- (func $~lib/array/Array<i64>#toString (; 289 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<i64>#toString (; 290 ;) (param $0 i32) (result i32)
   local.get $0
   i32.const 5360
   call $~lib/array/Array<i64>#join
  )
- (func $~lib/array/Array<~lib/string/String | null>#toString (; 290 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<~lib/string/String | null>#toString (; 291 ;) (param $0 i32) (result i32)
   local.get $0
   i32.const 5360
   call $~lib/array/Array<~lib/string/String | null>#join
  )
- (func $~lib/util/string/joinReferenceArray<~lib/array/Array<i32>> (; 291 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinReferenceArray<~lib/array/Array<i32>> (; 292 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -16778,7 +16790,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/array/Array<~lib/array/Array<i32>>#join (; 292 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<i32>>#join (; 293 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -16801,19 +16813,19 @@
   local.get $4
   return
  )
- (func $~lib/array/Array<~lib/array/Array<i32>>#toString (; 293 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<i32>>#toString (; 294 ;) (param $0 i32) (result i32)
   local.get $0
   i32.const 5360
   call $~lib/array/Array<~lib/array/Array<i32>>#join
  )
- (func $~lib/util/number/itoa<u8> (; 294 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/itoa<u8> (; 295 ;) (param $0 i32) (result i32)
   local.get $0
   i32.const 255
   i32.and
   call $~lib/util/number/utoa32
   return
  )
- (func $~lib/util/number/itoa_stream<u8> (; 295 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_stream<u8> (; 296 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -16856,7 +16868,7 @@
   call $~lib/util/number/utoa32_lut
   local.get $3
  )
- (func $~lib/util/string/joinIntegerArray<u8> (; 296 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<u8> (; 297 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -16999,7 +17011,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/array/Array<u8>#join (; 297 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u8>#join (; 298 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -17022,12 +17034,12 @@
   local.get $4
   return
  )
- (func $~lib/array/Array<u8>#toString (; 298 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<u8>#toString (; 299 ;) (param $0 i32) (result i32)
   local.get $0
   i32.const 5360
   call $~lib/array/Array<u8>#join
  )
- (func $~lib/util/string/joinReferenceArray<~lib/array/Array<u8>> (; 299 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinReferenceArray<~lib/array/Array<u8>> (; 300 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -17238,7 +17250,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/array/Array<~lib/array/Array<u8>>#join (; 300 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<u8>>#join (; 301 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -17261,17 +17273,17 @@
   local.get $4
   return
  )
- (func $~lib/array/Array<~lib/array/Array<u8>>#toString (; 301 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<u8>>#toString (; 302 ;) (param $0 i32) (result i32)
   local.get $0
   i32.const 5360
   call $~lib/array/Array<~lib/array/Array<u8>>#join
  )
- (func $~lib/array/Array<u32>#toString (; 302 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<u32>#toString (; 303 ;) (param $0 i32) (result i32)
   local.get $0
   i32.const 5360
   call $~lib/array/Array<u32>#join
  )
- (func $~lib/util/string/joinReferenceArray<~lib/array/Array<u32>> (; 303 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinReferenceArray<~lib/array/Array<u32>> (; 304 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -17482,7 +17494,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/array/Array<~lib/array/Array<u32>>#join (; 304 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<u32>>#join (; 305 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -17505,12 +17517,12 @@
   local.get $4
   return
  )
- (func $~lib/array/Array<~lib/array/Array<u32>>#toString (; 305 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<u32>>#toString (; 306 ;) (param $0 i32) (result i32)
   local.get $0
   i32.const 5360
   call $~lib/array/Array<~lib/array/Array<u32>>#join
  )
- (func $~lib/util/string/joinReferenceArray<~lib/array/Array<~lib/array/Array<u32>>> (; 306 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinReferenceArray<~lib/array/Array<~lib/array/Array<u32>>> (; 307 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -17721,7 +17733,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/array/Array<~lib/array/Array<~lib/array/Array<u32>>>#join (; 307 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<~lib/array/Array<u32>>>#join (; 308 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -17744,12 +17756,12 @@
   local.get $4
   return
  )
- (func $~lib/array/Array<~lib/array/Array<~lib/array/Array<u32>>>#toString (; 308 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<~lib/array/Array<u32>>>#toString (; 309 ;) (param $0 i32) (result i32)
   local.get $0
   i32.const 5360
   call $~lib/array/Array<~lib/array/Array<~lib/array/Array<u32>>>#join
  )
- (func $start:std/array (; 309 ;)
+ (func $start:std/array (; 310 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -17827,7 +17839,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 40
+   i32.const 41
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -17842,7 +17854,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 41
+   i32.const 42
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -17857,7 +17869,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 42
+   i32.const 43
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -17869,7 +17881,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 43
+   i32.const 44
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -17881,7 +17893,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 44
+   i32.const 45
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -17892,7 +17904,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 46
+   i32.const 47
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -17928,7 +17940,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 54
+   i32.const 55
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -17953,7 +17965,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 57
+   i32.const 58
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -17978,7 +17990,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 60
+   i32.const 61
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -18003,7 +18015,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 63
+   i32.const 64
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -18028,7 +18040,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 66
+   i32.const 67
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -18072,7 +18084,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 73
+   i32.const 74
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -18097,7 +18109,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 76
+   i32.const 77
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -18122,7 +18134,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 79
+   i32.const 80
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -18147,7 +18159,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 82
+   i32.const 83
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -18172,7 +18184,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 85
+   i32.const 86
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -18197,7 +18209,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 91
+   i32.const 92
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -18210,7 +18222,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 92
+   i32.const 93
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -18228,7 +18240,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 96
+   i32.const 97
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -18241,7 +18253,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 97
+   i32.const 98
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -18254,7 +18266,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 98
+   i32.const 99
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -18269,7 +18281,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 102
+   i32.const 103
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -18282,7 +18294,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 103
+   i32.const 104
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -18295,7 +18307,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 104
+   i32.const 105
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -18306,19 +18318,6 @@
   drop
   global.get $std/array/arr
   call $~lib/array/Array<i32>#get:length
-  i32.const 1
-  i32.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 304
-   i32.const 108
-   i32.const 2
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $std/array/arr
-  call $std/array/internalCapacity<i32>
   i32.const 1
   i32.eq
   i32.eqz
@@ -18331,9 +18330,8 @@
    unreachable
   end
   global.get $std/array/arr
-  i32.const 0
-  call $~lib/array/Array<i32>#__get
-  i32.const 43
+  call $std/array/internalCapacity<i32>
+  i32.const 1
   i32.eq
   i32.eqz
   if
@@ -18345,24 +18343,25 @@
    unreachable
   end
   global.get $std/array/arr
-  i32.const 44
-  call $~lib/array/Array<i32>#push
-  drop
-  global.get $std/array/arr
-  call $~lib/array/Array<i32>#get:length
-  i32.const 2
+  i32.const 0
+  call $~lib/array/Array<i32>#__get
+  i32.const 43
   i32.eq
   i32.eqz
   if
    i32.const 0
    i32.const 304
-   i32.const 114
+   i32.const 111
    i32.const 2
    call $~lib/builtins/abort
    unreachable
   end
   global.get $std/array/arr
-  call $std/array/internalCapacity<i32>
+  i32.const 44
+  call $~lib/array/Array<i32>#push
+  drop
+  global.get $std/array/arr
+  call $~lib/array/Array<i32>#get:length
   i32.const 2
   i32.eq
   i32.eqz
@@ -18375,6 +18374,19 @@
    unreachable
   end
   global.get $std/array/arr
+  call $std/array/internalCapacity<i32>
+  i32.const 2
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 304
+   i32.const 116
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $std/array/arr
   i32.const 0
   call $~lib/array/Array<i32>#__get
   i32.const 43
@@ -18383,7 +18395,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 116
+   i32.const 117
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -18397,7 +18409,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 117
+   i32.const 118
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -18414,7 +18426,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 121
+   i32.const 122
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -18427,7 +18439,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 122
+   i32.const 123
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -18441,7 +18453,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 123
+   i32.const 124
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -18455,7 +18467,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 124
+   i32.const 125
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -18469,7 +18481,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 125
+   i32.const 126
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -18511,7 +18523,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 133
+   i32.const 134
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -18538,7 +18550,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 142
+   i32.const 143
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -18551,7 +18563,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 143
+   i32.const 144
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -18564,7 +18576,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 144
+   i32.const 145
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -18587,7 +18599,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 147
+   i32.const 148
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -18601,7 +18613,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 149
+   i32.const 150
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -18615,7 +18627,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 150
+   i32.const 151
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -18629,7 +18641,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 151
+   i32.const 152
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -18658,7 +18670,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 158
+   i32.const 159
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -18671,7 +18683,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 159
+   i32.const 160
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -18684,7 +18696,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 160
+   i32.const 161
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -18698,7 +18710,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 161
+   i32.const 162
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -18712,7 +18724,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 162
+   i32.const 163
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -18726,7 +18738,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 163
+   i32.const 164
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -18740,7 +18752,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 164
+   i32.const 165
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -18754,7 +18766,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 165
+   i32.const 166
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -18770,7 +18782,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 168
+   i32.const 169
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -18790,7 +18802,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 176
+   i32.const 177
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -18811,7 +18823,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 178
+   i32.const 179
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -18824,7 +18836,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 179
+   i32.const 180
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -18863,7 +18875,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 186
+   i32.const 187
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -18898,7 +18910,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 188
+   i32.const 189
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -18933,7 +18945,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 190
+   i32.const 191
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -18968,7 +18980,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 192
+   i32.const 193
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -19003,7 +19015,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 194
+   i32.const 195
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -19038,7 +19050,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 196
+   i32.const 197
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -19073,7 +19085,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 198
+   i32.const 199
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -19108,7 +19120,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 200
+   i32.const 201
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -19143,7 +19155,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 202
+   i32.const 203
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -19178,7 +19190,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 204
+   i32.const 205
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -19213,7 +19225,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 206
+   i32.const 207
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -19248,7 +19260,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 208
+   i32.const 209
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -19315,7 +19327,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 216
+   i32.const 217
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -19328,7 +19340,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 217
+   i32.const 218
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -19342,7 +19354,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 218
+   i32.const 219
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -19356,7 +19368,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 219
+   i32.const 220
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -19370,7 +19382,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 220
+   i32.const 221
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -19384,7 +19396,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 221
+   i32.const 222
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -19401,7 +19413,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 225
+   i32.const 226
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -19414,7 +19426,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 226
+   i32.const 227
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -19428,7 +19440,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 227
+   i32.const 228
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -19442,7 +19454,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 228
+   i32.const 229
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -19456,7 +19468,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 229
+   i32.const 230
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -19470,7 +19482,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 230
+   i32.const 231
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -19484,7 +19496,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 231
+   i32.const 232
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -19499,7 +19511,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 240
+   i32.const 241
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -19512,7 +19524,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 241
+   i32.const 242
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -19525,7 +19537,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 242
+   i32.const 243
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -19539,7 +19551,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 243
+   i32.const 244
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -19553,7 +19565,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 244
+   i32.const 245
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -19567,7 +19579,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 245
+   i32.const 246
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -19581,7 +19593,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 246
+   i32.const 247
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -19596,7 +19608,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 250
+   i32.const 251
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -19609,7 +19621,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 251
+   i32.const 252
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -19622,7 +19634,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 252
+   i32.const 253
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -19636,7 +19648,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 253
+   i32.const 254
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -19650,7 +19662,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 254
+   i32.const 255
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -19664,7 +19676,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 255
+   i32.const 256
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -19680,7 +19692,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 263
+   i32.const 264
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -19693,7 +19705,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 264
+   i32.const 265
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -19707,7 +19719,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 265
+   i32.const 266
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -19721,7 +19733,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 266
+   i32.const 267
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -19735,7 +19747,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 267
+   i32.const 268
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -19760,7 +19772,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 277
+   i32.const 278
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -19777,7 +19789,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 280
+   i32.const 281
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -19794,7 +19806,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 283
+   i32.const 284
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -19811,7 +19823,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 286
+   i32.const 287
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -19828,7 +19840,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 289
+   i32.const 290
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -19845,7 +19857,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 292
+   i32.const 293
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -19862,7 +19874,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 295
+   i32.const 296
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -19879,7 +19891,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 298
+   i32.const 299
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -19896,7 +19908,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 301
+   i32.const 302
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -19913,7 +19925,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 304
+   i32.const 305
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -19934,7 +19946,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 306
+   i32.const 307
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -19955,7 +19967,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 307
+   i32.const 308
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -19976,7 +19988,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 314
+   i32.const 315
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -19993,7 +20005,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 317
+   i32.const 318
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -20010,7 +20022,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 320
+   i32.const 321
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -20027,7 +20039,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 323
+   i32.const 324
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -20044,7 +20056,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 326
+   i32.const 327
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -20061,7 +20073,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 329
+   i32.const 330
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -20078,7 +20090,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 332
+   i32.const 333
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -20095,7 +20107,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 335
+   i32.const 336
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -20112,7 +20124,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 338
+   i32.const 339
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -20129,7 +20141,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 341
+   i32.const 342
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -20148,7 +20160,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 343
+   i32.const 344
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -20167,7 +20179,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 344
+   i32.const 345
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -20185,7 +20197,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 348
+   i32.const 349
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -20198,7 +20210,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 349
+   i32.const 350
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -20212,7 +20224,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 350
+   i32.const 351
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -20226,7 +20238,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 351
+   i32.const 352
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -20260,7 +20272,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 358
+   i32.const 359
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -20279,7 +20291,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 359
+   i32.const 360
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -20313,7 +20325,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 362
+   i32.const 363
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -20332,7 +20344,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 363
+   i32.const 364
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -20366,7 +20378,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 366
+   i32.const 367
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -20385,7 +20397,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 367
+   i32.const 368
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -20419,7 +20431,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 370
+   i32.const 371
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -20438,7 +20450,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 371
+   i32.const 372
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -20472,7 +20484,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 374
+   i32.const 375
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -20491,7 +20503,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 375
+   i32.const 376
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -20525,7 +20537,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 378
+   i32.const 379
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -20544,7 +20556,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 379
+   i32.const 380
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -20578,7 +20590,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 382
+   i32.const 383
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -20597,7 +20609,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 383
+   i32.const 384
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -20631,7 +20643,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 386
+   i32.const 387
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -20650,7 +20662,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 387
+   i32.const 388
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -20684,7 +20696,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 390
+   i32.const 391
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -20703,7 +20715,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 391
+   i32.const 392
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -20737,7 +20749,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 394
+   i32.const 395
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -20756,7 +20768,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 395
+   i32.const 396
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -20790,7 +20802,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 398
+   i32.const 399
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -20809,7 +20821,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 399
+   i32.const 400
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -20843,7 +20855,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 402
+   i32.const 403
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -20862,7 +20874,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 403
+   i32.const 404
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -20896,7 +20908,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 406
+   i32.const 407
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -20915,7 +20927,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 407
+   i32.const 408
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -20949,7 +20961,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 410
+   i32.const 411
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -20968,7 +20980,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 411
+   i32.const 412
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -20993,7 +21005,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 415
+   i32.const 416
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -21006,7 +21018,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 416
+   i32.const 417
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -21079,7 +21091,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 421
+   i32.const 422
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -21095,7 +21107,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 422
+   i32.const 423
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -21111,7 +21123,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 423
+   i32.const 424
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -21124,7 +21136,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 425
+   i32.const 426
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -21140,7 +21152,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 426
+   i32.const 427
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -21156,7 +21168,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 427
+   i32.const 428
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -21172,7 +21184,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 428
+   i32.const 429
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -21220,7 +21232,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 433
+   i32.const 434
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -21235,7 +21247,7 @@
   else
    i32.const 0
    i32.const 304
-   i32.const 434
+   i32.const 435
    i32.const 9
    call $~lib/builtins/abort
    unreachable
@@ -21247,7 +21259,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 434
+   i32.const 435
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -21260,7 +21272,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 436
+   i32.const 437
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -21275,7 +21287,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 437
+   i32.const 438
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -21290,7 +21302,7 @@
   else
    i32.const 0
    i32.const 304
-   i32.const 438
+   i32.const 439
    i32.const 9
    call $~lib/builtins/abort
    unreachable
@@ -21302,7 +21314,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 438
+   i32.const 439
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -21450,7 +21462,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 451
+   i32.const 452
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -21466,7 +21478,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 454
+   i32.const 455
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -21482,7 +21494,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 457
+   i32.const 458
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -21498,7 +21510,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 465
+   i32.const 466
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -21511,7 +21523,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 466
+   i32.const 467
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -21527,7 +21539,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 468
+   i32.const 469
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -21555,7 +21567,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 481
+   i32.const 482
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -21568,7 +21580,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 482
+   i32.const 483
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -21592,7 +21604,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 492
+   i32.const 493
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -21608,7 +21620,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 495
+   i32.const 496
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -21624,7 +21636,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 503
+   i32.const 504
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -21637,7 +21649,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 504
+   i32.const 505
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -21653,7 +21665,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 506
+   i32.const 507
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -21681,7 +21693,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 519
+   i32.const 520
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -21694,7 +21706,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 520
+   i32.const 521
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -21718,7 +21730,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 530
+   i32.const 531
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -21734,7 +21746,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 533
+   i32.const 534
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -21750,7 +21762,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 541
+   i32.const 542
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -21763,7 +21775,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 542
+   i32.const 543
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -21779,7 +21791,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 544
+   i32.const 545
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -21807,7 +21819,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 557
+   i32.const 558
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -21820,7 +21832,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 558
+   i32.const 559
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -21845,7 +21857,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 569
+   i32.const 570
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -21862,7 +21874,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 578
+   i32.const 579
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -21875,7 +21887,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 579
+   i32.const 580
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -21892,7 +21904,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 582
+   i32.const 583
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -21921,7 +21933,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 596
+   i32.const 597
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -21934,7 +21946,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 597
+   i32.const 598
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -21958,7 +21970,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 622
+   i32.const 623
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -22010,7 +22022,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 636
+   i32.const 637
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -22027,7 +22039,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 637
+   i32.const 638
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -22045,7 +22057,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 646
+   i32.const 647
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -22058,7 +22070,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 647
+   i32.const 648
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -22076,7 +22088,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 654
+   i32.const 655
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -22106,7 +22118,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 669
+   i32.const 670
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -22119,7 +22131,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 670
+   i32.const 671
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -22146,7 +22158,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 680
+   i32.const 681
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -22164,7 +22176,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 689
+   i32.const 690
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -22177,7 +22189,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 690
+   i32.const 691
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -22195,7 +22207,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 697
+   i32.const 698
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -22225,7 +22237,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 712
+   i32.const 713
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -22238,7 +22250,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 713
+   i32.const 714
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -22265,7 +22277,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 723
+   i32.const 724
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -22282,7 +22294,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 727
+   i32.const 728
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -22301,7 +22313,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 730
+   i32.const 731
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -22320,7 +22332,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 733
+   i32.const 734
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -22337,7 +22349,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 741
+   i32.const 742
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -22350,7 +22362,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 742
+   i32.const 743
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -22367,7 +22379,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 744
+   i32.const 745
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -22396,7 +22408,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 757
+   i32.const 758
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -22409,7 +22421,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 758
+   i32.const 759
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -22434,7 +22446,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 768
+   i32.const 769
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -22451,7 +22463,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 772
+   i32.const 773
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -22470,7 +22482,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 775
+   i32.const 776
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -22489,7 +22501,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 778
+   i32.const 779
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -22506,7 +22518,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 786
+   i32.const 787
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -22519,7 +22531,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 787
+   i32.const 788
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -22536,7 +22548,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 789
+   i32.const 790
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -22565,7 +22577,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 802
+   i32.const 803
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -22578,7 +22590,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 803
+   i32.const 804
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -22629,7 +22641,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 892
+   i32.const 893
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -22661,7 +22673,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 896
+   i32.const 897
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -22693,7 +22705,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 900
+   i32.const 901
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -22725,7 +22737,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 904
+   i32.const 905
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -22798,7 +22810,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 924
+   i32.const 925
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -22819,7 +22831,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 927
+   i32.const 928
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -22834,7 +22846,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 930
+   i32.const 931
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -22849,7 +22861,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 933
+   i32.const 934
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -22864,7 +22876,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 936
+   i32.const 937
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -22879,7 +22891,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 939
+   i32.const 940
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -22894,7 +22906,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 942
+   i32.const 943
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -23006,7 +23018,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 979
+   i32.const 980
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -23041,7 +23053,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 988
+   i32.const 989
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -23062,7 +23074,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 989
+   i32.const 990
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -23083,7 +23095,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 990
+   i32.const 991
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -23104,7 +23116,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 991
+   i32.const 992
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -23125,7 +23137,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 992
+   i32.const 993
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -23146,7 +23158,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 993
+   i32.const 994
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -23191,7 +23203,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 995
+   i32.const 996
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -23232,7 +23244,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 998
+   i32.const 999
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -23314,7 +23326,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 1008
+   i32.const 1009
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -23328,7 +23340,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 1009
+   i32.const 1010
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -23342,7 +23354,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 1010
+   i32.const 1011
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -23356,7 +23368,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 1011
+   i32.const 1012
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -23376,7 +23388,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 1013
+   i32.const 1014
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -23396,7 +23408,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 1014
+   i32.const 1015
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -23416,7 +23428,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 1015
+   i32.const 1016
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -23436,7 +23448,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 1016
+   i32.const 1017
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -23457,7 +23469,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 1020
+   i32.const 1021
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -23477,7 +23489,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 1021
+   i32.const 1022
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -23523,7 +23535,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 1024
+   i32.const 1025
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -23569,7 +23581,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 1027
+   i32.const 1028
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -23620,7 +23632,7 @@
   if
    i32.const 0
    i32.const 304
-   i32.const 1030
+   i32.const 1031
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -23700,7 +23712,7 @@
   local.get $65
   call $~lib/rt/pure/__release
  )
- (func $~start (; 310 ;)
+ (func $~start (; 311 ;)
   global.get $~started
   if
    return
@@ -23710,10 +23722,10 @@
   end
   call $start:std/array
  )
- (func $~lib/rt/pure/__collect (; 311 ;)
+ (func $~lib/rt/pure/__collect (; 312 ;)
   return
  )
- (func $~lib/rt/pure/decrement (; 312 ;) (param $0 i32)
+ (func $~lib/rt/pure/decrement (; 313 ;) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -23733,7 +23745,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 256
+   i32.const 144
    i32.const 122
    i32.const 13
    call $~lib/builtins/abort
@@ -23755,7 +23767,7 @@
    i32.eqz
    if
     i32.const 0
-    i32.const 256
+    i32.const 144
     i32.const 126
     i32.const 17
     call $~lib/builtins/abort
@@ -23771,7 +23783,7 @@
    i32.eqz
    if
     i32.const 0
-    i32.const 256
+    i32.const 144
     i32.const 136
     i32.const 15
     call $~lib/builtins/abort
@@ -23790,7 +23802,7 @@
    i32.store offset=4
   end
  )
- (func $~lib/rt/pure/__visit (; 313 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/pure/__visit (; 314 ;) (param $0 i32) (param $1 i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.lt_u
@@ -23803,7 +23815,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 256
+   i32.const 144
    i32.const 69
    i32.const 15
    call $~lib/builtins/abort
@@ -23814,16 +23826,16 @@
   i32.sub
   call $~lib/rt/pure/decrement
  )
- (func $~lib/array/Array<i32>#__visit_impl (; 314 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i32>#__visit_impl (; 315 ;) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/array/Array<u8>#__visit_impl (; 315 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<u8>#__visit_impl (; 316 ;) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/array/Array<u32>#__visit_impl (; 316 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<u32>#__visit_impl (; 317 ;) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/array/Array<std/array/Ref>#__visit_impl (; 317 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<std/array/Ref>#__visit_impl (; 318 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -23862,13 +23874,13 @@
    end
   end
  )
- (func $~lib/array/Array<f32>#__visit_impl (; 318 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<f32>#__visit_impl (; 319 ;) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/array/Array<f64>#__visit_impl (; 319 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<f64>#__visit_impl (; 320 ;) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/array/Array<std/array/Ref | null>#__visit_impl (; 320 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<std/array/Ref | null>#__visit_impl (; 321 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -23907,7 +23919,7 @@
    end
   end
  )
- (func $~lib/array/Array<~lib/array/Array<i32>>#__visit_impl (; 321 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<~lib/array/Array<i32>>#__visit_impl (; 322 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -23946,7 +23958,7 @@
    end
   end
  )
- (func $~lib/array/Array<std/array/Proxy<i32>>#__visit_impl (; 322 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<std/array/Proxy<i32>>#__visit_impl (; 323 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -23985,7 +23997,7 @@
    end
   end
  )
- (func $~lib/array/Array<~lib/string/String | null>#__visit_impl (; 323 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<~lib/string/String | null>#__visit_impl (; 324 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -24024,7 +24036,7 @@
    end
   end
  )
- (func $~lib/array/Array<~lib/string/String>#__visit_impl (; 324 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<~lib/string/String>#__visit_impl (; 325 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -24063,25 +24075,25 @@
    end
   end
  )
- (func $~lib/array/Array<bool>#__visit_impl (; 325 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<bool>#__visit_impl (; 326 ;) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/array/Array<u64>#__visit_impl (; 326 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<u64>#__visit_impl (; 327 ;) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/array/Array<i16>#__visit_impl (; 327 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i16>#__visit_impl (; 328 ;) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/array/Array<i8>#__visit_impl (; 328 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i8>#__visit_impl (; 329 ;) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/array/Array<u16>#__visit_impl (; 329 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<u16>#__visit_impl (; 330 ;) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/array/Array<i64>#__visit_impl (; 330 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i64>#__visit_impl (; 331 ;) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/array/Array<~lib/array/Array<u8>>#__visit_impl (; 331 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<~lib/array/Array<u8>>#__visit_impl (; 332 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -24120,7 +24132,7 @@
    end
   end
  )
- (func $~lib/array/Array<~lib/array/Array<u32>>#__visit_impl (; 332 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<~lib/array/Array<u32>>#__visit_impl (; 333 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -24159,7 +24171,7 @@
    end
   end
  )
- (func $~lib/array/Array<~lib/array/Array<~lib/array/Array<u32>>>#__visit_impl (; 333 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<~lib/array/Array<~lib/array/Array<u32>>>#__visit_impl (; 334 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -24198,7 +24210,7 @@
    end
   end
  )
- (func $~lib/rt/__visit_members (; 334 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/__visit_members (; 335 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   block $block$4$break
    block $switch$1$default

--- a/tests/compiler/std/arraybuffer.optimized.wat
+++ b/tests/compiler/std/arraybuffer.optimized.wat
@@ -1,9 +1,9 @@
 (module
  (type $i32_=>_none (func (param i32)))
  (type $i32_i32_=>_none (func (param i32 i32)))
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
- (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
+ (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
@@ -1583,32 +1583,7 @@
    call $~lib/rt/pure/decrement
   end
  )
- (func $~lib/arraybuffer/ArrayBufferView#constructor (; 22 ;) (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  i32.const 1
-  i32.const 1073741808
-  local.get $1
-  i32.shr_u
-  i32.gt_u
-  if
-   i32.const 32
-   i32.const 80
-   i32.const 23
-   i32.const 56
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i32.const 1
-  local.get $1
-  i32.shl
-  local.tee $3
-  i32.const 0
-  call $~lib/rt/tlsf/__alloc
-  local.tee $1
-  local.get $3
-  call $~lib/memory/memory.fill
+ (func $~lib/arraybuffer/ArrayBufferView#constructor (; 22 ;) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -1627,6 +1602,34 @@
   local.get $0
   i32.const 0
   i32.store offset=8
+  local.get $0
+ )
+ (func $~lib/arraybuffer/ArrayBufferView#alloc (; 23 ;) (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  i32.const 1
+  i32.const 1073741808
+  local.get $1
+  i32.shr_u
+  i32.gt_u
+  if
+   i32.const 32
+   i32.const 80
+   i32.const 14
+   i32.const 56
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 1
+  local.get $1
+  i32.shl
+  local.tee $3
+  i32.const 0
+  call $~lib/rt/tlsf/__alloc
+  local.tee $1
+  local.get $3
+  call $~lib/memory/memory.fill
   local.get $1
   local.set $2
   local.get $0
@@ -1650,9 +1653,8 @@
   local.get $0
   local.get $3
   i32.store offset=8
-  local.get $0
  )
- (func $~lib/rt/__allocArray (; 23 ;) (result i32)
+ (func $~lib/rt/__allocArray (; 24 ;) (result i32)
   (local $0 i32)
   (local $1 i32)
   i32.const 16
@@ -1680,7 +1682,7 @@
   call $~lib/memory/memory.copy
   local.get $0
  )
- (func $~lib/dataview/DataView#constructor (; 24 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/dataview/DataView#constructor (; 25 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1738,17 +1740,19 @@
   i32.store offset=8
   local.get $2
  )
- (func $~setArgumentsLength (; 25 ;) (param $0 i32)
+ (func $~setArgumentsLength (; 26 ;) (param $0 i32)
   local.get $0
   global.set $~argumentsLength
  )
- (func $start:std/arraybuffer (; 26 ;)
+ (func $start:std/arraybuffer (; 27 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
   i32.const 8
   i32.const 0
   call $~lib/rt/tlsf/__alloc
@@ -1819,9 +1823,10 @@
   i32.const -1
   i32.const 1073741808
   call $~lib/arraybuffer/ArrayBuffer#slice
+  local.set $0
   local.get $1
   call $~lib/rt/pure/__release
-  local.tee $1
+  local.get $0
   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
   i32.const 1
   i32.ne
@@ -1837,9 +1842,9 @@
   i32.const 1
   i32.const 3
   call $~lib/arraybuffer/ArrayBuffer#slice
-  local.get $1
+  local.get $0
   call $~lib/rt/pure/__release
-  local.tee $1
+  local.tee $0
   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
   i32.const 2
   i32.ne
@@ -1855,9 +1860,9 @@
   i32.const 1
   i32.const -1
   call $~lib/arraybuffer/ArrayBuffer#slice
-  local.get $1
+  local.get $0
   call $~lib/rt/pure/__release
-  local.tee $1
+  local.tee $0
   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
   i32.const 6
   i32.ne
@@ -1873,10 +1878,9 @@
   i32.const -3
   i32.const -1
   call $~lib/arraybuffer/ArrayBuffer#slice
-  local.set $0
-  local.get $1
-  call $~lib/rt/pure/__release
   local.get $0
+  call $~lib/rt/pure/__release
+  local.tee $0
   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
   i32.const 2
   i32.ne
@@ -1892,10 +1896,10 @@
   i32.const -4
   i32.const 42
   call $~lib/arraybuffer/ArrayBuffer#slice
-  local.set $3
+  local.set $1
   local.get $0
   call $~lib/rt/pure/__release
-  local.get $3
+  local.get $1
   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
   i32.const 4
   i32.ne
@@ -1911,10 +1915,10 @@
   i32.const 42
   i32.const 1073741808
   call $~lib/arraybuffer/ArrayBuffer#slice
-  local.set $1
-  local.get $3
-  call $~lib/rt/pure/__release
+  local.set $3
   local.get $1
+  call $~lib/rt/pure/__release
+  local.get $3
   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
   if
    i32.const 0
@@ -1924,7 +1928,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $3
   i32.eqz
   if
    i32.const 0
@@ -1938,43 +1942,63 @@
   i32.const 5
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
-  i32.const 0
   call $~lib/arraybuffer/ArrayBufferView#constructor
-  local.set $0
+  local.tee $4
+  i32.const 0
+  call $~lib/arraybuffer/ArrayBufferView#alloc
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
   i32.const 12
   i32.const 9
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
-  i32.const 2
   call $~lib/arraybuffer/ArrayBufferView#constructor
-  local.set $5
+  local.tee $1
+  i32.const 2
+  call $~lib/arraybuffer/ArrayBufferView#alloc
   i32.const 1
   global.set $~argumentsLength
-  local.get $0
+  local.get $4
   i32.load
-  local.tee $3
-  local.get $3
-  call $~lib/arraybuffer/ArrayBuffer#get:byteLength
+  call $~lib/rt/pure/__retain
+  local.tee $0
+  local.set $6
+  block $2of2
+   block $1of2
+    block $outOfRange
+     global.get $~argumentsLength
+     i32.const 1
+     i32.sub
+     br_table $1of2 $1of2 $2of2 $outOfRange
+    end
+    unreachable
+   end
+   local.get $0
+   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
+   local.set $7
+  end
+  local.get $0
+  local.get $7
   call $~lib/dataview/DataView#constructor
-  local.set $3
+  local.set $0
   local.get $2
+  call $~lib/rt/pure/__release
+  local.get $3
+  call $~lib/rt/pure/__release
+  local.get $4
+  call $~lib/rt/pure/__release
   call $~lib/rt/pure/__release
   local.get $1
   call $~lib/rt/pure/__release
+  local.get $6
+  call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
-  call $~lib/rt/pure/__release
-  local.get $5
-  call $~lib/rt/pure/__release
-  local.get $3
-  call $~lib/rt/pure/__release
  )
- (func $~start (; 27 ;)
+ (func $~start (; 28 ;)
   call $start:std/arraybuffer
  )
- (func $~lib/rt/pure/decrement (; 28 ;) (param $0 i32)
+ (func $~lib/rt/pure/decrement (; 29 ;) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -2050,7 +2074,7 @@
    i32.store offset=4
   end
  )
- (func $~lib/rt/__visit_members (; 29 ;) (param $0 i32)
+ (func $~lib/rt/__visit_members (; 30 ;) (param $0 i32)
   block $block$4$break
    block $switch$1$default
     block $switch$1$case$2

--- a/tests/compiler/std/arraybuffer.untouched.wat
+++ b/tests/compiler/std/arraybuffer.untouched.wat
@@ -2,10 +2,10 @@
  (type $i32_=>_i32 (func (param i32) (result i32)))
  (type $i32_=>_none (func (param i32)))
  (type $i32_i32_=>_none (func (param i32 i32)))
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
- (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_none (func))
+ (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (type $i32_i32_i32_i32_=>_i32 (func (param i32 i32 i32 i32) (result i32)))
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $none_=>_i32 (func (result i32)))
@@ -1730,7 +1730,7 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 54
+   i32.const 45
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -3184,35 +3184,7 @@
   local.get $1
   return
  )
- (func $~lib/arraybuffer/ArrayBufferView#constructor (; 29 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  local.get $1
-  i32.const 1073741808
-  local.get $2
-  i32.shr_u
-  i32.gt_u
-  if
-   i32.const 32
-   i32.const 80
-   i32.const 23
-   i32.const 56
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $1
-  local.get $2
-  i32.shl
-  local.tee $1
-  i32.const 0
-  call $~lib/rt/tlsf/__alloc
-  local.set $3
-  local.get $3
-  i32.const 0
-  local.get $1
-  call $~lib/memory/memory.fill
+ (func $~lib/arraybuffer/ArrayBufferView#constructor (; 29 ;) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -3231,6 +3203,37 @@
   local.get $0
   i32.const 0
   i32.store offset=8
+  local.get $0
+ )
+ (func $~lib/arraybuffer/ArrayBufferView#alloc (; 30 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  local.get $1
+  i32.const 1073741808
+  local.get $2
+  i32.shr_u
+  i32.gt_u
+  if
+   i32.const 32
+   i32.const 80
+   i32.const 14
+   i32.const 56
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $1
+  local.get $2
+  i32.shl
+  local.tee $1
+  i32.const 0
+  call $~lib/rt/tlsf/__alloc
+  local.set $3
+  local.get $3
+  i32.const 0
+  local.get $1
+  call $~lib/memory/memory.fill
   local.get $0
   local.tee $4
   local.get $3
@@ -3254,9 +3257,8 @@
   local.get $0
   local.get $1
   i32.store offset=8
-  local.get $0
  )
- (func $~lib/typedarray/Uint8Array#constructor (; 30 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#constructor (; 31 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   if (result i32)
    local.get $0
@@ -3266,13 +3268,15 @@
    call $~lib/rt/tlsf/__alloc
    call $~lib/rt/pure/__retain
   end
-  local.get $1
-  i32.const 0
   call $~lib/arraybuffer/ArrayBufferView#constructor
   local.set $0
   local.get $0
+  local.get $1
+  i32.const 0
+  call $~lib/arraybuffer/ArrayBufferView#alloc
+  local.get $0
  )
- (func $~lib/rt/__allocArray (; 31 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $~lib/rt/__allocArray (; 32 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -3310,7 +3314,7 @@
   end
   local.get $4
  )
- (func $~lib/arraybuffer/ArrayBuffer.isView<~lib/array/Array<i32>> (; 32 ;) (param $0 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBuffer.isView<~lib/array/Array<i32>> (; 33 ;) (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -3321,7 +3325,7 @@
   call $~lib/rt/pure/__release
   local.get $1
  )
- (func $~lib/arraybuffer/ArrayBuffer.isView<~lib/typedarray/Uint8Array> (; 33 ;) (param $0 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBuffer.isView<~lib/typedarray/Uint8Array> (; 34 ;) (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -3333,7 +3337,7 @@
   local.get $1
   return
  )
- (func $~lib/typedarray/Int32Array#constructor (; 34 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#constructor (; 35 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   if (result i32)
    local.get $0
@@ -3343,13 +3347,15 @@
    call $~lib/rt/tlsf/__alloc
    call $~lib/rt/pure/__retain
   end
-  local.get $1
-  i32.const 2
   call $~lib/arraybuffer/ArrayBufferView#constructor
   local.set $0
   local.get $0
+  local.get $1
+  i32.const 2
+  call $~lib/arraybuffer/ArrayBufferView#alloc
+  local.get $0
  )
- (func $~lib/arraybuffer/ArrayBuffer.isView<~lib/typedarray/Int32Array> (; 35 ;) (param $0 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBuffer.isView<~lib/typedarray/Int32Array> (; 36 ;) (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -3361,7 +3367,7 @@
   local.get $1
   return
  )
- (func $~lib/dataview/DataView#constructor (; 36 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $~lib/dataview/DataView#constructor (; 37 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -3438,7 +3444,12 @@
   call $~lib/rt/pure/__release
   local.get $0
  )
- (func $~lib/dataview/DataView#constructor|trampoline (; 37 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#get:buffer (; 38 ;) (param $0 i32) (result i32)
+  local.get $0
+  i32.load
+  call $~lib/rt/pure/__retain
+ )
+ (func $~lib/dataview/DataView#constructor|trampoline (; 39 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   block $2of2
    block $1of2
     block $0of2
@@ -3463,11 +3474,11 @@
   local.get $3
   call $~lib/dataview/DataView#constructor
  )
- (func $~setArgumentsLength (; 38 ;) (param $0 i32)
+ (func $~setArgumentsLength (; 40 ;) (param $0 i32)
   local.get $0
   global.set $~argumentsLength
  )
- (func $~lib/arraybuffer/ArrayBuffer.isView<~lib/dataview/DataView> (; 39 ;) (param $0 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBuffer.isView<~lib/dataview/DataView> (; 41 ;) (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -3479,13 +3490,14 @@
   local.get $1
   return
  )
- (func $start:std/arraybuffer (; 40 ;)
+ (func $start:std/arraybuffer (; 42 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   i32.const 0
   i32.const 8
   call $~lib/arraybuffer/ArrayBuffer#constructor
@@ -3822,11 +3834,12 @@
   global.set $~argumentsLength
   i32.const 0
   local.get $2
-  i32.load
+  call $~lib/typedarray/Uint8Array#get:buffer
+  local.tee $5
   i32.const 0
   i32.const 0
   call $~lib/dataview/DataView#constructor|trampoline
-  local.tee $5
+  local.tee $6
   call $~lib/arraybuffer/ArrayBuffer.isView<~lib/dataview/DataView>
   i32.eqz
   if
@@ -3849,14 +3862,16 @@
   call $~lib/rt/pure/__release
   local.get $5
   call $~lib/rt/pure/__release
+  local.get $6
+  call $~lib/rt/pure/__release
  )
- (func $~start (; 41 ;)
+ (func $~start (; 43 ;)
   call $start:std/arraybuffer
  )
- (func $~lib/rt/pure/__collect (; 42 ;)
+ (func $~lib/rt/pure/__collect (; 44 ;)
   return
  )
- (func $~lib/rt/tlsf/freeBlock (; 43 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/freeBlock (; 45 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $1
   i32.load
@@ -3872,7 +3887,7 @@
   local.get $1
   call $~lib/rt/rtrace/onfree
  )
- (func $~lib/rt/pure/decrement (; 44 ;) (param $0 i32)
+ (func $~lib/rt/pure/decrement (; 46 ;) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -3949,7 +3964,7 @@
    i32.store offset=4
   end
  )
- (func $~lib/rt/pure/__visit (; 45 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/pure/__visit (; 47 ;) (param $0 i32) (param $1 i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.lt_u
@@ -3973,10 +3988,10 @@
   i32.sub
   call $~lib/rt/pure/decrement
  )
- (func $~lib/array/Array<i32>#__visit_impl (; 46 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i32>#__visit_impl (; 48 ;) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/rt/__visit_members (; 47 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/__visit_members (; 49 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   block $block$4$break
    block $switch$1$default

--- a/tests/compiler/std/dataview.optimized.wat
+++ b/tests/compiler/std/dataview.optimized.wat
@@ -21,11 +21,11 @@
  (import "rtrace" "ondecrement" (func $~lib/rt/rtrace/ondecrement (param i32)))
  (import "rtrace" "onfree" (func $~lib/rt/rtrace/onfree (param i32)))
  (memory $0 1)
- (data (i32.const 16) "\1c\00\00\00\01\00\00\00\01\00\00\00\1c\00\00\00I\00n\00v\00a\00l\00i\00d\00 \00l\00e\00n\00g\00t\00h")
- (data (i32.const 64) "&\00\00\00\01\00\00\00\01\00\00\00&\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00b\00u\00f\00f\00e\00r\00.\00t\00s")
- (data (i32.const 128) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s")
- (data (i32.const 176) "(\00\00\00\01\00\00\00\01\00\00\00(\00\00\00a\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e")
- (data (i32.const 240) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00p\00u\00r\00e\00.\00t\00s")
+ (data (i32.const 16) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s")
+ (data (i32.const 64) "(\00\00\00\01\00\00\00\01\00\00\00(\00\00\00a\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e")
+ (data (i32.const 128) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00p\00u\00r\00e\00.\00t\00s")
+ (data (i32.const 176) "\1c\00\00\00\01\00\00\00\01\00\00\00\1c\00\00\00I\00n\00v\00a\00l\00i\00d\00 \00l\00e\00n\00g\00t\00h")
+ (data (i32.const 224) "&\00\00\00\01\00\00\00\01\00\00\00&\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00b\00u\00f\00f\00e\00r\00.\00t\00s")
  (data (i32.const 288) "$\00\00\00\01\00\00\00\01\00\00\00$\00\00\00I\00n\00d\00e\00x\00 \00o\00u\00t\00 \00o\00f\00 \00r\00a\00n\00g\00e")
  (data (i32.const 352) "$\00\00\00\01\00\00\00\01\00\00\00$\00\00\00~\00l\00i\00b\00/\00t\00y\00p\00e\00d\00a\00r\00r\00a\00y\00.\00t\00s")
  (data (i32.const 416) " \00\00\00\01\00\00\00\01\00\00\00 \00\00\00~\00l\00i\00b\00/\00d\00a\00t\00a\00v\00i\00e\00w\00.\00t\00s")
@@ -49,7 +49,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 277
    i32.const 13
    call $~lib/builtins/abort
@@ -71,7 +71,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 279
    i32.const 13
    call $~lib/builtins/abort
@@ -116,7 +116,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 292
    i32.const 13
    call $~lib/builtins/abort
@@ -213,7 +213,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 205
    i32.const 13
    call $~lib/builtins/abort
@@ -227,7 +227,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 207
    i32.const 13
    call $~lib/builtins/abort
@@ -300,7 +300,7 @@
    i32.eqz
    if
     i32.const 0
-    i32.const 144
+    i32.const 32
     i32.const 228
     i32.const 15
     call $~lib/builtins/abort
@@ -355,7 +355,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 243
    i32.const 13
    call $~lib/builtins/abort
@@ -370,7 +370,7 @@
   i32.ne
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 244
    i32.const 13
    call $~lib/builtins/abort
@@ -420,7 +420,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 260
    i32.const 13
    call $~lib/builtins/abort
@@ -506,7 +506,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 386
    i32.const 4
    call $~lib/builtins/abort
@@ -523,7 +523,7 @@
    i32.lt_u
    if
     i32.const 0
-    i32.const 144
+    i32.const 32
     i32.const 396
     i32.const 15
     call $~lib/builtins/abort
@@ -551,7 +551,7 @@
    i32.lt_u
    if
     i32.const 0
-    i32.const 144
+    i32.const 32
     i32.const 408
     i32.const 4
     call $~lib/builtins/abort
@@ -691,8 +691,8 @@
   i32.const 1073741808
   i32.ge_u
   if
-   i32.const 192
-   i32.const 144
+   i32.const 80
+   i32.const 32
    i32.const 457
    i32.const 29
    call $~lib/builtins/abort
@@ -767,7 +767,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 338
    i32.const 13
    call $~lib/builtins/abort
@@ -819,7 +819,7 @@
     i32.eqz
     if
      i32.const 0
-     i32.const 144
+     i32.const 32
      i32.const 351
      i32.const 17
      call $~lib/builtins/abort
@@ -914,7 +914,7 @@
   i32.and
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 365
    i32.const 13
    call $~lib/builtins/abort
@@ -985,7 +985,7 @@
   global.get $~lib/rt/tlsf/collectLock
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 490
    i32.const 13
    call $~lib/builtins/abort
@@ -1019,7 +1019,7 @@
     i32.eqz
     if
      i32.const 0
-     i32.const 144
+     i32.const 32
      i32.const 502
      i32.const 19
      call $~lib/builtins/abort
@@ -1035,7 +1035,7 @@
   i32.lt_u
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 510
    i32.const 13
    call $~lib/builtins/abort
@@ -1069,7 +1069,81 @@
   i32.const 16
   i32.add
  )
- (func $~lib/memory/memory.fill (; 15 ;) (param $0 i32)
+ (func $~lib/rt/pure/increment (; 15 ;) (param $0 i32)
+  (local $1 i32)
+  local.get $0
+  i32.load offset=4
+  local.tee $1
+  i32.const -268435456
+  i32.and
+  local.get $1
+  i32.const 1
+  i32.add
+  i32.const -268435456
+  i32.and
+  i32.ne
+  if
+   i32.const 0
+   i32.const 144
+   i32.const 109
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  local.get $1
+  i32.const 1
+  i32.add
+  i32.store offset=4
+  local.get $0
+  call $~lib/rt/rtrace/onincrement
+  local.get $0
+  i32.load
+  i32.const 1
+  i32.and
+  if
+   i32.const 0
+   i32.const 144
+   i32.const 112
+   i32.const 13
+   call $~lib/builtins/abort
+   unreachable
+  end
+ )
+ (func $~lib/rt/pure/__retain (; 16 ;) (param $0 i32) (result i32)
+  local.get $0
+  i32.const 512
+  i32.gt_u
+  if
+   local.get $0
+   i32.const 16
+   i32.sub
+   call $~lib/rt/pure/increment
+  end
+  local.get $0
+ )
+ (func $~lib/arraybuffer/ArrayBufferView#constructor (; 17 ;) (param $0 i32) (result i32)
+  local.get $0
+  i32.eqz
+  if
+   i32.const 12
+   i32.const 2
+   call $~lib/rt/tlsf/__alloc
+   call $~lib/rt/pure/__retain
+   local.set $0
+  end
+  local.get $0
+  i32.const 0
+  i32.store
+  local.get $0
+  i32.const 0
+  i32.store offset=4
+  local.get $0
+  i32.const 0
+  i32.store offset=8
+  local.get $0
+ )
+ (func $~lib/memory/memory.fill (; 18 ;) (param $0 i32)
   (local $1 i32)
   local.get $0
   i32.const 0
@@ -1113,60 +1187,7 @@
   i32.const 0
   i32.store8
  )
- (func $~lib/rt/pure/increment (; 16 ;) (param $0 i32)
-  (local $1 i32)
-  local.get $0
-  i32.load offset=4
-  local.tee $1
-  i32.const -268435456
-  i32.and
-  local.get $1
-  i32.const 1
-  i32.add
-  i32.const -268435456
-  i32.and
-  i32.ne
-  if
-   i32.const 0
-   i32.const 256
-   i32.const 109
-   i32.const 2
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $0
-  local.get $1
-  i32.const 1
-  i32.add
-  i32.store offset=4
-  local.get $0
-  call $~lib/rt/rtrace/onincrement
-  local.get $0
-  i32.load
-  i32.const 1
-  i32.and
-  if
-   i32.const 0
-   i32.const 256
-   i32.const 112
-   i32.const 13
-   call $~lib/builtins/abort
-   unreachable
-  end
- )
- (func $~lib/rt/pure/__retain (; 17 ;) (param $0 i32) (result i32)
-  local.get $0
-  i32.const 512
-  i32.gt_u
-  if
-   local.get $0
-   i32.const 16
-   i32.sub
-   call $~lib/rt/pure/increment
-  end
-  local.get $0
- )
- (func $~lib/rt/pure/__release (; 18 ;) (param $0 i32)
+ (func $~lib/rt/pure/__release (; 19 ;) (param $0 i32)
   local.get $0
   i32.const 512
   i32.gt_u
@@ -1177,7 +1198,7 @@
    call $~lib/rt/pure/decrement
   end
  )
- (func $~lib/arraybuffer/ArrayBufferView#constructor (; 19 ;) (param $0 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBufferView#alloc (; 20 ;) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -1186,24 +1207,6 @@
   call $~lib/rt/tlsf/__alloc
   local.tee $1
   call $~lib/memory/memory.fill
-  local.get $0
-  i32.eqz
-  if
-   i32.const 12
-   i32.const 2
-   call $~lib/rt/tlsf/__alloc
-   call $~lib/rt/pure/__retain
-   local.set $0
-  end
-  local.get $0
-  i32.const 0
-  i32.store
-  local.get $0
-  i32.const 0
-  i32.store offset=4
-  local.get $0
-  i32.const 0
-  i32.store offset=8
   local.get $1
   local.set $2
   local.get $1
@@ -1227,9 +1230,8 @@
   local.get $0
   i32.const 8
   i32.store offset=8
-  local.get $0
  )
- (func $~lib/typedarray/Uint8Array#__set (; 20 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint8Array#__set (; 21 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -1237,7 +1239,7 @@
   if
    i32.const 304
    i32.const 368
-   i32.const 163
+   i32.const 190
    i32.const 44
    call $~lib/builtins/abort
    unreachable
@@ -1249,13 +1251,13 @@
   local.get $2
   i32.store8
  )
- (func $~lib/arraybuffer/ArrayBuffer#get:byteLength (; 21 ;) (param $0 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBuffer#get:byteLength (; 22 ;) (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub
   i32.load offset=12
  )
- (func $~lib/dataview/DataView#constructor (; 22 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/dataview/DataView#constructor (; 23 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1270,7 +1272,7 @@
   i32.gt_u
   i32.or
   if
-   i32.const 32
+   i32.const 192
    i32.const 432
    i32.const 25
    i32.const 6
@@ -1317,14 +1319,19 @@
   i32.store offset=8
   local.get $3
  )
- (func $~lib/arraybuffer/ArrayBufferView#get:byteOffset (; 23 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#get:buffer (; 24 ;) (param $0 i32) (result i32)
+  local.get $0
+  i32.load
+  call $~lib/rt/pure/__retain
+ )
+ (func $~lib/typedarray/Uint8Array#get:byteOffset (; 25 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $0
   i32.load
   i32.sub
  )
- (func $~lib/polyfills/bswap<u32> (; 24 ;) (param $0 i32) (result i32)
+ (func $~lib/polyfills/bswap<u32> (; 26 ;) (param $0 i32) (result i32)
   local.get $0
   i32.const -16711936
   i32.and
@@ -1337,7 +1344,7 @@
   i32.rotr
   i32.or
  )
- (func $~lib/dataview/DataView#getFloat32 (; 25 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result f32)
+ (func $~lib/dataview/DataView#getFloat32 (; 27 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result f32)
   local.get $1
   i32.const 31
   i32.shr_u
@@ -1373,7 +1380,7 @@
    f32.reinterpret_i32
   end
  )
- (func $~lib/polyfills/bswap<u64> (; 26 ;) (param $0 i64) (result i64)
+ (func $~lib/polyfills/bswap<u64> (; 28 ;) (param $0 i64) (result i64)
   local.get $0
   i64.const 8
   i64.shr_u
@@ -1399,7 +1406,7 @@
   i64.const 32
   i64.rotr
  )
- (func $~lib/dataview/DataView#getFloat64 (; 27 ;) (param $0 i32) (param $1 i32) (result f64)
+ (func $~lib/dataview/DataView#getFloat64 (; 29 ;) (param $0 i32) (param $1 i32) (result f64)
   i32.const 8
   local.get $0
   i32.load offset=8
@@ -1425,7 +1432,7 @@
    f64.reinterpret_i64
   end
  )
- (func $~lib/dataview/DataView#getInt8 (; 28 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/dataview/DataView#getInt8 (; 30 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -1444,7 +1451,7 @@
   i32.add
   i32.load8_s
  )
- (func $~lib/polyfills/bswap<i16> (; 29 ;) (param $0 i32) (result i32)
+ (func $~lib/polyfills/bswap<i16> (; 31 ;) (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.shl
@@ -1457,7 +1464,7 @@
   i32.shl
   i32.or
  )
- (func $~lib/dataview/DataView#getInt16 (; 30 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/dataview/DataView#getInt16 (; 32 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $1
   i32.const 31
   i32.shr_u
@@ -1491,7 +1498,7 @@
   end
   local.get $0
  )
- (func $~lib/dataview/DataView#getInt32 (; 31 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/dataview/DataView#getInt32 (; 33 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $1
   i32.const 31
   i32.shr_u
@@ -1525,7 +1532,7 @@
   end
   local.get $0
  )
- (func $~lib/dataview/DataView#getInt64 (; 32 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $~lib/dataview/DataView#getInt64 (; 34 ;) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i64)
   i32.const 8
   local.get $0
@@ -1551,7 +1558,7 @@
    call $~lib/polyfills/bswap<u64>
   end
  )
- (func $~lib/dataview/DataView#getUint8 (; 33 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/dataview/DataView#getUint8 (; 35 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -1570,7 +1577,7 @@
   i32.add
   i32.load8_u
  )
- (func $~lib/polyfills/bswap<u16> (; 34 ;) (param $0 i32) (result i32)
+ (func $~lib/polyfills/bswap<u16> (; 36 ;) (param $0 i32) (result i32)
   local.get $0
   i32.const 8
   i32.shl
@@ -1581,7 +1588,7 @@
   i32.shr_u
   i32.or
  )
- (func $~lib/dataview/DataView#getUint16 (; 35 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/dataview/DataView#getUint16 (; 37 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $1
   i32.const 31
   i32.shr_u
@@ -1615,7 +1622,7 @@
   end
   local.get $0
  )
- (func $~lib/dataview/DataView#getUint32 (; 36 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/dataview/DataView#getUint32 (; 38 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $1
   i32.const 31
   i32.shr_u
@@ -1649,7 +1656,7 @@
   end
   local.get $0
  )
- (func $~lib/dataview/DataView#getUint64 (; 37 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $~lib/dataview/DataView#getUint64 (; 39 ;) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i64)
   i32.const 8
   local.get $0
@@ -1675,7 +1682,7 @@
    call $~lib/polyfills/bswap<u64>
   end
  )
- (func $~lib/dataview/DataView#setFloat32 (; 38 ;) (param $0 i32) (param $1 f32) (param $2 i32)
+ (func $~lib/dataview/DataView#setFloat32 (; 40 ;) (param $0 i32) (param $1 f32) (param $2 i32)
   i32.const 4
   local.get $0
   i32.load offset=8
@@ -1703,7 +1710,7 @@
    i32.store
   end
  )
- (func $~lib/dataview/DataView#setFloat64 (; 39 ;) (param $0 i32) (param $1 f64) (param $2 i32)
+ (func $~lib/dataview/DataView#setFloat64 (; 41 ;) (param $0 i32) (param $1 f64) (param $2 i32)
   i32.const 8
   local.get $0
   i32.load offset=8
@@ -1731,7 +1738,7 @@
    i64.store
   end
  )
- (func $~lib/dataview/DataView#setInt8 (; 40 ;) (param $0 i32)
+ (func $~lib/dataview/DataView#setInt8 (; 42 ;) (param $0 i32)
   i32.const 0
   local.get $0
   i32.load offset=8
@@ -1749,7 +1756,7 @@
   i32.const 108
   i32.store8
  )
- (func $~lib/dataview/DataView#setInt16 (; 41 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/dataview/DataView#setInt16 (; 43 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   i32.const 2
   local.get $0
   i32.load offset=8
@@ -1773,7 +1780,7 @@
   end
   i32.store16
  )
- (func $~lib/dataview/DataView#setInt32 (; 42 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/dataview/DataView#setInt32 (; 44 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   i32.const 4
   local.get $0
   i32.load offset=8
@@ -1797,7 +1804,7 @@
   end
   i32.store
  )
- (func $~lib/dataview/DataView#setInt64 (; 43 ;) (param $0 i32) (param $1 i64) (param $2 i32)
+ (func $~lib/dataview/DataView#setInt64 (; 45 ;) (param $0 i32) (param $1 i64) (param $2 i32)
   i32.const 8
   local.get $0
   i32.load offset=8
@@ -1821,7 +1828,7 @@
   end
   i64.store
  )
- (func $~lib/dataview/DataView#setUint8 (; 44 ;) (param $0 i32)
+ (func $~lib/dataview/DataView#setUint8 (; 46 ;) (param $0 i32)
   i32.const 0
   local.get $0
   i32.load offset=8
@@ -1839,7 +1846,7 @@
   i32.const 238
   i32.store8
  )
- (func $~lib/dataview/DataView#setUint16 (; 45 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/dataview/DataView#setUint16 (; 47 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   i32.const 2
   local.get $0
   i32.load offset=8
@@ -1863,7 +1870,7 @@
   end
   i32.store16
  )
- (func $~lib/dataview/DataView#setUint32 (; 46 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/dataview/DataView#setUint32 (; 48 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   i32.const 4
   local.get $0
   i32.load offset=8
@@ -1887,7 +1894,7 @@
   end
   i32.store
  )
- (func $~lib/dataview/DataView#setUint64 (; 47 ;) (param $0 i32) (param $1 i64) (param $2 i32)
+ (func $~lib/dataview/DataView#setUint64 (; 49 ;) (param $0 i32) (param $1 i64) (param $2 i32)
   i32.const 8
   local.get $0
   i32.load offset=8
@@ -1911,7 +1918,7 @@
   end
   i64.store
  )
- (func $~lib/dataview/DataView#constructor|trampoline (; 48 ;) (param $0 i32) (result i32)
+ (func $~lib/dataview/DataView#constructor|trampoline (; 50 ;) (param $0 i32) (result i32)
   (local $1 i32)
   block $2of2
    block $1of2
@@ -1932,20 +1939,24 @@
   local.get $1
   call $~lib/dataview/DataView#constructor
  )
- (func $~setArgumentsLength (; 49 ;) (param $0 i32)
+ (func $~setArgumentsLength (; 51 ;) (param $0 i32)
   local.get $0
   global.set $~argumentsLength
  )
- (func $start:std/dataview (; 50 ;)
+ (func $start:std/dataview (; 52 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
   i32.const 12
   i32.const 3
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
   call $~lib/arraybuffer/ArrayBufferView#constructor
   local.tee $1
+  call $~lib/arraybuffer/ArrayBufferView#alloc
+  local.get $1
   i32.const 0
   i32.const 246
   call $~lib/typedarray/Uint8Array#__set
@@ -1978,9 +1989,10 @@
   i32.const 95
   call $~lib/typedarray/Uint8Array#__set
   local.get $1
-  i32.load
+  call $~lib/typedarray/Uint8Array#get:buffer
+  local.tee $3
   local.get $1
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Uint8Array#get:byteOffset
   local.get $1
   i32.load offset=8
   call $~lib/dataview/DataView#constructor
@@ -3461,13 +3473,14 @@
   i32.const 1
   global.set $~argumentsLength
   local.get $1
-  i32.load
+  call $~lib/typedarray/Uint8Array#get:buffer
+  local.tee $4
   call $~lib/dataview/DataView#constructor|trampoline
   local.set $2
   local.get $0
   call $~lib/rt/pure/__release
   local.get $2
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Uint8Array#get:byteOffset
   if
    i32.const 0
    i32.const 480
@@ -3490,13 +3503,17 @@
   end
   local.get $1
   call $~lib/rt/pure/__release
+  local.get $3
+  call $~lib/rt/pure/__release
   local.get $2
   call $~lib/rt/pure/__release
+  local.get $4
+  call $~lib/rt/pure/__release
  )
- (func $~start (; 51 ;)
+ (func $~start (; 53 ;)
   call $start:std/dataview
  )
- (func $~lib/rt/pure/decrement (; 52 ;) (param $0 i32)
+ (func $~lib/rt/pure/decrement (; 54 ;) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -3513,7 +3530,7 @@
   i32.and
   if
    i32.const 0
-   i32.const 256
+   i32.const 144
    i32.const 122
    i32.const 13
    call $~lib/builtins/abort
@@ -3532,7 +3549,7 @@
    i32.and
    if
     i32.const 0
-    i32.const 256
+    i32.const 144
     i32.const 126
     i32.const 17
     call $~lib/builtins/abort
@@ -3555,7 +3572,7 @@
    i32.le_u
    if
     i32.const 0
-    i32.const 256
+    i32.const 144
     i32.const 136
     i32.const 15
     call $~lib/builtins/abort
@@ -3572,7 +3589,7 @@
    i32.store offset=4
   end
  )
- (func $~lib/rt/__visit_members (; 53 ;) (param $0 i32)
+ (func $~lib/rt/__visit_members (; 55 ;) (param $0 i32)
   block $switch$1$default
    block $switch$1$case$4
     block $switch$1$case$2

--- a/tests/compiler/std/dataview.untouched.wat
+++ b/tests/compiler/std/dataview.untouched.wat
@@ -1,9 +1,9 @@
 (module
  (type $i32_=>_i32 (func (param i32) (result i32)))
  (type $i32_=>_none (func (param i32)))
- (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (type $i32_i32_=>_none (func (param i32 i32)))
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
+ (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_none (func))
@@ -22,11 +22,11 @@
  (import "rtrace" "ondecrement" (func $~lib/rt/rtrace/ondecrement (param i32)))
  (import "rtrace" "onfree" (func $~lib/rt/rtrace/onfree (param i32)))
  (memory $0 1)
- (data (i32.const 16) "\1c\00\00\00\01\00\00\00\01\00\00\00\1c\00\00\00I\00n\00v\00a\00l\00i\00d\00 \00l\00e\00n\00g\00t\00h\00")
- (data (i32.const 64) "&\00\00\00\01\00\00\00\01\00\00\00&\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00b\00u\00f\00f\00e\00r\00.\00t\00s\00")
- (data (i32.const 128) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s\00")
- (data (i32.const 176) "(\00\00\00\01\00\00\00\01\00\00\00(\00\00\00a\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e\00")
- (data (i32.const 240) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00p\00u\00r\00e\00.\00t\00s\00")
+ (data (i32.const 16) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s\00")
+ (data (i32.const 64) "(\00\00\00\01\00\00\00\01\00\00\00(\00\00\00a\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e\00")
+ (data (i32.const 128) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00p\00u\00r\00e\00.\00t\00s\00")
+ (data (i32.const 176) "\1c\00\00\00\01\00\00\00\01\00\00\00\1c\00\00\00I\00n\00v\00a\00l\00i\00d\00 \00l\00e\00n\00g\00t\00h\00")
+ (data (i32.const 224) "&\00\00\00\01\00\00\00\01\00\00\00&\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00b\00u\00f\00f\00e\00r\00.\00t\00s\00")
  (data (i32.const 288) "$\00\00\00\01\00\00\00\01\00\00\00$\00\00\00I\00n\00d\00e\00x\00 \00o\00u\00t\00 \00o\00f\00 \00r\00a\00n\00g\00e\00")
  (data (i32.const 352) "$\00\00\00\01\00\00\00\01\00\00\00$\00\00\00~\00l\00i\00b\00/\00t\00y\00p\00e\00d\00a\00r\00r\00a\00y\00.\00t\00s\00")
  (data (i32.const 416) " \00\00\00\01\00\00\00\01\00\00\00 \00\00\00~\00l\00i\00b\00/\00d\00a\00t\00a\00v\00i\00e\00w\00.\00t\00s\00")
@@ -61,7 +61,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 277
    i32.const 13
    call $~lib/builtins/abort
@@ -86,7 +86,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 279
    i32.const 13
    call $~lib/builtins/abort
@@ -138,7 +138,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 292
    i32.const 13
    call $~lib/builtins/abort
@@ -268,7 +268,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 205
    i32.const 13
    call $~lib/builtins/abort
@@ -283,7 +283,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 207
    i32.const 13
    call $~lib/builtins/abort
@@ -376,7 +376,7 @@
    i32.eqz
    if
     i32.const 0
-    i32.const 144
+    i32.const 32
     i32.const 228
     i32.const 15
     call $~lib/builtins/abort
@@ -439,7 +439,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 243
    i32.const 13
    call $~lib/builtins/abort
@@ -455,7 +455,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 244
    i32.const 13
    call $~lib/builtins/abort
@@ -512,7 +512,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 260
    i32.const 13
    call $~lib/builtins/abort
@@ -631,7 +631,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 386
    i32.const 4
    call $~lib/builtins/abort
@@ -654,7 +654,7 @@
    i32.eqz
    if
     i32.const 0
-    i32.const 144
+    i32.const 32
     i32.const 396
     i32.const 15
     call $~lib/builtins/abort
@@ -685,7 +685,7 @@
    i32.eqz
    if
     i32.const 0
-    i32.const 144
+    i32.const 32
     i32.const 408
     i32.const 4
     call $~lib/builtins/abort
@@ -906,8 +906,8 @@
   i32.const 1073741808
   i32.ge_u
   if
-   i32.const 192
-   i32.const 144
+   i32.const 80
+   i32.const 32
    i32.const 457
    i32.const 29
    call $~lib/builtins/abort
@@ -1001,7 +1001,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 338
    i32.const 13
    call $~lib/builtins/abort
@@ -1064,7 +1064,7 @@
     i32.eqz
     if
      i32.const 0
-     i32.const 144
+     i32.const 32
      i32.const 351
      i32.const 17
      call $~lib/builtins/abort
@@ -1209,7 +1209,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 365
    i32.const 13
    call $~lib/builtins/abort
@@ -1298,7 +1298,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 490
    i32.const 13
    call $~lib/builtins/abort
@@ -1339,7 +1339,7 @@
      i32.eqz
      if
       i32.const 0
-      i32.const 144
+      i32.const 32
       i32.const 502
       i32.const 19
       call $~lib/builtins/abort
@@ -1358,7 +1358,7 @@
     i32.eqz
     if
      i32.const 0
-     i32.const 144
+     i32.const 32
      i32.const 507
      i32.const 17
      call $~lib/builtins/abort
@@ -1375,7 +1375,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 510
    i32.const 13
    call $~lib/builtins/abort
@@ -1409,7 +1409,85 @@
   i32.const 16
   i32.add
  )
- (func $~lib/memory/memory.fill (; 15 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/rt/pure/increment (; 15 ;) (param $0 i32)
+  (local $1 i32)
+  local.get $0
+  i32.load offset=4
+  local.set $1
+  local.get $1
+  i32.const -268435456
+  i32.and
+  local.get $1
+  i32.const 1
+  i32.add
+  i32.const -268435456
+  i32.and
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 144
+   i32.const 109
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  local.get $1
+  i32.const 1
+  i32.add
+  i32.store offset=4
+  local.get $0
+  call $~lib/rt/rtrace/onincrement
+  local.get $0
+  i32.load
+  i32.const 1
+  i32.and
+  i32.eqz
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 144
+   i32.const 112
+   i32.const 13
+   call $~lib/builtins/abort
+   unreachable
+  end
+ )
+ (func $~lib/rt/pure/__retain (; 16 ;) (param $0 i32) (result i32)
+  local.get $0
+  global.get $~lib/heap/__heap_base
+  i32.gt_u
+  if
+   local.get $0
+   i32.const 16
+   i32.sub
+   call $~lib/rt/pure/increment
+  end
+  local.get $0
+ )
+ (func $~lib/arraybuffer/ArrayBufferView#constructor (; 17 ;) (param $0 i32) (result i32)
+  local.get $0
+  i32.eqz
+  if
+   i32.const 12
+   i32.const 2
+   call $~lib/rt/tlsf/__alloc
+   call $~lib/rt/pure/__retain
+   local.set $0
+  end
+  local.get $0
+  i32.const 0
+  i32.store
+  local.get $0
+  i32.const 0
+  i32.store offset=4
+  local.get $0
+  i32.const 0
+  i32.store offset=8
+  local.get $0
+ )
+ (func $~lib/memory/memory.fill (; 18 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1673,64 +1751,7 @@
    end
   end
  )
- (func $~lib/rt/pure/increment (; 16 ;) (param $0 i32)
-  (local $1 i32)
-  local.get $0
-  i32.load offset=4
-  local.set $1
-  local.get $1
-  i32.const -268435456
-  i32.and
-  local.get $1
-  i32.const 1
-  i32.add
-  i32.const -268435456
-  i32.and
-  i32.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 256
-   i32.const 109
-   i32.const 2
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $0
-  local.get $1
-  i32.const 1
-  i32.add
-  i32.store offset=4
-  local.get $0
-  call $~lib/rt/rtrace/onincrement
-  local.get $0
-  i32.load
-  i32.const 1
-  i32.and
-  i32.eqz
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 256
-   i32.const 112
-   i32.const 13
-   call $~lib/builtins/abort
-   unreachable
-  end
- )
- (func $~lib/rt/pure/__retain (; 17 ;) (param $0 i32) (result i32)
-  local.get $0
-  global.get $~lib/heap/__heap_base
-  i32.gt_u
-  if
-   local.get $0
-   i32.const 16
-   i32.sub
-   call $~lib/rt/pure/increment
-  end
-  local.get $0
- )
- (func $~lib/rt/pure/__release (; 18 ;) (param $0 i32)
+ (func $~lib/rt/pure/__release (; 19 ;) (param $0 i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.gt_u
@@ -1741,7 +1762,7 @@
    call $~lib/rt/pure/decrement
   end
  )
- (func $~lib/arraybuffer/ArrayBufferView#constructor (; 19 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBufferView#alloc (; 20 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1752,9 +1773,9 @@
   i32.shr_u
   i32.gt_u
   if
-   i32.const 32
-   i32.const 80
-   i32.const 23
+   i32.const 192
+   i32.const 240
+   i32.const 14
    i32.const 56
    call $~lib/builtins/abort
    unreachable
@@ -1770,24 +1791,6 @@
   i32.const 0
   local.get $1
   call $~lib/memory/memory.fill
-  local.get $0
-  i32.eqz
-  if
-   i32.const 12
-   i32.const 2
-   call $~lib/rt/tlsf/__alloc
-   call $~lib/rt/pure/__retain
-   local.set $0
-  end
-  local.get $0
-  i32.const 0
-  i32.store
-  local.get $0
-  i32.const 0
-  i32.store offset=4
-  local.get $0
-  i32.const 0
-  i32.store offset=8
   local.get $0
   local.tee $4
   local.get $3
@@ -1811,9 +1814,8 @@
   local.get $0
   local.get $1
   i32.store offset=8
-  local.get $0
  )
- (func $~lib/typedarray/Uint8Array#constructor (; 20 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#constructor (; 21 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   if (result i32)
    local.get $0
@@ -1823,13 +1825,15 @@
    call $~lib/rt/tlsf/__alloc
    call $~lib/rt/pure/__retain
   end
-  local.get $1
-  i32.const 0
   call $~lib/arraybuffer/ArrayBufferView#constructor
   local.set $0
   local.get $0
+  local.get $1
+  i32.const 0
+  call $~lib/arraybuffer/ArrayBufferView#alloc
+  local.get $0
  )
- (func $~lib/typedarray/Uint8Array#__set (; 21 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint8Array#__set (; 22 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -1837,7 +1841,7 @@
   if
    i32.const 304
    i32.const 368
-   i32.const 163
+   i32.const 190
    i32.const 44
    call $~lib/builtins/abort
    unreachable
@@ -1849,13 +1853,13 @@
   local.get $2
   i32.store8
  )
- (func $~lib/arraybuffer/ArrayBuffer#get:byteLength (; 22 ;) (param $0 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBuffer#get:byteLength (; 23 ;) (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub
   i32.load offset=12
  )
- (func $~lib/dataview/DataView#constructor (; 23 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $~lib/dataview/DataView#constructor (; 24 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -1876,7 +1880,7 @@
   if
    local.get $1
    call $~lib/rt/pure/__release
-   i32.const 32
+   i32.const 192
    i32.const 432
    i32.const 25
    i32.const 6
@@ -1932,14 +1936,23 @@
   call $~lib/rt/pure/__release
   local.get $0
  )
- (func $~lib/arraybuffer/ArrayBufferView#get:byteOffset (; 24 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#get:buffer (; 25 ;) (param $0 i32) (result i32)
+  local.get $0
+  i32.load
+  call $~lib/rt/pure/__retain
+ )
+ (func $~lib/typedarray/Uint8Array#get:byteOffset (; 26 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $0
   i32.load
   i32.sub
  )
- (func $~lib/polyfills/bswap<u32> (; 25 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#get:byteLength (; 27 ;) (param $0 i32) (result i32)
+  local.get $0
+  i32.load offset=8
+ )
+ (func $~lib/polyfills/bswap<u32> (; 28 ;) (param $0 i32) (result i32)
   local.get $0
   i32.const -16711936
   i32.and
@@ -1953,7 +1966,7 @@
   i32.or
   return
  )
- (func $~lib/dataview/DataView#getFloat32 (; 26 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result f32)
+ (func $~lib/dataview/DataView#getFloat32 (; 29 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result f32)
   local.get $1
   i32.const 31
   i32.shr_u
@@ -1989,7 +2002,7 @@
    f32.reinterpret_i32
   end
  )
- (func $~lib/polyfills/bswap<u64> (; 27 ;) (param $0 i64) (result i64)
+ (func $~lib/polyfills/bswap<u64> (; 30 ;) (param $0 i64) (result i64)
   (local $1 i64)
   (local $2 i64)
   (local $3 i64)
@@ -2028,7 +2041,7 @@
   i64.rotr
   return
  )
- (func $~lib/dataview/DataView#getFloat64 (; 28 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result f64)
+ (func $~lib/dataview/DataView#getFloat64 (; 31 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result f64)
   local.get $1
   i32.const 31
   i32.shr_u
@@ -2064,7 +2077,7 @@
    f64.reinterpret_i64
   end
  )
- (func $~lib/dataview/DataView#getInt8 (; 29 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/dataview/DataView#getInt8 (; 32 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -2083,7 +2096,7 @@
   i32.add
   i32.load8_s
  )
- (func $~lib/polyfills/bswap<i16> (; 30 ;) (param $0 i32) (result i32)
+ (func $~lib/polyfills/bswap<i16> (; 33 ;) (param $0 i32) (result i32)
   local.get $0
   i32.const 8
   i32.shl
@@ -2099,7 +2112,7 @@
   i32.or
   return
  )
- (func $~lib/dataview/DataView#getInt16 (; 31 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/dataview/DataView#getInt16 (; 34 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $1
   i32.const 31
@@ -2133,7 +2146,7 @@
    call $~lib/polyfills/bswap<i16>
   end
  )
- (func $~lib/polyfills/bswap<i32> (; 32 ;) (param $0 i32) (result i32)
+ (func $~lib/polyfills/bswap<i32> (; 35 ;) (param $0 i32) (result i32)
   local.get $0
   i32.const -16711936
   i32.and
@@ -2147,7 +2160,7 @@
   i32.or
   return
  )
- (func $~lib/dataview/DataView#getInt32 (; 33 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/dataview/DataView#getInt32 (; 36 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $1
   i32.const 31
@@ -2181,7 +2194,7 @@
    call $~lib/polyfills/bswap<i32>
   end
  )
- (func $~lib/polyfills/bswap<i64> (; 34 ;) (param $0 i64) (result i64)
+ (func $~lib/polyfills/bswap<i64> (; 37 ;) (param $0 i64) (result i64)
   (local $1 i64)
   (local $2 i64)
   (local $3 i64)
@@ -2220,7 +2233,7 @@
   i64.rotr
   return
  )
- (func $~lib/dataview/DataView#getInt64 (; 35 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i64)
+ (func $~lib/dataview/DataView#getInt64 (; 38 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i64)
   (local $3 i64)
   local.get $1
   i32.const 31
@@ -2254,7 +2267,7 @@
    call $~lib/polyfills/bswap<i64>
   end
  )
- (func $~lib/dataview/DataView#getUint8 (; 36 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/dataview/DataView#getUint8 (; 39 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -2273,7 +2286,7 @@
   i32.add
   i32.load8_u
  )
- (func $~lib/polyfills/bswap<u16> (; 37 ;) (param $0 i32) (result i32)
+ (func $~lib/polyfills/bswap<u16> (; 40 ;) (param $0 i32) (result i32)
   local.get $0
   i32.const 8
   i32.shl
@@ -2287,7 +2300,7 @@
   i32.or
   return
  )
- (func $~lib/dataview/DataView#getUint16 (; 38 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/dataview/DataView#getUint16 (; 41 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $1
   i32.const 31
@@ -2321,7 +2334,7 @@
    call $~lib/polyfills/bswap<u16>
   end
  )
- (func $~lib/dataview/DataView#getUint32 (; 39 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/dataview/DataView#getUint32 (; 42 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $1
   i32.const 31
@@ -2355,7 +2368,7 @@
    call $~lib/polyfills/bswap<u32>
   end
  )
- (func $~lib/dataview/DataView#getUint64 (; 40 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i64)
+ (func $~lib/dataview/DataView#getUint64 (; 43 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i64)
   (local $3 i64)
   local.get $1
   i32.const 31
@@ -2389,7 +2402,7 @@
    call $~lib/polyfills/bswap<u64>
   end
  )
- (func $~lib/dataview/DataView#setFloat32 (; 41 ;) (param $0 i32) (param $1 i32) (param $2 f32) (param $3 i32)
+ (func $~lib/dataview/DataView#setFloat32 (; 44 ;) (param $0 i32) (param $1 i32) (param $2 f32) (param $3 i32)
   local.get $1
   i32.const 31
   i32.shr_u
@@ -2427,7 +2440,7 @@
    i32.store
   end
  )
- (func $~lib/dataview/DataView#setFloat64 (; 42 ;) (param $0 i32) (param $1 i32) (param $2 f64) (param $3 i32)
+ (func $~lib/dataview/DataView#setFloat64 (; 45 ;) (param $0 i32) (param $1 i32) (param $2 f64) (param $3 i32)
   local.get $1
   i32.const 31
   i32.shr_u
@@ -2465,7 +2478,7 @@
    i64.store
   end
  )
- (func $~lib/dataview/DataView#setInt8 (; 43 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/dataview/DataView#setInt8 (; 46 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -2485,7 +2498,7 @@
   local.get $2
   i32.store8
  )
- (func $~lib/dataview/DataView#setInt16 (; 44 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/dataview/DataView#setInt16 (; 47 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   local.get $1
   i32.const 31
   i32.shr_u
@@ -2517,7 +2530,7 @@
   end
   i32.store16
  )
- (func $~lib/dataview/DataView#setInt32 (; 45 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/dataview/DataView#setInt32 (; 48 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   local.get $1
   i32.const 31
   i32.shr_u
@@ -2549,7 +2562,7 @@
   end
   i32.store
  )
- (func $~lib/dataview/DataView#setInt64 (; 46 ;) (param $0 i32) (param $1 i32) (param $2 i64) (param $3 i32)
+ (func $~lib/dataview/DataView#setInt64 (; 49 ;) (param $0 i32) (param $1 i32) (param $2 i64) (param $3 i32)
   local.get $1
   i32.const 31
   i32.shr_u
@@ -2581,7 +2594,7 @@
   end
   i64.store
  )
- (func $~lib/dataview/DataView#setUint8 (; 47 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/dataview/DataView#setUint8 (; 50 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -2601,7 +2614,7 @@
   local.get $2
   i32.store8
  )
- (func $~lib/dataview/DataView#setUint16 (; 48 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/dataview/DataView#setUint16 (; 51 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   local.get $1
   i32.const 31
   i32.shr_u
@@ -2633,7 +2646,7 @@
   end
   i32.store16
  )
- (func $~lib/dataview/DataView#setUint32 (; 49 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/dataview/DataView#setUint32 (; 52 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   local.get $1
   i32.const 31
   i32.shr_u
@@ -2665,7 +2678,7 @@
   end
   i32.store
  )
- (func $~lib/dataview/DataView#setUint64 (; 50 ;) (param $0 i32) (param $1 i32) (param $2 i64) (param $3 i32)
+ (func $~lib/dataview/DataView#setUint64 (; 53 ;) (param $0 i32) (param $1 i32) (param $2 i64) (param $3 i32)
   local.get $1
   i32.const 31
   i32.shr_u
@@ -2697,7 +2710,7 @@
   end
   i64.store
  )
- (func $~lib/dataview/DataView#constructor|trampoline (; 51 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $~lib/dataview/DataView#constructor|trampoline (; 54 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   block $2of2
    block $1of2
     block $0of2
@@ -2722,21 +2735,23 @@
   local.get $3
   call $~lib/dataview/DataView#constructor
  )
- (func $~setArgumentsLength (; 52 ;) (param $0 i32)
+ (func $~setArgumentsLength (; 55 ;) (param $0 i32)
   local.get $0
   global.set $~argumentsLength
  )
- (func $~lib/dataview/DataView#get:byteOffset (; 53 ;) (param $0 i32) (result i32)
+ (func $~lib/dataview/DataView#get:byteOffset (; 56 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $0
   i32.load
   i32.sub
  )
- (func $start:std/dataview (; 54 ;)
+ (func $start:std/dataview (; 57 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
   i32.const 0
   i32.const 8
   call $~lib/typedarray/Uint8Array#constructor
@@ -2775,14 +2790,15 @@
   call $~lib/typedarray/Uint8Array#__set
   i32.const 0
   local.get $0
-  i32.load
+  call $~lib/typedarray/Uint8Array#get:buffer
+  local.tee $1
   local.get $0
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Uint8Array#get:byteOffset
   local.get $0
-  i32.load offset=8
+  call $~lib/typedarray/Uint8Array#get:byteLength
   call $~lib/dataview/DataView#constructor
-  local.set $1
-  local.get $1
+  local.set $2
+  local.get $2
   i32.const 0
   i32.const 1
   call $~lib/dataview/DataView#getFloat32
@@ -2797,7 +2813,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 1
   i32.const 1
   call $~lib/dataview/DataView#getFloat32
@@ -2812,7 +2828,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 2
   i32.const 1
   call $~lib/dataview/DataView#getFloat32
@@ -2827,7 +2843,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 3
   i32.const 1
   call $~lib/dataview/DataView#getFloat32
@@ -2842,7 +2858,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 4
   i32.const 1
   call $~lib/dataview/DataView#getFloat32
@@ -2857,7 +2873,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 0
   i32.const 0
   call $~lib/dataview/DataView#getFloat32
@@ -2872,7 +2888,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 1
   i32.const 0
   call $~lib/dataview/DataView#getFloat32
@@ -2887,7 +2903,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 2
   i32.const 0
   call $~lib/dataview/DataView#getFloat32
@@ -2902,7 +2918,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 3
   i32.const 0
   call $~lib/dataview/DataView#getFloat32
@@ -2917,7 +2933,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 4
   i32.const 0
   call $~lib/dataview/DataView#getFloat32
@@ -2932,7 +2948,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 0
   i32.const 1
   call $~lib/dataview/DataView#getFloat64
@@ -2947,7 +2963,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 0
   i32.const 0
   call $~lib/dataview/DataView#getFloat64
@@ -2962,7 +2978,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 0
   call $~lib/dataview/DataView#getInt8
   i32.const -10
@@ -2976,7 +2992,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 1
   call $~lib/dataview/DataView#getInt8
   i32.const -32
@@ -2990,7 +3006,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 2
   call $~lib/dataview/DataView#getInt8
   i32.const 88
@@ -3004,7 +3020,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 3
   call $~lib/dataview/DataView#getInt8
   i32.const -97
@@ -3018,7 +3034,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 4
   call $~lib/dataview/DataView#getInt8
   i32.const -126
@@ -3032,7 +3048,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 5
   call $~lib/dataview/DataView#getInt8
   i32.const 101
@@ -3046,7 +3062,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 6
   call $~lib/dataview/DataView#getInt8
   i32.const 67
@@ -3060,7 +3076,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 7
   call $~lib/dataview/DataView#getInt8
   i32.const 95
@@ -3074,7 +3090,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 0
   i32.const 1
   call $~lib/dataview/DataView#getInt16
@@ -3093,7 +3109,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 1
   i32.const 1
   call $~lib/dataview/DataView#getInt16
@@ -3112,7 +3128,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 2
   i32.const 1
   call $~lib/dataview/DataView#getInt16
@@ -3131,7 +3147,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 3
   i32.const 1
   call $~lib/dataview/DataView#getInt16
@@ -3150,7 +3166,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 4
   i32.const 1
   call $~lib/dataview/DataView#getInt16
@@ -3169,7 +3185,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 5
   i32.const 1
   call $~lib/dataview/DataView#getInt16
@@ -3188,7 +3204,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 6
   i32.const 1
   call $~lib/dataview/DataView#getInt16
@@ -3207,7 +3223,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 0
   i32.const 0
   call $~lib/dataview/DataView#getInt16
@@ -3226,7 +3242,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 1
   i32.const 0
   call $~lib/dataview/DataView#getInt16
@@ -3245,7 +3261,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 2
   i32.const 0
   call $~lib/dataview/DataView#getInt16
@@ -3264,7 +3280,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 3
   i32.const 0
   call $~lib/dataview/DataView#getInt16
@@ -3283,7 +3299,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 4
   i32.const 0
   call $~lib/dataview/DataView#getInt16
@@ -3302,7 +3318,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 5
   i32.const 0
   call $~lib/dataview/DataView#getInt16
@@ -3321,7 +3337,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 6
   i32.const 0
   call $~lib/dataview/DataView#getInt16
@@ -3340,7 +3356,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 0
   i32.const 1
   call $~lib/dataview/DataView#getInt32
@@ -3355,7 +3371,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 1
   i32.const 1
   call $~lib/dataview/DataView#getInt32
@@ -3370,7 +3386,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 2
   i32.const 1
   call $~lib/dataview/DataView#getInt32
@@ -3385,7 +3401,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 3
   i32.const 1
   call $~lib/dataview/DataView#getInt32
@@ -3400,7 +3416,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 4
   i32.const 1
   call $~lib/dataview/DataView#getInt32
@@ -3415,7 +3431,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 0
   i32.const 0
   call $~lib/dataview/DataView#getInt32
@@ -3430,7 +3446,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 1
   i32.const 0
   call $~lib/dataview/DataView#getInt32
@@ -3445,7 +3461,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 2
   i32.const 0
   call $~lib/dataview/DataView#getInt32
@@ -3460,7 +3476,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 3
   i32.const 0
   call $~lib/dataview/DataView#getInt32
@@ -3475,7 +3491,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 4
   i32.const 0
   call $~lib/dataview/DataView#getInt32
@@ -3490,7 +3506,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 0
   i32.const 1
   call $~lib/dataview/DataView#getInt64
@@ -3505,7 +3521,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 0
   i32.const 0
   call $~lib/dataview/DataView#getInt64
@@ -3520,7 +3536,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 0
   call $~lib/dataview/DataView#getUint8
   i32.const 246
@@ -3534,7 +3550,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 1
   call $~lib/dataview/DataView#getUint8
   i32.const 224
@@ -3548,7 +3564,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 2
   call $~lib/dataview/DataView#getUint8
   i32.const 88
@@ -3562,7 +3578,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 3
   call $~lib/dataview/DataView#getUint8
   i32.const 159
@@ -3576,7 +3592,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 4
   call $~lib/dataview/DataView#getUint8
   i32.const 130
@@ -3590,7 +3606,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 5
   call $~lib/dataview/DataView#getUint8
   i32.const 101
@@ -3604,7 +3620,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 6
   call $~lib/dataview/DataView#getUint8
   i32.const 67
@@ -3618,7 +3634,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 7
   call $~lib/dataview/DataView#getUint8
   i32.const 95
@@ -3632,7 +3648,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 0
   i32.const 1
   call $~lib/dataview/DataView#getUint16
@@ -3649,7 +3665,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 1
   i32.const 1
   call $~lib/dataview/DataView#getUint16
@@ -3666,7 +3682,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 2
   i32.const 1
   call $~lib/dataview/DataView#getUint16
@@ -3683,7 +3699,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 3
   i32.const 1
   call $~lib/dataview/DataView#getUint16
@@ -3700,7 +3716,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 4
   i32.const 1
   call $~lib/dataview/DataView#getUint16
@@ -3717,7 +3733,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 5
   i32.const 1
   call $~lib/dataview/DataView#getUint16
@@ -3734,7 +3750,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 6
   i32.const 1
   call $~lib/dataview/DataView#getUint16
@@ -3751,7 +3767,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 0
   i32.const 0
   call $~lib/dataview/DataView#getUint16
@@ -3768,7 +3784,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 1
   i32.const 0
   call $~lib/dataview/DataView#getUint16
@@ -3785,7 +3801,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 2
   i32.const 0
   call $~lib/dataview/DataView#getUint16
@@ -3802,7 +3818,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 3
   i32.const 0
   call $~lib/dataview/DataView#getUint16
@@ -3819,7 +3835,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 4
   i32.const 0
   call $~lib/dataview/DataView#getUint16
@@ -3836,7 +3852,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 5
   i32.const 0
   call $~lib/dataview/DataView#getUint16
@@ -3853,7 +3869,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 6
   i32.const 0
   call $~lib/dataview/DataView#getUint16
@@ -3870,7 +3886,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 0
   i32.const 1
   call $~lib/dataview/DataView#getUint32
@@ -3885,7 +3901,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 1
   i32.const 1
   call $~lib/dataview/DataView#getUint32
@@ -3900,7 +3916,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 2
   i32.const 1
   call $~lib/dataview/DataView#getUint32
@@ -3915,7 +3931,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 3
   i32.const 1
   call $~lib/dataview/DataView#getUint32
@@ -3930,7 +3946,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 4
   i32.const 1
   call $~lib/dataview/DataView#getUint32
@@ -3945,7 +3961,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 0
   i32.const 0
   call $~lib/dataview/DataView#getUint32
@@ -3960,7 +3976,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 1
   i32.const 0
   call $~lib/dataview/DataView#getUint32
@@ -3975,7 +3991,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 2
   i32.const 0
   call $~lib/dataview/DataView#getUint32
@@ -3990,7 +4006,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 3
   i32.const 0
   call $~lib/dataview/DataView#getUint32
@@ -4005,7 +4021,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 4
   i32.const 0
   call $~lib/dataview/DataView#getUint32
@@ -4020,7 +4036,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 0
   i32.const 1
   call $~lib/dataview/DataView#getUint64
@@ -4035,7 +4051,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 0
   i32.const 0
   call $~lib/dataview/DataView#getUint64
@@ -4050,12 +4066,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 0
   f32.const 1.5976661625240943e-18
   i32.const 1
   call $~lib/dataview/DataView#setFloat32
-  local.get $1
+  local.get $2
   i32.const 0
   i32.const 1
   call $~lib/dataview/DataView#getFloat32
@@ -4070,12 +4086,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 0
   f32.const 1976281973381696323584
   i32.const 0
   call $~lib/dataview/DataView#setFloat32
-  local.get $1
+  local.get $2
   i32.const 0
   i32.const 0
   call $~lib/dataview/DataView#getFloat32
@@ -4090,12 +4106,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 0
   f64.const -1094252199637739024055454e124
   i32.const 1
   call $~lib/dataview/DataView#setFloat64
-  local.get $1
+  local.get $2
   i32.const 0
   i32.const 1
   call $~lib/dataview/DataView#getFloat64
@@ -4110,12 +4126,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 0
   f64.const 6.022586634778589e-103
   i32.const 0
   call $~lib/dataview/DataView#setFloat64
-  local.get $1
+  local.get $2
   i32.const 0
   i32.const 0
   call $~lib/dataview/DataView#getFloat64
@@ -4130,11 +4146,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 0
   i32.const 108
   call $~lib/dataview/DataView#setInt8
-  local.get $1
+  local.get $2
   i32.const 0
   call $~lib/dataview/DataView#getInt8
   i32.const 108
@@ -4148,12 +4164,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 0
   i32.const -13360
   i32.const 1
   call $~lib/dataview/DataView#setInt16
-  local.get $1
+  local.get $2
   i32.const 0
   i32.const 1
   call $~lib/dataview/DataView#getInt16
@@ -4172,12 +4188,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 0
   i32.const 14689
   i32.const 0
   call $~lib/dataview/DataView#setInt16
-  local.get $1
+  local.get $2
   i32.const 0
   i32.const 0
   call $~lib/dataview/DataView#getInt16
@@ -4196,12 +4212,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 0
   i32.const 1204680201
   i32.const 1
   call $~lib/dataview/DataView#setInt32
-  local.get $1
+  local.get $2
   i32.const 0
   i32.const 1
   call $~lib/dataview/DataView#getInt32
@@ -4216,12 +4232,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 0
   i32.const 660673230
   i32.const 0
   call $~lib/dataview/DataView#setInt32
-  local.get $1
+  local.get $2
   i32.const 0
   i32.const 0
   call $~lib/dataview/DataView#getInt32
@@ -4236,12 +4252,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 0
   i64.const -3290739641816099749
   i32.const 1
   call $~lib/dataview/DataView#setInt64
-  local.get $1
+  local.get $2
   i32.const 0
   i32.const 1
   call $~lib/dataview/DataView#getInt64
@@ -4256,12 +4272,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 0
   i64.const 8178932412950708047
   i32.const 0
   call $~lib/dataview/DataView#setInt64
-  local.get $1
+  local.get $2
   i32.const 0
   i32.const 0
   call $~lib/dataview/DataView#getInt64
@@ -4276,11 +4292,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 0
   i32.const 238
   call $~lib/dataview/DataView#setUint8
-  local.get $1
+  local.get $2
   i32.const 0
   call $~lib/dataview/DataView#getUint8
   i32.const 238
@@ -4294,12 +4310,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 0
   i32.const 58856
   i32.const 1
   call $~lib/dataview/DataView#setUint16
-  local.get $1
+  local.get $2
   i32.const 0
   i32.const 1
   call $~lib/dataview/DataView#getUint16
@@ -4316,12 +4332,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 0
   i32.const 60400
   i32.const 0
   call $~lib/dataview/DataView#setUint16
-  local.get $1
+  local.get $2
   i32.const 0
   i32.const 0
   call $~lib/dataview/DataView#getUint16
@@ -4338,12 +4354,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 0
   i32.const -846805744
   i32.const 1
   call $~lib/dataview/DataView#setUint32
-  local.get $1
+  local.get $2
   i32.const 0
   i32.const 1
   call $~lib/dataview/DataView#getUint32
@@ -4358,12 +4374,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 0
   i32.const -1510791631
   i32.const 0
   call $~lib/dataview/DataView#setUint32
-  local.get $1
+  local.get $2
   i32.const 0
   i32.const 0
   call $~lib/dataview/DataView#getUint32
@@ -4378,12 +4394,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 0
   i64.const 2334704782995986958
   i32.const 1
   call $~lib/dataview/DataView#setUint64
-  local.get $1
+  local.get $2
   i32.const 0
   i32.const 1
   call $~lib/dataview/DataView#getUint64
@@ -4398,12 +4414,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.const 0
   i64.const -7123186897289856329
   i32.const 0
   call $~lib/dataview/DataView#setUint64
-  local.get $1
+  local.get $2
   i32.const 0
   i32.const 0
   call $~lib/dataview/DataView#getUint64
@@ -4422,16 +4438,17 @@
   global.set $~argumentsLength
   i32.const 0
   local.get $0
-  i32.load
+  call $~lib/typedarray/Uint8Array#get:buffer
+  local.tee $3
   i32.const 0
   i32.const 0
   call $~lib/dataview/DataView#constructor|trampoline
-  local.set $2
-  local.get $1
-  call $~lib/rt/pure/__release
+  local.set $4
   local.get $2
-  local.set $1
-  local.get $1
+  call $~lib/rt/pure/__release
+  local.get $4
+  local.set $2
+  local.get $2
   call $~lib/dataview/DataView#get:byteOffset
   i32.const 0
   i32.eq
@@ -4444,7 +4461,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   i32.load offset=8
   i32.const 8
   i32.eq
@@ -4461,14 +4478,18 @@
   call $~lib/rt/pure/__release
   local.get $1
   call $~lib/rt/pure/__release
+  local.get $2
+  call $~lib/rt/pure/__release
+  local.get $3
+  call $~lib/rt/pure/__release
  )
- (func $~start (; 55 ;)
+ (func $~start (; 58 ;)
   call $start:std/dataview
  )
- (func $~lib/rt/pure/__collect (; 56 ;)
+ (func $~lib/rt/pure/__collect (; 59 ;)
   return
  )
- (func $~lib/rt/tlsf/freeBlock (; 57 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/freeBlock (; 60 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $1
   i32.load
@@ -4484,7 +4505,7 @@
   local.get $1
   call $~lib/rt/rtrace/onfree
  )
- (func $~lib/rt/pure/decrement (; 58 ;) (param $0 i32)
+ (func $~lib/rt/pure/decrement (; 61 ;) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -4504,7 +4525,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 256
+   i32.const 144
    i32.const 122
    i32.const 13
    call $~lib/builtins/abort
@@ -4526,7 +4547,7 @@
    i32.eqz
    if
     i32.const 0
-    i32.const 256
+    i32.const 144
     i32.const 126
     i32.const 17
     call $~lib/builtins/abort
@@ -4542,7 +4563,7 @@
    i32.eqz
    if
     i32.const 0
-    i32.const 256
+    i32.const 144
     i32.const 136
     i32.const 15
     call $~lib/builtins/abort
@@ -4561,7 +4582,7 @@
    i32.store offset=4
   end
  )
- (func $~lib/rt/pure/__visit (; 59 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/pure/__visit (; 62 ;) (param $0 i32) (param $1 i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.lt_u
@@ -4574,7 +4595,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 256
+   i32.const 144
    i32.const 69
    i32.const 15
    call $~lib/builtins/abort
@@ -4585,7 +4606,7 @@
   i32.sub
   call $~lib/rt/pure/decrement
  )
- (func $~lib/rt/__visit_members (; 60 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/__visit_members (; 63 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   block $switch$1$default
    block $switch$1$case$4

--- a/tests/compiler/std/map.optimized.wat
+++ b/tests/compiler/std/map.optimized.wat
@@ -1,7 +1,7 @@
 (module
  (type $i32_i32_=>_none (func (param i32 i32)))
- (type $none_=>_i32 (func (result i32)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
+ (type $none_=>_i32 (func (result i32)))
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (type $i32_=>_none (func (param i32)))
@@ -1353,7 +1353,7 @@
   if
    i32.const 192
    i32.const 240
-   i32.const 54
+   i32.const 45
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -1750,31 +1750,7 @@
   local.get $0
   i32.load offset=4
  )
- (func $~lib/arraybuffer/ArrayBufferView#constructor (; 29 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  local.get $1
-  i32.const 1073741808
-  local.get $2
-  i32.shr_u
-  i32.gt_u
-  if
-   i32.const 192
-   i32.const 240
-   i32.const 23
-   i32.const 56
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $1
-  local.get $2
-  i32.shl
-  local.tee $3
-  i32.const 0
-  call $~lib/rt/tlsf/__alloc
-  local.tee $2
-  local.get $3
-  call $~lib/memory/memory.fill
+ (func $~lib/arraybuffer/ArrayBufferView#constructor (; 29 ;) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -1793,6 +1769,33 @@
   local.get $0
   i32.const 0
   i32.store offset=8
+  local.get $0
+ )
+ (func $~lib/arraybuffer/ArrayBufferView#alloc (; 30 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  local.get $1
+  i32.const 1073741808
+  local.get $2
+  i32.shr_u
+  i32.gt_u
+  if
+   i32.const 192
+   i32.const 240
+   i32.const 14
+   i32.const 56
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $1
+  local.get $2
+  i32.shl
+  local.tee $3
+  i32.const 0
+  call $~lib/rt/tlsf/__alloc
+  local.tee $2
+  local.get $3
+  call $~lib/memory/memory.fill
   local.get $2
   local.set $1
   local.get $2
@@ -1816,9 +1819,27 @@
   local.get $0
   local.get $3
   i32.store offset=8
-  local.get $0
  )
- (func $~lib/rt/tlsf/checkUsedBlock (; 30 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<i8>#constructor (; 31 ;) (param $0 i32) (result i32)
+  (local $1 i32)
+  i32.const 16
+  i32.const 4
+  call $~lib/rt/tlsf/__alloc
+  call $~lib/rt/pure/__retain
+  call $~lib/arraybuffer/ArrayBufferView#constructor
+  local.tee $1
+  i32.const 0
+  i32.store offset=12
+  local.get $1
+  local.get $0
+  i32.const 0
+  call $~lib/arraybuffer/ArrayBufferView#alloc
+  local.get $1
+  local.get $0
+  i32.store offset=12
+  local.get $1
+ )
+ (func $~lib/rt/tlsf/checkUsedBlock (; 32 ;) (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   i32.const 16
@@ -1860,7 +1881,7 @@
   end
   local.get $1
  )
- (func $~lib/memory/memory.copy (; 31 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/memory/memory.copy (; 33 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   block $~lib/util/memory/memmove|inlined.0
@@ -2033,7 +2054,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/freeBlock (; 32 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/freeBlock (; 34 ;) (param $0 i32) (param $1 i32)
   local.get $1
   local.get $1
   i32.load
@@ -2046,7 +2067,7 @@
   local.get $1
   call $~lib/rt/rtrace/onfree
  )
- (func $~lib/rt/tlsf/reallocateBlock (; 33 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/reallocateBlock (; 35 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2149,7 +2170,7 @@
   end
   local.get $3
  )
- (func $~lib/array/ensureSize (; 34 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/ensureSize (; 36 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $1
@@ -2209,7 +2230,7 @@
    i32.store offset=8
   end
  )
- (func $~lib/array/Array<i8>#__set (; 35 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<i8>#__set (; 37 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $1
   local.get $0
@@ -2222,7 +2243,7 @@
    if
     i32.const 464
     i32.const 528
-    i32.const 109
+    i32.const 114
     i32.const 21
     call $~lib/builtins/abort
     unreachable
@@ -2245,7 +2266,7 @@
   local.get $2
   i32.store8
  )
- (func $~lib/array/Array<i8>#set:length (; 36 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i8>#set:length (; 38 ;) (param $0 i32) (param $1 i32)
   local.get $0
   i32.load offset=12
   drop
@@ -2257,7 +2278,7 @@
   local.get $1
   i32.store offset=12
  )
- (func $~lib/map/Map<i8,i32>#keys (; 37 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<i8,i32>#keys (; 39 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -2266,32 +2287,21 @@
   (local $6 i32)
   local.get $0
   i32.load offset=8
-  local.set $4
+  local.set $3
   local.get $0
   i32.load offset=16
-  local.set $2
-  i32.const 16
-  i32.const 4
-  call $~lib/rt/tlsf/__alloc
-  call $~lib/rt/pure/__retain
-  local.get $2
-  i32.const 0
-  call $~lib/arraybuffer/ArrayBufferView#constructor
-  local.tee $1
-  i32.const 0
-  i32.store offset=12
-  local.get $1
-  local.get $2
-  i32.store offset=12
+  local.tee $4
+  call $~lib/array/Array<i8>#constructor
+  local.set $1
   i32.const 0
   local.set $0
   loop $for-loop|0
-   local.get $3
    local.get $2
+   local.get $4
    i32.lt_s
    if
-    local.get $4
     local.get $3
+    local.get $2
     i32.const 12
     i32.mul
     i32.add
@@ -2312,10 +2322,10 @@
      i32.load8_s
      call $~lib/array/Array<i8>#__set
     end
-    local.get $3
+    local.get $2
     i32.const 1
     i32.add
-    local.set $3
+    local.set $2
     br $for-loop|0
    end
   end
@@ -2324,24 +2334,26 @@
   call $~lib/array/Array<i8>#set:length
   local.get $1
  )
- (func $~lib/array/Array<i32>#constructor (; 38 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<i32>#constructor (; 40 ;) (param $0 i32) (result i32)
   (local $1 i32)
   i32.const 16
   i32.const 5
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
-  local.get $0
-  i32.const 2
   call $~lib/arraybuffer/ArrayBufferView#constructor
   local.tee $1
   i32.const 0
   i32.store offset=12
   local.get $1
   local.get $0
+  i32.const 2
+  call $~lib/arraybuffer/ArrayBufferView#alloc
+  local.get $1
+  local.get $0
   i32.store offset=12
   local.get $1
  )
- (func $~lib/array/Array<i32>#__set (; 39 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<i32>#__set (; 41 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $1
   local.get $0
@@ -2354,7 +2366,7 @@
    if
     i32.const 464
     i32.const 528
-    i32.const 109
+    i32.const 114
     i32.const 21
     call $~lib/builtins/abort
     unreachable
@@ -2379,7 +2391,7 @@
   local.get $2
   i32.store
  )
- (func $~lib/array/Array<i32>#set:length (; 40 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i32>#set:length (; 42 ;) (param $0 i32) (param $1 i32)
   local.get $0
   i32.load offset=12
   drop
@@ -2391,7 +2403,7 @@
   local.get $1
   i32.store offset=12
  )
- (func $~lib/map/Map<i8,i32>#values (; 41 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<i8,i32>#values (; 43 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -2447,7 +2459,7 @@
   call $~lib/array/Array<i32>#set:length
   local.get $1
  )
- (func $~lib/map/Map<i8,i8>#clear (; 42 ;) (param $0 i32)
+ (func $~lib/map/Map<i8,i8>#clear (; 44 ;) (param $0 i32)
   (local $1 i32)
   i32.const 16
   call $~lib/arraybuffer/ArrayBuffer#constructor
@@ -2480,7 +2492,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<i8,i8>#constructor (; 43 ;) (result i32)
+ (func $~lib/map/Map<i8,i8>#constructor (; 45 ;) (result i32)
   (local $0 i32)
   i32.const 24
   i32.const 6
@@ -2508,7 +2520,7 @@
   call $~lib/map/Map<i8,i8>#clear
   local.get $0
  )
- (func $~lib/map/Map<i32,i32>#constructor (; 44 ;) (result i32)
+ (func $~lib/map/Map<i32,i32>#constructor (; 46 ;) (result i32)
   (local $0 i32)
   i32.const 24
   i32.const 7
@@ -2536,7 +2548,7 @@
   call $~lib/map/Map<i8,i32>#clear
   local.get $0
  )
- (func $~lib/array/Array<i8>#__get (; 45 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i8>#__get (; 47 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -2544,7 +2556,7 @@
   if
    i32.const 464
    i32.const 528
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -2555,7 +2567,7 @@
   i32.add
   i32.load8_s
  )
- (func $~lib/array/Array<i32>#__get (; 46 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#__get (; 48 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -2563,7 +2575,7 @@
   if
    i32.const 464
    i32.const 528
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -2576,7 +2588,7 @@
   i32.add
   i32.load
  )
- (func $~lib/map/Map<i8,i8>#find (; 47 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<i8,i8>#find (; 49 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.load
   local.get $2
@@ -2619,7 +2631,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<i8,i8>#rehash (; 48 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<i8,i8>#rehash (; 50 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2750,7 +2762,7 @@
   local.get $4
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<i8,i8>#set (; 49 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<i8,i8>#set (; 51 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2844,7 +2856,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/hash/hash32 (; 50 ;) (param $0 i32) (result i32)
+ (func $~lib/util/hash/hash32 (; 52 ;) (param $0 i32) (result i32)
   local.get $0
   i32.const 255
   i32.and
@@ -2875,7 +2887,7 @@
   i32.const 16777619
   i32.mul
  )
- (func $~lib/map/Map<i32,i32>#find (; 51 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<i32,i32>#find (; 53 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.load
   local.get $2
@@ -2916,7 +2928,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<i32,i32>#rehash (; 52 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<i32,i32>#rehash (; 54 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3047,7 +3059,7 @@
   local.get $4
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<i32,i32>#set (; 53 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<i32,i32>#set (; 55 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3137,7 +3149,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/map/Map<i8,i32>#delete (; 54 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<i8,i32>#delete (; 56 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -3200,7 +3212,7 @@
    call $~lib/map/Map<i8,i32>#rehash
   end
  )
- (func $std/map/testNumeric<i8,i32> (; 55 ;)
+ (func $std/map/testNumeric<i8,i32> (; 57 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -3667,7 +3679,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<u8,i32>#constructor (; 56 ;) (result i32)
+ (func $~lib/map/Map<u8,i32>#constructor (; 58 ;) (result i32)
   (local $0 i32)
   i32.const 24
   i32.const 8
@@ -3695,7 +3707,7 @@
   call $~lib/map/Map<i8,i32>#clear
   local.get $0
  )
- (func $~lib/map/Map<u8,i32>#has (; 57 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<u8,i32>#has (; 59 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -3706,7 +3718,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<u8,i32>#rehash (; 58 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<u8,i32>#rehash (; 60 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3837,7 +3849,7 @@
   local.get $4
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<u8,i32>#set (; 59 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<u8,i32>#set (; 61 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3929,7 +3941,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/map/Map<u8,i32>#get (; 60 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<u8,i32>#get (; 62 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -3950,7 +3962,26 @@
   local.get $0
   i32.load offset=4
  )
- (func $~lib/map/Map<u8,i32>#keys (; 61 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<u8>#constructor (; 63 ;) (param $0 i32) (result i32)
+  (local $1 i32)
+  i32.const 16
+  i32.const 9
+  call $~lib/rt/tlsf/__alloc
+  call $~lib/rt/pure/__retain
+  call $~lib/arraybuffer/ArrayBufferView#constructor
+  local.tee $1
+  i32.const 0
+  i32.store offset=12
+  local.get $1
+  local.get $0
+  i32.const 0
+  call $~lib/arraybuffer/ArrayBufferView#alloc
+  local.get $1
+  local.get $0
+  i32.store offset=12
+  local.get $1
+ )
+ (func $~lib/map/Map<u8,i32>#keys (; 64 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -3959,32 +3990,21 @@
   (local $6 i32)
   local.get $0
   i32.load offset=8
-  local.set $4
+  local.set $3
   local.get $0
   i32.load offset=16
-  local.set $2
-  i32.const 16
-  i32.const 9
-  call $~lib/rt/tlsf/__alloc
-  call $~lib/rt/pure/__retain
-  local.get $2
-  i32.const 0
-  call $~lib/arraybuffer/ArrayBufferView#constructor
-  local.tee $1
-  i32.const 0
-  i32.store offset=12
-  local.get $1
-  local.get $2
-  i32.store offset=12
+  local.tee $4
+  call $~lib/array/Array<u8>#constructor
+  local.set $1
   i32.const 0
   local.set $0
   loop $for-loop|0
-   local.get $3
    local.get $2
+   local.get $4
    i32.lt_s
    if
-    local.get $4
     local.get $3
+    local.get $2
     i32.const 12
     i32.mul
     i32.add
@@ -4005,10 +4025,10 @@
      i32.load8_u
      call $~lib/array/Array<i8>#__set
     end
-    local.get $3
+    local.get $2
     i32.const 1
     i32.add
-    local.set $3
+    local.set $2
     br $for-loop|0
    end
   end
@@ -4017,7 +4037,7 @@
   call $~lib/array/Array<i8>#set:length
   local.get $1
  )
- (func $~lib/map/Map<u8,u8>#constructor (; 62 ;) (result i32)
+ (func $~lib/map/Map<u8,u8>#constructor (; 65 ;) (result i32)
   (local $0 i32)
   i32.const 24
   i32.const 10
@@ -4045,7 +4065,7 @@
   call $~lib/map/Map<i8,i8>#clear
   local.get $0
  )
- (func $~lib/array/Array<u8>#__get (; 63 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u8>#__get (; 66 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -4053,7 +4073,7 @@
   if
    i32.const 464
    i32.const 528
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -4064,7 +4084,7 @@
   i32.add
   i32.load8_u
  )
- (func $~lib/map/Map<u8,u8>#rehash (; 64 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<u8,u8>#rehash (; 67 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4195,7 +4215,7 @@
   local.get $4
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<u8,u8>#set (; 65 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<u8,u8>#set (; 68 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -4287,7 +4307,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/map/Map<u8,i32>#delete (; 66 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<u8,i32>#delete (; 69 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -4348,7 +4368,7 @@
    call $~lib/map/Map<u8,i32>#rehash
   end
  )
- (func $std/map/testNumeric<u8,i32> (; 67 ;)
+ (func $std/map/testNumeric<u8,i32> (; 70 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -4793,7 +4813,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<i16,i32>#constructor (; 68 ;) (result i32)
+ (func $~lib/map/Map<i16,i32>#constructor (; 71 ;) (result i32)
   (local $0 i32)
   i32.const 24
   i32.const 11
@@ -4821,7 +4841,7 @@
   call $~lib/map/Map<i8,i32>#clear
   local.get $0
  )
- (func $~lib/util/hash/hash16 (; 69 ;) (param $0 i32) (result i32)
+ (func $~lib/util/hash/hash16 (; 72 ;) (param $0 i32) (result i32)
   local.get $0
   i32.const 255
   i32.and
@@ -4836,7 +4856,7 @@
   i32.const 16777619
   i32.mul
  )
- (func $~lib/map/Map<i16,i32>#find (; 70 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<i16,i32>#find (; 73 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.load
   local.get $2
@@ -4879,7 +4899,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<i16,i32>#has (; 71 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<i16,i32>#has (; 74 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -4892,7 +4912,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<i16,i32>#rehash (; 72 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<i16,i32>#rehash (; 75 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5023,7 +5043,7 @@
   local.get $4
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<i16,i32>#set (; 73 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<i16,i32>#set (; 76 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -5117,7 +5137,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/map/Map<i16,i32>#get (; 74 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<i16,i32>#get (; 77 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -5140,7 +5160,26 @@
   local.get $0
   i32.load offset=4
  )
- (func $~lib/array/Array<i16>#__set (; 75 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<i16>#constructor (; 78 ;) (param $0 i32) (result i32)
+  (local $1 i32)
+  i32.const 16
+  i32.const 12
+  call $~lib/rt/tlsf/__alloc
+  call $~lib/rt/pure/__retain
+  call $~lib/arraybuffer/ArrayBufferView#constructor
+  local.tee $1
+  i32.const 0
+  i32.store offset=12
+  local.get $1
+  local.get $0
+  i32.const 1
+  call $~lib/arraybuffer/ArrayBufferView#alloc
+  local.get $1
+  local.get $0
+  i32.store offset=12
+  local.get $1
+ )
+ (func $~lib/array/Array<i16>#__set (; 79 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $1
   local.get $0
@@ -5153,7 +5192,7 @@
    if
     i32.const 464
     i32.const 528
-    i32.const 109
+    i32.const 114
     i32.const 21
     call $~lib/builtins/abort
     unreachable
@@ -5178,7 +5217,7 @@
   local.get $2
   i32.store16
  )
- (func $~lib/array/Array<i16>#set:length (; 76 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i16>#set:length (; 80 ;) (param $0 i32) (param $1 i32)
   local.get $0
   i32.load offset=12
   drop
@@ -5190,7 +5229,7 @@
   local.get $1
   i32.store offset=12
  )
- (func $~lib/map/Map<i16,i32>#keys (; 77 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<i16,i32>#keys (; 81 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -5199,32 +5238,21 @@
   (local $6 i32)
   local.get $0
   i32.load offset=8
-  local.set $4
+  local.set $3
   local.get $0
   i32.load offset=16
-  local.set $2
-  i32.const 16
-  i32.const 12
-  call $~lib/rt/tlsf/__alloc
-  call $~lib/rt/pure/__retain
-  local.get $2
-  i32.const 1
-  call $~lib/arraybuffer/ArrayBufferView#constructor
-  local.tee $1
-  i32.const 0
-  i32.store offset=12
-  local.get $1
-  local.get $2
-  i32.store offset=12
+  local.tee $4
+  call $~lib/array/Array<i16>#constructor
+  local.set $1
   i32.const 0
   local.set $0
   loop $for-loop|0
-   local.get $3
    local.get $2
+   local.get $4
    i32.lt_s
    if
-    local.get $4
     local.get $3
+    local.get $2
     i32.const 12
     i32.mul
     i32.add
@@ -5245,10 +5273,10 @@
      i32.load16_s
      call $~lib/array/Array<i16>#__set
     end
-    local.get $3
+    local.get $2
     i32.const 1
     i32.add
-    local.set $3
+    local.set $2
     br $for-loop|0
    end
   end
@@ -5257,7 +5285,7 @@
   call $~lib/array/Array<i16>#set:length
   local.get $1
  )
- (func $~lib/map/Map<i16,i16>#constructor (; 78 ;) (result i32)
+ (func $~lib/map/Map<i16,i16>#constructor (; 82 ;) (result i32)
   (local $0 i32)
   i32.const 24
   i32.const 13
@@ -5285,7 +5313,7 @@
   call $~lib/map/Map<i8,i8>#clear
   local.get $0
  )
- (func $~lib/array/Array<i16>#__get (; 79 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i16>#__get (; 83 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -5293,7 +5321,7 @@
   if
    i32.const 464
    i32.const 528
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -5306,7 +5334,7 @@
   i32.add
   i32.load16_s
  )
- (func $~lib/map/Map<i16,i16>#find (; 80 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<i16,i16>#find (; 84 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.load
   local.get $2
@@ -5349,7 +5377,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<i16,i16>#rehash (; 81 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<i16,i16>#rehash (; 85 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5480,7 +5508,7 @@
   local.get $4
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<i16,i16>#set (; 82 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<i16,i16>#set (; 86 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -5574,7 +5602,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/map/Map<i16,i32>#delete (; 83 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<i16,i32>#delete (; 87 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -5637,7 +5665,7 @@
    call $~lib/map/Map<i16,i32>#rehash
   end
  )
- (func $std/map/testNumeric<i16,i32> (; 84 ;)
+ (func $std/map/testNumeric<i16,i32> (; 88 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -6104,7 +6132,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<u16,i32>#constructor (; 85 ;) (result i32)
+ (func $~lib/map/Map<u16,i32>#constructor (; 89 ;) (result i32)
   (local $0 i32)
   i32.const 24
   i32.const 14
@@ -6132,7 +6160,7 @@
   call $~lib/map/Map<i8,i32>#clear
   local.get $0
  )
- (func $~lib/map/Map<u16,i32>#has (; 86 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<u16,i32>#has (; 90 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -6143,7 +6171,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<u16,i32>#rehash (; 87 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<u16,i32>#rehash (; 91 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6274,7 +6302,7 @@
   local.get $4
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<u16,i32>#set (; 88 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<u16,i32>#set (; 92 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -6366,7 +6394,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/map/Map<u16,i32>#get (; 89 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<u16,i32>#get (; 93 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -6387,7 +6415,26 @@
   local.get $0
   i32.load offset=4
  )
- (func $~lib/map/Map<u16,i32>#keys (; 90 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<u16>#constructor (; 94 ;) (param $0 i32) (result i32)
+  (local $1 i32)
+  i32.const 16
+  i32.const 15
+  call $~lib/rt/tlsf/__alloc
+  call $~lib/rt/pure/__retain
+  call $~lib/arraybuffer/ArrayBufferView#constructor
+  local.tee $1
+  i32.const 0
+  i32.store offset=12
+  local.get $1
+  local.get $0
+  i32.const 1
+  call $~lib/arraybuffer/ArrayBufferView#alloc
+  local.get $1
+  local.get $0
+  i32.store offset=12
+  local.get $1
+ )
+ (func $~lib/map/Map<u16,i32>#keys (; 95 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -6396,32 +6443,21 @@
   (local $6 i32)
   local.get $0
   i32.load offset=8
-  local.set $4
+  local.set $3
   local.get $0
   i32.load offset=16
-  local.set $2
-  i32.const 16
-  i32.const 15
-  call $~lib/rt/tlsf/__alloc
-  call $~lib/rt/pure/__retain
-  local.get $2
-  i32.const 1
-  call $~lib/arraybuffer/ArrayBufferView#constructor
-  local.tee $1
-  i32.const 0
-  i32.store offset=12
-  local.get $1
-  local.get $2
-  i32.store offset=12
+  local.tee $4
+  call $~lib/array/Array<u16>#constructor
+  local.set $1
   i32.const 0
   local.set $0
   loop $for-loop|0
-   local.get $3
    local.get $2
+   local.get $4
    i32.lt_s
    if
-    local.get $4
     local.get $3
+    local.get $2
     i32.const 12
     i32.mul
     i32.add
@@ -6442,10 +6478,10 @@
      i32.load16_u
      call $~lib/array/Array<i16>#__set
     end
-    local.get $3
+    local.get $2
     i32.const 1
     i32.add
-    local.set $3
+    local.set $2
     br $for-loop|0
    end
   end
@@ -6454,7 +6490,7 @@
   call $~lib/array/Array<i16>#set:length
   local.get $1
  )
- (func $~lib/map/Map<u16,u16>#constructor (; 91 ;) (result i32)
+ (func $~lib/map/Map<u16,u16>#constructor (; 96 ;) (result i32)
   (local $0 i32)
   i32.const 24
   i32.const 16
@@ -6482,7 +6518,7 @@
   call $~lib/map/Map<i8,i8>#clear
   local.get $0
  )
- (func $~lib/array/Array<u16>#__get (; 92 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u16>#__get (; 97 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -6490,7 +6526,7 @@
   if
    i32.const 464
    i32.const 528
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -6503,7 +6539,7 @@
   i32.add
   i32.load16_u
  )
- (func $~lib/map/Map<u16,u16>#rehash (; 93 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<u16,u16>#rehash (; 98 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6634,7 +6670,7 @@
   local.get $4
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<u16,u16>#set (; 94 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<u16,u16>#set (; 99 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -6726,7 +6762,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/map/Map<u16,i32>#delete (; 95 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<u16,i32>#delete (; 100 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -6787,7 +6823,7 @@
    call $~lib/map/Map<u16,i32>#rehash
   end
  )
- (func $std/map/testNumeric<u16,i32> (; 96 ;)
+ (func $std/map/testNumeric<u16,i32> (; 101 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -7232,7 +7268,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<i32,i32>#has (; 97 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<i32,i32>#has (; 102 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -7241,7 +7277,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<i32,i32>#get (; 98 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<i32,i32>#get (; 103 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -7260,7 +7296,7 @@
   local.get $0
   i32.load offset=4
  )
- (func $~lib/map/Map<i32,i32>#keys (; 99 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<i32,i32>#keys (; 104 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -7316,7 +7352,7 @@
   call $~lib/array/Array<i32>#set:length
   local.get $1
  )
- (func $~lib/map/Map<i32,i32>#delete (; 100 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<i32,i32>#delete (; 105 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -7375,7 +7411,7 @@
    call $~lib/map/Map<i32,i32>#rehash
   end
  )
- (func $std/map/testNumeric<i32,i32> (; 101 ;)
+ (func $std/map/testNumeric<i32,i32> (; 106 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -7798,7 +7834,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<u32,i32>#constructor (; 102 ;) (result i32)
+ (func $~lib/map/Map<u32,i32>#constructor (; 107 ;) (result i32)
   (local $0 i32)
   i32.const 24
   i32.const 17
@@ -7826,7 +7862,26 @@
   call $~lib/map/Map<i8,i32>#clear
   local.get $0
  )
- (func $~lib/map/Map<u32,i32>#keys (; 103 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<u32>#constructor (; 108 ;) (param $0 i32) (result i32)
+  (local $1 i32)
+  i32.const 16
+  i32.const 18
+  call $~lib/rt/tlsf/__alloc
+  call $~lib/rt/pure/__retain
+  call $~lib/arraybuffer/ArrayBufferView#constructor
+  local.tee $1
+  i32.const 0
+  i32.store offset=12
+  local.get $1
+  local.get $0
+  i32.const 2
+  call $~lib/arraybuffer/ArrayBufferView#alloc
+  local.get $1
+  local.get $0
+  i32.store offset=12
+  local.get $1
+ )
+ (func $~lib/map/Map<u32,i32>#keys (; 109 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -7835,32 +7890,21 @@
   (local $6 i32)
   local.get $0
   i32.load offset=8
-  local.set $4
+  local.set $3
   local.get $0
   i32.load offset=16
-  local.set $2
-  i32.const 16
-  i32.const 18
-  call $~lib/rt/tlsf/__alloc
-  call $~lib/rt/pure/__retain
-  local.get $2
-  i32.const 2
-  call $~lib/arraybuffer/ArrayBufferView#constructor
-  local.tee $1
-  i32.const 0
-  i32.store offset=12
-  local.get $1
-  local.get $2
-  i32.store offset=12
+  local.tee $4
+  call $~lib/array/Array<u32>#constructor
+  local.set $1
   i32.const 0
   local.set $0
   loop $for-loop|0
-   local.get $3
    local.get $2
+   local.get $4
    i32.lt_s
    if
-    local.get $4
     local.get $3
+    local.get $2
     i32.const 12
     i32.mul
     i32.add
@@ -7881,10 +7925,10 @@
      i32.load
      call $~lib/array/Array<i32>#__set
     end
-    local.get $3
+    local.get $2
     i32.const 1
     i32.add
-    local.set $3
+    local.set $2
     br $for-loop|0
    end
   end
@@ -7893,7 +7937,7 @@
   call $~lib/array/Array<i32>#set:length
   local.get $1
  )
- (func $~lib/map/Map<u32,u32>#constructor (; 104 ;) (result i32)
+ (func $~lib/map/Map<u32,u32>#constructor (; 110 ;) (result i32)
   (local $0 i32)
   i32.const 24
   i32.const 19
@@ -7921,7 +7965,7 @@
   call $~lib/map/Map<i8,i32>#clear
   local.get $0
  )
- (func $std/map/testNumeric<u32,i32> (; 105 ;)
+ (func $std/map/testNumeric<u32,i32> (; 111 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -8344,7 +8388,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<i64,i32>#clear (; 106 ;) (param $0 i32)
+ (func $~lib/map/Map<i64,i32>#clear (; 112 ;) (param $0 i32)
   (local $1 i32)
   i32.const 16
   call $~lib/arraybuffer/ArrayBuffer#constructor
@@ -8377,7 +8421,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<i64,i32>#constructor (; 107 ;) (result i32)
+ (func $~lib/map/Map<i64,i32>#constructor (; 113 ;) (result i32)
   (local $0 i32)
   i32.const 24
   i32.const 20
@@ -8405,7 +8449,7 @@
   call $~lib/map/Map<i64,i32>#clear
   local.get $0
  )
- (func $~lib/util/hash/hash64 (; 108 ;) (param $0 i64) (result i32)
+ (func $~lib/util/hash/hash64 (; 114 ;) (param $0 i64) (result i32)
   (local $1 i32)
   local.get $0
   i32.wrap_i64
@@ -8471,7 +8515,7 @@
   i32.const 16777619
   i32.mul
  )
- (func $~lib/map/Map<i64,i32>#find (; 109 ;) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
+ (func $~lib/map/Map<i64,i32>#find (; 115 ;) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
   local.get $0
   i32.load
   local.get $2
@@ -8512,7 +8556,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<i64,i32>#has (; 110 ;) (param $0 i32) (param $1 i64) (result i32)
+ (func $~lib/map/Map<i64,i32>#has (; 116 ;) (param $0 i32) (param $1 i64) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -8521,7 +8565,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<i64,i32>#rehash (; 111 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<i64,i32>#rehash (; 117 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -8652,7 +8696,7 @@
   local.get $4
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<i64,i32>#set (; 112 ;) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
+ (func $~lib/map/Map<i64,i32>#set (; 118 ;) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -8742,7 +8786,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/map/Map<i64,i32>#get (; 113 ;) (param $0 i32) (param $1 i64) (result i32)
+ (func $~lib/map/Map<i64,i32>#get (; 119 ;) (param $0 i32) (param $1 i64) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -8761,7 +8805,26 @@
   local.get $0
   i32.load offset=8
  )
- (func $~lib/array/Array<i64>#__set (; 114 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $~lib/array/Array<i64>#constructor (; 120 ;) (param $0 i32) (result i32)
+  (local $1 i32)
+  i32.const 16
+  i32.const 21
+  call $~lib/rt/tlsf/__alloc
+  call $~lib/rt/pure/__retain
+  call $~lib/arraybuffer/ArrayBufferView#constructor
+  local.tee $1
+  i32.const 0
+  i32.store offset=12
+  local.get $1
+  local.get $0
+  i32.const 3
+  call $~lib/arraybuffer/ArrayBufferView#alloc
+  local.get $1
+  local.get $0
+  i32.store offset=12
+  local.get $1
+ )
+ (func $~lib/array/Array<i64>#__set (; 121 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   local.get $1
   local.get $0
@@ -8774,7 +8837,7 @@
    if
     i32.const 464
     i32.const 528
-    i32.const 109
+    i32.const 114
     i32.const 21
     call $~lib/builtins/abort
     unreachable
@@ -8799,7 +8862,7 @@
   local.get $2
   i64.store
  )
- (func $~lib/array/Array<i64>#set:length (; 115 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i64>#set:length (; 122 ;) (param $0 i32) (param $1 i32)
   local.get $0
   i32.load offset=12
   drop
@@ -8811,7 +8874,7 @@
   local.get $1
   i32.store offset=12
  )
- (func $~lib/map/Map<i64,i32>#keys (; 116 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<i64,i32>#keys (; 123 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -8820,32 +8883,21 @@
   (local $6 i32)
   local.get $0
   i32.load offset=8
-  local.set $4
+  local.set $3
   local.get $0
   i32.load offset=16
-  local.set $2
-  i32.const 16
-  i32.const 21
-  call $~lib/rt/tlsf/__alloc
-  call $~lib/rt/pure/__retain
-  local.get $2
-  i32.const 3
-  call $~lib/arraybuffer/ArrayBufferView#constructor
-  local.tee $1
-  i32.const 0
-  i32.store offset=12
-  local.get $1
-  local.get $2
-  i32.store offset=12
+  local.tee $4
+  call $~lib/array/Array<i64>#constructor
+  local.set $1
   i32.const 0
   local.set $0
   loop $for-loop|0
-   local.get $3
    local.get $2
+   local.get $4
    i32.lt_s
    if
-    local.get $4
     local.get $3
+    local.get $2
     i32.const 4
     i32.shl
     i32.add
@@ -8866,10 +8918,10 @@
      i64.load
      call $~lib/array/Array<i64>#__set
     end
-    local.get $3
+    local.get $2
     i32.const 1
     i32.add
-    local.set $3
+    local.set $2
     br $for-loop|0
    end
   end
@@ -8878,7 +8930,7 @@
   call $~lib/array/Array<i64>#set:length
   local.get $1
  )
- (func $~lib/map/Map<i64,i32>#values (; 117 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<i64,i32>#values (; 124 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -8934,7 +8986,7 @@
   call $~lib/array/Array<i32>#set:length
   local.get $1
  )
- (func $~lib/map/Map<i64,i64>#clear (; 118 ;) (param $0 i32)
+ (func $~lib/map/Map<i64,i64>#clear (; 125 ;) (param $0 i32)
   (local $1 i32)
   i32.const 16
   call $~lib/arraybuffer/ArrayBuffer#constructor
@@ -8967,7 +9019,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<i64,i64>#constructor (; 119 ;) (result i32)
+ (func $~lib/map/Map<i64,i64>#constructor (; 126 ;) (result i32)
   (local $0 i32)
   i32.const 24
   i32.const 22
@@ -8995,7 +9047,7 @@
   call $~lib/map/Map<i64,i64>#clear
   local.get $0
  )
- (func $~lib/array/Array<i64>#__get (; 120 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $~lib/array/Array<i64>#__get (; 127 ;) (param $0 i32) (param $1 i32) (result i64)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -9003,7 +9055,7 @@
   if
    i32.const 464
    i32.const 528
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -9016,7 +9068,7 @@
   i32.add
   i64.load
  )
- (func $~lib/map/Map<i64,i64>#find (; 121 ;) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
+ (func $~lib/map/Map<i64,i64>#find (; 128 ;) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
   local.get $0
   i32.load
   local.get $2
@@ -9057,7 +9109,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<i64,i64>#rehash (; 122 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<i64,i64>#rehash (; 129 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9188,7 +9240,7 @@
   local.get $4
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<i64,i64>#set (; 123 ;) (param $0 i32) (param $1 i64) (param $2 i64) (result i32)
+ (func $~lib/map/Map<i64,i64>#set (; 130 ;) (param $0 i32) (param $1 i64) (param $2 i64) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -9278,7 +9330,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/map/Map<i64,i32>#delete (; 124 ;) (param $0 i32) (param $1 i64)
+ (func $~lib/map/Map<i64,i32>#delete (; 131 ;) (param $0 i32) (param $1 i64)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -9338,7 +9390,7 @@
    call $~lib/map/Map<i64,i32>#rehash
   end
  )
- (func $std/map/testNumeric<i64,i32> (; 125 ;)
+ (func $std/map/testNumeric<i64,i32> (; 132 ;)
   (local $0 i64)
   (local $1 i32)
   (local $2 i32)
@@ -9767,7 +9819,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<u64,i32>#constructor (; 126 ;) (result i32)
+ (func $~lib/map/Map<u64,i32>#constructor (; 133 ;) (result i32)
   (local $0 i32)
   i32.const 24
   i32.const 23
@@ -9795,7 +9847,26 @@
   call $~lib/map/Map<i64,i32>#clear
   local.get $0
  )
- (func $~lib/map/Map<u64,i32>#keys (; 127 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<u64>#constructor (; 134 ;) (param $0 i32) (result i32)
+  (local $1 i32)
+  i32.const 16
+  i32.const 24
+  call $~lib/rt/tlsf/__alloc
+  call $~lib/rt/pure/__retain
+  call $~lib/arraybuffer/ArrayBufferView#constructor
+  local.tee $1
+  i32.const 0
+  i32.store offset=12
+  local.get $1
+  local.get $0
+  i32.const 3
+  call $~lib/arraybuffer/ArrayBufferView#alloc
+  local.get $1
+  local.get $0
+  i32.store offset=12
+  local.get $1
+ )
+ (func $~lib/map/Map<u64,i32>#keys (; 135 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -9804,32 +9875,21 @@
   (local $6 i32)
   local.get $0
   i32.load offset=8
-  local.set $4
+  local.set $3
   local.get $0
   i32.load offset=16
-  local.set $2
-  i32.const 16
-  i32.const 24
-  call $~lib/rt/tlsf/__alloc
-  call $~lib/rt/pure/__retain
-  local.get $2
-  i32.const 3
-  call $~lib/arraybuffer/ArrayBufferView#constructor
-  local.tee $1
-  i32.const 0
-  i32.store offset=12
-  local.get $1
-  local.get $2
-  i32.store offset=12
+  local.tee $4
+  call $~lib/array/Array<u64>#constructor
+  local.set $1
   i32.const 0
   local.set $0
   loop $for-loop|0
-   local.get $3
    local.get $2
+   local.get $4
    i32.lt_s
    if
-    local.get $4
     local.get $3
+    local.get $2
     i32.const 4
     i32.shl
     i32.add
@@ -9850,10 +9910,10 @@
      i64.load
      call $~lib/array/Array<i64>#__set
     end
-    local.get $3
+    local.get $2
     i32.const 1
     i32.add
-    local.set $3
+    local.set $2
     br $for-loop|0
    end
   end
@@ -9862,7 +9922,7 @@
   call $~lib/array/Array<i64>#set:length
   local.get $1
  )
- (func $~lib/map/Map<u64,u64>#constructor (; 128 ;) (result i32)
+ (func $~lib/map/Map<u64,u64>#constructor (; 136 ;) (result i32)
   (local $0 i32)
   i32.const 24
   i32.const 25
@@ -9890,7 +9950,7 @@
   call $~lib/map/Map<i64,i64>#clear
   local.get $0
  )
- (func $std/map/testNumeric<u64,i32> (; 129 ;)
+ (func $std/map/testNumeric<u64,i32> (; 137 ;)
   (local $0 i64)
   (local $1 i32)
   (local $2 i32)
@@ -10319,7 +10379,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<f32,i32>#constructor (; 130 ;) (result i32)
+ (func $~lib/map/Map<f32,i32>#constructor (; 138 ;) (result i32)
   (local $0 i32)
   i32.const 24
   i32.const 26
@@ -10347,7 +10407,7 @@
   call $~lib/map/Map<i8,i32>#clear
   local.get $0
  )
- (func $~lib/map/Map<f32,i32>#find (; 131 ;) (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<f32,i32>#find (; 139 ;) (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
   local.get $0
   i32.load
   local.get $2
@@ -10388,7 +10448,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<f32,i32>#has (; 132 ;) (param $0 i32) (param $1 f32) (result i32)
+ (func $~lib/map/Map<f32,i32>#has (; 140 ;) (param $0 i32) (param $1 f32) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -10398,7 +10458,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<f32,i32>#rehash (; 133 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<f32,i32>#rehash (; 141 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10530,7 +10590,7 @@
   local.get $4
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<f32,i32>#set (; 134 ;) (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<f32,i32>#set (; 142 ;) (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -10621,7 +10681,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/map/Map<f32,i32>#get (; 135 ;) (param $0 i32) (param $1 f32) (result i32)
+ (func $~lib/map/Map<f32,i32>#get (; 143 ;) (param $0 i32) (param $1 f32) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -10641,7 +10701,26 @@
   local.get $0
   i32.load offset=4
  )
- (func $~lib/array/Array<f32>#__set (; 136 ;) (param $0 i32) (param $1 i32) (param $2 f32)
+ (func $~lib/array/Array<f32>#constructor (; 144 ;) (param $0 i32) (result i32)
+  (local $1 i32)
+  i32.const 16
+  i32.const 27
+  call $~lib/rt/tlsf/__alloc
+  call $~lib/rt/pure/__retain
+  call $~lib/arraybuffer/ArrayBufferView#constructor
+  local.tee $1
+  i32.const 0
+  i32.store offset=12
+  local.get $1
+  local.get $0
+  i32.const 2
+  call $~lib/arraybuffer/ArrayBufferView#alloc
+  local.get $1
+  local.get $0
+  i32.store offset=12
+  local.get $1
+ )
+ (func $~lib/array/Array<f32>#__set (; 145 ;) (param $0 i32) (param $1 i32) (param $2 f32)
   (local $3 i32)
   local.get $1
   local.get $0
@@ -10654,7 +10733,7 @@
    if
     i32.const 464
     i32.const 528
-    i32.const 109
+    i32.const 114
     i32.const 21
     call $~lib/builtins/abort
     unreachable
@@ -10679,7 +10758,7 @@
   local.get $2
   f32.store
  )
- (func $~lib/map/Map<f32,i32>#keys (; 137 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<f32,i32>#keys (; 146 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -10688,32 +10767,21 @@
   (local $6 i32)
   local.get $0
   i32.load offset=8
-  local.set $4
+  local.set $3
   local.get $0
   i32.load offset=16
-  local.set $2
-  i32.const 16
-  i32.const 27
-  call $~lib/rt/tlsf/__alloc
-  call $~lib/rt/pure/__retain
-  local.get $2
-  i32.const 2
-  call $~lib/arraybuffer/ArrayBufferView#constructor
-  local.tee $1
-  i32.const 0
-  i32.store offset=12
-  local.get $1
-  local.get $2
-  i32.store offset=12
+  local.tee $4
+  call $~lib/array/Array<f32>#constructor
+  local.set $1
   i32.const 0
   local.set $0
   loop $for-loop|0
-   local.get $3
    local.get $2
+   local.get $4
    i32.lt_s
    if
-    local.get $4
     local.get $3
+    local.get $2
     i32.const 12
     i32.mul
     i32.add
@@ -10734,10 +10802,10 @@
      f32.load
      call $~lib/array/Array<f32>#__set
     end
-    local.get $3
+    local.get $2
     i32.const 1
     i32.add
-    local.set $3
+    local.set $2
     br $for-loop|0
    end
   end
@@ -10746,7 +10814,7 @@
   call $~lib/array/Array<i32>#set:length
   local.get $1
  )
- (func $~lib/map/Map<f32,f32>#constructor (; 138 ;) (result i32)
+ (func $~lib/map/Map<f32,f32>#constructor (; 147 ;) (result i32)
   (local $0 i32)
   i32.const 24
   i32.const 28
@@ -10774,7 +10842,7 @@
   call $~lib/map/Map<i8,i32>#clear
   local.get $0
  )
- (func $~lib/array/Array<f32>#__get (; 139 ;) (param $0 i32) (param $1 i32) (result f32)
+ (func $~lib/array/Array<f32>#__get (; 148 ;) (param $0 i32) (param $1 i32) (result f32)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -10782,7 +10850,7 @@
   if
    i32.const 464
    i32.const 528
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -10795,7 +10863,7 @@
   i32.add
   f32.load
  )
- (func $~lib/map/Map<f32,f32>#rehash (; 140 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<f32,f32>#rehash (; 149 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10927,7 +10995,7 @@
   local.get $4
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<f32,f32>#set (; 141 ;) (param $0 i32) (param $1 f32) (param $2 f32) (result i32)
+ (func $~lib/map/Map<f32,f32>#set (; 150 ;) (param $0 i32) (param $1 f32) (param $2 f32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -11018,7 +11086,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/map/Map<f32,i32>#delete (; 142 ;) (param $0 i32) (param $1 f32)
+ (func $~lib/map/Map<f32,i32>#delete (; 151 ;) (param $0 i32) (param $1 f32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -11079,7 +11147,7 @@
    call $~lib/map/Map<f32,i32>#rehash
   end
  )
- (func $std/map/testNumeric<f32,i32> (; 143 ;)
+ (func $std/map/testNumeric<f32,i32> (; 152 ;)
   (local $0 f32)
   (local $1 i32)
   (local $2 i32)
@@ -11508,7 +11576,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<f64,i32>#constructor (; 144 ;) (result i32)
+ (func $~lib/map/Map<f64,i32>#constructor (; 153 ;) (result i32)
   (local $0 i32)
   i32.const 24
   i32.const 29
@@ -11536,7 +11604,7 @@
   call $~lib/map/Map<i64,i32>#clear
   local.get $0
  )
- (func $~lib/map/Map<f64,i32>#find (; 145 ;) (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
+ (func $~lib/map/Map<f64,i32>#find (; 154 ;) (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
   local.get $0
   i32.load
   local.get $2
@@ -11577,7 +11645,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<f64,i32>#has (; 146 ;) (param $0 i32) (param $1 f64) (result i32)
+ (func $~lib/map/Map<f64,i32>#has (; 155 ;) (param $0 i32) (param $1 f64) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -11587,7 +11655,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<f64,i32>#rehash (; 147 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<f64,i32>#rehash (; 156 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -11719,7 +11787,7 @@
   local.get $4
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<f64,i32>#set (; 148 ;) (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
+ (func $~lib/map/Map<f64,i32>#set (; 157 ;) (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -11810,7 +11878,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/map/Map<f64,i32>#get (; 149 ;) (param $0 i32) (param $1 f64) (result i32)
+ (func $~lib/map/Map<f64,i32>#get (; 158 ;) (param $0 i32) (param $1 f64) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -11830,7 +11898,26 @@
   local.get $0
   i32.load offset=8
  )
- (func $~lib/array/Array<f64>#__set (; 150 ;) (param $0 i32) (param $1 i32) (param $2 f64)
+ (func $~lib/array/Array<f64>#constructor (; 159 ;) (param $0 i32) (result i32)
+  (local $1 i32)
+  i32.const 16
+  i32.const 30
+  call $~lib/rt/tlsf/__alloc
+  call $~lib/rt/pure/__retain
+  call $~lib/arraybuffer/ArrayBufferView#constructor
+  local.tee $1
+  i32.const 0
+  i32.store offset=12
+  local.get $1
+  local.get $0
+  i32.const 3
+  call $~lib/arraybuffer/ArrayBufferView#alloc
+  local.get $1
+  local.get $0
+  i32.store offset=12
+  local.get $1
+ )
+ (func $~lib/array/Array<f64>#__set (; 160 ;) (param $0 i32) (param $1 i32) (param $2 f64)
   (local $3 i32)
   local.get $1
   local.get $0
@@ -11843,7 +11930,7 @@
    if
     i32.const 464
     i32.const 528
-    i32.const 109
+    i32.const 114
     i32.const 21
     call $~lib/builtins/abort
     unreachable
@@ -11868,7 +11955,7 @@
   local.get $2
   f64.store
  )
- (func $~lib/map/Map<f64,i32>#keys (; 151 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<f64,i32>#keys (; 161 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -11877,32 +11964,21 @@
   (local $6 i32)
   local.get $0
   i32.load offset=8
-  local.set $4
+  local.set $3
   local.get $0
   i32.load offset=16
-  local.set $2
-  i32.const 16
-  i32.const 30
-  call $~lib/rt/tlsf/__alloc
-  call $~lib/rt/pure/__retain
-  local.get $2
-  i32.const 3
-  call $~lib/arraybuffer/ArrayBufferView#constructor
-  local.tee $1
-  i32.const 0
-  i32.store offset=12
-  local.get $1
-  local.get $2
-  i32.store offset=12
+  local.tee $4
+  call $~lib/array/Array<f64>#constructor
+  local.set $1
   i32.const 0
   local.set $0
   loop $for-loop|0
-   local.get $3
    local.get $2
+   local.get $4
    i32.lt_s
    if
-    local.get $4
     local.get $3
+    local.get $2
     i32.const 4
     i32.shl
     i32.add
@@ -11923,10 +11999,10 @@
      f64.load
      call $~lib/array/Array<f64>#__set
     end
-    local.get $3
+    local.get $2
     i32.const 1
     i32.add
-    local.set $3
+    local.set $2
     br $for-loop|0
    end
   end
@@ -11935,7 +12011,7 @@
   call $~lib/array/Array<i64>#set:length
   local.get $1
  )
- (func $~lib/map/Map<f64,f64>#constructor (; 152 ;) (result i32)
+ (func $~lib/map/Map<f64,f64>#constructor (; 162 ;) (result i32)
   (local $0 i32)
   i32.const 24
   i32.const 31
@@ -11963,7 +12039,7 @@
   call $~lib/map/Map<i64,i64>#clear
   local.get $0
  )
- (func $~lib/array/Array<f64>#__get (; 153 ;) (param $0 i32) (param $1 i32) (result f64)
+ (func $~lib/array/Array<f64>#__get (; 163 ;) (param $0 i32) (param $1 i32) (result f64)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -11971,7 +12047,7 @@
   if
    i32.const 464
    i32.const 528
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -11984,7 +12060,7 @@
   i32.add
   f64.load
  )
- (func $~lib/map/Map<f64,f64>#find (; 154 ;) (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
+ (func $~lib/map/Map<f64,f64>#find (; 164 ;) (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
   local.get $0
   i32.load
   local.get $2
@@ -12025,7 +12101,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<f64,f64>#rehash (; 155 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<f64,f64>#rehash (; 165 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -12157,7 +12233,7 @@
   local.get $4
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<f64,f64>#set (; 156 ;) (param $0 i32) (param $1 f64) (param $2 f64) (result i32)
+ (func $~lib/map/Map<f64,f64>#set (; 166 ;) (param $0 i32) (param $1 f64) (param $2 f64) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -12248,7 +12324,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/map/Map<f64,i32>#delete (; 157 ;) (param $0 i32) (param $1 f64)
+ (func $~lib/map/Map<f64,i32>#delete (; 167 ;) (param $0 i32) (param $1 f64)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -12309,7 +12385,7 @@
    call $~lib/map/Map<f64,i32>#rehash
   end
  )
- (func $std/map/testNumeric<f64,i32> (; 158 ;)
+ (func $std/map/testNumeric<f64,i32> (; 168 ;)
   (local $0 f64)
   (local $1 i32)
   (local $2 i32)
@@ -12738,7 +12814,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~start (; 159 ;)
+ (func $~start (; 169 ;)
   call $std/map/testNumeric<i8,i32>
   call $std/map/testNumeric<u8,i32>
   call $std/map/testNumeric<i16,i32>
@@ -12750,7 +12826,7 @@
   call $std/map/testNumeric<f32,i32>
   call $std/map/testNumeric<f64,i32>
  )
- (func $~lib/rt/pure/decrement (; 160 ;) (param $0 i32)
+ (func $~lib/rt/pure/decrement (; 170 ;) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -12818,7 +12894,7 @@
    i32.store offset=4
   end
  )
- (func $~lib/rt/pure/__visit (; 161 ;) (param $0 i32)
+ (func $~lib/rt/pure/__visit (; 171 ;) (param $0 i32)
   local.get $0
   i32.const 556
   i32.lt_u
@@ -12830,7 +12906,7 @@
   i32.sub
   call $~lib/rt/pure/decrement
  )
- (func $~lib/rt/__visit_members (; 162 ;) (param $0 i32)
+ (func $~lib/rt/__visit_members (; 172 ;) (param $0 i32)
   block $folding-inner0
    block $block$4$break
     block $switch$1$default

--- a/tests/compiler/std/map.untouched.wat
+++ b/tests/compiler/std/map.untouched.wat
@@ -1746,7 +1746,7 @@
   if
    i32.const 192
    i32.const 240
-   i32.const 54
+   i32.const 45
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -2224,35 +2224,7 @@
   local.get $0
   i32.load offset=20
  )
- (func $~lib/arraybuffer/ArrayBufferView#constructor (; 30 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  local.get $1
-  i32.const 1073741808
-  local.get $2
-  i32.shr_u
-  i32.gt_u
-  if
-   i32.const 192
-   i32.const 240
-   i32.const 23
-   i32.const 56
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $1
-  local.get $2
-  i32.shl
-  local.tee $1
-  i32.const 0
-  call $~lib/rt/tlsf/__alloc
-  local.set $3
-  local.get $3
-  i32.const 0
-  local.get $1
-  call $~lib/memory/memory.fill
+ (func $~lib/arraybuffer/ArrayBufferView#constructor (; 30 ;) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -2271,6 +2243,37 @@
   local.get $0
   i32.const 0
   i32.store offset=8
+  local.get $0
+ )
+ (func $~lib/arraybuffer/ArrayBufferView#alloc (; 31 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  local.get $1
+  i32.const 1073741808
+  local.get $2
+  i32.shr_u
+  i32.gt_u
+  if
+   i32.const 192
+   i32.const 240
+   i32.const 14
+   i32.const 56
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $1
+  local.get $2
+  i32.shl
+  local.tee $1
+  i32.const 0
+  call $~lib/rt/tlsf/__alloc
+  local.set $3
+  local.get $3
+  i32.const 0
+  local.get $1
+  call $~lib/memory/memory.fill
   local.get $0
   local.tee $4
   local.get $3
@@ -2294,9 +2297,8 @@
   local.get $0
   local.get $1
   i32.store offset=8
-  local.get $0
  )
- (func $~lib/array/Array<i8>#constructor (; 31 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i8>#constructor (; 32 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   if (result i32)
    local.get $0
@@ -2306,8 +2308,6 @@
    call $~lib/rt/tlsf/__alloc
    call $~lib/rt/pure/__retain
   end
-  local.get $1
-  i32.const 0
   call $~lib/arraybuffer/ArrayBufferView#constructor
   local.set $0
   local.get $0
@@ -2315,10 +2315,14 @@
   i32.store offset=12
   local.get $0
   local.get $1
+  i32.const 0
+  call $~lib/arraybuffer/ArrayBufferView#alloc
+  local.get $0
+  local.get $1
   i32.store offset=12
   local.get $0
  )
- (func $~lib/rt/tlsf/checkUsedBlock (; 32 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/tlsf/checkUsedBlock (; 33 ;) (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   i32.const 16
@@ -2364,7 +2368,7 @@
   end
   local.get $1
  )
- (func $~lib/util/memory/memcpy (; 33 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/memory/memcpy (; 34 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3388,7 +3392,7 @@
    i32.store8
   end
  )
- (func $~lib/memory/memory.copy (; 34 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/memory/memory.copy (; 35 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3608,7 +3612,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/freeBlock (; 35 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/freeBlock (; 36 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $1
   i32.load
@@ -3624,7 +3628,7 @@
   local.get $1
   call $~lib/rt/rtrace/onfree
  )
- (func $~lib/rt/tlsf/reallocateBlock (; 36 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/reallocateBlock (; 37 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3743,7 +3747,7 @@
   end
   local.get $8
  )
- (func $~lib/rt/tlsf/__realloc (; 37 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/__realloc (; 38 ;) (param $0 i32) (param $1 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
   local.get $0
   call $~lib/rt/tlsf/checkUsedBlock
@@ -3752,7 +3756,7 @@
   i32.const 16
   i32.add
  )
- (func $~lib/array/ensureSize (; 38 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/ensureSize (; 39 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3814,7 +3818,7 @@
    i32.store offset=8
   end
  )
- (func $~lib/array/Array<i8>#__unchecked_set (; 39 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<i8>#__unchecked_set (; 40 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -3824,7 +3828,7 @@
   local.get $2
   i32.store8
  )
- (func $~lib/array/Array<i8>#__set (; 40 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<i8>#__set (; 41 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -3836,7 +3840,7 @@
    if
     i32.const 464
     i32.const 528
-    i32.const 109
+    i32.const 114
     i32.const 21
     call $~lib/builtins/abort
     unreachable
@@ -3858,7 +3862,7 @@
   local.get $2
   call $~lib/array/Array<i8>#__unchecked_set
  )
- (func $~lib/array/Array<i8>#set:length (; 41 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i8>#set:length (; 42 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load offset=12
@@ -3871,7 +3875,7 @@
   local.get $1
   i32.store offset=12
  )
- (func $~lib/map/Map<i8,i32>#keys (; 42 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<i8,i32>#keys (; 43 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -3936,7 +3940,7 @@
   call $~lib/array/Array<i8>#set:length
   local.get $3
  )
- (func $~lib/array/Array<i32>#constructor (; 43 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#constructor (; 44 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   if (result i32)
    local.get $0
@@ -3946,8 +3950,6 @@
    call $~lib/rt/tlsf/__alloc
    call $~lib/rt/pure/__retain
   end
-  local.get $1
-  i32.const 2
   call $~lib/arraybuffer/ArrayBufferView#constructor
   local.set $0
   local.get $0
@@ -3955,10 +3957,14 @@
   i32.store offset=12
   local.get $0
   local.get $1
+  i32.const 2
+  call $~lib/arraybuffer/ArrayBufferView#alloc
+  local.get $0
+  local.get $1
   i32.store offset=12
   local.get $0
  )
- (func $~lib/array/Array<i32>#__unchecked_set (; 44 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<i32>#__unchecked_set (; 45 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -3968,7 +3974,7 @@
   local.get $2
   i32.store
  )
- (func $~lib/array/Array<i32>#__set (; 45 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<i32>#__set (; 46 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -3980,7 +3986,7 @@
    if
     i32.const 464
     i32.const 528
-    i32.const 109
+    i32.const 114
     i32.const 21
     call $~lib/builtins/abort
     unreachable
@@ -4002,7 +4008,7 @@
   local.get $2
   call $~lib/array/Array<i32>#__unchecked_set
  )
- (func $~lib/array/Array<i32>#set:length (; 46 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i32>#set:length (; 47 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load offset=12
@@ -4015,7 +4021,7 @@
   local.get $1
   i32.store offset=12
  )
- (func $~lib/map/Map<i8,i32>#values (; 47 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<i8,i32>#values (; 48 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -4080,7 +4086,7 @@
   call $~lib/array/Array<i32>#set:length
   local.get $3
  )
- (func $~lib/map/Map<i8,i8>#clear (; 48 ;) (param $0 i32)
+ (func $~lib/map/Map<i8,i8>#clear (; 49 ;) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -4120,7 +4126,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<i8,i8>#constructor (; 49 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<i8,i8>#constructor (; 50 ;) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -4152,7 +4158,7 @@
   call $~lib/map/Map<i8,i8>#clear
   local.get $0
  )
- (func $~lib/map/Map<i32,i32>#clear (; 50 ;) (param $0 i32)
+ (func $~lib/map/Map<i32,i32>#clear (; 51 ;) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -4192,7 +4198,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<i32,i32>#constructor (; 51 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<i32,i32>#constructor (; 52 ;) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -4224,11 +4230,11 @@
   call $~lib/map/Map<i32,i32>#clear
   local.get $0
  )
- (func $~lib/array/Array<i8>#get:length (; 52 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<i8>#get:length (; 53 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<i8>#__unchecked_get (; 53 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i8>#__unchecked_get (; 54 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -4237,7 +4243,7 @@
   i32.add
   i32.load8_s
  )
- (func $~lib/array/Array<i8>#__get (; 54 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i8>#__get (; 55 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   local.get $0
@@ -4246,7 +4252,7 @@
   if
    i32.const 464
    i32.const 528
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -4257,7 +4263,7 @@
   local.set $2
   local.get $2
  )
- (func $~lib/array/Array<i32>#__unchecked_get (; 55 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#__unchecked_get (; 56 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -4266,7 +4272,7 @@
   i32.add
   i32.load
  )
- (func $~lib/array/Array<i32>#__get (; 56 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#__get (; 57 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   local.get $0
@@ -4275,7 +4281,7 @@
   if
    i32.const 464
    i32.const 528
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -4286,7 +4292,7 @@
   local.set $2
   local.get $2
  )
- (func $~lib/map/Map<i8,i8>#find (; 57 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<i8,i8>#find (; 58 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -4338,7 +4344,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<i8,i8>#rehash (; 58 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<i8,i8>#rehash (; 59 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4495,7 +4501,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<i8,i8>#set (; 59 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<i8,i8>#set (; 60 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -4604,7 +4610,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/hash/hash32 (; 60 ;) (param $0 i32) (result i32)
+ (func $~lib/util/hash/hash32 (; 61 ;) (param $0 i32) (result i32)
   (local $1 i32)
   i32.const -2128831035
   local.set $1
@@ -4646,7 +4652,7 @@
   local.set $1
   local.get $1
  )
- (func $~lib/map/Map<i32,i32>#find (; 61 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<i32,i32>#find (; 62 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -4694,7 +4700,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<i32,i32>#rehash (; 62 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<i32,i32>#rehash (; 63 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4851,7 +4857,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<i32,i32>#set (; 63 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<i32,i32>#set (; 64 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -4956,15 +4962,15 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/map/Map<i8,i8>#get:size (; 64 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<i8,i8>#get:size (; 65 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/map/Map<i32,i32>#get:size (; 65 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<i32,i32>#get:size (; 66 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/map/Map<i8,i32>#delete (; 66 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<i8,i32>#delete (; 67 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5040,7 +5046,7 @@
   end
   i32.const 1
  )
- (func $std/map/testNumeric<i8,i32> (; 67 ;)
+ (func $std/map/testNumeric<i8,i32> (; 68 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -5549,7 +5555,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<u8,i32>#clear (; 68 ;) (param $0 i32)
+ (func $~lib/map/Map<u8,i32>#clear (; 69 ;) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -5589,7 +5595,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<u8,i32>#constructor (; 69 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u8,i32>#constructor (; 70 ;) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -5621,7 +5627,7 @@
   call $~lib/map/Map<u8,i32>#clear
   local.get $0
  )
- (func $~lib/map/Map<u8,i32>#find (; 70 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<u8,i32>#find (; 71 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -5671,7 +5677,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<u8,i32>#has (; 71 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<u8,i32>#has (; 72 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -5688,7 +5694,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<u8,i32>#rehash (; 72 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<u8,i32>#rehash (; 73 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5845,7 +5851,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<u8,i32>#set (; 73 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<u8,i32>#set (; 74 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -5952,7 +5958,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/map/Map<u8,i32>#get (; 74 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<u8,i32>#get (; 75 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -5981,11 +5987,11 @@
   local.get $3
   i32.load offset=4
  )
- (func $~lib/map/Map<u8,i32>#get:size (; 75 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u8,i32>#get:size (; 76 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/array/Array<u8>#constructor (; 76 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u8>#constructor (; 77 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   if (result i32)
    local.get $0
@@ -5995,8 +6001,6 @@
    call $~lib/rt/tlsf/__alloc
    call $~lib/rt/pure/__retain
   end
-  local.get $1
-  i32.const 0
   call $~lib/arraybuffer/ArrayBufferView#constructor
   local.set $0
   local.get $0
@@ -6004,10 +6008,14 @@
   i32.store offset=12
   local.get $0
   local.get $1
+  i32.const 0
+  call $~lib/arraybuffer/ArrayBufferView#alloc
+  local.get $0
+  local.get $1
   i32.store offset=12
   local.get $0
  )
- (func $~lib/array/Array<u8>#__unchecked_set (; 77 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<u8>#__unchecked_set (; 78 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -6017,7 +6025,7 @@
   local.get $2
   i32.store8
  )
- (func $~lib/array/Array<u8>#__set (; 78 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<u8>#__set (; 79 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -6029,7 +6037,7 @@
    if
     i32.const 464
     i32.const 528
-    i32.const 109
+    i32.const 114
     i32.const 21
     call $~lib/builtins/abort
     unreachable
@@ -6051,7 +6059,7 @@
   local.get $2
   call $~lib/array/Array<u8>#__unchecked_set
  )
- (func $~lib/array/Array<u8>#set:length (; 79 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<u8>#set:length (; 80 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load offset=12
@@ -6064,7 +6072,7 @@
   local.get $1
   i32.store offset=12
  )
- (func $~lib/map/Map<u8,i32>#keys (; 80 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u8,i32>#keys (; 81 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -6129,7 +6137,7 @@
   call $~lib/array/Array<u8>#set:length
   local.get $3
  )
- (func $~lib/map/Map<u8,i32>#values (; 81 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u8,i32>#values (; 82 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -6194,7 +6202,7 @@
   call $~lib/array/Array<i32>#set:length
   local.get $3
  )
- (func $~lib/map/Map<u8,u8>#clear (; 82 ;) (param $0 i32)
+ (func $~lib/map/Map<u8,u8>#clear (; 83 ;) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -6234,7 +6242,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<u8,u8>#constructor (; 83 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u8,u8>#constructor (; 84 ;) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -6266,11 +6274,11 @@
   call $~lib/map/Map<u8,u8>#clear
   local.get $0
  )
- (func $~lib/array/Array<u8>#get:length (; 84 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<u8>#get:length (; 85 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<u8>#__unchecked_get (; 85 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u8>#__unchecked_get (; 86 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -6279,7 +6287,7 @@
   i32.add
   i32.load8_u
  )
- (func $~lib/array/Array<u8>#__get (; 86 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u8>#__get (; 87 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   local.get $0
@@ -6288,7 +6296,7 @@
   if
    i32.const 464
    i32.const 528
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -6299,7 +6307,7 @@
   local.set $2
   local.get $2
  )
- (func $~lib/map/Map<u8,u8>#find (; 87 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<u8,u8>#find (; 88 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -6349,7 +6357,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<u8,u8>#rehash (; 88 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<u8,u8>#rehash (; 89 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6506,7 +6514,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<u8,u8>#set (; 89 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<u8,u8>#set (; 90 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -6613,11 +6621,11 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/map/Map<u8,u8>#get:size (; 90 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u8,u8>#get:size (; 91 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/map/Map<u8,i32>#delete (; 91 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<u8,i32>#delete (; 92 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6691,7 +6699,7 @@
   end
   i32.const 1
  )
- (func $std/map/testNumeric<u8,i32> (; 92 ;)
+ (func $std/map/testNumeric<u8,i32> (; 93 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -7178,7 +7186,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<i16,i32>#clear (; 93 ;) (param $0 i32)
+ (func $~lib/map/Map<i16,i32>#clear (; 94 ;) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -7218,7 +7226,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<i16,i32>#constructor (; 94 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<i16,i32>#constructor (; 95 ;) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -7250,7 +7258,7 @@
   call $~lib/map/Map<i16,i32>#clear
   local.get $0
  )
- (func $~lib/util/hash/hash16 (; 95 ;) (param $0 i32) (result i32)
+ (func $~lib/util/hash/hash16 (; 96 ;) (param $0 i32) (result i32)
   (local $1 i32)
   i32.const -2128831035
   local.set $1
@@ -7272,7 +7280,7 @@
   local.set $1
   local.get $1
  )
- (func $~lib/map/Map<i16,i32>#find (; 96 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<i16,i32>#find (; 97 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -7324,7 +7332,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<i16,i32>#has (; 97 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<i16,i32>#has (; 98 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -7343,7 +7351,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<i16,i32>#rehash (; 98 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<i16,i32>#rehash (; 99 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7500,7 +7508,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<i16,i32>#set (; 99 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<i16,i32>#set (; 100 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -7609,7 +7617,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/map/Map<i16,i32>#get (; 100 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<i16,i32>#get (; 101 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -7640,11 +7648,11 @@
   local.get $3
   i32.load offset=4
  )
- (func $~lib/map/Map<i16,i32>#get:size (; 101 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<i16,i32>#get:size (; 102 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/array/Array<i16>#constructor (; 102 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i16>#constructor (; 103 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   if (result i32)
    local.get $0
@@ -7654,8 +7662,6 @@
    call $~lib/rt/tlsf/__alloc
    call $~lib/rt/pure/__retain
   end
-  local.get $1
-  i32.const 1
   call $~lib/arraybuffer/ArrayBufferView#constructor
   local.set $0
   local.get $0
@@ -7663,10 +7669,14 @@
   i32.store offset=12
   local.get $0
   local.get $1
+  i32.const 1
+  call $~lib/arraybuffer/ArrayBufferView#alloc
+  local.get $0
+  local.get $1
   i32.store offset=12
   local.get $0
  )
- (func $~lib/array/Array<i16>#__unchecked_set (; 103 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<i16>#__unchecked_set (; 104 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -7676,7 +7686,7 @@
   local.get $2
   i32.store16
  )
- (func $~lib/array/Array<i16>#__set (; 104 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<i16>#__set (; 105 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -7688,7 +7698,7 @@
    if
     i32.const 464
     i32.const 528
-    i32.const 109
+    i32.const 114
     i32.const 21
     call $~lib/builtins/abort
     unreachable
@@ -7710,7 +7720,7 @@
   local.get $2
   call $~lib/array/Array<i16>#__unchecked_set
  )
- (func $~lib/array/Array<i16>#set:length (; 105 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i16>#set:length (; 106 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load offset=12
@@ -7723,7 +7733,7 @@
   local.get $1
   i32.store offset=12
  )
- (func $~lib/map/Map<i16,i32>#keys (; 106 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<i16,i32>#keys (; 107 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -7788,7 +7798,7 @@
   call $~lib/array/Array<i16>#set:length
   local.get $3
  )
- (func $~lib/map/Map<i16,i32>#values (; 107 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<i16,i32>#values (; 108 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -7853,7 +7863,7 @@
   call $~lib/array/Array<i32>#set:length
   local.get $3
  )
- (func $~lib/map/Map<i16,i16>#clear (; 108 ;) (param $0 i32)
+ (func $~lib/map/Map<i16,i16>#clear (; 109 ;) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -7893,7 +7903,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<i16,i16>#constructor (; 109 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<i16,i16>#constructor (; 110 ;) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -7925,11 +7935,11 @@
   call $~lib/map/Map<i16,i16>#clear
   local.get $0
  )
- (func $~lib/array/Array<i16>#get:length (; 110 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<i16>#get:length (; 111 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<i16>#__unchecked_get (; 111 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i16>#__unchecked_get (; 112 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -7938,7 +7948,7 @@
   i32.add
   i32.load16_s
  )
- (func $~lib/array/Array<i16>#__get (; 112 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i16>#__get (; 113 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   local.get $0
@@ -7947,7 +7957,7 @@
   if
    i32.const 464
    i32.const 528
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -7958,7 +7968,7 @@
   local.set $2
   local.get $2
  )
- (func $~lib/map/Map<i16,i16>#find (; 113 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<i16,i16>#find (; 114 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -8010,7 +8020,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<i16,i16>#rehash (; 114 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<i16,i16>#rehash (; 115 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -8167,7 +8177,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<i16,i16>#set (; 115 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<i16,i16>#set (; 116 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -8276,11 +8286,11 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/map/Map<i16,i16>#get:size (; 116 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<i16,i16>#get:size (; 117 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/map/Map<i16,i32>#delete (; 117 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<i16,i32>#delete (; 118 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -8356,7 +8366,7 @@
   end
   i32.const 1
  )
- (func $std/map/testNumeric<i16,i32> (; 118 ;)
+ (func $std/map/testNumeric<i16,i32> (; 119 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -8865,7 +8875,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<u16,i32>#clear (; 119 ;) (param $0 i32)
+ (func $~lib/map/Map<u16,i32>#clear (; 120 ;) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -8905,7 +8915,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<u16,i32>#constructor (; 120 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u16,i32>#constructor (; 121 ;) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -8937,7 +8947,7 @@
   call $~lib/map/Map<u16,i32>#clear
   local.get $0
  )
- (func $~lib/map/Map<u16,i32>#find (; 121 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<u16,i32>#find (; 122 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -8987,7 +8997,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<u16,i32>#has (; 122 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<u16,i32>#has (; 123 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -9004,7 +9014,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<u16,i32>#rehash (; 123 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<u16,i32>#rehash (; 124 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9161,7 +9171,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<u16,i32>#set (; 124 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<u16,i32>#set (; 125 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -9268,7 +9278,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/map/Map<u16,i32>#get (; 125 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<u16,i32>#get (; 126 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -9297,11 +9307,11 @@
   local.get $3
   i32.load offset=4
  )
- (func $~lib/map/Map<u16,i32>#get:size (; 126 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u16,i32>#get:size (; 127 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/array/Array<u16>#constructor (; 127 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u16>#constructor (; 128 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   if (result i32)
    local.get $0
@@ -9311,8 +9321,6 @@
    call $~lib/rt/tlsf/__alloc
    call $~lib/rt/pure/__retain
   end
-  local.get $1
-  i32.const 1
   call $~lib/arraybuffer/ArrayBufferView#constructor
   local.set $0
   local.get $0
@@ -9320,10 +9328,14 @@
   i32.store offset=12
   local.get $0
   local.get $1
+  i32.const 1
+  call $~lib/arraybuffer/ArrayBufferView#alloc
+  local.get $0
+  local.get $1
   i32.store offset=12
   local.get $0
  )
- (func $~lib/array/Array<u16>#__unchecked_set (; 128 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<u16>#__unchecked_set (; 129 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -9333,7 +9345,7 @@
   local.get $2
   i32.store16
  )
- (func $~lib/array/Array<u16>#__set (; 129 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<u16>#__set (; 130 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -9345,7 +9357,7 @@
    if
     i32.const 464
     i32.const 528
-    i32.const 109
+    i32.const 114
     i32.const 21
     call $~lib/builtins/abort
     unreachable
@@ -9367,7 +9379,7 @@
   local.get $2
   call $~lib/array/Array<u16>#__unchecked_set
  )
- (func $~lib/array/Array<u16>#set:length (; 130 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<u16>#set:length (; 131 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load offset=12
@@ -9380,7 +9392,7 @@
   local.get $1
   i32.store offset=12
  )
- (func $~lib/map/Map<u16,i32>#keys (; 131 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u16,i32>#keys (; 132 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -9445,7 +9457,7 @@
   call $~lib/array/Array<u16>#set:length
   local.get $3
  )
- (func $~lib/map/Map<u16,i32>#values (; 132 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u16,i32>#values (; 133 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -9510,7 +9522,7 @@
   call $~lib/array/Array<i32>#set:length
   local.get $3
  )
- (func $~lib/map/Map<u16,u16>#clear (; 133 ;) (param $0 i32)
+ (func $~lib/map/Map<u16,u16>#clear (; 134 ;) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -9550,7 +9562,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<u16,u16>#constructor (; 134 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u16,u16>#constructor (; 135 ;) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -9582,11 +9594,11 @@
   call $~lib/map/Map<u16,u16>#clear
   local.get $0
  )
- (func $~lib/array/Array<u16>#get:length (; 135 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<u16>#get:length (; 136 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<u16>#__unchecked_get (; 136 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u16>#__unchecked_get (; 137 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -9595,7 +9607,7 @@
   i32.add
   i32.load16_u
  )
- (func $~lib/array/Array<u16>#__get (; 137 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u16>#__get (; 138 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   local.get $0
@@ -9604,7 +9616,7 @@
   if
    i32.const 464
    i32.const 528
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -9615,7 +9627,7 @@
   local.set $2
   local.get $2
  )
- (func $~lib/map/Map<u16,u16>#find (; 138 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<u16,u16>#find (; 139 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -9665,7 +9677,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<u16,u16>#rehash (; 139 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<u16,u16>#rehash (; 140 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9822,7 +9834,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<u16,u16>#set (; 140 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<u16,u16>#set (; 141 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -9929,11 +9941,11 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/map/Map<u16,u16>#get:size (; 141 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u16,u16>#get:size (; 142 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/map/Map<u16,i32>#delete (; 142 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<u16,i32>#delete (; 143 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10007,7 +10019,7 @@
   end
   i32.const 1
  )
- (func $std/map/testNumeric<u16,i32> (; 143 ;)
+ (func $std/map/testNumeric<u16,i32> (; 144 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -10494,7 +10506,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<i32,i32>#has (; 144 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<i32,i32>#has (; 145 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -10509,7 +10521,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<i32,i32>#get (; 145 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<i32,i32>#get (; 146 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -10536,7 +10548,7 @@
   local.get $3
   i32.load offset=4
  )
- (func $~lib/map/Map<i32,i32>#keys (; 146 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<i32,i32>#keys (; 147 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -10601,7 +10613,7 @@
   call $~lib/array/Array<i32>#set:length
   local.get $3
  )
- (func $~lib/map/Map<i32,i32>#values (; 147 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<i32,i32>#values (; 148 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -10666,11 +10678,11 @@
   call $~lib/array/Array<i32>#set:length
   local.get $3
  )
- (func $~lib/array/Array<i32>#get:length (; 148 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<i32>#get:length (; 149 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/map/Map<i32,i32>#delete (; 149 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<i32,i32>#delete (; 150 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10742,7 +10754,7 @@
   end
   i32.const 1
  )
- (func $std/map/testNumeric<i32,i32> (; 150 ;)
+ (func $std/map/testNumeric<i32,i32> (; 151 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -11205,7 +11217,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<u32,i32>#clear (; 151 ;) (param $0 i32)
+ (func $~lib/map/Map<u32,i32>#clear (; 152 ;) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -11245,7 +11257,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<u32,i32>#constructor (; 152 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u32,i32>#constructor (; 153 ;) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -11277,7 +11289,7 @@
   call $~lib/map/Map<u32,i32>#clear
   local.get $0
  )
- (func $~lib/map/Map<u32,i32>#find (; 153 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<u32,i32>#find (; 154 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -11325,7 +11337,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<u32,i32>#has (; 154 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<u32,i32>#has (; 155 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -11340,7 +11352,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<u32,i32>#rehash (; 155 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<u32,i32>#rehash (; 156 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -11497,7 +11509,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<u32,i32>#set (; 156 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<u32,i32>#set (; 157 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -11602,7 +11614,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/map/Map<u32,i32>#get (; 157 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<u32,i32>#get (; 158 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -11629,11 +11641,11 @@
   local.get $3
   i32.load offset=4
  )
- (func $~lib/map/Map<u32,i32>#get:size (; 158 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u32,i32>#get:size (; 159 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/array/Array<u32>#constructor (; 159 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u32>#constructor (; 160 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   if (result i32)
    local.get $0
@@ -11643,8 +11655,6 @@
    call $~lib/rt/tlsf/__alloc
    call $~lib/rt/pure/__retain
   end
-  local.get $1
-  i32.const 2
   call $~lib/arraybuffer/ArrayBufferView#constructor
   local.set $0
   local.get $0
@@ -11652,10 +11662,14 @@
   i32.store offset=12
   local.get $0
   local.get $1
+  i32.const 2
+  call $~lib/arraybuffer/ArrayBufferView#alloc
+  local.get $0
+  local.get $1
   i32.store offset=12
   local.get $0
  )
- (func $~lib/array/Array<u32>#__unchecked_set (; 160 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<u32>#__unchecked_set (; 161 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -11665,7 +11679,7 @@
   local.get $2
   i32.store
  )
- (func $~lib/array/Array<u32>#__set (; 161 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<u32>#__set (; 162 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -11677,7 +11691,7 @@
    if
     i32.const 464
     i32.const 528
-    i32.const 109
+    i32.const 114
     i32.const 21
     call $~lib/builtins/abort
     unreachable
@@ -11699,7 +11713,7 @@
   local.get $2
   call $~lib/array/Array<u32>#__unchecked_set
  )
- (func $~lib/array/Array<u32>#set:length (; 162 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<u32>#set:length (; 163 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load offset=12
@@ -11712,7 +11726,7 @@
   local.get $1
   i32.store offset=12
  )
- (func $~lib/map/Map<u32,i32>#keys (; 163 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u32,i32>#keys (; 164 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -11777,7 +11791,7 @@
   call $~lib/array/Array<u32>#set:length
   local.get $3
  )
- (func $~lib/map/Map<u32,i32>#values (; 164 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u32,i32>#values (; 165 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -11842,7 +11856,7 @@
   call $~lib/array/Array<i32>#set:length
   local.get $3
  )
- (func $~lib/map/Map<u32,u32>#clear (; 165 ;) (param $0 i32)
+ (func $~lib/map/Map<u32,u32>#clear (; 166 ;) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -11882,7 +11896,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<u32,u32>#constructor (; 166 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u32,u32>#constructor (; 167 ;) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -11914,11 +11928,11 @@
   call $~lib/map/Map<u32,u32>#clear
   local.get $0
  )
- (func $~lib/array/Array<u32>#get:length (; 167 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<u32>#get:length (; 168 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<u32>#__unchecked_get (; 168 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u32>#__unchecked_get (; 169 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -11927,7 +11941,7 @@
   i32.add
   i32.load
  )
- (func $~lib/array/Array<u32>#__get (; 169 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u32>#__get (; 170 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   local.get $0
@@ -11936,7 +11950,7 @@
   if
    i32.const 464
    i32.const 528
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -11947,7 +11961,7 @@
   local.set $2
   local.get $2
  )
- (func $~lib/map/Map<u32,u32>#find (; 170 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<u32,u32>#find (; 171 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -11995,7 +12009,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<u32,u32>#rehash (; 171 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<u32,u32>#rehash (; 172 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -12152,7 +12166,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<u32,u32>#set (; 172 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<u32,u32>#set (; 173 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -12257,11 +12271,11 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/map/Map<u32,u32>#get:size (; 173 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u32,u32>#get:size (; 174 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/map/Map<u32,i32>#delete (; 174 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<u32,i32>#delete (; 175 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -12333,7 +12347,7 @@
   end
   i32.const 1
  )
- (func $std/map/testNumeric<u32,i32> (; 175 ;)
+ (func $std/map/testNumeric<u32,i32> (; 176 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -12796,7 +12810,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<i64,i32>#clear (; 176 ;) (param $0 i32)
+ (func $~lib/map/Map<i64,i32>#clear (; 177 ;) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -12836,7 +12850,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<i64,i32>#constructor (; 177 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<i64,i32>#constructor (; 178 ;) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -12868,7 +12882,7 @@
   call $~lib/map/Map<i64,i32>#clear
   local.get $0
  )
- (func $~lib/util/hash/hash64 (; 178 ;) (param $0 i64) (result i32)
+ (func $~lib/util/hash/hash64 (; 179 ;) (param $0 i64) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -12956,7 +12970,7 @@
   local.set $3
   local.get $3
  )
- (func $~lib/map/Map<i64,i32>#find (; 179 ;) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
+ (func $~lib/map/Map<i64,i32>#find (; 180 ;) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -13004,7 +13018,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<i64,i32>#has (; 180 ;) (param $0 i32) (param $1 i64) (result i32)
+ (func $~lib/map/Map<i64,i32>#has (; 181 ;) (param $0 i32) (param $1 i64) (result i32)
   (local $2 i64)
   local.get $0
   local.get $1
@@ -13019,7 +13033,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<i64,i32>#rehash (; 181 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<i64,i32>#rehash (; 182 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -13177,7 +13191,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<i64,i32>#set (; 182 ;) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
+ (func $~lib/map/Map<i64,i32>#set (; 183 ;) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
   (local $3 i64)
   (local $4 i32)
   (local $5 i32)
@@ -13283,7 +13297,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/map/Map<i64,i32>#get (; 183 ;) (param $0 i32) (param $1 i64) (result i32)
+ (func $~lib/map/Map<i64,i32>#get (; 184 ;) (param $0 i32) (param $1 i64) (result i32)
   (local $2 i64)
   (local $3 i32)
   local.get $0
@@ -13310,11 +13324,11 @@
   local.get $3
   i32.load offset=8
  )
- (func $~lib/map/Map<i64,i32>#get:size (; 184 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<i64,i32>#get:size (; 185 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/array/Array<i64>#constructor (; 185 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i64>#constructor (; 186 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   if (result i32)
    local.get $0
@@ -13324,8 +13338,6 @@
    call $~lib/rt/tlsf/__alloc
    call $~lib/rt/pure/__retain
   end
-  local.get $1
-  i32.const 3
   call $~lib/arraybuffer/ArrayBufferView#constructor
   local.set $0
   local.get $0
@@ -13333,10 +13345,14 @@
   i32.store offset=12
   local.get $0
   local.get $1
+  i32.const 3
+  call $~lib/arraybuffer/ArrayBufferView#alloc
+  local.get $0
+  local.get $1
   i32.store offset=12
   local.get $0
  )
- (func $~lib/array/Array<i64>#__unchecked_set (; 186 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $~lib/array/Array<i64>#__unchecked_set (; 187 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -13346,7 +13362,7 @@
   local.get $2
   i64.store
  )
- (func $~lib/array/Array<i64>#__set (; 187 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $~lib/array/Array<i64>#__set (; 188 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -13358,7 +13374,7 @@
    if
     i32.const 464
     i32.const 528
-    i32.const 109
+    i32.const 114
     i32.const 21
     call $~lib/builtins/abort
     unreachable
@@ -13380,7 +13396,7 @@
   local.get $2
   call $~lib/array/Array<i64>#__unchecked_set
  )
- (func $~lib/array/Array<i64>#set:length (; 188 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i64>#set:length (; 189 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load offset=12
@@ -13393,7 +13409,7 @@
   local.get $1
   i32.store offset=12
  )
- (func $~lib/map/Map<i64,i32>#keys (; 189 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<i64,i32>#keys (; 190 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -13458,7 +13474,7 @@
   call $~lib/array/Array<i64>#set:length
   local.get $3
  )
- (func $~lib/map/Map<i64,i32>#values (; 190 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<i64,i32>#values (; 191 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -13523,7 +13539,7 @@
   call $~lib/array/Array<i32>#set:length
   local.get $3
  )
- (func $~lib/map/Map<i64,i64>#clear (; 191 ;) (param $0 i32)
+ (func $~lib/map/Map<i64,i64>#clear (; 192 ;) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -13563,7 +13579,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<i64,i64>#constructor (; 192 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<i64,i64>#constructor (; 193 ;) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -13595,11 +13611,11 @@
   call $~lib/map/Map<i64,i64>#clear
   local.get $0
  )
- (func $~lib/array/Array<i64>#get:length (; 193 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<i64>#get:length (; 194 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<i64>#__unchecked_get (; 194 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $~lib/array/Array<i64>#__unchecked_get (; 195 ;) (param $0 i32) (param $1 i32) (result i64)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -13608,7 +13624,7 @@
   i32.add
   i64.load
  )
- (func $~lib/array/Array<i64>#__get (; 195 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $~lib/array/Array<i64>#__get (; 196 ;) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i64)
   local.get $1
   local.get $0
@@ -13617,7 +13633,7 @@
   if
    i32.const 464
    i32.const 528
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -13628,7 +13644,7 @@
   local.set $2
   local.get $2
  )
- (func $~lib/map/Map<i64,i64>#find (; 196 ;) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
+ (func $~lib/map/Map<i64,i64>#find (; 197 ;) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -13676,7 +13692,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<i64,i64>#rehash (; 197 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<i64,i64>#rehash (; 198 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -13834,7 +13850,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<i64,i64>#set (; 198 ;) (param $0 i32) (param $1 i64) (param $2 i64) (result i32)
+ (func $~lib/map/Map<i64,i64>#set (; 199 ;) (param $0 i32) (param $1 i64) (param $2 i64) (result i32)
   (local $3 i64)
   (local $4 i32)
   (local $5 i32)
@@ -13940,11 +13956,11 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/map/Map<i64,i64>#get:size (; 199 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<i64,i64>#get:size (; 200 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/map/Map<i64,i32>#delete (; 200 ;) (param $0 i32) (param $1 i64) (result i32)
+ (func $~lib/map/Map<i64,i32>#delete (; 201 ;) (param $0 i32) (param $1 i64) (result i32)
   (local $2 i64)
   (local $3 i32)
   (local $4 i32)
@@ -14017,7 +14033,7 @@
   end
   i32.const 1
  )
- (func $std/map/testNumeric<i64,i32> (; 201 ;)
+ (func $std/map/testNumeric<i64,i32> (; 202 ;)
   (local $0 i32)
   (local $1 i64)
   (local $2 i32)
@@ -14488,7 +14504,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<u64,i32>#clear (; 202 ;) (param $0 i32)
+ (func $~lib/map/Map<u64,i32>#clear (; 203 ;) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -14528,7 +14544,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<u64,i32>#constructor (; 203 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u64,i32>#constructor (; 204 ;) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -14560,7 +14576,7 @@
   call $~lib/map/Map<u64,i32>#clear
   local.get $0
  )
- (func $~lib/map/Map<u64,i32>#find (; 204 ;) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
+ (func $~lib/map/Map<u64,i32>#find (; 205 ;) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -14608,7 +14624,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<u64,i32>#has (; 205 ;) (param $0 i32) (param $1 i64) (result i32)
+ (func $~lib/map/Map<u64,i32>#has (; 206 ;) (param $0 i32) (param $1 i64) (result i32)
   (local $2 i64)
   local.get $0
   local.get $1
@@ -14623,7 +14639,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<u64,i32>#rehash (; 206 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<u64,i32>#rehash (; 207 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -14781,7 +14797,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<u64,i32>#set (; 207 ;) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
+ (func $~lib/map/Map<u64,i32>#set (; 208 ;) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
   (local $3 i64)
   (local $4 i32)
   (local $5 i32)
@@ -14887,7 +14903,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/map/Map<u64,i32>#get (; 208 ;) (param $0 i32) (param $1 i64) (result i32)
+ (func $~lib/map/Map<u64,i32>#get (; 209 ;) (param $0 i32) (param $1 i64) (result i32)
   (local $2 i64)
   (local $3 i32)
   local.get $0
@@ -14914,11 +14930,11 @@
   local.get $3
   i32.load offset=8
  )
- (func $~lib/map/Map<u64,i32>#get:size (; 209 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u64,i32>#get:size (; 210 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/array/Array<u64>#constructor (; 210 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u64>#constructor (; 211 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   if (result i32)
    local.get $0
@@ -14928,8 +14944,6 @@
    call $~lib/rt/tlsf/__alloc
    call $~lib/rt/pure/__retain
   end
-  local.get $1
-  i32.const 3
   call $~lib/arraybuffer/ArrayBufferView#constructor
   local.set $0
   local.get $0
@@ -14937,10 +14951,14 @@
   i32.store offset=12
   local.get $0
   local.get $1
+  i32.const 3
+  call $~lib/arraybuffer/ArrayBufferView#alloc
+  local.get $0
+  local.get $1
   i32.store offset=12
   local.get $0
  )
- (func $~lib/array/Array<u64>#__unchecked_set (; 211 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $~lib/array/Array<u64>#__unchecked_set (; 212 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -14950,7 +14968,7 @@
   local.get $2
   i64.store
  )
- (func $~lib/array/Array<u64>#__set (; 212 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $~lib/array/Array<u64>#__set (; 213 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -14962,7 +14980,7 @@
    if
     i32.const 464
     i32.const 528
-    i32.const 109
+    i32.const 114
     i32.const 21
     call $~lib/builtins/abort
     unreachable
@@ -14984,7 +15002,7 @@
   local.get $2
   call $~lib/array/Array<u64>#__unchecked_set
  )
- (func $~lib/array/Array<u64>#set:length (; 213 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<u64>#set:length (; 214 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load offset=12
@@ -14997,7 +15015,7 @@
   local.get $1
   i32.store offset=12
  )
- (func $~lib/map/Map<u64,i32>#keys (; 214 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u64,i32>#keys (; 215 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -15062,7 +15080,7 @@
   call $~lib/array/Array<u64>#set:length
   local.get $3
  )
- (func $~lib/map/Map<u64,i32>#values (; 215 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u64,i32>#values (; 216 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -15127,7 +15145,7 @@
   call $~lib/array/Array<i32>#set:length
   local.get $3
  )
- (func $~lib/map/Map<u64,u64>#clear (; 216 ;) (param $0 i32)
+ (func $~lib/map/Map<u64,u64>#clear (; 217 ;) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -15167,7 +15185,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<u64,u64>#constructor (; 217 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u64,u64>#constructor (; 218 ;) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -15199,11 +15217,11 @@
   call $~lib/map/Map<u64,u64>#clear
   local.get $0
  )
- (func $~lib/array/Array<u64>#get:length (; 218 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<u64>#get:length (; 219 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<u64>#__unchecked_get (; 219 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $~lib/array/Array<u64>#__unchecked_get (; 220 ;) (param $0 i32) (param $1 i32) (result i64)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -15212,7 +15230,7 @@
   i32.add
   i64.load
  )
- (func $~lib/array/Array<u64>#__get (; 220 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $~lib/array/Array<u64>#__get (; 221 ;) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i64)
   local.get $1
   local.get $0
@@ -15221,7 +15239,7 @@
   if
    i32.const 464
    i32.const 528
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -15232,7 +15250,7 @@
   local.set $2
   local.get $2
  )
- (func $~lib/map/Map<u64,u64>#find (; 221 ;) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
+ (func $~lib/map/Map<u64,u64>#find (; 222 ;) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -15280,7 +15298,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<u64,u64>#rehash (; 222 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<u64,u64>#rehash (; 223 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -15438,7 +15456,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<u64,u64>#set (; 223 ;) (param $0 i32) (param $1 i64) (param $2 i64) (result i32)
+ (func $~lib/map/Map<u64,u64>#set (; 224 ;) (param $0 i32) (param $1 i64) (param $2 i64) (result i32)
   (local $3 i64)
   (local $4 i32)
   (local $5 i32)
@@ -15544,11 +15562,11 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/map/Map<u64,u64>#get:size (; 224 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u64,u64>#get:size (; 225 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/map/Map<u64,i32>#delete (; 225 ;) (param $0 i32) (param $1 i64) (result i32)
+ (func $~lib/map/Map<u64,i32>#delete (; 226 ;) (param $0 i32) (param $1 i64) (result i32)
   (local $2 i64)
   (local $3 i32)
   (local $4 i32)
@@ -15621,7 +15639,7 @@
   end
   i32.const 1
  )
- (func $std/map/testNumeric<u64,i32> (; 226 ;)
+ (func $std/map/testNumeric<u64,i32> (; 227 ;)
   (local $0 i32)
   (local $1 i64)
   (local $2 i32)
@@ -16092,7 +16110,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<f32,i32>#clear (; 227 ;) (param $0 i32)
+ (func $~lib/map/Map<f32,i32>#clear (; 228 ;) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -16132,7 +16150,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<f32,i32>#constructor (; 228 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<f32,i32>#constructor (; 229 ;) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -16164,7 +16182,7 @@
   call $~lib/map/Map<f32,i32>#clear
   local.get $0
  )
- (func $~lib/map/Map<f32,i32>#find (; 229 ;) (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<f32,i32>#find (; 230 ;) (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -16212,7 +16230,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<f32,i32>#has (; 230 ;) (param $0 i32) (param $1 f32) (result i32)
+ (func $~lib/map/Map<f32,i32>#has (; 231 ;) (param $0 i32) (param $1 f32) (result i32)
   (local $2 f32)
   local.get $0
   local.get $1
@@ -16228,7 +16246,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<f32,i32>#rehash (; 231 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<f32,i32>#rehash (; 232 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -16387,7 +16405,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<f32,i32>#set (; 232 ;) (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<f32,i32>#set (; 233 ;) (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
   (local $3 f32)
   (local $4 i32)
   (local $5 i32)
@@ -16494,7 +16512,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/map/Map<f32,i32>#get (; 233 ;) (param $0 i32) (param $1 f32) (result i32)
+ (func $~lib/map/Map<f32,i32>#get (; 234 ;) (param $0 i32) (param $1 f32) (result i32)
   (local $2 f32)
   (local $3 i32)
   local.get $0
@@ -16522,11 +16540,11 @@
   local.get $3
   i32.load offset=4
  )
- (func $~lib/map/Map<f32,i32>#get:size (; 234 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<f32,i32>#get:size (; 235 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/array/Array<f32>#constructor (; 235 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<f32>#constructor (; 236 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   if (result i32)
    local.get $0
@@ -16536,8 +16554,6 @@
    call $~lib/rt/tlsf/__alloc
    call $~lib/rt/pure/__retain
   end
-  local.get $1
-  i32.const 2
   call $~lib/arraybuffer/ArrayBufferView#constructor
   local.set $0
   local.get $0
@@ -16545,10 +16561,14 @@
   i32.store offset=12
   local.get $0
   local.get $1
+  i32.const 2
+  call $~lib/arraybuffer/ArrayBufferView#alloc
+  local.get $0
+  local.get $1
   i32.store offset=12
   local.get $0
  )
- (func $~lib/array/Array<f32>#__unchecked_set (; 236 ;) (param $0 i32) (param $1 i32) (param $2 f32)
+ (func $~lib/array/Array<f32>#__unchecked_set (; 237 ;) (param $0 i32) (param $1 i32) (param $2 f32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -16558,7 +16578,7 @@
   local.get $2
   f32.store
  )
- (func $~lib/array/Array<f32>#__set (; 237 ;) (param $0 i32) (param $1 i32) (param $2 f32)
+ (func $~lib/array/Array<f32>#__set (; 238 ;) (param $0 i32) (param $1 i32) (param $2 f32)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -16570,7 +16590,7 @@
    if
     i32.const 464
     i32.const 528
-    i32.const 109
+    i32.const 114
     i32.const 21
     call $~lib/builtins/abort
     unreachable
@@ -16592,7 +16612,7 @@
   local.get $2
   call $~lib/array/Array<f32>#__unchecked_set
  )
- (func $~lib/array/Array<f32>#set:length (; 238 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<f32>#set:length (; 239 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load offset=12
@@ -16605,7 +16625,7 @@
   local.get $1
   i32.store offset=12
  )
- (func $~lib/map/Map<f32,i32>#keys (; 239 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<f32,i32>#keys (; 240 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -16670,7 +16690,7 @@
   call $~lib/array/Array<f32>#set:length
   local.get $3
  )
- (func $~lib/map/Map<f32,i32>#values (; 240 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<f32,i32>#values (; 241 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -16735,7 +16755,7 @@
   call $~lib/array/Array<i32>#set:length
   local.get $3
  )
- (func $~lib/map/Map<f32,f32>#clear (; 241 ;) (param $0 i32)
+ (func $~lib/map/Map<f32,f32>#clear (; 242 ;) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -16775,7 +16795,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<f32,f32>#constructor (; 242 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<f32,f32>#constructor (; 243 ;) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -16807,11 +16827,11 @@
   call $~lib/map/Map<f32,f32>#clear
   local.get $0
  )
- (func $~lib/array/Array<f32>#get:length (; 243 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<f32>#get:length (; 244 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<f32>#__unchecked_get (; 244 ;) (param $0 i32) (param $1 i32) (result f32)
+ (func $~lib/array/Array<f32>#__unchecked_get (; 245 ;) (param $0 i32) (param $1 i32) (result f32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -16820,7 +16840,7 @@
   i32.add
   f32.load
  )
- (func $~lib/array/Array<f32>#__get (; 245 ;) (param $0 i32) (param $1 i32) (result f32)
+ (func $~lib/array/Array<f32>#__get (; 246 ;) (param $0 i32) (param $1 i32) (result f32)
   (local $2 f32)
   local.get $1
   local.get $0
@@ -16829,7 +16849,7 @@
   if
    i32.const 464
    i32.const 528
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -16840,7 +16860,7 @@
   local.set $2
   local.get $2
  )
- (func $~lib/map/Map<f32,f32>#find (; 246 ;) (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<f32,f32>#find (; 247 ;) (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -16888,7 +16908,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<f32,f32>#rehash (; 247 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<f32,f32>#rehash (; 248 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -17047,7 +17067,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<f32,f32>#set (; 248 ;) (param $0 i32) (param $1 f32) (param $2 f32) (result i32)
+ (func $~lib/map/Map<f32,f32>#set (; 249 ;) (param $0 i32) (param $1 f32) (param $2 f32) (result i32)
   (local $3 f32)
   (local $4 i32)
   (local $5 i32)
@@ -17154,11 +17174,11 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/map/Map<f32,f32>#get:size (; 249 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<f32,f32>#get:size (; 250 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/map/Map<f32,i32>#delete (; 250 ;) (param $0 i32) (param $1 f32) (result i32)
+ (func $~lib/map/Map<f32,i32>#delete (; 251 ;) (param $0 i32) (param $1 f32) (result i32)
   (local $2 f32)
   (local $3 i32)
   (local $4 i32)
@@ -17232,7 +17252,7 @@
   end
   i32.const 1
  )
- (func $std/map/testNumeric<f32,i32> (; 251 ;)
+ (func $std/map/testNumeric<f32,i32> (; 252 ;)
   (local $0 i32)
   (local $1 f32)
   (local $2 i32)
@@ -17703,7 +17723,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<f64,i32>#clear (; 252 ;) (param $0 i32)
+ (func $~lib/map/Map<f64,i32>#clear (; 253 ;) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -17743,7 +17763,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<f64,i32>#constructor (; 253 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<f64,i32>#constructor (; 254 ;) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -17775,7 +17795,7 @@
   call $~lib/map/Map<f64,i32>#clear
   local.get $0
  )
- (func $~lib/map/Map<f64,i32>#find (; 254 ;) (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
+ (func $~lib/map/Map<f64,i32>#find (; 255 ;) (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -17823,7 +17843,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<f64,i32>#has (; 255 ;) (param $0 i32) (param $1 f64) (result i32)
+ (func $~lib/map/Map<f64,i32>#has (; 256 ;) (param $0 i32) (param $1 f64) (result i32)
   (local $2 f64)
   local.get $0
   local.get $1
@@ -17839,7 +17859,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<f64,i32>#rehash (; 256 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<f64,i32>#rehash (; 257 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -17998,7 +18018,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<f64,i32>#set (; 257 ;) (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
+ (func $~lib/map/Map<f64,i32>#set (; 258 ;) (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
   (local $3 f64)
   (local $4 i32)
   (local $5 i32)
@@ -18105,7 +18125,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/map/Map<f64,i32>#get (; 258 ;) (param $0 i32) (param $1 f64) (result i32)
+ (func $~lib/map/Map<f64,i32>#get (; 259 ;) (param $0 i32) (param $1 f64) (result i32)
   (local $2 f64)
   (local $3 i32)
   local.get $0
@@ -18133,11 +18153,11 @@
   local.get $3
   i32.load offset=8
  )
- (func $~lib/map/Map<f64,i32>#get:size (; 259 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<f64,i32>#get:size (; 260 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/array/Array<f64>#constructor (; 260 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<f64>#constructor (; 261 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   if (result i32)
    local.get $0
@@ -18147,8 +18167,6 @@
    call $~lib/rt/tlsf/__alloc
    call $~lib/rt/pure/__retain
   end
-  local.get $1
-  i32.const 3
   call $~lib/arraybuffer/ArrayBufferView#constructor
   local.set $0
   local.get $0
@@ -18156,10 +18174,14 @@
   i32.store offset=12
   local.get $0
   local.get $1
+  i32.const 3
+  call $~lib/arraybuffer/ArrayBufferView#alloc
+  local.get $0
+  local.get $1
   i32.store offset=12
   local.get $0
  )
- (func $~lib/array/Array<f64>#__unchecked_set (; 261 ;) (param $0 i32) (param $1 i32) (param $2 f64)
+ (func $~lib/array/Array<f64>#__unchecked_set (; 262 ;) (param $0 i32) (param $1 i32) (param $2 f64)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -18169,7 +18191,7 @@
   local.get $2
   f64.store
  )
- (func $~lib/array/Array<f64>#__set (; 262 ;) (param $0 i32) (param $1 i32) (param $2 f64)
+ (func $~lib/array/Array<f64>#__set (; 263 ;) (param $0 i32) (param $1 i32) (param $2 f64)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -18181,7 +18203,7 @@
    if
     i32.const 464
     i32.const 528
-    i32.const 109
+    i32.const 114
     i32.const 21
     call $~lib/builtins/abort
     unreachable
@@ -18203,7 +18225,7 @@
   local.get $2
   call $~lib/array/Array<f64>#__unchecked_set
  )
- (func $~lib/array/Array<f64>#set:length (; 263 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<f64>#set:length (; 264 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load offset=12
@@ -18216,7 +18238,7 @@
   local.get $1
   i32.store offset=12
  )
- (func $~lib/map/Map<f64,i32>#keys (; 264 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<f64,i32>#keys (; 265 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -18281,7 +18303,7 @@
   call $~lib/array/Array<f64>#set:length
   local.get $3
  )
- (func $~lib/map/Map<f64,i32>#values (; 265 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<f64,i32>#values (; 266 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -18346,7 +18368,7 @@
   call $~lib/array/Array<i32>#set:length
   local.get $3
  )
- (func $~lib/map/Map<f64,f64>#clear (; 266 ;) (param $0 i32)
+ (func $~lib/map/Map<f64,f64>#clear (; 267 ;) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -18386,7 +18408,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<f64,f64>#constructor (; 267 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<f64,f64>#constructor (; 268 ;) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -18418,11 +18440,11 @@
   call $~lib/map/Map<f64,f64>#clear
   local.get $0
  )
- (func $~lib/array/Array<f64>#get:length (; 268 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<f64>#get:length (; 269 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<f64>#__unchecked_get (; 269 ;) (param $0 i32) (param $1 i32) (result f64)
+ (func $~lib/array/Array<f64>#__unchecked_get (; 270 ;) (param $0 i32) (param $1 i32) (result f64)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -18431,7 +18453,7 @@
   i32.add
   f64.load
  )
- (func $~lib/array/Array<f64>#__get (; 270 ;) (param $0 i32) (param $1 i32) (result f64)
+ (func $~lib/array/Array<f64>#__get (; 271 ;) (param $0 i32) (param $1 i32) (result f64)
   (local $2 f64)
   local.get $1
   local.get $0
@@ -18440,7 +18462,7 @@
   if
    i32.const 464
    i32.const 528
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -18451,7 +18473,7 @@
   local.set $2
   local.get $2
  )
- (func $~lib/map/Map<f64,f64>#find (; 271 ;) (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
+ (func $~lib/map/Map<f64,f64>#find (; 272 ;) (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -18499,7 +18521,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<f64,f64>#rehash (; 272 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<f64,f64>#rehash (; 273 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -18658,7 +18680,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<f64,f64>#set (; 273 ;) (param $0 i32) (param $1 f64) (param $2 f64) (result i32)
+ (func $~lib/map/Map<f64,f64>#set (; 274 ;) (param $0 i32) (param $1 f64) (param $2 f64) (result i32)
   (local $3 f64)
   (local $4 i32)
   (local $5 i32)
@@ -18765,11 +18787,11 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/map/Map<f64,f64>#get:size (; 274 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<f64,f64>#get:size (; 275 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/map/Map<f64,i32>#delete (; 275 ;) (param $0 i32) (param $1 f64) (result i32)
+ (func $~lib/map/Map<f64,i32>#delete (; 276 ;) (param $0 i32) (param $1 f64) (result i32)
   (local $2 f64)
   (local $3 i32)
   (local $4 i32)
@@ -18843,7 +18865,7 @@
   end
   i32.const 1
  )
- (func $std/map/testNumeric<f64,i32> (; 276 ;)
+ (func $std/map/testNumeric<f64,i32> (; 277 ;)
   (local $0 i32)
   (local $1 f64)
   (local $2 i32)
@@ -19314,7 +19336,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $start:std/map (; 277 ;)
+ (func $start:std/map (; 278 ;)
   call $std/map/testNumeric<i8,i32>
   call $std/map/testNumeric<u8,i32>
   call $std/map/testNumeric<i16,i32>
@@ -19326,13 +19348,13 @@
   call $std/map/testNumeric<f32,i32>
   call $std/map/testNumeric<f64,i32>
  )
- (func $~start (; 278 ;)
+ (func $~start (; 279 ;)
   call $start:std/map
  )
- (func $~lib/rt/pure/__collect (; 279 ;)
+ (func $~lib/rt/pure/__collect (; 280 ;)
   return
  )
- (func $~lib/rt/pure/decrement (; 280 ;) (param $0 i32)
+ (func $~lib/rt/pure/decrement (; 281 ;) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -19409,7 +19431,7 @@
    i32.store offset=4
   end
  )
- (func $~lib/rt/pure/__visit (; 281 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/pure/__visit (; 282 ;) (param $0 i32) (param $1 i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.lt_u
@@ -19433,7 +19455,7 @@
   i32.sub
   call $~lib/rt/pure/decrement
  )
- (func $~lib/map/Map<i8,i32>#__visit_impl (; 282 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<i8,i32>#__visit_impl (; 283 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -19446,13 +19468,13 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/array/Array<i8>#__visit_impl (; 283 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i8>#__visit_impl (; 284 ;) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/array/Array<i32>#__visit_impl (; 284 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i32>#__visit_impl (; 285 ;) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/map/Map<i8,i8>#__visit_impl (; 285 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<i8,i8>#__visit_impl (; 286 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -19465,7 +19487,7 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/map/Map<i32,i32>#__visit_impl (; 286 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<i32,i32>#__visit_impl (; 287 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -19478,7 +19500,7 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/map/Map<u8,i32>#__visit_impl (; 287 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<u8,i32>#__visit_impl (; 288 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -19491,10 +19513,10 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/array/Array<u8>#__visit_impl (; 288 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<u8>#__visit_impl (; 289 ;) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/map/Map<u8,u8>#__visit_impl (; 289 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<u8,u8>#__visit_impl (; 290 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -19507,7 +19529,7 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/map/Map<i16,i32>#__visit_impl (; 290 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<i16,i32>#__visit_impl (; 291 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -19520,10 +19542,10 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/array/Array<i16>#__visit_impl (; 291 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i16>#__visit_impl (; 292 ;) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/map/Map<i16,i16>#__visit_impl (; 292 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<i16,i16>#__visit_impl (; 293 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -19536,7 +19558,7 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/map/Map<u16,i32>#__visit_impl (; 293 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<u16,i32>#__visit_impl (; 294 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -19549,10 +19571,10 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/array/Array<u16>#__visit_impl (; 294 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<u16>#__visit_impl (; 295 ;) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/map/Map<u16,u16>#__visit_impl (; 295 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<u16,u16>#__visit_impl (; 296 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -19565,7 +19587,7 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/map/Map<u32,i32>#__visit_impl (; 296 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<u32,i32>#__visit_impl (; 297 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -19578,10 +19600,10 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/array/Array<u32>#__visit_impl (; 297 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<u32>#__visit_impl (; 298 ;) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/map/Map<u32,u32>#__visit_impl (; 298 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<u32,u32>#__visit_impl (; 299 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -19594,7 +19616,7 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/map/Map<i64,i32>#__visit_impl (; 299 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<i64,i32>#__visit_impl (; 300 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -19607,10 +19629,10 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/array/Array<i64>#__visit_impl (; 300 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i64>#__visit_impl (; 301 ;) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/map/Map<i64,i64>#__visit_impl (; 301 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<i64,i64>#__visit_impl (; 302 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -19623,7 +19645,7 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/map/Map<u64,i32>#__visit_impl (; 302 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<u64,i32>#__visit_impl (; 303 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -19636,10 +19658,10 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/array/Array<u64>#__visit_impl (; 303 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<u64>#__visit_impl (; 304 ;) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/map/Map<u64,u64>#__visit_impl (; 304 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<u64,u64>#__visit_impl (; 305 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -19652,7 +19674,7 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/map/Map<f32,i32>#__visit_impl (; 305 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<f32,i32>#__visit_impl (; 306 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -19665,10 +19687,10 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/array/Array<f32>#__visit_impl (; 306 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<f32>#__visit_impl (; 307 ;) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/map/Map<f32,f32>#__visit_impl (; 307 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<f32,f32>#__visit_impl (; 308 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -19681,7 +19703,7 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/map/Map<f64,i32>#__visit_impl (; 308 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<f64,i32>#__visit_impl (; 309 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -19694,10 +19716,10 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/array/Array<f64>#__visit_impl (; 309 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<f64>#__visit_impl (; 310 ;) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/map/Map<f64,f64>#__visit_impl (; 310 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<f64,f64>#__visit_impl (; 311 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -19710,7 +19732,7 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/rt/__visit_members (; 311 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/__visit_members (; 312 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   block $block$4$break
    block $switch$1$default

--- a/tests/compiler/std/set.optimized.wat
+++ b/tests/compiler/std/set.optimized.wat
@@ -1,6 +1,6 @@
 (module
- (type $i32_i32_=>_none (func (param i32 i32)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
+ (type $i32_i32_=>_none (func (param i32 i32)))
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_none (func))
  (type $i32_=>_none (func (param i32)))
@@ -1348,7 +1348,7 @@
   if
    i32.const 192
    i32.const 240
-   i32.const 54
+   i32.const 45
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -1711,31 +1711,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/arraybuffer/ArrayBufferView#constructor (; 28 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  local.get $1
-  i32.const 1073741808
-  local.get $2
-  i32.shr_u
-  i32.gt_u
-  if
-   i32.const 192
-   i32.const 240
-   i32.const 23
-   i32.const 56
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $1
-  local.get $2
-  i32.shl
-  local.tee $3
-  i32.const 0
-  call $~lib/rt/tlsf/__alloc
-  local.tee $2
-  local.get $3
-  call $~lib/memory/memory.fill
+ (func $~lib/arraybuffer/ArrayBufferView#constructor (; 28 ;) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -1754,6 +1730,33 @@
   local.get $0
   i32.const 0
   i32.store offset=8
+  local.get $0
+ )
+ (func $~lib/arraybuffer/ArrayBufferView#alloc (; 29 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  local.get $1
+  i32.const 1073741808
+  local.get $2
+  i32.shr_u
+  i32.gt_u
+  if
+   i32.const 192
+   i32.const 240
+   i32.const 14
+   i32.const 56
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $1
+  local.get $2
+  i32.shl
+  local.tee $3
+  i32.const 0
+  call $~lib/rt/tlsf/__alloc
+  local.tee $2
+  local.get $3
+  call $~lib/memory/memory.fill
   local.get $2
   local.set $1
   local.get $2
@@ -1777,9 +1780,27 @@
   local.get $0
   local.get $3
   i32.store offset=8
-  local.get $0
  )
- (func $~lib/rt/tlsf/checkUsedBlock (; 29 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<i8>#constructor (; 30 ;) (param $0 i32) (result i32)
+  (local $1 i32)
+  i32.const 16
+  i32.const 4
+  call $~lib/rt/tlsf/__alloc
+  call $~lib/rt/pure/__retain
+  call $~lib/arraybuffer/ArrayBufferView#constructor
+  local.tee $1
+  i32.const 0
+  i32.store offset=12
+  local.get $1
+  local.get $0
+  i32.const 0
+  call $~lib/arraybuffer/ArrayBufferView#alloc
+  local.get $1
+  local.get $0
+  i32.store offset=12
+  local.get $1
+ )
+ (func $~lib/rt/tlsf/checkUsedBlock (; 31 ;) (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   i32.const 16
@@ -1821,7 +1842,7 @@
   end
   local.get $1
  )
- (func $~lib/memory/memory.copy (; 30 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/memory/memory.copy (; 32 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   block $~lib/util/memory/memmove|inlined.0
@@ -1994,7 +2015,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/freeBlock (; 31 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/freeBlock (; 33 ;) (param $0 i32) (param $1 i32)
   local.get $1
   local.get $1
   i32.load
@@ -2007,7 +2028,7 @@
   local.get $1
   call $~lib/rt/rtrace/onfree
  )
- (func $~lib/rt/tlsf/reallocateBlock (; 32 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/reallocateBlock (; 34 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2110,7 +2131,7 @@
   end
   local.get $3
  )
- (func $~lib/array/ensureSize (; 33 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/ensureSize (; 35 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $1
@@ -2170,7 +2191,7 @@
    i32.store offset=8
   end
  )
- (func $~lib/array/Array<i8>#__set (; 34 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<i8>#__set (; 36 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $1
   local.get $0
@@ -2183,7 +2204,7 @@
    if
     i32.const 352
     i32.const 416
-    i32.const 109
+    i32.const 114
     i32.const 21
     call $~lib/builtins/abort
     unreachable
@@ -2206,7 +2227,7 @@
   local.get $2
   i32.store8
  )
- (func $~lib/set/Set<i8>#values (; 35 ;) (param $0 i32) (result i32)
+ (func $~lib/set/Set<i8>#values (; 37 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -2215,32 +2236,21 @@
   (local $6 i32)
   local.get $0
   i32.load offset=8
-  local.set $4
+  local.set $3
   local.get $0
   i32.load offset=16
-  local.set $1
-  i32.const 16
-  i32.const 4
-  call $~lib/rt/tlsf/__alloc
-  call $~lib/rt/pure/__retain
-  local.get $1
-  i32.const 0
-  call $~lib/arraybuffer/ArrayBufferView#constructor
-  local.tee $2
-  i32.const 0
-  i32.store offset=12
-  local.get $2
-  local.get $1
-  i32.store offset=12
+  local.tee $4
+  call $~lib/array/Array<i8>#constructor
+  local.set $2
   i32.const 0
   local.set $0
   loop $for-loop|0
-   local.get $3
    local.get $1
+   local.get $4
    i32.lt_s
    if
-    local.get $4
     local.get $3
+    local.get $1
     i32.const 3
     i32.shl
     i32.add
@@ -2261,16 +2271,16 @@
      i32.load8_s
      call $~lib/array/Array<i8>#__set
     end
-    local.get $3
+    local.get $1
     i32.const 1
     i32.add
-    local.set $3
+    local.set $1
     br $for-loop|0
    end
   end
   local.get $2
  )
- (func $~lib/array/Array<i8>#__get (; 36 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i8>#__get (; 38 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -2278,7 +2288,7 @@
   if
    i32.const 352
    i32.const 416
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -2289,7 +2299,7 @@
   i32.add
   i32.load8_s
  )
- (func $~lib/set/Set<i8>#delete (; 37 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<i8>#delete (; 39 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -2352,7 +2362,7 @@
    call $~lib/set/Set<i8>#rehash
   end
  )
- (func $std/set/testNumeric<i8> (; 38 ;)
+ (func $std/set/testNumeric<i8> (; 40 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -2671,7 +2681,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<u8>#constructor (; 39 ;) (result i32)
+ (func $~lib/set/Set<u8>#constructor (; 41 ;) (result i32)
   (local $0 i32)
   i32.const 24
   i32.const 5
@@ -2699,7 +2709,7 @@
   call $~lib/set/Set<i8>#clear
   local.get $0
  )
- (func $~lib/set/Set<u8>#has (; 40 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/set/Set<u8>#has (; 42 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -2710,7 +2720,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/set/Set<u8>#rehash (; 41 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<u8>#rehash (; 43 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2837,7 +2847,7 @@
   local.get $4
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<u8>#add (; 42 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/set/Set<u8>#add (; 44 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2922,7 +2932,26 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/set/Set<u8>#values (; 43 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<u8>#constructor (; 45 ;) (param $0 i32) (result i32)
+  (local $1 i32)
+  i32.const 16
+  i32.const 6
+  call $~lib/rt/tlsf/__alloc
+  call $~lib/rt/pure/__retain
+  call $~lib/arraybuffer/ArrayBufferView#constructor
+  local.tee $1
+  i32.const 0
+  i32.store offset=12
+  local.get $1
+  local.get $0
+  i32.const 0
+  call $~lib/arraybuffer/ArrayBufferView#alloc
+  local.get $1
+  local.get $0
+  i32.store offset=12
+  local.get $1
+ )
+ (func $~lib/set/Set<u8>#values (; 46 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -2931,32 +2960,21 @@
   (local $6 i32)
   local.get $0
   i32.load offset=8
-  local.set $4
+  local.set $3
   local.get $0
   i32.load offset=16
-  local.set $1
-  i32.const 16
-  i32.const 6
-  call $~lib/rt/tlsf/__alloc
-  call $~lib/rt/pure/__retain
-  local.get $1
-  i32.const 0
-  call $~lib/arraybuffer/ArrayBufferView#constructor
-  local.tee $2
-  i32.const 0
-  i32.store offset=12
-  local.get $2
-  local.get $1
-  i32.store offset=12
+  local.tee $4
+  call $~lib/array/Array<u8>#constructor
+  local.set $2
   i32.const 0
   local.set $0
   loop $for-loop|0
-   local.get $3
    local.get $1
+   local.get $4
    i32.lt_s
    if
-    local.get $4
     local.get $3
+    local.get $1
     i32.const 3
     i32.shl
     i32.add
@@ -2977,16 +2995,16 @@
      i32.load8_u
      call $~lib/array/Array<i8>#__set
     end
-    local.get $3
+    local.get $1
     i32.const 1
     i32.add
-    local.set $3
+    local.set $1
     br $for-loop|0
    end
   end
   local.get $2
  )
- (func $~lib/array/Array<u8>#__get (; 44 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u8>#__get (; 47 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -2994,7 +3012,7 @@
   if
    i32.const 352
    i32.const 416
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -3005,7 +3023,7 @@
   i32.add
   i32.load8_u
  )
- (func $~lib/set/Set<u8>#delete (; 45 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<u8>#delete (; 48 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -3066,7 +3084,7 @@
    call $~lib/set/Set<u8>#rehash
   end
  )
- (func $std/set/testNumeric<u8> (; 46 ;)
+ (func $std/set/testNumeric<u8> (; 49 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -3377,7 +3395,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<i16>#constructor (; 47 ;) (result i32)
+ (func $~lib/set/Set<i16>#constructor (; 50 ;) (result i32)
   (local $0 i32)
   i32.const 24
   i32.const 7
@@ -3405,7 +3423,7 @@
   call $~lib/set/Set<i8>#clear
   local.get $0
  )
- (func $~lib/util/hash/hash16 (; 48 ;) (param $0 i32) (result i32)
+ (func $~lib/util/hash/hash16 (; 51 ;) (param $0 i32) (result i32)
   local.get $0
   i32.const 255
   i32.and
@@ -3420,7 +3438,7 @@
   i32.const 16777619
   i32.mul
  )
- (func $~lib/set/Set<i16>#find (; 49 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/set/Set<i16>#find (; 52 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.load
   local.get $2
@@ -3463,7 +3481,7 @@
   end
   i32.const 0
  )
- (func $~lib/set/Set<i16>#has (; 50 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/set/Set<i16>#has (; 53 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -3476,7 +3494,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/set/Set<i16>#rehash (; 51 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<i16>#rehash (; 54 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3603,7 +3621,7 @@
   local.get $4
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<i16>#add (; 52 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/set/Set<i16>#add (; 55 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3690,7 +3708,26 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/array/Array<i16>#__set (; 53 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<i16>#constructor (; 56 ;) (param $0 i32) (result i32)
+  (local $1 i32)
+  i32.const 16
+  i32.const 8
+  call $~lib/rt/tlsf/__alloc
+  call $~lib/rt/pure/__retain
+  call $~lib/arraybuffer/ArrayBufferView#constructor
+  local.tee $1
+  i32.const 0
+  i32.store offset=12
+  local.get $1
+  local.get $0
+  i32.const 1
+  call $~lib/arraybuffer/ArrayBufferView#alloc
+  local.get $1
+  local.get $0
+  i32.store offset=12
+  local.get $1
+ )
+ (func $~lib/array/Array<i16>#__set (; 57 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $1
   local.get $0
@@ -3703,7 +3740,7 @@
    if
     i32.const 352
     i32.const 416
-    i32.const 109
+    i32.const 114
     i32.const 21
     call $~lib/builtins/abort
     unreachable
@@ -3728,7 +3765,7 @@
   local.get $2
   i32.store16
  )
- (func $~lib/set/Set<i16>#values (; 54 ;) (param $0 i32) (result i32)
+ (func $~lib/set/Set<i16>#values (; 58 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -3737,32 +3774,21 @@
   (local $6 i32)
   local.get $0
   i32.load offset=8
-  local.set $4
+  local.set $3
   local.get $0
   i32.load offset=16
-  local.set $1
-  i32.const 16
-  i32.const 8
-  call $~lib/rt/tlsf/__alloc
-  call $~lib/rt/pure/__retain
-  local.get $1
-  i32.const 1
-  call $~lib/arraybuffer/ArrayBufferView#constructor
-  local.tee $2
-  i32.const 0
-  i32.store offset=12
-  local.get $2
-  local.get $1
-  i32.store offset=12
+  local.tee $4
+  call $~lib/array/Array<i16>#constructor
+  local.set $2
   i32.const 0
   local.set $0
   loop $for-loop|0
-   local.get $3
    local.get $1
+   local.get $4
    i32.lt_s
    if
-    local.get $4
     local.get $3
+    local.get $1
     i32.const 3
     i32.shl
     i32.add
@@ -3783,16 +3809,16 @@
      i32.load16_s
      call $~lib/array/Array<i16>#__set
     end
-    local.get $3
+    local.get $1
     i32.const 1
     i32.add
-    local.set $3
+    local.set $1
     br $for-loop|0
    end
   end
   local.get $2
  )
- (func $~lib/array/Array<i16>#__get (; 55 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i16>#__get (; 59 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -3800,7 +3826,7 @@
   if
    i32.const 352
    i32.const 416
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -3813,7 +3839,7 @@
   i32.add
   i32.load16_s
  )
- (func $~lib/set/Set<i16>#delete (; 56 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<i16>#delete (; 60 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -3876,7 +3902,7 @@
    call $~lib/set/Set<i16>#rehash
   end
  )
- (func $std/set/testNumeric<i16> (; 57 ;)
+ (func $std/set/testNumeric<i16> (; 61 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -4195,7 +4221,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<u16>#constructor (; 58 ;) (result i32)
+ (func $~lib/set/Set<u16>#constructor (; 62 ;) (result i32)
   (local $0 i32)
   i32.const 24
   i32.const 9
@@ -4223,7 +4249,7 @@
   call $~lib/set/Set<i8>#clear
   local.get $0
  )
- (func $~lib/set/Set<u16>#has (; 59 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/set/Set<u16>#has (; 63 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -4234,7 +4260,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/set/Set<u16>#rehash (; 60 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<u16>#rehash (; 64 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4361,7 +4387,7 @@
   local.get $4
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<u16>#add (; 61 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/set/Set<u16>#add (; 65 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4446,7 +4472,26 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/set/Set<u16>#values (; 62 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<u16>#constructor (; 66 ;) (param $0 i32) (result i32)
+  (local $1 i32)
+  i32.const 16
+  i32.const 10
+  call $~lib/rt/tlsf/__alloc
+  call $~lib/rt/pure/__retain
+  call $~lib/arraybuffer/ArrayBufferView#constructor
+  local.tee $1
+  i32.const 0
+  i32.store offset=12
+  local.get $1
+  local.get $0
+  i32.const 1
+  call $~lib/arraybuffer/ArrayBufferView#alloc
+  local.get $1
+  local.get $0
+  i32.store offset=12
+  local.get $1
+ )
+ (func $~lib/set/Set<u16>#values (; 67 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -4455,32 +4500,21 @@
   (local $6 i32)
   local.get $0
   i32.load offset=8
-  local.set $4
+  local.set $3
   local.get $0
   i32.load offset=16
-  local.set $1
-  i32.const 16
-  i32.const 10
-  call $~lib/rt/tlsf/__alloc
-  call $~lib/rt/pure/__retain
-  local.get $1
-  i32.const 1
-  call $~lib/arraybuffer/ArrayBufferView#constructor
-  local.tee $2
-  i32.const 0
-  i32.store offset=12
-  local.get $2
-  local.get $1
-  i32.store offset=12
+  local.tee $4
+  call $~lib/array/Array<u16>#constructor
+  local.set $2
   i32.const 0
   local.set $0
   loop $for-loop|0
-   local.get $3
    local.get $1
+   local.get $4
    i32.lt_s
    if
-    local.get $4
     local.get $3
+    local.get $1
     i32.const 3
     i32.shl
     i32.add
@@ -4501,16 +4535,16 @@
      i32.load16_u
      call $~lib/array/Array<i16>#__set
     end
-    local.get $3
+    local.get $1
     i32.const 1
     i32.add
-    local.set $3
+    local.set $1
     br $for-loop|0
    end
   end
   local.get $2
  )
- (func $~lib/array/Array<u16>#__get (; 63 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u16>#__get (; 68 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -4518,7 +4552,7 @@
   if
    i32.const 352
    i32.const 416
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -4531,7 +4565,7 @@
   i32.add
   i32.load16_u
  )
- (func $~lib/set/Set<u16>#delete (; 64 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<u16>#delete (; 69 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -4592,7 +4626,7 @@
    call $~lib/set/Set<u16>#rehash
   end
  )
- (func $std/set/testNumeric<u16> (; 65 ;)
+ (func $std/set/testNumeric<u16> (; 70 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -4903,7 +4937,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<i32>#constructor (; 66 ;) (result i32)
+ (func $~lib/set/Set<i32>#constructor (; 71 ;) (result i32)
   (local $0 i32)
   i32.const 24
   i32.const 11
@@ -4931,7 +4965,7 @@
   call $~lib/set/Set<i8>#clear
   local.get $0
  )
- (func $~lib/util/hash/hash32 (; 67 ;) (param $0 i32) (result i32)
+ (func $~lib/util/hash/hash32 (; 72 ;) (param $0 i32) (result i32)
   local.get $0
   i32.const 255
   i32.and
@@ -4962,7 +4996,7 @@
   i32.const 16777619
   i32.mul
  )
- (func $~lib/set/Set<i32>#find (; 68 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/set/Set<i32>#find (; 73 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.load
   local.get $2
@@ -5003,7 +5037,7 @@
   end
   i32.const 0
  )
- (func $~lib/set/Set<i32>#has (; 69 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/set/Set<i32>#has (; 74 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -5012,7 +5046,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/set/Set<i32>#rehash (; 70 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<i32>#rehash (; 75 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5139,7 +5173,7 @@
   local.get $4
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<i32>#add (; 71 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/set/Set<i32>#add (; 76 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5222,7 +5256,26 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/array/Array<i32>#__set (; 72 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<i32>#constructor (; 77 ;) (param $0 i32) (result i32)
+  (local $1 i32)
+  i32.const 16
+  i32.const 12
+  call $~lib/rt/tlsf/__alloc
+  call $~lib/rt/pure/__retain
+  call $~lib/arraybuffer/ArrayBufferView#constructor
+  local.tee $1
+  i32.const 0
+  i32.store offset=12
+  local.get $1
+  local.get $0
+  i32.const 2
+  call $~lib/arraybuffer/ArrayBufferView#alloc
+  local.get $1
+  local.get $0
+  i32.store offset=12
+  local.get $1
+ )
+ (func $~lib/array/Array<i32>#__set (; 78 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $1
   local.get $0
@@ -5235,7 +5288,7 @@
    if
     i32.const 352
     i32.const 416
-    i32.const 109
+    i32.const 114
     i32.const 21
     call $~lib/builtins/abort
     unreachable
@@ -5260,7 +5313,7 @@
   local.get $2
   i32.store
  )
- (func $~lib/set/Set<i32>#values (; 73 ;) (param $0 i32) (result i32)
+ (func $~lib/set/Set<i32>#values (; 79 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -5269,32 +5322,21 @@
   (local $6 i32)
   local.get $0
   i32.load offset=8
-  local.set $4
+  local.set $3
   local.get $0
   i32.load offset=16
-  local.set $1
-  i32.const 16
-  i32.const 12
-  call $~lib/rt/tlsf/__alloc
-  call $~lib/rt/pure/__retain
-  local.get $1
-  i32.const 2
-  call $~lib/arraybuffer/ArrayBufferView#constructor
-  local.tee $2
-  i32.const 0
-  i32.store offset=12
-  local.get $2
-  local.get $1
-  i32.store offset=12
+  local.tee $4
+  call $~lib/array/Array<i32>#constructor
+  local.set $2
   i32.const 0
   local.set $0
   loop $for-loop|0
-   local.get $3
    local.get $1
+   local.get $4
    i32.lt_s
    if
-    local.get $4
     local.get $3
+    local.get $1
     i32.const 3
     i32.shl
     i32.add
@@ -5315,16 +5357,16 @@
      i32.load
      call $~lib/array/Array<i32>#__set
     end
-    local.get $3
+    local.get $1
     i32.const 1
     i32.add
-    local.set $3
+    local.set $1
     br $for-loop|0
    end
   end
   local.get $2
  )
- (func $~lib/array/Array<i32>#__get (; 74 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#__get (; 80 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -5332,7 +5374,7 @@
   if
    i32.const 352
    i32.const 416
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -5345,7 +5387,7 @@
   i32.add
   i32.load
  )
- (func $~lib/set/Set<i32>#delete (; 75 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<i32>#delete (; 81 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -5404,7 +5446,7 @@
    call $~lib/set/Set<i32>#rehash
   end
  )
- (func $std/set/testNumeric<i32> (; 76 ;)
+ (func $std/set/testNumeric<i32> (; 82 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -5707,7 +5749,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<u32>#constructor (; 77 ;) (result i32)
+ (func $~lib/set/Set<u32>#constructor (; 83 ;) (result i32)
   (local $0 i32)
   i32.const 24
   i32.const 13
@@ -5735,7 +5777,26 @@
   call $~lib/set/Set<i8>#clear
   local.get $0
  )
- (func $~lib/set/Set<u32>#values (; 78 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<u32>#constructor (; 84 ;) (param $0 i32) (result i32)
+  (local $1 i32)
+  i32.const 16
+  i32.const 14
+  call $~lib/rt/tlsf/__alloc
+  call $~lib/rt/pure/__retain
+  call $~lib/arraybuffer/ArrayBufferView#constructor
+  local.tee $1
+  i32.const 0
+  i32.store offset=12
+  local.get $1
+  local.get $0
+  i32.const 2
+  call $~lib/arraybuffer/ArrayBufferView#alloc
+  local.get $1
+  local.get $0
+  i32.store offset=12
+  local.get $1
+ )
+ (func $~lib/set/Set<u32>#values (; 85 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -5744,32 +5805,21 @@
   (local $6 i32)
   local.get $0
   i32.load offset=8
-  local.set $4
+  local.set $3
   local.get $0
   i32.load offset=16
-  local.set $1
-  i32.const 16
-  i32.const 14
-  call $~lib/rt/tlsf/__alloc
-  call $~lib/rt/pure/__retain
-  local.get $1
-  i32.const 2
-  call $~lib/arraybuffer/ArrayBufferView#constructor
-  local.tee $2
-  i32.const 0
-  i32.store offset=12
-  local.get $2
-  local.get $1
-  i32.store offset=12
+  local.tee $4
+  call $~lib/array/Array<u32>#constructor
+  local.set $2
   i32.const 0
   local.set $0
   loop $for-loop|0
-   local.get $3
    local.get $1
+   local.get $4
    i32.lt_s
    if
-    local.get $4
     local.get $3
+    local.get $1
     i32.const 3
     i32.shl
     i32.add
@@ -5790,16 +5840,16 @@
      i32.load
      call $~lib/array/Array<i32>#__set
     end
-    local.get $3
+    local.get $1
     i32.const 1
     i32.add
-    local.set $3
+    local.set $1
     br $for-loop|0
    end
   end
   local.get $2
  )
- (func $std/set/testNumeric<u32> (; 79 ;)
+ (func $std/set/testNumeric<u32> (; 86 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -6102,7 +6152,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<i64>#clear (; 80 ;) (param $0 i32)
+ (func $~lib/set/Set<i64>#clear (; 87 ;) (param $0 i32)
   (local $1 i32)
   i32.const 16
   call $~lib/arraybuffer/ArrayBuffer#constructor
@@ -6135,7 +6185,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/set/Set<i64>#constructor (; 81 ;) (result i32)
+ (func $~lib/set/Set<i64>#constructor (; 88 ;) (result i32)
   (local $0 i32)
   i32.const 24
   i32.const 15
@@ -6163,7 +6213,7 @@
   call $~lib/set/Set<i64>#clear
   local.get $0
  )
- (func $~lib/util/hash/hash64 (; 82 ;) (param $0 i64) (result i32)
+ (func $~lib/util/hash/hash64 (; 89 ;) (param $0 i64) (result i32)
   (local $1 i32)
   local.get $0
   i32.wrap_i64
@@ -6229,7 +6279,7 @@
   i32.const 16777619
   i32.mul
  )
- (func $~lib/set/Set<i64>#find (; 83 ;) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
+ (func $~lib/set/Set<i64>#find (; 90 ;) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
   local.get $0
   i32.load
   local.get $2
@@ -6270,7 +6320,7 @@
   end
   i32.const 0
  )
- (func $~lib/set/Set<i64>#has (; 84 ;) (param $0 i32) (param $1 i64) (result i32)
+ (func $~lib/set/Set<i64>#has (; 91 ;) (param $0 i32) (param $1 i64) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -6279,7 +6329,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/set/Set<i64>#rehash (; 85 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<i64>#rehash (; 92 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6406,7 +6456,7 @@
   local.get $4
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<i64>#add (; 86 ;) (param $0 i32) (param $1 i64) (result i32)
+ (func $~lib/set/Set<i64>#add (; 93 ;) (param $0 i32) (param $1 i64) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6489,7 +6539,26 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/array/Array<i64>#__set (; 87 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $~lib/array/Array<i64>#constructor (; 94 ;) (param $0 i32) (result i32)
+  (local $1 i32)
+  i32.const 16
+  i32.const 16
+  call $~lib/rt/tlsf/__alloc
+  call $~lib/rt/pure/__retain
+  call $~lib/arraybuffer/ArrayBufferView#constructor
+  local.tee $1
+  i32.const 0
+  i32.store offset=12
+  local.get $1
+  local.get $0
+  i32.const 3
+  call $~lib/arraybuffer/ArrayBufferView#alloc
+  local.get $1
+  local.get $0
+  i32.store offset=12
+  local.get $1
+ )
+ (func $~lib/array/Array<i64>#__set (; 95 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   local.get $1
   local.get $0
@@ -6502,7 +6571,7 @@
    if
     i32.const 352
     i32.const 416
-    i32.const 109
+    i32.const 114
     i32.const 21
     call $~lib/builtins/abort
     unreachable
@@ -6527,7 +6596,7 @@
   local.get $2
   i64.store
  )
- (func $~lib/set/Set<i64>#values (; 88 ;) (param $0 i32) (result i32)
+ (func $~lib/set/Set<i64>#values (; 96 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -6536,32 +6605,21 @@
   (local $6 i32)
   local.get $0
   i32.load offset=8
-  local.set $4
+  local.set $3
   local.get $0
   i32.load offset=16
-  local.set $1
-  i32.const 16
-  i32.const 16
-  call $~lib/rt/tlsf/__alloc
-  call $~lib/rt/pure/__retain
-  local.get $1
-  i32.const 3
-  call $~lib/arraybuffer/ArrayBufferView#constructor
-  local.tee $2
-  i32.const 0
-  i32.store offset=12
-  local.get $2
-  local.get $1
-  i32.store offset=12
+  local.tee $4
+  call $~lib/array/Array<i64>#constructor
+  local.set $2
   i32.const 0
   local.set $0
   loop $for-loop|0
-   local.get $3
    local.get $1
+   local.get $4
    i32.lt_s
    if
-    local.get $4
     local.get $3
+    local.get $1
     i32.const 4
     i32.shl
     i32.add
@@ -6582,16 +6640,16 @@
      i64.load
      call $~lib/array/Array<i64>#__set
     end
-    local.get $3
+    local.get $1
     i32.const 1
     i32.add
-    local.set $3
+    local.set $1
     br $for-loop|0
    end
   end
   local.get $2
  )
- (func $~lib/array/Array<i64>#__get (; 89 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $~lib/array/Array<i64>#__get (; 97 ;) (param $0 i32) (param $1 i32) (result i64)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -6599,7 +6657,7 @@
   if
    i32.const 352
    i32.const 416
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -6612,7 +6670,7 @@
   i32.add
   i64.load
  )
- (func $~lib/set/Set<i64>#delete (; 90 ;) (param $0 i32) (param $1 i64)
+ (func $~lib/set/Set<i64>#delete (; 98 ;) (param $0 i32) (param $1 i64)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -6672,7 +6730,7 @@
    call $~lib/set/Set<i64>#rehash
   end
  )
- (func $std/set/testNumeric<i64> (; 91 ;)
+ (func $std/set/testNumeric<i64> (; 99 ;)
   (local $0 i64)
   (local $1 i32)
   (local $2 i32)
@@ -6974,7 +7032,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<u64>#constructor (; 92 ;) (result i32)
+ (func $~lib/set/Set<u64>#constructor (; 100 ;) (result i32)
   (local $0 i32)
   i32.const 24
   i32.const 17
@@ -7002,7 +7060,26 @@
   call $~lib/set/Set<i64>#clear
   local.get $0
  )
- (func $~lib/set/Set<u64>#values (; 93 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<u64>#constructor (; 101 ;) (param $0 i32) (result i32)
+  (local $1 i32)
+  i32.const 16
+  i32.const 18
+  call $~lib/rt/tlsf/__alloc
+  call $~lib/rt/pure/__retain
+  call $~lib/arraybuffer/ArrayBufferView#constructor
+  local.tee $1
+  i32.const 0
+  i32.store offset=12
+  local.get $1
+  local.get $0
+  i32.const 3
+  call $~lib/arraybuffer/ArrayBufferView#alloc
+  local.get $1
+  local.get $0
+  i32.store offset=12
+  local.get $1
+ )
+ (func $~lib/set/Set<u64>#values (; 102 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -7011,32 +7088,21 @@
   (local $6 i32)
   local.get $0
   i32.load offset=8
-  local.set $4
+  local.set $3
   local.get $0
   i32.load offset=16
-  local.set $1
-  i32.const 16
-  i32.const 18
-  call $~lib/rt/tlsf/__alloc
-  call $~lib/rt/pure/__retain
-  local.get $1
-  i32.const 3
-  call $~lib/arraybuffer/ArrayBufferView#constructor
-  local.tee $2
-  i32.const 0
-  i32.store offset=12
-  local.get $2
-  local.get $1
-  i32.store offset=12
+  local.tee $4
+  call $~lib/array/Array<u64>#constructor
+  local.set $2
   i32.const 0
   local.set $0
   loop $for-loop|0
-   local.get $3
    local.get $1
+   local.get $4
    i32.lt_s
    if
-    local.get $4
     local.get $3
+    local.get $1
     i32.const 4
     i32.shl
     i32.add
@@ -7057,16 +7123,16 @@
      i64.load
      call $~lib/array/Array<i64>#__set
     end
-    local.get $3
+    local.get $1
     i32.const 1
     i32.add
-    local.set $3
+    local.set $1
     br $for-loop|0
    end
   end
   local.get $2
  )
- (func $std/set/testNumeric<u64> (; 94 ;)
+ (func $std/set/testNumeric<u64> (; 103 ;)
   (local $0 i64)
   (local $1 i32)
   (local $2 i32)
@@ -7368,7 +7434,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<f32>#constructor (; 95 ;) (result i32)
+ (func $~lib/set/Set<f32>#constructor (; 104 ;) (result i32)
   (local $0 i32)
   i32.const 24
   i32.const 19
@@ -7396,7 +7462,7 @@
   call $~lib/set/Set<i8>#clear
   local.get $0
  )
- (func $~lib/set/Set<f32>#find (; 96 ;) (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
+ (func $~lib/set/Set<f32>#find (; 105 ;) (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
   local.get $0
   i32.load
   local.get $2
@@ -7437,7 +7503,7 @@
   end
   i32.const 0
  )
- (func $~lib/set/Set<f32>#has (; 97 ;) (param $0 i32) (param $1 f32) (result i32)
+ (func $~lib/set/Set<f32>#has (; 106 ;) (param $0 i32) (param $1 f32) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -7447,7 +7513,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/set/Set<f32>#rehash (; 98 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<f32>#rehash (; 107 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7575,7 +7641,7 @@
   local.get $4
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<f32>#add (; 99 ;) (param $0 i32) (param $1 f32) (result i32)
+ (func $~lib/set/Set<f32>#add (; 108 ;) (param $0 i32) (param $1 f32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7659,7 +7725,26 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/array/Array<f32>#__set (; 100 ;) (param $0 i32) (param $1 i32) (param $2 f32)
+ (func $~lib/array/Array<f32>#constructor (; 109 ;) (param $0 i32) (result i32)
+  (local $1 i32)
+  i32.const 16
+  i32.const 20
+  call $~lib/rt/tlsf/__alloc
+  call $~lib/rt/pure/__retain
+  call $~lib/arraybuffer/ArrayBufferView#constructor
+  local.tee $1
+  i32.const 0
+  i32.store offset=12
+  local.get $1
+  local.get $0
+  i32.const 2
+  call $~lib/arraybuffer/ArrayBufferView#alloc
+  local.get $1
+  local.get $0
+  i32.store offset=12
+  local.get $1
+ )
+ (func $~lib/array/Array<f32>#__set (; 110 ;) (param $0 i32) (param $1 i32) (param $2 f32)
   (local $3 i32)
   local.get $1
   local.get $0
@@ -7672,7 +7757,7 @@
    if
     i32.const 352
     i32.const 416
-    i32.const 109
+    i32.const 114
     i32.const 21
     call $~lib/builtins/abort
     unreachable
@@ -7697,7 +7782,7 @@
   local.get $2
   f32.store
  )
- (func $~lib/set/Set<f32>#values (; 101 ;) (param $0 i32) (result i32)
+ (func $~lib/set/Set<f32>#values (; 111 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -7706,32 +7791,21 @@
   (local $6 i32)
   local.get $0
   i32.load offset=8
-  local.set $4
+  local.set $3
   local.get $0
   i32.load offset=16
-  local.set $1
-  i32.const 16
-  i32.const 20
-  call $~lib/rt/tlsf/__alloc
-  call $~lib/rt/pure/__retain
-  local.get $1
-  i32.const 2
-  call $~lib/arraybuffer/ArrayBufferView#constructor
-  local.tee $2
-  i32.const 0
-  i32.store offset=12
-  local.get $2
-  local.get $1
-  i32.store offset=12
+  local.tee $4
+  call $~lib/array/Array<f32>#constructor
+  local.set $2
   i32.const 0
   local.set $0
   loop $for-loop|0
-   local.get $3
    local.get $1
+   local.get $4
    i32.lt_s
    if
-    local.get $4
     local.get $3
+    local.get $1
     i32.const 3
     i32.shl
     i32.add
@@ -7752,16 +7826,16 @@
      f32.load
      call $~lib/array/Array<f32>#__set
     end
-    local.get $3
+    local.get $1
     i32.const 1
     i32.add
-    local.set $3
+    local.set $1
     br $for-loop|0
    end
   end
   local.get $2
  )
- (func $~lib/array/Array<f32>#__get (; 102 ;) (param $0 i32) (param $1 i32) (result f32)
+ (func $~lib/array/Array<f32>#__get (; 112 ;) (param $0 i32) (param $1 i32) (result f32)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -7769,7 +7843,7 @@
   if
    i32.const 352
    i32.const 416
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -7782,7 +7856,7 @@
   i32.add
   f32.load
  )
- (func $~lib/set/Set<f32>#delete (; 103 ;) (param $0 i32) (param $1 f32)
+ (func $~lib/set/Set<f32>#delete (; 113 ;) (param $0 i32) (param $1 f32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -7843,7 +7917,7 @@
    call $~lib/set/Set<f32>#rehash
   end
  )
- (func $std/set/testNumeric<f32> (; 104 ;)
+ (func $std/set/testNumeric<f32> (; 114 ;)
   (local $0 f32)
   (local $1 i32)
   (local $2 i32)
@@ -8145,7 +8219,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<f64>#constructor (; 105 ;) (result i32)
+ (func $~lib/set/Set<f64>#constructor (; 115 ;) (result i32)
   (local $0 i32)
   i32.const 24
   i32.const 21
@@ -8173,7 +8247,7 @@
   call $~lib/set/Set<i64>#clear
   local.get $0
  )
- (func $~lib/set/Set<f64>#find (; 106 ;) (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
+ (func $~lib/set/Set<f64>#find (; 116 ;) (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
   local.get $0
   i32.load
   local.get $2
@@ -8214,7 +8288,7 @@
   end
   i32.const 0
  )
- (func $~lib/set/Set<f64>#has (; 107 ;) (param $0 i32) (param $1 f64) (result i32)
+ (func $~lib/set/Set<f64>#has (; 117 ;) (param $0 i32) (param $1 f64) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -8224,7 +8298,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/set/Set<f64>#rehash (; 108 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<f64>#rehash (; 118 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -8352,7 +8426,7 @@
   local.get $4
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<f64>#add (; 109 ;) (param $0 i32) (param $1 f64) (result i32)
+ (func $~lib/set/Set<f64>#add (; 119 ;) (param $0 i32) (param $1 f64) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -8436,7 +8510,26 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/array/Array<f64>#__set (; 110 ;) (param $0 i32) (param $1 i32) (param $2 f64)
+ (func $~lib/array/Array<f64>#constructor (; 120 ;) (param $0 i32) (result i32)
+  (local $1 i32)
+  i32.const 16
+  i32.const 22
+  call $~lib/rt/tlsf/__alloc
+  call $~lib/rt/pure/__retain
+  call $~lib/arraybuffer/ArrayBufferView#constructor
+  local.tee $1
+  i32.const 0
+  i32.store offset=12
+  local.get $1
+  local.get $0
+  i32.const 3
+  call $~lib/arraybuffer/ArrayBufferView#alloc
+  local.get $1
+  local.get $0
+  i32.store offset=12
+  local.get $1
+ )
+ (func $~lib/array/Array<f64>#__set (; 121 ;) (param $0 i32) (param $1 i32) (param $2 f64)
   (local $3 i32)
   local.get $1
   local.get $0
@@ -8449,7 +8542,7 @@
    if
     i32.const 352
     i32.const 416
-    i32.const 109
+    i32.const 114
     i32.const 21
     call $~lib/builtins/abort
     unreachable
@@ -8474,7 +8567,7 @@
   local.get $2
   f64.store
  )
- (func $~lib/set/Set<f64>#values (; 111 ;) (param $0 i32) (result i32)
+ (func $~lib/set/Set<f64>#values (; 122 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -8483,32 +8576,21 @@
   (local $6 i32)
   local.get $0
   i32.load offset=8
-  local.set $4
+  local.set $3
   local.get $0
   i32.load offset=16
-  local.set $1
-  i32.const 16
-  i32.const 22
-  call $~lib/rt/tlsf/__alloc
-  call $~lib/rt/pure/__retain
-  local.get $1
-  i32.const 3
-  call $~lib/arraybuffer/ArrayBufferView#constructor
-  local.tee $2
-  i32.const 0
-  i32.store offset=12
-  local.get $2
-  local.get $1
-  i32.store offset=12
+  local.tee $4
+  call $~lib/array/Array<f64>#constructor
+  local.set $2
   i32.const 0
   local.set $0
   loop $for-loop|0
-   local.get $3
    local.get $1
+   local.get $4
    i32.lt_s
    if
-    local.get $4
     local.get $3
+    local.get $1
     i32.const 4
     i32.shl
     i32.add
@@ -8529,16 +8611,16 @@
      f64.load
      call $~lib/array/Array<f64>#__set
     end
-    local.get $3
+    local.get $1
     i32.const 1
     i32.add
-    local.set $3
+    local.set $1
     br $for-loop|0
    end
   end
   local.get $2
  )
- (func $~lib/array/Array<f64>#__get (; 112 ;) (param $0 i32) (param $1 i32) (result f64)
+ (func $~lib/array/Array<f64>#__get (; 123 ;) (param $0 i32) (param $1 i32) (result f64)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -8546,7 +8628,7 @@
   if
    i32.const 352
    i32.const 416
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -8559,7 +8641,7 @@
   i32.add
   f64.load
  )
- (func $~lib/set/Set<f64>#delete (; 113 ;) (param $0 i32) (param $1 f64)
+ (func $~lib/set/Set<f64>#delete (; 124 ;) (param $0 i32) (param $1 f64)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -8620,7 +8702,7 @@
    call $~lib/set/Set<f64>#rehash
   end
  )
- (func $std/set/testNumeric<f64> (; 114 ;)
+ (func $std/set/testNumeric<f64> (; 125 ;)
   (local $0 f64)
   (local $1 i32)
   (local $2 i32)
@@ -8922,7 +9004,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~start (; 115 ;)
+ (func $~start (; 126 ;)
   call $std/set/testNumeric<i8>
   call $std/set/testNumeric<u8>
   call $std/set/testNumeric<i16>
@@ -8934,7 +9016,7 @@
   call $std/set/testNumeric<f32>
   call $std/set/testNumeric<f64>
  )
- (func $~lib/rt/pure/decrement (; 116 ;) (param $0 i32)
+ (func $~lib/rt/pure/decrement (; 127 ;) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -9002,7 +9084,7 @@
    i32.store offset=4
   end
  )
- (func $~lib/rt/pure/__visit (; 117 ;) (param $0 i32)
+ (func $~lib/rt/pure/__visit (; 128 ;) (param $0 i32)
   local.get $0
   i32.const 444
   i32.lt_u
@@ -9014,7 +9096,7 @@
   i32.sub
   call $~lib/rt/pure/decrement
  )
- (func $~lib/rt/__visit_members (; 118 ;) (param $0 i32)
+ (func $~lib/rt/__visit_members (; 129 ;) (param $0 i32)
   block $folding-inner0
    block $block$4$break
     block $switch$1$default

--- a/tests/compiler/std/set.untouched.wat
+++ b/tests/compiler/std/set.untouched.wat
@@ -2,8 +2,8 @@
  (type $i32_=>_i32 (func (param i32) (result i32)))
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_i32_=>_none (func (param i32 i32)))
- (type $i32_=>_none (func (param i32)))
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
+ (type $i32_=>_none (func (param i32)))
  (type $none_=>_none (func))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (type $i32_i64_=>_i32 (func (param i32 i64) (result i32)))
@@ -1741,7 +1741,7 @@
   if
    i32.const 192
    i32.const 240
-   i32.const 54
+   i32.const 45
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -2172,35 +2172,7 @@
   local.get $0
   i32.load offset=20
  )
- (func $~lib/arraybuffer/ArrayBufferView#constructor (; 29 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  local.get $1
-  i32.const 1073741808
-  local.get $2
-  i32.shr_u
-  i32.gt_u
-  if
-   i32.const 192
-   i32.const 240
-   i32.const 23
-   i32.const 56
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $1
-  local.get $2
-  i32.shl
-  local.tee $1
-  i32.const 0
-  call $~lib/rt/tlsf/__alloc
-  local.set $3
-  local.get $3
-  i32.const 0
-  local.get $1
-  call $~lib/memory/memory.fill
+ (func $~lib/arraybuffer/ArrayBufferView#constructor (; 29 ;) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -2219,6 +2191,37 @@
   local.get $0
   i32.const 0
   i32.store offset=8
+  local.get $0
+ )
+ (func $~lib/arraybuffer/ArrayBufferView#alloc (; 30 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  local.get $1
+  i32.const 1073741808
+  local.get $2
+  i32.shr_u
+  i32.gt_u
+  if
+   i32.const 192
+   i32.const 240
+   i32.const 14
+   i32.const 56
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $1
+  local.get $2
+  i32.shl
+  local.tee $1
+  i32.const 0
+  call $~lib/rt/tlsf/__alloc
+  local.set $3
+  local.get $3
+  i32.const 0
+  local.get $1
+  call $~lib/memory/memory.fill
   local.get $0
   local.tee $4
   local.get $3
@@ -2242,9 +2245,8 @@
   local.get $0
   local.get $1
   i32.store offset=8
-  local.get $0
  )
- (func $~lib/array/Array<i8>#constructor (; 30 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i8>#constructor (; 31 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   if (result i32)
    local.get $0
@@ -2254,8 +2256,6 @@
    call $~lib/rt/tlsf/__alloc
    call $~lib/rt/pure/__retain
   end
-  local.get $1
-  i32.const 0
   call $~lib/arraybuffer/ArrayBufferView#constructor
   local.set $0
   local.get $0
@@ -2263,10 +2263,14 @@
   i32.store offset=12
   local.get $0
   local.get $1
+  i32.const 0
+  call $~lib/arraybuffer/ArrayBufferView#alloc
+  local.get $0
+  local.get $1
   i32.store offset=12
   local.get $0
  )
- (func $~lib/rt/tlsf/checkUsedBlock (; 31 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/tlsf/checkUsedBlock (; 32 ;) (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   i32.const 16
@@ -2312,7 +2316,7 @@
   end
   local.get $1
  )
- (func $~lib/util/memory/memcpy (; 32 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/memory/memcpy (; 33 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3336,7 +3340,7 @@
    i32.store8
   end
  )
- (func $~lib/memory/memory.copy (; 33 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/memory/memory.copy (; 34 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3556,7 +3560,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/freeBlock (; 34 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/freeBlock (; 35 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $1
   i32.load
@@ -3572,7 +3576,7 @@
   local.get $1
   call $~lib/rt/rtrace/onfree
  )
- (func $~lib/rt/tlsf/reallocateBlock (; 35 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/reallocateBlock (; 36 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3691,7 +3695,7 @@
   end
   local.get $8
  )
- (func $~lib/rt/tlsf/__realloc (; 36 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/__realloc (; 37 ;) (param $0 i32) (param $1 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
   local.get $0
   call $~lib/rt/tlsf/checkUsedBlock
@@ -3700,7 +3704,7 @@
   i32.const 16
   i32.add
  )
- (func $~lib/array/ensureSize (; 37 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/ensureSize (; 38 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3762,7 +3766,7 @@
    i32.store offset=8
   end
  )
- (func $~lib/array/Array<i8>#__unchecked_set (; 38 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<i8>#__unchecked_set (; 39 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -3772,7 +3776,7 @@
   local.get $2
   i32.store8
  )
- (func $~lib/array/Array<i8>#__set (; 39 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<i8>#__set (; 40 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -3784,7 +3788,7 @@
    if
     i32.const 352
     i32.const 416
-    i32.const 109
+    i32.const 114
     i32.const 21
     call $~lib/builtins/abort
     unreachable
@@ -3806,7 +3810,7 @@
   local.get $2
   call $~lib/array/Array<i8>#__unchecked_set
  )
- (func $~lib/set/Set<i8>#values (; 40 ;) (param $0 i32) (result i32)
+ (func $~lib/set/Set<i8>#values (; 41 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -3868,11 +3872,11 @@
   end
   local.get $3
  )
- (func $~lib/array/Array<i8>#get:length (; 41 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<i8>#get:length (; 42 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<i8>#__unchecked_get (; 42 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i8>#__unchecked_get (; 43 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -3881,7 +3885,7 @@
   i32.add
   i32.load8_s
  )
- (func $~lib/array/Array<i8>#__get (; 43 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i8>#__get (; 44 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   local.get $0
@@ -3890,7 +3894,7 @@
   if
    i32.const 352
    i32.const 416
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -3901,7 +3905,7 @@
   local.set $2
   local.get $2
  )
- (func $~lib/set/Set<i8>#delete (; 44 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/set/Set<i8>#delete (; 45 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3977,7 +3981,7 @@
   end
   i32.const 1
  )
- (func $std/set/testNumeric<i8> (; 45 ;)
+ (func $std/set/testNumeric<i8> (; 46 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -4333,7 +4337,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<u8>#clear (; 46 ;) (param $0 i32)
+ (func $~lib/set/Set<u8>#clear (; 47 ;) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -4373,7 +4377,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/set/Set<u8>#constructor (; 47 ;) (param $0 i32) (result i32)
+ (func $~lib/set/Set<u8>#constructor (; 48 ;) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -4405,7 +4409,7 @@
   call $~lib/set/Set<u8>#clear
   local.get $0
  )
- (func $~lib/set/Set<u8>#find (; 48 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/set/Set<u8>#find (; 49 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -4455,7 +4459,7 @@
   end
   i32.const 0
  )
- (func $~lib/set/Set<u8>#has (; 49 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/set/Set<u8>#has (; 50 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -4472,7 +4476,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/set/Set<u8>#rehash (; 50 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<u8>#rehash (; 51 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4625,7 +4629,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<u8>#add (; 51 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/set/Set<u8>#add (; 52 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4720,11 +4724,11 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/set/Set<u8>#get:size (; 52 ;) (param $0 i32) (result i32)
+ (func $~lib/set/Set<u8>#get:size (; 53 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/array/Array<u8>#constructor (; 53 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u8>#constructor (; 54 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   if (result i32)
    local.get $0
@@ -4734,8 +4738,6 @@
    call $~lib/rt/tlsf/__alloc
    call $~lib/rt/pure/__retain
   end
-  local.get $1
-  i32.const 0
   call $~lib/arraybuffer/ArrayBufferView#constructor
   local.set $0
   local.get $0
@@ -4743,10 +4745,14 @@
   i32.store offset=12
   local.get $0
   local.get $1
+  i32.const 0
+  call $~lib/arraybuffer/ArrayBufferView#alloc
+  local.get $0
+  local.get $1
   i32.store offset=12
   local.get $0
  )
- (func $~lib/array/Array<u8>#__unchecked_set (; 54 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<u8>#__unchecked_set (; 55 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -4756,7 +4762,7 @@
   local.get $2
   i32.store8
  )
- (func $~lib/array/Array<u8>#__set (; 55 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<u8>#__set (; 56 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -4768,7 +4774,7 @@
    if
     i32.const 352
     i32.const 416
-    i32.const 109
+    i32.const 114
     i32.const 21
     call $~lib/builtins/abort
     unreachable
@@ -4790,7 +4796,7 @@
   local.get $2
   call $~lib/array/Array<u8>#__unchecked_set
  )
- (func $~lib/set/Set<u8>#values (; 56 ;) (param $0 i32) (result i32)
+ (func $~lib/set/Set<u8>#values (; 57 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -4852,11 +4858,11 @@
   end
   local.get $3
  )
- (func $~lib/array/Array<u8>#get:length (; 57 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<u8>#get:length (; 58 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<u8>#__unchecked_get (; 58 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u8>#__unchecked_get (; 59 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -4865,7 +4871,7 @@
   i32.add
   i32.load8_u
  )
- (func $~lib/array/Array<u8>#__get (; 59 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u8>#__get (; 60 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   local.get $0
@@ -4874,7 +4880,7 @@
   if
    i32.const 352
    i32.const 416
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -4885,7 +4891,7 @@
   local.set $2
   local.get $2
  )
- (func $~lib/set/Set<u8>#delete (; 60 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/set/Set<u8>#delete (; 61 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4959,7 +4965,7 @@
   end
   i32.const 1
  )
- (func $std/set/testNumeric<u8> (; 61 ;)
+ (func $std/set/testNumeric<u8> (; 62 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -5307,7 +5313,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<i16>#clear (; 62 ;) (param $0 i32)
+ (func $~lib/set/Set<i16>#clear (; 63 ;) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -5347,7 +5353,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/set/Set<i16>#constructor (; 63 ;) (param $0 i32) (result i32)
+ (func $~lib/set/Set<i16>#constructor (; 64 ;) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -5379,7 +5385,7 @@
   call $~lib/set/Set<i16>#clear
   local.get $0
  )
- (func $~lib/util/hash/hash16 (; 64 ;) (param $0 i32) (result i32)
+ (func $~lib/util/hash/hash16 (; 65 ;) (param $0 i32) (result i32)
   (local $1 i32)
   i32.const -2128831035
   local.set $1
@@ -5401,7 +5407,7 @@
   local.set $1
   local.get $1
  )
- (func $~lib/set/Set<i16>#find (; 65 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/set/Set<i16>#find (; 66 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -5453,7 +5459,7 @@
   end
   i32.const 0
  )
- (func $~lib/set/Set<i16>#has (; 66 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/set/Set<i16>#has (; 67 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -5472,7 +5478,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/set/Set<i16>#rehash (; 67 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<i16>#rehash (; 68 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5625,7 +5631,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<i16>#add (; 68 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/set/Set<i16>#add (; 69 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5722,11 +5728,11 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/set/Set<i16>#get:size (; 69 ;) (param $0 i32) (result i32)
+ (func $~lib/set/Set<i16>#get:size (; 70 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/array/Array<i16>#constructor (; 70 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i16>#constructor (; 71 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   if (result i32)
    local.get $0
@@ -5736,8 +5742,6 @@
    call $~lib/rt/tlsf/__alloc
    call $~lib/rt/pure/__retain
   end
-  local.get $1
-  i32.const 1
   call $~lib/arraybuffer/ArrayBufferView#constructor
   local.set $0
   local.get $0
@@ -5745,10 +5749,14 @@
   i32.store offset=12
   local.get $0
   local.get $1
+  i32.const 1
+  call $~lib/arraybuffer/ArrayBufferView#alloc
+  local.get $0
+  local.get $1
   i32.store offset=12
   local.get $0
  )
- (func $~lib/array/Array<i16>#__unchecked_set (; 71 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<i16>#__unchecked_set (; 72 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -5758,7 +5766,7 @@
   local.get $2
   i32.store16
  )
- (func $~lib/array/Array<i16>#__set (; 72 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<i16>#__set (; 73 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -5770,7 +5778,7 @@
    if
     i32.const 352
     i32.const 416
-    i32.const 109
+    i32.const 114
     i32.const 21
     call $~lib/builtins/abort
     unreachable
@@ -5792,7 +5800,7 @@
   local.get $2
   call $~lib/array/Array<i16>#__unchecked_set
  )
- (func $~lib/set/Set<i16>#values (; 73 ;) (param $0 i32) (result i32)
+ (func $~lib/set/Set<i16>#values (; 74 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -5854,11 +5862,11 @@
   end
   local.get $3
  )
- (func $~lib/array/Array<i16>#get:length (; 74 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<i16>#get:length (; 75 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<i16>#__unchecked_get (; 75 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i16>#__unchecked_get (; 76 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -5867,7 +5875,7 @@
   i32.add
   i32.load16_s
  )
- (func $~lib/array/Array<i16>#__get (; 76 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i16>#__get (; 77 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   local.get $0
@@ -5876,7 +5884,7 @@
   if
    i32.const 352
    i32.const 416
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -5887,7 +5895,7 @@
   local.set $2
   local.get $2
  )
- (func $~lib/set/Set<i16>#delete (; 77 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/set/Set<i16>#delete (; 78 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5963,7 +5971,7 @@
   end
   i32.const 1
  )
- (func $std/set/testNumeric<i16> (; 78 ;)
+ (func $std/set/testNumeric<i16> (; 79 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -6319,7 +6327,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<u16>#clear (; 79 ;) (param $0 i32)
+ (func $~lib/set/Set<u16>#clear (; 80 ;) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -6359,7 +6367,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/set/Set<u16>#constructor (; 80 ;) (param $0 i32) (result i32)
+ (func $~lib/set/Set<u16>#constructor (; 81 ;) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -6391,7 +6399,7 @@
   call $~lib/set/Set<u16>#clear
   local.get $0
  )
- (func $~lib/set/Set<u16>#find (; 81 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/set/Set<u16>#find (; 82 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -6441,7 +6449,7 @@
   end
   i32.const 0
  )
- (func $~lib/set/Set<u16>#has (; 82 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/set/Set<u16>#has (; 83 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -6458,7 +6466,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/set/Set<u16>#rehash (; 83 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<u16>#rehash (; 84 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6611,7 +6619,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<u16>#add (; 84 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/set/Set<u16>#add (; 85 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6706,11 +6714,11 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/set/Set<u16>#get:size (; 85 ;) (param $0 i32) (result i32)
+ (func $~lib/set/Set<u16>#get:size (; 86 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/array/Array<u16>#constructor (; 86 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u16>#constructor (; 87 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   if (result i32)
    local.get $0
@@ -6720,8 +6728,6 @@
    call $~lib/rt/tlsf/__alloc
    call $~lib/rt/pure/__retain
   end
-  local.get $1
-  i32.const 1
   call $~lib/arraybuffer/ArrayBufferView#constructor
   local.set $0
   local.get $0
@@ -6729,10 +6735,14 @@
   i32.store offset=12
   local.get $0
   local.get $1
+  i32.const 1
+  call $~lib/arraybuffer/ArrayBufferView#alloc
+  local.get $0
+  local.get $1
   i32.store offset=12
   local.get $0
  )
- (func $~lib/array/Array<u16>#__unchecked_set (; 87 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<u16>#__unchecked_set (; 88 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -6742,7 +6752,7 @@
   local.get $2
   i32.store16
  )
- (func $~lib/array/Array<u16>#__set (; 88 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<u16>#__set (; 89 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -6754,7 +6764,7 @@
    if
     i32.const 352
     i32.const 416
-    i32.const 109
+    i32.const 114
     i32.const 21
     call $~lib/builtins/abort
     unreachable
@@ -6776,7 +6786,7 @@
   local.get $2
   call $~lib/array/Array<u16>#__unchecked_set
  )
- (func $~lib/set/Set<u16>#values (; 89 ;) (param $0 i32) (result i32)
+ (func $~lib/set/Set<u16>#values (; 90 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -6838,11 +6848,11 @@
   end
   local.get $3
  )
- (func $~lib/array/Array<u16>#get:length (; 90 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<u16>#get:length (; 91 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<u16>#__unchecked_get (; 91 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u16>#__unchecked_get (; 92 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -6851,7 +6861,7 @@
   i32.add
   i32.load16_u
  )
- (func $~lib/array/Array<u16>#__get (; 92 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u16>#__get (; 93 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   local.get $0
@@ -6860,7 +6870,7 @@
   if
    i32.const 352
    i32.const 416
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -6871,7 +6881,7 @@
   local.set $2
   local.get $2
  )
- (func $~lib/set/Set<u16>#delete (; 93 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/set/Set<u16>#delete (; 94 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6945,7 +6955,7 @@
   end
   i32.const 1
  )
- (func $std/set/testNumeric<u16> (; 94 ;)
+ (func $std/set/testNumeric<u16> (; 95 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -7293,7 +7303,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<i32>#clear (; 95 ;) (param $0 i32)
+ (func $~lib/set/Set<i32>#clear (; 96 ;) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -7333,7 +7343,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/set/Set<i32>#constructor (; 96 ;) (param $0 i32) (result i32)
+ (func $~lib/set/Set<i32>#constructor (; 97 ;) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -7365,7 +7375,7 @@
   call $~lib/set/Set<i32>#clear
   local.get $0
  )
- (func $~lib/util/hash/hash32 (; 97 ;) (param $0 i32) (result i32)
+ (func $~lib/util/hash/hash32 (; 98 ;) (param $0 i32) (result i32)
   (local $1 i32)
   i32.const -2128831035
   local.set $1
@@ -7407,7 +7417,7 @@
   local.set $1
   local.get $1
  )
- (func $~lib/set/Set<i32>#find (; 98 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/set/Set<i32>#find (; 99 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -7455,7 +7465,7 @@
   end
   i32.const 0
  )
- (func $~lib/set/Set<i32>#has (; 99 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/set/Set<i32>#has (; 100 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -7470,7 +7480,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/set/Set<i32>#rehash (; 100 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<i32>#rehash (; 101 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7623,7 +7633,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<i32>#add (; 101 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/set/Set<i32>#add (; 102 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7716,11 +7726,11 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/set/Set<i32>#get:size (; 102 ;) (param $0 i32) (result i32)
+ (func $~lib/set/Set<i32>#get:size (; 103 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/array/Array<i32>#constructor (; 103 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#constructor (; 104 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   if (result i32)
    local.get $0
@@ -7730,8 +7740,6 @@
    call $~lib/rt/tlsf/__alloc
    call $~lib/rt/pure/__retain
   end
-  local.get $1
-  i32.const 2
   call $~lib/arraybuffer/ArrayBufferView#constructor
   local.set $0
   local.get $0
@@ -7739,10 +7747,14 @@
   i32.store offset=12
   local.get $0
   local.get $1
+  i32.const 2
+  call $~lib/arraybuffer/ArrayBufferView#alloc
+  local.get $0
+  local.get $1
   i32.store offset=12
   local.get $0
  )
- (func $~lib/array/Array<i32>#__unchecked_set (; 104 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<i32>#__unchecked_set (; 105 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -7752,7 +7764,7 @@
   local.get $2
   i32.store
  )
- (func $~lib/array/Array<i32>#__set (; 105 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<i32>#__set (; 106 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -7764,7 +7776,7 @@
    if
     i32.const 352
     i32.const 416
-    i32.const 109
+    i32.const 114
     i32.const 21
     call $~lib/builtins/abort
     unreachable
@@ -7786,7 +7798,7 @@
   local.get $2
   call $~lib/array/Array<i32>#__unchecked_set
  )
- (func $~lib/set/Set<i32>#values (; 106 ;) (param $0 i32) (result i32)
+ (func $~lib/set/Set<i32>#values (; 107 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -7848,11 +7860,11 @@
   end
   local.get $3
  )
- (func $~lib/array/Array<i32>#get:length (; 107 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<i32>#get:length (; 108 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<i32>#__unchecked_get (; 108 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#__unchecked_get (; 109 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -7861,7 +7873,7 @@
   i32.add
   i32.load
  )
- (func $~lib/array/Array<i32>#__get (; 109 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#__get (; 110 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   local.get $0
@@ -7870,7 +7882,7 @@
   if
    i32.const 352
    i32.const 416
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -7881,7 +7893,7 @@
   local.set $2
   local.get $2
  )
- (func $~lib/set/Set<i32>#delete (; 110 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/set/Set<i32>#delete (; 111 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7953,7 +7965,7 @@
   end
   i32.const 1
  )
- (func $std/set/testNumeric<i32> (; 111 ;)
+ (func $std/set/testNumeric<i32> (; 112 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -8289,7 +8301,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<u32>#clear (; 112 ;) (param $0 i32)
+ (func $~lib/set/Set<u32>#clear (; 113 ;) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -8329,7 +8341,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/set/Set<u32>#constructor (; 113 ;) (param $0 i32) (result i32)
+ (func $~lib/set/Set<u32>#constructor (; 114 ;) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -8361,7 +8373,7 @@
   call $~lib/set/Set<u32>#clear
   local.get $0
  )
- (func $~lib/set/Set<u32>#find (; 114 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/set/Set<u32>#find (; 115 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -8409,7 +8421,7 @@
   end
   i32.const 0
  )
- (func $~lib/set/Set<u32>#has (; 115 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/set/Set<u32>#has (; 116 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -8424,7 +8436,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/set/Set<u32>#rehash (; 116 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<u32>#rehash (; 117 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -8577,7 +8589,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<u32>#add (; 117 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/set/Set<u32>#add (; 118 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -8670,11 +8682,11 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/set/Set<u32>#get:size (; 118 ;) (param $0 i32) (result i32)
+ (func $~lib/set/Set<u32>#get:size (; 119 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/array/Array<u32>#constructor (; 119 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u32>#constructor (; 120 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   if (result i32)
    local.get $0
@@ -8684,8 +8696,6 @@
    call $~lib/rt/tlsf/__alloc
    call $~lib/rt/pure/__retain
   end
-  local.get $1
-  i32.const 2
   call $~lib/arraybuffer/ArrayBufferView#constructor
   local.set $0
   local.get $0
@@ -8693,10 +8703,14 @@
   i32.store offset=12
   local.get $0
   local.get $1
+  i32.const 2
+  call $~lib/arraybuffer/ArrayBufferView#alloc
+  local.get $0
+  local.get $1
   i32.store offset=12
   local.get $0
  )
- (func $~lib/array/Array<u32>#__unchecked_set (; 120 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<u32>#__unchecked_set (; 121 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -8706,7 +8720,7 @@
   local.get $2
   i32.store
  )
- (func $~lib/array/Array<u32>#__set (; 121 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<u32>#__set (; 122 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -8718,7 +8732,7 @@
    if
     i32.const 352
     i32.const 416
-    i32.const 109
+    i32.const 114
     i32.const 21
     call $~lib/builtins/abort
     unreachable
@@ -8740,7 +8754,7 @@
   local.get $2
   call $~lib/array/Array<u32>#__unchecked_set
  )
- (func $~lib/set/Set<u32>#values (; 122 ;) (param $0 i32) (result i32)
+ (func $~lib/set/Set<u32>#values (; 123 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -8802,11 +8816,11 @@
   end
   local.get $3
  )
- (func $~lib/array/Array<u32>#get:length (; 123 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<u32>#get:length (; 124 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<u32>#__unchecked_get (; 124 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u32>#__unchecked_get (; 125 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -8815,7 +8829,7 @@
   i32.add
   i32.load
  )
- (func $~lib/array/Array<u32>#__get (; 125 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u32>#__get (; 126 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   local.get $0
@@ -8824,7 +8838,7 @@
   if
    i32.const 352
    i32.const 416
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -8835,7 +8849,7 @@
   local.set $2
   local.get $2
  )
- (func $~lib/set/Set<u32>#delete (; 126 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/set/Set<u32>#delete (; 127 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -8907,7 +8921,7 @@
   end
   i32.const 1
  )
- (func $std/set/testNumeric<u32> (; 127 ;)
+ (func $std/set/testNumeric<u32> (; 128 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -9243,7 +9257,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<i64>#clear (; 128 ;) (param $0 i32)
+ (func $~lib/set/Set<i64>#clear (; 129 ;) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -9283,7 +9297,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/set/Set<i64>#constructor (; 129 ;) (param $0 i32) (result i32)
+ (func $~lib/set/Set<i64>#constructor (; 130 ;) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -9315,7 +9329,7 @@
   call $~lib/set/Set<i64>#clear
   local.get $0
  )
- (func $~lib/util/hash/hash64 (; 130 ;) (param $0 i64) (result i32)
+ (func $~lib/util/hash/hash64 (; 131 ;) (param $0 i64) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -9403,7 +9417,7 @@
   local.set $3
   local.get $3
  )
- (func $~lib/set/Set<i64>#find (; 131 ;) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
+ (func $~lib/set/Set<i64>#find (; 132 ;) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -9451,7 +9465,7 @@
   end
   i32.const 0
  )
- (func $~lib/set/Set<i64>#has (; 132 ;) (param $0 i32) (param $1 i64) (result i32)
+ (func $~lib/set/Set<i64>#has (; 133 ;) (param $0 i32) (param $1 i64) (result i32)
   (local $2 i64)
   local.get $0
   local.get $1
@@ -9466,7 +9480,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/set/Set<i64>#rehash (; 133 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<i64>#rehash (; 134 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9620,7 +9634,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<i64>#add (; 134 ;) (param $0 i32) (param $1 i64) (result i32)
+ (func $~lib/set/Set<i64>#add (; 135 ;) (param $0 i32) (param $1 i64) (result i32)
   (local $2 i64)
   (local $3 i32)
   (local $4 i32)
@@ -9714,11 +9728,11 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/set/Set<i64>#get:size (; 135 ;) (param $0 i32) (result i32)
+ (func $~lib/set/Set<i64>#get:size (; 136 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/array/Array<i64>#constructor (; 136 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i64>#constructor (; 137 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   if (result i32)
    local.get $0
@@ -9728,8 +9742,6 @@
    call $~lib/rt/tlsf/__alloc
    call $~lib/rt/pure/__retain
   end
-  local.get $1
-  i32.const 3
   call $~lib/arraybuffer/ArrayBufferView#constructor
   local.set $0
   local.get $0
@@ -9737,10 +9749,14 @@
   i32.store offset=12
   local.get $0
   local.get $1
+  i32.const 3
+  call $~lib/arraybuffer/ArrayBufferView#alloc
+  local.get $0
+  local.get $1
   i32.store offset=12
   local.get $0
  )
- (func $~lib/array/Array<i64>#__unchecked_set (; 137 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $~lib/array/Array<i64>#__unchecked_set (; 138 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -9750,7 +9766,7 @@
   local.get $2
   i64.store
  )
- (func $~lib/array/Array<i64>#__set (; 138 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $~lib/array/Array<i64>#__set (; 139 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -9762,7 +9778,7 @@
    if
     i32.const 352
     i32.const 416
-    i32.const 109
+    i32.const 114
     i32.const 21
     call $~lib/builtins/abort
     unreachable
@@ -9784,7 +9800,7 @@
   local.get $2
   call $~lib/array/Array<i64>#__unchecked_set
  )
- (func $~lib/set/Set<i64>#values (; 139 ;) (param $0 i32) (result i32)
+ (func $~lib/set/Set<i64>#values (; 140 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -9846,11 +9862,11 @@
   end
   local.get $3
  )
- (func $~lib/array/Array<i64>#get:length (; 140 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<i64>#get:length (; 141 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<i64>#__unchecked_get (; 141 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $~lib/array/Array<i64>#__unchecked_get (; 142 ;) (param $0 i32) (param $1 i32) (result i64)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -9859,7 +9875,7 @@
   i32.add
   i64.load
  )
- (func $~lib/array/Array<i64>#__get (; 142 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $~lib/array/Array<i64>#__get (; 143 ;) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i64)
   local.get $1
   local.get $0
@@ -9868,7 +9884,7 @@
   if
    i32.const 352
    i32.const 416
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -9879,7 +9895,7 @@
   local.set $2
   local.get $2
  )
- (func $~lib/set/Set<i64>#delete (; 143 ;) (param $0 i32) (param $1 i64) (result i32)
+ (func $~lib/set/Set<i64>#delete (; 144 ;) (param $0 i32) (param $1 i64) (result i32)
   (local $2 i64)
   (local $3 i32)
   (local $4 i32)
@@ -9952,7 +9968,7 @@
   end
   i32.const 1
  )
- (func $std/set/testNumeric<i64> (; 144 ;)
+ (func $std/set/testNumeric<i64> (; 145 ;)
   (local $0 i32)
   (local $1 i64)
   (local $2 i32)
@@ -10289,7 +10305,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<u64>#clear (; 145 ;) (param $0 i32)
+ (func $~lib/set/Set<u64>#clear (; 146 ;) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -10329,7 +10345,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/set/Set<u64>#constructor (; 146 ;) (param $0 i32) (result i32)
+ (func $~lib/set/Set<u64>#constructor (; 147 ;) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -10361,7 +10377,7 @@
   call $~lib/set/Set<u64>#clear
   local.get $0
  )
- (func $~lib/set/Set<u64>#find (; 147 ;) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
+ (func $~lib/set/Set<u64>#find (; 148 ;) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -10409,7 +10425,7 @@
   end
   i32.const 0
  )
- (func $~lib/set/Set<u64>#has (; 148 ;) (param $0 i32) (param $1 i64) (result i32)
+ (func $~lib/set/Set<u64>#has (; 149 ;) (param $0 i32) (param $1 i64) (result i32)
   (local $2 i64)
   local.get $0
   local.get $1
@@ -10424,7 +10440,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/set/Set<u64>#rehash (; 149 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<u64>#rehash (; 150 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10578,7 +10594,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<u64>#add (; 150 ;) (param $0 i32) (param $1 i64) (result i32)
+ (func $~lib/set/Set<u64>#add (; 151 ;) (param $0 i32) (param $1 i64) (result i32)
   (local $2 i64)
   (local $3 i32)
   (local $4 i32)
@@ -10672,11 +10688,11 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/set/Set<u64>#get:size (; 151 ;) (param $0 i32) (result i32)
+ (func $~lib/set/Set<u64>#get:size (; 152 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/array/Array<u64>#constructor (; 152 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u64>#constructor (; 153 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   if (result i32)
    local.get $0
@@ -10686,8 +10702,6 @@
    call $~lib/rt/tlsf/__alloc
    call $~lib/rt/pure/__retain
   end
-  local.get $1
-  i32.const 3
   call $~lib/arraybuffer/ArrayBufferView#constructor
   local.set $0
   local.get $0
@@ -10695,10 +10709,14 @@
   i32.store offset=12
   local.get $0
   local.get $1
+  i32.const 3
+  call $~lib/arraybuffer/ArrayBufferView#alloc
+  local.get $0
+  local.get $1
   i32.store offset=12
   local.get $0
  )
- (func $~lib/array/Array<u64>#__unchecked_set (; 153 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $~lib/array/Array<u64>#__unchecked_set (; 154 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -10708,7 +10726,7 @@
   local.get $2
   i64.store
  )
- (func $~lib/array/Array<u64>#__set (; 154 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $~lib/array/Array<u64>#__set (; 155 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -10720,7 +10738,7 @@
    if
     i32.const 352
     i32.const 416
-    i32.const 109
+    i32.const 114
     i32.const 21
     call $~lib/builtins/abort
     unreachable
@@ -10742,7 +10760,7 @@
   local.get $2
   call $~lib/array/Array<u64>#__unchecked_set
  )
- (func $~lib/set/Set<u64>#values (; 155 ;) (param $0 i32) (result i32)
+ (func $~lib/set/Set<u64>#values (; 156 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -10804,11 +10822,11 @@
   end
   local.get $3
  )
- (func $~lib/array/Array<u64>#get:length (; 156 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<u64>#get:length (; 157 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<u64>#__unchecked_get (; 157 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $~lib/array/Array<u64>#__unchecked_get (; 158 ;) (param $0 i32) (param $1 i32) (result i64)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -10817,7 +10835,7 @@
   i32.add
   i64.load
  )
- (func $~lib/array/Array<u64>#__get (; 158 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $~lib/array/Array<u64>#__get (; 159 ;) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i64)
   local.get $1
   local.get $0
@@ -10826,7 +10844,7 @@
   if
    i32.const 352
    i32.const 416
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -10837,7 +10855,7 @@
   local.set $2
   local.get $2
  )
- (func $~lib/set/Set<u64>#delete (; 159 ;) (param $0 i32) (param $1 i64) (result i32)
+ (func $~lib/set/Set<u64>#delete (; 160 ;) (param $0 i32) (param $1 i64) (result i32)
   (local $2 i64)
   (local $3 i32)
   (local $4 i32)
@@ -10910,7 +10928,7 @@
   end
   i32.const 1
  )
- (func $std/set/testNumeric<u64> (; 160 ;)
+ (func $std/set/testNumeric<u64> (; 161 ;)
   (local $0 i32)
   (local $1 i64)
   (local $2 i32)
@@ -11247,7 +11265,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<f32>#clear (; 161 ;) (param $0 i32)
+ (func $~lib/set/Set<f32>#clear (; 162 ;) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -11287,7 +11305,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/set/Set<f32>#constructor (; 162 ;) (param $0 i32) (result i32)
+ (func $~lib/set/Set<f32>#constructor (; 163 ;) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -11319,7 +11337,7 @@
   call $~lib/set/Set<f32>#clear
   local.get $0
  )
- (func $~lib/set/Set<f32>#find (; 163 ;) (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
+ (func $~lib/set/Set<f32>#find (; 164 ;) (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -11367,7 +11385,7 @@
   end
   i32.const 0
  )
- (func $~lib/set/Set<f32>#has (; 164 ;) (param $0 i32) (param $1 f32) (result i32)
+ (func $~lib/set/Set<f32>#has (; 165 ;) (param $0 i32) (param $1 f32) (result i32)
   (local $2 f32)
   local.get $0
   local.get $1
@@ -11383,7 +11401,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/set/Set<f32>#rehash (; 165 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<f32>#rehash (; 166 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -11538,7 +11556,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<f32>#add (; 166 ;) (param $0 i32) (param $1 f32) (result i32)
+ (func $~lib/set/Set<f32>#add (; 167 ;) (param $0 i32) (param $1 f32) (result i32)
   (local $2 f32)
   (local $3 i32)
   (local $4 i32)
@@ -11633,11 +11651,11 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/set/Set<f32>#get:size (; 167 ;) (param $0 i32) (result i32)
+ (func $~lib/set/Set<f32>#get:size (; 168 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/array/Array<f32>#constructor (; 168 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<f32>#constructor (; 169 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   if (result i32)
    local.get $0
@@ -11647,8 +11665,6 @@
    call $~lib/rt/tlsf/__alloc
    call $~lib/rt/pure/__retain
   end
-  local.get $1
-  i32.const 2
   call $~lib/arraybuffer/ArrayBufferView#constructor
   local.set $0
   local.get $0
@@ -11656,10 +11672,14 @@
   i32.store offset=12
   local.get $0
   local.get $1
+  i32.const 2
+  call $~lib/arraybuffer/ArrayBufferView#alloc
+  local.get $0
+  local.get $1
   i32.store offset=12
   local.get $0
  )
- (func $~lib/array/Array<f32>#__unchecked_set (; 169 ;) (param $0 i32) (param $1 i32) (param $2 f32)
+ (func $~lib/array/Array<f32>#__unchecked_set (; 170 ;) (param $0 i32) (param $1 i32) (param $2 f32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -11669,7 +11689,7 @@
   local.get $2
   f32.store
  )
- (func $~lib/array/Array<f32>#__set (; 170 ;) (param $0 i32) (param $1 i32) (param $2 f32)
+ (func $~lib/array/Array<f32>#__set (; 171 ;) (param $0 i32) (param $1 i32) (param $2 f32)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -11681,7 +11701,7 @@
    if
     i32.const 352
     i32.const 416
-    i32.const 109
+    i32.const 114
     i32.const 21
     call $~lib/builtins/abort
     unreachable
@@ -11703,7 +11723,7 @@
   local.get $2
   call $~lib/array/Array<f32>#__unchecked_set
  )
- (func $~lib/set/Set<f32>#values (; 171 ;) (param $0 i32) (result i32)
+ (func $~lib/set/Set<f32>#values (; 172 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -11765,11 +11785,11 @@
   end
   local.get $3
  )
- (func $~lib/array/Array<f32>#get:length (; 172 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<f32>#get:length (; 173 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<f32>#__unchecked_get (; 173 ;) (param $0 i32) (param $1 i32) (result f32)
+ (func $~lib/array/Array<f32>#__unchecked_get (; 174 ;) (param $0 i32) (param $1 i32) (result f32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -11778,7 +11798,7 @@
   i32.add
   f32.load
  )
- (func $~lib/array/Array<f32>#__get (; 174 ;) (param $0 i32) (param $1 i32) (result f32)
+ (func $~lib/array/Array<f32>#__get (; 175 ;) (param $0 i32) (param $1 i32) (result f32)
   (local $2 f32)
   local.get $1
   local.get $0
@@ -11787,7 +11807,7 @@
   if
    i32.const 352
    i32.const 416
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -11798,7 +11818,7 @@
   local.set $2
   local.get $2
  )
- (func $~lib/set/Set<f32>#delete (; 175 ;) (param $0 i32) (param $1 f32) (result i32)
+ (func $~lib/set/Set<f32>#delete (; 176 ;) (param $0 i32) (param $1 f32) (result i32)
   (local $2 f32)
   (local $3 i32)
   (local $4 i32)
@@ -11872,7 +11892,7 @@
   end
   i32.const 1
  )
- (func $std/set/testNumeric<f32> (; 176 ;)
+ (func $std/set/testNumeric<f32> (; 177 ;)
   (local $0 i32)
   (local $1 f32)
   (local $2 i32)
@@ -12209,7 +12229,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<f64>#clear (; 177 ;) (param $0 i32)
+ (func $~lib/set/Set<f64>#clear (; 178 ;) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -12249,7 +12269,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/set/Set<f64>#constructor (; 178 ;) (param $0 i32) (result i32)
+ (func $~lib/set/Set<f64>#constructor (; 179 ;) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -12281,7 +12301,7 @@
   call $~lib/set/Set<f64>#clear
   local.get $0
  )
- (func $~lib/set/Set<f64>#find (; 179 ;) (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
+ (func $~lib/set/Set<f64>#find (; 180 ;) (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -12329,7 +12349,7 @@
   end
   i32.const 0
  )
- (func $~lib/set/Set<f64>#has (; 180 ;) (param $0 i32) (param $1 f64) (result i32)
+ (func $~lib/set/Set<f64>#has (; 181 ;) (param $0 i32) (param $1 f64) (result i32)
   (local $2 f64)
   local.get $0
   local.get $1
@@ -12345,7 +12365,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/set/Set<f64>#rehash (; 181 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<f64>#rehash (; 182 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -12500,7 +12520,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<f64>#add (; 182 ;) (param $0 i32) (param $1 f64) (result i32)
+ (func $~lib/set/Set<f64>#add (; 183 ;) (param $0 i32) (param $1 f64) (result i32)
   (local $2 f64)
   (local $3 i32)
   (local $4 i32)
@@ -12595,11 +12615,11 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/set/Set<f64>#get:size (; 183 ;) (param $0 i32) (result i32)
+ (func $~lib/set/Set<f64>#get:size (; 184 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/array/Array<f64>#constructor (; 184 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<f64>#constructor (; 185 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   if (result i32)
    local.get $0
@@ -12609,8 +12629,6 @@
    call $~lib/rt/tlsf/__alloc
    call $~lib/rt/pure/__retain
   end
-  local.get $1
-  i32.const 3
   call $~lib/arraybuffer/ArrayBufferView#constructor
   local.set $0
   local.get $0
@@ -12618,10 +12636,14 @@
   i32.store offset=12
   local.get $0
   local.get $1
+  i32.const 3
+  call $~lib/arraybuffer/ArrayBufferView#alloc
+  local.get $0
+  local.get $1
   i32.store offset=12
   local.get $0
  )
- (func $~lib/array/Array<f64>#__unchecked_set (; 185 ;) (param $0 i32) (param $1 i32) (param $2 f64)
+ (func $~lib/array/Array<f64>#__unchecked_set (; 186 ;) (param $0 i32) (param $1 i32) (param $2 f64)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -12631,7 +12653,7 @@
   local.get $2
   f64.store
  )
- (func $~lib/array/Array<f64>#__set (; 186 ;) (param $0 i32) (param $1 i32) (param $2 f64)
+ (func $~lib/array/Array<f64>#__set (; 187 ;) (param $0 i32) (param $1 i32) (param $2 f64)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -12643,7 +12665,7 @@
    if
     i32.const 352
     i32.const 416
-    i32.const 109
+    i32.const 114
     i32.const 21
     call $~lib/builtins/abort
     unreachable
@@ -12665,7 +12687,7 @@
   local.get $2
   call $~lib/array/Array<f64>#__unchecked_set
  )
- (func $~lib/set/Set<f64>#values (; 187 ;) (param $0 i32) (result i32)
+ (func $~lib/set/Set<f64>#values (; 188 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -12727,11 +12749,11 @@
   end
   local.get $3
  )
- (func $~lib/array/Array<f64>#get:length (; 188 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<f64>#get:length (; 189 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<f64>#__unchecked_get (; 189 ;) (param $0 i32) (param $1 i32) (result f64)
+ (func $~lib/array/Array<f64>#__unchecked_get (; 190 ;) (param $0 i32) (param $1 i32) (result f64)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -12740,7 +12762,7 @@
   i32.add
   f64.load
  )
- (func $~lib/array/Array<f64>#__get (; 190 ;) (param $0 i32) (param $1 i32) (result f64)
+ (func $~lib/array/Array<f64>#__get (; 191 ;) (param $0 i32) (param $1 i32) (result f64)
   (local $2 f64)
   local.get $1
   local.get $0
@@ -12749,7 +12771,7 @@
   if
    i32.const 352
    i32.const 416
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -12760,7 +12782,7 @@
   local.set $2
   local.get $2
  )
- (func $~lib/set/Set<f64>#delete (; 191 ;) (param $0 i32) (param $1 f64) (result i32)
+ (func $~lib/set/Set<f64>#delete (; 192 ;) (param $0 i32) (param $1 f64) (result i32)
   (local $2 f64)
   (local $3 i32)
   (local $4 i32)
@@ -12834,7 +12856,7 @@
   end
   i32.const 1
  )
- (func $std/set/testNumeric<f64> (; 192 ;)
+ (func $std/set/testNumeric<f64> (; 193 ;)
   (local $0 i32)
   (local $1 f64)
   (local $2 i32)
@@ -13171,7 +13193,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $start:std/set (; 193 ;)
+ (func $start:std/set (; 194 ;)
   call $std/set/testNumeric<i8>
   call $std/set/testNumeric<u8>
   call $std/set/testNumeric<i16>
@@ -13183,13 +13205,13 @@
   call $std/set/testNumeric<f32>
   call $std/set/testNumeric<f64>
  )
- (func $~start (; 194 ;)
+ (func $~start (; 195 ;)
   call $start:std/set
  )
- (func $~lib/rt/pure/__collect (; 195 ;)
+ (func $~lib/rt/pure/__collect (; 196 ;)
   return
  )
- (func $~lib/rt/pure/decrement (; 196 ;) (param $0 i32)
+ (func $~lib/rt/pure/decrement (; 197 ;) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -13266,7 +13288,7 @@
    i32.store offset=4
   end
  )
- (func $~lib/rt/pure/__visit (; 197 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/pure/__visit (; 198 ;) (param $0 i32) (param $1 i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.lt_u
@@ -13290,7 +13312,7 @@
   i32.sub
   call $~lib/rt/pure/decrement
  )
- (func $~lib/set/Set<i8>#__visit_impl (; 198 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<i8>#__visit_impl (; 199 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -13303,10 +13325,10 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/array/Array<i8>#__visit_impl (; 199 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i8>#__visit_impl (; 200 ;) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/set/Set<u8>#__visit_impl (; 200 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<u8>#__visit_impl (; 201 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -13319,10 +13341,10 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/array/Array<u8>#__visit_impl (; 201 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<u8>#__visit_impl (; 202 ;) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/set/Set<i16>#__visit_impl (; 202 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<i16>#__visit_impl (; 203 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -13335,10 +13357,10 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/array/Array<i16>#__visit_impl (; 203 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i16>#__visit_impl (; 204 ;) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/set/Set<u16>#__visit_impl (; 204 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<u16>#__visit_impl (; 205 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -13351,10 +13373,10 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/array/Array<u16>#__visit_impl (; 205 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<u16>#__visit_impl (; 206 ;) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/set/Set<i32>#__visit_impl (; 206 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<i32>#__visit_impl (; 207 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -13367,10 +13389,10 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/array/Array<i32>#__visit_impl (; 207 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i32>#__visit_impl (; 208 ;) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/set/Set<u32>#__visit_impl (; 208 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<u32>#__visit_impl (; 209 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -13383,10 +13405,10 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/array/Array<u32>#__visit_impl (; 209 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<u32>#__visit_impl (; 210 ;) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/set/Set<i64>#__visit_impl (; 210 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<i64>#__visit_impl (; 211 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -13399,10 +13421,10 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/array/Array<i64>#__visit_impl (; 211 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i64>#__visit_impl (; 212 ;) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/set/Set<u64>#__visit_impl (; 212 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<u64>#__visit_impl (; 213 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -13415,10 +13437,10 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/array/Array<u64>#__visit_impl (; 213 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<u64>#__visit_impl (; 214 ;) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/set/Set<f32>#__visit_impl (; 214 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<f32>#__visit_impl (; 215 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -13431,10 +13453,10 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/array/Array<f32>#__visit_impl (; 215 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<f32>#__visit_impl (; 216 ;) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/set/Set<f64>#__visit_impl (; 216 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<f64>#__visit_impl (; 217 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -13447,10 +13469,10 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/array/Array<f64>#__visit_impl (; 217 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<f64>#__visit_impl (; 218 ;) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/rt/__visit_members (; 218 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/__visit_members (; 219 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   block $block$4$break
    block $switch$1$default

--- a/tests/compiler/std/static-array.optimized.wat
+++ b/tests/compiler/std/static-array.optimized.wat
@@ -37,7 +37,7 @@
   if
    i32.const 352
    i32.const 416
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -714,7 +714,7 @@
   if
    i32.const 352
    i32.const 416
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -753,7 +753,7 @@
   if
    i32.const 352
    i32.const 416
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -792,7 +792,7 @@
   if
    i32.const 352
    i32.const 416
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/static-array.untouched.wat
+++ b/tests/compiler/std/static-array.untouched.wat
@@ -59,7 +59,7 @@
   if
    i32.const 352
    i32.const 416
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -1892,7 +1892,7 @@
    if
     i32.const 352
     i32.const 416
-    i32.const 109
+    i32.const 114
     i32.const 21
     call $~lib/builtins/abort
     unreachable
@@ -1936,7 +1936,7 @@
   if
    i32.const 352
    i32.const 416
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -1969,7 +1969,7 @@
    if
     i32.const 352
     i32.const 416
-    i32.const 109
+    i32.const 114
     i32.const 21
     call $~lib/builtins/abort
     unreachable
@@ -2013,7 +2013,7 @@
   if
    i32.const 352
    i32.const 416
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -2046,7 +2046,7 @@
    if
     i32.const 352
     i32.const 416
-    i32.const 109
+    i32.const 114
     i32.const 21
     call $~lib/builtins/abort
     unreachable
@@ -2090,7 +2090,7 @@
   if
    i32.const 352
    i32.const 416
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -2123,7 +2123,7 @@
    if
     i32.const 352
     i32.const 416
-    i32.const 109
+    i32.const 114
     i32.const 21
     call $~lib/builtins/abort
     unreachable

--- a/tests/compiler/std/string.optimized.wat
+++ b/tests/compiler/std/string.optimized.wat
@@ -5748,7 +5748,7 @@
   if
    i32.const 12240
    i32.const 12192
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -5768,7 +5768,7 @@
    call $~lib/rt/pure/__release
    i32.const 12304
    i32.const 12192
-   i32.const 97
+   i32.const 102
    i32.const 39
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/string.untouched.wat
+++ b/tests/compiler/std/string.untouched.wat
@@ -8756,7 +8756,7 @@
   if
    i32.const 12240
    i32.const 12192
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -8772,7 +8772,7 @@
    call $~lib/rt/pure/__release
    i32.const 12304
    i32.const 12192
-   i32.const 97
+   i32.const 102
    i32.const 39
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/symbol.optimized.wat
+++ b/tests/compiler/std/symbol.optimized.wat
@@ -372,7 +372,7 @@
   if
    i32.const 112
    i32.const 160
-   i32.const 54
+   i32.const 45
    i32.const 42
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/symbol.untouched.wat
+++ b/tests/compiler/std/symbol.untouched.wat
@@ -466,7 +466,7 @@
   if
    i32.const 112
    i32.const 160
-   i32.const 54
+   i32.const 45
    i32.const 42
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/typedarray.optimized.wat
+++ b/tests/compiler/std/typedarray.optimized.wat
@@ -53,11 +53,11 @@
  (import "env" "trace" (func $~lib/builtins/trace (param i32 i32 f64 f64 f64 f64 f64)))
  (import "rtrace" "ondecrement" (func $~lib/rt/rtrace/ondecrement (param i32)))
  (memory $0 1)
- (data (i32.const 16) "\1c\00\00\00\01\00\00\00\01\00\00\00\1c\00\00\00I\00n\00v\00a\00l\00i\00d\00 \00l\00e\00n\00g\00t\00h")
- (data (i32.const 64) "&\00\00\00\01\00\00\00\01\00\00\00&\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00b\00u\00f\00f\00e\00r\00.\00t\00s")
- (data (i32.const 128) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s")
- (data (i32.const 176) "(\00\00\00\01\00\00\00\01\00\00\00(\00\00\00a\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e")
- (data (i32.const 240) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00p\00u\00r\00e\00.\00t\00s")
+ (data (i32.const 16) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s")
+ (data (i32.const 64) "(\00\00\00\01\00\00\00\01\00\00\00(\00\00\00a\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e")
+ (data (i32.const 128) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00p\00u\00r\00e\00.\00t\00s")
+ (data (i32.const 176) "\1c\00\00\00\01\00\00\00\01\00\00\00\1c\00\00\00I\00n\00v\00a\00l\00i\00d\00 \00l\00e\00n\00g\00t\00h")
+ (data (i32.const 224) "&\00\00\00\01\00\00\00\01\00\00\00&\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00b\00u\00f\00f\00e\00r\00.\00t\00s")
  (data (i32.const 288) "\"\00\00\00\01\00\00\00\01\00\00\00\"\00\00\00s\00t\00d\00/\00t\00y\00p\00e\00d\00a\00r\00r\00a\00y\00.\00t\00s")
  (data (i32.const 352) "$\00\00\00\01\00\00\00\01\00\00\00$\00\00\00I\00n\00d\00e\00x\00 \00o\00u\00t\00 \00o\00f\00 \00r\00a\00n\00g\00e")
  (data (i32.const 416) "$\00\00\00\01\00\00\00\01\00\00\00$\00\00\00~\00l\00i\00b\00/\00t\00y\00p\00e\00d\00a\00r\00r\00a\00y\00.\00t\00s")
@@ -225,7 +225,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 277
    i32.const 13
    call $~lib/builtins/abort
@@ -247,7 +247,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 279
    i32.const 13
    call $~lib/builtins/abort
@@ -292,7 +292,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 292
    i32.const 13
    call $~lib/builtins/abort
@@ -389,7 +389,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 205
    i32.const 13
    call $~lib/builtins/abort
@@ -403,7 +403,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 207
    i32.const 13
    call $~lib/builtins/abort
@@ -476,7 +476,7 @@
    i32.eqz
    if
     i32.const 0
-    i32.const 144
+    i32.const 32
     i32.const 228
     i32.const 15
     call $~lib/builtins/abort
@@ -531,7 +531,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 243
    i32.const 13
    call $~lib/builtins/abort
@@ -546,7 +546,7 @@
   i32.ne
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 244
    i32.const 13
    call $~lib/builtins/abort
@@ -596,7 +596,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 260
    i32.const 13
    call $~lib/builtins/abort
@@ -682,7 +682,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 386
    i32.const 4
    call $~lib/builtins/abort
@@ -699,7 +699,7 @@
    i32.lt_u
    if
     i32.const 0
-    i32.const 144
+    i32.const 32
     i32.const 396
     i32.const 15
     call $~lib/builtins/abort
@@ -727,7 +727,7 @@
    i32.lt_u
    if
     i32.const 0
-    i32.const 144
+    i32.const 32
     i32.const 408
     i32.const 4
     call $~lib/builtins/abort
@@ -867,8 +867,8 @@
   i32.const 1073741808
   i32.ge_u
   if
-   i32.const 192
-   i32.const 144
+   i32.const 80
+   i32.const 32
    i32.const 457
    i32.const 29
    call $~lib/builtins/abort
@@ -943,7 +943,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 338
    i32.const 13
    call $~lib/builtins/abort
@@ -995,7 +995,7 @@
     i32.eqz
     if
      i32.const 0
-     i32.const 144
+     i32.const 32
      i32.const 351
      i32.const 17
      call $~lib/builtins/abort
@@ -1090,7 +1090,7 @@
   i32.and
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 365
    i32.const 13
    call $~lib/builtins/abort
@@ -1161,7 +1161,7 @@
   global.get $~lib/rt/tlsf/collectLock
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 490
    i32.const 13
    call $~lib/builtins/abort
@@ -1195,7 +1195,7 @@
     i32.eqz
     if
      i32.const 0
-     i32.const 144
+     i32.const 32
      i32.const 502
      i32.const 19
      call $~lib/builtins/abort
@@ -1211,7 +1211,7 @@
   i32.lt_u
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 510
    i32.const 13
    call $~lib/builtins/abort
@@ -1245,7 +1245,81 @@
   i32.const 16
   i32.add
  )
- (func $~lib/memory/memory.fill (; 17 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/rt/pure/increment (; 17 ;) (param $0 i32)
+  (local $1 i32)
+  local.get $0
+  i32.load offset=4
+  local.tee $1
+  i32.const -268435456
+  i32.and
+  local.get $1
+  i32.const 1
+  i32.add
+  i32.const -268435456
+  i32.and
+  i32.ne
+  if
+   i32.const 0
+   i32.const 144
+   i32.const 109
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  local.get $1
+  i32.const 1
+  i32.add
+  i32.store offset=4
+  local.get $0
+  call $~lib/rt/rtrace/onincrement
+  local.get $0
+  i32.load
+  i32.const 1
+  i32.and
+  if
+   i32.const 0
+   i32.const 144
+   i32.const 112
+   i32.const 13
+   call $~lib/builtins/abort
+   unreachable
+  end
+ )
+ (func $~lib/rt/pure/__retain (; 18 ;) (param $0 i32) (result i32)
+  local.get $0
+  i32.const 7484
+  i32.gt_u
+  if
+   local.get $0
+   i32.const 16
+   i32.sub
+   call $~lib/rt/pure/increment
+  end
+  local.get $0
+ )
+ (func $~lib/arraybuffer/ArrayBufferView#constructor (; 19 ;) (param $0 i32) (result i32)
+  local.get $0
+  i32.eqz
+  if
+   i32.const 12
+   i32.const 2
+   call $~lib/rt/tlsf/__alloc
+   call $~lib/rt/pure/__retain
+   local.set $0
+  end
+  local.get $0
+  i32.const 0
+  i32.store
+  local.get $0
+  i32.const 0
+  i32.store offset=4
+  local.get $0
+  i32.const 0
+  i32.store offset=8
+  local.get $0
+ )
+ (func $~lib/memory/memory.fill (; 20 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i64)
   block $~lib/util/memory/memset|inlined.0
@@ -1470,60 +1544,7 @@
    end
   end
  )
- (func $~lib/rt/pure/increment (; 18 ;) (param $0 i32)
-  (local $1 i32)
-  local.get $0
-  i32.load offset=4
-  local.tee $1
-  i32.const -268435456
-  i32.and
-  local.get $1
-  i32.const 1
-  i32.add
-  i32.const -268435456
-  i32.and
-  i32.ne
-  if
-   i32.const 0
-   i32.const 256
-   i32.const 109
-   i32.const 2
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $0
-  local.get $1
-  i32.const 1
-  i32.add
-  i32.store offset=4
-  local.get $0
-  call $~lib/rt/rtrace/onincrement
-  local.get $0
-  i32.load
-  i32.const 1
-  i32.and
-  if
-   i32.const 0
-   i32.const 256
-   i32.const 112
-   i32.const 13
-   call $~lib/builtins/abort
-   unreachable
-  end
- )
- (func $~lib/rt/pure/__retain (; 19 ;) (param $0 i32) (result i32)
-  local.get $0
-  i32.const 7484
-  i32.gt_u
-  if
-   local.get $0
-   i32.const 16
-   i32.sub
-   call $~lib/rt/pure/increment
-  end
-  local.get $0
- )
- (func $~lib/rt/pure/__release (; 20 ;) (param $0 i32)
+ (func $~lib/rt/pure/__release (; 21 ;) (param $0 i32)
   local.get $0
   i32.const 7484
   i32.gt_u
@@ -1534,7 +1555,7 @@
    call $~lib/rt/pure/decrement
   end
  )
- (func $~lib/arraybuffer/ArrayBufferView#constructor (; 21 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBufferView#alloc (; 22 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $1
@@ -1543,9 +1564,9 @@
   i32.shr_u
   i32.gt_u
   if
-   i32.const 32
-   i32.const 80
-   i32.const 23
+   i32.const 192
+   i32.const 240
+   i32.const 14
    i32.const 56
    call $~lib/builtins/abort
    unreachable
@@ -1560,24 +1581,6 @@
   i32.const 0
   local.get $3
   call $~lib/memory/memory.fill
-  local.get $0
-  i32.eqz
-  if
-   i32.const 12
-   i32.const 2
-   call $~lib/rt/tlsf/__alloc
-   call $~lib/rt/pure/__retain
-   local.set $0
-  end
-  local.get $0
-  i32.const 0
-  i32.store
-  local.get $0
-  i32.const 0
-  i32.store offset=4
-  local.get $0
-  i32.const 0
-  i32.store offset=8
   local.get $2
   local.set $1
   local.get $2
@@ -1601,133 +1604,176 @@
   local.get $0
   local.get $3
   i32.store offset=8
-  local.get $0
  )
- (func $~lib/typedarray/Int8Array#constructor (; 22 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#constructor (; 23 ;) (param $0 i32) (result i32)
+  (local $1 i32)
   i32.const 12
   i32.const 3
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
+  call $~lib/arraybuffer/ArrayBufferView#constructor
+  local.tee $1
   local.get $0
   i32.const 0
-  call $~lib/arraybuffer/ArrayBufferView#constructor
+  call $~lib/arraybuffer/ArrayBufferView#alloc
+  local.get $1
  )
- (func $~lib/arraybuffer/ArrayBufferView#get:byteOffset (; 23 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#get:byteOffset (; 24 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $0
   i32.load
   i32.sub
  )
- (func $~lib/typedarray/Uint8Array#constructor (; 24 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#constructor (; 25 ;) (param $0 i32) (result i32)
+  (local $1 i32)
   i32.const 12
   i32.const 4
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
+  call $~lib/arraybuffer/ArrayBufferView#constructor
+  local.tee $1
   local.get $0
   i32.const 0
-  call $~lib/arraybuffer/ArrayBufferView#constructor
+  call $~lib/arraybuffer/ArrayBufferView#alloc
+  local.get $1
  )
- (func $~lib/typedarray/Uint8ClampedArray#constructor (; 25 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint8ClampedArray#constructor (; 26 ;) (param $0 i32) (result i32)
+  (local $1 i32)
   i32.const 12
   i32.const 5
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
+  call $~lib/arraybuffer/ArrayBufferView#constructor
+  local.tee $1
   local.get $0
   i32.const 0
-  call $~lib/arraybuffer/ArrayBufferView#constructor
+  call $~lib/arraybuffer/ArrayBufferView#alloc
+  local.get $1
  )
- (func $~lib/typedarray/Int16Array#constructor (; 26 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#constructor (; 27 ;) (param $0 i32) (result i32)
+  (local $1 i32)
   i32.const 12
   i32.const 6
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
+  call $~lib/arraybuffer/ArrayBufferView#constructor
+  local.tee $1
   local.get $0
   i32.const 1
-  call $~lib/arraybuffer/ArrayBufferView#constructor
+  call $~lib/arraybuffer/ArrayBufferView#alloc
+  local.get $1
  )
- (func $~lib/typedarray/Int16Array#get:length (; 27 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#get:length (; 28 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=8
   i32.const 1
   i32.shr_u
  )
- (func $~lib/typedarray/Uint16Array#constructor (; 28 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#constructor (; 29 ;) (param $0 i32) (result i32)
+  (local $1 i32)
   i32.const 12
   i32.const 7
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
+  call $~lib/arraybuffer/ArrayBufferView#constructor
+  local.tee $1
   local.get $0
   i32.const 1
-  call $~lib/arraybuffer/ArrayBufferView#constructor
+  call $~lib/arraybuffer/ArrayBufferView#alloc
+  local.get $1
  )
- (func $~lib/typedarray/Int32Array#constructor (; 29 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#constructor (; 30 ;) (param $0 i32) (result i32)
+  (local $1 i32)
   i32.const 12
   i32.const 8
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
+  call $~lib/arraybuffer/ArrayBufferView#constructor
+  local.tee $1
   local.get $0
   i32.const 2
-  call $~lib/arraybuffer/ArrayBufferView#constructor
+  call $~lib/arraybuffer/ArrayBufferView#alloc
+  local.get $1
  )
- (func $~lib/typedarray/Int32Array#get:length (; 30 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#get:length (; 31 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=8
   i32.const 2
   i32.shr_u
  )
- (func $~lib/typedarray/Uint32Array#constructor (; 31 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint32Array#constructor (; 32 ;) (param $0 i32) (result i32)
+  (local $1 i32)
   i32.const 12
   i32.const 9
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
+  call $~lib/arraybuffer/ArrayBufferView#constructor
+  local.tee $1
   local.get $0
   i32.const 2
-  call $~lib/arraybuffer/ArrayBufferView#constructor
+  call $~lib/arraybuffer/ArrayBufferView#alloc
+  local.get $1
  )
- (func $~lib/typedarray/Int64Array#constructor (; 32 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int64Array#constructor (; 33 ;) (param $0 i32) (result i32)
+  (local $1 i32)
   i32.const 12
   i32.const 10
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
+  call $~lib/arraybuffer/ArrayBufferView#constructor
+  local.tee $1
   local.get $0
   i32.const 3
-  call $~lib/arraybuffer/ArrayBufferView#constructor
+  call $~lib/arraybuffer/ArrayBufferView#alloc
+  local.get $1
  )
- (func $~lib/typedarray/Int64Array#get:length (; 33 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int64Array#get:length (; 34 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=8
   i32.const 3
   i32.shr_u
  )
- (func $~lib/typedarray/Uint64Array#constructor (; 34 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint64Array#constructor (; 35 ;) (param $0 i32) (result i32)
+  (local $1 i32)
   i32.const 12
   i32.const 11
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
+  call $~lib/arraybuffer/ArrayBufferView#constructor
+  local.tee $1
   local.get $0
   i32.const 3
-  call $~lib/arraybuffer/ArrayBufferView#constructor
+  call $~lib/arraybuffer/ArrayBufferView#alloc
+  local.get $1
  )
- (func $~lib/typedarray/Float32Array#constructor (; 35 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#constructor (; 36 ;) (param $0 i32) (result i32)
+  (local $1 i32)
   i32.const 12
   i32.const 12
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
+  call $~lib/arraybuffer/ArrayBufferView#constructor
+  local.tee $1
   local.get $0
   i32.const 2
-  call $~lib/arraybuffer/ArrayBufferView#constructor
+  call $~lib/arraybuffer/ArrayBufferView#alloc
+  local.get $1
  )
- (func $~lib/typedarray/Float64Array#constructor (; 36 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#constructor (; 37 ;) (param $0 i32) (result i32)
+  (local $1 i32)
   i32.const 12
   i32.const 13
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
+  call $~lib/arraybuffer/ArrayBufferView#constructor
+  local.tee $1
   local.get $0
   i32.const 3
-  call $~lib/arraybuffer/ArrayBufferView#constructor
+  call $~lib/arraybuffer/ArrayBufferView#alloc
+  local.get $1
  )
- (func $std/typedarray/testInstantiate (; 37 ;) (param $0 i32)
+ (func $std/typedarray/testInstantiate (; 38 ;) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -1742,7 +1788,7 @@
   local.get $0
   call $~lib/typedarray/Int8Array#constructor
   local.tee $1
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Int8Array#get:byteOffset
   if
    i32.const 0
    i32.const 304
@@ -1778,7 +1824,7 @@
   local.get $0
   call $~lib/typedarray/Uint8Array#constructor
   local.tee $2
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Int8Array#get:byteOffset
   if
    i32.const 0
    i32.const 304
@@ -1814,7 +1860,7 @@
   local.get $0
   call $~lib/typedarray/Uint8ClampedArray#constructor
   local.tee $3
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Int8Array#get:byteOffset
   if
    i32.const 0
    i32.const 304
@@ -1850,7 +1896,7 @@
   local.get $0
   call $~lib/typedarray/Int16Array#constructor
   local.tee $4
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Int8Array#get:byteOffset
   if
    i32.const 0
    i32.const 304
@@ -1888,7 +1934,7 @@
   local.get $0
   call $~lib/typedarray/Uint16Array#constructor
   local.tee $5
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Int8Array#get:byteOffset
   if
    i32.const 0
    i32.const 304
@@ -1926,7 +1972,7 @@
   local.get $0
   call $~lib/typedarray/Int32Array#constructor
   local.tee $6
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Int8Array#get:byteOffset
   if
    i32.const 0
    i32.const 304
@@ -1964,7 +2010,7 @@
   local.get $0
   call $~lib/typedarray/Uint32Array#constructor
   local.tee $7
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Int8Array#get:byteOffset
   if
    i32.const 0
    i32.const 304
@@ -2002,7 +2048,7 @@
   local.get $0
   call $~lib/typedarray/Int64Array#constructor
   local.tee $8
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Int8Array#get:byteOffset
   if
    i32.const 0
    i32.const 304
@@ -2040,7 +2086,7 @@
   local.get $0
   call $~lib/typedarray/Uint64Array#constructor
   local.tee $9
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Int8Array#get:byteOffset
   if
    i32.const 0
    i32.const 304
@@ -2078,7 +2124,7 @@
   local.get $0
   call $~lib/typedarray/Float32Array#constructor
   local.tee $10
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Int8Array#get:byteOffset
   if
    i32.const 0
    i32.const 304
@@ -2116,7 +2162,7 @@
   local.get $0
   call $~lib/typedarray/Float64Array#constructor
   local.tee $11
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Int8Array#get:byteOffset
   if
    i32.const 0
    i32.const 304
@@ -2174,7 +2220,7 @@
   local.get $11
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int32Array#__set (; 38 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int32Array#__set (; 39 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -2184,7 +2230,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 675
+   i32.const 754
    i32.const 63
    call $~lib/builtins/abort
    unreachable
@@ -2198,7 +2244,7 @@
   local.get $2
   i32.store
  )
- (func $~lib/typedarray/Int32Array#__get (; 39 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#__get (; 40 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -2208,7 +2254,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 664
+   i32.const 743
    i32.const 63
    call $~lib/builtins/abort
    unreachable
@@ -2221,7 +2267,7 @@
   i32.add
   i32.load
  )
- (func $~lib/typedarray/Int32Array#subarray (; 40 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#subarray (; 41 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -2303,7 +2349,7 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~lib/typedarray/Float64Array#__set (; 41 ;) (param $0 i32) (param $1 i32) (param $2 f64)
+ (func $~lib/typedarray/Float64Array#__set (; 42 ;) (param $0 i32) (param $1 i32) (param $2 f64)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -2313,7 +2359,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 1315
+   i32.const 1459
    i32.const 63
    call $~lib/builtins/abort
    unreachable
@@ -2327,7 +2373,7 @@
   local.get $2
   f64.store
  )
- (func $~lib/typedarray/Float64Array#subarray (; 42 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#subarray (; 43 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -2409,11 +2455,11 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~setArgumentsLength (; 43 ;) (param $0 i32)
+ (func $~setArgumentsLength (; 44 ;) (param $0 i32)
   local.get $0
   global.set $~argumentsLength
  )
- (func $~lib/util/sort/insertionSort<f64> (; 44 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/util/sort/insertionSort<f64> (; 45 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 f64)
@@ -2491,7 +2537,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/checkUsedBlock (; 45 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/tlsf/checkUsedBlock (; 46 ;) (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   i32.const 16
@@ -2525,7 +2571,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 570
    i32.const 2
    call $~lib/builtins/abort
@@ -2533,7 +2579,7 @@
   end
   local.get $1
  )
- (func $~lib/rt/tlsf/freeBlock (; 46 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/freeBlock (; 47 ;) (param $0 i32) (param $1 i32)
   local.get $1
   local.get $1
   i32.load
@@ -2546,13 +2592,13 @@
   local.get $1
   call $~lib/rt/rtrace/onfree
  )
- (func $~lib/rt/tlsf/__free (; 47 ;) (param $0 i32)
+ (func $~lib/rt/tlsf/__free (; 48 ;) (param $0 i32)
   call $~lib/rt/tlsf/maybeInitialize
   local.get $0
   call $~lib/rt/tlsf/checkUsedBlock
   call $~lib/rt/tlsf/freeBlock
  )
- (func $~lib/util/sort/weakHeapSort<f64> (; 48 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/util/sort/weakHeapSort<f64> (; 49 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 f64)
@@ -2809,7 +2855,7 @@
   local.get $4
   f64.store
  )
- (func $~lib/typedarray/Float64Array#sort (; 49 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#sort (; 50 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 f64)
@@ -2868,7 +2914,7 @@
   end
   local.get $2
  )
- (func $~lib/util/sort/COMPARATOR<f64>~anonymous|0 (; 50 ;) (param $0 f64) (param $1 f64) (result i32)
+ (func $~lib/util/sort/COMPARATOR<f64>~anonymous|0 (; 51 ;) (param $0 f64) (param $1 f64) (result i32)
   (local $2 i64)
   (local $3 i64)
   local.get $0
@@ -2897,7 +2943,7 @@
   i64.lt_s
   i32.sub
  )
- (func $~lib/typedarray/Float64Array#__get (; 51 ;) (param $0 i32) (param $1 i32) (result f64)
+ (func $~lib/typedarray/Float64Array#__get (; 52 ;) (param $0 i32) (param $1 i32) (result f64)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -2907,7 +2953,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 1304
+   i32.const 1448
    i32.const 63
    call $~lib/builtins/abort
    unreachable
@@ -2920,7 +2966,7 @@
   i32.add
   f64.load
  )
- (func $~lib/typedarray/Uint8ClampedArray#__set (; 52 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint8ClampedArray#__set (; 53 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -2928,7 +2974,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 291
+   i32.const 331
    i32.const 44
    call $~lib/builtins/abort
    unreachable
@@ -2952,7 +2998,7 @@
   i32.and
   i32.store8
  )
- (func $~lib/typedarray/Uint8ClampedArray#__get (; 53 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8ClampedArray#__get (; 54 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -2960,7 +3006,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 280
+   i32.const 320
    i32.const 44
    call $~lib/builtins/abort
    unreachable
@@ -2971,7 +3017,7 @@
   i32.add
   i32.load8_u
  )
- (func $~lib/typedarray/Int8Array#__set (; 54 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int8Array#__set (; 55 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -2979,7 +3025,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 35
+   i32.const 49
    i32.const 44
    call $~lib/builtins/abort
    unreachable
@@ -2991,7 +3037,7 @@
   local.get $2
   i32.store8
  )
- (func $~lib/typedarray/Int8Array#fill (; 55 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#fill (; 56 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -3060,7 +3106,7 @@
   end
   local.get $5
  )
- (func $~lib/memory/memory.copy (; 56 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/memory/memory.copy (; 57 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   block $~lib/util/memory/memmove|inlined.0
@@ -3233,7 +3279,7 @@
    end
   end
  )
- (func $~lib/rt/__allocArray (; 57 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $~lib/rt/__allocArray (; 58 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   i32.const 16
   local.get $2
@@ -3266,7 +3312,7 @@
   end
   local.get $2
  )
- (func $~lib/typedarray/Int8Array#__get (; 58 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#__get (; 59 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -3274,7 +3320,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 24
+   i32.const 38
    i32.const 44
    call $~lib/builtins/abort
    unreachable
@@ -3285,14 +3331,14 @@
   i32.add
   i32.load8_s
  )
- (func $~lib/array/Array<i8>#__unchecked_get (; 59 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i8>#__unchecked_get (; 60 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
   i32.add
   i32.load8_s
  )
- (func $~lib/array/Array<i8>#__get (; 60 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i8>#__get (; 61 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -3300,7 +3346,7 @@
   if
    i32.const 368
    i32.const 528
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -3309,7 +3355,7 @@
   local.get $1
   call $~lib/array/Array<i8>#__unchecked_get
  )
- (func $std/typedarray/isInt8ArrayEqual (; 61 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/typedarray/isInt8ArrayEqual (; 62 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -3349,7 +3395,7 @@
   end
   i32.const 1
  )
- (func $~lib/typedarray/Int8Array#subarray (; 62 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#subarray (; 63 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -3427,7 +3473,7 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~lib/typedarray/Int32Array#fill (; 63 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#fill (; 64 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -3506,7 +3552,7 @@
   end
   local.get $4
  )
- (func $~lib/array/Array<i32>#__unchecked_get (; 64 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#__unchecked_get (; 65 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -3515,7 +3561,7 @@
   i32.add
   i32.load
  )
- (func $~lib/array/Array<i32>#__get (; 65 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#__get (; 66 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -3523,7 +3569,7 @@
   if
    i32.const 368
    i32.const 528
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -3532,7 +3578,7 @@
   local.get $1
   call $~lib/array/Array<i32>#__unchecked_get
  )
- (func $std/typedarray/isInt32ArrayEqual (; 66 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/typedarray/isInt32ArrayEqual (; 67 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -3572,7 +3618,7 @@
   end
   i32.const 1
  )
- (func $~lib/typedarray/Int32Array#slice (; 67 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#slice (; 68 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -3649,7 +3695,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/typedarray/Int32Array#copyWithin (; 68 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#copyWithin (; 69 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -3755,12 +3801,12 @@
   call $~lib/memory/memory.copy
   local.get $5
  )
- (func $std/typedarray/testReduce<~lib/typedarray/Int8Array,i8>~anonymous|0 (; 69 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduce<~lib/typedarray/Int8Array,i8>~anonymous|0 (; 70 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   local.get $0
   local.get $1
   i32.add
  )
- (func $~lib/typedarray/Int8Array#reduce<i8> (; 70 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#reduce<i8> (; 71 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -3796,7 +3842,7 @@
   end
   local.get $2
  )
- (func $std/typedarray/testReduce<~lib/typedarray/Int8Array,i8> (; 71 ;)
+ (func $std/typedarray/testReduce<~lib/typedarray/Int8Array,i8> (; 72 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 3
@@ -3831,7 +3877,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8Array#__set (; 72 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint8Array#__set (; 73 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -3839,7 +3885,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 163
+   i32.const 190
    i32.const 44
    call $~lib/builtins/abort
    unreachable
@@ -3851,7 +3897,7 @@
   local.get $2
   i32.store8
  )
- (func $~lib/typedarray/Uint8Array#reduce<u8> (; 73 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#reduce<u8> (; 74 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3888,7 +3934,7 @@
   end
   local.get $3
  )
- (func $std/typedarray/testReduce<~lib/typedarray/Uint8Array,u8> (; 74 ;)
+ (func $std/typedarray/testReduce<~lib/typedarray/Uint8Array,u8> (; 75 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 3
@@ -3924,7 +3970,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testReduce<~lib/typedarray/Uint8ClampedArray,u8> (; 75 ;)
+ (func $std/typedarray/testReduce<~lib/typedarray/Uint8ClampedArray,u8> (; 76 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 3
@@ -3960,7 +4006,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int16Array#__set (; 76 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int16Array#__set (; 77 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -3970,7 +4016,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 419
+   i32.const 472
    i32.const 63
    call $~lib/builtins/abort
    unreachable
@@ -3984,7 +4030,7 @@
   local.get $2
   i32.store16
  )
- (func $~lib/typedarray/Int16Array#reduce<i16> (; 77 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#reduce<i16> (; 78 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -4022,7 +4068,7 @@
   end
   local.get $2
  )
- (func $std/typedarray/testReduce<~lib/typedarray/Int16Array,i16> (; 78 ;)
+ (func $std/typedarray/testReduce<~lib/typedarray/Int16Array,i16> (; 79 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 3
@@ -4057,7 +4103,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint16Array#__set (; 79 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint16Array#__set (; 80 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -4067,7 +4113,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 547
+   i32.const 613
    i32.const 63
    call $~lib/builtins/abort
    unreachable
@@ -4081,7 +4127,7 @@
   local.get $2
   i32.store16
  )
- (func $~lib/typedarray/Uint16Array#reduce<u16> (; 80 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#reduce<u16> (; 81 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -4119,7 +4165,7 @@
   end
   local.get $2
  )
- (func $std/typedarray/testReduce<~lib/typedarray/Uint16Array,u16> (; 81 ;)
+ (func $std/typedarray/testReduce<~lib/typedarray/Uint16Array,u16> (; 82 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 3
@@ -4154,7 +4200,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int32Array#reduce<i32> (; 82 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#reduce<i32> (; 83 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4193,7 +4239,7 @@
   end
   local.get $3
  )
- (func $std/typedarray/testReduce<~lib/typedarray/Int32Array,i32> (; 83 ;)
+ (func $std/typedarray/testReduce<~lib/typedarray/Int32Array,i32> (; 84 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 3
@@ -4227,7 +4273,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint32Array#__set (; 84 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint32Array#__set (; 85 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -4237,7 +4283,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 803
+   i32.const 895
    i32.const 63
    call $~lib/builtins/abort
    unreachable
@@ -4251,7 +4297,7 @@
   local.get $2
   i32.store
  )
- (func $std/typedarray/testReduce<~lib/typedarray/Uint32Array,u32> (; 85 ;)
+ (func $std/typedarray/testReduce<~lib/typedarray/Uint32Array,u32> (; 86 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 3
@@ -4285,7 +4331,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int64Array#__set (; 86 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $~lib/typedarray/Int64Array#__set (; 87 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -4295,7 +4341,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 931
+   i32.const 1036
    i32.const 63
    call $~lib/builtins/abort
    unreachable
@@ -4309,12 +4355,12 @@
   local.get $2
   i64.store
  )
- (func $std/typedarray/testReduce<~lib/typedarray/Int64Array,i64>~anonymous|0 (; 87 ;) (param $0 i64) (param $1 i64) (param $2 i32) (param $3 i32) (result i64)
+ (func $std/typedarray/testReduce<~lib/typedarray/Int64Array,i64>~anonymous|0 (; 88 ;) (param $0 i64) (param $1 i64) (param $2 i32) (param $3 i32) (result i64)
   local.get $0
   local.get $1
   i64.add
  )
- (func $~lib/typedarray/Int64Array#reduce<i64> (; 88 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $~lib/typedarray/Int64Array#reduce<i64> (; 89 ;) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local $3 i64)
   (local $4 i32)
@@ -4353,7 +4399,7 @@
   end
   local.get $3
  )
- (func $std/typedarray/testReduce<~lib/typedarray/Int64Array,i64> (; 89 ;)
+ (func $std/typedarray/testReduce<~lib/typedarray/Int64Array,i64> (; 90 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 3
@@ -4387,7 +4433,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint64Array#__set (; 90 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $~lib/typedarray/Uint64Array#__set (; 91 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -4397,7 +4443,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 1059
+   i32.const 1177
    i32.const 63
    call $~lib/builtins/abort
    unreachable
@@ -4411,7 +4457,7 @@
   local.get $2
   i64.store
  )
- (func $std/typedarray/testReduce<~lib/typedarray/Uint64Array,u64> (; 91 ;)
+ (func $std/typedarray/testReduce<~lib/typedarray/Uint64Array,u64> (; 92 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 3
@@ -4445,7 +4491,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float32Array#__set (; 92 ;) (param $0 i32) (param $1 i32) (param $2 f32)
+ (func $~lib/typedarray/Float32Array#__set (; 93 ;) (param $0 i32) (param $1 i32) (param $2 f32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -4455,7 +4501,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 1187
+   i32.const 1318
    i32.const 63
    call $~lib/builtins/abort
    unreachable
@@ -4469,12 +4515,12 @@
   local.get $2
   f32.store
  )
- (func $std/typedarray/testReduce<~lib/typedarray/Float32Array,f32>~anonymous|0 (; 93 ;) (param $0 f32) (param $1 f32) (param $2 i32) (param $3 i32) (result f32)
+ (func $std/typedarray/testReduce<~lib/typedarray/Float32Array,f32>~anonymous|0 (; 94 ;) (param $0 f32) (param $1 f32) (param $2 i32) (param $3 i32) (result f32)
   local.get $0
   local.get $1
   f32.add
  )
- (func $~lib/typedarray/Float32Array#reduce<f32> (; 94 ;) (param $0 i32) (result f32)
+ (func $~lib/typedarray/Float32Array#reduce<f32> (; 95 ;) (param $0 i32) (result f32)
   (local $1 i32)
   (local $2 f32)
   (local $3 i32)
@@ -4512,7 +4558,7 @@
   end
   local.get $2
  )
- (func $std/typedarray/testReduce<~lib/typedarray/Float32Array,f32> (; 95 ;)
+ (func $std/typedarray/testReduce<~lib/typedarray/Float32Array,f32> (; 96 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 3
@@ -4545,12 +4591,12 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testReduce<~lib/typedarray/Float64Array,f64>~anonymous|0 (; 96 ;) (param $0 f64) (param $1 f64) (param $2 i32) (param $3 i32) (result f64)
+ (func $std/typedarray/testReduce<~lib/typedarray/Float64Array,f64>~anonymous|0 (; 97 ;) (param $0 f64) (param $1 f64) (param $2 i32) (param $3 i32) (result f64)
   local.get $0
   local.get $1
   f64.add
  )
- (func $~lib/typedarray/Float64Array#reduce<f64> (; 97 ;) (param $0 i32) (result f64)
+ (func $~lib/typedarray/Float64Array#reduce<f64> (; 98 ;) (param $0 i32) (result f64)
   (local $1 i32)
   (local $2 f64)
   (local $3 i32)
@@ -4588,7 +4634,7 @@
   end
   local.get $2
  )
- (func $std/typedarray/testReduce<~lib/typedarray/Float64Array,f64> (; 98 ;)
+ (func $std/typedarray/testReduce<~lib/typedarray/Float64Array,f64> (; 99 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 3
@@ -4621,7 +4667,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int8Array#reduceRight<i8> (; 99 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#reduceRight<i8> (; 100 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -4658,7 +4704,7 @@
   end
   local.get $2
  )
- (func $std/typedarray/testReduceRight<~lib/typedarray/Int8Array,i8> (; 100 ;)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Int8Array,i8> (; 101 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 3
@@ -4693,7 +4739,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8Array#reduceRight<u8> (; 101 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#reduceRight<u8> (; 102 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4731,7 +4777,7 @@
   end
   local.get $3
  )
- (func $std/typedarray/testReduceRight<~lib/typedarray/Uint8Array,u8> (; 102 ;)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Uint8Array,u8> (; 103 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 3
@@ -4767,7 +4813,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testReduceRight<~lib/typedarray/Uint8ClampedArray,u8> (; 103 ;)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Uint8ClampedArray,u8> (; 104 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 3
@@ -4803,7 +4849,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int16Array#reduceRight<i16> (; 104 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#reduceRight<i16> (; 105 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -4842,7 +4888,7 @@
   end
   local.get $2
  )
- (func $std/typedarray/testReduceRight<~lib/typedarray/Int16Array,i16> (; 105 ;)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Int16Array,i16> (; 106 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 3
@@ -4877,7 +4923,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint16Array#reduceRight<u16> (; 106 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#reduceRight<u16> (; 107 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -4916,7 +4962,7 @@
   end
   local.get $2
  )
- (func $std/typedarray/testReduceRight<~lib/typedarray/Uint16Array,u16> (; 107 ;)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Uint16Array,u16> (; 108 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 3
@@ -4951,7 +4997,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int32Array#reduceRight<i32> (; 108 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#reduceRight<i32> (; 109 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4991,7 +5037,7 @@
   end
   local.get $3
  )
- (func $std/typedarray/testReduceRight<~lib/typedarray/Int32Array,i32> (; 109 ;)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Int32Array,i32> (; 110 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 3
@@ -5025,7 +5071,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testReduceRight<~lib/typedarray/Uint32Array,u32> (; 110 ;)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Uint32Array,u32> (; 111 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 3
@@ -5059,7 +5105,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int64Array#reduceRight<i64> (; 111 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $~lib/typedarray/Int64Array#reduceRight<i64> (; 112 ;) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local $3 i64)
   (local $4 i32)
@@ -5099,7 +5145,7 @@
   end
   local.get $3
  )
- (func $std/typedarray/testReduceRight<~lib/typedarray/Int64Array,i64> (; 112 ;)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Int64Array,i64> (; 113 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 3
@@ -5133,7 +5179,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testReduceRight<~lib/typedarray/Uint64Array,u64> (; 113 ;)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Uint64Array,u64> (; 114 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 3
@@ -5167,7 +5213,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float32Array#reduceRight<f32> (; 114 ;) (param $0 i32) (result f32)
+ (func $~lib/typedarray/Float32Array#reduceRight<f32> (; 115 ;) (param $0 i32) (result f32)
   (local $1 i32)
   (local $2 f32)
   (local $3 i32)
@@ -5206,7 +5252,7 @@
   end
   local.get $2
  )
- (func $std/typedarray/testReduceRight<~lib/typedarray/Float32Array,f32> (; 115 ;)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Float32Array,f32> (; 116 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 3
@@ -5239,7 +5285,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float64Array#reduceRight<f64> (; 116 ;) (param $0 i32) (result f64)
+ (func $~lib/typedarray/Float64Array#reduceRight<f64> (; 117 ;) (param $0 i32) (result f64)
   (local $1 i32)
   (local $2 f64)
   (local $3 i32)
@@ -5278,7 +5324,7 @@
   end
   local.get $2
  )
- (func $std/typedarray/testReduceRight<~lib/typedarray/Float64Array,f64> (; 117 ;)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Float64Array,f64> (; 118 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 3
@@ -5311,12 +5357,12 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayMap<~lib/typedarray/Int8Array,i8>~anonymous|0 (; 118 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Int8Array,i8>~anonymous|0 (; 119 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   local.get $0
   i32.mul
  )
- (func $~lib/typedarray/Int8Array#map (; 119 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#map (; 120 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -5374,7 +5420,7 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $std/typedarray/testArrayMap<~lib/typedarray/Int8Array,i8> (; 120 ;)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Int8Array,i8> (; 121 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 3
@@ -5438,7 +5484,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8Array#map (; 121 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#map (; 122 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -5496,7 +5542,7 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~lib/typedarray/Uint8Array#__get (; 122 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#__get (; 123 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -5504,7 +5550,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 152
+   i32.const 179
    i32.const 44
    call $~lib/builtins/abort
    unreachable
@@ -5515,7 +5561,7 @@
   i32.add
   i32.load8_u
  )
- (func $std/typedarray/testArrayMap<~lib/typedarray/Uint8Array,u8> (; 123 ;)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Uint8Array,u8> (; 124 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 3
@@ -5579,7 +5625,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8ClampedArray#map (; 124 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint8ClampedArray#map (; 125 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -5637,7 +5683,7 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $std/typedarray/testArrayMap<~lib/typedarray/Uint8ClampedArray,u8> (; 125 ;)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Uint8ClampedArray,u8> (; 126 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 3
@@ -5701,7 +5747,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int16Array#map (; 126 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#map (; 127 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -5770,7 +5816,7 @@
   local.get $1
   call $~lib/rt/pure/__retain
  )
- (func $~lib/typedarray/Int16Array#__get (; 127 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#__get (; 128 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -5780,7 +5826,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 408
+   i32.const 461
    i32.const 63
    call $~lib/builtins/abort
    unreachable
@@ -5793,7 +5839,7 @@
   i32.add
   i32.load16_s
  )
- (func $std/typedarray/testArrayMap<~lib/typedarray/Int16Array,i16> (; 128 ;)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Int16Array,i16> (; 129 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 3
@@ -5857,7 +5903,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint16Array#map (; 129 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#map (; 130 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -5926,7 +5972,7 @@
   local.get $1
   call $~lib/rt/pure/__retain
  )
- (func $~lib/typedarray/Uint16Array#__get (; 130 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#__get (; 131 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -5936,7 +5982,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 536
+   i32.const 602
    i32.const 63
    call $~lib/builtins/abort
    unreachable
@@ -5949,7 +5995,7 @@
   i32.add
   i32.load16_u
  )
- (func $std/typedarray/testArrayMap<~lib/typedarray/Uint16Array,u16> (; 131 ;)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Uint16Array,u16> (; 132 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 3
@@ -6013,7 +6059,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int32Array#map (; 132 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#map (; 133 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -6082,7 +6128,7 @@
   local.get $1
   call $~lib/rt/pure/__retain
  )
- (func $std/typedarray/testArrayMap<~lib/typedarray/Int32Array,i32> (; 133 ;)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Int32Array,i32> (; 134 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 3
@@ -6146,7 +6192,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint32Array#map (; 134 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint32Array#map (; 135 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -6215,7 +6261,7 @@
   local.get $1
   call $~lib/rt/pure/__retain
  )
- (func $~lib/typedarray/Uint32Array#__get (; 135 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint32Array#__get (; 136 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -6225,7 +6271,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 792
+   i32.const 884
    i32.const 63
    call $~lib/builtins/abort
    unreachable
@@ -6238,7 +6284,7 @@
   i32.add
   i32.load
  )
- (func $std/typedarray/testArrayMap<~lib/typedarray/Uint32Array,u32> (; 136 ;)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Uint32Array,u32> (; 137 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 3
@@ -6302,12 +6348,12 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayMap<~lib/typedarray/Int64Array,i64>~anonymous|0 (; 137 ;) (param $0 i64) (param $1 i32) (param $2 i32) (result i64)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Int64Array,i64>~anonymous|0 (; 138 ;) (param $0 i64) (param $1 i32) (param $2 i32) (result i64)
   local.get $0
   local.get $0
   i64.mul
  )
- (func $~lib/typedarray/Int64Array#map (; 138 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int64Array#map (; 139 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -6376,7 +6422,7 @@
   local.get $1
   call $~lib/rt/pure/__retain
  )
- (func $~lib/typedarray/Int64Array#__get (; 139 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $~lib/typedarray/Int64Array#__get (; 140 ;) (param $0 i32) (param $1 i32) (result i64)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -6386,7 +6432,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 920
+   i32.const 1025
    i32.const 63
    call $~lib/builtins/abort
    unreachable
@@ -6399,7 +6445,7 @@
   i32.add
   i64.load
  )
- (func $std/typedarray/testArrayMap<~lib/typedarray/Int64Array,i64> (; 140 ;)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Int64Array,i64> (; 141 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 3
@@ -6463,7 +6509,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint64Array#map (; 141 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint64Array#map (; 142 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -6532,7 +6578,7 @@
   local.get $1
   call $~lib/rt/pure/__retain
  )
- (func $~lib/typedarray/Uint64Array#__get (; 142 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $~lib/typedarray/Uint64Array#__get (; 143 ;) (param $0 i32) (param $1 i32) (result i64)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -6542,7 +6588,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 1048
+   i32.const 1166
    i32.const 63
    call $~lib/builtins/abort
    unreachable
@@ -6555,7 +6601,7 @@
   i32.add
   i64.load
  )
- (func $std/typedarray/testArrayMap<~lib/typedarray/Uint64Array,u64> (; 143 ;)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Uint64Array,u64> (; 144 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 3
@@ -6619,12 +6665,12 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayMap<~lib/typedarray/Float32Array,f32>~anonymous|0 (; 144 ;) (param $0 f32) (param $1 i32) (param $2 i32) (result f32)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Float32Array,f32>~anonymous|0 (; 145 ;) (param $0 f32) (param $1 i32) (param $2 i32) (result f32)
   local.get $0
   local.get $0
   f32.mul
  )
- (func $~lib/typedarray/Float32Array#map (; 145 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#map (; 146 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -6693,7 +6739,7 @@
   local.get $1
   call $~lib/rt/pure/__retain
  )
- (func $~lib/typedarray/Float32Array#__get (; 146 ;) (param $0 i32) (param $1 i32) (result f32)
+ (func $~lib/typedarray/Float32Array#__get (; 147 ;) (param $0 i32) (param $1 i32) (result f32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -6703,7 +6749,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 1176
+   i32.const 1307
    i32.const 63
    call $~lib/builtins/abort
    unreachable
@@ -6716,7 +6762,7 @@
   i32.add
   f32.load
  )
- (func $std/typedarray/testArrayMap<~lib/typedarray/Float32Array,f32> (; 147 ;)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Float32Array,f32> (; 148 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 3
@@ -6780,12 +6826,12 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayMap<~lib/typedarray/Float64Array,f64>~anonymous|0 (; 148 ;) (param $0 f64) (param $1 i32) (param $2 i32) (result f64)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Float64Array,f64>~anonymous|0 (; 149 ;) (param $0 f64) (param $1 i32) (param $2 i32) (result f64)
   local.get $0
   local.get $0
   f64.mul
  )
- (func $~lib/typedarray/Float64Array#map (; 149 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#map (; 150 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -6854,7 +6900,7 @@
   local.get $1
   call $~lib/rt/pure/__retain
  )
- (func $std/typedarray/testArrayMap<~lib/typedarray/Float64Array,f64> (; 150 ;)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Float64Array,f64> (; 151 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 3
@@ -6918,7 +6964,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Int8Array,i8>~anonymous|0 (; 151 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Int8Array,i8>~anonymous|0 (; 152 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 24
   i32.shl
@@ -6927,7 +6973,7 @@
   i32.const 2
   i32.gt_s
  )
- (func $~lib/rt/tlsf/reallocateBlock (; 152 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/reallocateBlock (; 153 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -7030,7 +7076,7 @@
   end
   local.get $3
  )
- (func $~lib/rt/tlsf/__realloc (; 153 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/__realloc (; 154 ;) (param $0 i32) (param $1 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
   local.get $0
   call $~lib/rt/tlsf/checkUsedBlock
@@ -7039,7 +7085,7 @@
   i32.const 16
   i32.add
  )
- (func $~lib/typedarray/Int8Array#filter (; 154 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#filter (; 155 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -7105,15 +7151,15 @@
   call $~lib/rt/pure/__retain
   i32.store
   local.get $1
-  local.get $3
-  i32.store offset=8
-  local.get $1
   local.get $0
   i32.store offset=4
   local.get $1
+  local.get $3
+  i32.store offset=8
+  local.get $1
   call $~lib/rt/pure/__retain
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Int8Array,i8> (; 155 ;)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Int8Array,i8> (; 156 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 6
@@ -7141,7 +7187,7 @@
   local.get $0
   call $~lib/typedarray/Int8Array#filter
   local.tee $1
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Int8Array#get:byteOffset
   if
    i32.const 0
    i32.const 304
@@ -7206,14 +7252,14 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint8Array,u8>~anonymous|0 (; 156 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint8Array,u8>~anonymous|0 (; 157 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 255
   i32.and
   i32.const 2
   i32.gt_u
  )
- (func $~lib/typedarray/Uint8Array#filter (; 157 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#filter (; 158 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -7279,15 +7325,15 @@
   call $~lib/rt/pure/__retain
   i32.store
   local.get $1
-  local.get $3
-  i32.store offset=8
-  local.get $1
   local.get $0
   i32.store offset=4
   local.get $1
+  local.get $3
+  i32.store offset=8
+  local.get $1
   call $~lib/rt/pure/__retain
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint8Array,u8> (; 158 ;)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint8Array,u8> (; 159 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 6
@@ -7315,7 +7361,7 @@
   local.get $0
   call $~lib/typedarray/Uint8Array#filter
   local.tee $1
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Int8Array#get:byteOffset
   if
    i32.const 0
    i32.const 304
@@ -7380,7 +7426,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8ClampedArray#filter (; 159 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint8ClampedArray#filter (; 160 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -7446,15 +7492,15 @@
   call $~lib/rt/pure/__retain
   i32.store
   local.get $1
-  local.get $3
-  i32.store offset=8
-  local.get $1
   local.get $0
   i32.store offset=4
   local.get $1
+  local.get $3
+  i32.store offset=8
+  local.get $1
   call $~lib/rt/pure/__retain
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint8ClampedArray,u8> (; 160 ;)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint8ClampedArray,u8> (; 161 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 6
@@ -7482,7 +7528,7 @@
   local.get $0
   call $~lib/typedarray/Uint8ClampedArray#filter
   local.tee $1
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Int8Array#get:byteOffset
   if
    i32.const 0
    i32.const 304
@@ -7547,7 +7593,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Int16Array,i16>~anonymous|0 (; 161 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Int16Array,i16>~anonymous|0 (; 162 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 16
   i32.shl
@@ -7556,7 +7602,7 @@
   i32.const 2
   i32.gt_s
  )
- (func $~lib/typedarray/Int16Array#filter (; 162 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#filter (; 163 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -7631,15 +7677,15 @@
   call $~lib/rt/pure/__retain
   i32.store
   local.get $1
-  local.get $0
-  i32.store offset=8
-  local.get $1
   local.get $3
   i32.store offset=4
   local.get $1
+  local.get $0
+  i32.store offset=8
+  local.get $1
   call $~lib/rt/pure/__retain
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Int16Array,i16> (; 163 ;)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Int16Array,i16> (; 164 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 6
@@ -7668,7 +7714,7 @@
   local.get $0
   call $~lib/typedarray/Int16Array#filter
   local.tee $0
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Int8Array#get:byteOffset
   if
    i32.const 0
    i32.const 304
@@ -7733,14 +7779,14 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint16Array,u16>~anonymous|0 (; 164 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint16Array,u16>~anonymous|0 (; 165 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 65535
   i32.and
   i32.const 2
   i32.gt_u
  )
- (func $~lib/typedarray/Uint16Array#filter (; 165 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#filter (; 166 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -7815,15 +7861,15 @@
   call $~lib/rt/pure/__retain
   i32.store
   local.get $1
-  local.get $0
-  i32.store offset=8
-  local.get $1
   local.get $3
   i32.store offset=4
   local.get $1
+  local.get $0
+  i32.store offset=8
+  local.get $1
   call $~lib/rt/pure/__retain
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint16Array,u16> (; 166 ;)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint16Array,u16> (; 167 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 6
@@ -7852,7 +7898,7 @@
   local.get $0
   call $~lib/typedarray/Uint16Array#filter
   local.tee $0
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Int8Array#get:byteOffset
   if
    i32.const 0
    i32.const 304
@@ -7917,12 +7963,12 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Int32Array,i32>~anonymous|0 (; 167 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Int32Array,i32>~anonymous|0 (; 168 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 2
   i32.gt_s
  )
- (func $~lib/typedarray/Int32Array#filter (; 168 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#filter (; 169 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -7997,15 +8043,15 @@
   call $~lib/rt/pure/__retain
   i32.store
   local.get $1
-  local.get $0
-  i32.store offset=8
-  local.get $1
   local.get $3
   i32.store offset=4
   local.get $1
+  local.get $0
+  i32.store offset=8
+  local.get $1
   call $~lib/rt/pure/__retain
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Int32Array,i32> (; 169 ;)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Int32Array,i32> (; 170 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 6
@@ -8034,7 +8080,7 @@
   local.get $0
   call $~lib/typedarray/Int32Array#filter
   local.tee $0
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Int8Array#get:byteOffset
   if
    i32.const 0
    i32.const 304
@@ -8099,12 +8145,12 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint32Array,u32>~anonymous|0 (; 170 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint32Array,u32>~anonymous|0 (; 171 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 2
   i32.gt_u
  )
- (func $~lib/typedarray/Uint32Array#filter (; 171 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint32Array#filter (; 172 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -8179,15 +8225,15 @@
   call $~lib/rt/pure/__retain
   i32.store
   local.get $1
-  local.get $0
-  i32.store offset=8
-  local.get $1
   local.get $3
   i32.store offset=4
   local.get $1
+  local.get $0
+  i32.store offset=8
+  local.get $1
   call $~lib/rt/pure/__retain
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint32Array,u32> (; 172 ;)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint32Array,u32> (; 173 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 6
@@ -8216,7 +8262,7 @@
   local.get $0
   call $~lib/typedarray/Uint32Array#filter
   local.tee $0
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Int8Array#get:byteOffset
   if
    i32.const 0
    i32.const 304
@@ -8281,12 +8327,12 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Int64Array,i64>~anonymous|0 (; 173 ;) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Int64Array,i64>~anonymous|0 (; 174 ;) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i64.const 2
   i64.gt_s
  )
- (func $~lib/typedarray/Int64Array#filter (; 174 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int64Array#filter (; 175 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -8361,15 +8407,15 @@
   call $~lib/rt/pure/__retain
   i32.store
   local.get $1
-  local.get $0
-  i32.store offset=8
-  local.get $1
   local.get $3
   i32.store offset=4
   local.get $1
+  local.get $0
+  i32.store offset=8
+  local.get $1
   call $~lib/rt/pure/__retain
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Int64Array,i64> (; 175 ;)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Int64Array,i64> (; 176 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 6
@@ -8398,7 +8444,7 @@
   local.get $0
   call $~lib/typedarray/Int64Array#filter
   local.tee $0
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Int8Array#get:byteOffset
   if
    i32.const 0
    i32.const 304
@@ -8463,12 +8509,12 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint64Array,u64>~anonymous|0 (; 176 ;) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint64Array,u64>~anonymous|0 (; 177 ;) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i64.const 2
   i64.gt_u
  )
- (func $~lib/typedarray/Uint64Array#filter (; 177 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint64Array#filter (; 178 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -8543,15 +8589,15 @@
   call $~lib/rt/pure/__retain
   i32.store
   local.get $1
-  local.get $0
-  i32.store offset=8
-  local.get $1
   local.get $3
   i32.store offset=4
   local.get $1
+  local.get $0
+  i32.store offset=8
+  local.get $1
   call $~lib/rt/pure/__retain
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint64Array,u64> (; 178 ;)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint64Array,u64> (; 179 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 6
@@ -8580,7 +8626,7 @@
   local.get $0
   call $~lib/typedarray/Uint64Array#filter
   local.tee $0
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Int8Array#get:byteOffset
   if
    i32.const 0
    i32.const 304
@@ -8645,12 +8691,12 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Float32Array,f32>~anonymous|0 (; 179 ;) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Float32Array,f32>~anonymous|0 (; 180 ;) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   f32.const 2
   f32.gt
  )
- (func $~lib/typedarray/Float32Array#filter (; 180 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#filter (; 181 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -8725,15 +8771,15 @@
   call $~lib/rt/pure/__retain
   i32.store
   local.get $1
-  local.get $0
-  i32.store offset=8
-  local.get $1
   local.get $3
   i32.store offset=4
   local.get $1
+  local.get $0
+  i32.store offset=8
+  local.get $1
   call $~lib/rt/pure/__retain
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Float32Array,f32> (; 181 ;)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Float32Array,f32> (; 182 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 6
@@ -8762,7 +8808,7 @@
   local.get $0
   call $~lib/typedarray/Float32Array#filter
   local.tee $0
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Int8Array#get:byteOffset
   if
    i32.const 0
    i32.const 304
@@ -8827,12 +8873,12 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Float64Array,f64>~anonymous|0 (; 182 ;) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Float64Array,f64>~anonymous|0 (; 183 ;) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   f64.const 2
   f64.gt
  )
- (func $~lib/typedarray/Float64Array#filter (; 183 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#filter (; 184 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -8907,15 +8953,15 @@
   call $~lib/rt/pure/__retain
   i32.store
   local.get $1
-  local.get $0
-  i32.store offset=8
-  local.get $1
   local.get $3
   i32.store offset=4
   local.get $1
+  local.get $0
+  i32.store offset=8
+  local.get $1
   call $~lib/rt/pure/__retain
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Float64Array,f64> (; 184 ;)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Float64Array,f64> (; 185 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 6
@@ -8944,7 +8990,7 @@
   local.get $0
   call $~lib/typedarray/Float64Array#filter
   local.tee $0
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Int8Array#get:byteOffset
   if
    i32.const 0
    i32.const 304
@@ -9009,14 +9055,14 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Int8Array,i8>~anonymous|0 (; 185 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Int8Array,i8>~anonymous|0 (; 186 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 255
   i32.and
   i32.const 2
   i32.eq
  )
- (func $~lib/typedarray/Int8Array#some (; 186 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#some (; 187 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9055,13 +9101,13 @@
    i32.const 0
   end
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Int8Array,i8>~anonymous|1 (; 187 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Int8Array,i8>~anonymous|1 (; 188 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 255
   i32.and
   i32.eqz
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Int8Array,i8> (; 188 ;)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Int8Array,i8> (; 189 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 3
@@ -9105,7 +9151,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8Array#some (; 189 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#some (; 190 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9144,7 +9190,7 @@
    i32.const 0
   end
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Uint8Array,u8> (; 190 ;)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Uint8Array,u8> (; 191 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 3
@@ -9188,7 +9234,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Uint8ClampedArray,u8> (; 191 ;)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Uint8ClampedArray,u8> (; 192 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 3
@@ -9232,14 +9278,14 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Int16Array,i16>~anonymous|0 (; 192 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Int16Array,i16>~anonymous|0 (; 193 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 65535
   i32.and
   i32.const 2
   i32.eq
  )
- (func $~lib/typedarray/Int16Array#some (; 193 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#some (; 194 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9280,13 +9326,13 @@
    i32.const 0
   end
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Int16Array,i16>~anonymous|1 (; 194 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Int16Array,i16>~anonymous|1 (; 195 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 65535
   i32.and
   i32.eqz
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Int16Array,i16> (; 195 ;)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Int16Array,i16> (; 196 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 3
@@ -9330,7 +9376,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint16Array#some (; 196 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#some (; 197 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9371,7 +9417,7 @@
    i32.const 0
   end
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Uint16Array,u16> (; 197 ;)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Uint16Array,u16> (; 198 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 3
@@ -9415,12 +9461,12 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Int32Array,i32>~anonymous|0 (; 198 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Int32Array,i32>~anonymous|0 (; 199 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 2
   i32.eq
  )
- (func $~lib/typedarray/Int32Array#some (; 199 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#some (; 200 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9461,11 +9507,11 @@
    i32.const 0
   end
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Int32Array,i32>~anonymous|1 (; 200 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Int32Array,i32>~anonymous|1 (; 201 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.eqz
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Int32Array,i32> (; 201 ;)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Int32Array,i32> (; 202 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 3
@@ -9509,7 +9555,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Uint32Array,u32> (; 202 ;)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Uint32Array,u32> (; 203 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 3
@@ -9553,12 +9599,12 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Int64Array,i64>~anonymous|0 (; 203 ;) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Int64Array,i64>~anonymous|0 (; 204 ;) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i64.const 2
   i64.eq
  )
- (func $~lib/typedarray/Int64Array#some (; 204 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int64Array#some (; 205 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9599,11 +9645,11 @@
    i32.const 0
   end
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Int64Array,i64>~anonymous|1 (; 205 ;) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Int64Array,i64>~anonymous|1 (; 206 ;) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i64.eqz
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Int64Array,i64> (; 206 ;)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Int64Array,i64> (; 207 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 3
@@ -9647,7 +9693,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Uint64Array,u64> (; 207 ;)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Uint64Array,u64> (; 208 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 3
@@ -9691,12 +9737,12 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Float32Array,f32>~anonymous|0 (; 208 ;) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Float32Array,f32>~anonymous|0 (; 209 ;) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   f32.const 2
   f32.eq
  )
- (func $~lib/typedarray/Float32Array#some (; 209 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#some (; 210 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9737,12 +9783,12 @@
    i32.const 0
   end
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Float32Array,f32>~anonymous|1 (; 210 ;) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Float32Array,f32>~anonymous|1 (; 211 ;) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   f32.const 0
   f32.eq
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Float32Array,f32> (; 211 ;)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Float32Array,f32> (; 212 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 3
@@ -9786,12 +9832,12 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Float64Array,f64>~anonymous|0 (; 212 ;) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Float64Array,f64>~anonymous|0 (; 213 ;) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   f64.const 2
   f64.eq
  )
- (func $~lib/typedarray/Float64Array#some (; 213 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#some (; 214 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9832,12 +9878,12 @@
    i32.const 0
   end
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Float64Array,f64>~anonymous|1 (; 214 ;) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Float64Array,f64>~anonymous|1 (; 215 ;) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   f64.const 0
   f64.eq
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Float64Array,f64> (; 215 ;)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Float64Array,f64> (; 216 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 3
@@ -9881,7 +9927,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int8Array#findIndex (; 216 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#findIndex (; 217 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9920,14 +9966,14 @@
   end
   local.get $2
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int8Array,i8>~anonymous|1 (; 217 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int8Array,i8>~anonymous|1 (; 218 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 255
   i32.and
   i32.const 4
   i32.eq
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int8Array,i8> (; 218 ;)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int8Array,i8> (; 219 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 3
@@ -9974,7 +10020,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8Array#findIndex (; 219 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#findIndex (; 220 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10013,7 +10059,7 @@
   end
   local.get $2
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint8Array,u8> (; 220 ;)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint8Array,u8> (; 221 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 3
@@ -10060,7 +10106,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint8ClampedArray,u8> (; 221 ;)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint8ClampedArray,u8> (; 222 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 3
@@ -10107,7 +10153,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int16Array#findIndex (; 222 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#findIndex (; 223 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10148,14 +10194,14 @@
    i32.const -1
   end
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int16Array,i16>~anonymous|1 (; 223 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int16Array,i16>~anonymous|1 (; 224 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 65535
   i32.and
   i32.const 4
   i32.eq
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int16Array,i16> (; 224 ;)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int16Array,i16> (; 225 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 3
@@ -10202,7 +10248,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint16Array#findIndex (; 225 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#findIndex (; 226 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10243,7 +10289,7 @@
    i32.const -1
   end
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint16Array,u16> (; 226 ;)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint16Array,u16> (; 227 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 3
@@ -10290,7 +10336,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int32Array#findIndex (; 227 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#findIndex (; 228 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10331,12 +10377,12 @@
    i32.const -1
   end
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int32Array,i32>~anonymous|1 (; 228 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int32Array,i32>~anonymous|1 (; 229 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 4
   i32.eq
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int32Array,i32> (; 229 ;)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int32Array,i32> (; 230 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 3
@@ -10383,7 +10429,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint32Array,u32> (; 230 ;)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint32Array,u32> (; 231 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 3
@@ -10430,7 +10476,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int64Array#findIndex (; 231 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int64Array#findIndex (; 232 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10471,12 +10517,12 @@
    i32.const -1
   end
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int64Array,i64>~anonymous|1 (; 232 ;) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int64Array,i64>~anonymous|1 (; 233 ;) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i64.const 4
   i64.eq
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int64Array,i64> (; 233 ;)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int64Array,i64> (; 234 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 3
@@ -10523,7 +10569,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint64Array,u64> (; 234 ;)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint64Array,u64> (; 235 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 3
@@ -10570,7 +10616,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float32Array#findIndex (; 235 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#findIndex (; 236 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10611,12 +10657,12 @@
    i32.const -1
   end
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Float32Array,f32>~anonymous|1 (; 236 ;) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Float32Array,f32>~anonymous|1 (; 237 ;) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   f32.const 4
   f32.eq
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Float32Array,f32> (; 237 ;)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Float32Array,f32> (; 238 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 3
@@ -10663,7 +10709,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float64Array#findIndex (; 238 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#findIndex (; 239 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10704,12 +10750,12 @@
    i32.const -1
   end
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Float64Array,f64>~anonymous|1 (; 239 ;) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Float64Array,f64>~anonymous|1 (; 240 ;) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   f64.const 4
   f64.eq
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Float64Array,f64> (; 240 ;)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Float64Array,f64> (; 241 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 3
@@ -10756,7 +10802,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Int8Array,i8>~anonymous|0 (; 241 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Int8Array,i8>~anonymous|0 (; 242 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 24
   i32.shl
@@ -10766,7 +10812,7 @@
   i32.rem_s
   i32.eqz
  )
- (func $~lib/typedarray/Int8Array#every (; 242 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#every (; 243 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10806,7 +10852,7 @@
    i32.const 1
   end
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Int8Array,i8> (; 243 ;)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Int8Array,i8> (; 244 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 3
@@ -10850,13 +10896,13 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint8Array,u8>~anonymous|0 (; 244 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint8Array,u8>~anonymous|0 (; 245 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 1
   i32.and
   i32.eqz
  )
- (func $~lib/typedarray/Uint8Array#every (; 245 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#every (; 246 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10896,7 +10942,7 @@
    i32.const 1
   end
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint8Array,u8> (; 246 ;)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint8Array,u8> (; 247 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 3
@@ -10940,7 +10986,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint8ClampedArray,u8> (; 247 ;)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint8ClampedArray,u8> (; 248 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 3
@@ -10984,7 +11030,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Int16Array,i16>~anonymous|0 (; 248 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Int16Array,i16>~anonymous|0 (; 249 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 16
   i32.shl
@@ -10994,7 +11040,7 @@
   i32.rem_s
   i32.eqz
  )
- (func $~lib/typedarray/Int16Array#every (; 249 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#every (; 250 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -11036,7 +11082,7 @@
    i32.const 1
   end
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Int16Array,i16> (; 250 ;)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Int16Array,i16> (; 251 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 3
@@ -11080,7 +11126,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint16Array#every (; 251 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#every (; 252 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -11122,7 +11168,7 @@
    i32.const 1
   end
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint16Array,u16> (; 252 ;)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint16Array,u16> (; 253 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 3
@@ -11166,13 +11212,13 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Int32Array,i32>~anonymous|0 (; 253 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Int32Array,i32>~anonymous|0 (; 254 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 2
   i32.rem_s
   i32.eqz
  )
- (func $~lib/typedarray/Int32Array#every (; 254 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#every (; 255 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -11214,7 +11260,7 @@
    i32.const 1
   end
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Int32Array,i32> (; 255 ;)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Int32Array,i32> (; 256 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 3
@@ -11258,7 +11304,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint32Array,u32> (; 256 ;)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint32Array,u32> (; 257 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 3
@@ -11302,13 +11348,13 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Int64Array,i64>~anonymous|0 (; 257 ;) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Int64Array,i64>~anonymous|0 (; 258 ;) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i64.const 2
   i64.rem_s
   i64.eqz
  )
- (func $~lib/typedarray/Int64Array#every (; 258 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int64Array#every (; 259 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -11350,7 +11396,7 @@
    i32.const 1
   end
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Int64Array,i64> (; 259 ;)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Int64Array,i64> (; 260 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 3
@@ -11394,13 +11440,13 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint64Array,u64>~anonymous|0 (; 260 ;) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint64Array,u64>~anonymous|0 (; 261 ;) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i64.const 2
   i64.rem_u
   i64.eqz
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint64Array,u64> (; 261 ;)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint64Array,u64> (; 262 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 3
@@ -11444,7 +11490,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/math/NativeMathf.mod (; 262 ;) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.mod (; 263 ;) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -11591,13 +11637,13 @@
   local.get $0
   f32.mul
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Float32Array,f32>~anonymous|0 (; 263 ;) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Float32Array,f32>~anonymous|0 (; 264 ;) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.mod
   f32.const 0
   f32.eq
  )
- (func $~lib/typedarray/Float32Array#every (; 264 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#every (; 265 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -11639,7 +11685,7 @@
    i32.const 1
   end
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Float32Array,f32> (; 265 ;)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Float32Array,f32> (; 266 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 3
@@ -11683,7 +11729,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/math/NativeMath.mod (; 266 ;) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.mod (; 267 ;) (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i64)
   (local $3 i64)
@@ -11837,13 +11883,13 @@
   local.get $0
   f64.mul
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Float64Array,f64>~anonymous|0 (; 267 ;) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Float64Array,f64>~anonymous|0 (; 268 ;) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMath.mod
   f64.const 0
   f64.eq
  )
- (func $~lib/typedarray/Float64Array#every (; 268 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#every (; 269 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -11885,7 +11931,7 @@
    i32.const 1
   end
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Float64Array,f64> (; 269 ;)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Float64Array,f64> (; 270 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 3
@@ -11929,7 +11975,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Int8Array,i8>~anonymous|0 (; 270 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Int8Array,i8>~anonymous|0 (; 271 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $0
   i32.const 255
   i32.and
@@ -11974,7 +12020,7 @@
   i32.add
   global.set $std/typedarray/forEachCallCount
  )
- (func $~lib/typedarray/Int8Array#forEach (; 271 ;) (param $0 i32)
+ (func $~lib/typedarray/Int8Array#forEach (; 272 ;) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -12006,7 +12052,7 @@
    end
   end
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Int8Array,i8> (; 272 ;)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Int8Array,i8> (; 273 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -12062,7 +12108,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8Array#forEach (; 273 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Uint8Array#forEach (; 274 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -12095,7 +12141,7 @@
    end
   end
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint8Array,u8> (; 274 ;)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint8Array,u8> (; 275 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -12146,7 +12192,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint8ClampedArray,u8> (; 275 ;)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint8ClampedArray,u8> (; 276 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -12197,7 +12243,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Int16Array,i16>~anonymous|0 (; 276 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Int16Array,i16>~anonymous|0 (; 277 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $0
   i32.const 65535
   i32.and
@@ -12242,7 +12288,7 @@
   i32.add
   global.set $std/typedarray/forEachCallCount
  )
- (func $~lib/typedarray/Int16Array#forEach (; 277 ;) (param $0 i32)
+ (func $~lib/typedarray/Int16Array#forEach (; 278 ;) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -12276,7 +12322,7 @@
    end
   end
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Int16Array,i16> (; 278 ;)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Int16Array,i16> (; 279 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -12332,7 +12378,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint16Array#forEach (; 279 ;) (param $0 i32)
+ (func $~lib/typedarray/Uint16Array#forEach (; 280 ;) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -12366,7 +12412,7 @@
    end
   end
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint16Array,u16> (; 280 ;)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint16Array,u16> (; 281 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -12416,7 +12462,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Int32Array,i32>~anonymous|0 (; 281 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Int32Array,i32>~anonymous|0 (; 282 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   i32.const 1696
   local.get $1
   call $~lib/array/Array<i32>#__get
@@ -12457,7 +12503,7 @@
   i32.add
   global.set $std/typedarray/forEachCallCount
  )
- (func $~lib/typedarray/Int32Array#forEach (; 282 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Int32Array#forEach (; 283 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -12492,7 +12538,7 @@
    end
   end
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Int32Array,i32> (; 283 ;)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Int32Array,i32> (; 284 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -12537,7 +12583,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint32Array,u32> (; 284 ;)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint32Array,u32> (; 285 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -12582,7 +12628,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Int64Array,i64>~anonymous|0 (; 285 ;) (param $0 i64) (param $1 i32) (param $2 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Int64Array,i64>~anonymous|0 (; 286 ;) (param $0 i64) (param $1 i32) (param $2 i32)
   local.get $0
   i32.const 1696
   local.get $1
@@ -12624,7 +12670,7 @@
   i32.add
   global.set $std/typedarray/forEachCallCount
  )
- (func $~lib/typedarray/Int64Array#forEach (; 286 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Int64Array#forEach (; 287 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -12659,7 +12705,7 @@
    end
   end
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Int64Array,i64> (; 287 ;)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Int64Array,i64> (; 288 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -12707,7 +12753,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint64Array,u64> (; 288 ;)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint64Array,u64> (; 289 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -12755,7 +12801,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Float32Array,f32>~anonymous|0 (; 289 ;) (param $0 f32) (param $1 i32) (param $2 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Float32Array,f32>~anonymous|0 (; 290 ;) (param $0 f32) (param $1 i32) (param $2 i32)
   local.get $0
   i32.const 1696
   local.get $1
@@ -12797,7 +12843,7 @@
   i32.add
   global.set $std/typedarray/forEachCallCount
  )
- (func $~lib/typedarray/Float32Array#forEach (; 290 ;) (param $0 i32)
+ (func $~lib/typedarray/Float32Array#forEach (; 291 ;) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -12831,7 +12877,7 @@
    end
   end
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Float32Array,f32> (; 291 ;)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Float32Array,f32> (; 292 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -12878,7 +12924,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Float64Array,f64>~anonymous|0 (; 292 ;) (param $0 f64) (param $1 i32) (param $2 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Float64Array,f64>~anonymous|0 (; 293 ;) (param $0 f64) (param $1 i32) (param $2 i32)
   local.get $0
   i32.const 1696
   local.get $1
@@ -12920,7 +12966,7 @@
   i32.add
   global.set $std/typedarray/forEachCallCount
  )
- (func $~lib/typedarray/Float64Array#forEach (; 293 ;) (param $0 i32)
+ (func $~lib/typedarray/Float64Array#forEach (; 294 ;) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -12954,7 +13000,7 @@
    end
   end
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Float64Array,f64> (; 294 ;)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Float64Array,f64> (; 295 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -13001,7 +13047,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int8Array#reverse (; 295 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#reverse (; 296 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -13053,7 +13099,7 @@
   end
   local.get $3
  )
- (func $std/typedarray/testArrayReverse<~lib/typedarray/Int8Array,i8> (; 296 ;)
+ (func $std/typedarray/testArrayReverse<~lib/typedarray/Int8Array,i8> (; 297 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -13209,7 +13255,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8Array#reverse (; 297 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#reverse (; 298 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -13261,7 +13307,7 @@
   end
   local.get $3
  )
- (func $~lib/typedarray/Uint8Array#subarray (; 298 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#subarray (; 299 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   i32.const 4
@@ -13322,7 +13368,7 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $std/typedarray/testArrayReverse<~lib/typedarray/Uint8Array,u8> (; 299 ;)
+ (func $std/typedarray/testArrayReverse<~lib/typedarray/Uint8Array,u8> (; 300 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -13471,7 +13517,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8ClampedArray#subarray (; 300 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8ClampedArray#subarray (; 301 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   i32.const 4
@@ -13532,7 +13578,7 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $std/typedarray/testArrayReverse<~lib/typedarray/Uint8ClampedArray,u8> (; 301 ;)
+ (func $std/typedarray/testArrayReverse<~lib/typedarray/Uint8ClampedArray,u8> (; 302 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -13681,7 +13727,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int16Array#reverse (; 302 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#reverse (; 303 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -13737,7 +13783,7 @@
   end
   local.get $3
  )
- (func $~lib/typedarray/Int16Array#subarray (; 303 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#subarray (; 304 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   i32.const 4
@@ -13802,7 +13848,7 @@
   local.get $1
   call $~lib/rt/pure/__retain
  )
- (func $std/typedarray/testArrayReverse<~lib/typedarray/Int16Array,i16> (; 304 ;)
+ (func $std/typedarray/testArrayReverse<~lib/typedarray/Int16Array,i16> (; 305 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -13957,7 +14003,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint16Array#reverse (; 305 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#reverse (; 306 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -14013,7 +14059,7 @@
   end
   local.get $3
  )
- (func $~lib/typedarray/Uint16Array#subarray (; 306 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#subarray (; 307 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   i32.const 4
@@ -14078,7 +14124,7 @@
   local.get $1
   call $~lib/rt/pure/__retain
  )
- (func $std/typedarray/testArrayReverse<~lib/typedarray/Uint16Array,u16> (; 307 ;)
+ (func $std/typedarray/testArrayReverse<~lib/typedarray/Uint16Array,u16> (; 308 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -14227,7 +14273,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int32Array#reverse (; 308 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#reverse (; 309 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -14283,7 +14329,7 @@
   end
   local.get $3
  )
- (func $std/typedarray/testArrayReverse<~lib/typedarray/Int32Array,i32> (; 309 ;)
+ (func $std/typedarray/testArrayReverse<~lib/typedarray/Int32Array,i32> (; 310 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -14427,7 +14473,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint32Array#subarray (; 310 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint32Array#subarray (; 311 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   i32.const 4
@@ -14492,7 +14538,7 @@
   local.get $1
   call $~lib/rt/pure/__retain
  )
- (func $std/typedarray/testArrayReverse<~lib/typedarray/Uint32Array,u32> (; 311 ;)
+ (func $std/typedarray/testArrayReverse<~lib/typedarray/Uint32Array,u32> (; 312 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -14635,7 +14681,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int64Array#reverse (; 312 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int64Array#reverse (; 313 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -14691,7 +14737,7 @@
   end
   local.get $3
  )
- (func $~lib/typedarray/Int64Array#subarray (; 313 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int64Array#subarray (; 314 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   i32.const 4
@@ -14756,7 +14802,7 @@
   local.get $1
   call $~lib/rt/pure/__retain
  )
- (func $std/typedarray/testArrayReverse<~lib/typedarray/Int64Array,i64> (; 314 ;)
+ (func $std/typedarray/testArrayReverse<~lib/typedarray/Int64Array,i64> (; 315 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -14902,7 +14948,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint64Array#subarray (; 315 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint64Array#subarray (; 316 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   i32.const 4
@@ -14967,7 +15013,7 @@
   local.get $1
   call $~lib/rt/pure/__retain
  )
- (func $std/typedarray/testArrayReverse<~lib/typedarray/Uint64Array,u64> (; 316 ;)
+ (func $std/typedarray/testArrayReverse<~lib/typedarray/Uint64Array,u64> (; 317 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -15113,7 +15159,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float32Array#reverse (; 317 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#reverse (; 318 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -15169,7 +15215,7 @@
   end
   local.get $3
  )
- (func $~lib/typedarray/Float32Array#subarray (; 318 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#subarray (; 319 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   i32.const 4
@@ -15234,7 +15280,7 @@
   local.get $1
   call $~lib/rt/pure/__retain
  )
- (func $std/typedarray/testArrayReverse<~lib/typedarray/Float32Array,f32> (; 319 ;)
+ (func $std/typedarray/testArrayReverse<~lib/typedarray/Float32Array,f32> (; 320 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -15380,7 +15426,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float64Array#reverse (; 320 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#reverse (; 321 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -15436,7 +15482,7 @@
   end
   local.get $3
  )
- (func $std/typedarray/testArrayReverse<~lib/typedarray/Float64Array,f64> (; 321 ;)
+ (func $std/typedarray/testArrayReverse<~lib/typedarray/Float64Array,f64> (; 322 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -15583,7 +15629,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int8Array#indexOf (; 322 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#indexOf (; 323 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   block $~lib/typedarray/INDEX_OF<~lib/typedarray/Int8Array,i8>|inlined.0
    local.get $0
@@ -15645,7 +15691,7 @@
   end
   local.get $2
  )
- (func $~lib/typedarray/Int8Array#lastIndexOf (; 323 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#lastIndexOf (; 324 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   block $~lib/typedarray/LAST_INDEX_OF<~lib/typedarray/Int8Array,i8>|inlined.0
    local.get $0
@@ -15702,7 +15748,7 @@
   end
   local.get $2
  )
- (func $~lib/typedarray/Int8Array#lastIndexOf|trampoline (; 324 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#lastIndexOf|trampoline (; 325 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   block $1of1
    block $0of1
@@ -15723,7 +15769,7 @@
   local.get $2
   call $~lib/typedarray/Int8Array#lastIndexOf
  )
- (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Int8Array,i8> (; 325 ;)
+ (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Int8Array,i8> (; 326 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -16143,7 +16189,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Uint8Array,u8> (; 326 ;)
+ (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Uint8Array,u8> (; 327 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -16560,7 +16606,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Uint8ClampedArray,u8> (; 327 ;)
+ (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Uint8ClampedArray,u8> (; 328 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -16977,7 +17023,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int16Array#indexOf (; 328 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#indexOf (; 329 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   block $~lib/typedarray/INDEX_OF<~lib/typedarray/Int16Array,i16>|inlined.0
    local.get $0
@@ -17041,7 +17087,7 @@
   end
   local.get $2
  )
- (func $~lib/typedarray/Int16Array#lastIndexOf (; 329 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#lastIndexOf (; 330 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   block $~lib/typedarray/LAST_INDEX_OF<~lib/typedarray/Int16Array,i16>|inlined.0
    local.get $0
@@ -17100,7 +17146,7 @@
   end
   local.get $2
  )
- (func $~lib/typedarray/Int16Array#lastIndexOf|trampoline (; 330 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#lastIndexOf|trampoline (; 331 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   block $1of1
    block $0of1
@@ -17121,7 +17167,7 @@
   local.get $2
   call $~lib/typedarray/Int16Array#lastIndexOf
  )
- (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Int16Array,i16> (; 331 ;)
+ (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Int16Array,i16> (; 332 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -17540,7 +17586,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Uint16Array,u16> (; 332 ;)
+ (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Uint16Array,u16> (; 333 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -17957,7 +18003,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int32Array#indexOf (; 333 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#indexOf (; 334 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   block $~lib/typedarray/INDEX_OF<~lib/typedarray/Int32Array,i32>|inlined.0
    local.get $0
@@ -18019,7 +18065,7 @@
   end
   local.get $2
  )
- (func $~lib/typedarray/Int32Array#lastIndexOf (; 334 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#lastIndexOf (; 335 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   block $~lib/typedarray/LAST_INDEX_OF<~lib/typedarray/Int32Array,i32>|inlined.0
    local.get $0
@@ -18076,7 +18122,7 @@
   end
   local.get $2
  )
- (func $~lib/typedarray/Int32Array#lastIndexOf|trampoline (; 335 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#lastIndexOf|trampoline (; 336 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   block $1of1
    block $0of1
@@ -18097,7 +18143,7 @@
   local.get $2
   call $~lib/typedarray/Int32Array#lastIndexOf
  )
- (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Int32Array,i32> (; 336 ;)
+ (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Int32Array,i32> (; 337 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -18513,7 +18559,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Uint32Array,u32> (; 337 ;)
+ (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Uint32Array,u32> (; 338 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -18928,7 +18974,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int64Array#indexOf (; 338 ;) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int64Array#indexOf (; 339 ;) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
   (local $3 i32)
   block $~lib/typedarray/INDEX_OF<~lib/typedarray/Int64Array,i64>|inlined.0
    local.get $0
@@ -18990,7 +19036,7 @@
   end
   local.get $2
  )
- (func $~lib/typedarray/Int64Array#lastIndexOf (; 339 ;) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int64Array#lastIndexOf (; 340 ;) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
   (local $3 i32)
   block $~lib/typedarray/LAST_INDEX_OF<~lib/typedarray/Int64Array,i64>|inlined.0
    local.get $0
@@ -19047,7 +19093,7 @@
   end
   local.get $2
  )
- (func $~lib/typedarray/Int64Array#lastIndexOf|trampoline (; 340 ;) (param $0 i32) (param $1 i64) (result i32)
+ (func $~lib/typedarray/Int64Array#lastIndexOf|trampoline (; 341 ;) (param $0 i32) (param $1 i64) (result i32)
   (local $2 i32)
   block $1of1
    block $0of1
@@ -19068,7 +19114,7 @@
   local.get $2
   call $~lib/typedarray/Int64Array#lastIndexOf
  )
- (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Int64Array,i64> (; 341 ;)
+ (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Int64Array,i64> (; 342 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -19484,7 +19530,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Uint64Array,u64> (; 342 ;)
+ (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Uint64Array,u64> (; 343 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -19900,7 +19946,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float32Array#indexOf (; 343 ;) (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#indexOf (; 344 ;) (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
   (local $3 i32)
   block $~lib/typedarray/INDEX_OF<~lib/typedarray/Float32Array,f32>|inlined.0
    local.get $0
@@ -19962,7 +20008,7 @@
   end
   local.get $2
  )
- (func $~lib/typedarray/Float32Array#lastIndexOf (; 344 ;) (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#lastIndexOf (; 345 ;) (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
   (local $3 i32)
   block $~lib/typedarray/LAST_INDEX_OF<~lib/typedarray/Float32Array,f32>|inlined.0
    local.get $0
@@ -20019,7 +20065,7 @@
   end
   local.get $2
  )
- (func $~lib/typedarray/Float32Array#lastIndexOf|trampoline (; 345 ;) (param $0 i32) (param $1 f32) (result i32)
+ (func $~lib/typedarray/Float32Array#lastIndexOf|trampoline (; 346 ;) (param $0 i32) (param $1 f32) (result i32)
   (local $2 i32)
   block $1of1
    block $0of1
@@ -20040,7 +20086,7 @@
   local.get $2
   call $~lib/typedarray/Float32Array#lastIndexOf
  )
- (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Float32Array,f32> (; 346 ;)
+ (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Float32Array,f32> (; 347 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -20456,7 +20502,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float64Array#indexOf (; 347 ;) (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#indexOf (; 348 ;) (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
   (local $3 i32)
   block $~lib/typedarray/INDEX_OF<~lib/typedarray/Float64Array,f64>|inlined.0
    local.get $0
@@ -20518,7 +20564,7 @@
   end
   local.get $2
  )
- (func $~lib/typedarray/Float64Array#lastIndexOf (; 348 ;) (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#lastIndexOf (; 349 ;) (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
   (local $3 i32)
   block $~lib/typedarray/LAST_INDEX_OF<~lib/typedarray/Float64Array,f64>|inlined.0
    local.get $0
@@ -20575,7 +20621,7 @@
   end
   local.get $2
  )
- (func $~lib/typedarray/Float64Array#lastIndexOf|trampoline (; 349 ;) (param $0 i32) (param $1 f64) (result i32)
+ (func $~lib/typedarray/Float64Array#lastIndexOf|trampoline (; 350 ;) (param $0 i32) (param $1 f64) (result i32)
   (local $2 i32)
   block $1of1
    block $0of1
@@ -20596,7 +20642,7 @@
   local.get $2
   call $~lib/typedarray/Float64Array#lastIndexOf
  )
- (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Float64Array,f64> (; 350 ;)
+ (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Float64Array,f64> (; 351 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -21013,7 +21059,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float64Array#includes (; 351 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#includes (; 352 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 f64)
@@ -21068,7 +21114,7 @@
    i32.const 0
   end
  )
- (func $~lib/typedarray/Float32Array#includes (; 352 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#includes (; 353 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 f32)
@@ -21123,7 +21169,7 @@
    i32.const 0
   end
  )
- (func $~lib/util/number/decimalCount32 (; 353 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/decimalCount32 (; 354 ;) (param $0 i32) (result i32)
   i32.const 1
   i32.const 2
   local.get $0
@@ -21171,7 +21217,7 @@
   i32.lt_u
   select
  )
- (func $~lib/util/number/utoa_simple<u32> (; 354 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/number/utoa_simple<u32> (; 355 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   loop $do-continue|0
    local.get $1
@@ -21195,7 +21241,7 @@
    br_if $do-continue|0
   end
  )
- (func $~lib/util/number/itoa32 (; 355 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/itoa32 (; 356 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -21237,7 +21283,7 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~lib/string/String#get:length (; 356 ;) (param $0 i32) (result i32)
+ (func $~lib/string/String#get:length (; 357 ;) (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub
@@ -21245,7 +21291,7 @@
   i32.const 1
   i32.shr_u
  )
- (func $~lib/util/number/itoa_stream<i8> (; 357 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_stream<i8> (; 358 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $0
   local.get $1
@@ -21300,7 +21346,7 @@
   end
   local.get $2
  )
- (func $~lib/string/String#substring (; 358 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String#substring (; 359 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -21374,7 +21420,7 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/string/joinIntegerArray<i8> (; 359 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<i8> (; 360 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -21477,14 +21523,14 @@
   end
   local.get $2
  )
- (func $~lib/typedarray/Int8Array#join (; 360 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#join (; 361 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $0
   i32.load offset=8
   call $~lib/util/string/joinIntegerArray<i8>
  )
- (func $~lib/util/string/compareImpl (; 361 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/compareImpl (; 362 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -21560,7 +21606,7 @@
   end
   i32.const 0
  )
- (func $~lib/string/String.__eq (; 362 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__eq (; 363 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -21594,7 +21640,7 @@
   call $~lib/util/string/compareImpl
   i32.eqz
  )
- (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Int8Array,i8> (; 363 ;)
+ (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Int8Array,i8> (; 364 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -21656,7 +21702,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/util/number/utoa32 (; 364 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/utoa32 (; 365 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -21679,7 +21725,7 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/itoa_stream<u8> (; 365 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_stream<u8> (; 366 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   local.get $1
   i32.const 1
@@ -21709,7 +21755,7 @@
   call $~lib/util/number/utoa_simple<u32>
   local.get $1
  )
- (func $~lib/util/string/joinIntegerArray<u8> (; 366 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<u8> (; 367 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -21812,14 +21858,14 @@
   end
   local.get $2
  )
- (func $~lib/typedarray/Uint8Array#join (; 367 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#join (; 368 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $0
   i32.load offset=8
   call $~lib/util/string/joinIntegerArray<u8>
  )
- (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Uint8Array,u8> (; 368 ;)
+ (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Uint8Array,u8> (; 369 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -21881,7 +21927,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Uint8ClampedArray,u8> (; 369 ;)
+ (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Uint8ClampedArray,u8> (; 370 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -21943,7 +21989,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/util/number/itoa_stream<i16> (; 370 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_stream<i16> (; 371 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $0
   local.get $1
@@ -21998,7 +22044,7 @@
   end
   local.get $2
  )
- (func $~lib/util/string/joinIntegerArray<i16> (; 371 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<i16> (; 372 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -22105,14 +22151,14 @@
   end
   local.get $2
  )
- (func $~lib/typedarray/Int16Array#join (; 372 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#join (; 373 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $0
   call $~lib/typedarray/Int16Array#get:length
   call $~lib/util/string/joinIntegerArray<i16>
  )
- (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Int16Array,i16> (; 373 ;)
+ (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Int16Array,i16> (; 374 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -22174,7 +22220,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/util/number/itoa_stream<u16> (; 374 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_stream<u16> (; 375 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   local.get $1
   i32.const 1
@@ -22204,7 +22250,7 @@
   call $~lib/util/number/utoa_simple<u32>
   local.get $1
  )
- (func $~lib/util/string/joinIntegerArray<u16> (; 375 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<u16> (; 376 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -22311,14 +22357,14 @@
   end
   local.get $2
  )
- (func $~lib/typedarray/Uint16Array#join (; 376 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#join (; 377 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $0
   call $~lib/typedarray/Int16Array#get:length
   call $~lib/util/string/joinIntegerArray<u16>
  )
- (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Uint16Array,u16> (; 377 ;)
+ (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Uint16Array,u16> (; 378 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -22380,7 +22426,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/util/number/itoa_stream<i32> (; 378 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_stream<i32> (; 379 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   local.get $1
   i32.const 1
@@ -22422,7 +22468,7 @@
   end
   local.get $2
  )
- (func $~lib/util/string/joinIntegerArray<i32> (; 379 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<i32> (; 380 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -22529,14 +22575,14 @@
   end
   local.get $2
  )
- (func $~lib/typedarray/Int32Array#join (; 380 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#join (; 381 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $0
   call $~lib/typedarray/Int32Array#get:length
   call $~lib/util/string/joinIntegerArray<i32>
  )
- (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Int32Array,i32> (; 381 ;)
+ (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Int32Array,i32> (; 382 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -22598,7 +22644,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/util/number/itoa_stream<u32> (; 382 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_stream<u32> (; 383 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   local.get $1
   i32.const 1
@@ -22622,7 +22668,7 @@
   call $~lib/util/number/utoa_simple<u32>
   local.get $0
  )
- (func $~lib/util/string/joinIntegerArray<u32> (; 383 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<u32> (; 384 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -22729,14 +22775,14 @@
   end
   local.get $2
  )
- (func $~lib/typedarray/Uint32Array#join (; 384 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint32Array#join (; 385 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $0
   call $~lib/typedarray/Int32Array#get:length
   call $~lib/util/string/joinIntegerArray<u32>
  )
- (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Uint32Array,u32> (; 385 ;)
+ (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Uint32Array,u32> (; 386 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -22798,7 +22844,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/util/number/decimalCount64 (; 386 ;) (param $0 i64) (result i32)
+ (func $~lib/util/number/decimalCount64 (; 387 ;) (param $0 i64) (result i32)
   i32.const 10
   i32.const 11
   i32.const 12
@@ -22851,7 +22897,7 @@
   i64.lt_u
   select
  )
- (func $~lib/util/number/utoa_simple<u64> (; 387 ;) (param $0 i32) (param $1 i64) (param $2 i32)
+ (func $~lib/util/number/utoa_simple<u64> (; 388 ;) (param $0 i32) (param $1 i64) (param $2 i32)
   (local $3 i64)
   loop $do-continue|0
    local.get $1
@@ -22878,7 +22924,7 @@
    br_if $do-continue|0
   end
  )
- (func $~lib/util/number/itoa64 (; 388 ;) (param $0 i64) (result i32)
+ (func $~lib/util/number/itoa64 (; 389 ;) (param $0 i64) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -22942,7 +22988,7 @@
   local.get $3
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/itoa_stream<i64> (; 389 ;) (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
+ (func $~lib/util/number/itoa_stream<i64> (; 390 ;) (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -23003,7 +23049,7 @@
   end
   local.get $3
  )
- (func $~lib/util/string/joinIntegerArray<i64> (; 390 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<i64> (; 391 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -23110,14 +23156,14 @@
   end
   local.get $2
  )
- (func $~lib/typedarray/Int64Array#join (; 391 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int64Array#join (; 392 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $0
   call $~lib/typedarray/Int64Array#get:length
   call $~lib/util/string/joinIntegerArray<i64>
  )
- (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Int64Array,i64> (; 392 ;)
+ (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Int64Array,i64> (; 393 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -23179,7 +23225,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/util/number/utoa64 (; 393 ;) (param $0 i64) (result i32)
+ (func $~lib/util/number/utoa64 (; 394 ;) (param $0 i64) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -23222,7 +23268,7 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/itoa_stream<u64> (; 394 ;) (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
+ (func $~lib/util/number/itoa_stream<u64> (; 395 ;) (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
   (local $3 i32)
   local.get $0
   local.get $1
@@ -23262,7 +23308,7 @@
   end
   local.get $1
  )
- (func $~lib/util/string/joinIntegerArray<u64> (; 395 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<u64> (; 396 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -23369,14 +23415,14 @@
   end
   local.get $2
  )
- (func $~lib/typedarray/Uint64Array#join (; 396 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint64Array#join (; 397 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $0
   call $~lib/typedarray/Int64Array#get:length
   call $~lib/util/string/joinIntegerArray<u64>
  )
- (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Uint64Array,u64> (; 397 ;)
+ (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Uint64Array,u64> (; 398 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -23438,7 +23484,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/array/Array<u64>#__unchecked_get (; 398 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $~lib/array/Array<u64>#__unchecked_get (; 399 ;) (param $0 i32) (param $1 i32) (result i64)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -23447,7 +23493,7 @@
   i32.add
   i64.load
  )
- (func $~lib/array/Array<i16>#__unchecked_get (; 399 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i16>#__unchecked_get (; 400 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -23456,7 +23502,7 @@
   i32.add
   i32.load16_s
  )
- (func $~lib/util/number/genDigits (; 400 ;) (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (param $6 i32) (result i32)
+ (func $~lib/util/number/genDigits (; 401 ;) (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (param $6 i32) (result i32)
   (local $7 i32)
   (local $8 i32)
   (local $9 i64)
@@ -23850,7 +23896,7 @@
    local.get $6
   end
  )
- (func $~lib/util/number/prettify (; 401 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/prettify (; 402 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   i32.eqz
@@ -24095,7 +24141,7 @@
    end
   end
  )
- (func $~lib/util/number/dtoa_core (; 402 ;) (param $0 i32) (param $1 f64) (result i32)
+ (func $~lib/util/number/dtoa_core (; 403 ;) (param $0 i32) (param $1 f64) (result i32)
   (local $2 i64)
   (local $3 i32)
   (local $4 i64)
@@ -24399,7 +24445,7 @@
   local.get $9
   i32.add
  )
- (func $~lib/util/number/dtoa (; 403 ;) (param $0 f64) (result i32)
+ (func $~lib/util/number/dtoa (; 404 ;) (param $0 f64) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -24451,7 +24497,7 @@
   local.get $1
   call $~lib/rt/tlsf/__free
  )
- (func $~lib/util/number/dtoa_stream (; 404 ;) (param $0 i32) (param $1 i32) (param $2 f64) (result i32)
+ (func $~lib/util/number/dtoa_stream (; 405 ;) (param $0 i32) (param $1 i32) (param $2 f64) (result i32)
   (local $3 i32)
   local.get $0
   local.get $1
@@ -24522,7 +24568,7 @@
   local.get $2
   call $~lib/util/number/dtoa_core
  )
- (func $~lib/util/string/joinFloatArray<f32> (; 405 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/joinFloatArray<f32> (; 406 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -24632,14 +24678,14 @@
   end
   local.get $2
  )
- (func $~lib/typedarray/Float32Array#join (; 406 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#join (; 407 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $0
   call $~lib/typedarray/Int32Array#get:length
   call $~lib/util/string/joinFloatArray<f32>
  )
- (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Float32Array,f32> (; 407 ;)
+ (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Float32Array,f32> (; 408 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -24701,7 +24747,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/util/string/joinFloatArray<f64> (; 408 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/joinFloatArray<f64> (; 409 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -24808,14 +24854,14 @@
   end
   local.get $2
  )
- (func $~lib/typedarray/Float64Array#join (; 409 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#join (; 410 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $0
   call $~lib/typedarray/Int64Array#get:length
   call $~lib/util/string/joinFloatArray<f64>
  )
- (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Float64Array,f64> (; 410 ;)
+ (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Float64Array,f64> (; 411 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -24877,15 +24923,15 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/arraybuffer/ArrayBuffer#constructor (; 411 ;) (param $0 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBuffer#constructor (; 412 ;) (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   i32.const 1073741808
   i32.gt_u
   if
-   i32.const 32
-   i32.const 80
-   i32.const 54
+   i32.const 192
+   i32.const 240
+   i32.const 45
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -24900,13 +24946,13 @@
   local.get $1
   call $~lib/rt/pure/__retain
  )
- (func $~lib/arraybuffer/ArrayBuffer#get:byteLength (; 412 ;) (param $0 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBuffer#get:byteLength (; 413 ;) (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub
   i32.load offset=12
  )
- (func $~lib/typedarray/Uint8Array.wrap (; 413 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array.wrap (; 414 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $1
   local.get $0
@@ -24916,7 +24962,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 1741
+   i32.const 1885
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -24933,9 +24979,9 @@
     local.get $1
     i32.sub
    else
-    i32.const 32
+    i32.const 192
     i32.const 432
-    i32.const 1750
+    i32.const 1894
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -24948,9 +24994,9 @@
    local.get $3
    i32.gt_s
    if
-    i32.const 32
+    i32.const 192
     i32.const 432
-    i32.const 1755
+    i32.const 1899
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -24964,17 +25010,17 @@
   call $~lib/rt/pure/__retain
   i32.store
   local.get $3
-  local.get $2
-  i32.store offset=8
-  local.get $3
   local.get $0
   local.get $1
   i32.add
   i32.store offset=4
   local.get $3
+  local.get $2
+  i32.store offset=8
+  local.get $3
   call $~lib/rt/pure/__retain
  )
- (func $~lib/typedarray/Uint8Array.wrap|trampoline (; 414 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array.wrap|trampoline (; 415 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   block $2of2
    block $1of2
@@ -24998,7 +25044,12 @@
   local.get $2
   call $~lib/typedarray/Uint8Array.wrap
  )
- (func $~lib/arraybuffer/ArrayBuffer#slice (; 415 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#get:buffer (; 416 ;) (param $0 i32) (result i32)
+  local.get $0
+  i32.load
+  call $~lib/rt/pure/__retain
+ )
+ (func $~lib/arraybuffer/ArrayBuffer#slice (; 417 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $0
   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
@@ -25066,7 +25117,7 @@
   local.get $3
   call $~lib/rt/pure/__retain
  )
- (func $~lib/typedarray/Int8Array.wrap (; 416 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int8Array.wrap (; 418 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   i32.const 0
@@ -25077,7 +25128,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 1741
+   i32.const 1885
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -25090,21 +25141,22 @@
   call $~lib/rt/pure/__retain
   i32.store
   local.get $1
-  local.get $2
-  i32.store offset=8
-  local.get $1
   local.get $0
   i32.store offset=4
   local.get $1
+  local.get $2
+  i32.store offset=8
+  local.get $1
   call $~lib/rt/pure/__retain
  )
- (func $std/typedarray/testArrayWrap<~lib/typedarray/Int8Array,i8> (; 417 ;)
+ (func $std/typedarray/testArrayWrap<~lib/typedarray/Int8Array,i8> (; 419 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   i32.const 3404
   i32.load
   local.tee $3
@@ -25134,11 +25186,12 @@
    end
   end
   local.get $1
-  i32.load
+  call $~lib/typedarray/Int8Array#get:buffer
+  local.tee $6
   local.get $1
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Int8Array#get:byteOffset
   local.get $1
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Int8Array#get:byteOffset
   local.get $1
   i32.load offset=8
   i32.add
@@ -25178,18 +25231,21 @@
   end
   local.get $5
   call $~lib/rt/pure/__release
+  local.get $6
+  call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
   local.get $4
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayWrap<~lib/typedarray/Uint8Array,u8> (; 418 ;)
+ (func $std/typedarray/testArrayWrap<~lib/typedarray/Uint8Array,u8> (; 420 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   i32.const 3404
   i32.load
   local.tee $3
@@ -25217,11 +25273,12 @@
    end
   end
   local.get $1
-  i32.load
+  call $~lib/typedarray/Int8Array#get:buffer
+  local.tee $6
   local.get $1
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Int8Array#get:byteOffset
   local.get $1
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Int8Array#get:byteOffset
   local.get $1
   i32.load offset=8
   i32.add
@@ -25262,12 +25319,14 @@
   end
   local.get $5
   call $~lib/rt/pure/__release
+  local.get $6
+  call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
   local.get $4
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8ClampedArray.wrap (; 419 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint8ClampedArray.wrap (; 421 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   i32.const 0
@@ -25278,7 +25337,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 1741
+   i32.const 1885
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -25291,21 +25350,22 @@
   call $~lib/rt/pure/__retain
   i32.store
   local.get $1
-  local.get $2
-  i32.store offset=8
-  local.get $1
   local.get $0
   i32.store offset=4
   local.get $1
+  local.get $2
+  i32.store offset=8
+  local.get $1
   call $~lib/rt/pure/__retain
  )
- (func $std/typedarray/testArrayWrap<~lib/typedarray/Uint8ClampedArray,u8> (; 420 ;)
+ (func $std/typedarray/testArrayWrap<~lib/typedarray/Uint8ClampedArray,u8> (; 422 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   i32.const 3404
   i32.load
   local.tee $3
@@ -25333,11 +25393,12 @@
    end
   end
   local.get $1
-  i32.load
+  call $~lib/typedarray/Int8Array#get:buffer
+  local.tee $6
   local.get $1
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Int8Array#get:byteOffset
   local.get $1
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Int8Array#get:byteOffset
   local.get $1
   i32.load offset=8
   i32.add
@@ -25377,12 +25438,14 @@
   end
   local.get $5
   call $~lib/rt/pure/__release
+  local.get $6
+  call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
   local.get $4
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int16Array.wrap (; 421 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int16Array.wrap (; 423 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   i32.const 0
@@ -25393,7 +25456,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 1741
+   i32.const 1885
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -25402,9 +25465,9 @@
   i32.const 1
   i32.and
   if
-   i32.const 32
+   i32.const 192
    i32.const 432
-   i32.const 1746
+   i32.const 1890
    i32.const 8
    call $~lib/builtins/abort
    unreachable
@@ -25417,21 +25480,22 @@
   call $~lib/rt/pure/__retain
   i32.store
   local.get $1
-  local.get $2
-  i32.store offset=8
-  local.get $1
   local.get $0
   i32.store offset=4
   local.get $1
+  local.get $2
+  i32.store offset=8
+  local.get $1
   call $~lib/rt/pure/__retain
  )
- (func $std/typedarray/testArrayWrap<~lib/typedarray/Int16Array,i16> (; 422 ;)
+ (func $std/typedarray/testArrayWrap<~lib/typedarray/Int16Array,i16> (; 424 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   i32.const 3404
   i32.load
   local.tee $3
@@ -25461,11 +25525,12 @@
    end
   end
   local.get $1
-  i32.load
+  call $~lib/typedarray/Int8Array#get:buffer
+  local.tee $6
   local.get $1
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Int8Array#get:byteOffset
   local.get $1
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Int8Array#get:byteOffset
   local.get $1
   i32.load offset=8
   i32.add
@@ -25505,12 +25570,14 @@
   end
   local.get $5
   call $~lib/rt/pure/__release
+  local.get $6
+  call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
   local.get $4
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint16Array.wrap (; 423 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array.wrap (; 425 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   i32.const 0
@@ -25521,7 +25588,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 1741
+   i32.const 1885
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -25530,9 +25597,9 @@
   i32.const 1
   i32.and
   if
-   i32.const 32
+   i32.const 192
    i32.const 432
-   i32.const 1746
+   i32.const 1890
    i32.const 8
    call $~lib/builtins/abort
    unreachable
@@ -25545,21 +25612,22 @@
   call $~lib/rt/pure/__retain
   i32.store
   local.get $1
-  local.get $2
-  i32.store offset=8
-  local.get $1
   local.get $0
   i32.store offset=4
   local.get $1
+  local.get $2
+  i32.store offset=8
+  local.get $1
   call $~lib/rt/pure/__retain
  )
- (func $std/typedarray/testArrayWrap<~lib/typedarray/Uint16Array,u16> (; 424 ;)
+ (func $std/typedarray/testArrayWrap<~lib/typedarray/Uint16Array,u16> (; 426 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   i32.const 3404
   i32.load
   local.tee $3
@@ -25587,11 +25655,12 @@
    end
   end
   local.get $1
-  i32.load
+  call $~lib/typedarray/Int8Array#get:buffer
+  local.tee $6
   local.get $1
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Int8Array#get:byteOffset
   local.get $1
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Int8Array#get:byteOffset
   local.get $1
   i32.load offset=8
   i32.add
@@ -25631,12 +25700,14 @@
   end
   local.get $5
   call $~lib/rt/pure/__release
+  local.get $6
+  call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
   local.get $4
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int32Array.wrap (; 425 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int32Array.wrap (; 427 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   i32.const 0
@@ -25647,7 +25718,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 1741
+   i32.const 1885
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -25656,9 +25727,9 @@
   i32.const 3
   i32.and
   if
-   i32.const 32
+   i32.const 192
    i32.const 432
-   i32.const 1746
+   i32.const 1890
    i32.const 8
    call $~lib/builtins/abort
    unreachable
@@ -25671,21 +25742,22 @@
   call $~lib/rt/pure/__retain
   i32.store
   local.get $1
-  local.get $2
-  i32.store offset=8
-  local.get $1
   local.get $0
   i32.store offset=4
   local.get $1
+  local.get $2
+  i32.store offset=8
+  local.get $1
   call $~lib/rt/pure/__retain
  )
- (func $std/typedarray/testArrayWrap<~lib/typedarray/Int32Array,i32> (; 426 ;)
+ (func $std/typedarray/testArrayWrap<~lib/typedarray/Int32Array,i32> (; 428 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   i32.const 3404
   i32.load
   local.tee $3
@@ -25711,11 +25783,12 @@
    end
   end
   local.get $1
-  i32.load
+  call $~lib/typedarray/Int8Array#get:buffer
+  local.tee $6
   local.get $1
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Int8Array#get:byteOffset
   local.get $1
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Int8Array#get:byteOffset
   local.get $1
   i32.load offset=8
   i32.add
@@ -25755,12 +25828,14 @@
   end
   local.get $5
   call $~lib/rt/pure/__release
+  local.get $6
+  call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
   local.get $4
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint32Array.wrap (; 427 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint32Array.wrap (; 429 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   i32.const 0
@@ -25771,7 +25846,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 1741
+   i32.const 1885
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -25780,9 +25855,9 @@
   i32.const 3
   i32.and
   if
-   i32.const 32
+   i32.const 192
    i32.const 432
-   i32.const 1746
+   i32.const 1890
    i32.const 8
    call $~lib/builtins/abort
    unreachable
@@ -25795,21 +25870,22 @@
   call $~lib/rt/pure/__retain
   i32.store
   local.get $1
-  local.get $2
-  i32.store offset=8
-  local.get $1
   local.get $0
   i32.store offset=4
   local.get $1
+  local.get $2
+  i32.store offset=8
+  local.get $1
   call $~lib/rt/pure/__retain
  )
- (func $std/typedarray/testArrayWrap<~lib/typedarray/Uint32Array,u32> (; 428 ;)
+ (func $std/typedarray/testArrayWrap<~lib/typedarray/Uint32Array,u32> (; 430 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   i32.const 3404
   i32.load
   local.tee $3
@@ -25835,11 +25911,12 @@
    end
   end
   local.get $1
-  i32.load
+  call $~lib/typedarray/Int8Array#get:buffer
+  local.tee $6
   local.get $1
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Int8Array#get:byteOffset
   local.get $1
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Int8Array#get:byteOffset
   local.get $1
   i32.load offset=8
   i32.add
@@ -25879,12 +25956,14 @@
   end
   local.get $5
   call $~lib/rt/pure/__release
+  local.get $6
+  call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
   local.get $4
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int64Array.wrap (; 429 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int64Array.wrap (; 431 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   i32.const 0
@@ -25895,7 +25974,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 1741
+   i32.const 1885
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -25904,9 +25983,9 @@
   i32.const 7
   i32.and
   if
-   i32.const 32
+   i32.const 192
    i32.const 432
-   i32.const 1746
+   i32.const 1890
    i32.const 8
    call $~lib/builtins/abort
    unreachable
@@ -25919,21 +25998,22 @@
   call $~lib/rt/pure/__retain
   i32.store
   local.get $1
-  local.get $2
-  i32.store offset=8
-  local.get $1
   local.get $0
   i32.store offset=4
   local.get $1
+  local.get $2
+  i32.store offset=8
+  local.get $1
   call $~lib/rt/pure/__retain
  )
- (func $std/typedarray/testArrayWrap<~lib/typedarray/Int64Array,i64> (; 430 ;)
+ (func $std/typedarray/testArrayWrap<~lib/typedarray/Int64Array,i64> (; 432 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   i32.const 3404
   i32.load
   local.tee $3
@@ -25960,11 +26040,12 @@
    end
   end
   local.get $1
-  i32.load
+  call $~lib/typedarray/Int8Array#get:buffer
+  local.tee $6
   local.get $1
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Int8Array#get:byteOffset
   local.get $1
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Int8Array#get:byteOffset
   local.get $1
   i32.load offset=8
   i32.add
@@ -26004,12 +26085,14 @@
   end
   local.get $5
   call $~lib/rt/pure/__release
+  local.get $6
+  call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
   local.get $4
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint64Array.wrap (; 431 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint64Array.wrap (; 433 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   i32.const 0
@@ -26020,7 +26103,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 1741
+   i32.const 1885
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -26029,9 +26112,9 @@
   i32.const 7
   i32.and
   if
-   i32.const 32
+   i32.const 192
    i32.const 432
-   i32.const 1746
+   i32.const 1890
    i32.const 8
    call $~lib/builtins/abort
    unreachable
@@ -26044,21 +26127,22 @@
   call $~lib/rt/pure/__retain
   i32.store
   local.get $1
-  local.get $2
-  i32.store offset=8
-  local.get $1
   local.get $0
   i32.store offset=4
   local.get $1
+  local.get $2
+  i32.store offset=8
+  local.get $1
   call $~lib/rt/pure/__retain
  )
- (func $std/typedarray/testArrayWrap<~lib/typedarray/Uint64Array,u64> (; 432 ;)
+ (func $std/typedarray/testArrayWrap<~lib/typedarray/Uint64Array,u64> (; 434 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   i32.const 3404
   i32.load
   local.tee $3
@@ -26085,11 +26169,12 @@
    end
   end
   local.get $1
-  i32.load
+  call $~lib/typedarray/Int8Array#get:buffer
+  local.tee $6
   local.get $1
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Int8Array#get:byteOffset
   local.get $1
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Int8Array#get:byteOffset
   local.get $1
   i32.load offset=8
   i32.add
@@ -26129,12 +26214,14 @@
   end
   local.get $5
   call $~lib/rt/pure/__release
+  local.get $6
+  call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
   local.get $4
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float32Array.wrap (; 433 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Float32Array.wrap (; 435 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   i32.const 0
@@ -26145,7 +26232,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 1741
+   i32.const 1885
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -26154,9 +26241,9 @@
   i32.const 3
   i32.and
   if
-   i32.const 32
+   i32.const 192
    i32.const 432
-   i32.const 1746
+   i32.const 1890
    i32.const 8
    call $~lib/builtins/abort
    unreachable
@@ -26169,21 +26256,22 @@
   call $~lib/rt/pure/__retain
   i32.store
   local.get $1
-  local.get $2
-  i32.store offset=8
-  local.get $1
   local.get $0
   i32.store offset=4
   local.get $1
+  local.get $2
+  i32.store offset=8
+  local.get $1
   call $~lib/rt/pure/__retain
  )
- (func $std/typedarray/testArrayWrap<~lib/typedarray/Float32Array,f32> (; 434 ;)
+ (func $std/typedarray/testArrayWrap<~lib/typedarray/Float32Array,f32> (; 436 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   i32.const 3404
   i32.load
   local.tee $3
@@ -26210,11 +26298,12 @@
    end
   end
   local.get $1
-  i32.load
+  call $~lib/typedarray/Int8Array#get:buffer
+  local.tee $6
   local.get $1
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Int8Array#get:byteOffset
   local.get $1
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Int8Array#get:byteOffset
   local.get $1
   i32.load offset=8
   i32.add
@@ -26254,12 +26343,14 @@
   end
   local.get $5
   call $~lib/rt/pure/__release
+  local.get $6
+  call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
   local.get $4
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float64Array.wrap (; 435 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Float64Array.wrap (; 437 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   i32.const 0
@@ -26270,7 +26361,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 1741
+   i32.const 1885
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -26279,9 +26370,9 @@
   i32.const 7
   i32.and
   if
-   i32.const 32
+   i32.const 192
    i32.const 432
-   i32.const 1746
+   i32.const 1890
    i32.const 8
    call $~lib/builtins/abort
    unreachable
@@ -26294,21 +26385,22 @@
   call $~lib/rt/pure/__retain
   i32.store
   local.get $1
-  local.get $2
-  i32.store offset=8
-  local.get $1
   local.get $0
   i32.store offset=4
   local.get $1
+  local.get $2
+  i32.store offset=8
+  local.get $1
   call $~lib/rt/pure/__retain
  )
- (func $std/typedarray/testArrayWrap<~lib/typedarray/Float64Array,f64> (; 436 ;)
+ (func $std/typedarray/testArrayWrap<~lib/typedarray/Float64Array,f64> (; 438 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   i32.const 3404
   i32.load
   local.tee $3
@@ -26335,11 +26427,12 @@
    end
   end
   local.get $1
-  i32.load
+  call $~lib/typedarray/Int8Array#get:buffer
+  local.tee $6
   local.get $1
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Int8Array#get:byteOffset
   local.get $1
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Int8Array#get:byteOffset
   local.get $1
   i32.load offset=8
   i32.add
@@ -26379,12 +26472,14 @@
   end
   local.get $5
   call $~lib/rt/pure/__release
+  local.get $6
+  call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
   local.get $4
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int8Array#set<~lib/array/Array<i32>> (; 437 ;) (param $0 i32)
+ (func $~lib/typedarray/Int8Array#set<~lib/array/Array<i32>> (; 439 ;) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -26396,7 +26491,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -26435,7 +26530,7 @@
    end
   end
  )
- (func $std/typedarray/valuesEqual<~lib/typedarray/Int8Array> (; 438 ;) (param $0 i32) (param $1 i32)
+ (func $std/typedarray/valuesEqual<~lib/typedarray/Int8Array> (; 440 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -26495,7 +26590,7 @@
    end
   end
  )
- (func $~lib/typedarray/Int8Array#set<~lib/array/Array<f32>> (; 439 ;) (param $0 i32)
+ (func $~lib/typedarray/Int8Array#set<~lib/array/Array<f32>> (; 441 ;) (param $0 i32)
   (local $1 f32)
   (local $2 i32)
   (local $3 i32)
@@ -26510,7 +26605,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -26562,7 +26657,7 @@
    end
   end
  )
- (func $~lib/typedarray/Int8Array#set<~lib/typedarray/Int64Array> (; 440 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Int8Array#set<~lib/typedarray/Int64Array> (; 442 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   local.get $1
@@ -26575,7 +26670,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -26616,7 +26711,7 @@
    end
   end
  )
- (func $~lib/typedarray/Int8Array#set<~lib/array/Array<f64>> (; 441 ;) (param $0 i32)
+ (func $~lib/typedarray/Int8Array#set<~lib/array/Array<f64>> (; 443 ;) (param $0 i32)
   (local $1 f64)
   (local $2 i32)
   (local $3 i32)
@@ -26631,7 +26726,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -26683,7 +26778,7 @@
    end
   end
  )
- (func $~lib/typedarray/Int8Array#set<~lib/typedarray/Uint8Array> (; 442 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Int8Array#set<~lib/typedarray/Uint8Array> (; 444 ;) (param $0 i32) (param $1 i32)
   local.get $1
   i32.load offset=8
   local.get $0
@@ -26692,7 +26787,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -26705,7 +26800,7 @@
   i32.load offset=8
   call $~lib/memory/memory.copy
  )
- (func $~lib/typedarray/Int8Array#set<~lib/typedarray/Int16Array> (; 443 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Int8Array#set<~lib/typedarray/Int16Array> (; 445 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   local.get $1
@@ -26718,7 +26813,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -26759,7 +26854,7 @@
    end
   end
  )
- (func $~lib/typedarray/Int8Array#set<~lib/array/Array<i8>> (; 444 ;) (param $0 i32)
+ (func $~lib/typedarray/Int8Array#set<~lib/array/Array<i8>> (; 446 ;) (param $0 i32)
   i32.const 3676
   i32.load
   i32.const 7
@@ -26770,7 +26865,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -26785,7 +26880,7 @@
   i32.load
   call $~lib/memory/memory.copy
  )
- (func $std/typedarray/testTypedArraySet<~lib/typedarray/Int8Array> (; 445 ;)
+ (func $std/typedarray/testTypedArraySet<~lib/typedarray/Int8Array> (; 447 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -26923,14 +27018,14 @@
   local.get $7
   call $~lib/rt/pure/__release
  )
- (func $~lib/array/Array<u8>#__unchecked_get (; 446 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u8>#__unchecked_get (; 448 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
   i32.add
   i32.load8_u
  )
- (func $std/typedarray/valuesEqual<~lib/typedarray/Uint8Array> (; 447 ;) (param $0 i32) (param $1 i32)
+ (func $std/typedarray/valuesEqual<~lib/typedarray/Uint8Array> (; 449 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -26990,7 +27085,7 @@
    end
   end
  )
- (func $~lib/typedarray/Uint8Array#set<~lib/array/Array<f32>> (; 448 ;) (param $0 i32)
+ (func $~lib/typedarray/Uint8Array#set<~lib/array/Array<f32>> (; 450 ;) (param $0 i32)
   (local $1 f32)
   (local $2 i32)
   (local $3 i32)
@@ -27005,7 +27100,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -27057,7 +27152,7 @@
    end
   end
  )
- (func $~lib/typedarray/Uint8Array#set<~lib/array/Array<f64>> (; 449 ;) (param $0 i32)
+ (func $~lib/typedarray/Uint8Array#set<~lib/array/Array<f64>> (; 451 ;) (param $0 i32)
   (local $1 f64)
   (local $2 i32)
   (local $3 i32)
@@ -27072,7 +27167,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -27124,7 +27219,7 @@
    end
   end
  )
- (func $std/typedarray/testTypedArraySet<~lib/typedarray/Uint8Array> (; 450 ;)
+ (func $std/typedarray/testTypedArraySet<~lib/typedarray/Uint8Array> (; 452 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -27262,7 +27357,7 @@
   local.get $7
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8ClampedArray#set<~lib/array/Array<i32>> (; 451 ;) (param $0 i32)
+ (func $~lib/typedarray/Uint8ClampedArray#set<~lib/array/Array<i32>> (; 453 ;) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -27275,7 +27370,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -27327,7 +27422,7 @@
    end
   end
  )
- (func $std/typedarray/valuesEqual<~lib/typedarray/Uint8ClampedArray> (; 452 ;) (param $0 i32) (param $1 i32)
+ (func $std/typedarray/valuesEqual<~lib/typedarray/Uint8ClampedArray> (; 454 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -27387,7 +27482,7 @@
    end
   end
  )
- (func $~lib/typedarray/Uint8ClampedArray#set<~lib/array/Array<f32>> (; 453 ;) (param $0 i32)
+ (func $~lib/typedarray/Uint8ClampedArray#set<~lib/array/Array<f32>> (; 455 ;) (param $0 i32)
   (local $1 f32)
   (local $2 i32)
   (local $3 i32)
@@ -27402,7 +27497,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -27458,7 +27553,7 @@
    end
   end
  )
- (func $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Int64Array> (; 454 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Int64Array> (; 456 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i64)
   (local $4 i32)
   local.get $2
@@ -27467,7 +27562,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 1774
+   i32.const 1918
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -27482,7 +27577,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -27540,7 +27635,7 @@
    end
   end
  )
- (func $~lib/typedarray/Uint8ClampedArray#set<~lib/array/Array<f64>> (; 455 ;) (param $0 i32)
+ (func $~lib/typedarray/Uint8ClampedArray#set<~lib/array/Array<f64>> (; 457 ;) (param $0 i32)
   (local $1 f64)
   (local $2 i32)
   (local $3 i32)
@@ -27555,7 +27650,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -27611,7 +27706,7 @@
    end
   end
  )
- (func $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Int16Array> (; 456 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Int16Array> (; 458 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $2
@@ -27620,7 +27715,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 1774
+   i32.const 1918
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -27635,7 +27730,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -27689,7 +27784,7 @@
    end
   end
  )
- (func $~lib/typedarray/Uint8ClampedArray#set<~lib/array/Array<i8>> (; 457 ;) (param $0 i32)
+ (func $~lib/typedarray/Uint8ClampedArray#set<~lib/array/Array<i8>> (; 459 ;) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -27704,7 +27799,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -27756,7 +27851,7 @@
    end
   end
  )
- (func $std/typedarray/testTypedArraySet<~lib/typedarray/Uint8ClampedArray> (; 458 ;)
+ (func $std/typedarray/testTypedArraySet<~lib/typedarray/Uint8ClampedArray> (; 460 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -27896,7 +27991,7 @@
   local.get $7
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int16Array#set<~lib/array/Array<i32>> (; 459 ;) (param $0 i32)
+ (func $~lib/typedarray/Int16Array#set<~lib/array/Array<i32>> (; 461 ;) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -27908,7 +28003,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -27949,7 +28044,7 @@
    end
   end
  )
- (func $std/typedarray/valuesEqual<~lib/typedarray/Int16Array> (; 460 ;) (param $0 i32) (param $1 i32)
+ (func $std/typedarray/valuesEqual<~lib/typedarray/Int16Array> (; 462 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -28009,7 +28104,7 @@
    end
   end
  )
- (func $~lib/typedarray/Int16Array#set<~lib/array/Array<f32>> (; 461 ;) (param $0 i32)
+ (func $~lib/typedarray/Int16Array#set<~lib/array/Array<f32>> (; 463 ;) (param $0 i32)
   (local $1 f32)
   (local $2 i32)
   (local $3 i32)
@@ -28024,7 +28119,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -28078,7 +28173,7 @@
    end
   end
  )
- (func $~lib/typedarray/Int16Array#set<~lib/typedarray/Int64Array> (; 462 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Int16Array#set<~lib/typedarray/Int64Array> (; 464 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   local.get $1
@@ -28091,7 +28186,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -28134,7 +28229,7 @@
    end
   end
  )
- (func $~lib/typedarray/Int16Array#set<~lib/array/Array<f64>> (; 463 ;) (param $0 i32)
+ (func $~lib/typedarray/Int16Array#set<~lib/array/Array<f64>> (; 465 ;) (param $0 i32)
   (local $1 f64)
   (local $2 i32)
   (local $3 i32)
@@ -28149,7 +28244,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -28203,7 +28298,7 @@
    end
   end
  )
- (func $~lib/typedarray/Int16Array#set<~lib/typedarray/Uint8Array> (; 464 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Int16Array#set<~lib/typedarray/Uint8Array> (; 466 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   local.get $1
@@ -28214,7 +28309,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -28253,7 +28348,7 @@
    end
   end
  )
- (func $~lib/typedarray/Int16Array#set<~lib/typedarray/Int16Array> (; 465 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Int16Array#set<~lib/typedarray/Int16Array> (; 467 ;) (param $0 i32) (param $1 i32)
   local.get $1
   call $~lib/typedarray/Int16Array#get:length
   i32.const 4
@@ -28264,7 +28359,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -28279,7 +28374,7 @@
   i32.load offset=8
   call $~lib/memory/memory.copy
  )
- (func $~lib/typedarray/Int16Array#set<~lib/array/Array<i8>> (; 466 ;) (param $0 i32)
+ (func $~lib/typedarray/Int16Array#set<~lib/array/Array<i8>> (; 468 ;) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -28293,7 +28388,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -28334,7 +28429,7 @@
    end
   end
  )
- (func $std/typedarray/testTypedArraySet<~lib/typedarray/Int16Array> (; 467 ;)
+ (func $std/typedarray/testTypedArraySet<~lib/typedarray/Int16Array> (; 469 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -28472,7 +28567,7 @@
   local.get $7
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/valuesEqual<~lib/typedarray/Uint16Array> (; 468 ;) (param $0 i32) (param $1 i32)
+ (func $std/typedarray/valuesEqual<~lib/typedarray/Uint16Array> (; 470 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -28540,7 +28635,7 @@
    end
   end
  )
- (func $~lib/typedarray/Uint16Array#set<~lib/array/Array<f32>> (; 469 ;) (param $0 i32)
+ (func $~lib/typedarray/Uint16Array#set<~lib/array/Array<f32>> (; 471 ;) (param $0 i32)
   (local $1 f32)
   (local $2 i32)
   (local $3 i32)
@@ -28555,7 +28650,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -28609,7 +28704,7 @@
    end
   end
  )
- (func $~lib/typedarray/Uint16Array#set<~lib/array/Array<f64>> (; 470 ;) (param $0 i32)
+ (func $~lib/typedarray/Uint16Array#set<~lib/array/Array<f64>> (; 472 ;) (param $0 i32)
   (local $1 f64)
   (local $2 i32)
   (local $3 i32)
@@ -28624,7 +28719,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -28678,7 +28773,7 @@
    end
   end
  )
- (func $std/typedarray/testTypedArraySet<~lib/typedarray/Uint16Array> (; 471 ;)
+ (func $std/typedarray/testTypedArraySet<~lib/typedarray/Uint16Array> (; 473 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -28816,14 +28911,14 @@
   local.get $7
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int32Array#set<~lib/array/Array<i32>> (; 472 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int32Array#set<~lib/array/Array<i32>> (; 474 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $2
   i32.const 0
   i32.lt_s
   if
    i32.const 368
    i32.const 432
-   i32.const 1774
+   i32.const 1918
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -28838,7 +28933,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -28855,7 +28950,7 @@
   i32.load offset=8
   call $~lib/memory/memory.copy
  )
- (func $std/typedarray/valuesEqual<~lib/typedarray/Int32Array> (; 473 ;) (param $0 i32) (param $1 i32)
+ (func $std/typedarray/valuesEqual<~lib/typedarray/Int32Array> (; 475 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -28915,7 +29010,7 @@
    end
   end
  )
- (func $~lib/typedarray/Int32Array#set<~lib/array/Array<f32>> (; 474 ;) (param $0 i32)
+ (func $~lib/typedarray/Int32Array#set<~lib/array/Array<f32>> (; 476 ;) (param $0 i32)
   (local $1 f32)
   (local $2 i32)
   (local $3 i32)
@@ -28931,7 +29026,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -28984,7 +29079,7 @@
    end
   end
  )
- (func $~lib/typedarray/Int32Array#set<~lib/typedarray/Int64Array> (; 475 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Int32Array#set<~lib/typedarray/Int64Array> (; 477 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   local.get $1
@@ -28997,7 +29092,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -29040,7 +29135,7 @@
    end
   end
  )
- (func $~lib/typedarray/Int32Array#set<~lib/array/Array<f64>> (; 476 ;) (param $0 i32)
+ (func $~lib/typedarray/Int32Array#set<~lib/array/Array<f64>> (; 478 ;) (param $0 i32)
   (local $1 f64)
   (local $2 i32)
   (local $3 i32)
@@ -29055,7 +29150,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -29109,7 +29204,7 @@
    end
   end
  )
- (func $~lib/typedarray/Int32Array#set<~lib/typedarray/Uint8Array> (; 477 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Int32Array#set<~lib/typedarray/Uint8Array> (; 479 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   local.get $1
@@ -29120,7 +29215,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -29159,7 +29254,7 @@
    end
   end
  )
- (func $~lib/typedarray/Int32Array#set<~lib/typedarray/Int16Array> (; 478 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Int32Array#set<~lib/typedarray/Int16Array> (; 480 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   local.get $1
@@ -29172,7 +29267,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -29215,7 +29310,7 @@
    end
   end
  )
- (func $~lib/typedarray/Int32Array#set<~lib/array/Array<i8>> (; 479 ;) (param $0 i32)
+ (func $~lib/typedarray/Int32Array#set<~lib/array/Array<i8>> (; 481 ;) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -29229,7 +29324,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -29270,7 +29365,7 @@
    end
   end
  )
- (func $std/typedarray/testTypedArraySet<~lib/typedarray/Int32Array> (; 480 ;)
+ (func $std/typedarray/testTypedArraySet<~lib/typedarray/Int32Array> (; 482 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -29410,7 +29505,7 @@
   local.get $7
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/valuesEqual<~lib/typedarray/Uint32Array> (; 481 ;) (param $0 i32) (param $1 i32)
+ (func $std/typedarray/valuesEqual<~lib/typedarray/Uint32Array> (; 483 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -29470,7 +29565,7 @@
    end
   end
  )
- (func $~lib/typedarray/Uint32Array#set<~lib/array/Array<f32>> (; 482 ;) (param $0 i32)
+ (func $~lib/typedarray/Uint32Array#set<~lib/array/Array<f32>> (; 484 ;) (param $0 i32)
   (local $1 f32)
   (local $2 i32)
   (local $3 i32)
@@ -29486,7 +29581,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -29539,7 +29634,7 @@
    end
   end
  )
- (func $~lib/typedarray/Uint32Array#set<~lib/array/Array<f64>> (; 483 ;) (param $0 i32)
+ (func $~lib/typedarray/Uint32Array#set<~lib/array/Array<f64>> (; 485 ;) (param $0 i32)
   (local $1 f64)
   (local $2 i32)
   (local $3 i32)
@@ -29554,7 +29649,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -29608,7 +29703,7 @@
    end
   end
  )
- (func $std/typedarray/testTypedArraySet<~lib/typedarray/Uint32Array> (; 484 ;)
+ (func $std/typedarray/testTypedArraySet<~lib/typedarray/Uint32Array> (; 486 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -29748,7 +29843,7 @@
   local.get $7
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int64Array#set<~lib/array/Array<i32>> (; 485 ;) (param $0 i32)
+ (func $~lib/typedarray/Int64Array#set<~lib/array/Array<i32>> (; 487 ;) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -29760,7 +29855,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -29801,7 +29896,7 @@
    end
   end
  )
- (func $std/typedarray/valuesEqual<~lib/typedarray/Int64Array> (; 486 ;) (param $0 i32) (param $1 i32)
+ (func $std/typedarray/valuesEqual<~lib/typedarray/Int64Array> (; 488 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i64)
@@ -29861,7 +29956,7 @@
    end
   end
  )
- (func $~lib/typedarray/Int64Array#set<~lib/array/Array<f32>> (; 487 ;) (param $0 i32)
+ (func $~lib/typedarray/Int64Array#set<~lib/array/Array<f32>> (; 489 ;) (param $0 i32)
   (local $1 f32)
   (local $2 i32)
   (local $3 i32)
@@ -29876,7 +29971,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -29930,7 +30025,7 @@
    end
   end
  )
- (func $~lib/typedarray/Int64Array#set<~lib/typedarray/Int64Array> (; 488 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Int64Array#set<~lib/typedarray/Int64Array> (; 490 ;) (param $0 i32) (param $1 i32)
   local.get $1
   call $~lib/typedarray/Int64Array#get:length
   i32.const 6
@@ -29941,7 +30036,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -29956,7 +30051,7 @@
   i32.load offset=8
   call $~lib/memory/memory.copy
  )
- (func $~lib/typedarray/Int64Array#set<~lib/array/Array<f64>> (; 489 ;) (param $0 i32)
+ (func $~lib/typedarray/Int64Array#set<~lib/array/Array<f64>> (; 491 ;) (param $0 i32)
   (local $1 f64)
   (local $2 i32)
   (local $3 i32)
@@ -29972,7 +30067,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -30025,7 +30120,7 @@
    end
   end
  )
- (func $~lib/typedarray/Int64Array#set<~lib/typedarray/Uint8Array> (; 490 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Int64Array#set<~lib/typedarray/Uint8Array> (; 492 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   local.get $1
@@ -30036,7 +30131,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -30075,7 +30170,7 @@
    end
   end
  )
- (func $~lib/typedarray/Int64Array#set<~lib/typedarray/Int16Array> (; 491 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Int64Array#set<~lib/typedarray/Int16Array> (; 493 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   local.get $1
@@ -30088,7 +30183,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -30131,7 +30226,7 @@
    end
   end
  )
- (func $~lib/typedarray/Int64Array#set<~lib/array/Array<i8>> (; 492 ;) (param $0 i32)
+ (func $~lib/typedarray/Int64Array#set<~lib/array/Array<i8>> (; 494 ;) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -30145,7 +30240,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -30186,7 +30281,7 @@
    end
   end
  )
- (func $std/typedarray/testTypedArraySet<~lib/typedarray/Int64Array> (; 493 ;)
+ (func $std/typedarray/testTypedArraySet<~lib/typedarray/Int64Array> (; 495 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -30324,7 +30419,7 @@
   local.get $7
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/valuesEqual<~lib/typedarray/Uint64Array> (; 494 ;) (param $0 i32) (param $1 i32)
+ (func $std/typedarray/valuesEqual<~lib/typedarray/Uint64Array> (; 496 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i64)
@@ -30384,7 +30479,7 @@
    end
   end
  )
- (func $~lib/typedarray/Uint64Array#set<~lib/array/Array<f32>> (; 495 ;) (param $0 i32)
+ (func $~lib/typedarray/Uint64Array#set<~lib/array/Array<f32>> (; 497 ;) (param $0 i32)
   (local $1 f32)
   (local $2 i32)
   (local $3 i32)
@@ -30399,7 +30494,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -30453,7 +30548,7 @@
    end
   end
  )
- (func $~lib/typedarray/Uint64Array#set<~lib/array/Array<f64>> (; 496 ;) (param $0 i32)
+ (func $~lib/typedarray/Uint64Array#set<~lib/array/Array<f64>> (; 498 ;) (param $0 i32)
   (local $1 f64)
   (local $2 i32)
   (local $3 i32)
@@ -30469,7 +30564,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -30522,7 +30617,7 @@
    end
   end
  )
- (func $std/typedarray/testTypedArraySet<~lib/typedarray/Uint64Array> (; 497 ;)
+ (func $std/typedarray/testTypedArraySet<~lib/typedarray/Uint64Array> (; 499 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -30660,7 +30755,7 @@
   local.get $7
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float32Array#set<~lib/array/Array<i32>> (; 498 ;) (param $0 i32)
+ (func $~lib/typedarray/Float32Array#set<~lib/array/Array<i32>> (; 500 ;) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -30673,7 +30768,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -30714,7 +30809,7 @@
    end
   end
  )
- (func $std/typedarray/valuesEqual<~lib/typedarray/Float32Array> (; 499 ;) (param $0 i32) (param $1 i32)
+ (func $std/typedarray/valuesEqual<~lib/typedarray/Float32Array> (; 501 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 f32)
   (local $4 i32)
@@ -30782,7 +30877,7 @@
    end
   end
  )
- (func $~lib/typedarray/Float32Array#set<~lib/typedarray/Int64Array> (; 500 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Float32Array#set<~lib/typedarray/Int64Array> (; 502 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   local.get $1
@@ -30795,7 +30890,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -30839,7 +30934,7 @@
    end
   end
  )
- (func $~lib/typedarray/Float32Array#set<~lib/typedarray/Uint8Array> (; 501 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Float32Array#set<~lib/typedarray/Uint8Array> (; 503 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   local.get $1
@@ -30850,7 +30945,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -30890,7 +30985,7 @@
    end
   end
  )
- (func $~lib/typedarray/Float32Array#set<~lib/typedarray/Int16Array> (; 502 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Float32Array#set<~lib/typedarray/Int16Array> (; 504 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   local.get $1
@@ -30903,7 +30998,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -30947,7 +31042,7 @@
    end
   end
  )
- (func $~lib/typedarray/Float32Array#set<~lib/array/Array<i8>> (; 503 ;) (param $0 i32)
+ (func $~lib/typedarray/Float32Array#set<~lib/array/Array<i8>> (; 505 ;) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -30961,7 +31056,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -31003,7 +31098,7 @@
    end
   end
  )
- (func $std/typedarray/testTypedArraySet<~lib/typedarray/Float32Array> (; 504 ;)
+ (func $std/typedarray/testTypedArraySet<~lib/typedarray/Float32Array> (; 506 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -31130,7 +31225,7 @@
   local.get $6
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float64Array#set<~lib/array/Array<i32>> (; 505 ;) (param $0 i32)
+ (func $~lib/typedarray/Float64Array#set<~lib/array/Array<i32>> (; 507 ;) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -31142,7 +31237,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -31184,7 +31279,7 @@
    end
   end
  )
- (func $std/typedarray/valuesEqual<~lib/typedarray/Float64Array> (; 506 ;) (param $0 i32) (param $1 i32)
+ (func $std/typedarray/valuesEqual<~lib/typedarray/Float64Array> (; 508 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 f64)
   (local $4 i32)
@@ -31250,7 +31345,7 @@
    end
   end
  )
- (func $~lib/typedarray/Float64Array#set<~lib/array/Array<f32>> (; 507 ;) (param $0 i32)
+ (func $~lib/typedarray/Float64Array#set<~lib/array/Array<f32>> (; 509 ;) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -31264,7 +31359,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -31308,7 +31403,7 @@
    end
   end
  )
- (func $~lib/typedarray/Float64Array#set<~lib/typedarray/Int64Array> (; 508 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Float64Array#set<~lib/typedarray/Int64Array> (; 510 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -31322,7 +31417,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -31365,7 +31460,7 @@
    end
   end
  )
- (func $~lib/typedarray/Float64Array#set<~lib/typedarray/Uint8Array> (; 509 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Float64Array#set<~lib/typedarray/Uint8Array> (; 511 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   local.get $1
@@ -31376,7 +31471,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -31416,7 +31511,7 @@
    end
   end
  )
- (func $~lib/typedarray/Float64Array#set<~lib/typedarray/Int16Array> (; 510 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Float64Array#set<~lib/typedarray/Int16Array> (; 512 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   local.get $1
@@ -31429,7 +31524,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -31473,7 +31568,7 @@
    end
   end
  )
- (func $~lib/typedarray/Float64Array#set<~lib/array/Array<i8>> (; 511 ;) (param $0 i32)
+ (func $~lib/typedarray/Float64Array#set<~lib/array/Array<i8>> (; 513 ;) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -31487,7 +31582,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -31529,7 +31624,7 @@
    end
   end
  )
- (func $std/typedarray/testTypedArraySet<~lib/typedarray/Float64Array> (; 512 ;)
+ (func $std/typedarray/testTypedArraySet<~lib/typedarray/Float64Array> (; 514 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -31654,7 +31749,7 @@
   local.get $6
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Float32Array> (; 513 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Float32Array> (; 515 ;) (param $0 i32) (param $1 i32)
   (local $2 f32)
   (local $3 i32)
   (local $4 i32)
@@ -31668,7 +31763,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -31724,7 +31819,7 @@
    end
   end
  )
- (func $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Int32Array> (; 514 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Int32Array> (; 516 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -31738,7 +31833,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -31792,7 +31887,7 @@
    end
   end
  )
- (func $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Uint32Array> (; 515 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Uint32Array> (; 517 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -31804,7 +31899,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -31849,7 +31944,7 @@
    end
   end
  )
- (func $start:std/typedarray (; 516 ;)
+ (func $start:std/typedarray (; 518 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -31907,7 +32002,7 @@
    unreachable
   end
   local.get $0
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Int8Array#get:byteOffset
   if
    i32.const 0
    i32.const 304
@@ -31987,7 +32082,7 @@
    unreachable
   end
   local.get $1
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Int8Array#get:byteOffset
   i32.const 4
   i32.ne
   if
@@ -32079,7 +32174,7 @@
    unreachable
   end
   local.get $0
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Int8Array#get:byteOffset
   i32.const 16
   i32.ne
   if
@@ -32368,7 +32463,7 @@
    unreachable
   end
   local.get $1
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Int8Array#get:byteOffset
   i32.const 1
   i32.ne
   if
@@ -32610,7 +32705,7 @@
    unreachable
   end
   local.get $1
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Int8Array#get:byteOffset
   i32.const 4
   i32.ne
   if
@@ -32743,7 +32838,7 @@
    unreachable
   end
   local.get $1
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Int8Array#get:byteOffset
   i32.const 1
   i32.ne
   if
@@ -32796,7 +32891,7 @@
    unreachable
   end
   local.get $2
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Int8Array#get:byteOffset
   i32.const 2
   i32.ne
   if
@@ -32849,7 +32944,7 @@
    unreachable
   end
   local.get $3
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Int8Array#get:byteOffset
   i32.const 3
   i32.ne
   if
@@ -33341,7 +33436,7 @@
    unreachable
   end
   local.get $2
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Int8Array#get:byteOffset
   i32.const 4
   i32.ne
   if
@@ -33407,7 +33502,7 @@
    unreachable
   end
   local.get $1
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Int8Array#get:byteOffset
   if
    i32.const 0
    i32.const 304
@@ -33458,7 +33553,7 @@
    unreachable
   end
   local.get $3
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Int8Array#get:byteOffset
   if
    i32.const 0
    i32.const 304
@@ -33508,9 +33603,9 @@
    unreachable
   end
   local.get $4
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Int8Array#get:byteOffset
   local.get $0
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Int8Array#get:byteOffset
   i32.ne
   if
    i32.const 0
@@ -33936,7 +34031,7 @@
   local.get $7
   call $~lib/rt/pure/__release
  )
- (func $~start (; 517 ;)
+ (func $~start (; 519 ;)
   global.get $~started
   if
    return
@@ -33946,7 +34041,7 @@
   end
   call $start:std/typedarray
  )
- (func $~lib/rt/pure/decrement (; 518 ;) (param $0 i32)
+ (func $~lib/rt/pure/decrement (; 520 ;) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -33963,7 +34058,7 @@
   i32.and
   if
    i32.const 0
-   i32.const 256
+   i32.const 144
    i32.const 122
    i32.const 13
    call $~lib/builtins/abort
@@ -33982,7 +34077,7 @@
    i32.and
    if
     i32.const 0
-    i32.const 256
+    i32.const 144
     i32.const 126
     i32.const 17
     call $~lib/builtins/abort
@@ -33997,7 +34092,7 @@
    i32.le_u
    if
     i32.const 0
-    i32.const 256
+    i32.const 144
     i32.const 136
     i32.const 15
     call $~lib/builtins/abort
@@ -34014,7 +34109,7 @@
    i32.store offset=4
   end
  )
- (func $~lib/rt/__visit_members (; 519 ;) (param $0 i32)
+ (func $~lib/rt/__visit_members (; 521 ;) (param $0 i32)
   block $block$4$break
    block $switch$1$default
     block $switch$1$case$2

--- a/tests/compiler/std/typedarray.untouched.wat
+++ b/tests/compiler/std/typedarray.untouched.wat
@@ -53,11 +53,11 @@
  (import "env" "trace" (func $~lib/builtins/trace (param i32 i32 f64 f64 f64 f64 f64)))
  (import "rtrace" "ondecrement" (func $~lib/rt/rtrace/ondecrement (param i32)))
  (memory $0 1)
- (data (i32.const 16) "\1c\00\00\00\01\00\00\00\01\00\00\00\1c\00\00\00I\00n\00v\00a\00l\00i\00d\00 \00l\00e\00n\00g\00t\00h\00")
- (data (i32.const 64) "&\00\00\00\01\00\00\00\01\00\00\00&\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00b\00u\00f\00f\00e\00r\00.\00t\00s\00")
- (data (i32.const 128) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s\00")
- (data (i32.const 176) "(\00\00\00\01\00\00\00\01\00\00\00(\00\00\00a\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e\00")
- (data (i32.const 240) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00p\00u\00r\00e\00.\00t\00s\00")
+ (data (i32.const 16) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s\00")
+ (data (i32.const 64) "(\00\00\00\01\00\00\00\01\00\00\00(\00\00\00a\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e\00")
+ (data (i32.const 128) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00p\00u\00r\00e\00.\00t\00s\00")
+ (data (i32.const 176) "\1c\00\00\00\01\00\00\00\01\00\00\00\1c\00\00\00I\00n\00v\00a\00l\00i\00d\00 \00l\00e\00n\00g\00t\00h\00")
+ (data (i32.const 224) "&\00\00\00\01\00\00\00\01\00\00\00&\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00b\00u\00f\00f\00e\00r\00.\00t\00s\00")
  (data (i32.const 288) "\"\00\00\00\01\00\00\00\01\00\00\00\"\00\00\00s\00t\00d\00/\00t\00y\00p\00e\00d\00a\00r\00r\00a\00y\00.\00t\00s\00")
  (data (i32.const 352) "$\00\00\00\01\00\00\00\01\00\00\00$\00\00\00I\00n\00d\00e\00x\00 \00o\00u\00t\00 \00o\00f\00 \00r\00a\00n\00g\00e\00")
  (data (i32.const 416) "$\00\00\00\01\00\00\00\01\00\00\00$\00\00\00~\00l\00i\00b\00/\00t\00y\00p\00e\00d\00a\00r\00r\00a\00y\00.\00t\00s\00")
@@ -248,7 +248,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 277
    i32.const 13
    call $~lib/builtins/abort
@@ -273,7 +273,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 279
    i32.const 13
    call $~lib/builtins/abort
@@ -325,7 +325,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 292
    i32.const 13
    call $~lib/builtins/abort
@@ -455,7 +455,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 205
    i32.const 13
    call $~lib/builtins/abort
@@ -470,7 +470,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 207
    i32.const 13
    call $~lib/builtins/abort
@@ -563,7 +563,7 @@
    i32.eqz
    if
     i32.const 0
-    i32.const 144
+    i32.const 32
     i32.const 228
     i32.const 15
     call $~lib/builtins/abort
@@ -626,7 +626,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 243
    i32.const 13
    call $~lib/builtins/abort
@@ -642,7 +642,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 244
    i32.const 13
    call $~lib/builtins/abort
@@ -699,7 +699,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 260
    i32.const 13
    call $~lib/builtins/abort
@@ -818,7 +818,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 386
    i32.const 4
    call $~lib/builtins/abort
@@ -841,7 +841,7 @@
    i32.eqz
    if
     i32.const 0
-    i32.const 144
+    i32.const 32
     i32.const 396
     i32.const 15
     call $~lib/builtins/abort
@@ -872,7 +872,7 @@
    i32.eqz
    if
     i32.const 0
-    i32.const 144
+    i32.const 32
     i32.const 408
     i32.const 4
     call $~lib/builtins/abort
@@ -1093,8 +1093,8 @@
   i32.const 1073741808
   i32.ge_u
   if
-   i32.const 192
-   i32.const 144
+   i32.const 80
+   i32.const 32
    i32.const 457
    i32.const 29
    call $~lib/builtins/abort
@@ -1188,7 +1188,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 338
    i32.const 13
    call $~lib/builtins/abort
@@ -1251,7 +1251,7 @@
     i32.eqz
     if
      i32.const 0
-     i32.const 144
+     i32.const 32
      i32.const 351
      i32.const 17
      call $~lib/builtins/abort
@@ -1396,7 +1396,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 365
    i32.const 13
    call $~lib/builtins/abort
@@ -1485,7 +1485,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 490
    i32.const 13
    call $~lib/builtins/abort
@@ -1526,7 +1526,7 @@
      i32.eqz
      if
       i32.const 0
-      i32.const 144
+      i32.const 32
       i32.const 502
       i32.const 19
       call $~lib/builtins/abort
@@ -1545,7 +1545,7 @@
     i32.eqz
     if
      i32.const 0
-     i32.const 144
+     i32.const 32
      i32.const 507
      i32.const 17
      call $~lib/builtins/abort
@@ -1562,7 +1562,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 510
    i32.const 13
    call $~lib/builtins/abort
@@ -1596,7 +1596,85 @@
   i32.const 16
   i32.add
  )
- (func $~lib/memory/memory.fill (; 17 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/rt/pure/increment (; 17 ;) (param $0 i32)
+  (local $1 i32)
+  local.get $0
+  i32.load offset=4
+  local.set $1
+  local.get $1
+  i32.const -268435456
+  i32.and
+  local.get $1
+  i32.const 1
+  i32.add
+  i32.const -268435456
+  i32.and
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 144
+   i32.const 109
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  local.get $1
+  i32.const 1
+  i32.add
+  i32.store offset=4
+  local.get $0
+  call $~lib/rt/rtrace/onincrement
+  local.get $0
+  i32.load
+  i32.const 1
+  i32.and
+  i32.eqz
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 144
+   i32.const 112
+   i32.const 13
+   call $~lib/builtins/abort
+   unreachable
+  end
+ )
+ (func $~lib/rt/pure/__retain (; 18 ;) (param $0 i32) (result i32)
+  local.get $0
+  global.get $~lib/heap/__heap_base
+  i32.gt_u
+  if
+   local.get $0
+   i32.const 16
+   i32.sub
+   call $~lib/rt/pure/increment
+  end
+  local.get $0
+ )
+ (func $~lib/arraybuffer/ArrayBufferView#constructor (; 19 ;) (param $0 i32) (result i32)
+  local.get $0
+  i32.eqz
+  if
+   i32.const 12
+   i32.const 2
+   call $~lib/rt/tlsf/__alloc
+   call $~lib/rt/pure/__retain
+   local.set $0
+  end
+  local.get $0
+  i32.const 0
+  i32.store
+  local.get $0
+  i32.const 0
+  i32.store offset=4
+  local.get $0
+  i32.const 0
+  i32.store offset=8
+  local.get $0
+ )
+ (func $~lib/memory/memory.fill (; 20 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1860,64 +1938,7 @@
    end
   end
  )
- (func $~lib/rt/pure/increment (; 18 ;) (param $0 i32)
-  (local $1 i32)
-  local.get $0
-  i32.load offset=4
-  local.set $1
-  local.get $1
-  i32.const -268435456
-  i32.and
-  local.get $1
-  i32.const 1
-  i32.add
-  i32.const -268435456
-  i32.and
-  i32.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 256
-   i32.const 109
-   i32.const 2
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $0
-  local.get $1
-  i32.const 1
-  i32.add
-  i32.store offset=4
-  local.get $0
-  call $~lib/rt/rtrace/onincrement
-  local.get $0
-  i32.load
-  i32.const 1
-  i32.and
-  i32.eqz
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 256
-   i32.const 112
-   i32.const 13
-   call $~lib/builtins/abort
-   unreachable
-  end
- )
- (func $~lib/rt/pure/__retain (; 19 ;) (param $0 i32) (result i32)
-  local.get $0
-  global.get $~lib/heap/__heap_base
-  i32.gt_u
-  if
-   local.get $0
-   i32.const 16
-   i32.sub
-   call $~lib/rt/pure/increment
-  end
-  local.get $0
- )
- (func $~lib/rt/pure/__release (; 20 ;) (param $0 i32)
+ (func $~lib/rt/pure/__release (; 21 ;) (param $0 i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.gt_u
@@ -1928,7 +1949,7 @@
    call $~lib/rt/pure/decrement
   end
  )
- (func $~lib/arraybuffer/ArrayBufferView#constructor (; 21 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBufferView#alloc (; 22 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1939,9 +1960,9 @@
   i32.shr_u
   i32.gt_u
   if
-   i32.const 32
-   i32.const 80
-   i32.const 23
+   i32.const 192
+   i32.const 240
+   i32.const 14
    i32.const 56
    call $~lib/builtins/abort
    unreachable
@@ -1957,24 +1978,6 @@
   i32.const 0
   local.get $1
   call $~lib/memory/memory.fill
-  local.get $0
-  i32.eqz
-  if
-   i32.const 12
-   i32.const 2
-   call $~lib/rt/tlsf/__alloc
-   call $~lib/rt/pure/__retain
-   local.set $0
-  end
-  local.get $0
-  i32.const 0
-  i32.store
-  local.get $0
-  i32.const 0
-  i32.store offset=4
-  local.get $0
-  i32.const 0
-  i32.store offset=8
   local.get $0
   local.tee $4
   local.get $3
@@ -1998,9 +2001,8 @@
   local.get $0
   local.get $1
   i32.store offset=8
-  local.get $0
  )
- (func $~lib/typedarray/Int8Array#constructor (; 22 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#constructor (; 23 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   if (result i32)
    local.get $0
@@ -2010,24 +2012,30 @@
    call $~lib/rt/tlsf/__alloc
    call $~lib/rt/pure/__retain
   end
-  local.get $1
-  i32.const 0
   call $~lib/arraybuffer/ArrayBufferView#constructor
   local.set $0
   local.get $0
+  local.get $1
+  i32.const 0
+  call $~lib/arraybuffer/ArrayBufferView#alloc
+  local.get $0
  )
- (func $~lib/arraybuffer/ArrayBufferView#get:byteOffset (; 23 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#get:byteOffset (; 24 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $0
   i32.load
   i32.sub
  )
- (func $~lib/typedarray/Int8Array#get:length (; 24 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#get:byteLength (; 25 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=8
  )
- (func $~lib/typedarray/Uint8Array#constructor (; 25 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#get:length (; 26 ;) (param $0 i32) (result i32)
+  local.get $0
+  i32.load offset=8
+ )
+ (func $~lib/typedarray/Uint8Array#constructor (; 27 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   if (result i32)
    local.get $0
@@ -2037,17 +2045,30 @@
    call $~lib/rt/tlsf/__alloc
    call $~lib/rt/pure/__retain
   end
-  local.get $1
-  i32.const 0
   call $~lib/arraybuffer/ArrayBufferView#constructor
   local.set $0
   local.get $0
+  local.get $1
+  i32.const 0
+  call $~lib/arraybuffer/ArrayBufferView#alloc
+  local.get $0
  )
- (func $~lib/typedarray/Uint8Array#get:length (; 26 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#get:byteOffset (; 28 ;) (param $0 i32) (result i32)
+  local.get $0
+  i32.load offset=4
+  local.get $0
+  i32.load
+  i32.sub
+ )
+ (func $~lib/typedarray/Uint8Array#get:byteLength (; 29 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=8
  )
- (func $~lib/typedarray/Uint8ClampedArray#constructor (; 27 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#get:length (; 30 ;) (param $0 i32) (result i32)
+  local.get $0
+  i32.load offset=8
+ )
+ (func $~lib/typedarray/Uint8ClampedArray#constructor (; 31 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   if (result i32)
    local.get $0
@@ -2057,17 +2078,30 @@
    call $~lib/rt/tlsf/__alloc
    call $~lib/rt/pure/__retain
   end
-  local.get $1
-  i32.const 0
   call $~lib/arraybuffer/ArrayBufferView#constructor
   local.set $0
   local.get $0
+  local.get $1
+  i32.const 0
+  call $~lib/arraybuffer/ArrayBufferView#alloc
+  local.get $0
  )
- (func $~lib/typedarray/Uint8ClampedArray#get:length (; 28 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint8ClampedArray#get:byteOffset (; 32 ;) (param $0 i32) (result i32)
+  local.get $0
+  i32.load offset=4
+  local.get $0
+  i32.load
+  i32.sub
+ )
+ (func $~lib/typedarray/Uint8ClampedArray#get:byteLength (; 33 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=8
  )
- (func $~lib/typedarray/Int16Array#constructor (; 29 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8ClampedArray#get:length (; 34 ;) (param $0 i32) (result i32)
+  local.get $0
+  i32.load offset=8
+ )
+ (func $~lib/typedarray/Int16Array#constructor (; 35 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   if (result i32)
    local.get $0
@@ -2077,19 +2111,32 @@
    call $~lib/rt/tlsf/__alloc
    call $~lib/rt/pure/__retain
   end
-  local.get $1
-  i32.const 1
   call $~lib/arraybuffer/ArrayBufferView#constructor
   local.set $0
   local.get $0
+  local.get $1
+  i32.const 1
+  call $~lib/arraybuffer/ArrayBufferView#alloc
+  local.get $0
  )
- (func $~lib/typedarray/Int16Array#get:length (; 30 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#get:byteOffset (; 36 ;) (param $0 i32) (result i32)
+  local.get $0
+  i32.load offset=4
+  local.get $0
+  i32.load
+  i32.sub
+ )
+ (func $~lib/typedarray/Int16Array#get:byteLength (; 37 ;) (param $0 i32) (result i32)
+  local.get $0
+  i32.load offset=8
+ )
+ (func $~lib/typedarray/Int16Array#get:length (; 38 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=8
   i32.const 1
   i32.shr_u
  )
- (func $~lib/typedarray/Uint16Array#constructor (; 31 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#constructor (; 39 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   if (result i32)
    local.get $0
@@ -2099,19 +2146,32 @@
    call $~lib/rt/tlsf/__alloc
    call $~lib/rt/pure/__retain
   end
-  local.get $1
-  i32.const 1
   call $~lib/arraybuffer/ArrayBufferView#constructor
   local.set $0
   local.get $0
+  local.get $1
+  i32.const 1
+  call $~lib/arraybuffer/ArrayBufferView#alloc
+  local.get $0
  )
- (func $~lib/typedarray/Uint16Array#get:length (; 32 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#get:byteOffset (; 40 ;) (param $0 i32) (result i32)
+  local.get $0
+  i32.load offset=4
+  local.get $0
+  i32.load
+  i32.sub
+ )
+ (func $~lib/typedarray/Uint16Array#get:byteLength (; 41 ;) (param $0 i32) (result i32)
+  local.get $0
+  i32.load offset=8
+ )
+ (func $~lib/typedarray/Uint16Array#get:length (; 42 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=8
   i32.const 1
   i32.shr_u
  )
- (func $~lib/typedarray/Int32Array#constructor (; 33 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#constructor (; 43 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   if (result i32)
    local.get $0
@@ -2121,19 +2181,32 @@
    call $~lib/rt/tlsf/__alloc
    call $~lib/rt/pure/__retain
   end
-  local.get $1
-  i32.const 2
   call $~lib/arraybuffer/ArrayBufferView#constructor
   local.set $0
   local.get $0
+  local.get $1
+  i32.const 2
+  call $~lib/arraybuffer/ArrayBufferView#alloc
+  local.get $0
  )
- (func $~lib/typedarray/Int32Array#get:length (; 34 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#get:byteOffset (; 44 ;) (param $0 i32) (result i32)
+  local.get $0
+  i32.load offset=4
+  local.get $0
+  i32.load
+  i32.sub
+ )
+ (func $~lib/typedarray/Int32Array#get:byteLength (; 45 ;) (param $0 i32) (result i32)
+  local.get $0
+  i32.load offset=8
+ )
+ (func $~lib/typedarray/Int32Array#get:length (; 46 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=8
   i32.const 2
   i32.shr_u
  )
- (func $~lib/typedarray/Uint32Array#constructor (; 35 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint32Array#constructor (; 47 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   if (result i32)
    local.get $0
@@ -2143,19 +2216,32 @@
    call $~lib/rt/tlsf/__alloc
    call $~lib/rt/pure/__retain
   end
-  local.get $1
-  i32.const 2
   call $~lib/arraybuffer/ArrayBufferView#constructor
   local.set $0
   local.get $0
+  local.get $1
+  i32.const 2
+  call $~lib/arraybuffer/ArrayBufferView#alloc
+  local.get $0
  )
- (func $~lib/typedarray/Uint32Array#get:length (; 36 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint32Array#get:byteOffset (; 48 ;) (param $0 i32) (result i32)
+  local.get $0
+  i32.load offset=4
+  local.get $0
+  i32.load
+  i32.sub
+ )
+ (func $~lib/typedarray/Uint32Array#get:byteLength (; 49 ;) (param $0 i32) (result i32)
+  local.get $0
+  i32.load offset=8
+ )
+ (func $~lib/typedarray/Uint32Array#get:length (; 50 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=8
   i32.const 2
   i32.shr_u
  )
- (func $~lib/typedarray/Int64Array#constructor (; 37 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int64Array#constructor (; 51 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   if (result i32)
    local.get $0
@@ -2165,19 +2251,32 @@
    call $~lib/rt/tlsf/__alloc
    call $~lib/rt/pure/__retain
   end
-  local.get $1
-  i32.const 3
   call $~lib/arraybuffer/ArrayBufferView#constructor
   local.set $0
   local.get $0
+  local.get $1
+  i32.const 3
+  call $~lib/arraybuffer/ArrayBufferView#alloc
+  local.get $0
  )
- (func $~lib/typedarray/Int64Array#get:length (; 38 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int64Array#get:byteOffset (; 52 ;) (param $0 i32) (result i32)
+  local.get $0
+  i32.load offset=4
+  local.get $0
+  i32.load
+  i32.sub
+ )
+ (func $~lib/typedarray/Int64Array#get:byteLength (; 53 ;) (param $0 i32) (result i32)
+  local.get $0
+  i32.load offset=8
+ )
+ (func $~lib/typedarray/Int64Array#get:length (; 54 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=8
   i32.const 3
   i32.shr_u
  )
- (func $~lib/typedarray/Uint64Array#constructor (; 39 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint64Array#constructor (; 55 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   if (result i32)
    local.get $0
@@ -2187,19 +2286,32 @@
    call $~lib/rt/tlsf/__alloc
    call $~lib/rt/pure/__retain
   end
-  local.get $1
-  i32.const 3
   call $~lib/arraybuffer/ArrayBufferView#constructor
   local.set $0
   local.get $0
+  local.get $1
+  i32.const 3
+  call $~lib/arraybuffer/ArrayBufferView#alloc
+  local.get $0
  )
- (func $~lib/typedarray/Uint64Array#get:length (; 40 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint64Array#get:byteOffset (; 56 ;) (param $0 i32) (result i32)
+  local.get $0
+  i32.load offset=4
+  local.get $0
+  i32.load
+  i32.sub
+ )
+ (func $~lib/typedarray/Uint64Array#get:byteLength (; 57 ;) (param $0 i32) (result i32)
+  local.get $0
+  i32.load offset=8
+ )
+ (func $~lib/typedarray/Uint64Array#get:length (; 58 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=8
   i32.const 3
   i32.shr_u
  )
- (func $~lib/typedarray/Float32Array#constructor (; 41 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#constructor (; 59 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   if (result i32)
    local.get $0
@@ -2209,19 +2321,32 @@
    call $~lib/rt/tlsf/__alloc
    call $~lib/rt/pure/__retain
   end
-  local.get $1
-  i32.const 2
   call $~lib/arraybuffer/ArrayBufferView#constructor
   local.set $0
   local.get $0
+  local.get $1
+  i32.const 2
+  call $~lib/arraybuffer/ArrayBufferView#alloc
+  local.get $0
  )
- (func $~lib/typedarray/Float32Array#get:length (; 42 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#get:byteOffset (; 60 ;) (param $0 i32) (result i32)
+  local.get $0
+  i32.load offset=4
+  local.get $0
+  i32.load
+  i32.sub
+ )
+ (func $~lib/typedarray/Float32Array#get:byteLength (; 61 ;) (param $0 i32) (result i32)
+  local.get $0
+  i32.load offset=8
+ )
+ (func $~lib/typedarray/Float32Array#get:length (; 62 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=8
   i32.const 2
   i32.shr_u
  )
- (func $~lib/typedarray/Float64Array#constructor (; 43 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#constructor (; 63 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   if (result i32)
    local.get $0
@@ -2231,19 +2356,32 @@
    call $~lib/rt/tlsf/__alloc
    call $~lib/rt/pure/__retain
   end
-  local.get $1
-  i32.const 3
   call $~lib/arraybuffer/ArrayBufferView#constructor
   local.set $0
   local.get $0
+  local.get $1
+  i32.const 3
+  call $~lib/arraybuffer/ArrayBufferView#alloc
+  local.get $0
  )
- (func $~lib/typedarray/Float64Array#get:length (; 44 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#get:byteOffset (; 64 ;) (param $0 i32) (result i32)
+  local.get $0
+  i32.load offset=4
+  local.get $0
+  i32.load
+  i32.sub
+ )
+ (func $~lib/typedarray/Float64Array#get:byteLength (; 65 ;) (param $0 i32) (result i32)
+  local.get $0
+  i32.load offset=8
+ )
+ (func $~lib/typedarray/Float64Array#get:length (; 66 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=8
   i32.const 3
   i32.shr_u
  )
- (func $std/typedarray/testInstantiate (; 45 ;) (param $0 i32)
+ (func $std/typedarray/testInstantiate (; 67 ;) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -2260,7 +2398,7 @@
   call $~lib/typedarray/Int8Array#constructor
   local.set $1
   local.get $1
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Int8Array#get:byteOffset
   i32.const 0
   i32.eq
   i32.eqz
@@ -2273,7 +2411,7 @@
    unreachable
   end
   local.get $1
-  i32.load offset=8
+  call $~lib/typedarray/Int8Array#get:byteLength
   local.get $0
   i32.const 1
   i32.mul
@@ -2305,7 +2443,7 @@
   call $~lib/typedarray/Uint8Array#constructor
   local.set $2
   local.get $2
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Uint8Array#get:byteOffset
   i32.const 0
   i32.eq
   i32.eqz
@@ -2318,7 +2456,7 @@
    unreachable
   end
   local.get $2
-  i32.load offset=8
+  call $~lib/typedarray/Uint8Array#get:byteLength
   local.get $0
   i32.const 1
   i32.mul
@@ -2350,7 +2488,7 @@
   call $~lib/typedarray/Uint8ClampedArray#constructor
   local.set $3
   local.get $3
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Uint8ClampedArray#get:byteOffset
   i32.const 0
   i32.eq
   i32.eqz
@@ -2363,7 +2501,7 @@
    unreachable
   end
   local.get $3
-  i32.load offset=8
+  call $~lib/typedarray/Uint8ClampedArray#get:byteLength
   local.get $0
   i32.const 1
   i32.mul
@@ -2395,7 +2533,7 @@
   call $~lib/typedarray/Int16Array#constructor
   local.set $4
   local.get $4
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Int16Array#get:byteOffset
   i32.const 0
   i32.eq
   i32.eqz
@@ -2408,7 +2546,7 @@
    unreachable
   end
   local.get $4
-  i32.load offset=8
+  call $~lib/typedarray/Int16Array#get:byteLength
   local.get $0
   i32.const 2
   i32.mul
@@ -2440,7 +2578,7 @@
   call $~lib/typedarray/Uint16Array#constructor
   local.set $5
   local.get $5
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Uint16Array#get:byteOffset
   i32.const 0
   i32.eq
   i32.eqz
@@ -2453,7 +2591,7 @@
    unreachable
   end
   local.get $5
-  i32.load offset=8
+  call $~lib/typedarray/Uint16Array#get:byteLength
   local.get $0
   i32.const 2
   i32.mul
@@ -2485,7 +2623,7 @@
   call $~lib/typedarray/Int32Array#constructor
   local.set $6
   local.get $6
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Int32Array#get:byteOffset
   i32.const 0
   i32.eq
   i32.eqz
@@ -2498,7 +2636,7 @@
    unreachable
   end
   local.get $6
-  i32.load offset=8
+  call $~lib/typedarray/Int32Array#get:byteLength
   local.get $0
   i32.const 4
   i32.mul
@@ -2530,7 +2668,7 @@
   call $~lib/typedarray/Uint32Array#constructor
   local.set $7
   local.get $7
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Uint32Array#get:byteOffset
   i32.const 0
   i32.eq
   i32.eqz
@@ -2543,7 +2681,7 @@
    unreachable
   end
   local.get $7
-  i32.load offset=8
+  call $~lib/typedarray/Uint32Array#get:byteLength
   local.get $0
   i32.const 4
   i32.mul
@@ -2575,7 +2713,7 @@
   call $~lib/typedarray/Int64Array#constructor
   local.set $8
   local.get $8
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Int64Array#get:byteOffset
   i32.const 0
   i32.eq
   i32.eqz
@@ -2588,7 +2726,7 @@
    unreachable
   end
   local.get $8
-  i32.load offset=8
+  call $~lib/typedarray/Int64Array#get:byteLength
   local.get $0
   i32.const 8
   i32.mul
@@ -2620,7 +2758,7 @@
   call $~lib/typedarray/Uint64Array#constructor
   local.set $9
   local.get $9
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Uint64Array#get:byteOffset
   i32.const 0
   i32.eq
   i32.eqz
@@ -2633,7 +2771,7 @@
    unreachable
   end
   local.get $9
-  i32.load offset=8
+  call $~lib/typedarray/Uint64Array#get:byteLength
   local.get $0
   i32.const 8
   i32.mul
@@ -2665,7 +2803,7 @@
   call $~lib/typedarray/Float32Array#constructor
   local.set $10
   local.get $10
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Float32Array#get:byteOffset
   i32.const 0
   i32.eq
   i32.eqz
@@ -2678,7 +2816,7 @@
    unreachable
   end
   local.get $10
-  i32.load offset=8
+  call $~lib/typedarray/Float32Array#get:byteLength
   local.get $0
   i32.const 4
   i32.mul
@@ -2710,7 +2848,7 @@
   call $~lib/typedarray/Float64Array#constructor
   local.set $11
   local.get $11
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Float64Array#get:byteOffset
   i32.const 0
   i32.eq
   i32.eqz
@@ -2723,7 +2861,7 @@
    unreachable
   end
   local.get $11
-  i32.load offset=8
+  call $~lib/typedarray/Float64Array#get:byteLength
   local.get $0
   i32.const 8
   i32.mul
@@ -2773,7 +2911,7 @@
   local.get $11
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int32Array#__set (; 46 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int32Array#__set (; 68 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -2783,7 +2921,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 675
+   i32.const 754
    i32.const 63
    call $~lib/builtins/abort
    unreachable
@@ -2797,7 +2935,7 @@
   local.get $2
   i32.store
  )
- (func $~lib/typedarray/Int32Array#__get (; 47 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#__get (; 69 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -2807,7 +2945,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 664
+   i32.const 743
    i32.const 63
    call $~lib/builtins/abort
    unreachable
@@ -2820,7 +2958,7 @@
   i32.add
   i32.load
  )
- (func $~lib/typedarray/Int32Array#subarray (; 48 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#subarray (; 70 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2927,7 +3065,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $~lib/typedarray/Float64Array#__set (; 49 ;) (param $0 i32) (param $1 i32) (param $2 f64)
+ (func $~lib/typedarray/Float64Array#__set (; 71 ;) (param $0 i32) (param $1 i32) (param $2 f64)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -2937,7 +3075,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 1315
+   i32.const 1459
    i32.const 63
    call $~lib/builtins/abort
    unreachable
@@ -2951,7 +3089,7 @@
   local.get $2
   f64.store
  )
- (func $~lib/typedarray/Float64Array#subarray (; 50 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#subarray (; 72 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3058,11 +3196,11 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $~setArgumentsLength (; 51 ;) (param $0 i32)
+ (func $~setArgumentsLength (; 73 ;) (param $0 i32)
   local.get $0
   global.set $~argumentsLength
  )
- (func $~lib/util/sort/insertionSort<f64> (; 52 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/sort/insertionSort<f64> (; 74 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 f64)
@@ -3152,7 +3290,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/checkUsedBlock (; 53 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/tlsf/checkUsedBlock (; 75 ;) (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   i32.const 16
@@ -3190,7 +3328,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 570
    i32.const 2
    call $~lib/builtins/abort
@@ -3198,7 +3336,7 @@
   end
   local.get $1
  )
- (func $~lib/rt/tlsf/freeBlock (; 54 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/freeBlock (; 76 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $1
   i32.load
@@ -3214,13 +3352,13 @@
   local.get $1
   call $~lib/rt/rtrace/onfree
  )
- (func $~lib/rt/tlsf/__free (; 55 ;) (param $0 i32)
+ (func $~lib/rt/tlsf/__free (; 77 ;) (param $0 i32)
   call $~lib/rt/tlsf/maybeInitialize
   local.get $0
   call $~lib/rt/tlsf/checkUsedBlock
   call $~lib/rt/tlsf/freeBlock
  )
- (func $~lib/util/sort/weakHeapSort<f64> (; 56 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/sort/weakHeapSort<f64> (; 78 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3509,7 +3647,7 @@
   local.get $12
   f64.store
  )
- (func $~lib/typedarray/Float64Array#sort (; 57 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#sort (; 79 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3590,7 +3728,7 @@
    local.get $3
   end
  )
- (func $~lib/util/sort/COMPARATOR<f64>~anonymous|0 (; 58 ;) (param $0 f64) (param $1 f64) (result i32)
+ (func $~lib/util/sort/COMPARATOR<f64>~anonymous|0 (; 80 ;) (param $0 f64) (param $1 f64) (result i32)
   (local $2 i64)
   (local $3 i64)
   local.get $0
@@ -3623,7 +3761,7 @@
   i64.lt_s
   i32.sub
  )
- (func $~lib/typedarray/Float64Array#sort|trampoline (; 59 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#sort|trampoline (; 81 ;) (param $0 i32) (param $1 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -3642,7 +3780,7 @@
   local.get $1
   call $~lib/typedarray/Float64Array#sort
  )
- (func $~lib/typedarray/Float64Array#__get (; 60 ;) (param $0 i32) (param $1 i32) (result f64)
+ (func $~lib/typedarray/Float64Array#__get (; 82 ;) (param $0 i32) (param $1 i32) (result f64)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -3652,7 +3790,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 1304
+   i32.const 1448
    i32.const 63
    call $~lib/builtins/abort
    unreachable
@@ -3665,7 +3803,7 @@
   i32.add
   f64.load
  )
- (func $~lib/typedarray/Uint8ClampedArray#__set (; 61 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint8ClampedArray#__set (; 83 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -3673,7 +3811,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 291
+   i32.const 331
    i32.const 44
    call $~lib/builtins/abort
    unreachable
@@ -3697,7 +3835,7 @@
   i32.and
   i32.store8
  )
- (func $~lib/typedarray/Uint8ClampedArray#__get (; 62 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8ClampedArray#__get (; 84 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -3705,7 +3843,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 280
+   i32.const 320
    i32.const 44
    call $~lib/builtins/abort
    unreachable
@@ -3716,7 +3854,7 @@
   i32.add
   i32.load8_u
  )
- (func $~lib/typedarray/Int8Array#__set (; 63 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int8Array#__set (; 85 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -3724,7 +3862,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 35
+   i32.const 49
    i32.const 44
    call $~lib/builtins/abort
    unreachable
@@ -3736,7 +3874,7 @@
   local.get $2
   i32.store8
  )
- (func $~lib/typedarray/Int8Array#fill (; 64 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#fill (; 86 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -3825,7 +3963,7 @@
   end
   local.get $7
  )
- (func $~lib/util/memory/memcpy (; 65 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/memory/memcpy (; 87 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -4849,7 +4987,7 @@
    i32.store8
   end
  )
- (func $~lib/memory/memory.copy (; 66 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/memory/memory.copy (; 88 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -5069,7 +5207,7 @@
    end
   end
  )
- (func $~lib/rt/__allocArray (; 67 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $~lib/rt/__allocArray (; 89 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -5107,11 +5245,11 @@
   end
   local.get $4
  )
- (func $~lib/array/Array<i8>#get:length (; 68 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<i8>#get:length (; 90 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/typedarray/Int8Array#__get (; 69 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#__get (; 91 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -5119,7 +5257,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 24
+   i32.const 38
    i32.const 44
    call $~lib/builtins/abort
    unreachable
@@ -5130,7 +5268,7 @@
   i32.add
   i32.load8_s
  )
- (func $~lib/array/Array<i8>#__unchecked_get (; 70 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i8>#__unchecked_get (; 92 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -5139,7 +5277,7 @@
   i32.add
   i32.load8_s
  )
- (func $~lib/array/Array<i8>#__get (; 71 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i8>#__get (; 93 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   local.get $0
@@ -5148,7 +5286,7 @@
   if
    i32.const 368
    i32.const 528
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -5159,7 +5297,7 @@
   local.set $2
   local.get $2
  )
- (func $std/typedarray/isInt8ArrayEqual (; 72 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/typedarray/isInt8ArrayEqual (; 94 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5229,7 +5367,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Int8Array#subarray (; 73 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#subarray (; 95 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -5336,7 +5474,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $~lib/typedarray/Int32Array#fill (; 74 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#fill (; 96 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -5433,11 +5571,11 @@
   end
   local.get $7
  )
- (func $~lib/array/Array<i32>#get:length (; 75 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<i32>#get:length (; 97 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<i32>#__unchecked_get (; 76 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#__unchecked_get (; 98 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -5446,7 +5584,7 @@
   i32.add
   i32.load
  )
- (func $~lib/array/Array<i32>#__get (; 77 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#__get (; 99 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   local.get $0
@@ -5455,7 +5593,7 @@
   if
    i32.const 368
    i32.const 528
-   i32.const 93
+   i32.const 98
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -5466,7 +5604,7 @@
   local.set $2
   local.get $2
  )
- (func $std/typedarray/isInt32ArrayEqual (; 78 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/typedarray/isInt32ArrayEqual (; 100 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5536,7 +5674,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Int32Array#slice (; 79 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#slice (; 101 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -5641,7 +5779,7 @@
   call $~lib/rt/pure/__release
   local.get $9
  )
- (func $~lib/typedarray/Int32Array#copyWithin (; 80 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#copyWithin (; 102 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -5781,7 +5919,7 @@
   call $~lib/memory/memory.copy
   local.get $7
  )
- (func $std/typedarray/testReduce<~lib/typedarray/Int8Array,i8>~anonymous|0 (; 81 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduce<~lib/typedarray/Int8Array,i8>~anonymous|0 (; 103 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -5794,7 +5932,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/typedarray/Int8Array#reduce<i8> (; 82 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#reduce<i8> (; 104 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -5851,7 +5989,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $std/typedarray/testReduce<~lib/typedarray/Int8Array,i8> (; 83 ;)
+ (func $std/typedarray/testReduce<~lib/typedarray/Int8Array,i8> (; 105 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -5899,7 +6037,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8Array#__set (; 84 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint8Array#__set (; 106 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -5907,7 +6045,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 163
+   i32.const 190
    i32.const 44
    call $~lib/builtins/abort
    unreachable
@@ -5919,7 +6057,7 @@
   local.get $2
   i32.store8
  )
- (func $std/typedarray/testReduce<~lib/typedarray/Uint8Array,u8>~anonymous|0 (; 85 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduce<~lib/typedarray/Uint8Array,u8>~anonymous|0 (; 107 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -5932,7 +6070,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/typedarray/Uint8Array#reduce<u8> (; 86 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#reduce<u8> (; 108 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -5989,7 +6127,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $std/typedarray/testReduce<~lib/typedarray/Uint8Array,u8> (; 87 ;)
+ (func $std/typedarray/testReduce<~lib/typedarray/Uint8Array,u8> (; 109 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -6035,7 +6173,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testReduce<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|0 (; 88 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduce<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|0 (; 110 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -6048,7 +6186,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/typedarray/Uint8ClampedArray#reduce<u8> (; 89 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint8ClampedArray#reduce<u8> (; 111 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -6105,7 +6243,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $std/typedarray/testReduce<~lib/typedarray/Uint8ClampedArray,u8> (; 90 ;)
+ (func $std/typedarray/testReduce<~lib/typedarray/Uint8ClampedArray,u8> (; 112 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -6151,7 +6289,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int16Array#__set (; 91 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int16Array#__set (; 113 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -6161,7 +6299,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 419
+   i32.const 472
    i32.const 63
    call $~lib/builtins/abort
    unreachable
@@ -6175,7 +6313,7 @@
   local.get $2
   i32.store16
  )
- (func $std/typedarray/testReduce<~lib/typedarray/Int16Array,i16>~anonymous|0 (; 92 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduce<~lib/typedarray/Int16Array,i16>~anonymous|0 (; 114 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -6188,7 +6326,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/typedarray/Int16Array#reduce<i16> (; 93 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#reduce<i16> (; 115 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -6245,7 +6383,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $std/typedarray/testReduce<~lib/typedarray/Int16Array,i16> (; 94 ;)
+ (func $std/typedarray/testReduce<~lib/typedarray/Int16Array,i16> (; 116 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -6293,7 +6431,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint16Array#__set (; 95 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint16Array#__set (; 117 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -6303,7 +6441,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 547
+   i32.const 613
    i32.const 63
    call $~lib/builtins/abort
    unreachable
@@ -6317,7 +6455,7 @@
   local.get $2
   i32.store16
  )
- (func $std/typedarray/testReduce<~lib/typedarray/Uint16Array,u16>~anonymous|0 (; 96 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduce<~lib/typedarray/Uint16Array,u16>~anonymous|0 (; 118 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -6330,7 +6468,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/typedarray/Uint16Array#reduce<u16> (; 97 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#reduce<u16> (; 119 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -6387,7 +6525,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $std/typedarray/testReduce<~lib/typedarray/Uint16Array,u16> (; 98 ;)
+ (func $std/typedarray/testReduce<~lib/typedarray/Uint16Array,u16> (; 120 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -6433,7 +6571,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testReduce<~lib/typedarray/Int32Array,i32>~anonymous|0 (; 99 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduce<~lib/typedarray/Int32Array,i32>~anonymous|0 (; 121 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -6446,7 +6584,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/typedarray/Int32Array#reduce<i32> (; 100 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#reduce<i32> (; 122 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -6503,7 +6641,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $std/typedarray/testReduce<~lib/typedarray/Int32Array,i32> (; 101 ;)
+ (func $std/typedarray/testReduce<~lib/typedarray/Int32Array,i32> (; 123 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -6547,7 +6685,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint32Array#__set (; 102 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint32Array#__set (; 124 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -6557,7 +6695,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 803
+   i32.const 895
    i32.const 63
    call $~lib/builtins/abort
    unreachable
@@ -6571,7 +6709,7 @@
   local.get $2
   i32.store
  )
- (func $std/typedarray/testReduce<~lib/typedarray/Uint32Array,u32>~anonymous|0 (; 103 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduce<~lib/typedarray/Uint32Array,u32>~anonymous|0 (; 125 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -6584,7 +6722,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/typedarray/Uint32Array#reduce<u32> (; 104 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint32Array#reduce<u32> (; 126 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -6641,7 +6779,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $std/typedarray/testReduce<~lib/typedarray/Uint32Array,u32> (; 105 ;)
+ (func $std/typedarray/testReduce<~lib/typedarray/Uint32Array,u32> (; 127 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -6685,7 +6823,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int64Array#__set (; 106 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $~lib/typedarray/Int64Array#__set (; 128 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -6695,7 +6833,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 931
+   i32.const 1036
    i32.const 63
    call $~lib/builtins/abort
    unreachable
@@ -6709,7 +6847,7 @@
   local.get $2
   i64.store
  )
- (func $std/typedarray/testReduce<~lib/typedarray/Int64Array,i64>~anonymous|0 (; 107 ;) (param $0 i64) (param $1 i64) (param $2 i32) (param $3 i32) (result i64)
+ (func $std/typedarray/testReduce<~lib/typedarray/Int64Array,i64>~anonymous|0 (; 129 ;) (param $0 i64) (param $1 i64) (param $2 i32) (param $3 i32) (result i64)
   (local $4 i64)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -6722,7 +6860,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/typedarray/Int64Array#reduce<i64> (; 108 ;) (param $0 i32) (param $1 i32) (param $2 i64) (result i64)
+ (func $~lib/typedarray/Int64Array#reduce<i64> (; 130 ;) (param $0 i32) (param $1 i32) (param $2 i64) (result i64)
   (local $3 i64)
   (local $4 i32)
   (local $5 i32)
@@ -6780,7 +6918,7 @@
   call $~lib/rt/pure/__release
   local.get $10
  )
- (func $std/typedarray/testReduce<~lib/typedarray/Int64Array,i64> (; 109 ;)
+ (func $std/typedarray/testReduce<~lib/typedarray/Int64Array,i64> (; 131 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i64)
@@ -6824,7 +6962,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint64Array#__set (; 110 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $~lib/typedarray/Uint64Array#__set (; 132 ;) (param $0 i32) (param $1 i32) (param $2 i64)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -6834,7 +6972,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 1059
+   i32.const 1177
    i32.const 63
    call $~lib/builtins/abort
    unreachable
@@ -6848,7 +6986,7 @@
   local.get $2
   i64.store
  )
- (func $std/typedarray/testReduce<~lib/typedarray/Uint64Array,u64>~anonymous|0 (; 111 ;) (param $0 i64) (param $1 i64) (param $2 i32) (param $3 i32) (result i64)
+ (func $std/typedarray/testReduce<~lib/typedarray/Uint64Array,u64>~anonymous|0 (; 133 ;) (param $0 i64) (param $1 i64) (param $2 i32) (param $3 i32) (result i64)
   (local $4 i64)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -6861,7 +6999,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/typedarray/Uint64Array#reduce<u64> (; 112 ;) (param $0 i32) (param $1 i32) (param $2 i64) (result i64)
+ (func $~lib/typedarray/Uint64Array#reduce<u64> (; 134 ;) (param $0 i32) (param $1 i32) (param $2 i64) (result i64)
   (local $3 i64)
   (local $4 i32)
   (local $5 i32)
@@ -6919,7 +7057,7 @@
   call $~lib/rt/pure/__release
   local.get $10
  )
- (func $std/typedarray/testReduce<~lib/typedarray/Uint64Array,u64> (; 113 ;)
+ (func $std/typedarray/testReduce<~lib/typedarray/Uint64Array,u64> (; 135 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i64)
@@ -6963,7 +7101,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float32Array#__set (; 114 ;) (param $0 i32) (param $1 i32) (param $2 f32)
+ (func $~lib/typedarray/Float32Array#__set (; 136 ;) (param $0 i32) (param $1 i32) (param $2 f32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -6973,7 +7111,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 1187
+   i32.const 1318
    i32.const 63
    call $~lib/builtins/abort
    unreachable
@@ -6987,7 +7125,7 @@
   local.get $2
   f32.store
  )
- (func $std/typedarray/testReduce<~lib/typedarray/Float32Array,f32>~anonymous|0 (; 115 ;) (param $0 f32) (param $1 f32) (param $2 i32) (param $3 i32) (result f32)
+ (func $std/typedarray/testReduce<~lib/typedarray/Float32Array,f32>~anonymous|0 (; 137 ;) (param $0 f32) (param $1 f32) (param $2 i32) (param $3 i32) (result f32)
   (local $4 f32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -7000,7 +7138,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/typedarray/Float32Array#reduce<f32> (; 116 ;) (param $0 i32) (param $1 i32) (param $2 f32) (result f32)
+ (func $~lib/typedarray/Float32Array#reduce<f32> (; 138 ;) (param $0 i32) (param $1 i32) (param $2 f32) (result f32)
   (local $3 f32)
   (local $4 i32)
   (local $5 i32)
@@ -7058,7 +7196,7 @@
   call $~lib/rt/pure/__release
   local.get $10
  )
- (func $std/typedarray/testReduce<~lib/typedarray/Float32Array,f32> (; 117 ;)
+ (func $std/typedarray/testReduce<~lib/typedarray/Float32Array,f32> (; 139 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 f32)
@@ -7102,7 +7240,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testReduce<~lib/typedarray/Float64Array,f64>~anonymous|0 (; 118 ;) (param $0 f64) (param $1 f64) (param $2 i32) (param $3 i32) (result f64)
+ (func $std/typedarray/testReduce<~lib/typedarray/Float64Array,f64>~anonymous|0 (; 140 ;) (param $0 f64) (param $1 f64) (param $2 i32) (param $3 i32) (result f64)
   (local $4 f64)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -7115,7 +7253,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/typedarray/Float64Array#reduce<f64> (; 119 ;) (param $0 i32) (param $1 i32) (param $2 f64) (result f64)
+ (func $~lib/typedarray/Float64Array#reduce<f64> (; 141 ;) (param $0 i32) (param $1 i32) (param $2 f64) (result f64)
   (local $3 f64)
   (local $4 i32)
   (local $5 i32)
@@ -7173,7 +7311,7 @@
   call $~lib/rt/pure/__release
   local.get $10
  )
- (func $std/typedarray/testReduce<~lib/typedarray/Float64Array,f64> (; 120 ;)
+ (func $std/typedarray/testReduce<~lib/typedarray/Float64Array,f64> (; 142 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 f64)
@@ -7217,7 +7355,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testReduceRight<~lib/typedarray/Int8Array,i8>~anonymous|0 (; 121 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Int8Array,i8>~anonymous|0 (; 143 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -7230,7 +7368,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/typedarray/Int8Array#reduceRight<i8> (; 122 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#reduceRight<i8> (; 144 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -7286,7 +7424,7 @@
   call $~lib/rt/pure/__release
   local.get $7
  )
- (func $std/typedarray/testReduceRight<~lib/typedarray/Int8Array,i8> (; 123 ;)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Int8Array,i8> (; 145 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -7334,7 +7472,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testReduceRight<~lib/typedarray/Uint8Array,u8>~anonymous|0 (; 124 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Uint8Array,u8>~anonymous|0 (; 146 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -7347,7 +7485,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/typedarray/Uint8Array#reduceRight<u8> (; 125 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#reduceRight<u8> (; 147 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -7403,7 +7541,7 @@
   call $~lib/rt/pure/__release
   local.get $7
  )
- (func $std/typedarray/testReduceRight<~lib/typedarray/Uint8Array,u8> (; 126 ;)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Uint8Array,u8> (; 148 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -7449,7 +7587,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testReduceRight<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|0 (; 127 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|0 (; 149 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -7462,7 +7600,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/typedarray/Uint8ClampedArray#reduceRight<u8> (; 128 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint8ClampedArray#reduceRight<u8> (; 150 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -7518,7 +7656,7 @@
   call $~lib/rt/pure/__release
   local.get $7
  )
- (func $std/typedarray/testReduceRight<~lib/typedarray/Uint8ClampedArray,u8> (; 129 ;)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Uint8ClampedArray,u8> (; 151 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -7564,7 +7702,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testReduceRight<~lib/typedarray/Int16Array,i16>~anonymous|0 (; 130 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Int16Array,i16>~anonymous|0 (; 152 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -7577,7 +7715,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/typedarray/Int16Array#reduceRight<i16> (; 131 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#reduceRight<i16> (; 153 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -7633,7 +7771,7 @@
   call $~lib/rt/pure/__release
   local.get $7
  )
- (func $std/typedarray/testReduceRight<~lib/typedarray/Int16Array,i16> (; 132 ;)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Int16Array,i16> (; 154 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -7681,7 +7819,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testReduceRight<~lib/typedarray/Uint16Array,u16>~anonymous|0 (; 133 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Uint16Array,u16>~anonymous|0 (; 155 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -7694,7 +7832,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/typedarray/Uint16Array#reduceRight<u16> (; 134 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#reduceRight<u16> (; 156 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -7750,7 +7888,7 @@
   call $~lib/rt/pure/__release
   local.get $7
  )
- (func $std/typedarray/testReduceRight<~lib/typedarray/Uint16Array,u16> (; 135 ;)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Uint16Array,u16> (; 157 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -7796,7 +7934,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testReduceRight<~lib/typedarray/Int32Array,i32>~anonymous|0 (; 136 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Int32Array,i32>~anonymous|0 (; 158 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -7809,7 +7947,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/typedarray/Int32Array#reduceRight<i32> (; 137 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#reduceRight<i32> (; 159 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -7865,7 +8003,7 @@
   call $~lib/rt/pure/__release
   local.get $7
  )
- (func $std/typedarray/testReduceRight<~lib/typedarray/Int32Array,i32> (; 138 ;)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Int32Array,i32> (; 160 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -7909,7 +8047,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testReduceRight<~lib/typedarray/Uint32Array,u32>~anonymous|0 (; 139 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Uint32Array,u32>~anonymous|0 (; 161 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -7922,7 +8060,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/typedarray/Uint32Array#reduceRight<u32> (; 140 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint32Array#reduceRight<u32> (; 162 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -7978,7 +8116,7 @@
   call $~lib/rt/pure/__release
   local.get $7
  )
- (func $std/typedarray/testReduceRight<~lib/typedarray/Uint32Array,u32> (; 141 ;)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Uint32Array,u32> (; 163 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -8022,7 +8160,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testReduceRight<~lib/typedarray/Int64Array,i64>~anonymous|0 (; 142 ;) (param $0 i64) (param $1 i64) (param $2 i32) (param $3 i32) (result i64)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Int64Array,i64>~anonymous|0 (; 164 ;) (param $0 i64) (param $1 i64) (param $2 i32) (param $3 i32) (result i64)
   (local $4 i64)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -8035,7 +8173,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/typedarray/Int64Array#reduceRight<i64> (; 143 ;) (param $0 i32) (param $1 i32) (param $2 i64) (result i64)
+ (func $~lib/typedarray/Int64Array#reduceRight<i64> (; 165 ;) (param $0 i32) (param $1 i32) (param $2 i64) (result i64)
   (local $3 i64)
   (local $4 i32)
   (local $5 i32)
@@ -8092,7 +8230,7 @@
   call $~lib/rt/pure/__release
   local.get $9
  )
- (func $std/typedarray/testReduceRight<~lib/typedarray/Int64Array,i64> (; 144 ;)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Int64Array,i64> (; 166 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i64)
@@ -8136,7 +8274,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testReduceRight<~lib/typedarray/Uint64Array,u64>~anonymous|0 (; 145 ;) (param $0 i64) (param $1 i64) (param $2 i32) (param $3 i32) (result i64)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Uint64Array,u64>~anonymous|0 (; 167 ;) (param $0 i64) (param $1 i64) (param $2 i32) (param $3 i32) (result i64)
   (local $4 i64)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -8149,7 +8287,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/typedarray/Uint64Array#reduceRight<u64> (; 146 ;) (param $0 i32) (param $1 i32) (param $2 i64) (result i64)
+ (func $~lib/typedarray/Uint64Array#reduceRight<u64> (; 168 ;) (param $0 i32) (param $1 i32) (param $2 i64) (result i64)
   (local $3 i64)
   (local $4 i32)
   (local $5 i32)
@@ -8206,7 +8344,7 @@
   call $~lib/rt/pure/__release
   local.get $9
  )
- (func $std/typedarray/testReduceRight<~lib/typedarray/Uint64Array,u64> (; 147 ;)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Uint64Array,u64> (; 169 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i64)
@@ -8250,7 +8388,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testReduceRight<~lib/typedarray/Float32Array,f32>~anonymous|0 (; 148 ;) (param $0 f32) (param $1 f32) (param $2 i32) (param $3 i32) (result f32)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Float32Array,f32>~anonymous|0 (; 170 ;) (param $0 f32) (param $1 f32) (param $2 i32) (param $3 i32) (result f32)
   (local $4 f32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -8263,7 +8401,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/typedarray/Float32Array#reduceRight<f32> (; 149 ;) (param $0 i32) (param $1 i32) (param $2 f32) (result f32)
+ (func $~lib/typedarray/Float32Array#reduceRight<f32> (; 171 ;) (param $0 i32) (param $1 i32) (param $2 f32) (result f32)
   (local $3 f32)
   (local $4 i32)
   (local $5 i32)
@@ -8320,7 +8458,7 @@
   call $~lib/rt/pure/__release
   local.get $9
  )
- (func $std/typedarray/testReduceRight<~lib/typedarray/Float32Array,f32> (; 150 ;)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Float32Array,f32> (; 172 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 f32)
@@ -8364,7 +8502,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testReduceRight<~lib/typedarray/Float64Array,f64>~anonymous|0 (; 151 ;) (param $0 f64) (param $1 f64) (param $2 i32) (param $3 i32) (result f64)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Float64Array,f64>~anonymous|0 (; 173 ;) (param $0 f64) (param $1 f64) (param $2 i32) (param $3 i32) (result f64)
   (local $4 f64)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -8377,7 +8515,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/typedarray/Float64Array#reduceRight<f64> (; 152 ;) (param $0 i32) (param $1 i32) (param $2 f64) (result f64)
+ (func $~lib/typedarray/Float64Array#reduceRight<f64> (; 174 ;) (param $0 i32) (param $1 i32) (param $2 f64) (result f64)
   (local $3 f64)
   (local $4 i32)
   (local $5 i32)
@@ -8434,7 +8572,7 @@
   call $~lib/rt/pure/__release
   local.get $9
  )
- (func $std/typedarray/testReduceRight<~lib/typedarray/Float64Array,f64> (; 153 ;)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Float64Array,f64> (; 175 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 f64)
@@ -8478,7 +8616,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayMap<~lib/typedarray/Int8Array,i8>~anonymous|0 (; 154 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Int8Array,i8>~anonymous|0 (; 176 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -8491,7 +8629,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Int8Array#map (; 155 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#map (; 177 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -8575,7 +8713,7 @@
   call $~lib/rt/pure/__release
   local.get $9
  )
- (func $std/typedarray/testArrayMap<~lib/typedarray/Int8Array,i8> (; 156 ;)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Int8Array,i8> (; 178 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -8650,7 +8788,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayMap<~lib/typedarray/Uint8Array,u8>~anonymous|0 (; 157 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Uint8Array,u8>~anonymous|0 (; 179 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -8663,7 +8801,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Uint8Array#map (; 158 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#map (; 180 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -8747,7 +8885,7 @@
   call $~lib/rt/pure/__release
   local.get $9
  )
- (func $~lib/typedarray/Uint8Array#__get (; 159 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#__get (; 181 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -8755,7 +8893,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 152
+   i32.const 179
    i32.const 44
    call $~lib/builtins/abort
    unreachable
@@ -8766,7 +8904,7 @@
   i32.add
   i32.load8_u
  )
- (func $std/typedarray/testArrayMap<~lib/typedarray/Uint8Array,u8> (; 160 ;)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Uint8Array,u8> (; 182 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -8841,7 +8979,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayMap<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|0 (; 161 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|0 (; 183 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -8854,7 +8992,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Uint8ClampedArray#map (; 162 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8ClampedArray#map (; 184 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -8938,7 +9076,7 @@
   call $~lib/rt/pure/__release
   local.get $9
  )
- (func $std/typedarray/testArrayMap<~lib/typedarray/Uint8ClampedArray,u8> (; 163 ;)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Uint8ClampedArray,u8> (; 185 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -9013,7 +9151,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayMap<~lib/typedarray/Int16Array,i16>~anonymous|0 (; 164 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Int16Array,i16>~anonymous|0 (; 186 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -9026,7 +9164,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Int16Array#map (; 165 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#map (; 187 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9110,7 +9248,7 @@
   call $~lib/rt/pure/__release
   local.get $9
  )
- (func $~lib/typedarray/Int16Array#__get (; 166 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#__get (; 188 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -9120,7 +9258,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 408
+   i32.const 461
    i32.const 63
    call $~lib/builtins/abort
    unreachable
@@ -9133,7 +9271,7 @@
   i32.add
   i32.load16_s
  )
- (func $std/typedarray/testArrayMap<~lib/typedarray/Int16Array,i16> (; 167 ;)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Int16Array,i16> (; 189 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -9208,7 +9346,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayMap<~lib/typedarray/Uint16Array,u16>~anonymous|0 (; 168 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Uint16Array,u16>~anonymous|0 (; 190 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -9221,7 +9359,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Uint16Array#map (; 169 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#map (; 191 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9305,7 +9443,7 @@
   call $~lib/rt/pure/__release
   local.get $9
  )
- (func $~lib/typedarray/Uint16Array#__get (; 170 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#__get (; 192 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -9315,7 +9453,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 536
+   i32.const 602
    i32.const 63
    call $~lib/builtins/abort
    unreachable
@@ -9328,7 +9466,7 @@
   i32.add
   i32.load16_u
  )
- (func $std/typedarray/testArrayMap<~lib/typedarray/Uint16Array,u16> (; 171 ;)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Uint16Array,u16> (; 193 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -9403,7 +9541,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayMap<~lib/typedarray/Int32Array,i32>~anonymous|0 (; 172 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Int32Array,i32>~anonymous|0 (; 194 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -9416,7 +9554,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Int32Array#map (; 173 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#map (; 195 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9500,7 +9638,7 @@
   call $~lib/rt/pure/__release
   local.get $9
  )
- (func $std/typedarray/testArrayMap<~lib/typedarray/Int32Array,i32> (; 174 ;)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Int32Array,i32> (; 196 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -9575,7 +9713,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayMap<~lib/typedarray/Uint32Array,u32>~anonymous|0 (; 175 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Uint32Array,u32>~anonymous|0 (; 197 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -9588,7 +9726,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Uint32Array#map (; 176 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint32Array#map (; 198 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9672,7 +9810,7 @@
   call $~lib/rt/pure/__release
   local.get $9
  )
- (func $~lib/typedarray/Uint32Array#__get (; 177 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint32Array#__get (; 199 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -9682,7 +9820,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 792
+   i32.const 884
    i32.const 63
    call $~lib/builtins/abort
    unreachable
@@ -9695,7 +9833,7 @@
   i32.add
   i32.load
  )
- (func $std/typedarray/testArrayMap<~lib/typedarray/Uint32Array,u32> (; 178 ;)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Uint32Array,u32> (; 200 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -9770,7 +9908,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayMap<~lib/typedarray/Int64Array,i64>~anonymous|0 (; 179 ;) (param $0 i64) (param $1 i32) (param $2 i32) (result i64)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Int64Array,i64>~anonymous|0 (; 201 ;) (param $0 i64) (param $1 i32) (param $2 i32) (result i64)
   (local $3 i64)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -9783,7 +9921,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Int64Array#map (; 180 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int64Array#map (; 202 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9867,7 +10005,7 @@
   call $~lib/rt/pure/__release
   local.get $9
  )
- (func $~lib/typedarray/Int64Array#__get (; 181 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $~lib/typedarray/Int64Array#__get (; 203 ;) (param $0 i32) (param $1 i32) (result i64)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -9877,7 +10015,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 920
+   i32.const 1025
    i32.const 63
    call $~lib/builtins/abort
    unreachable
@@ -9890,7 +10028,7 @@
   i32.add
   i64.load
  )
- (func $std/typedarray/testArrayMap<~lib/typedarray/Int64Array,i64> (; 182 ;)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Int64Array,i64> (; 204 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -9965,7 +10103,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayMap<~lib/typedarray/Uint64Array,u64>~anonymous|0 (; 183 ;) (param $0 i64) (param $1 i32) (param $2 i32) (result i64)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Uint64Array,u64>~anonymous|0 (; 205 ;) (param $0 i64) (param $1 i32) (param $2 i32) (result i64)
   (local $3 i64)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -9978,7 +10116,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Uint64Array#map (; 184 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint64Array#map (; 206 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10062,7 +10200,7 @@
   call $~lib/rt/pure/__release
   local.get $9
  )
- (func $~lib/typedarray/Uint64Array#__get (; 185 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $~lib/typedarray/Uint64Array#__get (; 207 ;) (param $0 i32) (param $1 i32) (result i64)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -10072,7 +10210,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 1048
+   i32.const 1166
    i32.const 63
    call $~lib/builtins/abort
    unreachable
@@ -10085,7 +10223,7 @@
   i32.add
   i64.load
  )
- (func $std/typedarray/testArrayMap<~lib/typedarray/Uint64Array,u64> (; 186 ;)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Uint64Array,u64> (; 208 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -10160,7 +10298,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayMap<~lib/typedarray/Float32Array,f32>~anonymous|0 (; 187 ;) (param $0 f32) (param $1 i32) (param $2 i32) (result f32)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Float32Array,f32>~anonymous|0 (; 209 ;) (param $0 f32) (param $1 i32) (param $2 i32) (result f32)
   (local $3 f32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -10173,7 +10311,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Float32Array#map (; 188 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#map (; 210 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10257,7 +10395,7 @@
   call $~lib/rt/pure/__release
   local.get $9
  )
- (func $~lib/typedarray/Float32Array#__get (; 189 ;) (param $0 i32) (param $1 i32) (result f32)
+ (func $~lib/typedarray/Float32Array#__get (; 211 ;) (param $0 i32) (param $1 i32) (result f32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -10267,7 +10405,7 @@
   if
    i32.const 368
    i32.const 432
-   i32.const 1176
+   i32.const 1307
    i32.const 63
    call $~lib/builtins/abort
    unreachable
@@ -10280,7 +10418,7 @@
   i32.add
   f32.load
  )
- (func $std/typedarray/testArrayMap<~lib/typedarray/Float32Array,f32> (; 190 ;)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Float32Array,f32> (; 212 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -10355,7 +10493,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayMap<~lib/typedarray/Float64Array,f64>~anonymous|0 (; 191 ;) (param $0 f64) (param $1 i32) (param $2 i32) (result f64)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Float64Array,f64>~anonymous|0 (; 213 ;) (param $0 f64) (param $1 i32) (param $2 i32) (result f64)
   (local $3 f64)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -10368,7 +10506,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Float64Array#map (; 192 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#map (; 214 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10452,7 +10590,7 @@
   call $~lib/rt/pure/__release
   local.get $9
  )
- (func $std/typedarray/testArrayMap<~lib/typedarray/Float64Array,f64> (; 193 ;)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Float64Array,f64> (; 215 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -10527,7 +10665,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Int8Array,i8>~anonymous|0 (; 194 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Int8Array,i8>~anonymous|0 (; 216 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -10544,7 +10682,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/rt/tlsf/reallocateBlock (; 195 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/reallocateBlock (; 217 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -10663,7 +10801,7 @@
   end
   local.get $8
  )
- (func $~lib/rt/tlsf/__realloc (; 196 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/__realloc (; 218 ;) (param $0 i32) (param $1 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
   local.get $0
   call $~lib/rt/tlsf/checkUsedBlock
@@ -10672,7 +10810,7 @@
   i32.const 16
   i32.add
  )
- (func $~lib/typedarray/Int8Array#filter (; 197 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#filter (; 219 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10764,11 +10902,11 @@
   call $~lib/rt/pure/__retain
   i32.store
   local.get $5
-  local.get $9
-  i32.store offset=8
-  local.get $5
   local.get $10
   i32.store offset=4
+  local.get $5
+  local.get $9
+  i32.store offset=8
   local.get $5
   call $~lib/rt/pure/__retain
   local.set $11
@@ -10776,7 +10914,7 @@
   call $~lib/rt/pure/__release
   local.get $11
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Int8Array,i8> (; 198 ;)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Int8Array,i8> (; 220 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -10811,7 +10949,7 @@
   call $~lib/typedarray/Int8Array#filter
   local.set $2
   local.get $2
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Int8Array#get:byteOffset
   i32.const 0
   i32.eq
   i32.eqz
@@ -10885,7 +11023,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint8Array,u8>~anonymous|0 (; 199 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint8Array,u8>~anonymous|0 (; 221 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -10900,7 +11038,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Uint8Array#filter (; 200 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#filter (; 222 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10992,11 +11130,11 @@
   call $~lib/rt/pure/__retain
   i32.store
   local.get $5
-  local.get $9
-  i32.store offset=8
-  local.get $5
   local.get $10
   i32.store offset=4
+  local.get $5
+  local.get $9
+  i32.store offset=8
   local.get $5
   call $~lib/rt/pure/__retain
   local.set $11
@@ -11004,7 +11142,7 @@
   call $~lib/rt/pure/__release
   local.get $11
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint8Array,u8> (; 201 ;)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint8Array,u8> (; 223 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -11039,7 +11177,7 @@
   call $~lib/typedarray/Uint8Array#filter
   local.set $2
   local.get $2
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Uint8Array#get:byteOffset
   i32.const 0
   i32.eq
   i32.eqz
@@ -11113,7 +11251,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|0 (; 202 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|0 (; 224 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -11128,7 +11266,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Uint8ClampedArray#filter (; 203 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8ClampedArray#filter (; 225 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -11220,11 +11358,11 @@
   call $~lib/rt/pure/__retain
   i32.store
   local.get $5
-  local.get $9
-  i32.store offset=8
-  local.get $5
   local.get $10
   i32.store offset=4
+  local.get $5
+  local.get $9
+  i32.store offset=8
   local.get $5
   call $~lib/rt/pure/__retain
   local.set $11
@@ -11232,7 +11370,7 @@
   call $~lib/rt/pure/__release
   local.get $11
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint8ClampedArray,u8> (; 204 ;)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint8ClampedArray,u8> (; 226 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -11267,7 +11405,7 @@
   call $~lib/typedarray/Uint8ClampedArray#filter
   local.set $2
   local.get $2
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Uint8ClampedArray#get:byteOffset
   i32.const 0
   i32.eq
   i32.eqz
@@ -11341,7 +11479,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Int16Array,i16>~anonymous|0 (; 205 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Int16Array,i16>~anonymous|0 (; 227 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -11358,7 +11496,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Int16Array#filter (; 206 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#filter (; 228 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -11450,11 +11588,11 @@
   call $~lib/rt/pure/__retain
   i32.store
   local.get $5
-  local.get $9
-  i32.store offset=8
-  local.get $5
   local.get $10
   i32.store offset=4
+  local.get $5
+  local.get $9
+  i32.store offset=8
   local.get $5
   call $~lib/rt/pure/__retain
   local.set $11
@@ -11462,7 +11600,7 @@
   call $~lib/rt/pure/__release
   local.get $11
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Int16Array,i16> (; 207 ;)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Int16Array,i16> (; 229 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -11497,7 +11635,7 @@
   call $~lib/typedarray/Int16Array#filter
   local.set $2
   local.get $2
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Int16Array#get:byteOffset
   i32.const 0
   i32.eq
   i32.eqz
@@ -11571,7 +11709,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint16Array,u16>~anonymous|0 (; 208 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint16Array,u16>~anonymous|0 (; 230 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -11586,7 +11724,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Uint16Array#filter (; 209 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#filter (; 231 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -11678,11 +11816,11 @@
   call $~lib/rt/pure/__retain
   i32.store
   local.get $5
-  local.get $9
-  i32.store offset=8
-  local.get $5
   local.get $10
   i32.store offset=4
+  local.get $5
+  local.get $9
+  i32.store offset=8
   local.get $5
   call $~lib/rt/pure/__retain
   local.set $11
@@ -11690,7 +11828,7 @@
   call $~lib/rt/pure/__release
   local.get $11
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint16Array,u16> (; 210 ;)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint16Array,u16> (; 232 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -11725,7 +11863,7 @@
   call $~lib/typedarray/Uint16Array#filter
   local.set $2
   local.get $2
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Uint16Array#get:byteOffset
   i32.const 0
   i32.eq
   i32.eqz
@@ -11799,7 +11937,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Int32Array,i32>~anonymous|0 (; 211 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Int32Array,i32>~anonymous|0 (; 233 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -11812,7 +11950,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Int32Array#filter (; 212 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#filter (; 234 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -11904,11 +12042,11 @@
   call $~lib/rt/pure/__retain
   i32.store
   local.get $5
-  local.get $9
-  i32.store offset=8
-  local.get $5
   local.get $10
   i32.store offset=4
+  local.get $5
+  local.get $9
+  i32.store offset=8
   local.get $5
   call $~lib/rt/pure/__retain
   local.set $11
@@ -11916,7 +12054,7 @@
   call $~lib/rt/pure/__release
   local.get $11
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Int32Array,i32> (; 213 ;)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Int32Array,i32> (; 235 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -11951,7 +12089,7 @@
   call $~lib/typedarray/Int32Array#filter
   local.set $2
   local.get $2
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Int32Array#get:byteOffset
   i32.const 0
   i32.eq
   i32.eqz
@@ -12025,7 +12163,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint32Array,u32>~anonymous|0 (; 214 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint32Array,u32>~anonymous|0 (; 236 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -12038,7 +12176,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Uint32Array#filter (; 215 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint32Array#filter (; 237 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -12130,11 +12268,11 @@
   call $~lib/rt/pure/__retain
   i32.store
   local.get $5
-  local.get $9
-  i32.store offset=8
-  local.get $5
   local.get $10
   i32.store offset=4
+  local.get $5
+  local.get $9
+  i32.store offset=8
   local.get $5
   call $~lib/rt/pure/__retain
   local.set $11
@@ -12142,7 +12280,7 @@
   call $~lib/rt/pure/__release
   local.get $11
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint32Array,u32> (; 216 ;)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint32Array,u32> (; 238 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -12177,7 +12315,7 @@
   call $~lib/typedarray/Uint32Array#filter
   local.set $2
   local.get $2
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Uint32Array#get:byteOffset
   i32.const 0
   i32.eq
   i32.eqz
@@ -12251,7 +12389,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Int64Array,i64>~anonymous|0 (; 217 ;) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Int64Array,i64>~anonymous|0 (; 239 ;) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -12264,7 +12402,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Int64Array#filter (; 218 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int64Array#filter (; 240 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -12356,11 +12494,11 @@
   call $~lib/rt/pure/__retain
   i32.store
   local.get $5
-  local.get $9
-  i32.store offset=8
-  local.get $5
   local.get $10
   i32.store offset=4
+  local.get $5
+  local.get $9
+  i32.store offset=8
   local.get $5
   call $~lib/rt/pure/__retain
   local.set $12
@@ -12368,7 +12506,7 @@
   call $~lib/rt/pure/__release
   local.get $12
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Int64Array,i64> (; 219 ;)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Int64Array,i64> (; 241 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -12403,7 +12541,7 @@
   call $~lib/typedarray/Int64Array#filter
   local.set $2
   local.get $2
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Int64Array#get:byteOffset
   i32.const 0
   i32.eq
   i32.eqz
@@ -12477,7 +12615,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint64Array,u64>~anonymous|0 (; 220 ;) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint64Array,u64>~anonymous|0 (; 242 ;) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -12490,7 +12628,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Uint64Array#filter (; 221 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint64Array#filter (; 243 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -12582,11 +12720,11 @@
   call $~lib/rt/pure/__retain
   i32.store
   local.get $5
-  local.get $9
-  i32.store offset=8
-  local.get $5
   local.get $10
   i32.store offset=4
+  local.get $5
+  local.get $9
+  i32.store offset=8
   local.get $5
   call $~lib/rt/pure/__retain
   local.set $12
@@ -12594,7 +12732,7 @@
   call $~lib/rt/pure/__release
   local.get $12
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint64Array,u64> (; 222 ;)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint64Array,u64> (; 244 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -12629,7 +12767,7 @@
   call $~lib/typedarray/Uint64Array#filter
   local.set $2
   local.get $2
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Uint64Array#get:byteOffset
   i32.const 0
   i32.eq
   i32.eqz
@@ -12703,7 +12841,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Float32Array,f32>~anonymous|0 (; 223 ;) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Float32Array,f32>~anonymous|0 (; 245 ;) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -12716,7 +12854,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Float32Array#filter (; 224 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#filter (; 246 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -12808,11 +12946,11 @@
   call $~lib/rt/pure/__retain
   i32.store
   local.get $5
-  local.get $9
-  i32.store offset=8
-  local.get $5
   local.get $10
   i32.store offset=4
+  local.get $5
+  local.get $9
+  i32.store offset=8
   local.get $5
   call $~lib/rt/pure/__retain
   local.set $12
@@ -12820,7 +12958,7 @@
   call $~lib/rt/pure/__release
   local.get $12
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Float32Array,f32> (; 225 ;)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Float32Array,f32> (; 247 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -12855,7 +12993,7 @@
   call $~lib/typedarray/Float32Array#filter
   local.set $2
   local.get $2
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Float32Array#get:byteOffset
   i32.const 0
   i32.eq
   i32.eqz
@@ -12929,7 +13067,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Float64Array,f64>~anonymous|0 (; 226 ;) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Float64Array,f64>~anonymous|0 (; 248 ;) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -12942,7 +13080,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Float64Array#filter (; 227 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#filter (; 249 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -13034,11 +13172,11 @@
   call $~lib/rt/pure/__retain
   i32.store
   local.get $5
-  local.get $9
-  i32.store offset=8
-  local.get $5
   local.get $10
   i32.store offset=4
+  local.get $5
+  local.get $9
+  i32.store offset=8
   local.get $5
   call $~lib/rt/pure/__retain
   local.set $12
@@ -13046,7 +13184,7 @@
   call $~lib/rt/pure/__release
   local.get $12
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Float64Array,f64> (; 228 ;)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Float64Array,f64> (; 250 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -13081,7 +13219,7 @@
   call $~lib/typedarray/Float64Array#filter
   local.set $2
   local.get $2
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Float64Array#get:byteOffset
   i32.const 0
   i32.eq
   i32.eqz
@@ -13155,7 +13293,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Int8Array,i8>~anonymous|0 (; 229 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Int8Array,i8>~anonymous|0 (; 251 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -13172,7 +13310,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Int8Array#some (; 230 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#some (; 252 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -13235,7 +13373,7 @@
    local.get $6
   end
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Int8Array,i8>~anonymous|1 (; 231 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Int8Array,i8>~anonymous|1 (; 253 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -13252,7 +13390,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Int8Array,i8> (; 232 ;)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Int8Array,i8> (; 254 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -13311,7 +13449,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Uint8Array,u8>~anonymous|0 (; 233 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Uint8Array,u8>~anonymous|0 (; 255 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -13326,7 +13464,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Uint8Array#some (; 234 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#some (; 256 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -13389,7 +13527,7 @@
    local.get $6
   end
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Uint8Array,u8>~anonymous|1 (; 235 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Uint8Array,u8>~anonymous|1 (; 257 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -13404,7 +13542,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Uint8Array,u8> (; 236 ;)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Uint8Array,u8> (; 258 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -13463,7 +13601,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|0 (; 237 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|0 (; 259 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -13478,7 +13616,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Uint8ClampedArray#some (; 238 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8ClampedArray#some (; 260 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -13541,7 +13679,7 @@
    local.get $6
   end
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|1 (; 239 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|1 (; 261 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -13556,7 +13694,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Uint8ClampedArray,u8> (; 240 ;)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Uint8ClampedArray,u8> (; 262 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -13615,7 +13753,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Int16Array,i16>~anonymous|0 (; 241 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Int16Array,i16>~anonymous|0 (; 263 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -13632,7 +13770,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Int16Array#some (; 242 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#some (; 264 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -13695,7 +13833,7 @@
    local.get $6
   end
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Int16Array,i16>~anonymous|1 (; 243 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Int16Array,i16>~anonymous|1 (; 265 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -13712,7 +13850,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Int16Array,i16> (; 244 ;)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Int16Array,i16> (; 266 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -13771,7 +13909,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Uint16Array,u16>~anonymous|0 (; 245 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Uint16Array,u16>~anonymous|0 (; 267 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -13786,7 +13924,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Uint16Array#some (; 246 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#some (; 268 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -13849,7 +13987,7 @@
    local.get $6
   end
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Uint16Array,u16>~anonymous|1 (; 247 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Uint16Array,u16>~anonymous|1 (; 269 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -13864,7 +14002,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Uint16Array,u16> (; 248 ;)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Uint16Array,u16> (; 270 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -13923,7 +14061,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Int32Array,i32>~anonymous|0 (; 249 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Int32Array,i32>~anonymous|0 (; 271 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -13936,7 +14074,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Int32Array#some (; 250 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#some (; 272 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -13999,7 +14137,7 @@
    local.get $6
   end
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Int32Array,i32>~anonymous|1 (; 251 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Int32Array,i32>~anonymous|1 (; 273 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -14012,7 +14150,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Int32Array,i32> (; 252 ;)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Int32Array,i32> (; 274 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -14071,7 +14209,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Uint32Array,u32>~anonymous|0 (; 253 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Uint32Array,u32>~anonymous|0 (; 275 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -14084,7 +14222,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Uint32Array#some (; 254 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint32Array#some (; 276 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -14147,7 +14285,7 @@
    local.get $6
   end
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Uint32Array,u32>~anonymous|1 (; 255 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Uint32Array,u32>~anonymous|1 (; 277 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -14160,7 +14298,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Uint32Array,u32> (; 256 ;)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Uint32Array,u32> (; 278 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -14219,7 +14357,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Int64Array,i64>~anonymous|0 (; 257 ;) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Int64Array,i64>~anonymous|0 (; 279 ;) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -14232,7 +14370,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Int64Array#some (; 258 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int64Array#some (; 280 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -14295,7 +14433,7 @@
    local.get $6
   end
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Int64Array,i64>~anonymous|1 (; 259 ;) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Int64Array,i64>~anonymous|1 (; 281 ;) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -14308,7 +14446,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Int64Array,i64> (; 260 ;)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Int64Array,i64> (; 282 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -14367,7 +14505,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Uint64Array,u64>~anonymous|0 (; 261 ;) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Uint64Array,u64>~anonymous|0 (; 283 ;) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -14380,7 +14518,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Uint64Array#some (; 262 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint64Array#some (; 284 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -14443,7 +14581,7 @@
    local.get $6
   end
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Uint64Array,u64>~anonymous|1 (; 263 ;) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Uint64Array,u64>~anonymous|1 (; 285 ;) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -14456,7 +14594,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Uint64Array,u64> (; 264 ;)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Uint64Array,u64> (; 286 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -14515,7 +14653,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Float32Array,f32>~anonymous|0 (; 265 ;) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Float32Array,f32>~anonymous|0 (; 287 ;) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -14528,7 +14666,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Float32Array#some (; 266 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#some (; 288 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -14591,7 +14729,7 @@
    local.get $6
   end
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Float32Array,f32>~anonymous|1 (; 267 ;) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Float32Array,f32>~anonymous|1 (; 289 ;) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -14604,7 +14742,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Float32Array,f32> (; 268 ;)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Float32Array,f32> (; 290 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -14663,7 +14801,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Float64Array,f64>~anonymous|0 (; 269 ;) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Float64Array,f64>~anonymous|0 (; 291 ;) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -14676,7 +14814,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Float64Array#some (; 270 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#some (; 292 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -14739,7 +14877,7 @@
    local.get $6
   end
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Float64Array,f64>~anonymous|1 (; 271 ;) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Float64Array,f64>~anonymous|1 (; 293 ;) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -14752,7 +14890,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Float64Array,f64> (; 272 ;)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Float64Array,f64> (; 294 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -14811,7 +14949,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int8Array,i8>~anonymous|0 (; 273 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int8Array,i8>~anonymous|0 (; 295 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -14828,7 +14966,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Int8Array#findIndex (; 274 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#findIndex (; 296 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -14891,7 +15029,7 @@
    local.get $6
   end
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int8Array,i8>~anonymous|1 (; 275 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int8Array,i8>~anonymous|1 (; 297 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -14908,7 +15046,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int8Array,i8> (; 276 ;)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int8Array,i8> (; 298 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -14968,7 +15106,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint8Array,u8>~anonymous|0 (; 277 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint8Array,u8>~anonymous|0 (; 299 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -14983,7 +15121,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Uint8Array#findIndex (; 278 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#findIndex (; 300 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -15046,7 +15184,7 @@
    local.get $6
   end
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint8Array,u8>~anonymous|1 (; 279 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint8Array,u8>~anonymous|1 (; 301 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -15061,7 +15199,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint8Array,u8> (; 280 ;)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint8Array,u8> (; 302 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -15121,7 +15259,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|0 (; 281 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|0 (; 303 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -15136,7 +15274,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Uint8ClampedArray#findIndex (; 282 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8ClampedArray#findIndex (; 304 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -15199,7 +15337,7 @@
    local.get $6
   end
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|1 (; 283 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|1 (; 305 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -15214,7 +15352,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint8ClampedArray,u8> (; 284 ;)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint8ClampedArray,u8> (; 306 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -15274,7 +15412,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int16Array,i16>~anonymous|0 (; 285 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int16Array,i16>~anonymous|0 (; 307 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -15291,7 +15429,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Int16Array#findIndex (; 286 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#findIndex (; 308 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -15354,7 +15492,7 @@
    local.get $6
   end
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int16Array,i16>~anonymous|1 (; 287 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int16Array,i16>~anonymous|1 (; 309 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -15371,7 +15509,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int16Array,i16> (; 288 ;)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int16Array,i16> (; 310 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -15431,7 +15569,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint16Array,u16>~anonymous|0 (; 289 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint16Array,u16>~anonymous|0 (; 311 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -15446,7 +15584,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Uint16Array#findIndex (; 290 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#findIndex (; 312 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -15509,7 +15647,7 @@
    local.get $6
   end
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint16Array,u16>~anonymous|1 (; 291 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint16Array,u16>~anonymous|1 (; 313 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -15524,7 +15662,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint16Array,u16> (; 292 ;)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint16Array,u16> (; 314 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -15584,7 +15722,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int32Array,i32>~anonymous|0 (; 293 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int32Array,i32>~anonymous|0 (; 315 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -15597,7 +15735,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Int32Array#findIndex (; 294 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#findIndex (; 316 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -15660,7 +15798,7 @@
    local.get $6
   end
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int32Array,i32>~anonymous|1 (; 295 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int32Array,i32>~anonymous|1 (; 317 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -15673,7 +15811,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int32Array,i32> (; 296 ;)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int32Array,i32> (; 318 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -15733,7 +15871,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint32Array,u32>~anonymous|0 (; 297 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint32Array,u32>~anonymous|0 (; 319 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -15746,7 +15884,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Uint32Array#findIndex (; 298 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint32Array#findIndex (; 320 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -15809,7 +15947,7 @@
    local.get $6
   end
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint32Array,u32>~anonymous|1 (; 299 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint32Array,u32>~anonymous|1 (; 321 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -15822,7 +15960,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint32Array,u32> (; 300 ;)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint32Array,u32> (; 322 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -15882,7 +16020,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int64Array,i64>~anonymous|0 (; 301 ;) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int64Array,i64>~anonymous|0 (; 323 ;) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -15895,7 +16033,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Int64Array#findIndex (; 302 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int64Array#findIndex (; 324 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -15958,7 +16096,7 @@
    local.get $6
   end
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int64Array,i64>~anonymous|1 (; 303 ;) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int64Array,i64>~anonymous|1 (; 325 ;) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -15971,7 +16109,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int64Array,i64> (; 304 ;)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int64Array,i64> (; 326 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -16031,7 +16169,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint64Array,u64>~anonymous|0 (; 305 ;) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint64Array,u64>~anonymous|0 (; 327 ;) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -16044,7 +16182,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Uint64Array#findIndex (; 306 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint64Array#findIndex (; 328 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -16107,7 +16245,7 @@
    local.get $6
   end
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint64Array,u64>~anonymous|1 (; 307 ;) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint64Array,u64>~anonymous|1 (; 329 ;) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -16120,7 +16258,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint64Array,u64> (; 308 ;)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint64Array,u64> (; 330 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -16180,7 +16318,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Float32Array,f32>~anonymous|0 (; 309 ;) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Float32Array,f32>~anonymous|0 (; 331 ;) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -16193,7 +16331,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Float32Array#findIndex (; 310 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#findIndex (; 332 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -16256,7 +16394,7 @@
    local.get $6
   end
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Float32Array,f32>~anonymous|1 (; 311 ;) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Float32Array,f32>~anonymous|1 (; 333 ;) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -16269,7 +16407,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Float32Array,f32> (; 312 ;)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Float32Array,f32> (; 334 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -16329,7 +16467,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Float64Array,f64>~anonymous|0 (; 313 ;) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Float64Array,f64>~anonymous|0 (; 335 ;) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -16342,7 +16480,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Float64Array#findIndex (; 314 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#findIndex (; 336 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -16405,7 +16543,7 @@
    local.get $6
   end
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Float64Array,f64>~anonymous|1 (; 315 ;) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Float64Array,f64>~anonymous|1 (; 337 ;) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -16418,7 +16556,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Float64Array,f64> (; 316 ;)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Float64Array,f64> (; 338 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -16478,7 +16616,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Int8Array,i8>~anonymous|0 (; 317 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Int8Array,i8>~anonymous|0 (; 339 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -16497,7 +16635,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Int8Array#every (; 318 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#every (; 340 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -16563,7 +16701,7 @@
    local.get $6
   end
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Int8Array,i8>~anonymous|1 (; 319 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Int8Array,i8>~anonymous|1 (; 341 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -16580,7 +16718,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Int8Array,i8> (; 320 ;)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Int8Array,i8> (; 342 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -16639,7 +16777,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint8Array,u8>~anonymous|0 (; 321 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint8Array,u8>~anonymous|0 (; 343 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -16656,7 +16794,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Uint8Array#every (; 322 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#every (; 344 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -16722,7 +16860,7 @@
    local.get $6
   end
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint8Array,u8>~anonymous|1 (; 323 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint8Array,u8>~anonymous|1 (; 345 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -16737,7 +16875,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint8Array,u8> (; 324 ;)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint8Array,u8> (; 346 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -16796,7 +16934,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|0 (; 325 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|0 (; 347 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -16813,7 +16951,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Uint8ClampedArray#every (; 326 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8ClampedArray#every (; 348 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -16879,7 +17017,7 @@
    local.get $6
   end
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|1 (; 327 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|1 (; 349 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -16894,7 +17032,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint8ClampedArray,u8> (; 328 ;)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint8ClampedArray,u8> (; 350 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -16953,7 +17091,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Int16Array,i16>~anonymous|0 (; 329 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Int16Array,i16>~anonymous|0 (; 351 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -16972,7 +17110,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Int16Array#every (; 330 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#every (; 352 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -17038,7 +17176,7 @@
    local.get $6
   end
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Int16Array,i16>~anonymous|1 (; 331 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Int16Array,i16>~anonymous|1 (; 353 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -17055,7 +17193,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Int16Array,i16> (; 332 ;)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Int16Array,i16> (; 354 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -17114,7 +17252,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint16Array,u16>~anonymous|0 (; 333 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint16Array,u16>~anonymous|0 (; 355 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -17131,7 +17269,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Uint16Array#every (; 334 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#every (; 356 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -17197,7 +17335,7 @@
    local.get $6
   end
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint16Array,u16>~anonymous|1 (; 335 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint16Array,u16>~anonymous|1 (; 357 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -17212,7 +17350,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint16Array,u16> (; 336 ;)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint16Array,u16> (; 358 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -17271,7 +17409,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Int32Array,i32>~anonymous|0 (; 337 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Int32Array,i32>~anonymous|0 (; 359 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -17286,7 +17424,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Int32Array#every (; 338 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#every (; 360 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -17352,7 +17490,7 @@
    local.get $6
   end
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Int32Array,i32>~anonymous|1 (; 339 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Int32Array,i32>~anonymous|1 (; 361 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -17365,7 +17503,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Int32Array,i32> (; 340 ;)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Int32Array,i32> (; 362 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -17424,7 +17562,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint32Array,u32>~anonymous|0 (; 341 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint32Array,u32>~anonymous|0 (; 363 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -17439,7 +17577,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Uint32Array#every (; 342 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint32Array#every (; 364 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -17505,7 +17643,7 @@
    local.get $6
   end
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint32Array,u32>~anonymous|1 (; 343 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint32Array,u32>~anonymous|1 (; 365 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -17518,7 +17656,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint32Array,u32> (; 344 ;)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint32Array,u32> (; 366 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -17577,7 +17715,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Int64Array,i64>~anonymous|0 (; 345 ;) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Int64Array,i64>~anonymous|0 (; 367 ;) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -17592,7 +17730,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Int64Array#every (; 346 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int64Array#every (; 368 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -17658,7 +17796,7 @@
    local.get $6
   end
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Int64Array,i64>~anonymous|1 (; 347 ;) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Int64Array,i64>~anonymous|1 (; 369 ;) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -17671,7 +17809,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Int64Array,i64> (; 348 ;)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Int64Array,i64> (; 370 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -17730,7 +17868,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint64Array,u64>~anonymous|0 (; 349 ;) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint64Array,u64>~anonymous|0 (; 371 ;) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -17745,7 +17883,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Uint64Array#every (; 350 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint64Array#every (; 372 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -17811,7 +17949,7 @@
    local.get $6
   end
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint64Array,u64>~anonymous|1 (; 351 ;) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint64Array,u64>~anonymous|1 (; 373 ;) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -17824,7 +17962,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint64Array,u64> (; 352 ;)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint64Array,u64> (; 374 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -17883,7 +18021,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/math/NativeMathf.mod (; 353 ;) (param $0 f32) (param $1 f32) (result f32)
+ (func $~lib/math/NativeMathf.mod (; 375 ;) (param $0 f32) (param $1 f32) (result f32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -18131,7 +18269,7 @@
   local.get $2
   f32.reinterpret_i32
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Float32Array,f32>~anonymous|0 (; 354 ;) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Float32Array,f32>~anonymous|0 (; 376 ;) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -18146,7 +18284,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Float32Array#every (; 355 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#every (; 377 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -18212,7 +18350,7 @@
    local.get $6
   end
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Float32Array,f32>~anonymous|1 (; 356 ;) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Float32Array,f32>~anonymous|1 (; 378 ;) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -18225,7 +18363,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Float32Array,f32> (; 357 ;)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Float32Array,f32> (; 379 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -18284,7 +18422,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/math/NativeMath.mod (; 358 ;) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.mod (; 380 ;) (param $0 f64) (param $1 f64) (result f64)
   (local $2 i64)
   (local $3 i64)
   (local $4 i64)
@@ -18538,7 +18676,7 @@
   local.get $2
   f64.reinterpret_i64
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Float64Array,f64>~anonymous|0 (; 359 ;) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Float64Array,f64>~anonymous|0 (; 381 ;) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -18553,7 +18691,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Float64Array#every (; 360 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#every (; 382 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -18619,7 +18757,7 @@
    local.get $6
   end
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Float64Array,f64>~anonymous|1 (; 361 ;) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Float64Array,f64>~anonymous|1 (; 383 ;) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -18632,7 +18770,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Float64Array,f64> (; 362 ;)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Float64Array,f64> (; 384 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -18691,7 +18829,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Int8Array,i8>~anonymous|0 (; 363 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Int8Array,i8>~anonymous|0 (; 385 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -18751,7 +18889,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int8Array#forEach (; 364 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Int8Array#forEach (; 386 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -18800,7 +18938,7 @@
   local.get $3
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Int8Array,i8> (; 365 ;)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Int8Array,i8> (; 387 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -18863,7 +19001,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint8Array,u8>~anonymous|0 (; 366 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint8Array,u8>~anonymous|0 (; 388 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -18919,7 +19057,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8Array#forEach (; 367 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Uint8Array#forEach (; 389 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -18968,7 +19106,7 @@
   local.get $3
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint8Array,u8> (; 368 ;)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint8Array,u8> (; 390 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -19025,7 +19163,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|0 (; 369 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|0 (; 391 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -19081,7 +19219,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8ClampedArray#forEach (; 370 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Uint8ClampedArray#forEach (; 392 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -19130,7 +19268,7 @@
   local.get $3
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint8ClampedArray,u8> (; 371 ;)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint8ClampedArray,u8> (; 393 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -19187,7 +19325,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Int16Array,i16>~anonymous|0 (; 372 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Int16Array,i16>~anonymous|0 (; 394 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -19247,7 +19385,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int16Array#forEach (; 373 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Int16Array#forEach (; 395 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -19296,7 +19434,7 @@
   local.get $3
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Int16Array,i16> (; 374 ;)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Int16Array,i16> (; 396 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -19359,7 +19497,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint16Array,u16>~anonymous|0 (; 375 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint16Array,u16>~anonymous|0 (; 397 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -19415,7 +19553,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint16Array#forEach (; 376 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Uint16Array#forEach (; 398 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -19464,7 +19602,7 @@
   local.get $3
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint16Array,u16> (; 377 ;)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint16Array,u16> (; 399 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -19521,7 +19659,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Int32Array,i32>~anonymous|0 (; 378 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Int32Array,i32>~anonymous|0 (; 400 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -19573,7 +19711,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int32Array#forEach (; 379 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Int32Array#forEach (; 401 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -19622,7 +19760,7 @@
   local.get $3
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Int32Array,i32> (; 380 ;)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Int32Array,i32> (; 402 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -19673,7 +19811,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint32Array,u32>~anonymous|0 (; 381 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint32Array,u32>~anonymous|0 (; 403 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -19725,7 +19863,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint32Array#forEach (; 382 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Uint32Array#forEach (; 404 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -19774,7 +19912,7 @@
   local.get $3
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint32Array,u32> (; 383 ;)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint32Array,u32> (; 405 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -19825,7 +19963,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Int64Array,i64>~anonymous|0 (; 384 ;) (param $0 i64) (param $1 i32) (param $2 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Int64Array,i64>~anonymous|0 (; 406 ;) (param $0 i64) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -19878,7 +20016,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int64Array#forEach (; 385 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Int64Array#forEach (; 407 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -19927,7 +20065,7 @@
   local.get $3
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Int64Array,i64> (; 386 ;)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Int64Array,i64> (; 408 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -19981,7 +20119,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint64Array,u64>~anonymous|0 (; 387 ;) (param $0 i64) (param $1 i32) (param $2 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint64Array,u64>~anonymous|0 (; 409 ;) (param $0 i64) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -20034,7 +20172,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint64Array#forEach (; 388 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Uint64Array#forEach (; 410 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -20083,7 +20221,7 @@
   local.get $3
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint64Array,u64> (; 389 ;)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint64Array,u64> (; 411 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -20137,7 +20275,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Float32Array,f32>~anonymous|0 (; 390 ;) (param $0 f32) (param $1 i32) (param $2 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Float32Array,f32>~anonymous|0 (; 412 ;) (param $0 f32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -20190,7 +20328,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float32Array#forEach (; 391 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Float32Array#forEach (; 413 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -20239,7 +20377,7 @@
   local.get $3
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Float32Array,f32> (; 392 ;)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Float32Array,f32> (; 414 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -20293,7 +20431,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Float64Array,f64>~anonymous|0 (; 393 ;) (param $0 f64) (param $1 i32) (param $2 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Float64Array,f64>~anonymous|0 (; 415 ;) (param $0 f64) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -20346,7 +20484,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float64Array#forEach (; 394 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Float64Array#forEach (; 416 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -20395,7 +20533,7 @@
   local.get $3
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Float64Array,f64> (; 395 ;)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Float64Array,f64> (; 417 ;)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -20449,7 +20587,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int8Array#reverse (; 396 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#reverse (; 418 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -20513,7 +20651,7 @@
   end
   local.get $1
  )
- (func $std/typedarray/testArrayReverse<~lib/typedarray/Int8Array,i8> (; 397 ;)
+ (func $std/typedarray/testArrayReverse<~lib/typedarray/Int8Array,i8> (; 419 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -20698,7 +20836,7 @@
   local.get $8
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8Array#reverse (; 398 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#reverse (; 420 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -20762,7 +20900,7 @@
   end
   local.get $1
  )
- (func $~lib/typedarray/Uint8Array#subarray (; 399 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#subarray (; 421 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -20869,7 +21007,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $std/typedarray/testArrayReverse<~lib/typedarray/Uint8Array,u8> (; 400 ;)
+ (func $std/typedarray/testArrayReverse<~lib/typedarray/Uint8Array,u8> (; 422 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -21048,7 +21186,7 @@
   local.get $8
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8ClampedArray#reverse (; 401 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint8ClampedArray#reverse (; 423 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -21112,7 +21250,7 @@
   end
   local.get $1
  )
- (func $~lib/typedarray/Uint8ClampedArray#subarray (; 402 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint8ClampedArray#subarray (; 424 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -21219,7 +21357,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $std/typedarray/testArrayReverse<~lib/typedarray/Uint8ClampedArray,u8> (; 403 ;)
+ (func $std/typedarray/testArrayReverse<~lib/typedarray/Uint8ClampedArray,u8> (; 425 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -21398,7 +21536,7 @@
   local.get $8
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int16Array#reverse (; 404 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#reverse (; 426 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -21462,7 +21600,7 @@
   end
   local.get $1
  )
- (func $~lib/typedarray/Int16Array#subarray (; 405 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#subarray (; 427 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -21569,7 +21707,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $std/typedarray/testArrayReverse<~lib/typedarray/Int16Array,i16> (; 406 ;)
+ (func $std/typedarray/testArrayReverse<~lib/typedarray/Int16Array,i16> (; 428 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -21754,7 +21892,7 @@
   local.get $8
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint16Array#reverse (; 407 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#reverse (; 429 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -21818,7 +21956,7 @@
   end
   local.get $1
  )
- (func $~lib/typedarray/Uint16Array#subarray (; 408 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#subarray (; 430 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -21925,7 +22063,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $std/typedarray/testArrayReverse<~lib/typedarray/Uint16Array,u16> (; 409 ;)
+ (func $std/typedarray/testArrayReverse<~lib/typedarray/Uint16Array,u16> (; 431 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -22104,7 +22242,7 @@
   local.get $8
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int32Array#reverse (; 410 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#reverse (; 432 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -22168,7 +22306,7 @@
   end
   local.get $1
  )
- (func $std/typedarray/testArrayReverse<~lib/typedarray/Int32Array,i32> (; 411 ;)
+ (func $std/typedarray/testArrayReverse<~lib/typedarray/Int32Array,i32> (; 433 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -22341,7 +22479,7 @@
   local.get $8
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint32Array#reverse (; 412 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint32Array#reverse (; 434 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -22405,7 +22543,7 @@
   end
   local.get $1
  )
- (func $~lib/typedarray/Uint32Array#subarray (; 413 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint32Array#subarray (; 435 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -22512,7 +22650,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $std/typedarray/testArrayReverse<~lib/typedarray/Uint32Array,u32> (; 414 ;)
+ (func $std/typedarray/testArrayReverse<~lib/typedarray/Uint32Array,u32> (; 436 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -22685,7 +22823,7 @@
   local.get $8
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int64Array#reverse (; 415 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int64Array#reverse (; 437 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -22749,7 +22887,7 @@
   end
   local.get $1
  )
- (func $~lib/typedarray/Int64Array#subarray (; 416 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int64Array#subarray (; 438 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -22856,7 +22994,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $std/typedarray/testArrayReverse<~lib/typedarray/Int64Array,i64> (; 417 ;)
+ (func $std/typedarray/testArrayReverse<~lib/typedarray/Int64Array,i64> (; 439 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -23032,7 +23170,7 @@
   local.get $8
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint64Array#reverse (; 418 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint64Array#reverse (; 440 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -23096,7 +23234,7 @@
   end
   local.get $1
  )
- (func $~lib/typedarray/Uint64Array#subarray (; 419 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint64Array#subarray (; 441 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -23203,7 +23341,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $std/typedarray/testArrayReverse<~lib/typedarray/Uint64Array,u64> (; 420 ;)
+ (func $std/typedarray/testArrayReverse<~lib/typedarray/Uint64Array,u64> (; 442 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -23379,7 +23517,7 @@
   local.get $8
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float32Array#reverse (; 421 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#reverse (; 443 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -23443,7 +23581,7 @@
   end
   local.get $1
  )
- (func $~lib/typedarray/Float32Array#subarray (; 422 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#subarray (; 444 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -23550,7 +23688,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $std/typedarray/testArrayReverse<~lib/typedarray/Float32Array,f32> (; 423 ;)
+ (func $std/typedarray/testArrayReverse<~lib/typedarray/Float32Array,f32> (; 445 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -23726,7 +23864,7 @@
   local.get $8
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float64Array#reverse (; 424 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#reverse (; 446 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -23790,7 +23928,7 @@
   end
   local.get $1
  )
- (func $std/typedarray/testArrayReverse<~lib/typedarray/Float64Array,f64> (; 425 ;)
+ (func $std/typedarray/testArrayReverse<~lib/typedarray/Float64Array,f64> (; 447 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -23966,7 +24104,7 @@
   local.get $8
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int8Array#indexOf (; 426 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#indexOf (; 448 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -24066,7 +24204,7 @@
    local.get $9
   end
  )
- (func $~lib/typedarray/Int8Array#lastIndexOf (; 427 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#lastIndexOf (; 449 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -24162,7 +24300,7 @@
    local.get $9
   end
  )
- (func $~lib/typedarray/Int8Array#lastIndexOf|trampoline (; 428 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#lastIndexOf|trampoline (; 450 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -24182,7 +24320,7 @@
   local.get $2
   call $~lib/typedarray/Int8Array#lastIndexOf
  )
- (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Int8Array,i8> (; 429 ;)
+ (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Int8Array,i8> (; 451 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -24655,7 +24793,7 @@
   local.get $6
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8Array#indexOf (; 430 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#indexOf (; 452 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -24753,7 +24891,7 @@
    local.get $9
   end
  )
- (func $~lib/typedarray/Uint8Array#lastIndexOf (; 431 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#lastIndexOf (; 453 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -24847,7 +24985,7 @@
    local.get $9
   end
  )
- (func $~lib/typedarray/Uint8Array#lastIndexOf|trampoline (; 432 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#lastIndexOf|trampoline (; 454 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -24867,7 +25005,7 @@
   local.get $2
   call $~lib/typedarray/Uint8Array#lastIndexOf
  )
- (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Uint8Array,u8> (; 433 ;)
+ (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Uint8Array,u8> (; 455 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -25338,7 +25476,7 @@
   local.get $6
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8ClampedArray#indexOf (; 434 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint8ClampedArray#indexOf (; 456 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -25436,7 +25574,7 @@
    local.get $9
   end
  )
- (func $~lib/typedarray/Uint8ClampedArray#lastIndexOf (; 435 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint8ClampedArray#lastIndexOf (; 457 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -25530,7 +25668,7 @@
    local.get $9
   end
  )
- (func $~lib/typedarray/Uint8ClampedArray#lastIndexOf|trampoline (; 436 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint8ClampedArray#lastIndexOf|trampoline (; 458 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -25550,7 +25688,7 @@
   local.get $2
   call $~lib/typedarray/Uint8ClampedArray#lastIndexOf
  )
- (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Uint8ClampedArray,u8> (; 437 ;)
+ (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Uint8ClampedArray,u8> (; 459 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -26021,7 +26159,7 @@
   local.get $6
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int16Array#indexOf (; 438 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#indexOf (; 460 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -26121,7 +26259,7 @@
    local.get $9
   end
  )
- (func $~lib/typedarray/Int16Array#lastIndexOf (; 439 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#lastIndexOf (; 461 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -26217,7 +26355,7 @@
    local.get $9
   end
  )
- (func $~lib/typedarray/Int16Array#lastIndexOf|trampoline (; 440 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#lastIndexOf|trampoline (; 462 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -26237,7 +26375,7 @@
   local.get $2
   call $~lib/typedarray/Int16Array#lastIndexOf
  )
- (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Int16Array,i16> (; 441 ;)
+ (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Int16Array,i16> (; 463 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -26710,7 +26848,7 @@
   local.get $6
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint16Array#indexOf (; 442 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#indexOf (; 464 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -26808,7 +26946,7 @@
    local.get $9
   end
  )
- (func $~lib/typedarray/Uint16Array#lastIndexOf (; 443 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#lastIndexOf (; 465 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -26902,7 +27040,7 @@
    local.get $9
   end
  )
- (func $~lib/typedarray/Uint16Array#lastIndexOf|trampoline (; 444 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#lastIndexOf|trampoline (; 466 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -26922,7 +27060,7 @@
   local.get $2
   call $~lib/typedarray/Uint16Array#lastIndexOf
  )
- (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Uint16Array,u16> (; 445 ;)
+ (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Uint16Array,u16> (; 467 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -27393,7 +27531,7 @@
   local.get $6
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int32Array#indexOf (; 446 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#indexOf (; 468 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -27489,7 +27627,7 @@
    local.get $9
   end
  )
- (func $~lib/typedarray/Int32Array#lastIndexOf (; 447 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#lastIndexOf (; 469 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -27581,7 +27719,7 @@
    local.get $9
   end
  )
- (func $~lib/typedarray/Int32Array#lastIndexOf|trampoline (; 448 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#lastIndexOf|trampoline (; 470 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -27601,7 +27739,7 @@
   local.get $2
   call $~lib/typedarray/Int32Array#lastIndexOf
  )
- (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Int32Array,i32> (; 449 ;)
+ (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Int32Array,i32> (; 471 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -28070,7 +28208,7 @@
   local.get $6
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint32Array#indexOf (; 450 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint32Array#indexOf (; 472 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -28166,7 +28304,7 @@
    local.get $9
   end
  )
- (func $~lib/typedarray/Uint32Array#lastIndexOf (; 451 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint32Array#lastIndexOf (; 473 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -28258,7 +28396,7 @@
    local.get $9
   end
  )
- (func $~lib/typedarray/Uint32Array#lastIndexOf|trampoline (; 452 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint32Array#lastIndexOf|trampoline (; 474 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -28278,7 +28416,7 @@
   local.get $2
   call $~lib/typedarray/Uint32Array#lastIndexOf
  )
- (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Uint32Array,u32> (; 453 ;)
+ (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Uint32Array,u32> (; 475 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -28747,7 +28885,7 @@
   local.get $6
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int64Array#indexOf (; 454 ;) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int64Array#indexOf (; 476 ;) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i64)
   (local $5 i32)
@@ -28843,7 +28981,7 @@
    local.get $9
   end
  )
- (func $~lib/typedarray/Int64Array#lastIndexOf (; 455 ;) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int64Array#lastIndexOf (; 477 ;) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i64)
   (local $5 i32)
@@ -28935,7 +29073,7 @@
    local.get $9
   end
  )
- (func $~lib/typedarray/Int64Array#lastIndexOf|trampoline (; 456 ;) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int64Array#lastIndexOf|trampoline (; 478 ;) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -28955,7 +29093,7 @@
   local.get $2
   call $~lib/typedarray/Int64Array#lastIndexOf
  )
- (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Int64Array,i64> (; 457 ;)
+ (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Int64Array,i64> (; 479 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -29425,7 +29563,7 @@
   local.get $6
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint64Array#indexOf (; 458 ;) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint64Array#indexOf (; 480 ;) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i64)
   (local $5 i32)
@@ -29521,7 +29659,7 @@
    local.get $9
   end
  )
- (func $~lib/typedarray/Uint64Array#lastIndexOf (; 459 ;) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint64Array#lastIndexOf (; 481 ;) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i64)
   (local $5 i32)
@@ -29613,7 +29751,7 @@
    local.get $9
   end
  )
- (func $~lib/typedarray/Uint64Array#lastIndexOf|trampoline (; 460 ;) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint64Array#lastIndexOf|trampoline (; 482 ;) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -29633,7 +29771,7 @@
   local.get $2
   call $~lib/typedarray/Uint64Array#lastIndexOf
  )
- (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Uint64Array,u64> (; 461 ;)
+ (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Uint64Array,u64> (; 483 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -30103,7 +30241,7 @@
   local.get $6
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float32Array#indexOf (; 462 ;) (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#indexOf (; 484 ;) (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 f32)
   (local $5 i32)
@@ -30199,7 +30337,7 @@
    local.get $9
   end
  )
- (func $~lib/typedarray/Float32Array#lastIndexOf (; 463 ;) (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#lastIndexOf (; 485 ;) (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 f32)
   (local $5 i32)
@@ -30291,7 +30429,7 @@
    local.get $9
   end
  )
- (func $~lib/typedarray/Float32Array#lastIndexOf|trampoline (; 464 ;) (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#lastIndexOf|trampoline (; 486 ;) (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -30311,7 +30449,7 @@
   local.get $2
   call $~lib/typedarray/Float32Array#lastIndexOf
  )
- (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Float32Array,f32> (; 465 ;)
+ (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Float32Array,f32> (; 487 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -30781,7 +30919,7 @@
   local.get $6
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float64Array#indexOf (; 466 ;) (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#indexOf (; 488 ;) (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 f64)
   (local $5 i32)
@@ -30877,7 +31015,7 @@
    local.get $9
   end
  )
- (func $~lib/typedarray/Float64Array#lastIndexOf (; 467 ;) (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#lastIndexOf (; 489 ;) (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 f64)
   (local $5 i32)
@@ -30969,7 +31107,7 @@
    local.get $9
   end
  )
- (func $~lib/typedarray/Float64Array#lastIndexOf|trampoline (; 468 ;) (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#lastIndexOf|trampoline (; 490 ;) (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -30989,7 +31127,7 @@
   local.get $2
   call $~lib/typedarray/Float64Array#lastIndexOf
  )
- (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Float64Array,f64> (; 469 ;)
+ (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Float64Array,f64> (; 491 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -31459,7 +31597,7 @@
   local.get $6
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float64Array#includes (; 470 ;) (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#includes (; 492 ;) (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 f64)
   (local $5 i32)
@@ -31570,7 +31708,7 @@
    br $~lib/typedarray/INCLUDES<~lib/typedarray/Float64Array,f64>|inlined.0
   end
  )
- (func $~lib/typedarray/Float32Array#includes (; 471 ;) (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#includes (; 493 ;) (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 f32)
   (local $5 i32)
@@ -31681,7 +31819,7 @@
    br $~lib/typedarray/INCLUDES<~lib/typedarray/Float32Array,f32>|inlined.0
   end
  )
- (func $~lib/util/number/decimalCount32 (; 472 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/decimalCount32 (; 494 ;) (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   i32.const 100000
@@ -31747,7 +31885,7 @@
   end
   unreachable
  )
- (func $~lib/util/number/utoa32_lut (; 473 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/number/utoa32_lut (; 495 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -31891,7 +32029,7 @@
    i32.store16
   end
  )
- (func $~lib/util/number/itoa32 (; 474 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/itoa32 (; 496 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -31945,7 +32083,7 @@
   local.get $3
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/itoa<i8> (; 475 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/itoa<i8> (; 497 ;) (param $0 i32) (result i32)
   local.get $0
   i32.const 24
   i32.shl
@@ -31954,7 +32092,7 @@
   call $~lib/util/number/itoa32
   return
  )
- (func $~lib/string/String#get:length (; 476 ;) (param $0 i32) (result i32)
+ (func $~lib/string/String#get:length (; 498 ;) (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub
@@ -31962,7 +32100,7 @@
   i32.const 1
   i32.shr_u
  )
- (func $~lib/util/number/itoa_stream<i8> (; 477 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_stream<i8> (; 499 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -32035,7 +32173,7 @@
   end
   local.get $3
  )
- (func $~lib/string/String#substring (; 478 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/string/String#substring (; 500 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -32142,7 +32280,7 @@
   local.get $11
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/string/joinIntegerArray<i8> (; 479 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<i8> (; 501 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -32285,7 +32423,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/typedarray/Int8Array#join (; 480 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#join (; 502 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   call $~lib/rt/pure/__retain
@@ -32301,7 +32439,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/util/string/compareImpl (; 481 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
+ (func $~lib/util/string/compareImpl (; 503 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
@@ -32423,7 +32561,7 @@
   call $~lib/rt/pure/__release
   local.get $7
  )
- (func $~lib/string/String.__eq (; 482 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__eq (; 504 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -32496,12 +32634,12 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/typedarray/Int8Array#toString (; 483 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#toString (; 505 ;) (param $0 i32) (result i32)
   local.get $0
   i32.const 2416
   call $~lib/typedarray/Int8Array#join
  )
- (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Int8Array,i8> (; 484 ;)
+ (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Int8Array,i8> (; 506 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -32570,7 +32708,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/util/number/utoa32 (; 485 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/utoa32 (; 507 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -32604,14 +32742,14 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/itoa<u8> (; 486 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/itoa<u8> (; 508 ;) (param $0 i32) (result i32)
   local.get $0
   i32.const 255
   i32.and
   call $~lib/util/number/utoa32
   return
  )
- (func $~lib/util/number/itoa_stream<u8> (; 487 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_stream<u8> (; 509 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -32654,7 +32792,7 @@
   call $~lib/util/number/utoa32_lut
   local.get $3
  )
- (func $~lib/util/string/joinIntegerArray<u8> (; 488 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<u8> (; 510 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -32797,7 +32935,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/typedarray/Uint8Array#join (; 489 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#join (; 511 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   call $~lib/rt/pure/__retain
@@ -32813,12 +32951,12 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/typedarray/Uint8Array#toString (; 490 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#toString (; 512 ;) (param $0 i32) (result i32)
   local.get $0
   i32.const 2416
   call $~lib/typedarray/Uint8Array#join
  )
- (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Uint8Array,u8> (; 491 ;)
+ (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Uint8Array,u8> (; 513 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -32887,7 +33025,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8ClampedArray#join (; 492 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8ClampedArray#join (; 514 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   call $~lib/rt/pure/__retain
@@ -32903,12 +33041,12 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/typedarray/Uint8ClampedArray#toString (; 493 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint8ClampedArray#toString (; 515 ;) (param $0 i32) (result i32)
   local.get $0
   i32.const 2416
   call $~lib/typedarray/Uint8ClampedArray#join
  )
- (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Uint8ClampedArray,u8> (; 494 ;)
+ (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Uint8ClampedArray,u8> (; 516 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -32977,7 +33115,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/util/number/itoa<i16> (; 495 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/itoa<i16> (; 517 ;) (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.shl
@@ -32986,7 +33124,7 @@
   call $~lib/util/number/itoa32
   return
  )
- (func $~lib/util/number/itoa_stream<i16> (; 496 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_stream<i16> (; 518 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -33059,7 +33197,7 @@
   end
   local.get $3
  )
- (func $~lib/util/string/joinIntegerArray<i16> (; 497 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<i16> (; 519 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -33202,7 +33340,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/typedarray/Int16Array#join (; 498 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#join (; 520 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   call $~lib/rt/pure/__retain
@@ -33218,12 +33356,12 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/typedarray/Int16Array#toString (; 499 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#toString (; 521 ;) (param $0 i32) (result i32)
   local.get $0
   i32.const 2416
   call $~lib/typedarray/Int16Array#join
  )
- (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Int16Array,i16> (; 500 ;)
+ (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Int16Array,i16> (; 522 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -33292,14 +33430,14 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/util/number/itoa<u16> (; 501 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/itoa<u16> (; 523 ;) (param $0 i32) (result i32)
   local.get $0
   i32.const 65535
   i32.and
   call $~lib/util/number/utoa32
   return
  )
- (func $~lib/util/number/itoa_stream<u16> (; 502 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_stream<u16> (; 524 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -33342,7 +33480,7 @@
   call $~lib/util/number/utoa32_lut
   local.get $3
  )
- (func $~lib/util/string/joinIntegerArray<u16> (; 503 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<u16> (; 525 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -33485,7 +33623,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/typedarray/Uint16Array#join (; 504 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#join (; 526 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   call $~lib/rt/pure/__retain
@@ -33501,12 +33639,12 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/typedarray/Uint16Array#toString (; 505 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#toString (; 527 ;) (param $0 i32) (result i32)
   local.get $0
   i32.const 2416
   call $~lib/typedarray/Uint16Array#join
  )
- (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Uint16Array,u16> (; 506 ;)
+ (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Uint16Array,u16> (; 528 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -33575,12 +33713,12 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/util/number/itoa<i32> (; 507 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/itoa<i32> (; 529 ;) (param $0 i32) (result i32)
   local.get $0
   call $~lib/util/number/itoa32
   return
  )
- (func $~lib/util/number/itoa_stream<i32> (; 508 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_stream<i32> (; 530 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -33637,7 +33775,7 @@
   end
   local.get $3
  )
- (func $~lib/util/string/joinIntegerArray<i32> (; 509 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<i32> (; 531 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -33780,7 +33918,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/typedarray/Int32Array#join (; 510 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#join (; 532 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   call $~lib/rt/pure/__retain
@@ -33796,12 +33934,12 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/typedarray/Int32Array#toString (; 511 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#toString (; 533 ;) (param $0 i32) (result i32)
   local.get $0
   i32.const 2416
   call $~lib/typedarray/Int32Array#join
  )
- (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Int32Array,i32> (; 512 ;)
+ (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Int32Array,i32> (; 534 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -33870,12 +34008,12 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/util/number/itoa<u32> (; 513 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/itoa<u32> (; 535 ;) (param $0 i32) (result i32)
   local.get $0
   call $~lib/util/number/utoa32
   return
  )
- (func $~lib/util/number/itoa_stream<u32> (; 514 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_stream<u32> (; 536 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -33912,7 +34050,7 @@
   call $~lib/util/number/utoa32_lut
   local.get $3
  )
- (func $~lib/util/string/joinIntegerArray<u32> (; 515 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<u32> (; 537 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -34055,7 +34193,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/typedarray/Uint32Array#join (; 516 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint32Array#join (; 538 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   call $~lib/rt/pure/__retain
@@ -34071,12 +34209,12 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/typedarray/Uint32Array#toString (; 517 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint32Array#toString (; 539 ;) (param $0 i32) (result i32)
   local.get $0
   i32.const 2416
   call $~lib/typedarray/Uint32Array#join
  )
- (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Uint32Array,u32> (; 518 ;)
+ (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Uint32Array,u32> (; 540 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -34145,7 +34283,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/util/number/decimalCount64 (; 519 ;) (param $0 i64) (result i32)
+ (func $~lib/util/number/decimalCount64 (; 541 ;) (param $0 i64) (result i32)
   (local $1 i32)
   local.get $0
   i64.const 1000000000000000
@@ -34218,7 +34356,7 @@
   end
   unreachable
  )
- (func $~lib/util/number/utoa64_lut (; 520 ;) (param $0 i32) (param $1 i64) (param $2 i32)
+ (func $~lib/util/number/utoa64_lut (; 542 ;) (param $0 i32) (param $1 i64) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i64)
@@ -34345,7 +34483,7 @@
   local.get $2
   call $~lib/util/number/utoa32_lut
  )
- (func $~lib/util/number/itoa64 (; 521 ;) (param $0 i64) (result i32)
+ (func $~lib/util/number/itoa64 (; 543 ;) (param $0 i64) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -34433,12 +34571,12 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/itoa<i64> (; 522 ;) (param $0 i64) (result i32)
+ (func $~lib/util/number/itoa<i64> (; 544 ;) (param $0 i64) (result i32)
   local.get $0
   call $~lib/util/number/itoa64
   return
  )
- (func $~lib/util/number/itoa_stream<i64> (; 523 ;) (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
+ (func $~lib/util/number/itoa_stream<i64> (; 545 ;) (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -34523,7 +34661,7 @@
   end
   local.get $3
  )
- (func $~lib/util/string/joinIntegerArray<i64> (; 524 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<i64> (; 546 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -34666,7 +34804,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/typedarray/Int64Array#join (; 525 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int64Array#join (; 547 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   call $~lib/rt/pure/__retain
@@ -34682,12 +34820,12 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/typedarray/Int64Array#toString (; 526 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int64Array#toString (; 548 ;) (param $0 i32) (result i32)
   local.get $0
   i32.const 2416
   call $~lib/typedarray/Int64Array#join
  )
- (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Int64Array,i64> (; 527 ;)
+ (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Int64Array,i64> (; 549 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -34756,7 +34894,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/util/number/utoa64 (; 528 ;) (param $0 i64) (result i32)
+ (func $~lib/util/number/utoa64 (; 550 ;) (param $0 i64) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -34822,12 +34960,12 @@
   local.get $1
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/itoa<u64> (; 529 ;) (param $0 i64) (result i32)
+ (func $~lib/util/number/itoa<u64> (; 551 ;) (param $0 i64) (result i32)
   local.get $0
   call $~lib/util/number/utoa64
   return
  )
- (func $~lib/util/number/itoa_stream<u64> (; 530 ;) (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
+ (func $~lib/util/number/itoa_stream<u64> (; 552 ;) (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -34890,7 +35028,7 @@
   end
   local.get $3
  )
- (func $~lib/util/string/joinIntegerArray<u64> (; 531 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<u64> (; 553 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -35033,7 +35171,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/typedarray/Uint64Array#join (; 532 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint64Array#join (; 554 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   call $~lib/rt/pure/__retain
@@ -35049,12 +35187,12 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/typedarray/Uint64Array#toString (; 533 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint64Array#toString (; 555 ;) (param $0 i32) (result i32)
   local.get $0
   i32.const 2416
   call $~lib/typedarray/Uint64Array#join
  )
- (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Uint64Array,u64> (; 534 ;)
+ (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Uint64Array,u64> (; 556 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -35123,7 +35261,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/array/Array<u64>#__unchecked_get (; 535 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $~lib/array/Array<u64>#__unchecked_get (; 557 ;) (param $0 i32) (param $1 i32) (result i64)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -35132,7 +35270,7 @@
   i32.add
   i64.load
  )
- (func $~lib/array/Array<i16>#__unchecked_get (; 536 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i16>#__unchecked_get (; 558 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -35141,7 +35279,7 @@
   i32.add
   i32.load16_s
  )
- (func $~lib/util/number/genDigits (; 537 ;) (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (param $6 i32) (result i32)
+ (func $~lib/util/number/genDigits (; 559 ;) (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (param $6 i32) (result i32)
   (local $7 i32)
   (local $8 i64)
   (local $9 i64)
@@ -35648,7 +35786,7 @@
   end
   local.get $15
  )
- (func $~lib/util/number/prettify (; 538 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/prettify (; 560 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -35965,7 +36103,7 @@
   end
   unreachable
  )
- (func $~lib/util/number/dtoa_core (; 539 ;) (param $0 i32) (param $1 f64) (result i32)
+ (func $~lib/util/number/dtoa_core (; 561 ;) (param $0 i32) (param $1 f64) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -36387,7 +36525,7 @@
   local.get $2
   i32.add
  )
- (func $~lib/util/number/dtoa (; 540 ;) (param $0 f64) (result i32)
+ (func $~lib/util/number/dtoa (; 562 ;) (param $0 f64) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -36448,7 +36586,7 @@
   call $~lib/rt/tlsf/__free
   local.get $3
  )
- (func $~lib/util/number/dtoa_stream (; 541 ;) (param $0 i32) (param $1 i32) (param $2 f64) (result i32)
+ (func $~lib/util/number/dtoa_stream (; 563 ;) (param $0 i32) (param $1 i32) (param $2 f64) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -36522,7 +36660,7 @@
   local.get $2
   call $~lib/util/number/dtoa_core
  )
- (func $~lib/util/string/joinFloatArray<f32> (; 542 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinFloatArray<f32> (; 564 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -36668,7 +36806,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/typedarray/Float32Array#join (; 543 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#join (; 565 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   call $~lib/rt/pure/__retain
@@ -36684,12 +36822,12 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/typedarray/Float32Array#toString (; 544 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#toString (; 566 ;) (param $0 i32) (result i32)
   local.get $0
   i32.const 2416
   call $~lib/typedarray/Float32Array#join
  )
- (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Float32Array,f32> (; 545 ;)
+ (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Float32Array,f32> (; 567 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -36758,7 +36896,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/util/string/joinFloatArray<f64> (; 546 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinFloatArray<f64> (; 568 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -36901,7 +37039,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/typedarray/Float64Array#join (; 547 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#join (; 569 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   call $~lib/rt/pure/__retain
@@ -36917,12 +37055,12 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/typedarray/Float64Array#toString (; 548 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#toString (; 570 ;) (param $0 i32) (result i32)
   local.get $0
   i32.const 2416
   call $~lib/typedarray/Float64Array#join
  )
- (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Float64Array,f64> (; 549 ;)
+ (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Float64Array,f64> (; 571 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -36991,15 +37129,15 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/arraybuffer/ArrayBuffer#constructor (; 550 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBuffer#constructor (; 572 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   i32.const 1073741808
   i32.gt_u
   if
-   i32.const 32
-   i32.const 80
-   i32.const 54
+   i32.const 192
+   i32.const 240
+   i32.const 45
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -37015,13 +37153,13 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~lib/arraybuffer/ArrayBuffer#get:byteLength (; 551 ;) (param $0 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBuffer#get:byteLength (; 573 ;) (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub
   i32.load offset=12
  )
- (func $~lib/typedarray/Uint8Array.wrap (; 552 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array.wrap (; 574 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -37054,7 +37192,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1741
+   i32.const 1885
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -37073,9 +37211,9 @@
     if
      local.get $5
      call $~lib/rt/pure/__release
-     i32.const 32
+     i32.const 192
      i32.const 432
-     i32.const 1746
+     i32.const 1890
      i32.const 8
      call $~lib/builtins/abort
      unreachable
@@ -37087,9 +37225,9 @@
    else
     local.get $5
     call $~lib/rt/pure/__release
-    i32.const 32
+    i32.const 192
     i32.const 432
-    i32.const 1750
+    i32.const 1894
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -37107,9 +37245,9 @@
    if
     local.get $5
     call $~lib/rt/pure/__release
-    i32.const 32
+    i32.const 192
     i32.const 432
-    i32.const 1755
+    i32.const 1899
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -37124,13 +37262,13 @@
   call $~lib/rt/pure/__retain
   i32.store
   local.get $8
-  local.get $6
-  i32.store offset=8
-  local.get $8
   local.get $5
   local.get $4
   i32.add
   i32.store offset=4
+  local.get $8
+  local.get $6
+  i32.store offset=8
   local.get $8
   call $~lib/rt/pure/__retain
   local.set $9
@@ -37142,7 +37280,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $~lib/typedarray/Uint8Array.wrap|trampoline (; 553 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array.wrap|trampoline (; 575 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $2of2
    block $1of2
     block $0of2
@@ -37165,7 +37303,12 @@
   local.get $2
   call $~lib/typedarray/Uint8Array.wrap
  )
- (func $~lib/arraybuffer/ArrayBuffer#slice (; 554 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#get:buffer (; 576 ;) (param $0 i32) (result i32)
+  local.get $0
+  i32.load
+  call $~lib/rt/pure/__retain
+ )
+ (func $~lib/arraybuffer/ArrayBuffer#slice (; 577 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -37248,7 +37391,7 @@
   local.get $7
   call $~lib/rt/pure/__retain
  )
- (func $~lib/typedarray/Int8Array.wrap (; 555 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int8Array.wrap (; 578 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -37281,7 +37424,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1741
+   i32.const 1885
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -37300,9 +37443,9 @@
     if
      local.get $5
      call $~lib/rt/pure/__release
-     i32.const 32
+     i32.const 192
      i32.const 432
-     i32.const 1746
+     i32.const 1890
      i32.const 8
      call $~lib/builtins/abort
      unreachable
@@ -37314,9 +37457,9 @@
    else
     local.get $5
     call $~lib/rt/pure/__release
-    i32.const 32
+    i32.const 192
     i32.const 432
-    i32.const 1750
+    i32.const 1894
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -37334,9 +37477,9 @@
    if
     local.get $5
     call $~lib/rt/pure/__release
-    i32.const 32
+    i32.const 192
     i32.const 432
-    i32.const 1755
+    i32.const 1899
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -37351,13 +37494,13 @@
   call $~lib/rt/pure/__retain
   i32.store
   local.get $8
-  local.get $6
-  i32.store offset=8
-  local.get $8
   local.get $5
   local.get $4
   i32.add
   i32.store offset=4
+  local.get $8
+  local.get $6
+  i32.store offset=8
   local.get $8
   call $~lib/rt/pure/__retain
   local.set $9
@@ -37369,7 +37512,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $~lib/typedarray/Int8Array.wrap|trampoline (; 556 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int8Array.wrap|trampoline (; 579 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $2of2
    block $1of2
     block $0of2
@@ -37392,7 +37535,7 @@
   local.get $2
   call $~lib/typedarray/Int8Array.wrap
  )
- (func $std/typedarray/testArrayWrap<~lib/typedarray/Int8Array,i8> (; 557 ;)
+ (func $std/typedarray/testArrayWrap<~lib/typedarray/Int8Array,i8> (; 580 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -37401,6 +37544,7 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
   global.get $std/typedarray/testArrayWrapValues
   call $~lib/rt/pure/__retain
   local.set $0
@@ -37440,13 +37584,14 @@
    end
   end
   local.get $3
-  i32.load
+  call $~lib/typedarray/Int8Array#get:buffer
+  local.tee $4
   local.get $3
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Int8Array#get:byteOffset
   local.get $3
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Int8Array#get:byteOffset
   local.get $3
-  i32.load offset=8
+  call $~lib/typedarray/Int8Array#get:byteLength
   i32.add
   call $~lib/arraybuffer/ArrayBuffer#slice
   local.set $6
@@ -37469,8 +37614,8 @@
    local.get $5
    local.get $1
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $8
+   local.get $8
    if
     local.get $3
     local.get $5
@@ -37497,6 +37642,8 @@
   end
   local.get $2
   call $~lib/rt/pure/__release
+  local.get $4
+  call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
   local.get $3
@@ -37506,7 +37653,12 @@
   local.get $7
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayWrap<~lib/typedarray/Uint8Array,u8> (; 558 ;)
+ (func $~lib/typedarray/Uint8Array#get:buffer (; 581 ;) (param $0 i32) (result i32)
+  local.get $0
+  i32.load
+  call $~lib/rt/pure/__retain
+ )
+ (func $std/typedarray/testArrayWrap<~lib/typedarray/Uint8Array,u8> (; 582 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -37515,6 +37667,7 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
   global.get $std/typedarray/testArrayWrapValues
   call $~lib/rt/pure/__retain
   local.set $0
@@ -37552,13 +37705,14 @@
    end
   end
   local.get $3
-  i32.load
+  call $~lib/typedarray/Uint8Array#get:buffer
+  local.tee $4
   local.get $3
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Uint8Array#get:byteOffset
   local.get $3
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Uint8Array#get:byteOffset
   local.get $3
-  i32.load offset=8
+  call $~lib/typedarray/Uint8Array#get:byteLength
   i32.add
   call $~lib/arraybuffer/ArrayBuffer#slice
   local.set $6
@@ -37581,8 +37735,8 @@
    local.get $5
    local.get $1
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $8
+   local.get $8
    if
     local.get $3
     local.get $5
@@ -37609,6 +37763,8 @@
   end
   local.get $2
   call $~lib/rt/pure/__release
+  local.get $4
+  call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
   local.get $3
@@ -37618,7 +37774,12 @@
   local.get $7
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8ClampedArray.wrap (; 559 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint8ClampedArray#get:buffer (; 583 ;) (param $0 i32) (result i32)
+  local.get $0
+  i32.load
+  call $~lib/rt/pure/__retain
+ )
+ (func $~lib/typedarray/Uint8ClampedArray.wrap (; 584 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -37651,7 +37812,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1741
+   i32.const 1885
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -37670,9 +37831,9 @@
     if
      local.get $5
      call $~lib/rt/pure/__release
-     i32.const 32
+     i32.const 192
      i32.const 432
-     i32.const 1746
+     i32.const 1890
      i32.const 8
      call $~lib/builtins/abort
      unreachable
@@ -37684,9 +37845,9 @@
    else
     local.get $5
     call $~lib/rt/pure/__release
-    i32.const 32
+    i32.const 192
     i32.const 432
-    i32.const 1750
+    i32.const 1894
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -37704,9 +37865,9 @@
    if
     local.get $5
     call $~lib/rt/pure/__release
-    i32.const 32
+    i32.const 192
     i32.const 432
-    i32.const 1755
+    i32.const 1899
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -37721,13 +37882,13 @@
   call $~lib/rt/pure/__retain
   i32.store
   local.get $8
-  local.get $6
-  i32.store offset=8
-  local.get $8
   local.get $5
   local.get $4
   i32.add
   i32.store offset=4
+  local.get $8
+  local.get $6
+  i32.store offset=8
   local.get $8
   call $~lib/rt/pure/__retain
   local.set $9
@@ -37739,7 +37900,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $~lib/typedarray/Uint8ClampedArray.wrap|trampoline (; 560 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint8ClampedArray.wrap|trampoline (; 585 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $2of2
    block $1of2
     block $0of2
@@ -37762,7 +37923,7 @@
   local.get $2
   call $~lib/typedarray/Uint8ClampedArray.wrap
  )
- (func $std/typedarray/testArrayWrap<~lib/typedarray/Uint8ClampedArray,u8> (; 561 ;)
+ (func $std/typedarray/testArrayWrap<~lib/typedarray/Uint8ClampedArray,u8> (; 586 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -37771,6 +37932,7 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
   global.get $std/typedarray/testArrayWrapValues
   call $~lib/rt/pure/__retain
   local.set $0
@@ -37808,13 +37970,14 @@
    end
   end
   local.get $3
-  i32.load
+  call $~lib/typedarray/Uint8ClampedArray#get:buffer
+  local.tee $4
   local.get $3
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Uint8ClampedArray#get:byteOffset
   local.get $3
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Uint8ClampedArray#get:byteOffset
   local.get $3
-  i32.load offset=8
+  call $~lib/typedarray/Uint8ClampedArray#get:byteLength
   i32.add
   call $~lib/arraybuffer/ArrayBuffer#slice
   local.set $6
@@ -37837,8 +38000,8 @@
    local.get $5
    local.get $1
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $8
+   local.get $8
    if
     local.get $3
     local.get $5
@@ -37865,6 +38028,8 @@
   end
   local.get $2
   call $~lib/rt/pure/__release
+  local.get $4
+  call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
   local.get $3
@@ -37874,7 +38039,12 @@
   local.get $7
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int16Array.wrap (; 562 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#get:buffer (; 587 ;) (param $0 i32) (result i32)
+  local.get $0
+  i32.load
+  call $~lib/rt/pure/__retain
+ )
+ (func $~lib/typedarray/Int16Array.wrap (; 588 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -37907,7 +38077,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1741
+   i32.const 1885
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -37926,9 +38096,9 @@
     if
      local.get $5
      call $~lib/rt/pure/__release
-     i32.const 32
+     i32.const 192
      i32.const 432
-     i32.const 1746
+     i32.const 1890
      i32.const 8
      call $~lib/builtins/abort
      unreachable
@@ -37940,9 +38110,9 @@
    else
     local.get $5
     call $~lib/rt/pure/__release
-    i32.const 32
+    i32.const 192
     i32.const 432
-    i32.const 1750
+    i32.const 1894
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -37960,9 +38130,9 @@
    if
     local.get $5
     call $~lib/rt/pure/__release
-    i32.const 32
+    i32.const 192
     i32.const 432
-    i32.const 1755
+    i32.const 1899
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -37977,13 +38147,13 @@
   call $~lib/rt/pure/__retain
   i32.store
   local.get $8
-  local.get $6
-  i32.store offset=8
-  local.get $8
   local.get $5
   local.get $4
   i32.add
   i32.store offset=4
+  local.get $8
+  local.get $6
+  i32.store offset=8
   local.get $8
   call $~lib/rt/pure/__retain
   local.set $9
@@ -37995,7 +38165,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $~lib/typedarray/Int16Array.wrap|trampoline (; 563 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int16Array.wrap|trampoline (; 589 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $2of2
    block $1of2
     block $0of2
@@ -38018,7 +38188,7 @@
   local.get $2
   call $~lib/typedarray/Int16Array.wrap
  )
- (func $std/typedarray/testArrayWrap<~lib/typedarray/Int16Array,i16> (; 564 ;)
+ (func $std/typedarray/testArrayWrap<~lib/typedarray/Int16Array,i16> (; 590 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -38027,6 +38197,7 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
   global.get $std/typedarray/testArrayWrapValues
   call $~lib/rt/pure/__retain
   local.set $0
@@ -38066,13 +38237,14 @@
    end
   end
   local.get $3
-  i32.load
+  call $~lib/typedarray/Int16Array#get:buffer
+  local.tee $4
   local.get $3
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Int16Array#get:byteOffset
   local.get $3
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Int16Array#get:byteOffset
   local.get $3
-  i32.load offset=8
+  call $~lib/typedarray/Int16Array#get:byteLength
   i32.add
   call $~lib/arraybuffer/ArrayBuffer#slice
   local.set $6
@@ -38095,8 +38267,8 @@
    local.get $5
    local.get $1
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $8
+   local.get $8
    if
     local.get $3
     local.get $5
@@ -38123,6 +38295,8 @@
   end
   local.get $2
   call $~lib/rt/pure/__release
+  local.get $4
+  call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
   local.get $3
@@ -38132,7 +38306,12 @@
   local.get $7
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint16Array.wrap (; 565 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#get:buffer (; 591 ;) (param $0 i32) (result i32)
+  local.get $0
+  i32.load
+  call $~lib/rt/pure/__retain
+ )
+ (func $~lib/typedarray/Uint16Array.wrap (; 592 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -38165,7 +38344,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1741
+   i32.const 1885
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -38184,9 +38363,9 @@
     if
      local.get $5
      call $~lib/rt/pure/__release
-     i32.const 32
+     i32.const 192
      i32.const 432
-     i32.const 1746
+     i32.const 1890
      i32.const 8
      call $~lib/builtins/abort
      unreachable
@@ -38198,9 +38377,9 @@
    else
     local.get $5
     call $~lib/rt/pure/__release
-    i32.const 32
+    i32.const 192
     i32.const 432
-    i32.const 1750
+    i32.const 1894
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -38218,9 +38397,9 @@
    if
     local.get $5
     call $~lib/rt/pure/__release
-    i32.const 32
+    i32.const 192
     i32.const 432
-    i32.const 1755
+    i32.const 1899
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -38235,13 +38414,13 @@
   call $~lib/rt/pure/__retain
   i32.store
   local.get $8
-  local.get $6
-  i32.store offset=8
-  local.get $8
   local.get $5
   local.get $4
   i32.add
   i32.store offset=4
+  local.get $8
+  local.get $6
+  i32.store offset=8
   local.get $8
   call $~lib/rt/pure/__retain
   local.set $9
@@ -38253,7 +38432,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $~lib/typedarray/Uint16Array.wrap|trampoline (; 566 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array.wrap|trampoline (; 593 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $2of2
    block $1of2
     block $0of2
@@ -38276,7 +38455,7 @@
   local.get $2
   call $~lib/typedarray/Uint16Array.wrap
  )
- (func $std/typedarray/testArrayWrap<~lib/typedarray/Uint16Array,u16> (; 567 ;)
+ (func $std/typedarray/testArrayWrap<~lib/typedarray/Uint16Array,u16> (; 594 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -38285,6 +38464,7 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
   global.get $std/typedarray/testArrayWrapValues
   call $~lib/rt/pure/__retain
   local.set $0
@@ -38322,13 +38502,14 @@
    end
   end
   local.get $3
-  i32.load
+  call $~lib/typedarray/Uint16Array#get:buffer
+  local.tee $4
   local.get $3
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Uint16Array#get:byteOffset
   local.get $3
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Uint16Array#get:byteOffset
   local.get $3
-  i32.load offset=8
+  call $~lib/typedarray/Uint16Array#get:byteLength
   i32.add
   call $~lib/arraybuffer/ArrayBuffer#slice
   local.set $6
@@ -38351,8 +38532,8 @@
    local.get $5
    local.get $1
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $8
+   local.get $8
    if
     local.get $3
     local.get $5
@@ -38379,6 +38560,8 @@
   end
   local.get $2
   call $~lib/rt/pure/__release
+  local.get $4
+  call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
   local.get $3
@@ -38388,7 +38571,12 @@
   local.get $7
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int32Array.wrap (; 568 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#get:buffer (; 595 ;) (param $0 i32) (result i32)
+  local.get $0
+  i32.load
+  call $~lib/rt/pure/__retain
+ )
+ (func $~lib/typedarray/Int32Array.wrap (; 596 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -38421,7 +38609,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1741
+   i32.const 1885
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -38440,9 +38628,9 @@
     if
      local.get $5
      call $~lib/rt/pure/__release
-     i32.const 32
+     i32.const 192
      i32.const 432
-     i32.const 1746
+     i32.const 1890
      i32.const 8
      call $~lib/builtins/abort
      unreachable
@@ -38454,9 +38642,9 @@
    else
     local.get $5
     call $~lib/rt/pure/__release
-    i32.const 32
+    i32.const 192
     i32.const 432
-    i32.const 1750
+    i32.const 1894
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -38474,9 +38662,9 @@
    if
     local.get $5
     call $~lib/rt/pure/__release
-    i32.const 32
+    i32.const 192
     i32.const 432
-    i32.const 1755
+    i32.const 1899
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -38491,13 +38679,13 @@
   call $~lib/rt/pure/__retain
   i32.store
   local.get $8
-  local.get $6
-  i32.store offset=8
-  local.get $8
   local.get $5
   local.get $4
   i32.add
   i32.store offset=4
+  local.get $8
+  local.get $6
+  i32.store offset=8
   local.get $8
   call $~lib/rt/pure/__retain
   local.set $9
@@ -38509,7 +38697,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $~lib/typedarray/Int32Array.wrap|trampoline (; 569 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int32Array.wrap|trampoline (; 597 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $2of2
    block $1of2
     block $0of2
@@ -38532,7 +38720,7 @@
   local.get $2
   call $~lib/typedarray/Int32Array.wrap
  )
- (func $std/typedarray/testArrayWrap<~lib/typedarray/Int32Array,i32> (; 570 ;)
+ (func $std/typedarray/testArrayWrap<~lib/typedarray/Int32Array,i32> (; 598 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -38541,6 +38729,7 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
   global.get $std/typedarray/testArrayWrapValues
   call $~lib/rt/pure/__retain
   local.set $0
@@ -38576,13 +38765,14 @@
    end
   end
   local.get $3
-  i32.load
+  call $~lib/typedarray/Int32Array#get:buffer
+  local.tee $4
   local.get $3
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Int32Array#get:byteOffset
   local.get $3
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Int32Array#get:byteOffset
   local.get $3
-  i32.load offset=8
+  call $~lib/typedarray/Int32Array#get:byteLength
   i32.add
   call $~lib/arraybuffer/ArrayBuffer#slice
   local.set $6
@@ -38605,8 +38795,8 @@
    local.get $5
    local.get $1
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $8
+   local.get $8
    if
     local.get $3
     local.get $5
@@ -38633,6 +38823,8 @@
   end
   local.get $2
   call $~lib/rt/pure/__release
+  local.get $4
+  call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
   local.get $3
@@ -38642,7 +38834,12 @@
   local.get $7
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint32Array.wrap (; 571 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint32Array#get:buffer (; 599 ;) (param $0 i32) (result i32)
+  local.get $0
+  i32.load
+  call $~lib/rt/pure/__retain
+ )
+ (func $~lib/typedarray/Uint32Array.wrap (; 600 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -38675,7 +38872,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1741
+   i32.const 1885
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -38694,9 +38891,9 @@
     if
      local.get $5
      call $~lib/rt/pure/__release
-     i32.const 32
+     i32.const 192
      i32.const 432
-     i32.const 1746
+     i32.const 1890
      i32.const 8
      call $~lib/builtins/abort
      unreachable
@@ -38708,9 +38905,9 @@
    else
     local.get $5
     call $~lib/rt/pure/__release
-    i32.const 32
+    i32.const 192
     i32.const 432
-    i32.const 1750
+    i32.const 1894
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -38728,9 +38925,9 @@
    if
     local.get $5
     call $~lib/rt/pure/__release
-    i32.const 32
+    i32.const 192
     i32.const 432
-    i32.const 1755
+    i32.const 1899
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -38745,13 +38942,13 @@
   call $~lib/rt/pure/__retain
   i32.store
   local.get $8
-  local.get $6
-  i32.store offset=8
-  local.get $8
   local.get $5
   local.get $4
   i32.add
   i32.store offset=4
+  local.get $8
+  local.get $6
+  i32.store offset=8
   local.get $8
   call $~lib/rt/pure/__retain
   local.set $9
@@ -38763,7 +38960,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $~lib/typedarray/Uint32Array.wrap|trampoline (; 572 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint32Array.wrap|trampoline (; 601 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $2of2
    block $1of2
     block $0of2
@@ -38786,7 +38983,7 @@
   local.get $2
   call $~lib/typedarray/Uint32Array.wrap
  )
- (func $std/typedarray/testArrayWrap<~lib/typedarray/Uint32Array,u32> (; 573 ;)
+ (func $std/typedarray/testArrayWrap<~lib/typedarray/Uint32Array,u32> (; 602 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -38795,6 +38992,7 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
   global.get $std/typedarray/testArrayWrapValues
   call $~lib/rt/pure/__retain
   local.set $0
@@ -38830,13 +39028,14 @@
    end
   end
   local.get $3
-  i32.load
+  call $~lib/typedarray/Uint32Array#get:buffer
+  local.tee $4
   local.get $3
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Uint32Array#get:byteOffset
   local.get $3
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Uint32Array#get:byteOffset
   local.get $3
-  i32.load offset=8
+  call $~lib/typedarray/Uint32Array#get:byteLength
   i32.add
   call $~lib/arraybuffer/ArrayBuffer#slice
   local.set $6
@@ -38859,8 +39058,8 @@
    local.get $5
    local.get $1
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $8
+   local.get $8
    if
     local.get $3
     local.get $5
@@ -38887,6 +39086,8 @@
   end
   local.get $2
   call $~lib/rt/pure/__release
+  local.get $4
+  call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
   local.get $3
@@ -38896,7 +39097,12 @@
   local.get $7
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int64Array.wrap (; 574 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int64Array#get:buffer (; 603 ;) (param $0 i32) (result i32)
+  local.get $0
+  i32.load
+  call $~lib/rt/pure/__retain
+ )
+ (func $~lib/typedarray/Int64Array.wrap (; 604 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -38929,7 +39135,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1741
+   i32.const 1885
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -38948,9 +39154,9 @@
     if
      local.get $5
      call $~lib/rt/pure/__release
-     i32.const 32
+     i32.const 192
      i32.const 432
-     i32.const 1746
+     i32.const 1890
      i32.const 8
      call $~lib/builtins/abort
      unreachable
@@ -38962,9 +39168,9 @@
    else
     local.get $5
     call $~lib/rt/pure/__release
-    i32.const 32
+    i32.const 192
     i32.const 432
-    i32.const 1750
+    i32.const 1894
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -38982,9 +39188,9 @@
    if
     local.get $5
     call $~lib/rt/pure/__release
-    i32.const 32
+    i32.const 192
     i32.const 432
-    i32.const 1755
+    i32.const 1899
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -38999,13 +39205,13 @@
   call $~lib/rt/pure/__retain
   i32.store
   local.get $8
-  local.get $6
-  i32.store offset=8
-  local.get $8
   local.get $5
   local.get $4
   i32.add
   i32.store offset=4
+  local.get $8
+  local.get $6
+  i32.store offset=8
   local.get $8
   call $~lib/rt/pure/__retain
   local.set $9
@@ -39017,7 +39223,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $~lib/typedarray/Int64Array.wrap|trampoline (; 575 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int64Array.wrap|trampoline (; 605 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $2of2
    block $1of2
     block $0of2
@@ -39040,7 +39246,7 @@
   local.get $2
   call $~lib/typedarray/Int64Array.wrap
  )
- (func $std/typedarray/testArrayWrap<~lib/typedarray/Int64Array,i64> (; 576 ;)
+ (func $std/typedarray/testArrayWrap<~lib/typedarray/Int64Array,i64> (; 606 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -39049,6 +39255,7 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
   global.get $std/typedarray/testArrayWrapValues
   call $~lib/rt/pure/__retain
   local.set $0
@@ -39085,13 +39292,14 @@
    end
   end
   local.get $3
-  i32.load
+  call $~lib/typedarray/Int64Array#get:buffer
+  local.tee $4
   local.get $3
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Int64Array#get:byteOffset
   local.get $3
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Int64Array#get:byteOffset
   local.get $3
-  i32.load offset=8
+  call $~lib/typedarray/Int64Array#get:byteLength
   i32.add
   call $~lib/arraybuffer/ArrayBuffer#slice
   local.set $6
@@ -39114,8 +39322,8 @@
    local.get $5
    local.get $1
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $8
+   local.get $8
    if
     local.get $3
     local.get $5
@@ -39142,6 +39350,8 @@
   end
   local.get $2
   call $~lib/rt/pure/__release
+  local.get $4
+  call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
   local.get $3
@@ -39151,7 +39361,12 @@
   local.get $7
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint64Array.wrap (; 577 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint64Array#get:buffer (; 607 ;) (param $0 i32) (result i32)
+  local.get $0
+  i32.load
+  call $~lib/rt/pure/__retain
+ )
+ (func $~lib/typedarray/Uint64Array.wrap (; 608 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -39184,7 +39399,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1741
+   i32.const 1885
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -39203,9 +39418,9 @@
     if
      local.get $5
      call $~lib/rt/pure/__release
-     i32.const 32
+     i32.const 192
      i32.const 432
-     i32.const 1746
+     i32.const 1890
      i32.const 8
      call $~lib/builtins/abort
      unreachable
@@ -39217,9 +39432,9 @@
    else
     local.get $5
     call $~lib/rt/pure/__release
-    i32.const 32
+    i32.const 192
     i32.const 432
-    i32.const 1750
+    i32.const 1894
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -39237,9 +39452,9 @@
    if
     local.get $5
     call $~lib/rt/pure/__release
-    i32.const 32
+    i32.const 192
     i32.const 432
-    i32.const 1755
+    i32.const 1899
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -39254,13 +39469,13 @@
   call $~lib/rt/pure/__retain
   i32.store
   local.get $8
-  local.get $6
-  i32.store offset=8
-  local.get $8
   local.get $5
   local.get $4
   i32.add
   i32.store offset=4
+  local.get $8
+  local.get $6
+  i32.store offset=8
   local.get $8
   call $~lib/rt/pure/__retain
   local.set $9
@@ -39272,7 +39487,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $~lib/typedarray/Uint64Array.wrap|trampoline (; 578 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint64Array.wrap|trampoline (; 609 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $2of2
    block $1of2
     block $0of2
@@ -39295,7 +39510,7 @@
   local.get $2
   call $~lib/typedarray/Uint64Array.wrap
  )
- (func $std/typedarray/testArrayWrap<~lib/typedarray/Uint64Array,u64> (; 579 ;)
+ (func $std/typedarray/testArrayWrap<~lib/typedarray/Uint64Array,u64> (; 610 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -39304,6 +39519,7 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
   global.get $std/typedarray/testArrayWrapValues
   call $~lib/rt/pure/__retain
   local.set $0
@@ -39340,13 +39556,14 @@
    end
   end
   local.get $3
-  i32.load
+  call $~lib/typedarray/Uint64Array#get:buffer
+  local.tee $4
   local.get $3
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Uint64Array#get:byteOffset
   local.get $3
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Uint64Array#get:byteOffset
   local.get $3
-  i32.load offset=8
+  call $~lib/typedarray/Uint64Array#get:byteLength
   i32.add
   call $~lib/arraybuffer/ArrayBuffer#slice
   local.set $6
@@ -39369,8 +39586,8 @@
    local.get $5
    local.get $1
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $8
+   local.get $8
    if
     local.get $3
     local.get $5
@@ -39397,6 +39614,8 @@
   end
   local.get $2
   call $~lib/rt/pure/__release
+  local.get $4
+  call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
   local.get $3
@@ -39406,7 +39625,12 @@
   local.get $7
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float32Array.wrap (; 580 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#get:buffer (; 611 ;) (param $0 i32) (result i32)
+  local.get $0
+  i32.load
+  call $~lib/rt/pure/__retain
+ )
+ (func $~lib/typedarray/Float32Array.wrap (; 612 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -39439,7 +39663,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1741
+   i32.const 1885
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -39458,9 +39682,9 @@
     if
      local.get $5
      call $~lib/rt/pure/__release
-     i32.const 32
+     i32.const 192
      i32.const 432
-     i32.const 1746
+     i32.const 1890
      i32.const 8
      call $~lib/builtins/abort
      unreachable
@@ -39472,9 +39696,9 @@
    else
     local.get $5
     call $~lib/rt/pure/__release
-    i32.const 32
+    i32.const 192
     i32.const 432
-    i32.const 1750
+    i32.const 1894
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -39492,9 +39716,9 @@
    if
     local.get $5
     call $~lib/rt/pure/__release
-    i32.const 32
+    i32.const 192
     i32.const 432
-    i32.const 1755
+    i32.const 1899
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -39509,13 +39733,13 @@
   call $~lib/rt/pure/__retain
   i32.store
   local.get $8
-  local.get $6
-  i32.store offset=8
-  local.get $8
   local.get $5
   local.get $4
   i32.add
   i32.store offset=4
+  local.get $8
+  local.get $6
+  i32.store offset=8
   local.get $8
   call $~lib/rt/pure/__retain
   local.set $9
@@ -39527,7 +39751,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $~lib/typedarray/Float32Array.wrap|trampoline (; 581 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Float32Array.wrap|trampoline (; 613 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $2of2
    block $1of2
     block $0of2
@@ -39550,7 +39774,7 @@
   local.get $2
   call $~lib/typedarray/Float32Array.wrap
  )
- (func $std/typedarray/testArrayWrap<~lib/typedarray/Float32Array,f32> (; 582 ;)
+ (func $std/typedarray/testArrayWrap<~lib/typedarray/Float32Array,f32> (; 614 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -39559,6 +39783,7 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
   global.get $std/typedarray/testArrayWrapValues
   call $~lib/rt/pure/__retain
   local.set $0
@@ -39595,13 +39820,14 @@
    end
   end
   local.get $3
-  i32.load
+  call $~lib/typedarray/Float32Array#get:buffer
+  local.tee $4
   local.get $3
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Float32Array#get:byteOffset
   local.get $3
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Float32Array#get:byteOffset
   local.get $3
-  i32.load offset=8
+  call $~lib/typedarray/Float32Array#get:byteLength
   i32.add
   call $~lib/arraybuffer/ArrayBuffer#slice
   local.set $6
@@ -39624,8 +39850,8 @@
    local.get $5
    local.get $1
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $8
+   local.get $8
    if
     local.get $3
     local.get $5
@@ -39652,6 +39878,8 @@
   end
   local.get $2
   call $~lib/rt/pure/__release
+  local.get $4
+  call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
   local.get $3
@@ -39661,7 +39889,12 @@
   local.get $7
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float64Array.wrap (; 583 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#get:buffer (; 615 ;) (param $0 i32) (result i32)
+  local.get $0
+  i32.load
+  call $~lib/rt/pure/__retain
+ )
+ (func $~lib/typedarray/Float64Array.wrap (; 616 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -39694,7 +39927,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1741
+   i32.const 1885
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -39713,9 +39946,9 @@
     if
      local.get $5
      call $~lib/rt/pure/__release
-     i32.const 32
+     i32.const 192
      i32.const 432
-     i32.const 1746
+     i32.const 1890
      i32.const 8
      call $~lib/builtins/abort
      unreachable
@@ -39727,9 +39960,9 @@
    else
     local.get $5
     call $~lib/rt/pure/__release
-    i32.const 32
+    i32.const 192
     i32.const 432
-    i32.const 1750
+    i32.const 1894
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -39747,9 +39980,9 @@
    if
     local.get $5
     call $~lib/rt/pure/__release
-    i32.const 32
+    i32.const 192
     i32.const 432
-    i32.const 1755
+    i32.const 1899
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -39764,13 +39997,13 @@
   call $~lib/rt/pure/__retain
   i32.store
   local.get $8
-  local.get $6
-  i32.store offset=8
-  local.get $8
   local.get $5
   local.get $4
   i32.add
   i32.store offset=4
+  local.get $8
+  local.get $6
+  i32.store offset=8
   local.get $8
   call $~lib/rt/pure/__retain
   local.set $9
@@ -39782,7 +40015,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $~lib/typedarray/Float64Array.wrap|trampoline (; 584 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Float64Array.wrap|trampoline (; 617 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $2of2
    block $1of2
     block $0of2
@@ -39805,7 +40038,7 @@
   local.get $2
   call $~lib/typedarray/Float64Array.wrap
  )
- (func $std/typedarray/testArrayWrap<~lib/typedarray/Float64Array,f64> (; 585 ;)
+ (func $std/typedarray/testArrayWrap<~lib/typedarray/Float64Array,f64> (; 618 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -39814,6 +40047,7 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
   global.get $std/typedarray/testArrayWrapValues
   call $~lib/rt/pure/__retain
   local.set $0
@@ -39850,13 +40084,14 @@
    end
   end
   local.get $3
-  i32.load
+  call $~lib/typedarray/Float64Array#get:buffer
+  local.tee $4
   local.get $3
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Float64Array#get:byteOffset
   local.get $3
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Float64Array#get:byteOffset
   local.get $3
-  i32.load offset=8
+  call $~lib/typedarray/Float64Array#get:byteLength
   i32.add
   call $~lib/arraybuffer/ArrayBuffer#slice
   local.set $6
@@ -39879,8 +40114,8 @@
    local.get $5
    local.get $1
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $8
+   local.get $8
    if
     local.get $3
     local.get $5
@@ -39907,6 +40142,8 @@
   end
   local.get $2
   call $~lib/rt/pure/__release
+  local.get $4
+  call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
   local.get $3
@@ -39916,7 +40153,7 @@
   local.get $7
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int8Array#set<~lib/array/Array<i32>> (; 586 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int8Array#set<~lib/array/Array<i32>> (; 619 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -39946,7 +40183,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1774
+   i32.const 1918
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -39965,7 +40202,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -40018,7 +40255,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/valuesEqual<~lib/typedarray/Int8Array> (; 587 ;) (param $0 i32) (param $1 i32)
+ (func $std/typedarray/valuesEqual<~lib/typedarray/Int8Array> (; 620 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -40101,11 +40338,11 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/array/Array<f32>#get:length (; 588 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<f32>#get:length (; 621 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/typedarray/Int8Array#set<~lib/array/Array<f32>> (; 589 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int8Array#set<~lib/array/Array<f32>> (; 622 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -40136,7 +40373,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1774
+   i32.const 1918
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -40155,7 +40392,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -40220,7 +40457,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int8Array#set<~lib/typedarray/Int64Array> (; 590 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int8Array#set<~lib/typedarray/Int64Array> (; 623 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -40250,7 +40487,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1774
+   i32.const 1918
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -40269,7 +40506,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -40322,11 +40559,11 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/array/Array<f64>#get:length (; 591 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<f64>#get:length (; 624 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/typedarray/Int8Array#set<~lib/array/Array<f64>> (; 592 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int8Array#set<~lib/array/Array<f64>> (; 625 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -40357,7 +40594,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1774
+   i32.const 1918
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -40376,7 +40613,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -40441,7 +40678,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int8Array#set<~lib/typedarray/Uint8Array> (; 593 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int8Array#set<~lib/typedarray/Uint8Array> (; 626 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -40466,7 +40703,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1774
+   i32.const 1918
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -40485,7 +40722,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -40508,7 +40745,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int8Array#set<~lib/typedarray/Int16Array> (; 594 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int8Array#set<~lib/typedarray/Int16Array> (; 627 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -40538,7 +40775,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1774
+   i32.const 1918
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -40557,7 +40794,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -40610,7 +40847,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int8Array#set<~lib/array/Array<i8>> (; 595 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int8Array#set<~lib/array/Array<i8>> (; 628 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -40635,7 +40872,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1774
+   i32.const 1918
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -40654,7 +40891,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -40677,7 +40914,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testTypedArraySet<~lib/typedarray/Int8Array> (; 596 ;)
+ (func $std/typedarray/testTypedArraySet<~lib/typedarray/Int8Array> (; 629 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -40840,7 +41077,7 @@
   local.get $8
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8Array#set<~lib/array/Array<i32>> (; 597 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint8Array#set<~lib/array/Array<i32>> (; 630 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -40870,7 +41107,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1774
+   i32.const 1918
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -40889,7 +41126,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -40942,11 +41179,11 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/array/Array<u8>#get:length (; 598 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<u8>#get:length (; 631 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<u8>#__unchecked_get (; 599 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u8>#__unchecked_get (; 632 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -40955,7 +41192,7 @@
   i32.add
   i32.load8_u
  )
- (func $std/typedarray/valuesEqual<~lib/typedarray/Uint8Array> (; 600 ;) (param $0 i32) (param $1 i32)
+ (func $std/typedarray/valuesEqual<~lib/typedarray/Uint8Array> (; 633 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -41038,7 +41275,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8Array#set<~lib/array/Array<f32>> (; 601 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint8Array#set<~lib/array/Array<f32>> (; 634 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -41069,7 +41306,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1774
+   i32.const 1918
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -41088,7 +41325,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -41153,7 +41390,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8Array#set<~lib/typedarray/Int64Array> (; 602 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint8Array#set<~lib/typedarray/Int64Array> (; 635 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -41183,7 +41420,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1774
+   i32.const 1918
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -41202,7 +41439,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -41255,7 +41492,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8Array#set<~lib/array/Array<f64>> (; 603 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint8Array#set<~lib/array/Array<f64>> (; 636 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -41286,7 +41523,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1774
+   i32.const 1918
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -41305,7 +41542,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -41370,7 +41607,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8Array#set<~lib/typedarray/Uint8Array> (; 604 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint8Array#set<~lib/typedarray/Uint8Array> (; 637 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -41395,7 +41632,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1774
+   i32.const 1918
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -41414,7 +41651,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -41437,7 +41674,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8Array#set<~lib/typedarray/Int16Array> (; 605 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint8Array#set<~lib/typedarray/Int16Array> (; 638 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -41467,7 +41704,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1774
+   i32.const 1918
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -41486,7 +41723,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -41539,7 +41776,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8Array#set<~lib/array/Array<i8>> (; 606 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint8Array#set<~lib/array/Array<i8>> (; 639 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -41564,7 +41801,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1774
+   i32.const 1918
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -41583,7 +41820,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -41606,7 +41843,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testTypedArraySet<~lib/typedarray/Uint8Array> (; 607 ;)
+ (func $std/typedarray/testTypedArraySet<~lib/typedarray/Uint8Array> (; 640 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -41769,7 +42006,7 @@
   local.get $8
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8ClampedArray#set<~lib/array/Array<i32>> (; 608 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint8ClampedArray#set<~lib/array/Array<i32>> (; 641 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -41800,7 +42037,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1774
+   i32.const 1918
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -41819,7 +42056,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -41886,7 +42123,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/valuesEqual<~lib/typedarray/Uint8ClampedArray> (; 609 ;) (param $0 i32) (param $1 i32)
+ (func $std/typedarray/valuesEqual<~lib/typedarray/Uint8ClampedArray> (; 642 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -41969,7 +42206,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8ClampedArray#set<~lib/array/Array<f32>> (; 610 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint8ClampedArray#set<~lib/array/Array<f32>> (; 643 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -42000,7 +42237,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1774
+   i32.const 1918
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -42019,7 +42256,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -42088,7 +42325,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Int64Array> (; 611 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Int64Array> (; 644 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -42119,7 +42356,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1774
+   i32.const 1918
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -42138,7 +42375,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -42209,7 +42446,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8ClampedArray#set<~lib/array/Array<f64>> (; 612 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint8ClampedArray#set<~lib/array/Array<f64>> (; 645 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -42240,7 +42477,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1774
+   i32.const 1918
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -42259,7 +42496,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -42328,7 +42565,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Uint8Array> (; 613 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Uint8Array> (; 646 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -42353,7 +42590,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1774
+   i32.const 1918
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -42372,7 +42609,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -42395,7 +42632,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Int16Array> (; 614 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Int16Array> (; 647 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -42426,7 +42663,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1774
+   i32.const 1918
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -42445,7 +42682,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -42512,7 +42749,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8ClampedArray#set<~lib/array/Array<i8>> (; 615 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint8ClampedArray#set<~lib/array/Array<i8>> (; 648 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -42543,7 +42780,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1774
+   i32.const 1918
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -42562,7 +42799,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -42629,7 +42866,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testTypedArraySet<~lib/typedarray/Uint8ClampedArray> (; 616 ;)
+ (func $std/typedarray/testTypedArraySet<~lib/typedarray/Uint8ClampedArray> (; 649 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -42792,7 +43029,7 @@
   local.get $8
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int16Array#set<~lib/array/Array<i32>> (; 617 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int16Array#set<~lib/array/Array<i32>> (; 650 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -42822,7 +43059,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1774
+   i32.const 1918
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -42841,7 +43078,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -42894,11 +43131,11 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/array/Array<i16>#get:length (; 618 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<i16>#get:length (; 651 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $std/typedarray/valuesEqual<~lib/typedarray/Int16Array> (; 619 ;) (param $0 i32) (param $1 i32)
+ (func $std/typedarray/valuesEqual<~lib/typedarray/Int16Array> (; 652 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -42981,7 +43218,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int16Array#set<~lib/array/Array<f32>> (; 620 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int16Array#set<~lib/array/Array<f32>> (; 653 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -43012,7 +43249,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1774
+   i32.const 1918
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -43031,7 +43268,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -43096,7 +43333,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int16Array#set<~lib/typedarray/Int64Array> (; 621 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int16Array#set<~lib/typedarray/Int64Array> (; 654 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -43126,7 +43363,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1774
+   i32.const 1918
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -43145,7 +43382,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -43198,7 +43435,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int16Array#set<~lib/array/Array<f64>> (; 622 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int16Array#set<~lib/array/Array<f64>> (; 655 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -43229,7 +43466,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1774
+   i32.const 1918
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -43248,7 +43485,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -43313,7 +43550,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int16Array#set<~lib/typedarray/Uint8Array> (; 623 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int16Array#set<~lib/typedarray/Uint8Array> (; 656 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -43343,7 +43580,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1774
+   i32.const 1918
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -43362,7 +43599,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -43415,7 +43652,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int16Array#set<~lib/typedarray/Int16Array> (; 624 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int16Array#set<~lib/typedarray/Int16Array> (; 657 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -43440,7 +43677,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1774
+   i32.const 1918
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -43459,7 +43696,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -43482,7 +43719,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int16Array#set<~lib/array/Array<i8>> (; 625 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int16Array#set<~lib/array/Array<i8>> (; 658 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -43512,7 +43749,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1774
+   i32.const 1918
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -43531,7 +43768,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -43584,7 +43821,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testTypedArraySet<~lib/typedarray/Int16Array> (; 626 ;)
+ (func $std/typedarray/testTypedArraySet<~lib/typedarray/Int16Array> (; 659 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -43747,7 +43984,7 @@
   local.get $8
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint16Array#set<~lib/array/Array<i32>> (; 627 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint16Array#set<~lib/array/Array<i32>> (; 660 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -43777,7 +44014,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1774
+   i32.const 1918
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -43796,7 +44033,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -43849,11 +44086,11 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/array/Array<u16>#get:length (; 628 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<u16>#get:length (; 661 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<u16>#__unchecked_get (; 629 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u16>#__unchecked_get (; 662 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -43862,7 +44099,7 @@
   i32.add
   i32.load16_u
  )
- (func $std/typedarray/valuesEqual<~lib/typedarray/Uint16Array> (; 630 ;) (param $0 i32) (param $1 i32)
+ (func $std/typedarray/valuesEqual<~lib/typedarray/Uint16Array> (; 663 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -43945,7 +44182,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint16Array#set<~lib/array/Array<f32>> (; 631 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint16Array#set<~lib/array/Array<f32>> (; 664 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -43976,7 +44213,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1774
+   i32.const 1918
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -43995,7 +44232,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -44060,7 +44297,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint16Array#set<~lib/typedarray/Int64Array> (; 632 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint16Array#set<~lib/typedarray/Int64Array> (; 665 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -44090,7 +44327,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1774
+   i32.const 1918
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -44109,7 +44346,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -44162,7 +44399,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint16Array#set<~lib/array/Array<f64>> (; 633 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint16Array#set<~lib/array/Array<f64>> (; 666 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -44193,7 +44430,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1774
+   i32.const 1918
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -44212,7 +44449,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -44277,7 +44514,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint16Array#set<~lib/typedarray/Uint8Array> (; 634 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint16Array#set<~lib/typedarray/Uint8Array> (; 667 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -44307,7 +44544,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1774
+   i32.const 1918
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -44326,7 +44563,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -44379,7 +44616,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint16Array#set<~lib/typedarray/Int16Array> (; 635 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint16Array#set<~lib/typedarray/Int16Array> (; 668 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -44404,7 +44641,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1774
+   i32.const 1918
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -44423,7 +44660,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -44446,7 +44683,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint16Array#set<~lib/array/Array<i8>> (; 636 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint16Array#set<~lib/array/Array<i8>> (; 669 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -44476,7 +44713,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1774
+   i32.const 1918
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -44495,7 +44732,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -44548,7 +44785,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testTypedArraySet<~lib/typedarray/Uint16Array> (; 637 ;)
+ (func $std/typedarray/testTypedArraySet<~lib/typedarray/Uint16Array> (; 670 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -44711,7 +44948,7 @@
   local.get $8
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int32Array#set<~lib/array/Array<i32>> (; 638 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int32Array#set<~lib/array/Array<i32>> (; 671 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -44736,7 +44973,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1774
+   i32.const 1918
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -44755,7 +44992,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -44778,7 +45015,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/valuesEqual<~lib/typedarray/Int32Array> (; 639 ;) (param $0 i32) (param $1 i32)
+ (func $std/typedarray/valuesEqual<~lib/typedarray/Int32Array> (; 672 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -44861,7 +45098,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int32Array#set<~lib/array/Array<f32>> (; 640 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int32Array#set<~lib/array/Array<f32>> (; 673 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -44892,7 +45129,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1774
+   i32.const 1918
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -44911,7 +45148,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -44976,7 +45213,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int32Array#set<~lib/typedarray/Int64Array> (; 641 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int32Array#set<~lib/typedarray/Int64Array> (; 674 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -45006,7 +45243,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1774
+   i32.const 1918
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -45025,7 +45262,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -45078,7 +45315,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int32Array#set<~lib/array/Array<f64>> (; 642 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int32Array#set<~lib/array/Array<f64>> (; 675 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -45109,7 +45346,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1774
+   i32.const 1918
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -45128,7 +45365,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -45193,7 +45430,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int32Array#set<~lib/typedarray/Uint8Array> (; 643 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int32Array#set<~lib/typedarray/Uint8Array> (; 676 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -45223,7 +45460,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1774
+   i32.const 1918
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -45242,7 +45479,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -45295,7 +45532,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int32Array#set<~lib/typedarray/Int16Array> (; 644 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int32Array#set<~lib/typedarray/Int16Array> (; 677 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -45325,7 +45562,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1774
+   i32.const 1918
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -45344,7 +45581,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -45397,7 +45634,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int32Array#set<~lib/array/Array<i8>> (; 645 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int32Array#set<~lib/array/Array<i8>> (; 678 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -45427,7 +45664,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1774
+   i32.const 1918
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -45446,7 +45683,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -45499,7 +45736,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testTypedArraySet<~lib/typedarray/Int32Array> (; 646 ;)
+ (func $std/typedarray/testTypedArraySet<~lib/typedarray/Int32Array> (; 679 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -45662,7 +45899,7 @@
   local.get $8
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint32Array#set<~lib/array/Array<i32>> (; 647 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint32Array#set<~lib/array/Array<i32>> (; 680 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -45687,7 +45924,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1774
+   i32.const 1918
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -45706,7 +45943,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -45729,11 +45966,11 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/array/Array<u32>#get:length (; 648 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<u32>#get:length (; 681 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<u32>#__unchecked_get (; 649 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u32>#__unchecked_get (; 682 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -45742,7 +45979,7 @@
   i32.add
   i32.load
  )
- (func $std/typedarray/valuesEqual<~lib/typedarray/Uint32Array> (; 650 ;) (param $0 i32) (param $1 i32)
+ (func $std/typedarray/valuesEqual<~lib/typedarray/Uint32Array> (; 683 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -45825,7 +46062,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint32Array#set<~lib/array/Array<f32>> (; 651 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint32Array#set<~lib/array/Array<f32>> (; 684 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -45856,7 +46093,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1774
+   i32.const 1918
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -45875,7 +46112,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -45940,7 +46177,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint32Array#set<~lib/typedarray/Int64Array> (; 652 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint32Array#set<~lib/typedarray/Int64Array> (; 685 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -45970,7 +46207,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1774
+   i32.const 1918
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -45989,7 +46226,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -46042,7 +46279,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint32Array#set<~lib/array/Array<f64>> (; 653 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint32Array#set<~lib/array/Array<f64>> (; 686 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -46073,7 +46310,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1774
+   i32.const 1918
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -46092,7 +46329,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -46157,7 +46394,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint32Array#set<~lib/typedarray/Uint8Array> (; 654 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint32Array#set<~lib/typedarray/Uint8Array> (; 687 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -46187,7 +46424,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1774
+   i32.const 1918
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -46206,7 +46443,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -46259,7 +46496,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint32Array#set<~lib/typedarray/Int16Array> (; 655 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint32Array#set<~lib/typedarray/Int16Array> (; 688 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -46289,7 +46526,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1774
+   i32.const 1918
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -46308,7 +46545,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -46361,7 +46598,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint32Array#set<~lib/array/Array<i8>> (; 656 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint32Array#set<~lib/array/Array<i8>> (; 689 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -46391,7 +46628,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1774
+   i32.const 1918
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -46410,7 +46647,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -46463,7 +46700,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testTypedArraySet<~lib/typedarray/Uint32Array> (; 657 ;)
+ (func $std/typedarray/testTypedArraySet<~lib/typedarray/Uint32Array> (; 690 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -46626,7 +46863,7 @@
   local.get $8
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int64Array#set<~lib/array/Array<i32>> (; 658 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int64Array#set<~lib/array/Array<i32>> (; 691 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -46656,7 +46893,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1774
+   i32.const 1918
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -46675,7 +46912,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -46728,11 +46965,11 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/array/Array<i64>#get:length (; 659 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<i64>#get:length (; 692 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<i64>#__unchecked_get (; 660 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $~lib/array/Array<i64>#__unchecked_get (; 693 ;) (param $0 i32) (param $1 i32) (result i64)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -46741,7 +46978,7 @@
   i32.add
   i64.load
  )
- (func $std/typedarray/valuesEqual<~lib/typedarray/Int64Array> (; 661 ;) (param $0 i32) (param $1 i32)
+ (func $std/typedarray/valuesEqual<~lib/typedarray/Int64Array> (; 694 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -46824,7 +47061,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int64Array#set<~lib/array/Array<f32>> (; 662 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int64Array#set<~lib/array/Array<f32>> (; 695 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -46855,7 +47092,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1774
+   i32.const 1918
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -46874,7 +47111,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -46939,7 +47176,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int64Array#set<~lib/typedarray/Int64Array> (; 663 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int64Array#set<~lib/typedarray/Int64Array> (; 696 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -46964,7 +47201,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1774
+   i32.const 1918
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -46983,7 +47220,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -47006,7 +47243,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int64Array#set<~lib/array/Array<f64>> (; 664 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int64Array#set<~lib/array/Array<f64>> (; 697 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -47037,7 +47274,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1774
+   i32.const 1918
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -47056,7 +47293,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -47121,7 +47358,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int64Array#set<~lib/typedarray/Uint8Array> (; 665 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int64Array#set<~lib/typedarray/Uint8Array> (; 698 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -47151,7 +47388,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1774
+   i32.const 1918
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -47170,7 +47407,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -47223,7 +47460,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int64Array#set<~lib/typedarray/Int16Array> (; 666 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int64Array#set<~lib/typedarray/Int16Array> (; 699 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -47253,7 +47490,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1774
+   i32.const 1918
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -47272,7 +47509,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -47325,7 +47562,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int64Array#set<~lib/array/Array<i8>> (; 667 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int64Array#set<~lib/array/Array<i8>> (; 700 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -47355,7 +47592,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1774
+   i32.const 1918
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -47374,7 +47611,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -47427,7 +47664,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testTypedArraySet<~lib/typedarray/Int64Array> (; 668 ;)
+ (func $std/typedarray/testTypedArraySet<~lib/typedarray/Int64Array> (; 701 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -47590,7 +47827,7 @@
   local.get $8
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint64Array#set<~lib/array/Array<i32>> (; 669 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint64Array#set<~lib/array/Array<i32>> (; 702 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -47620,7 +47857,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1774
+   i32.const 1918
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -47639,7 +47876,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -47692,11 +47929,11 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/array/Array<u64>#get:length (; 670 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<u64>#get:length (; 703 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $std/typedarray/valuesEqual<~lib/typedarray/Uint64Array> (; 671 ;) (param $0 i32) (param $1 i32)
+ (func $std/typedarray/valuesEqual<~lib/typedarray/Uint64Array> (; 704 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -47779,7 +48016,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint64Array#set<~lib/array/Array<f32>> (; 672 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint64Array#set<~lib/array/Array<f32>> (; 705 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -47810,7 +48047,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1774
+   i32.const 1918
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -47829,7 +48066,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -47894,7 +48131,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint64Array#set<~lib/typedarray/Int64Array> (; 673 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint64Array#set<~lib/typedarray/Int64Array> (; 706 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -47919,7 +48156,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1774
+   i32.const 1918
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -47938,7 +48175,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -47961,7 +48198,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint64Array#set<~lib/array/Array<f64>> (; 674 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint64Array#set<~lib/array/Array<f64>> (; 707 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -47992,7 +48229,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1774
+   i32.const 1918
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -48011,7 +48248,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -48076,7 +48313,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint64Array#set<~lib/typedarray/Uint8Array> (; 675 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint64Array#set<~lib/typedarray/Uint8Array> (; 708 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -48106,7 +48343,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1774
+   i32.const 1918
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -48125,7 +48362,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -48178,7 +48415,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint64Array#set<~lib/typedarray/Int16Array> (; 676 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint64Array#set<~lib/typedarray/Int16Array> (; 709 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -48208,7 +48445,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1774
+   i32.const 1918
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -48227,7 +48464,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -48280,7 +48517,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint64Array#set<~lib/array/Array<i8>> (; 677 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint64Array#set<~lib/array/Array<i8>> (; 710 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -48310,7 +48547,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1774
+   i32.const 1918
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -48329,7 +48566,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -48382,7 +48619,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testTypedArraySet<~lib/typedarray/Uint64Array> (; 678 ;)
+ (func $std/typedarray/testTypedArraySet<~lib/typedarray/Uint64Array> (; 711 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -48545,7 +48782,7 @@
   local.get $8
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float32Array#set<~lib/array/Array<i32>> (; 679 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Float32Array#set<~lib/array/Array<i32>> (; 712 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -48575,7 +48812,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1774
+   i32.const 1918
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -48594,7 +48831,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -48648,7 +48885,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/array/Array<f32>#__unchecked_get (; 680 ;) (param $0 i32) (param $1 i32) (result f32)
+ (func $~lib/array/Array<f32>#__unchecked_get (; 713 ;) (param $0 i32) (param $1 i32) (result f32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -48657,7 +48894,7 @@
   i32.add
   f32.load
  )
- (func $std/typedarray/valuesEqual<~lib/typedarray/Float32Array> (; 681 ;) (param $0 i32) (param $1 i32)
+ (func $std/typedarray/valuesEqual<~lib/typedarray/Float32Array> (; 714 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -48740,7 +48977,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float32Array#set<~lib/array/Array<f32>> (; 682 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Float32Array#set<~lib/array/Array<f32>> (; 715 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -48765,7 +49002,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1774
+   i32.const 1918
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -48784,7 +49021,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -48807,7 +49044,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float32Array#set<~lib/typedarray/Int64Array> (; 683 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Float32Array#set<~lib/typedarray/Int64Array> (; 716 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -48837,7 +49074,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1774
+   i32.const 1918
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -48856,7 +49093,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -48910,7 +49147,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float32Array#set<~lib/typedarray/Uint8Array> (; 684 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Float32Array#set<~lib/typedarray/Uint8Array> (; 717 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -48940,7 +49177,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1774
+   i32.const 1918
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -48959,7 +49196,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -49013,7 +49250,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float32Array#set<~lib/typedarray/Int16Array> (; 685 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Float32Array#set<~lib/typedarray/Int16Array> (; 718 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -49043,7 +49280,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1774
+   i32.const 1918
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -49062,7 +49299,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -49116,7 +49353,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float32Array#set<~lib/array/Array<i8>> (; 686 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Float32Array#set<~lib/array/Array<i8>> (; 719 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -49146,7 +49383,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1774
+   i32.const 1918
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -49165,7 +49402,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -49219,7 +49456,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testTypedArraySet<~lib/typedarray/Float32Array> (; 687 ;)
+ (func $std/typedarray/testTypedArraySet<~lib/typedarray/Float32Array> (; 720 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -49367,7 +49604,7 @@
   local.get $8
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float64Array#set<~lib/array/Array<i32>> (; 688 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Float64Array#set<~lib/array/Array<i32>> (; 721 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -49397,7 +49634,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1774
+   i32.const 1918
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -49416,7 +49653,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -49470,7 +49707,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/array/Array<f64>#__unchecked_get (; 689 ;) (param $0 i32) (param $1 i32) (result f64)
+ (func $~lib/array/Array<f64>#__unchecked_get (; 722 ;) (param $0 i32) (param $1 i32) (result f64)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -49479,7 +49716,7 @@
   i32.add
   f64.load
  )
- (func $std/typedarray/valuesEqual<~lib/typedarray/Float64Array> (; 690 ;) (param $0 i32) (param $1 i32)
+ (func $std/typedarray/valuesEqual<~lib/typedarray/Float64Array> (; 723 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -49560,7 +49797,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float64Array#set<~lib/array/Array<f32>> (; 691 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Float64Array#set<~lib/array/Array<f32>> (; 724 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -49590,7 +49827,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1774
+   i32.const 1918
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -49609,7 +49846,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -49663,7 +49900,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float64Array#set<~lib/typedarray/Int64Array> (; 692 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Float64Array#set<~lib/typedarray/Int64Array> (; 725 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -49693,7 +49930,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1774
+   i32.const 1918
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -49712,7 +49949,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -49766,7 +50003,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float64Array#set<~lib/typedarray/Uint8Array> (; 693 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Float64Array#set<~lib/typedarray/Uint8Array> (; 726 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -49796,7 +50033,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1774
+   i32.const 1918
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -49815,7 +50052,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -49869,7 +50106,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float64Array#set<~lib/typedarray/Int16Array> (; 694 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Float64Array#set<~lib/typedarray/Int16Array> (; 727 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -49899,7 +50136,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1774
+   i32.const 1918
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -49918,7 +50155,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -49972,7 +50209,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float64Array#set<~lib/array/Array<i8>> (; 695 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Float64Array#set<~lib/array/Array<i8>> (; 728 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -50002,7 +50239,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1774
+   i32.const 1918
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -50021,7 +50258,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -50075,7 +50312,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testTypedArraySet<~lib/typedarray/Float64Array> (; 696 ;)
+ (func $std/typedarray/testTypedArraySet<~lib/typedarray/Float64Array> (; 729 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -50223,7 +50460,7 @@
   local.get $8
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Float32Array> (; 697 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Float32Array> (; 730 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -50254,7 +50491,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1774
+   i32.const 1918
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -50273,7 +50510,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -50342,7 +50579,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Int32Array> (; 698 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Int32Array> (; 731 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -50373,7 +50610,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1774
+   i32.const 1918
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -50392,7 +50629,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -50459,7 +50696,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Uint32Array> (; 699 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Uint32Array> (; 732 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -50492,7 +50729,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1774
+   i32.const 1918
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -50511,7 +50748,7 @@
    call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
-   i32.const 1775
+   i32.const 1919
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -50573,7 +50810,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $start:std/typedarray (; 700 ;)
+ (func $start:std/typedarray (; 733 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -50635,7 +50872,7 @@
    unreachable
   end
   local.get $0
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Int32Array#get:byteOffset
   i32.const 0
   i32.eq
   i32.eqz
@@ -50648,7 +50885,7 @@
    unreachable
   end
   local.get $0
-  i32.load offset=8
+  call $~lib/typedarray/Int32Array#get:byteLength
   i32.const 12
   i32.eq
   i32.eqz
@@ -50725,7 +50962,7 @@
    unreachable
   end
   local.get $0
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Int32Array#get:byteOffset
   i32.const 4
   i32.eq
   i32.eqz
@@ -50738,7 +50975,7 @@
    unreachable
   end
   local.get $0
-  i32.load offset=8
+  call $~lib/typedarray/Int32Array#get:byteLength
   i32.const 4
   i32.eq
   i32.eqz
@@ -50825,7 +51062,7 @@
    unreachable
   end
   local.get $0
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Float64Array#get:byteOffset
   i32.const 16
   i32.eq
   i32.eqz
@@ -50838,7 +51075,7 @@
    unreachable
   end
   local.get $0
-  i32.load offset=8
+  call $~lib/typedarray/Float64Array#get:byteLength
   i32.const 32
   i32.eq
   i32.eqz
@@ -51128,7 +51365,7 @@
    unreachable
   end
   local.get $1
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Int8Array#get:byteOffset
   i32.const 1
   i32.eq
   i32.eqz
@@ -51141,7 +51378,7 @@
    unreachable
   end
   local.get $1
-  i32.load offset=8
+  call $~lib/typedarray/Int8Array#get:byteLength
   i32.const 3
   i32.eq
   i32.eqz
@@ -51376,7 +51613,7 @@
    unreachable
   end
   local.get $8
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Int32Array#get:byteOffset
   i32.const 4
   i32.eq
   i32.eqz
@@ -51389,7 +51626,7 @@
    unreachable
   end
   local.get $8
-  i32.load offset=8
+  call $~lib/typedarray/Int32Array#get:byteLength
   i32.const 12
   i32.eq
   i32.eqz
@@ -51516,7 +51753,7 @@
    unreachable
   end
   local.get $0
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Int8Array#get:byteOffset
   i32.const 1
   i32.eq
   i32.eqz
@@ -51529,7 +51766,7 @@
    unreachable
   end
   local.get $0
-  i32.load offset=8
+  call $~lib/typedarray/Int8Array#get:byteLength
   i32.const 5
   i32.eq
   i32.eqz
@@ -51574,7 +51811,7 @@
    unreachable
   end
   local.get $8
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Int8Array#get:byteOffset
   i32.const 2
   i32.eq
   i32.eqz
@@ -51587,7 +51824,7 @@
    unreachable
   end
   local.get $8
-  i32.load offset=8
+  call $~lib/typedarray/Int8Array#get:byteLength
   i32.const 4
   i32.eq
   i32.eqz
@@ -51632,7 +51869,7 @@
    unreachable
   end
   local.get $3
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Int8Array#get:byteOffset
   i32.const 3
   i32.eq
   i32.eqz
@@ -51645,7 +51882,7 @@
    unreachable
   end
   local.get $3
-  i32.load offset=8
+  call $~lib/typedarray/Int8Array#get:byteLength
   i32.const 3
   i32.eq
   i32.eqz
@@ -52164,7 +52401,7 @@
    unreachable
   end
   local.get $23
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Int32Array#get:byteOffset
   i32.const 4
   i32.eq
   i32.eqz
@@ -52177,7 +52414,7 @@
    unreachable
   end
   local.get $23
-  i32.load offset=8
+  call $~lib/typedarray/Int32Array#get:byteLength
   i32.const 12
   i32.eq
   i32.eqz
@@ -52236,7 +52473,7 @@
    unreachable
   end
   local.get $24
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Int32Array#get:byteOffset
   i32.const 0
   i32.eq
   i32.eqz
@@ -52249,7 +52486,7 @@
    unreachable
   end
   local.get $24
-  i32.load offset=8
+  call $~lib/typedarray/Int32Array#get:byteLength
   i32.const 8
   i32.eq
   i32.eqz
@@ -52294,7 +52531,7 @@
    unreachable
   end
   local.get $21
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Int32Array#get:byteOffset
   i32.const 0
   i32.eq
   i32.eqz
@@ -52307,7 +52544,7 @@
    unreachable
   end
   local.get $21
-  i32.load offset=8
+  call $~lib/typedarray/Int32Array#get:byteLength
   i32.const 4
   i32.eq
   i32.eqz
@@ -52351,9 +52588,9 @@
    unreachable
   end
   local.get $22
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Int32Array#get:byteOffset
   local.get $26
-  call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
+  call $~lib/typedarray/Int32Array#get:byteOffset
   i32.eq
   i32.eqz
   if
@@ -52365,9 +52602,9 @@
    unreachable
   end
   local.get $22
-  i32.load offset=8
+  call $~lib/typedarray/Int32Array#get:byteLength
   local.get $26
-  i32.load offset=8
+  call $~lib/typedarray/Int32Array#get:byteLength
   i32.eq
   i32.eqz
   if
@@ -52822,7 +53059,7 @@
   local.get $20
   call $~lib/rt/pure/__release
  )
- (func $~start (; 701 ;)
+ (func $~start (; 734 ;)
   global.get $~started
   if
    return
@@ -52832,10 +53069,10 @@
   end
   call $start:std/typedarray
  )
- (func $~lib/rt/pure/__collect (; 702 ;)
+ (func $~lib/rt/pure/__collect (; 735 ;)
   return
  )
- (func $~lib/rt/pure/decrement (; 703 ;) (param $0 i32)
+ (func $~lib/rt/pure/decrement (; 736 ;) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -52855,7 +53092,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 256
+   i32.const 144
    i32.const 122
    i32.const 13
    call $~lib/builtins/abort
@@ -52877,7 +53114,7 @@
    i32.eqz
    if
     i32.const 0
-    i32.const 256
+    i32.const 144
     i32.const 126
     i32.const 17
     call $~lib/builtins/abort
@@ -52893,7 +53130,7 @@
    i32.eqz
    if
     i32.const 0
-    i32.const 256
+    i32.const 144
     i32.const 136
     i32.const 15
     call $~lib/builtins/abort
@@ -52912,7 +53149,7 @@
    i32.store offset=4
   end
  )
- (func $~lib/rt/pure/__visit (; 704 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/pure/__visit (; 737 ;) (param $0 i32) (param $1 i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.lt_u
@@ -52925,7 +53162,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 256
+   i32.const 144
    i32.const 69
    i32.const 15
    call $~lib/builtins/abort
@@ -52936,37 +53173,37 @@
   i32.sub
   call $~lib/rt/pure/decrement
  )
- (func $~lib/array/Array<i8>#__visit_impl (; 705 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i8>#__visit_impl (; 738 ;) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/array/Array<i32>#__visit_impl (; 706 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i32>#__visit_impl (; 739 ;) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/array/Array<u32>#__visit_impl (; 707 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<u32>#__visit_impl (; 740 ;) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/array/Array<u64>#__visit_impl (; 708 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<u64>#__visit_impl (; 741 ;) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/array/Array<i16>#__visit_impl (; 709 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i16>#__visit_impl (; 742 ;) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/array/Array<f32>#__visit_impl (; 710 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<f32>#__visit_impl (; 743 ;) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/array/Array<f64>#__visit_impl (; 711 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<f64>#__visit_impl (; 744 ;) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/array/Array<u8>#__visit_impl (; 712 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<u8>#__visit_impl (; 745 ;) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/array/Array<u16>#__visit_impl (; 713 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<u16>#__visit_impl (; 746 ;) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/array/Array<i64>#__visit_impl (; 714 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i64>#__visit_impl (; 747 ;) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/rt/__visit_members (; 715 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/__visit_members (; 748 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   block $block$4$break
    block $switch$1$default


### PR DESCRIPTION
There has been a change a while ago that tried to unify the `ArrayBufferView` interface, but it turned out that the changes there are unsafe. In particular:

* `Array<T>` must not expose `.buffer` since it can resize automatically, leading to use-after-free scenarios in the worst case.
* `Array<T>` does not have a `.byteLength` property.

The only sensible solution there is to use distinct `@unsafe` fields for the ABV interface, with actual implementations providing safe getters.

Original breaking PR: https://github.com/AssemblyScript/assemblyscript/pull/865
Related docs issue: https://github.com/AssemblyScript/docs/pull/7