### PR TITLE
Warn on usize mismatch between 32/64 bits

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -3456,6 +3456,14 @@ export class Compiler extends DiagnosticEmitter {
             expr = this.ensureSmallIntegerWrap(expr, fromType); // must clear garbage bits
             wrap = false;
           }
+        // same size
+        } else {
+          if (!explicit && !this.options.isWasm64 && fromType.is(TypeFlags.POINTER) && !toType.is(TypeFlags.POINTER)) {
+            this.warning(
+              DiagnosticCode.Conversion_from_type_0_to_1_will_require_an_explicit_cast_when_switching_between_32_64_bit,
+              reportNode.range, fromType.toString(), toType.toString()
+            );
+          }
         }
       }
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -133,6 +133,7 @@ export class Type {
 
   /** Returns the closest int type representing this type. */
   get intType(): Type {
+    if (this == Type.auto) return this; // keep auto as a hint
     switch (this.kind) {
       case TypeKind.I8: return Type.i8;
       case TypeKind.I16: return Type.i16;

--- a/std/assembly/map.ts
+++ b/std/assembly/map.ts
@@ -137,7 +137,7 @@ export class Map<K,V> {
       }
       // append new entry
       let entries = this.entries;
-      entry = changetype<MapEntry<K,V>>(changetype<usize>(entries) + this.entriesOffset++ * ENTRY_SIZE<K,V>());
+      entry = changetype<MapEntry<K,V>>(changetype<usize>(entries) + <usize>(this.entriesOffset++) * ENTRY_SIZE<K,V>());
       // link with the map
       entry.key = isManaged<K>()
         ? changetype<K>(__retain(changetype<usize>(key)))

--- a/std/assembly/rt/common.ts
+++ b/std/assembly/rt/common.ts
@@ -37,7 +37,7 @@
 }
 
 // @ts-ignore: decorator
-@inline export const BLOCK_OVERHEAD = (offsetof<BLOCK>() + AL_MASK) & ~AL_MASK;
+@inline export const BLOCK_OVERHEAD: usize = (offsetof<BLOCK>() + AL_MASK) & ~AL_MASK;
 
 // @ts-ignore: decorator
 @inline export const BLOCK_MAXSIZE: usize = (1 << 30) - BLOCK_OVERHEAD;

--- a/std/assembly/rt/stub.ts
+++ b/std/assembly/rt/stub.ts
@@ -13,7 +13,7 @@ function maybeGrowMemory(newOffset: usize): void {
   var pagesBefore = memory.size();
   var maxOffset = <usize>pagesBefore << 16;
   if (newOffset > maxOffset) {
-    let pagesNeeded = ((newOffset - maxOffset + 0xffff) & ~0xffff) >>> 16;
+    let pagesNeeded = <i32>(((newOffset - maxOffset + 0xffff) & ~0xffff) >>> 16);
     let pagesWanted = max(pagesBefore, pagesNeeded); // double memory
     if (memory.grow(pagesWanted) < 0) {
       if (memory.grow(pagesNeeded) < 0) unreachable(); // out of memory
@@ -33,7 +33,7 @@ export function __alloc(size: usize, id: u32): usize {
   block.mmInfo = actualSize;
   if (DEBUG) block.gcInfo = 1;
   block.rtId = id;
-  block.rtSize = size;
+  block.rtSize = <u32>size;
   return ptr;
 }
 
@@ -60,7 +60,7 @@ export function __realloc(ptr: usize, size: usize): usize {
     offset = ptr + alignedSize;
     block.mmInfo = alignedSize;
   }
-  block.rtSize = size;
+  block.rtSize = <u32>size;
   return ptr;
 }
 

--- a/std/assembly/rt/tlsf.ts
+++ b/std/assembly/rt/tlsf.ts
@@ -19,12 +19,12 @@ import { REFCOUNT_MASK } from "./pure";
 // @ts-ignore: decorator
 @inline const SL_BITS: u32 = 4;
 // @ts-ignore: decorator
-@inline const SL_SIZE: usize = 1 << <usize>SL_BITS;
+@inline const SL_SIZE: u32 = 1 << SL_BITS;
 
 // @ts-ignore: decorator
-@inline const SB_BITS: usize = <usize>(SL_BITS + AL_BITS);
+@inline const SB_BITS: u32 = SL_BITS + AL_BITS;
 // @ts-ignore: decorator
-@inline const SB_SIZE: usize = 1 << <usize>SB_BITS;
+@inline const SB_SIZE: u32 = 1 << SB_BITS;
 
 // @ts-ignore: decorator
 @inline const FL_BITS: u32 = 31 - SB_BITS;
@@ -130,15 +130,15 @@ import { REFCOUNT_MASK } from "./pure";
 // Root constants. Where stuff is stored inside of the root structure.
 
 // @ts-ignore: decorator
-@inline const SL_START = sizeof<usize>();
+@inline const SL_START: usize = sizeof<usize>();
 // @ts-ignore: decorator
-@inline const SL_END = SL_START + (FL_BITS << alignof<u32>());
+@inline const SL_END: usize = SL_START + (FL_BITS << alignof<u32>());
 // @ts-ignore: decorator
-@inline const HL_START = (SL_END + AL_MASK) & ~AL_MASK;
+@inline const HL_START: usize = (SL_END + AL_MASK) & ~AL_MASK;
 // @ts-ignore: decorator
-@inline const HL_END = HL_START + FL_BITS * SL_SIZE * sizeof<usize>();
+@inline const HL_END: usize = HL_START + FL_BITS * SL_SIZE * sizeof<usize>();
 // @ts-ignore: decorator
-@inline const ROOT_SIZE = HL_END + sizeof<usize>();
+@inline const ROOT_SIZE: usize = HL_END + sizeof<usize>();
 
 // @ts-ignore: decorator
 @lazy export var ROOT: Root;
@@ -510,7 +510,7 @@ export function allocateBlock(root: Root, size: usize, id: u32): Block {
   if (DEBUG) assert((block.mmInfo & ~TAGS_MASK) >= payloadSize); // must fit
   block.gcInfo = 0; // RC=0
   block.rtId = id;
-  block.rtSize = size;
+  block.rtSize = <u32>size;
   removeBlock(root, <Block>block);
   prepareBlock(root, <Block>block, payloadSize);
   if (isDefined(ASC_RTRACE)) onalloc(<Block>block);
@@ -525,7 +525,7 @@ export function reallocateBlock(root: Root, block: Block, size: usize): Block {
   // possibly split and update runtime size if it still fits
   if (payloadSize <= (blockInfo & ~TAGS_MASK)) {
     prepareBlock(root, block, payloadSize);
-    block.rtSize = size;
+    block.rtSize = <u32>size;
     return block;
   }
 
@@ -539,7 +539,7 @@ export function reallocateBlock(root: Root, block: Block, size: usize): Block {
       // TODO: this can yield an intermediate block larger than BLOCK_MAXSIZE, which
       // is immediately split though. does this trigger any assertions / issues?
       block.mmInfo = (blockInfo & TAGS_MASK) | mergeSize;
-      block.rtSize = size;
+      block.rtSize = <u32>size;
       prepareBlock(root, block, payloadSize);
       return block;
     }

--- a/std/assembly/set.ts
+++ b/std/assembly/set.ts
@@ -114,7 +114,7 @@ export class Set<T> {
         );
       }
       // append new entry
-      entry = changetype<SetEntry<T>>(changetype<usize>(this.entries) + this.entriesOffset++ * ENTRY_SIZE<T>());
+      entry = changetype<SetEntry<T>>(changetype<usize>(this.entries) + <usize>(this.entriesOffset++) * ENTRY_SIZE<T>());
       entry.key = isManaged<T>()
         ? changetype<T>(__retain(changetype<usize>(key)))
         : key;

--- a/std/assembly/string.ts
+++ b/std/assembly/string.ts
@@ -8,7 +8,7 @@ import { idof } from "./builtins";
 
 @sealed export abstract class String {
 
-  @lazy static readonly MAX_LENGTH: i32 = BLOCK_MAXSIZE >>> alignof<u16>();
+  @lazy static readonly MAX_LENGTH: i32 = <i32>(BLOCK_MAXSIZE >>> alignof<u16>());
 
   static fromCharCode(unit: i32, surr: i32 = -1): String {
     var hasSur = surr > 0;
@@ -446,13 +446,13 @@ import { idof } from "./builtins";
     if (!limit) return changetype<Array<String>>(__allocArray(0, alignof<String>(), idof<Array<String>>())); // retains
     if (separator === null) return [this];
     var length: isize = this.length;
-    var sepLen: isize = separator.length;
+    var sepLen = separator.length;
     if (limit < 0) limit = i32.MAX_VALUE;
     if (!sepLen) {
       if (!length) return changetype<Array<String>>(__allocArray(0, alignof<String>(), idof<Array<String>>()));  // retains
       // split by chars
       length = min<isize>(length, <isize>limit);
-      let result = changetype<Array<String>>(__allocArray(length, alignof<String>(), idof<Array<String>>())); // retains
+      let result = changetype<Array<String>>(__allocArray(<i32>length, alignof<String>(), idof<Array<String>>())); // retains
       // @ts-ignore: cast
       let resultStart = result.dataStart as usize;
       for (let i: isize = 0; i < length; ++i) {
@@ -578,7 +578,7 @@ import { idof } from "./builtins";
           // monkey patch
           store<u16>(codes + (j << 1), c - 26);
         } else {
-          let index = -1;
+          let index: usize = -1;
           // Fast range check. See first and last rows in specialsUpper table
           if (c - 0x00DF <= 0xFB17 - 0x00DF) {
             index = <usize>bsearch(c, changetype<usize>(SPECIALS_UPPER), specialsUpperLen);

--- a/std/assembly/symbol.ts
+++ b/std/assembly/symbol.ts
@@ -85,7 +85,7 @@ var nextId: usize = 12; // Symbol.unscopables + 1
   toString(): string {
     var id = changetype<usize>(this);
     var str = "";
-    switch (id) {
+    switch (<u32>id) {
       case 1:  { str = "hasInstance"; break; }
       case 2:  { str = "isConcatSpreadable"; break; }
       case 3:  { str = "isRegExp"; break; }

--- a/std/assembly/typedarray.ts
+++ b/std/assembly/typedarray.ts
@@ -9,7 +9,7 @@ export class Int8Array extends ArrayBufferView {
 
   // @ts-ignore: decorator
   @lazy
-  static readonly BYTES_PER_ELEMENT: usize = sizeof<i8>();
+  static readonly BYTES_PER_ELEMENT: i32 = sizeof<i8>();
 
   constructor(length: i32) {
     super(length, alignof<i8>());
@@ -137,7 +137,7 @@ export class Uint8Array extends ArrayBufferView {
 
   // @ts-ignore: decorator
   @lazy
-  static readonly BYTES_PER_ELEMENT: usize = sizeof<u8>();
+  static readonly BYTES_PER_ELEMENT: i32 = sizeof<u8>();
 
   constructor(length: i32) {
     super(length, alignof<u8>());
@@ -265,7 +265,7 @@ export class Uint8ClampedArray extends ArrayBufferView {
 
   // @ts-ignore: decorator
   @lazy
-  static readonly BYTES_PER_ELEMENT: usize = sizeof<u8>();
+  static readonly BYTES_PER_ELEMENT: i32 = sizeof<u8>();
 
   constructor(length: i32) {
     super(length, alignof<u8>());
@@ -393,7 +393,7 @@ export class Int16Array extends ArrayBufferView {
 
   // @ts-ignore: decorator
   @lazy
-  static readonly BYTES_PER_ELEMENT: usize = sizeof<i16>();
+  static readonly BYTES_PER_ELEMENT: i32 = sizeof<i16>();
 
   constructor(length: i32) {
     super(length, alignof<i16>());
@@ -521,7 +521,7 @@ export class Uint16Array extends ArrayBufferView {
 
   // @ts-ignore: decorator
   @lazy
-  static readonly BYTES_PER_ELEMENT: usize = sizeof<u16>();
+  static readonly BYTES_PER_ELEMENT: i32 = sizeof<u16>();
 
   constructor(length: i32) {
     super(length, alignof<u16>());
@@ -649,7 +649,7 @@ export class Int32Array extends ArrayBufferView {
 
   // @ts-ignore: decorator
   @lazy
-  static readonly BYTES_PER_ELEMENT: usize = sizeof<i32>();
+  static readonly BYTES_PER_ELEMENT: i32 = sizeof<i32>();
 
   constructor(length: i32) {
     super(length, alignof<i32>());
@@ -777,7 +777,7 @@ export class Uint32Array extends ArrayBufferView {
 
   // @ts-ignore: decorator
   @lazy
-  static readonly BYTES_PER_ELEMENT: usize = sizeof<u32>();
+  static readonly BYTES_PER_ELEMENT: i32 = sizeof<u32>();
 
   constructor(length: i32) {
     super(length, alignof<u32>());
@@ -905,7 +905,7 @@ export class Int64Array extends ArrayBufferView {
 
   // @ts-ignore: decorator
   @lazy
-  static readonly BYTES_PER_ELEMENT: usize = sizeof<i64>();
+  static readonly BYTES_PER_ELEMENT: i32 = sizeof<i64>();
 
   constructor(length: i32) {
     super(length, alignof<i64>());
@@ -1033,7 +1033,7 @@ export class Uint64Array extends ArrayBufferView {
 
   // @ts-ignore: decorator
   @lazy
-  static readonly BYTES_PER_ELEMENT: usize = sizeof<u64>();
+  static readonly BYTES_PER_ELEMENT: i32 = sizeof<u64>();
 
   constructor(length: i32) {
     super(length, alignof<u64>());
@@ -1161,7 +1161,7 @@ export class Float32Array extends ArrayBufferView {
 
   // @ts-ignore: decorator
   @lazy
-  static readonly BYTES_PER_ELEMENT: usize = sizeof<f32>();
+  static readonly BYTES_PER_ELEMENT: i32 = sizeof<f32>();
 
   constructor(length: i32) {
     super(length, alignof<f32>());
@@ -1289,7 +1289,7 @@ export class Float64Array extends ArrayBufferView {
 
   // @ts-ignore: decorator
   @lazy
-  static readonly BYTES_PER_ELEMENT: usize = sizeof<f64>();
+  static readonly BYTES_PER_ELEMENT: i32 = sizeof<f64>();
 
   constructor(length: i32) {
     super(length, alignof<f64>());
@@ -1736,7 +1736,7 @@ function REVERSE<TArray extends ArrayBufferView, T>(array: TArray): TArray {
 function WRAP<TArray extends ArrayBufferView, T>(buffer: ArrayBuffer, byteOffset: i32 = 0, length: i32 = -1): TArray {
   var byteLength: i32;
   var bufferByteLength = buffer.byteLength;
-  const mask = sizeof<T>() - 1;
+  const mask: u32 = sizeof<T>() - 1;
   if (i32(<u32>byteOffset > <u32>bufferByteLength) | (byteOffset & mask)) {
     throw new RangeError(E_INDEXOUTOFRANGE);
   }

--- a/std/assembly/util/memory.ts
+++ b/std/assembly/util/memory.ts
@@ -38,7 +38,7 @@ export function memcpy(dest: usize, src: usize, n: usize): void { // see: musl/s
   // if dst is not aligned to 4 bytes, use alternating shifts to copy 4 bytes each
   // doing shifts if faster when copying enough bytes (here: 32 or more)
   if (n >= 32) {
-    switch (dest & 3) {
+    switch (<u32>dest & 3) {
       // known to be != 0
       case 1: {
         w = load<u32>(src);

--- a/std/assembly/util/sort.ts
+++ b/std/assembly/util/sort.ts
@@ -86,7 +86,7 @@ function weakHeapSort<T>(
 ): void {
   const shift32 = alignof<u32>();
 
-  var bitsetSize = (length + 31) >> 5 << shift32;
+  var bitsetSize = (<usize>length + 31) >> 5 << shift32;
   var bitset = __alloc(bitsetSize, 0); // indexed in 32-bit chunks below
   memory.fill(bitset, 0, bitsetSize);
 
@@ -94,15 +94,15 @@ function weakHeapSort<T>(
 
   for (let i = length - 1; i > 0; i--) {
     let j = i;
-    while ((j & 1) == (load<u32>(bitset + (j >> 6 << shift32)) >> (j >> 1 & 31) & 1)) j >>= 1;
+    while ((j & 1) == (load<u32>(bitset + (<usize>j >> 6 << shift32)) >> (j >> 1 & 31) & 1)) j >>= 1;
 
     let p = j >> 1;
     let a: T = load<T>(dataStart + (<usize>p << alignof<T>())); // a = arr[p]
     let b: T = load<T>(dataStart + (<usize>i << alignof<T>())); // b = arr[i]
     if (comparator(a, b) < 0) {
       store<u32>(
-        bitset + (i >> 5 << shift32),
-        load<u32>(bitset + (i >> 5 << shift32)) ^ (1 << (i & 31))
+        bitset + (<usize>i >> 5 << shift32),
+        load<u32>(bitset + (<usize>i >> 5 << shift32)) ^ (1 << (i & 31))
       );
       store<T>(dataStart + (<usize>i << alignof<T>()), a); // arr[i] = a
       store<T>(dataStart + (<usize>p << alignof<T>()), b); // arr[p] = b
@@ -115,7 +115,7 @@ function weakHeapSort<T>(
     store<T>(dataStart + (<usize>i << alignof<T>()), a); // arr[i] = a
 
     let x = 1, y: i32;
-    while ((y = (x << 1) + ((load<u32>(bitset + (x >> 5 << shift32)) >> (x & 31)) & 1)) < i) x = y;
+    while ((y = (x << 1) + ((load<u32>(bitset + (<usize>x >> 5 << shift32)) >> (x & 31)) & 1)) < i) x = y;
 
     while (x > 0) {
       a = load<T>(dataStart); // a = arr[0]
@@ -123,8 +123,8 @@ function weakHeapSort<T>(
 
       if (comparator(a, b) < 0) {
         store<u32>(
-          bitset + (x >> 5 << shift32),
-          load<u32>(bitset + (x >> 5 << shift32)) ^ (1 << (x & 31))
+          bitset + (<usize>x >> 5 << shift32),
+          load<u32>(bitset + (<usize>x >> 5 << shift32)) ^ (1 << (x & 31))
         );
         store<T>(dataStart + (<usize>x << alignof<T>()), a); // arr[x] = a
         store<T>(dataStart, b); // arr[0] = b

--- a/tests/compiler/memcpy.ts
+++ b/tests/compiler/memcpy.ts
@@ -39,7 +39,7 @@ export function memcpy(dest: usize, src: usize, n: usize): usize {
   // if dst is not aligned to 4 bytes, use alternating shifts to copy 4 bytes each
   // doing shifts if faster when copying enough bytes (here: 32 or more)
   if (n >= 32) {
-    switch (dest % 4) {
+    switch (<u32>dest % 4) {
       // known to be != 0
       case 1:
         w = load<u32>(src);

--- a/tests/compiler/std/array.optimized.wat
+++ b/tests/compiler/std/array.optimized.wat
@@ -4325,7 +4325,7 @@
   i32.const 31
   i32.add
   i32.const 5
-  i32.shr_s
+  i32.shr_u
   i32.const 2
   i32.shl
   local.tee $2
@@ -4353,7 +4353,7 @@
      local.get $5
      local.get $2
      i32.const 6
-     i32.shr_s
+     i32.shr_u
      i32.const 2
      i32.shl
      i32.add
@@ -4403,7 +4403,7 @@
      local.get $5
      local.get $3
      i32.const 5
-     i32.shr_s
+     i32.shr_u
      i32.const 2
      i32.shl
      i32.add
@@ -4469,7 +4469,7 @@
      local.get $5
      local.get $1
      i32.const 5
-     i32.shr_s
+     i32.shr_u
      i32.const 2
      i32.shl
      i32.add
@@ -4519,7 +4519,7 @@
        local.get $5
        local.get $1
        i32.const 5
-       i32.shr_s
+       i32.shr_u
        i32.const 2
        i32.shl
        i32.add
@@ -4816,7 +4816,7 @@
   i32.const 31
   i32.add
   i32.const 5
-  i32.shr_s
+  i32.shr_u
   i32.const 2
   i32.shl
   local.tee $2
@@ -4844,7 +4844,7 @@
      local.get $5
      local.get $2
      i32.const 6
-     i32.shr_s
+     i32.shr_u
      i32.const 2
      i32.shl
      i32.add
@@ -4894,7 +4894,7 @@
      local.get $5
      local.get $3
      i32.const 5
-     i32.shr_s
+     i32.shr_u
      i32.const 2
      i32.shl
      i32.add
@@ -4960,7 +4960,7 @@
      local.get $5
      local.get $1
      i32.const 5
-     i32.shr_s
+     i32.shr_u
      i32.const 2
      i32.shl
      i32.add
@@ -5010,7 +5010,7 @@
        local.get $5
        local.get $1
        i32.const 5
-       i32.shr_s
+       i32.shr_u
        i32.const 2
        i32.shl
        i32.add
@@ -5329,7 +5329,7 @@
   i32.const 31
   i32.add
   i32.const 5
-  i32.shr_s
+  i32.shr_u
   i32.const 2
   i32.shl
   local.tee $3
@@ -5357,7 +5357,7 @@
      local.get $5
      local.get $3
      i32.const 6
-     i32.shr_s
+     i32.shr_u
      i32.const 2
      i32.shl
      i32.add
@@ -5408,7 +5408,7 @@
      local.get $5
      local.get $4
      i32.const 5
-     i32.shr_s
+     i32.shr_u
      i32.const 2
      i32.shl
      i32.add
@@ -5474,7 +5474,7 @@
      local.get $5
      local.get $1
      i32.const 5
-     i32.shr_s
+     i32.shr_u
      i32.const 2
      i32.shl
      i32.add
@@ -5525,7 +5525,7 @@
        local.get $5
        local.get $1
        i32.const 5
-       i32.shr_s
+       i32.shr_u
        i32.const 2
        i32.shl
        i32.add

--- a/tests/compiler/std/array.untouched.wat
+++ b/tests/compiler/std/array.untouched.wat
@@ -7121,7 +7121,7 @@
   i32.const 31
   i32.add
   i32.const 5
-  i32.shr_s
+  i32.shr_u
   i32.const 2
   i32.shl
   local.set $3
@@ -7153,7 +7153,7 @@
      local.get $4
      local.get $7
      i32.const 6
-     i32.shr_s
+     i32.shr_u
      i32.const 2
      i32.shl
      i32.add
@@ -7207,14 +7207,14 @@
      local.get $4
      local.get $5
      i32.const 5
-     i32.shr_s
+     i32.shr_u
      i32.const 2
      i32.shl
      i32.add
      local.get $4
      local.get $5
      i32.const 5
-     i32.shr_s
+     i32.shr_u
      i32.const 2
      i32.shl
      i32.add
@@ -7286,7 +7286,7 @@
      local.get $4
      local.get $8
      i32.const 5
-     i32.shr_s
+     i32.shr_u
      i32.const 2
      i32.shl
      i32.add
@@ -7338,14 +7338,14 @@
        local.get $4
        local.get $8
        i32.const 5
-       i32.shr_s
+       i32.shr_u
        i32.const 2
        i32.shl
        i32.add
        local.get $4
        local.get $8
        i32.const 5
-       i32.shr_s
+       i32.shr_u
        i32.const 2
        i32.shl
        i32.add
@@ -7734,7 +7734,7 @@
   i32.const 31
   i32.add
   i32.const 5
-  i32.shr_s
+  i32.shr_u
   i32.const 2
   i32.shl
   local.set $3
@@ -7766,7 +7766,7 @@
      local.get $4
      local.get $7
      i32.const 6
-     i32.shr_s
+     i32.shr_u
      i32.const 2
      i32.shl
      i32.add
@@ -7820,14 +7820,14 @@
      local.get $4
      local.get $5
      i32.const 5
-     i32.shr_s
+     i32.shr_u
      i32.const 2
      i32.shl
      i32.add
      local.get $4
      local.get $5
      i32.const 5
-     i32.shr_s
+     i32.shr_u
      i32.const 2
      i32.shl
      i32.add
@@ -7899,7 +7899,7 @@
      local.get $4
      local.get $8
      i32.const 5
-     i32.shr_s
+     i32.shr_u
      i32.const 2
      i32.shl
      i32.add
@@ -7951,14 +7951,14 @@
        local.get $4
        local.get $8
        i32.const 5
-       i32.shr_s
+       i32.shr_u
        i32.const 2
        i32.shl
        i32.add
        local.get $4
        local.get $8
        i32.const 5
-       i32.shr_s
+       i32.shr_u
        i32.const 2
        i32.shl
        i32.add
@@ -8380,7 +8380,7 @@
   i32.const 31
   i32.add
   i32.const 5
-  i32.shr_s
+  i32.shr_u
   i32.const 2
   i32.shl
   local.set $3
@@ -8412,7 +8412,7 @@
      local.get $4
      local.get $7
      i32.const 6
-     i32.shr_s
+     i32.shr_u
      i32.const 2
      i32.shl
      i32.add
@@ -8466,14 +8466,14 @@
      local.get $4
      local.get $5
      i32.const 5
-     i32.shr_s
+     i32.shr_u
      i32.const 2
      i32.shl
      i32.add
      local.get $4
      local.get $5
      i32.const 5
-     i32.shr_s
+     i32.shr_u
      i32.const 2
      i32.shl
      i32.add
@@ -8545,7 +8545,7 @@
      local.get $4
      local.get $9
      i32.const 5
-     i32.shr_s
+     i32.shr_u
      i32.const 2
      i32.shl
      i32.add
@@ -8597,14 +8597,14 @@
        local.get $4
        local.get $9
        i32.const 5
-       i32.shr_s
+       i32.shr_u
        i32.const 2
        i32.shl
        i32.add
        local.get $4
        local.get $9
        i32.const 5
-       i32.shr_s
+       i32.shr_u
        i32.const 2
        i32.shl
        i32.add
@@ -8856,7 +8856,7 @@
   i32.const 31
   i32.add
   i32.const 5
-  i32.shr_s
+  i32.shr_u
   i32.const 2
   i32.shl
   local.set $3
@@ -8888,7 +8888,7 @@
      local.get $4
      local.get $7
      i32.const 6
-     i32.shr_s
+     i32.shr_u
      i32.const 2
      i32.shl
      i32.add
@@ -8942,14 +8942,14 @@
      local.get $4
      local.get $5
      i32.const 5
-     i32.shr_s
+     i32.shr_u
      i32.const 2
      i32.shl
      i32.add
      local.get $4
      local.get $5
      i32.const 5
-     i32.shr_s
+     i32.shr_u
      i32.const 2
      i32.shl
      i32.add
@@ -9021,7 +9021,7 @@
      local.get $4
      local.get $9
      i32.const 5
-     i32.shr_s
+     i32.shr_u
      i32.const 2
      i32.shl
      i32.add
@@ -9073,14 +9073,14 @@
        local.get $4
        local.get $9
        i32.const 5
-       i32.shr_s
+       i32.shr_u
        i32.const 2
        i32.shl
        i32.add
        local.get $4
        local.get $9
        i32.const 5
-       i32.shr_s
+       i32.shr_u
        i32.const 2
        i32.shl
        i32.add

--- a/tests/compiler/std/typedarray.optimized.wat
+++ b/tests/compiler/std/typedarray.optimized.wat
@@ -2560,7 +2560,7 @@
   i32.const 31
   i32.add
   i32.const 5
-  i32.shr_s
+  i32.shr_u
   i32.const 2
   i32.shl
   local.tee $2
@@ -2588,7 +2588,7 @@
      local.get $5
      local.get $2
      i32.const 6
-     i32.shr_s
+     i32.shr_u
      i32.const 2
      i32.shl
      i32.add
@@ -2638,7 +2638,7 @@
      local.get $5
      local.get $3
      i32.const 5
-     i32.shr_s
+     i32.shr_u
      i32.const 2
      i32.shl
      i32.add
@@ -2704,7 +2704,7 @@
      local.get $5
      local.get $1
      i32.const 5
-     i32.shr_s
+     i32.shr_u
      i32.const 2
      i32.shl
      i32.add
@@ -2754,7 +2754,7 @@
        local.get $5
        local.get $1
        i32.const 5
-       i32.shr_s
+       i32.shr_u
        i32.const 2
        i32.shl
        i32.add

--- a/tests/compiler/std/typedarray.untouched.wat
+++ b/tests/compiler/std/typedarray.untouched.wat
@@ -3231,7 +3231,7 @@
   i32.const 31
   i32.add
   i32.const 5
-  i32.shr_s
+  i32.shr_u
   i32.const 2
   i32.shl
   local.set $3
@@ -3263,7 +3263,7 @@
      local.get $4
      local.get $7
      i32.const 6
-     i32.shr_s
+     i32.shr_u
      i32.const 2
      i32.shl
      i32.add
@@ -3317,14 +3317,14 @@
      local.get $4
      local.get $5
      i32.const 5
-     i32.shr_s
+     i32.shr_u
      i32.const 2
      i32.shl
      i32.add
      local.get $4
      local.get $5
      i32.const 5
-     i32.shr_s
+     i32.shr_u
      i32.const 2
      i32.shl
      i32.add
@@ -3396,7 +3396,7 @@
      local.get $4
      local.get $8
      i32.const 5
-     i32.shr_s
+     i32.shr_u
      i32.const 2
      i32.shl
      i32.add
@@ -3448,14 +3448,14 @@
        local.get $4
        local.get $8
        i32.const 5
-       i32.shr_s
+       i32.shr_u
        i32.const 2
        i32.shl
        i32.add
        local.get $4
        local.get $8
        i32.const 5
-       i32.shr_s
+       i32.shr_u
        i32.const 2
        i32.shl
        i32.add


### PR DESCRIPTION
This PR investigates re-introducing the

> Conversion from type '{0}' to '{1}' will require an explicit cast when switching between 32/64-bit.

warning that was intended to be emitted when an `usize` value is implicitly assigned to a 32-bit integer, which is valid on 32-bit, but would fail on 64-bit. Not particularly important, yet turned out that there are a few such problems in stdlib.

cc @MaxGraey as there are a bunch of `_s` -> `_u` changes that might be of interest