### PR TITLE
Fix const enum compilation failure

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -19,6 +19,7 @@ under the licensing terms detailed in LICENSE:
 * jhwgh1968 <jhwgh1968@protonmail.com>
 * Jeffrey Charles <jeffreycharles@gmail.com>
 * Vladimir Tikhonov <reg@tikhonov.by>
+* Duncan Uszkay <duncan.uszkay@shopify.com>
 
 Portions of this software are derived from third-party works licensed under
 the following terms:

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -1084,10 +1084,16 @@ export class Compiler extends DiagnosticEmitter {
               (<EnumValue>member).identifierNode.range.atEnd
             );
           }
-          initExpr = module.binary(BinaryOp.AddI32,
-            module.global_get(previousValue.internalName, NativeType.I32),
-            module.i32(1)
-          );
+          if (isInline) {
+            let value = i64_add(previousValue.constantIntegerValue, i64_new(1));
+            assert(!i64_high(value));
+            initExpr = module.i32(i64_low(value));
+          } else {
+            initExpr = module.binary(BinaryOp.AddI32,
+              module.global_get(previousValue.internalName, NativeType.I32),
+              module.i32(1)
+            );
+          }
           initExpr = module.precomputeExpression(initExpr);
           if (getExpressionId(initExpr) != ExpressionId.Const) {
             if (element.is(CommonFlags.CONST)) {

--- a/tests/compiler/enum.ts
+++ b/tests/compiler/enum.ts
@@ -12,6 +12,13 @@ export const enum ImplicitConst {
   THREE
 }
 
+const enum ImplicitConstNoExport {
+  ZERO,
+  ONE,
+  TWO,
+  THREE
+}
+
 export enum Explicit {
   ZERO = 0,
   ONE = 0 + 1,


### PR DESCRIPTION
Issue: https://github.com/AssemblyScript/assemblyscript/issues/574

If you tried to use a const enum with multiple members, you would receive a compilation failure.

This was because the compiler relied upon each enum value to be registered as a global value in order to determine what the next enum value was. As a result, when we inlined the enum values and did not register that global value, compilation would fail.

To fix this, I've changed this method around a bit to rely upon the last expression value used (held in `initExpr`) rather than trying to load from the global store.

I'm not sure why it was implemented the way it was originally- it's possible that there is some tradeoff involved here I'm unaware of which causes reading from the global store to be faster/more efficient than simply reusing the last expression statement used in the loop. This certainly seems to work from a functional perspective 🤷‍♂ 