### PR TITLE
optimize decimalCount32/64 + minor refactoring in util/number

### DIFF
--- a/std/assembly/util/number.ts
+++ b/std/assembly/util/number.ts
@@ -661,14 +661,14 @@ export function dtoa_stream(buffer: usize, offset: usize, value: f64): u32 {
       store<u16>(buffer, CharCode.N, 4);
       return 3;
     } else {
-      let sign = u32(value < 0);
+      let sign = value < 0;
       if (sign) {
         store<u16>(buffer, CharCode.MINUS); // -
         buffer += 2;
       }
       store<u64>(buffer, 0x690066006E0049, 0); // ifnI
       store<u64>(buffer, 0x7900740069006E, 8); // ytin
-      return 8 + sign;
+      return 8 + u32(sign);
     }
   }
   return dtoa_core(buffer, value);

--- a/std/assembly/util/number.ts
+++ b/std/assembly/util/number.ts
@@ -661,10 +661,14 @@ export function dtoa_stream(buffer: usize, offset: usize, value: f64): u32 {
       store<u16>(buffer, CharCode.N, 4);
       return 3;
     } else {
-      let sign = value < 0;
-      let len  = 8 + u32(sign);
-      memory.copy(buffer, changetype<usize>(select<String>("-Infinity", "Infinity", sign)), len << 1);
-      return len;
+      let sign = u32(value < 0);
+      if (sign) {
+        store<u16>(buffer, CharCode.MINUS); // -
+        buffer += 2;
+      }
+      store<u64>(buffer, 0x690066006E0049, 0); // ifnI
+      store<u64>(buffer, 0x7900740069006E, 8); // ytin
+      return 8 + sign;
     }
   }
   return dtoa_core(buffer, value);

--- a/std/assembly/util/number.ts
+++ b/std/assembly/util/number.ts
@@ -607,9 +607,16 @@ export function dtoa(value: f64): String {
 export function itoa_stream<T extends number>(buffer: usize, offset: usize, value: T): u32 {
   buffer += (offset << 1);
   if (ASC_SHRINK_LEVEL <= 1) {
-    if (<u64>value < 10) {
-      store<u16>(buffer, value | CharCode._0);
-      return 1;
+    if (sizeof<T>() <= 4) {
+      if (<u32>value < 10) {
+        store<u16>(buffer, value | CharCode._0);
+        return 1;
+      }
+    } else {
+      if (<u64>value < 10) {
+        store<u16>(buffer, value | CharCode._0);
+        return 1;
+      }
     }
   }
   var decimals: u32 = 0;

--- a/std/assembly/util/number.ts
+++ b/std/assembly/util/number.ts
@@ -615,15 +615,22 @@ export function itoa_stream<T extends number>(buffer: usize, offset: usize, valu
     }
   }
   if (ASC_SHRINK_LEVEL <= 1) {
-    if (sizeof<T>() <= 4) {
-      if (<u32>value < 10) {
-        store<u16>(buffer + (sign << 1), value | CharCode._0);
-        return 1 + sign;
+    if (isSigned<T>()) {
+      if (sizeof<T>() <= 4) {
+        if (<u32>value < 10) {
+          store<u16>(buffer + (sign << 1), value | CharCode._0);
+          return 1 + sign;
+        }
+      } else {
+        if (<u64>value < 10) {
+          store<u16>(buffer + (sign << 1), value | CharCode._0);
+          return 1 + sign;
+        }
       }
     } else {
-      if (<u64>value < 10) {
-        store<u16>(buffer + (sign << 1), value | CharCode._0);
-        return 1 + sign;
+      if (value < 10) {
+        store<u16>(buffer, value | CharCode._0);
+        return 1;
       }
     }
   }

--- a/std/assembly/util/number.ts
+++ b/std/assembly/util/number.ts
@@ -606,9 +606,11 @@ export function dtoa(value: f64): String {
 
 export function itoa_stream<T extends number>(buffer: usize, offset: usize, value: T): u32 {
   buffer += (offset << 1);
-  if (!value) {
-    store<u16>(buffer, CharCode._0);
-    return 1;
+  if (ASC_SHRINK_LEVEL <= 1) {
+    if (<u64>value < 10) {
+      store<u16>(buffer, value | CharCode._0);
+      return 1;
+    }
   }
   var decimals: u32 = 0;
   if (isSigned<T>()) {
@@ -648,7 +650,7 @@ export function itoa_stream<T extends number>(buffer: usize, offset: usize, valu
 
 export function dtoa_stream(buffer: usize, offset: usize, value: f64): u32 {
   buffer += offset << 1;
-  if (value == 0.0) {
+  if (value == 0) {
     store<u16>(buffer, CharCode._0);
     store<u16>(buffer, CharCode.DOT, 2);
     store<u16>(buffer, CharCode._0,  4);

--- a/std/assembly/util/number.ts
+++ b/std/assembly/util/number.ts
@@ -108,17 +108,15 @@ const FRC_POWERS: StaticArray<u64> = [
 export function decimalCount32(value: u32): u32 {
   if (value < 100000) {
     if (value < 100) {
-      return select<u32>(1, 2, value < 10);
+      return 1 + i32(value >= 10);
     } else {
-      let m = select<u32>(4, 5, value < 10000);
-      return select<u32>(3, m, value < 1000);
+      return 3 + u32(value >= 10000) + u32(value >= 1000);
     }
   } else {
     if (value < 10000000) {
-      return select<u32>(6, 7, value < 1000000);
+      return 6 + u32(value >= 1000000);
     } else {
-      let m = select<u32>(9, 10, value < 1000000000);
-      return select<u32>(8, m, value < 100000000);
+      return 8 + u32(value >= 1000000000) + u32(value >= 100000000);
     }
   }
 }
@@ -128,18 +126,15 @@ export function decimalCount32(value: u32): u32 {
 export function decimalCount64(value: u64): u32 {
   if (value < 1000000000000000) {
     if (value < 1000000000000) {
-      let m = select<u32>(11, 12, value < 100000000000);
-      return select<u32>(10, m, value < 10000000000);
+      return 10 + u32(value >= 100000000000) + u32(value >= 10000000000);
     } else {
-      let m = select<u32>(14, 15, value < 100000000000000);
-      return select<u32>(13, m, value < 10000000000000);
+      return 13 + u32(value >= 100000000000000) + u32(value >= 10000000000000);
     }
   } else {
     if (value < 100000000000000000) {
-      return select<u32>(16, 17, value < 10000000000000000);
+      return 16 + u32(value >= 10000000000000000);
     } else {
-      let m = select<u32>(19, 20, value < 10000000000000000000);
-      return select<u32>(18, m, value < 1000000000000000000);
+      return 18 + u32(value >= 10000000000000000000) + u32(value >= 1000000000000000000);
     }
   }
 }

--- a/std/assembly/util/number.ts
+++ b/std/assembly/util/number.ts
@@ -108,7 +108,7 @@ const FRC_POWERS: StaticArray<u64> = [
 export function decimalCount32(value: u32): u32 {
   if (value < 100000) {
     if (value < 100) {
-      return 1 + i32(value >= 10);
+      return 1 + u32(value >= 10);
     } else {
       return 3 + u32(value >= 10000) + u32(value >= 1000);
     }
@@ -249,10 +249,10 @@ export function utoa32(value: u32): String {
 export function itoa32(value: i32): String {
   if (!value) return "0";
 
-  var sign = value < 0;
+  var sign = value >>> 31;
   if (sign) value = -value;
 
-  var decimals = decimalCount32(value) + u32(sign);
+  var decimals = decimalCount32(value) + sign;
   var out = __alloc(decimals << 1, idof<String>());
 
   utoa32_core(out, value, decimals);
@@ -280,22 +280,21 @@ export function utoa64(value: u64): String {
 export function itoa64(value: i64): String {
   if (!value) return "0";
 
-  var sign = value < 0;
+  var sign = u32(value >>> 63);
   if (sign) value = -value;
 
   var out: usize;
   if (<u64>value <= <u64>u32.MAX_VALUE) {
     let val32    = <u32>value;
-    let decimals = decimalCount32(val32) + u32(sign);
+    let decimals = decimalCount32(val32) + sign;
     out = __alloc(decimals << 1, idof<String>());
     utoa32_core(out, val32, decimals);
   } else {
-    let decimals = decimalCount64High(value) + u32(sign);
+    let decimals = decimalCount64High(value) + sign;
     out = __alloc(decimals << 1, idof<String>());
     utoa64_core(out, value, decimals);
   }
   if (sign) store<u16>(out, CharCode.MINUS);
-
   return changetype<String>(out); // retains
 }
 

--- a/std/assembly/util/number.ts
+++ b/std/assembly/util/number.ts
@@ -424,10 +424,10 @@ function grisu2(value: f64, buffer: usize, sign: i32): i32 {
 
   // frexp routine
   var uv  = reinterpret<u64>(value);
-  var exp = <i32>((uv & 0x7FF0000000000000) >>> 52);
+  var exp = i32((uv & 0x7FF0000000000000) >>> 52);
   var sid = uv & 0x000FFFFFFFFFFFFF;
   var frc = (u64(exp != 0) << 52) + sid;
-      exp = select<i32>(exp, 1, exp != 0) - (0x3FF + 52);
+      exp = select<i32>(exp, 1, exp) - (0x3FF + 52);
 
   normalizedBoundaries(frc, exp);
   getCachedPower(_exp);
@@ -444,7 +444,7 @@ function grisu2(value: f64, buffer: usize, sign: i32): i32 {
   var w_exp = umul64e(exp, exp_pow);
 
   var wp_frc = umul64f(_frc_plus, frc_pow) - 1;
-  var wp_exp = umul64e(_exp,      exp_pow);
+  var wp_exp = umul64e(_exp, exp_pow);
 
   var wm_frc = umul64f(_frc_minus, frc_pow) + 1;
   var delta  = wp_frc - wm_frc;
@@ -460,7 +460,7 @@ function genDigits(buffer: usize, w_frc: u64, w_exp: i32, mp_frc: u64, mp_exp: i
   var wp_w_frc = mp_frc - w_frc;
   var wp_w_exp = mp_exp;
 
-  var p1 = <u32>(mp_frc >> one_exp);
+  var p1 = u32(mp_frc >> one_exp);
   var p2 = mp_frc & mask;
 
   var kappa = <i32>decimalCount32(p1);
@@ -592,8 +592,8 @@ export function dtoa_core(buffer: usize, value: f64): i32 {
 
 export function dtoa(value: f64): String {
   if (value == 0) return "0.0";
-  if (!isFinite<f64>(value)) {
-    if (isNaN<f64>(value)) return "NaN";
+  if (!isFinite(value)) {
+    if (isNaN(value)) return "NaN";
     return select<String>("-Infinity", "Infinity", value < 0);
   }
   var buffer = __alloc(MAX_DOUBLE_LENGTH << 1, idof<String>());
@@ -612,18 +612,18 @@ export function itoa_stream<T extends number>(buffer: usize, offset: usize, valu
   }
   var decimals: u32 = 0;
   if (isSigned<T>()) {
-    let sign = i32(value < 0);
+    let sign = u32(value < 0);
     if (sign) value = changetype<T>(-value);
     if (sizeof<T>() <= 4) {
-      decimals = decimalCount32(value) + <u32>sign;
+      decimals = decimalCount32(value) + sign;
       utoa32_core(buffer, value, decimals);
     } else {
       if (<u64>value <= <u64>u32.MAX_VALUE) {
         let val32 = <u32>value;
-        decimals = decimalCount32(val32) + <u32>sign;
+        decimals = decimalCount32(val32) + sign;
         utoa32_core(buffer, val32, decimals);
       } else {
-        decimals = decimalCount64High(value) + <u32>sign;
+        decimals = decimalCount64High(value) + sign;
         utoa64_core(buffer, value, decimals);
       }
     }
@@ -647,22 +647,22 @@ export function itoa_stream<T extends number>(buffer: usize, offset: usize, valu
 }
 
 export function dtoa_stream(buffer: usize, offset: usize, value: f64): u32 {
-  buffer += (offset << 1);
+  buffer += offset << 1;
   if (value == 0.0) {
     store<u16>(buffer, CharCode._0);
     store<u16>(buffer, CharCode.DOT, 2);
     store<u16>(buffer, CharCode._0,  4);
     return 3;
   }
-  if (!isFinite<f64>(value)) {
-    if (isNaN<f64>(value)) {
+  if (!isFinite(value)) {
+    if (isNaN(value)) {
       store<u16>(buffer, CharCode.N);
       store<u16>(buffer, CharCode.a, 2);
       store<u16>(buffer, CharCode.N, 4);
       return 3;
     } else {
-      let sign = i32(value < 0);
-      let len  = 8 + sign;
+      let sign = value < 0;
+      let len  = 8 + u32(sign);
       memory.copy(buffer, changetype<usize>(select<String>("-Infinity", "Infinity", sign)), len << 1);
       return len;
     }

--- a/std/assembly/util/number.ts
+++ b/std/assembly/util/number.ts
@@ -123,7 +123,7 @@ export function decimalCount32(value: u32): u32 {
 
 // Count number of decimals for u64 values
 // In our case input value always greater than 2^32-1 so we can skip some parts
-export function decimalCount64(value: u64): u32 {
+export function decimalCount64High(value: u64): u32 {
   if (value < 1000000000000000) {
     if (value < 1000000000000) {
       return 10 + u32(value >= 100000000000) + u32(value >= 10000000000);
@@ -270,7 +270,7 @@ export function utoa64(value: u64): String {
     out = __alloc(decimals << 1, idof<String>());
     utoa32_core(out, val32, decimals);
   } else {
-    let decimals = decimalCount64(value);
+    let decimals = decimalCount64High(value);
     out = __alloc(decimals << 1, idof<String>());
     utoa64_core(out, value, decimals);
   }
@@ -290,7 +290,7 @@ export function itoa64(value: i64): String {
     out = __alloc(decimals << 1, idof<String>());
     utoa32_core(out, val32, decimals);
   } else {
-    let decimals = decimalCount64(value) + u32(sign);
+    let decimals = decimalCount64High(value) + u32(sign);
     out = __alloc(decimals << 1, idof<String>());
     utoa64_core(out, value, decimals);
   }
@@ -624,7 +624,7 @@ export function itoa_stream<T extends number>(buffer: usize, offset: usize, valu
         decimals = decimalCount32(val32) + <u32>sign;
         utoa32_core(buffer, val32, decimals);
       } else {
-        decimals = decimalCount64(value) + <u32>sign;
+        decimals = decimalCount64High(value) + <u32>sign;
         utoa64_core(buffer, value, decimals);
       }
     }
@@ -639,7 +639,7 @@ export function itoa_stream<T extends number>(buffer: usize, offset: usize, valu
         decimals = decimalCount32(val32);
         utoa32_core(buffer, val32, decimals);
       } else {
-        decimals = decimalCount64(value);
+        decimals = decimalCount64High(value);
         utoa64_core(buffer, value, decimals);
       }
     }

--- a/std/assembly/util/number.ts
+++ b/std/assembly/util/number.ts
@@ -622,7 +622,10 @@ export function itoa_stream<T extends number>(buffer: usize, offset: usize, valu
   var decimals: u32 = 0;
   if (isSigned<T>()) {
     let sign = u32(value < 0);
-    if (sign) value = changetype<T>(-value);
+    if (sign) {
+      value = changetype<T>(-value);
+      store<u16>(buffer, CharCode.MINUS);
+    }
     if (sizeof<T>() <= 4) {
       decimals = decimalCount32(value) + sign;
       utoa32_core(buffer, value, decimals);
@@ -636,7 +639,6 @@ export function itoa_stream<T extends number>(buffer: usize, offset: usize, valu
         utoa64_core(buffer, value, decimals);
       }
     }
-    if (sign) store<u16>(buffer, CharCode.MINUS);
   } else {
     if (sizeof<T>() <= 4) {
       decimals = decimalCount32(value);

--- a/tests/compiler/number.optimized.wat
+++ b/tests/compiler/number.optimized.wat
@@ -43,44 +43,38 @@
  (export "memory" (memory $0))
  (start $~start)
  (func $~lib/util/number/decimalCount32 (; 1 ;) (param $0 i32) (result i32)
-  i32.const 1
-  i32.const 2
   local.get $0
   i32.const 10
-  i32.lt_u
-  select
-  i32.const 3
-  i32.const 4
-  i32.const 5
+  i32.ge_u
+  i32.const 1
+  i32.add
   local.get $0
   i32.const 10000
-  i32.lt_u
-  select
+  i32.ge_u
+  i32.const 3
+  i32.add
   local.get $0
   i32.const 1000
-  i32.lt_u
-  select
+  i32.ge_u
+  i32.add
   local.get $0
   i32.const 100
   i32.lt_u
   select
-  i32.const 6
-  i32.const 7
   local.get $0
   i32.const 1000000
-  i32.lt_u
-  select
-  i32.const 8
-  i32.const 9
-  i32.const 10
+  i32.ge_u
+  i32.const 6
+  i32.add
   local.get $0
   i32.const 1000000000
-  i32.lt_u
-  select
+  i32.ge_u
+  i32.const 8
+  i32.add
   local.get $0
   i32.const 100000000
-  i32.lt_u
-  select
+  i32.ge_u
+  i32.add
   local.get $0
   i32.const 10000000
   i32.lt_u

--- a/tests/compiler/number.optimized.wat
+++ b/tests/compiler/number.optimized.wat
@@ -206,8 +206,8 @@
    return
   end
   local.get $0
-  i32.const 0
-  i32.lt_s
+  i32.const 31
+  i32.shr_u
   local.tee $1
   if
    i32.const 0

--- a/tests/compiler/number.untouched.wat
+++ b/tests/compiler/number.untouched.wat
@@ -375,8 +375,8 @@
    return
   end
   local.get $0
-  i32.const 0
-  i32.lt_s
+  i32.const 31
+  i32.shr_u
   local.set $1
   local.get $1
   if

--- a/tests/compiler/number.untouched.wat
+++ b/tests/compiler/number.untouched.wat
@@ -57,7 +57,6 @@
  (export "memory" (memory $0))
  (start $~start)
  (func $~lib/util/number/decimalCount32 (; 1 ;) (param $0 i32) (result i32)
-  (local $1 i32)
   local.get $0
   i32.const 100000
   i32.lt_u
@@ -67,26 +66,21 @@
    i32.lt_u
    if
     i32.const 1
-    i32.const 2
     local.get $0
     i32.const 10
-    i32.lt_u
-    select
+    i32.ge_u
+    i32.add
     return
    else
-    i32.const 4
-    i32.const 5
+    i32.const 3
     local.get $0
     i32.const 10000
-    i32.lt_u
-    select
-    local.set $1
-    i32.const 3
-    local.get $1
+    i32.ge_u
+    i32.add
     local.get $0
     i32.const 1000
-    i32.lt_u
-    select
+    i32.ge_u
+    i32.add
     return
    end
    unreachable
@@ -96,26 +90,21 @@
    i32.lt_u
    if
     i32.const 6
-    i32.const 7
     local.get $0
     i32.const 1000000
-    i32.lt_u
-    select
+    i32.ge_u
+    i32.add
     return
    else
-    i32.const 9
-    i32.const 10
+    i32.const 8
     local.get $0
     i32.const 1000000000
-    i32.lt_u
-    select
-    local.set $1
-    i32.const 8
-    local.get $1
+    i32.ge_u
+    i32.add
     local.get $0
     i32.const 100000000
-    i32.lt_u
-    select
+    i32.ge_u
+    i32.add
     return
    end
    unreachable

--- a/tests/compiler/number.untouched.wat
+++ b/tests/compiler/number.untouched.wat
@@ -2767,8 +2767,6 @@
   local.get $7
   i32.const 1
   local.get $7
-  i32.const 0
-  i32.ne
   select
   i32.const 1023
   i32.const 52

--- a/tests/compiler/resolve-access.optimized.wat
+++ b/tests/compiler/resolve-access.optimized.wat
@@ -324,44 +324,38 @@
   i64.load
  )
  (func $~lib/util/number/decimalCount32 (; 6 ;) (param $0 i32) (result i32)
-  i32.const 1
-  i32.const 2
   local.get $0
   i32.const 10
-  i32.lt_u
-  select
-  i32.const 3
-  i32.const 4
-  i32.const 5
+  i32.ge_u
+  i32.const 1
+  i32.add
   local.get $0
   i32.const 10000
-  i32.lt_u
-  select
+  i32.ge_u
+  i32.const 3
+  i32.add
   local.get $0
   i32.const 1000
-  i32.lt_u
-  select
+  i32.ge_u
+  i32.add
   local.get $0
   i32.const 100
   i32.lt_u
   select
-  i32.const 6
-  i32.const 7
   local.get $0
   i32.const 1000000
-  i32.lt_u
-  select
-  i32.const 8
-  i32.const 9
-  i32.const 10
+  i32.ge_u
+  i32.const 6
+  i32.add
   local.get $0
   i32.const 1000000000
-  i32.lt_u
-  select
+  i32.ge_u
+  i32.const 8
+  i32.add
   local.get $0
   i32.const 100000000
-  i32.lt_u
-  select
+  i32.ge_u
+  i32.add
   local.get $0
   i32.const 10000000
   i32.lt_u
@@ -396,49 +390,42 @@
   end
  )
  (func $~lib/util/number/decimalCount64 (; 8 ;) (param $0 i64) (result i32)
-  i32.const 10
-  i32.const 11
-  i32.const 12
   local.get $0
   i64.const 100000000000
-  i64.lt_u
-  select
+  i64.ge_u
+  i32.const 10
+  i32.add
   local.get $0
   i64.const 10000000000
-  i64.lt_u
-  select
-  i32.const 13
-  i32.const 14
-  i32.const 15
+  i64.ge_u
+  i32.add
   local.get $0
   i64.const 100000000000000
-  i64.lt_u
-  select
+  i64.ge_u
+  i32.const 13
+  i32.add
   local.get $0
   i64.const 10000000000000
-  i64.lt_u
-  select
+  i64.ge_u
+  i32.add
   local.get $0
   i64.const 1000000000000
   i64.lt_u
   select
-  i32.const 16
-  i32.const 17
   local.get $0
   i64.const 10000000000000000
-  i64.lt_u
-  select
-  i32.const 18
-  i32.const 19
-  i32.const 20
+  i64.ge_u
+  i32.const 16
+  i32.add
   local.get $0
   i64.const -8446744073709551616
-  i64.lt_u
-  select
+  i64.ge_u
+  i32.const 18
+  i32.add
   local.get $0
   i64.const 1000000000000000000
-  i64.lt_u
-  select
+  i64.ge_u
+  i32.add
   local.get $0
   i64.const 100000000000000000
   i64.lt_u

--- a/tests/compiler/resolve-access.optimized.wat
+++ b/tests/compiler/resolve-access.optimized.wat
@@ -389,7 +389,7 @@
    br_if $do-continue|0
   end
  )
- (func $~lib/util/number/decimalCount64 (; 8 ;) (param $0 i64) (result i32)
+ (func $~lib/util/number/decimalCount64High (; 8 ;) (param $0 i64) (result i32)
   local.get $0
   i64.const 100000000000
   i64.ge_u
@@ -491,7 +491,7 @@
    call $~lib/util/number/utoa_simple<u32>
   else
    local.get $0
-   call $~lib/util/number/decimalCount64
+   call $~lib/util/number/decimalCount64High
    local.tee $1
    i32.const 1
    i32.shl

--- a/tests/compiler/resolve-access.untouched.wat
+++ b/tests/compiler/resolve-access.untouched.wat
@@ -1654,7 +1654,7 @@
    i32.store16
   end
  )
- (func $~lib/util/number/decimalCount64 (; 12 ;) (param $0 i64) (result i32)
+ (func $~lib/util/number/decimalCount64High (; 12 ;) (param $0 i64) (result i32)
   local.get $0
   i64.const 1000000000000000
   i64.lt_u
@@ -1880,7 +1880,7 @@
    call $~lib/util/number/utoa32_lut
   else
    local.get $0
-   call $~lib/util/number/decimalCount64
+   call $~lib/util/number/decimalCount64High
    local.set $3
    local.get $3
    i32.const 1

--- a/tests/compiler/resolve-access.untouched.wat
+++ b/tests/compiler/resolve-access.untouched.wat
@@ -1460,7 +1460,6 @@
   local.get $2
  )
  (func $~lib/util/number/decimalCount32 (; 10 ;) (param $0 i32) (result i32)
-  (local $1 i32)
   local.get $0
   i32.const 100000
   i32.lt_u
@@ -1470,26 +1469,21 @@
    i32.lt_u
    if
     i32.const 1
-    i32.const 2
     local.get $0
     i32.const 10
-    i32.lt_u
-    select
+    i32.ge_u
+    i32.add
     return
    else
-    i32.const 4
-    i32.const 5
+    i32.const 3
     local.get $0
     i32.const 10000
-    i32.lt_u
-    select
-    local.set $1
-    i32.const 3
-    local.get $1
+    i32.ge_u
+    i32.add
     local.get $0
     i32.const 1000
-    i32.lt_u
-    select
+    i32.ge_u
+    i32.add
     return
    end
    unreachable
@@ -1499,26 +1493,21 @@
    i32.lt_u
    if
     i32.const 6
-    i32.const 7
     local.get $0
     i32.const 1000000
-    i32.lt_u
-    select
+    i32.ge_u
+    i32.add
     return
    else
-    i32.const 9
-    i32.const 10
+    i32.const 8
     local.get $0
     i32.const 1000000000
-    i32.lt_u
-    select
-    local.set $1
-    i32.const 8
-    local.get $1
+    i32.ge_u
+    i32.add
     local.get $0
     i32.const 100000000
-    i32.lt_u
-    select
+    i32.ge_u
+    i32.add
     return
    end
    unreachable
@@ -1666,7 +1655,6 @@
   end
  )
  (func $~lib/util/number/decimalCount64 (; 12 ;) (param $0 i64) (result i32)
-  (local $1 i32)
   local.get $0
   i64.const 1000000000000000
   i64.lt_u
@@ -1675,34 +1663,26 @@
    i64.const 1000000000000
    i64.lt_u
    if
-    i32.const 11
-    i32.const 12
+    i32.const 10
     local.get $0
     i64.const 100000000000
-    i64.lt_u
-    select
-    local.set $1
-    i32.const 10
-    local.get $1
+    i64.ge_u
+    i32.add
     local.get $0
     i64.const 10000000000
-    i64.lt_u
-    select
+    i64.ge_u
+    i32.add
     return
    else
-    i32.const 14
-    i32.const 15
+    i32.const 13
     local.get $0
     i64.const 100000000000000
-    i64.lt_u
-    select
-    local.set $1
-    i32.const 13
-    local.get $1
+    i64.ge_u
+    i32.add
     local.get $0
     i64.const 10000000000000
-    i64.lt_u
-    select
+    i64.ge_u
+    i32.add
     return
    end
    unreachable
@@ -1712,26 +1692,21 @@
    i64.lt_u
    if
     i32.const 16
-    i32.const 17
     local.get $0
     i64.const 10000000000000000
-    i64.lt_u
-    select
+    i64.ge_u
+    i32.add
     return
    else
-    i32.const 19
-    i32.const 20
+    i32.const 18
     local.get $0
     i64.const -8446744073709551616
-    i64.lt_u
-    select
-    local.set $1
-    i32.const 18
-    local.get $1
+    i64.ge_u
+    i32.add
     local.get $0
     i64.const 1000000000000000000
-    i64.lt_u
-    select
+    i64.ge_u
+    i32.add
     return
    end
    unreachable

--- a/tests/compiler/resolve-binary.optimized.wat
+++ b/tests/compiler/resolve-binary.optimized.wat
@@ -180,44 +180,38 @@
   i32.const 0
  )
  (func $~lib/util/number/decimalCount32 (; 5 ;) (param $0 i32) (result i32)
-  i32.const 1
-  i32.const 2
   local.get $0
   i32.const 10
-  i32.lt_u
-  select
-  i32.const 3
-  i32.const 4
-  i32.const 5
+  i32.ge_u
+  i32.const 1
+  i32.add
   local.get $0
   i32.const 10000
-  i32.lt_u
-  select
+  i32.ge_u
+  i32.const 3
+  i32.add
   local.get $0
   i32.const 1000
-  i32.lt_u
-  select
+  i32.ge_u
+  i32.add
   local.get $0
   i32.const 100
   i32.lt_u
   select
-  i32.const 6
-  i32.const 7
   local.get $0
   i32.const 1000000
-  i32.lt_u
-  select
-  i32.const 8
-  i32.const 9
-  i32.const 10
+  i32.ge_u
+  i32.const 6
+  i32.add
   local.get $0
   i32.const 1000000000
-  i32.lt_u
-  select
+  i32.ge_u
+  i32.const 8
+  i32.add
   local.get $0
   i32.const 100000000
-  i32.lt_u
-  select
+  i32.ge_u
+  i32.add
   local.get $0
   i32.const 10000000
   i32.lt_u

--- a/tests/compiler/resolve-binary.optimized.wat
+++ b/tests/compiler/resolve-binary.optimized.wat
@@ -343,8 +343,8 @@
    return
   end
   local.get $0
-  i32.const 0
-  i32.lt_s
+  i32.const 31
+  i32.shr_u
   local.tee $1
   if
    i32.const 0

--- a/tests/compiler/resolve-binary.untouched.wat
+++ b/tests/compiler/resolve-binary.untouched.wat
@@ -601,8 +601,8 @@
    return
   end
   local.get $0
-  i32.const 0
-  i32.lt_s
+  i32.const 31
+  i32.shr_u
   local.set $1
   local.get $1
   if

--- a/tests/compiler/resolve-binary.untouched.wat
+++ b/tests/compiler/resolve-binary.untouched.wat
@@ -286,7 +286,6 @@
   local.get $2
  )
  (func $~lib/util/number/decimalCount32 (; 7 ;) (param $0 i32) (result i32)
-  (local $1 i32)
   local.get $0
   i32.const 100000
   i32.lt_u
@@ -296,26 +295,21 @@
    i32.lt_u
    if
     i32.const 1
-    i32.const 2
     local.get $0
     i32.const 10
-    i32.lt_u
-    select
+    i32.ge_u
+    i32.add
     return
    else
-    i32.const 4
-    i32.const 5
+    i32.const 3
     local.get $0
     i32.const 10000
-    i32.lt_u
-    select
-    local.set $1
-    i32.const 3
-    local.get $1
+    i32.ge_u
+    i32.add
     local.get $0
     i32.const 1000
-    i32.lt_u
-    select
+    i32.ge_u
+    i32.add
     return
    end
    unreachable
@@ -325,26 +319,21 @@
    i32.lt_u
    if
     i32.const 6
-    i32.const 7
     local.get $0
     i32.const 1000000
-    i32.lt_u
-    select
+    i32.ge_u
+    i32.add
     return
    else
-    i32.const 9
-    i32.const 10
+    i32.const 8
     local.get $0
     i32.const 1000000000
-    i32.lt_u
-    select
-    local.set $1
-    i32.const 8
-    local.get $1
+    i32.ge_u
+    i32.add
     local.get $0
     i32.const 100000000
-    i32.lt_u
-    select
+    i32.ge_u
+    i32.add
     return
    end
    unreachable

--- a/tests/compiler/resolve-binary.untouched.wat
+++ b/tests/compiler/resolve-binary.untouched.wat
@@ -3747,8 +3747,6 @@
   local.get $7
   i32.const 1
   local.get $7
-  i32.const 0
-  i32.ne
   select
   i32.const 1023
   i32.const 52

--- a/tests/compiler/resolve-elementaccess.optimized.wat
+++ b/tests/compiler/resolve-elementaccess.optimized.wat
@@ -1327,10 +1327,10 @@
   (local $3 i32)
   (local $4 i64)
   (local $5 i32)
-  (local $6 i32)
+  (local $6 i64)
   (local $7 i64)
   (local $8 i64)
-  (local $9 i64)
+  (local $9 i32)
   (local $10 i32)
   (local $11 i64)
   (local $12 i64)
@@ -1343,7 +1343,7 @@
   local.get $1
   f64.const 0
   f64.lt
-  local.tee $10
+  local.tee $9
   if (result f64)
    local.get $0
    i32.const 45
@@ -1367,7 +1367,6 @@
   local.get $5
   i32.const 0
   i32.ne
-  local.tee $6
   i64.extend_i32_u
   i64.const 52
   i64.shl
@@ -1377,18 +1376,18 @@
   i64.shl
   i64.const 1
   i64.add
-  local.tee $7
+  local.tee $6
   i64.clz
   i32.wrap_i64
   local.set $3
-  local.get $7
+  local.get $6
   local.get $3
   i64.extend_i32_s
   i64.shl
   global.set $~lib/util/number/_frc_plus
   local.get $5
   i32.const 1
-  local.get $6
+  local.get $5
   select
   i32.const 1075
   i32.sub
@@ -1404,13 +1403,13 @@
   i64.eq
   i32.const 1
   i32.add
-  local.tee $6
+  local.tee $10
   i64.extend_i32_s
   i64.shl
   i64.const 1
   i64.sub
   local.get $5
-  local.get $6
+  local.get $10
   i32.sub
   local.get $3
   i32.sub
@@ -1443,10 +1442,10 @@
   local.tee $3
   i32.const 3
   i32.shl
-  local.tee $6
+  local.tee $10
   i32.sub
   global.set $~lib/util/number/_K
-  local.get $6
+  local.get $10
   i32.const 416
   i32.add
   i64.load
@@ -1465,7 +1464,7 @@
   local.tee $3
   i64.extend_i32_s
   i64.shl
-  local.tee $7
+  local.tee $6
   i64.const 4294967295
   i64.and
   local.tee $11
@@ -1477,14 +1476,14 @@
   i64.mul
   local.set $14
   global.get $~lib/util/number/_frc_plus
-  local.tee $8
+  local.tee $7
   i64.const 4294967295
   i64.and
   local.tee $4
   local.get $2
   i64.const 4294967295
   i64.and
-  local.tee $9
+  local.tee $8
   i64.mul
   local.set $12
   global.get $~lib/util/number/_frc_minus
@@ -1504,17 +1503,17 @@
   i64.shr_u
   local.tee $4
   i64.mul
-  local.get $9
   local.get $8
+  local.get $7
   i64.const 32
   i64.shr_u
-  local.tee $8
+  local.tee $7
   i64.mul
   local.get $12
   i64.const 32
   i64.shr_u
   i64.add
-  local.tee $9
+  local.tee $8
   i64.const 4294967295
   i64.and
   i64.add
@@ -1523,16 +1522,16 @@
   i64.const 32
   i64.shr_u
   local.get $4
-  local.get $8
+  local.get $7
   i64.mul
-  local.get $9
+  local.get $8
   i64.const 32
   i64.shr_u
   i64.add
   i64.add
   i64.const 1
   i64.sub
-  local.tee $8
+  local.tee $7
   local.get $16
   local.get $2
   i64.const 32
@@ -1543,7 +1542,7 @@
   local.get $15
   i64.const 32
   i64.shr_u
-  local.tee $9
+  local.tee $8
   i64.mul
   local.get $18
   i64.const 32
@@ -1558,7 +1557,7 @@
   i64.const 32
   i64.shr_u
   local.get $4
-  local.get $9
+  local.get $8
   i64.mul
   local.get $12
   i64.const 32
@@ -1570,7 +1569,7 @@
   i64.sub
   local.set $4
   local.get $0
-  local.get $10
+  local.get $9
   i32.const 1
   i32.shl
   i32.add
@@ -1582,10 +1581,10 @@
   local.tee $2
   i64.mul
   local.get $13
-  local.get $7
+  local.get $6
   i64.const 32
   i64.shr_u
-  local.tee $7
+  local.tee $6
   i64.mul
   local.get $14
   i64.const 32
@@ -1600,7 +1599,7 @@
   i64.const 32
   i64.shr_u
   local.get $2
-  local.get $7
+  local.get $6
   i64.mul
   local.get $11
   i64.const 32
@@ -1615,20 +1614,20 @@
   i32.add
   i32.const -64
   i32.sub
-  local.get $8
+  local.get $7
   local.get $0
   global.get $~lib/util/number/_exp
   i32.add
   i32.const -64
   i32.sub
   local.get $4
-  local.get $10
+  local.get $9
   call $~lib/util/number/genDigits
-  local.get $10
+  local.get $9
   i32.sub
   global.get $~lib/util/number/_K
   call $~lib/util/number/prettify
-  local.get $10
+  local.get $9
   i32.add
  )
  (func $~lib/string/String#get:length (; 13 ;) (param $0 i32) (result i32)

--- a/tests/compiler/resolve-elementaccess.optimized.wat
+++ b/tests/compiler/resolve-elementaccess.optimized.wat
@@ -449,44 +449,38 @@
   f32.load
  )
  (func $~lib/util/number/decimalCount32 (; 7 ;) (param $0 i32) (result i32)
-  i32.const 1
-  i32.const 2
   local.get $0
   i32.const 10
-  i32.lt_u
-  select
-  i32.const 3
-  i32.const 4
-  i32.const 5
+  i32.ge_u
+  i32.const 1
+  i32.add
   local.get $0
   i32.const 10000
-  i32.lt_u
-  select
+  i32.ge_u
+  i32.const 3
+  i32.add
   local.get $0
   i32.const 1000
-  i32.lt_u
-  select
+  i32.ge_u
+  i32.add
   local.get $0
   i32.const 100
   i32.lt_u
   select
-  i32.const 6
-  i32.const 7
   local.get $0
   i32.const 1000000
-  i32.lt_u
-  select
-  i32.const 8
-  i32.const 9
-  i32.const 10
+  i32.ge_u
+  i32.const 6
+  i32.add
   local.get $0
   i32.const 1000000000
-  i32.lt_u
-  select
+  i32.ge_u
+  i32.const 8
+  i32.add
   local.get $0
   i32.const 100000000
-  i32.lt_u
-  select
+  i32.ge_u
+  i32.add
   local.get $0
   i32.const 10000000
   i32.lt_u

--- a/tests/compiler/resolve-elementaccess.untouched.wat
+++ b/tests/compiler/resolve-elementaccess.untouched.wat
@@ -565,7 +565,6 @@
   f32.load
  )
  (func $~lib/util/number/decimalCount32 (; 10 ;) (param $0 i32) (result i32)
-  (local $1 i32)
   local.get $0
   i32.const 100000
   i32.lt_u
@@ -575,26 +574,21 @@
    i32.lt_u
    if
     i32.const 1
-    i32.const 2
     local.get $0
     i32.const 10
-    i32.lt_u
-    select
+    i32.ge_u
+    i32.add
     return
    else
-    i32.const 4
-    i32.const 5
+    i32.const 3
     local.get $0
     i32.const 10000
-    i32.lt_u
-    select
-    local.set $1
-    i32.const 3
-    local.get $1
+    i32.ge_u
+    i32.add
     local.get $0
     i32.const 1000
-    i32.lt_u
-    select
+    i32.ge_u
+    i32.add
     return
    end
    unreachable
@@ -604,26 +598,21 @@
    i32.lt_u
    if
     i32.const 6
-    i32.const 7
     local.get $0
     i32.const 1000000
-    i32.lt_u
-    select
+    i32.ge_u
+    i32.add
     return
    else
-    i32.const 9
-    i32.const 10
+    i32.const 8
     local.get $0
     i32.const 1000000000
-    i32.lt_u
-    select
-    local.set $1
-    i32.const 8
-    local.get $1
+    i32.ge_u
+    i32.add
     local.get $0
     i32.const 100000000
-    i32.lt_u
-    select
+    i32.ge_u
+    i32.add
     return
    end
    unreachable

--- a/tests/compiler/resolve-elementaccess.untouched.wat
+++ b/tests/compiler/resolve-elementaccess.untouched.wat
@@ -2896,8 +2896,6 @@
   local.get $7
   i32.const 1
   local.get $7
-  i32.const 0
-  i32.ne
   select
   i32.const 1023
   i32.const 52

--- a/tests/compiler/resolve-function-expression.optimized.wat
+++ b/tests/compiler/resolve-function-expression.optimized.wat
@@ -36,44 +36,38 @@
   i32.add
  )
  (func $~lib/util/number/decimalCount32 (; 5 ;) (param $0 i32) (result i32)
-  i32.const 1
-  i32.const 2
   local.get $0
   i32.const 10
-  i32.lt_u
-  select
-  i32.const 3
-  i32.const 4
-  i32.const 5
+  i32.ge_u
+  i32.const 1
+  i32.add
   local.get $0
   i32.const 10000
-  i32.lt_u
-  select
+  i32.ge_u
+  i32.const 3
+  i32.add
   local.get $0
   i32.const 1000
-  i32.lt_u
-  select
+  i32.ge_u
+  i32.add
   local.get $0
   i32.const 100
   i32.lt_u
   select
-  i32.const 6
-  i32.const 7
   local.get $0
   i32.const 1000000
-  i32.lt_u
-  select
-  i32.const 8
-  i32.const 9
-  i32.const 10
+  i32.ge_u
+  i32.const 6
+  i32.add
   local.get $0
   i32.const 1000000000
-  i32.lt_u
-  select
+  i32.ge_u
+  i32.const 8
+  i32.add
   local.get $0
   i32.const 100000000
-  i32.lt_u
-  select
+  i32.ge_u
+  i32.add
   local.get $0
   i32.const 10000000
   i32.lt_u

--- a/tests/compiler/resolve-function-expression.optimized.wat
+++ b/tests/compiler/resolve-function-expression.optimized.wat
@@ -199,8 +199,8 @@
    return
   end
   local.get $0
-  i32.const 0
-  i32.lt_s
+  i32.const 31
+  i32.shr_u
   local.tee $1
   if
    i32.const 0

--- a/tests/compiler/resolve-function-expression.untouched.wat
+++ b/tests/compiler/resolve-function-expression.untouched.wat
@@ -42,7 +42,6 @@
   i32.add
  )
  (func $~lib/util/number/decimalCount32 (; 5 ;) (param $0 i32) (result i32)
-  (local $1 i32)
   local.get $0
   i32.const 100000
   i32.lt_u
@@ -52,26 +51,21 @@
    i32.lt_u
    if
     i32.const 1
-    i32.const 2
     local.get $0
     i32.const 10
-    i32.lt_u
-    select
+    i32.ge_u
+    i32.add
     return
    else
-    i32.const 4
-    i32.const 5
+    i32.const 3
     local.get $0
     i32.const 10000
-    i32.lt_u
-    select
-    local.set $1
-    i32.const 3
-    local.get $1
+    i32.ge_u
+    i32.add
     local.get $0
     i32.const 1000
-    i32.lt_u
-    select
+    i32.ge_u
+    i32.add
     return
    end
    unreachable
@@ -81,26 +75,21 @@
    i32.lt_u
    if
     i32.const 6
-    i32.const 7
     local.get $0
     i32.const 1000000
-    i32.lt_u
-    select
+    i32.ge_u
+    i32.add
     return
    else
-    i32.const 9
-    i32.const 10
+    i32.const 8
     local.get $0
     i32.const 1000000000
-    i32.lt_u
-    select
-    local.set $1
-    i32.const 8
-    local.get $1
+    i32.ge_u
+    i32.add
     local.get $0
     i32.const 100000000
-    i32.lt_u
-    select
+    i32.ge_u
+    i32.add
     return
    end
    unreachable

--- a/tests/compiler/resolve-function-expression.untouched.wat
+++ b/tests/compiler/resolve-function-expression.untouched.wat
@@ -360,8 +360,8 @@
    return
   end
   local.get $0
-  i32.const 0
-  i32.lt_s
+  i32.const 31
+  i32.shr_u
   local.set $1
   local.get $1
   if

--- a/tests/compiler/resolve-propertyaccess.optimized.wat
+++ b/tests/compiler/resolve-propertyaccess.optimized.wat
@@ -25,44 +25,38 @@
  (export "memory" (memory $0))
  (start $~start)
  (func $~lib/util/number/decimalCount32 (; 1 ;) (param $0 i32) (result i32)
-  i32.const 1
-  i32.const 2
   local.get $0
   i32.const 10
-  i32.lt_u
-  select
-  i32.const 3
-  i32.const 4
-  i32.const 5
+  i32.ge_u
+  i32.const 1
+  i32.add
   local.get $0
   i32.const 10000
-  i32.lt_u
-  select
+  i32.ge_u
+  i32.const 3
+  i32.add
   local.get $0
   i32.const 1000
-  i32.lt_u
-  select
+  i32.ge_u
+  i32.add
   local.get $0
   i32.const 100
   i32.lt_u
   select
-  i32.const 6
-  i32.const 7
   local.get $0
   i32.const 1000000
-  i32.lt_u
-  select
-  i32.const 8
-  i32.const 9
-  i32.const 10
+  i32.ge_u
+  i32.const 6
+  i32.add
   local.get $0
   i32.const 1000000000
-  i32.lt_u
-  select
+  i32.ge_u
+  i32.const 8
+  i32.add
   local.get $0
   i32.const 100000000
-  i32.lt_u
-  select
+  i32.ge_u
+  i32.add
   local.get $0
   i32.const 10000000
   i32.lt_u

--- a/tests/compiler/resolve-propertyaccess.optimized.wat
+++ b/tests/compiler/resolve-propertyaccess.optimized.wat
@@ -188,8 +188,8 @@
    return
   end
   local.get $0
-  i32.const 0
-  i32.lt_s
+  i32.const 31
+  i32.shr_u
   local.tee $1
   if
    i32.const 0

--- a/tests/compiler/resolve-propertyaccess.untouched.wat
+++ b/tests/compiler/resolve-propertyaccess.untouched.wat
@@ -356,8 +356,8 @@
    return
   end
   local.get $0
-  i32.const 0
-  i32.lt_s
+  i32.const 31
+  i32.shr_u
   local.set $1
   local.get $1
   if

--- a/tests/compiler/resolve-propertyaccess.untouched.wat
+++ b/tests/compiler/resolve-propertyaccess.untouched.wat
@@ -38,7 +38,6 @@
  (export "memory" (memory $0))
  (start $~start)
  (func $~lib/util/number/decimalCount32 (; 1 ;) (param $0 i32) (result i32)
-  (local $1 i32)
   local.get $0
   i32.const 100000
   i32.lt_u
@@ -48,26 +47,21 @@
    i32.lt_u
    if
     i32.const 1
-    i32.const 2
     local.get $0
     i32.const 10
-    i32.lt_u
-    select
+    i32.ge_u
+    i32.add
     return
    else
-    i32.const 4
-    i32.const 5
+    i32.const 3
     local.get $0
     i32.const 10000
-    i32.lt_u
-    select
-    local.set $1
-    i32.const 3
-    local.get $1
+    i32.ge_u
+    i32.add
     local.get $0
     i32.const 1000
-    i32.lt_u
-    select
+    i32.ge_u
+    i32.add
     return
    end
    unreachable
@@ -77,26 +71,21 @@
    i32.lt_u
    if
     i32.const 6
-    i32.const 7
     local.get $0
     i32.const 1000000
-    i32.lt_u
-    select
+    i32.ge_u
+    i32.add
     return
    else
-    i32.const 9
-    i32.const 10
+    i32.const 8
     local.get $0
     i32.const 1000000000
-    i32.lt_u
-    select
-    local.set $1
-    i32.const 8
-    local.get $1
+    i32.ge_u
+    i32.add
     local.get $0
     i32.const 100000000
-    i32.lt_u
-    select
+    i32.ge_u
+    i32.add
     return
    end
    unreachable

--- a/tests/compiler/resolve-ternary.optimized.wat
+++ b/tests/compiler/resolve-ternary.optimized.wat
@@ -1139,44 +1139,38 @@
   end
  )
  (func $~lib/util/number/decimalCount32 (; 14 ;) (param $0 i32) (result i32)
-  i32.const 1
-  i32.const 2
   local.get $0
   i32.const 10
-  i32.lt_u
-  select
-  i32.const 3
-  i32.const 4
-  i32.const 5
+  i32.ge_u
+  i32.const 1
+  i32.add
   local.get $0
   i32.const 10000
-  i32.lt_u
-  select
+  i32.ge_u
+  i32.const 3
+  i32.add
   local.get $0
   i32.const 1000
-  i32.lt_u
-  select
+  i32.ge_u
+  i32.add
   local.get $0
   i32.const 100
   i32.lt_u
   select
-  i32.const 6
-  i32.const 7
   local.get $0
   i32.const 1000000
-  i32.lt_u
-  select
-  i32.const 8
-  i32.const 9
-  i32.const 10
+  i32.ge_u
+  i32.const 6
+  i32.add
   local.get $0
   i32.const 1000000000
-  i32.lt_u
-  select
+  i32.ge_u
+  i32.const 8
+  i32.add
   local.get $0
   i32.const 100000000
-  i32.lt_u
-  select
+  i32.ge_u
+  i32.add
   local.get $0
   i32.const 10000000
   i32.lt_u

--- a/tests/compiler/resolve-ternary.untouched.wat
+++ b/tests/compiler/resolve-ternary.untouched.wat
@@ -1699,8 +1699,8 @@
    return
   end
   local.get $0
-  i32.const 0
-  i32.lt_s
+  i32.const 31
+  i32.shr_u
   local.set $1
   local.get $1
   if

--- a/tests/compiler/resolve-ternary.untouched.wat
+++ b/tests/compiler/resolve-ternary.untouched.wat
@@ -1491,7 +1491,6 @@
   end
  )
  (func $~lib/util/number/decimalCount32 (; 14 ;) (param $0 i32) (result i32)
-  (local $1 i32)
   local.get $0
   i32.const 100000
   i32.lt_u
@@ -1501,26 +1500,21 @@
    i32.lt_u
    if
     i32.const 1
-    i32.const 2
     local.get $0
     i32.const 10
-    i32.lt_u
-    select
+    i32.ge_u
+    i32.add
     return
    else
-    i32.const 4
-    i32.const 5
+    i32.const 3
     local.get $0
     i32.const 10000
-    i32.lt_u
-    select
-    local.set $1
-    i32.const 3
-    local.get $1
+    i32.ge_u
+    i32.add
     local.get $0
     i32.const 1000
-    i32.lt_u
-    select
+    i32.ge_u
+    i32.add
     return
    end
    unreachable
@@ -1530,26 +1524,21 @@
    i32.lt_u
    if
     i32.const 6
-    i32.const 7
     local.get $0
     i32.const 1000000
-    i32.lt_u
-    select
+    i32.ge_u
+    i32.add
     return
    else
-    i32.const 9
-    i32.const 10
+    i32.const 8
     local.get $0
     i32.const 1000000000
-    i32.lt_u
-    select
-    local.set $1
-    i32.const 8
-    local.get $1
+    i32.ge_u
+    i32.add
     local.get $0
     i32.const 100000000
-    i32.lt_u
-    select
+    i32.ge_u
+    i32.add
     return
    end
    unreachable

--- a/tests/compiler/resolve-ternary.untouched.wat
+++ b/tests/compiler/resolve-ternary.untouched.wat
@@ -4088,8 +4088,6 @@
   local.get $7
   i32.const 1
   local.get $7
-  i32.const 0
-  i32.ne
   select
   i32.const 1023
   i32.const 52

--- a/tests/compiler/resolve-unary.optimized.wat
+++ b/tests/compiler/resolve-unary.optimized.wat
@@ -33,44 +33,38 @@
  (export "memory" (memory $0))
  (start $~start)
  (func $~lib/util/number/decimalCount32 (; 1 ;) (param $0 i32) (result i32)
-  i32.const 1
-  i32.const 2
   local.get $0
   i32.const 10
-  i32.lt_u
-  select
-  i32.const 3
-  i32.const 4
-  i32.const 5
+  i32.ge_u
+  i32.const 1
+  i32.add
   local.get $0
   i32.const 10000
-  i32.lt_u
-  select
+  i32.ge_u
+  i32.const 3
+  i32.add
   local.get $0
   i32.const 1000
-  i32.lt_u
-  select
+  i32.ge_u
+  i32.add
   local.get $0
   i32.const 100
   i32.lt_u
   select
-  i32.const 6
-  i32.const 7
   local.get $0
   i32.const 1000000
-  i32.lt_u
-  select
-  i32.const 8
-  i32.const 9
-  i32.const 10
+  i32.ge_u
+  i32.const 6
+  i32.add
   local.get $0
   i32.const 1000000000
-  i32.lt_u
-  select
+  i32.ge_u
+  i32.const 8
+  i32.add
   local.get $0
   i32.const 100000000
-  i32.lt_u
-  select
+  i32.ge_u
+  i32.add
   local.get $0
   i32.const 10000000
   i32.lt_u

--- a/tests/compiler/resolve-unary.optimized.wat
+++ b/tests/compiler/resolve-unary.optimized.wat
@@ -196,8 +196,8 @@
    return
   end
   local.get $0
-  i32.const 0
-  i32.lt_s
+  i32.const 31
+  i32.shr_u
   local.tee $1
   if
    i32.const 0

--- a/tests/compiler/resolve-unary.untouched.wat
+++ b/tests/compiler/resolve-unary.untouched.wat
@@ -37,7 +37,6 @@
  (export "memory" (memory $0))
  (start $~start)
  (func $~lib/util/number/decimalCount32 (; 1 ;) (param $0 i32) (result i32)
-  (local $1 i32)
   local.get $0
   i32.const 100000
   i32.lt_u
@@ -47,26 +46,21 @@
    i32.lt_u
    if
     i32.const 1
-    i32.const 2
     local.get $0
     i32.const 10
-    i32.lt_u
-    select
+    i32.ge_u
+    i32.add
     return
    else
-    i32.const 4
-    i32.const 5
+    i32.const 3
     local.get $0
     i32.const 10000
-    i32.lt_u
-    select
-    local.set $1
-    i32.const 3
-    local.get $1
+    i32.ge_u
+    i32.add
     local.get $0
     i32.const 1000
-    i32.lt_u
-    select
+    i32.ge_u
+    i32.add
     return
    end
    unreachable
@@ -76,26 +70,21 @@
    i32.lt_u
    if
     i32.const 6
-    i32.const 7
     local.get $0
     i32.const 1000000
-    i32.lt_u
-    select
+    i32.ge_u
+    i32.add
     return
    else
-    i32.const 9
-    i32.const 10
+    i32.const 8
     local.get $0
     i32.const 1000000000
-    i32.lt_u
-    select
-    local.set $1
-    i32.const 8
-    local.get $1
+    i32.ge_u
+    i32.add
     local.get $0
     i32.const 100000000
-    i32.lt_u
-    select
+    i32.ge_u
+    i32.add
     return
    end
    unreachable

--- a/tests/compiler/resolve-unary.untouched.wat
+++ b/tests/compiler/resolve-unary.untouched.wat
@@ -355,8 +355,8 @@
    return
   end
   local.get $0
-  i32.const 0
-  i32.lt_s
+  i32.const 31
+  i32.shr_u
   local.set $1
   local.get $1
   if

--- a/tests/compiler/std/array.optimized.wat
+++ b/tests/compiler/std/array.optimized.wat
@@ -7872,10 +7872,10 @@
   (local $3 i32)
   (local $4 i64)
   (local $5 i32)
-  (local $6 i32)
+  (local $6 i64)
   (local $7 i64)
   (local $8 i64)
-  (local $9 i64)
+  (local $9 i32)
   (local $10 i32)
   (local $11 i64)
   (local $12 i64)
@@ -7888,7 +7888,7 @@
   local.get $1
   f64.const 0
   f64.lt
-  local.tee $10
+  local.tee $9
   if (result f64)
    local.get $0
    i32.const 45
@@ -7912,7 +7912,6 @@
   local.get $5
   i32.const 0
   i32.ne
-  local.tee $6
   i64.extend_i32_u
   i64.const 52
   i64.shl
@@ -7922,18 +7921,18 @@
   i64.shl
   i64.const 1
   i64.add
-  local.tee $7
+  local.tee $6
   i64.clz
   i32.wrap_i64
   local.set $3
-  local.get $7
+  local.get $6
   local.get $3
   i64.extend_i32_s
   i64.shl
   global.set $~lib/util/number/_frc_plus
   local.get $5
   i32.const 1
-  local.get $6
+  local.get $5
   select
   i32.const 1075
   i32.sub
@@ -7949,13 +7948,13 @@
   i64.eq
   i32.const 1
   i32.add
-  local.tee $6
+  local.tee $10
   i64.extend_i32_s
   i64.shl
   i64.const 1
   i64.sub
   local.get $5
-  local.get $6
+  local.get $10
   i32.sub
   local.get $3
   i32.sub
@@ -7988,10 +7987,10 @@
   local.tee $3
   i32.const 3
   i32.shl
-  local.tee $6
+  local.tee $10
   i32.sub
   global.set $~lib/util/number/_K
-  local.get $6
+  local.get $10
   i32.const 5968
   i32.add
   i64.load
@@ -8010,7 +8009,7 @@
   local.tee $3
   i64.extend_i32_s
   i64.shl
-  local.tee $7
+  local.tee $6
   i64.const 4294967295
   i64.and
   local.tee $11
@@ -8022,14 +8021,14 @@
   i64.mul
   local.set $14
   global.get $~lib/util/number/_frc_plus
-  local.tee $8
+  local.tee $7
   i64.const 4294967295
   i64.and
   local.tee $4
   local.get $2
   i64.const 4294967295
   i64.and
-  local.tee $9
+  local.tee $8
   i64.mul
   local.set $12
   global.get $~lib/util/number/_frc_minus
@@ -8049,17 +8048,17 @@
   i64.shr_u
   local.tee $4
   i64.mul
-  local.get $9
   local.get $8
+  local.get $7
   i64.const 32
   i64.shr_u
-  local.tee $8
+  local.tee $7
   i64.mul
   local.get $12
   i64.const 32
   i64.shr_u
   i64.add
-  local.tee $9
+  local.tee $8
   i64.const 4294967295
   i64.and
   i64.add
@@ -8068,16 +8067,16 @@
   i64.const 32
   i64.shr_u
   local.get $4
-  local.get $8
+  local.get $7
   i64.mul
-  local.get $9
+  local.get $8
   i64.const 32
   i64.shr_u
   i64.add
   i64.add
   i64.const 1
   i64.sub
-  local.tee $8
+  local.tee $7
   local.get $16
   local.get $2
   i64.const 32
@@ -8088,7 +8087,7 @@
   local.get $15
   i64.const 32
   i64.shr_u
-  local.tee $9
+  local.tee $8
   i64.mul
   local.get $18
   i64.const 32
@@ -8103,7 +8102,7 @@
   i64.const 32
   i64.shr_u
   local.get $4
-  local.get $9
+  local.get $8
   i64.mul
   local.get $12
   i64.const 32
@@ -8115,7 +8114,7 @@
   i64.sub
   local.set $4
   local.get $0
-  local.get $10
+  local.get $9
   i32.const 1
   i32.shl
   i32.add
@@ -8127,10 +8126,10 @@
   local.tee $2
   i64.mul
   local.get $13
-  local.get $7
+  local.get $6
   i64.const 32
   i64.shr_u
-  local.tee $7
+  local.tee $6
   i64.mul
   local.get $14
   i64.const 32
@@ -8145,7 +8144,7 @@
   i64.const 32
   i64.shr_u
   local.get $2
-  local.get $7
+  local.get $6
   i64.mul
   local.get $11
   i64.const 32
@@ -8160,20 +8159,20 @@
   i32.add
   i32.const -64
   i32.sub
-  local.get $8
+  local.get $7
   local.get $0
   global.get $~lib/util/number/_exp
   i32.add
   i32.const -64
   i32.sub
   local.get $4
-  local.get $10
+  local.get $9
   call $~lib/util/number/genDigits
-  local.get $10
+  local.get $9
   i32.sub
   global.get $~lib/util/number/_K
   call $~lib/util/number/prettify
-  local.get $10
+  local.get $9
   i32.add
  )
  (func $~lib/util/number/dtoa (; 165 ;) (param $0 f64) (result i32)

--- a/tests/compiler/std/array.optimized.wat
+++ b/tests/compiler/std/array.optimized.wat
@@ -6921,10 +6921,14 @@
   i32.add
   local.set $0
   local.get $2
-  i32.eqz
+  i64.extend_i32_s
+  i64.const 10
+  i64.lt_u
   if
    local.get $0
+   local.get $2
    i32.const 48
+   i32.or
    i32.store16
    i32.const 1
    return
@@ -7101,10 +7105,14 @@
   i32.add
   local.set $0
   local.get $2
-  i32.eqz
+  i64.extend_i32_u
+  i64.const 10
+  i64.lt_u
   if
    local.get $0
+   local.get $2
    i32.const 48
+   i32.or
    i32.store16
    i32.const 1
    return
@@ -8758,12 +8766,22 @@
   i32.add
   local.set $0
   local.get $2
-  i32.const 255
-  i32.and
-  i32.eqz
+  i32.const 24
+  i32.shl
+  i32.const 24
+  i32.shr_s
+  i64.extend_i32_s
+  i64.const 10
+  i64.lt_u
   if
    local.get $0
+   local.get $2
+   i32.const 24
+   i32.shl
+   i32.const 24
+   i32.shr_s
    i32.const 48
+   i32.or
    i32.store16
    i32.const 1
    return
@@ -8917,10 +8935,16 @@
   local.get $2
   i32.const 65535
   i32.and
-  i32.eqz
+  i64.extend_i32_u
+  i64.const 10
+  i64.lt_u
   if
    local.get $0
+   local.get $2
+   i32.const 65535
+   i32.and
    i32.const 48
+   i32.or
    i32.store16
    i32.const 1
    return
@@ -9169,11 +9193,14 @@
   i32.add
   local.set $0
   local.get $2
-  i64.eqz
+  i64.const 10
+  i64.lt_u
   if
    local.get $0
-   i32.const 48
-   i32.store16
+   local.get $2
+   i64.const 48
+   i64.or
+   i64.store16
    i32.const 1
    return
   end
@@ -9382,11 +9409,14 @@
   i32.add
   local.set $0
   local.get $2
-  i64.eqz
+  i64.const 10
+  i64.lt_u
   if
    local.get $0
-   i32.const 48
-   i32.store16
+   local.get $2
+   i64.const 48
+   i64.or
+   i64.store16
    i32.const 1
    return
   end
@@ -9719,10 +9749,16 @@
   local.get $2
   i32.const 255
   i32.and
-  i32.eqz
+  i64.extend_i32_u
+  i64.const 10
+  i64.lt_u
   if
    local.get $0
+   local.get $2
+   i32.const 255
+   i32.and
    i32.const 48
+   i32.or
    i32.store16
    i32.const 1
    return

--- a/tests/compiler/std/array.optimized.wat
+++ b/tests/compiler/std/array.optimized.wat
@@ -9041,7 +9041,7 @@
   end
   local.get $2
  )
- (func $~lib/util/number/decimalCount64 (; 177 ;) (param $0 i64) (result i32)
+ (func $~lib/util/number/decimalCount64High (; 177 ;) (param $0 i64) (result i32)
   local.get $0
   i64.const 100000000000
   i64.ge_u
@@ -9143,7 +9143,7 @@
    call $~lib/util/number/utoa_simple<u32>
   else
    local.get $0
-   call $~lib/util/number/decimalCount64
+   call $~lib/util/number/decimalCount64High
    local.tee $1
    i32.const 1
    i32.shl
@@ -9191,7 +9191,7 @@
    local.get $0
    local.get $2
    local.get $2
-   call $~lib/util/number/decimalCount64
+   call $~lib/util/number/decimalCount64High
    local.tee $1
    call $~lib/util/number/utoa_simple<u64>
   end
@@ -9346,7 +9346,7 @@
    call $~lib/util/number/utoa_simple<u32>
   else
    local.get $0
-   call $~lib/util/number/decimalCount64
+   call $~lib/util/number/decimalCount64High
    local.get $1
    i32.add
    local.tee $2
@@ -9415,7 +9415,7 @@
    local.get $0
    local.get $2
    local.get $2
-   call $~lib/util/number/decimalCount64
+   call $~lib/util/number/decimalCount64High
    local.get $1
    i32.add
    local.tee $3

--- a/tests/compiler/std/array.optimized.wat
+++ b/tests/compiler/std/array.optimized.wat
@@ -6806,44 +6806,38 @@
   local.get $3
  )
  (func $~lib/util/number/decimalCount32 (; 152 ;) (param $0 i32) (result i32)
-  i32.const 1
-  i32.const 2
   local.get $0
   i32.const 10
-  i32.lt_u
-  select
-  i32.const 3
-  i32.const 4
-  i32.const 5
+  i32.ge_u
+  i32.const 1
+  i32.add
   local.get $0
   i32.const 10000
-  i32.lt_u
-  select
+  i32.ge_u
+  i32.const 3
+  i32.add
   local.get $0
   i32.const 1000
-  i32.lt_u
-  select
+  i32.ge_u
+  i32.add
   local.get $0
   i32.const 100
   i32.lt_u
   select
-  i32.const 6
-  i32.const 7
   local.get $0
   i32.const 1000000
-  i32.lt_u
-  select
-  i32.const 8
-  i32.const 9
-  i32.const 10
+  i32.ge_u
+  i32.const 6
+  i32.add
   local.get $0
   i32.const 1000000000
-  i32.lt_u
-  select
+  i32.ge_u
+  i32.const 8
+  i32.add
   local.get $0
   i32.const 100000000
-  i32.lt_u
-  select
+  i32.ge_u
+  i32.add
   local.get $0
   i32.const 10000000
   i32.lt_u
@@ -9048,49 +9042,42 @@
   local.get $2
  )
  (func $~lib/util/number/decimalCount64 (; 177 ;) (param $0 i64) (result i32)
-  i32.const 10
-  i32.const 11
-  i32.const 12
   local.get $0
   i64.const 100000000000
-  i64.lt_u
-  select
+  i64.ge_u
+  i32.const 10
+  i32.add
   local.get $0
   i64.const 10000000000
-  i64.lt_u
-  select
-  i32.const 13
-  i32.const 14
-  i32.const 15
+  i64.ge_u
+  i32.add
   local.get $0
   i64.const 100000000000000
-  i64.lt_u
-  select
+  i64.ge_u
+  i32.const 13
+  i32.add
   local.get $0
   i64.const 10000000000000
-  i64.lt_u
-  select
+  i64.ge_u
+  i32.add
   local.get $0
   i64.const 1000000000000
   i64.lt_u
   select
-  i32.const 16
-  i32.const 17
   local.get $0
   i64.const 10000000000000000
-  i64.lt_u
-  select
-  i32.const 18
-  i32.const 19
-  i32.const 20
+  i64.ge_u
+  i32.const 16
+  i32.add
   local.get $0
   i64.const -8446744073709551616
-  i64.lt_u
-  select
+  i64.ge_u
+  i32.const 18
+  i32.add
   local.get $0
   i64.const 1000000000000000000
-  i64.lt_u
-  select
+  i64.ge_u
+  i32.add
   local.get $0
   i64.const 100000000000000000
   i64.lt_u

--- a/tests/compiler/std/array.optimized.wat
+++ b/tests/compiler/std/array.optimized.wat
@@ -6921,19 +6921,6 @@
   i32.add
   local.set $0
   local.get $2
-  i32.const 10
-  i32.lt_u
-  if
-   local.get $0
-   local.get $2
-   i32.const 48
-   i32.or
-   i32.store16
-   i32.const 1
-   return
-  end
-  local.get $0
-  local.get $2
   i32.const 0
   i32.lt_s
   local.tee $1
@@ -6946,6 +6933,25 @@
    i32.sub
    local.set $2
   end
+  local.get $2
+  i32.const 10
+  i32.lt_u
+  if
+   local.get $0
+   local.get $1
+   i32.const 1
+   i32.shl
+   i32.add
+   local.get $2
+   i32.const 48
+   i32.or
+   i32.store16
+   local.get $1
+   i32.const 1
+   i32.add
+   return
+  end
+  local.get $0
   local.get $2
   local.get $2
   call $~lib/util/number/decimalCount32
@@ -8764,26 +8770,6 @@
   i32.shl
   i32.const 24
   i32.shr_s
-  i32.const 10
-  i32.lt_u
-  if
-   local.get $0
-   local.get $2
-   i32.const 24
-   i32.shl
-   i32.const 24
-   i32.shr_s
-   i32.const 48
-   i32.or
-   i32.store16
-   i32.const 1
-   return
-  end
-  local.get $2
-  i32.const 24
-  i32.shl
-  i32.const 24
-  i32.shr_s
   i32.const 0
   i32.lt_s
   local.tee $1
@@ -8795,6 +8781,32 @@
    local.get $2
    i32.sub
    local.set $2
+  end
+  local.get $2
+  i32.const 24
+  i32.shl
+  i32.const 24
+  i32.shr_s
+  i32.const 10
+  i32.lt_u
+  if
+   local.get $0
+   local.get $1
+   i32.const 1
+   i32.shl
+   i32.add
+   local.get $2
+   i32.const 24
+   i32.shl
+   i32.const 24
+   i32.shr_s
+   i32.const 48
+   i32.or
+   i32.store16
+   local.get $1
+   i32.const 1
+   i32.add
+   return
   end
   local.get $2
   i32.const 24
@@ -9395,31 +9407,37 @@
   i32.const 1
   i32.shl
   i32.add
-  local.set $0
-  local.get $2
-  i64.const 10
-  i64.lt_u
-  if
-   local.get $0
-   local.get $2
-   i64.const 48
-   i64.or
-   i64.store16
-   i32.const 1
-   return
-  end
+  local.set $1
   local.get $2
   i64.const 0
   i64.lt_s
-  local.tee $1
+  local.tee $0
   if
-   local.get $0
+   local.get $1
    i32.const 45
    i32.store16
    i64.const 0
    local.get $2
    i64.sub
    local.set $2
+  end
+  local.get $2
+  i64.const 10
+  i64.lt_u
+  if
+   local.get $1
+   local.get $0
+   i32.const 1
+   i32.shl
+   i32.add
+   local.get $2
+   i64.const 48
+   i64.or
+   i64.store16
+   local.get $0
+   i32.const 1
+   i32.add
+   return
   end
   local.get $2
   i64.const 4294967295
@@ -9429,24 +9447,24 @@
    i32.wrap_i64
    local.tee $3
    call $~lib/util/number/decimalCount32
-   local.get $1
-   i32.add
-   local.set $1
    local.get $0
-   local.get $3
+   i32.add
+   local.set $0
    local.get $1
+   local.get $3
+   local.get $0
    call $~lib/util/number/utoa_simple<u32>
   else
-   local.get $0
+   local.get $1
    local.get $2
    local.get $2
    call $~lib/util/number/decimalCount64High
-   local.get $1
+   local.get $0
    i32.add
-   local.tee $1
+   local.tee $0
    call $~lib/util/number/utoa_simple<u64>
   end
-  local.get $1
+  local.get $0
  )
  (func $~lib/util/string/joinIntegerArray<i64> (; 184 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)

--- a/tests/compiler/std/array.optimized.wat
+++ b/tests/compiler/std/array.optimized.wat
@@ -6921,9 +6921,8 @@
   i32.add
   local.set $0
   local.get $2
-  i64.extend_i32_s
-  i64.const 10
-  i64.lt_u
+  i32.const 10
+  i32.lt_u
   if
    local.get $0
    local.get $2
@@ -7105,9 +7104,8 @@
   i32.add
   local.set $0
   local.get $2
-  i64.extend_i32_u
-  i64.const 10
-  i64.lt_u
+  i32.const 10
+  i32.lt_u
   if
    local.get $0
    local.get $2
@@ -8770,9 +8768,8 @@
   i32.shl
   i32.const 24
   i32.shr_s
-  i64.extend_i32_s
-  i64.const 10
-  i64.lt_u
+  i32.const 10
+  i32.lt_u
   if
    local.get $0
    local.get $2
@@ -8935,9 +8932,8 @@
   local.get $2
   i32.const 65535
   i32.and
-  i64.extend_i32_u
-  i64.const 10
-  i64.lt_u
+  i32.const 10
+  i32.lt_u
   if
    local.get $0
    local.get $2
@@ -9749,9 +9745,8 @@
   local.get $2
   i32.const 255
   i32.and
-  i64.extend_i32_u
-  i64.const 10
-  i64.lt_u
+  i32.const 10
+  i32.lt_u
   if
    local.get $0
    local.get $2

--- a/tests/compiler/std/array.optimized.wat
+++ b/tests/compiler/std/array.optimized.wat
@@ -6882,8 +6882,8 @@
    return
   end
   local.get $0
-  i32.const 0
-  i32.lt_s
+  i32.const 31
+  i32.shr_u
   local.tee $1
   if
    i32.const 0
@@ -9316,8 +9316,9 @@
    return
   end
   local.get $0
-  i64.const 0
-  i64.lt_s
+  i64.const 63
+  i64.shr_u
+  i32.wrap_i64
   local.tee $1
   if
    i64.const 0

--- a/tests/compiler/std/array.optimized.wat
+++ b/tests/compiler/std/array.optimized.wat
@@ -8228,7 +8228,6 @@
   call $~lib/rt/tlsf/__free
  )
  (func $~lib/util/number/dtoa_stream (; 166 ;) (param $0 i32) (param $1 i32) (param $2 f64) (result i32)
-  (local $3 i32)
   local.get $0
   local.get $1
   i32.const 1
@@ -8276,20 +8275,25 @@
     local.get $2
     f64.const 0
     f64.lt
-    local.tee $3
+    local.tee $1
+    if
+     local.get $0
+     i32.const 45
+     i32.store16
+     local.get $0
+     i32.const 2
+     i32.add
+     local.set $0
+    end
+    local.get $0
+    i64.const 29555310648492105
+    i64.store
+    local.get $0
+    i64.const 34058970405077102
+    i64.store offset=8
+    local.get $1
     i32.const 8
     i32.add
-    local.set $1
-    local.get $0
-    i32.const 5888
-    i32.const 5936
-    local.get $3
-    select
-    local.get $1
-    i32.const 1
-    i32.shl
-    call $~lib/memory/memory.copy
-    local.get $1
     return
    end
    unreachable

--- a/tests/compiler/std/array.optimized.wat
+++ b/tests/compiler/std/array.optimized.wat
@@ -6938,6 +6938,9 @@
   i32.lt_s
   local.tee $1
   if
+   local.get $0
+   i32.const 45
+   i32.store16
    i32.const 0
    local.get $2
    i32.sub
@@ -6948,15 +6951,9 @@
   call $~lib/util/number/decimalCount32
   local.get $1
   i32.add
-  local.tee $2
+  local.tee $0
   call $~lib/util/number/utoa_simple<u32>
-  local.get $1
-  if
-   local.get $0
-   i32.const 45
-   i32.store16
-  end
-  local.get $2
+  local.get $0
  )
  (func $~lib/util/string/joinIntegerArray<i32> (; 156 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
@@ -8756,7 +8753,6 @@
   call $~lib/array/Array<i32>#join
  )
  (func $~lib/util/number/itoa_stream<i8> (; 173 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
   local.get $0
   local.get $1
   i32.const 1
@@ -8792,6 +8788,9 @@
   i32.lt_s
   local.tee $1
   if
+   local.get $0
+   i32.const 45
+   i32.store16
    i32.const 0
    local.get $2
    i32.sub
@@ -8802,22 +8801,16 @@
   i32.shl
   i32.const 24
   i32.shr_s
-  local.tee $3
+  local.tee $2
   call $~lib/util/number/decimalCount32
   local.get $1
   i32.add
-  local.set $2
+  local.set $1
   local.get $0
-  local.get $3
   local.get $2
+  local.get $1
   call $~lib/util/number/utoa_simple<u32>
   local.get $1
-  if
-   local.get $0
-   i32.const 45
-   i32.store16
-  end
-  local.get $2
  )
  (func $~lib/util/string/joinIntegerArray<i8> (; 174 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
@@ -9397,7 +9390,6 @@
  )
  (func $~lib/util/number/itoa_stream<i64> (; 183 ;) (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
   (local $3 i32)
-  (local $4 i32)
   local.get $0
   local.get $1
   i32.const 1
@@ -9421,6 +9413,9 @@
   i64.lt_s
   local.tee $1
   if
+   local.get $0
+   i32.const 45
+   i32.store16
    i64.const 0
    local.get $2
    i64.sub
@@ -9432,14 +9427,14 @@
   if
    local.get $2
    i32.wrap_i64
-   local.tee $4
+   local.tee $3
    call $~lib/util/number/decimalCount32
    local.get $1
    i32.add
-   local.set $3
+   local.set $1
    local.get $0
-   local.get $4
    local.get $3
+   local.get $1
    call $~lib/util/number/utoa_simple<u32>
   else
    local.get $0
@@ -9448,16 +9443,10 @@
    call $~lib/util/number/decimalCount64High
    local.get $1
    i32.add
-   local.tee $3
+   local.tee $1
    call $~lib/util/number/utoa_simple<u64>
   end
   local.get $1
-  if
-   local.get $0
-   i32.const 45
-   i32.store16
-  end
-  local.get $3
  )
  (func $~lib/util/string/joinIntegerArray<i64> (; 184 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)

--- a/tests/compiler/std/array.untouched.wat
+++ b/tests/compiler/std/array.untouched.wat
@@ -12478,9 +12478,8 @@
   i32.add
   local.set $0
   local.get $2
-  i64.extend_i32_s
-  i64.const 10
-  i64.lt_u
+  i32.const 10
+  i32.lt_u
   if
    local.get $0
    local.get $2
@@ -12743,9 +12742,8 @@
   i32.add
   local.set $0
   local.get $2
-  i64.extend_i32_u
-  i64.const 10
-  i64.lt_u
+  i32.const 10
+  i32.lt_u
   if
    local.get $0
    local.get $2
@@ -15243,9 +15241,8 @@
   i32.shl
   i32.const 24
   i32.shr_s
-  i64.extend_i32_s
-  i64.const 10
-  i64.lt_u
+  i32.const 10
+  i32.lt_u
   if
    local.get $0
    local.get $2
@@ -15499,9 +15496,8 @@
   local.get $2
   i32.const 65535
   i32.and
-  i64.extend_i32_u
-  i64.const 10
-  i64.lt_u
+  i32.const 10
+  i32.lt_u
   if
    local.get $0
    local.get $2
@@ -16809,9 +16805,8 @@
   local.get $2
   i32.const 255
   i32.and
-  i64.extend_i32_u
-  i64.const 10
-  i64.lt_u
+  i32.const 10
+  i32.lt_u
   if
    local.get $0
    local.get $2

--- a/tests/compiler/std/array.untouched.wat
+++ b/tests/compiler/std/array.untouched.wat
@@ -12478,10 +12478,14 @@
   i32.add
   local.set $0
   local.get $2
-  i32.eqz
+  i64.extend_i32_s
+  i64.const 10
+  i64.lt_u
   if
    local.get $0
+   local.get $2
    i32.const 48
+   i32.or
    i32.store16
    i32.const 1
    return
@@ -12739,10 +12743,14 @@
   i32.add
   local.set $0
   local.get $2
-  i32.eqz
+  i64.extend_i32_u
+  i64.const 10
+  i64.lt_u
   if
    local.get $0
+   local.get $2
    i32.const 48
+   i32.or
    i32.store16
    i32.const 1
    return
@@ -15235,10 +15243,18 @@
   i32.shl
   i32.const 24
   i32.shr_s
-  i32.eqz
+  i64.extend_i32_s
+  i64.const 10
+  i64.lt_u
   if
    local.get $0
+   local.get $2
+   i32.const 24
+   i32.shl
+   i32.const 24
+   i32.shr_s
    i32.const 48
+   i32.or
    i32.store16
    i32.const 1
    return
@@ -15483,10 +15499,16 @@
   local.get $2
   i32.const 65535
   i32.and
-  i32.eqz
+  i64.extend_i32_u
+  i64.const 10
+  i64.lt_u
   if
    local.get $0
+   local.get $2
+   i32.const 65535
+   i32.and
    i32.const 48
+   i32.or
    i32.store16
    i32.const 1
    return
@@ -15950,13 +15972,14 @@
   i32.add
   local.set $0
   local.get $2
-  i64.const 0
-  i64.ne
-  i32.eqz
+  i64.const 10
+  i64.lt_u
   if
    local.get $0
-   i32.const 48
-   i32.store16
+   local.get $2
+   i64.const 48
+   i64.or
+   i64.store16
    i32.const 1
    return
   end
@@ -16279,13 +16302,14 @@
   i32.add
   local.set $0
   local.get $2
-  i64.const 0
-  i64.ne
-  i32.eqz
+  i64.const 10
+  i64.lt_u
   if
    local.get $0
-   i32.const 48
-   i32.store16
+   local.get $2
+   i64.const 48
+   i64.or
+   i64.store16
    i32.const 1
    return
   end
@@ -16785,10 +16809,16 @@
   local.get $2
   i32.const 255
   i32.and
-  i32.eqz
+  i64.extend_i32_u
+  i64.const 10
+  i64.lt_u
   if
    local.get $0
+   local.get $2
+   i32.const 255
+   i32.and
    i32.const 48
+   i32.or
    i32.store16
    i32.const 1
    return

--- a/tests/compiler/std/array.untouched.wat
+++ b/tests/compiler/std/array.untouched.wat
@@ -12501,6 +12501,9 @@
    local.get $2
    i32.sub
    local.set $2
+   local.get $0
+   i32.const 45
+   i32.store16
   end
   local.get $2
   call $~lib/util/number/decimalCount32
@@ -12517,12 +12520,6 @@
   local.get $6
   local.get $5
   call $~lib/util/number/utoa32_lut
-  local.get $4
-  if
-   local.get $0
-   i32.const 45
-   i32.store16
-  end
   local.get $3
  )
  (func $~lib/util/string/joinIntegerArray<i32> (; 243 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -15272,6 +15269,9 @@
    local.get $2
    i32.sub
    local.set $2
+   local.get $0
+   i32.const 45
+   i32.store16
   end
   local.get $2
   i32.const 24
@@ -15296,12 +15296,6 @@
   local.get $6
   local.get $5
   call $~lib/util/number/utoa32_lut
-  local.get $4
-  if
-   local.get $0
-   i32.const 45
-   i32.store16
-  end
   local.get $3
  )
  (func $~lib/util/string/joinIntegerArray<i8> (; 267 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -16321,6 +16315,9 @@
    local.get $2
    i64.sub
    local.set $2
+   local.get $0
+   i32.const 45
+   i32.store16
   end
   local.get $2
   i64.const 4294967295
@@ -16360,12 +16357,6 @@
    local.get $9
    local.get $6
    call $~lib/util/number/utoa64_lut
-  end
-  local.get $4
-  if
-   local.get $0
-   i32.const 45
-   i32.store16
   end
   local.get $3
  )

--- a/tests/compiler/std/array.untouched.wat
+++ b/tests/compiler/std/array.untouched.wat
@@ -12212,7 +12212,6 @@
   return
  )
  (func $~lib/util/number/decimalCount32 (; 238 ;) (param $0 i32) (result i32)
-  (local $1 i32)
   local.get $0
   i32.const 100000
   i32.lt_u
@@ -12222,26 +12221,21 @@
    i32.lt_u
    if
     i32.const 1
-    i32.const 2
     local.get $0
     i32.const 10
-    i32.lt_u
-    select
+    i32.ge_u
+    i32.add
     return
    else
-    i32.const 4
-    i32.const 5
+    i32.const 3
     local.get $0
     i32.const 10000
-    i32.lt_u
-    select
-    local.set $1
-    i32.const 3
-    local.get $1
+    i32.ge_u
+    i32.add
     local.get $0
     i32.const 1000
-    i32.lt_u
-    select
+    i32.ge_u
+    i32.add
     return
    end
    unreachable
@@ -12251,26 +12245,21 @@
    i32.lt_u
    if
     i32.const 6
-    i32.const 7
     local.get $0
     i32.const 1000000
-    i32.lt_u
-    select
+    i32.ge_u
+    i32.add
     return
    else
-    i32.const 9
-    i32.const 10
+    i32.const 8
     local.get $0
     i32.const 1000000000
-    i32.lt_u
-    select
-    local.set $1
-    i32.const 8
-    local.get $1
+    i32.ge_u
+    i32.add
     local.get $0
     i32.const 100000000
-    i32.lt_u
-    select
+    i32.ge_u
+    i32.add
     return
    end
    unreachable
@@ -15693,7 +15682,6 @@
   call $~lib/array/Array<u16>#join
  )
  (func $~lib/util/number/decimalCount64 (; 275 ;) (param $0 i64) (result i32)
-  (local $1 i32)
   local.get $0
   i64.const 1000000000000000
   i64.lt_u
@@ -15702,34 +15690,26 @@
    i64.const 1000000000000
    i64.lt_u
    if
-    i32.const 11
-    i32.const 12
+    i32.const 10
     local.get $0
     i64.const 100000000000
-    i64.lt_u
-    select
-    local.set $1
-    i32.const 10
-    local.get $1
+    i64.ge_u
+    i32.add
     local.get $0
     i64.const 10000000000
-    i64.lt_u
-    select
+    i64.ge_u
+    i32.add
     return
    else
-    i32.const 14
-    i32.const 15
+    i32.const 13
     local.get $0
     i64.const 100000000000000
-    i64.lt_u
-    select
-    local.set $1
-    i32.const 13
-    local.get $1
+    i64.ge_u
+    i32.add
     local.get $0
     i64.const 10000000000000
-    i64.lt_u
-    select
+    i64.ge_u
+    i32.add
     return
    end
    unreachable
@@ -15739,26 +15719,21 @@
    i64.lt_u
    if
     i32.const 16
-    i32.const 17
     local.get $0
     i64.const 10000000000000000
-    i64.lt_u
-    select
+    i64.ge_u
+    i32.add
     return
    else
-    i32.const 19
-    i32.const 20
+    i32.const 18
     local.get $0
     i64.const -8446744073709551616
-    i64.lt_u
-    select
-    local.set $1
-    i32.const 18
-    local.get $1
+    i64.ge_u
+    i32.add
     local.get $0
     i64.const 1000000000000000000
-    i64.lt_u
-    select
+    i64.ge_u
+    i32.add
     return
    end
    unreachable

--- a/tests/compiler/std/array.untouched.wat
+++ b/tests/compiler/std/array.untouched.wat
@@ -15681,7 +15681,7 @@
   i32.const 5360
   call $~lib/array/Array<u16>#join
  )
- (func $~lib/util/number/decimalCount64 (; 275 ;) (param $0 i64) (result i32)
+ (func $~lib/util/number/decimalCount64High (; 275 ;) (param $0 i64) (result i32)
   local.get $0
   i64.const 1000000000000000
   i64.lt_u
@@ -15907,7 +15907,7 @@
    call $~lib/util/number/utoa32_lut
   else
    local.get $0
-   call $~lib/util/number/decimalCount64
+   call $~lib/util/number/decimalCount64High
    local.set $3
    local.get $3
    i32.const 1
@@ -15982,7 +15982,7 @@
    call $~lib/util/number/utoa32_lut
   else
    local.get $2
-   call $~lib/util/number/decimalCount64
+   call $~lib/util/number/decimalCount64High
    local.set $3
    local.get $0
    local.set $6
@@ -16226,7 +16226,7 @@
    call $~lib/util/number/utoa32_lut
   else
    local.get $0
-   call $~lib/util/number/decimalCount64
+   call $~lib/util/number/decimalCount64High
    local.get $1
    i32.add
    local.set $4
@@ -16323,7 +16323,7 @@
    call $~lib/util/number/utoa32_lut
   else
    local.get $2
-   call $~lib/util/number/decimalCount64
+   call $~lib/util/number/decimalCount64High
    local.get $4
    i32.add
    local.set $3

--- a/tests/compiler/std/array.untouched.wat
+++ b/tests/compiler/std/array.untouched.wat
@@ -13823,8 +13823,6 @@
   local.get $7
   i32.const 1
   local.get $7
-  i32.const 0
-  i32.ne
   select
   i32.const 1023
   i32.const 52

--- a/tests/compiler/std/array.untouched.wat
+++ b/tests/compiler/std/array.untouched.wat
@@ -12477,25 +12477,13 @@
   i32.shl
   i32.add
   local.set $0
-  local.get $2
-  i32.const 10
-  i32.lt_u
-  if
-   local.get $0
-   local.get $2
-   i32.const 48
-   i32.or
-   i32.store16
-   i32.const 1
-   return
-  end
   i32.const 0
   local.set $3
   local.get $2
   i32.const 0
   i32.lt_s
-  local.set $4
-  local.get $4
+  local.set $3
+  local.get $3
   if
    i32.const 0
    local.get $2
@@ -12506,21 +12494,41 @@
    i32.store16
   end
   local.get $2
-  call $~lib/util/number/decimalCount32
+  i32.const 10
+  i32.lt_u
+  if
+   local.get $0
+   local.get $3
+   i32.const 1
+   i32.shl
+   i32.add
+   local.get $2
+   i32.const 48
+   i32.or
+   i32.store16
+   i32.const 1
+   local.get $3
+   i32.add
+   return
+  end
+  local.get $3
+  local.set $4
   local.get $4
+  local.get $2
+  call $~lib/util/number/decimalCount32
   i32.add
-  local.set $3
+  local.set $4
   local.get $0
   local.set $7
   local.get $2
   local.set $6
-  local.get $3
+  local.get $4
   local.set $5
   local.get $7
   local.get $6
   local.get $5
   call $~lib/util/number/utoa32_lut
-  local.get $3
+  local.get $4
  )
  (func $~lib/util/string/joinIntegerArray<i32> (; 243 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
@@ -12732,40 +12740,51 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
   local.get $0
   local.get $1
   i32.const 1
   i32.shl
   i32.add
   local.set $0
+  i32.const 0
+  local.set $3
   local.get $2
   i32.const 10
   i32.lt_u
   if
    local.get $0
+   local.get $3
+   i32.const 1
+   i32.shl
+   i32.add
    local.get $2
    i32.const 48
    i32.or
    i32.store16
    i32.const 1
+   local.get $3
+   i32.add
    return
   end
-  i32.const 0
-  local.set $3
-  local.get $2
-  call $~lib/util/number/decimalCount32
-  local.set $3
-  local.get $0
-  local.set $6
-  local.get $2
-  local.set $5
   local.get $3
   local.set $4
+  local.get $4
+  local.get $2
+  call $~lib/util/number/decimalCount32
+  i32.add
+  local.set $4
+  local.get $0
+  local.set $7
+  local.get $2
+  local.set $6
+  local.get $4
+  local.set $5
+  local.get $7
   local.get $6
   local.get $5
-  local.get $4
   call $~lib/util/number/utoa32_lut
-  local.get $3
+  local.get $4
  )
  (func $~lib/util/string/joinIntegerArray<u32> (; 248 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
@@ -15233,26 +15252,6 @@
   i32.shl
   i32.add
   local.set $0
-  local.get $2
-  i32.const 24
-  i32.shl
-  i32.const 24
-  i32.shr_s
-  i32.const 10
-  i32.lt_u
-  if
-   local.get $0
-   local.get $2
-   i32.const 24
-   i32.shl
-   i32.const 24
-   i32.shr_s
-   i32.const 48
-   i32.or
-   i32.store16
-   i32.const 1
-   return
-  end
   i32.const 0
   local.set $3
   local.get $2
@@ -15262,8 +15261,8 @@
   i32.shr_s
   i32.const 0
   i32.lt_s
-  local.set $4
-  local.get $4
+  local.set $3
+  local.get $3
   if
    i32.const 0
    local.get $2
@@ -15278,10 +15277,38 @@
   i32.shl
   i32.const 24
   i32.shr_s
-  call $~lib/util/number/decimalCount32
+  i32.const 10
+  i32.lt_u
+  if
+   local.get $0
+   local.get $3
+   i32.const 1
+   i32.shl
+   i32.add
+   local.get $2
+   i32.const 24
+   i32.shl
+   i32.const 24
+   i32.shr_s
+   i32.const 48
+   i32.or
+   i32.store16
+   i32.const 1
+   local.get $3
+   i32.add
+   return
+  end
+  local.get $3
+  local.set $4
   local.get $4
+  local.get $2
+  i32.const 24
+  i32.shl
+  i32.const 24
+  i32.shr_s
+  call $~lib/util/number/decimalCount32
   i32.add
-  local.set $3
+  local.set $4
   local.get $0
   local.set $7
   local.get $2
@@ -15290,13 +15317,13 @@
   i32.const 24
   i32.shr_s
   local.set $6
-  local.get $3
+  local.get $4
   local.set $5
   local.get $7
   local.get $6
   local.get $5
   call $~lib/util/number/utoa32_lut
-  local.get $3
+  local.get $4
  )
  (func $~lib/util/string/joinIntegerArray<i8> (; 267 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
@@ -15481,12 +15508,15 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
   local.get $0
   local.get $1
   i32.const 1
   i32.shl
   i32.add
   local.set $0
+  i32.const 0
+  local.set $3
   local.get $2
   i32.const 65535
   i32.and
@@ -15494,6 +15524,10 @@
   i32.lt_u
   if
    local.get $0
+   local.get $3
+   i32.const 1
+   i32.shl
+   i32.add
    local.get $2
    i32.const 65535
    i32.and
@@ -15501,28 +15535,32 @@
    i32.or
    i32.store16
    i32.const 1
+   local.get $3
+   i32.add
    return
   end
-  i32.const 0
-  local.set $3
+  local.get $3
+  local.set $4
+  local.get $4
   local.get $2
   i32.const 65535
   i32.and
   call $~lib/util/number/decimalCount32
-  local.set $3
+  i32.add
+  local.set $4
   local.get $0
-  local.set $6
+  local.set $7
   local.get $2
   i32.const 65535
   i32.and
+  local.set $6
+  local.get $4
   local.set $5
-  local.get $3
-  local.set $4
+  local.get $7
   local.get $6
   local.get $5
-  local.get $4
   call $~lib/util/number/utoa32_lut
-  local.get $3
+  local.get $4
  )
  (func $~lib/util/string/joinIntegerArray<u16> (; 272 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
@@ -15954,63 +15992,76 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i64)
+  (local $8 i32)
+  (local $9 i64)
   local.get $0
   local.get $1
   i32.const 1
   i32.shl
   i32.add
   local.set $0
+  i32.const 0
+  local.set $3
   local.get $2
   i64.const 10
   i64.lt_u
   if
    local.get $0
+   local.get $3
+   i32.const 1
+   i32.shl
+   i32.add
    local.get $2
    i64.const 48
    i64.or
    i64.store16
    i32.const 1
+   local.get $3
+   i32.add
    return
   end
-  i32.const 0
-  local.set $3
+  local.get $3
+  local.set $4
   local.get $2
   i64.const 4294967295
   i64.le_u
   if
    local.get $2
    i32.wrap_i64
-   local.set $4
+   local.set $5
    local.get $4
+   local.get $5
    call $~lib/util/number/decimalCount32
-   local.set $3
+   i32.add
+   local.set $4
    local.get $0
+   local.set $8
+   local.get $5
    local.set $7
    local.get $4
    local.set $6
-   local.get $3
-   local.set $5
+   local.get $8
    local.get $7
    local.get $6
-   local.get $5
    call $~lib/util/number/utoa32_lut
   else
+   local.get $4
    local.get $2
    call $~lib/util/number/decimalCount64High
-   local.set $3
+   i32.add
+   local.set $4
    local.get $0
-   local.set $6
+   local.set $7
    local.get $2
-   local.set $8
-   local.get $3
-   local.set $5
+   local.set $9
+   local.get $4
+   local.set $6
+   local.get $7
+   local.get $9
    local.get $6
-   local.get $8
-   local.get $5
    call $~lib/util/number/utoa64_lut
   end
-  local.get $3
+  local.get $4
  )
  (func $~lib/util/string/joinIntegerArray<u64> (; 280 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
@@ -16291,25 +16342,13 @@
   i32.shl
   i32.add
   local.set $0
-  local.get $2
-  i64.const 10
-  i64.lt_u
-  if
-   local.get $0
-   local.get $2
-   i64.const 48
-   i64.or
-   i64.store16
-   i32.const 1
-   return
-  end
   i32.const 0
   local.set $3
   local.get $2
   i64.const 0
   i64.lt_s
-  local.set $4
-  local.get $4
+  local.set $3
+  local.get $3
   if
    i64.const 0
    local.get $2
@@ -16320,45 +16359,65 @@
    i32.store16
   end
   local.get $2
+  i64.const 10
+  i64.lt_u
+  if
+   local.get $0
+   local.get $3
+   i32.const 1
+   i32.shl
+   i32.add
+   local.get $2
+   i64.const 48
+   i64.or
+   i64.store16
+   i32.const 1
+   local.get $3
+   i32.add
+   return
+  end
+  local.get $3
+  local.set $4
+  local.get $2
   i64.const 4294967295
   i64.le_u
   if
    local.get $2
    i32.wrap_i64
    local.set $5
+   local.get $4
    local.get $5
    call $~lib/util/number/decimalCount32
-   local.get $4
    i32.add
-   local.set $3
+   local.set $4
    local.get $0
    local.set $8
    local.get $5
    local.set $7
-   local.get $3
+   local.get $4
    local.set $6
    local.get $8
    local.get $7
    local.get $6
    call $~lib/util/number/utoa32_lut
   else
+   local.get $4
    local.get $2
    call $~lib/util/number/decimalCount64High
-   local.get $4
    i32.add
-   local.set $3
+   local.set $4
    local.get $0
    local.set $7
    local.get $2
    local.set $9
-   local.get $3
+   local.get $4
    local.set $6
    local.get $7
    local.get $9
    local.get $6
    call $~lib/util/number/utoa64_lut
   end
-  local.get $3
+  local.get $4
  )
  (func $~lib/util/string/joinIntegerArray<i64> (; 286 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
@@ -16787,12 +16846,15 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
   local.get $0
   local.get $1
   i32.const 1
   i32.shl
   i32.add
   local.set $0
+  i32.const 0
+  local.set $3
   local.get $2
   i32.const 255
   i32.and
@@ -16800,6 +16862,10 @@
   i32.lt_u
   if
    local.get $0
+   local.get $3
+   i32.const 1
+   i32.shl
+   i32.add
    local.get $2
    i32.const 255
    i32.and
@@ -16807,28 +16873,32 @@
    i32.or
    i32.store16
    i32.const 1
+   local.get $3
+   i32.add
    return
   end
-  i32.const 0
-  local.set $3
+  local.get $3
+  local.set $4
+  local.get $4
   local.get $2
   i32.const 255
   i32.and
   call $~lib/util/number/decimalCount32
-  local.set $3
+  i32.add
+  local.set $4
   local.get $0
-  local.set $6
+  local.set $7
   local.get $2
   i32.const 255
   i32.and
+  local.set $6
+  local.get $4
   local.set $5
-  local.get $3
-  local.set $4
+  local.get $7
   local.get $6
   local.get $5
-  local.get $4
   call $~lib/util/number/utoa32_lut
-  local.get $3
+  local.get $4
  )
  (func $~lib/util/string/joinIntegerArray<u8> (; 295 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)

--- a/tests/compiler/std/array.untouched.wat
+++ b/tests/compiler/std/array.untouched.wat
@@ -12420,8 +12420,8 @@
    return
   end
   local.get $0
-  i32.const 0
-  i32.lt_s
+  i32.const 31
+  i32.shr_u
   local.set $1
   local.get $1
   if
@@ -16186,8 +16186,9 @@
    return
   end
   local.get $0
-  i64.const 0
-  i64.lt_s
+  i64.const 63
+  i64.shr_u
+  i32.wrap_i64
   local.set $1
   local.get $1
   if

--- a/tests/compiler/std/array.untouched.wat
+++ b/tests/compiler/std/array.untouched.wat
@@ -12754,17 +12754,11 @@
   i32.lt_u
   if
    local.get $0
-   local.get $3
-   i32.const 1
-   i32.shl
-   i32.add
    local.get $2
    i32.const 48
    i32.or
    i32.store16
    i32.const 1
-   local.get $3
-   i32.add
    return
   end
   local.get $3
@@ -15524,10 +15518,6 @@
   i32.lt_u
   if
    local.get $0
-   local.get $3
-   i32.const 1
-   i32.shl
-   i32.add
    local.get $2
    i32.const 65535
    i32.and
@@ -15535,8 +15525,6 @@
    i32.or
    i32.store16
    i32.const 1
-   local.get $3
-   i32.add
    return
   end
   local.get $3
@@ -16007,17 +15995,11 @@
   i64.lt_u
   if
    local.get $0
-   local.get $3
-   i32.const 1
-   i32.shl
-   i32.add
    local.get $2
    i64.const 48
    i64.or
    i64.store16
    i32.const 1
-   local.get $3
-   i32.add
    return
   end
   local.get $3
@@ -16862,10 +16844,6 @@
   i32.lt_u
   if
    local.get $0
-   local.get $3
-   i32.const 1
-   i32.shl
-   i32.add
    local.get $2
    i32.const 255
    i32.and
@@ -16873,8 +16851,6 @@
    i32.or
    i32.store16
    i32.const 1
-   local.get $3
-   i32.add
    return
   end
   local.get $3

--- a/tests/compiler/std/array.untouched.wat
+++ b/tests/compiler/std/array.untouched.wat
@@ -14239,7 +14239,6 @@
  )
  (func $~lib/util/number/dtoa_stream (; 254 ;) (param $0 i32) (param $1 i32) (param $2 f64) (result i32)
   (local $3 i32)
-  (local $4 i32)
   local.get $0
   local.get $1
   i32.const 1
@@ -14289,20 +14288,25 @@
     f64.const 0
     f64.lt
     local.set $3
+    local.get $3
+    if
+     local.get $0
+     i32.const 45
+     i32.store16
+     local.get $0
+     i32.const 2
+     i32.add
+     local.set $0
+    end
+    local.get $0
+    i64.const 29555310648492105
+    i64.store
+    local.get $0
+    i64.const 34058970405077102
+    i64.store offset=8
     i32.const 8
     local.get $3
     i32.add
-    local.set $4
-    local.get $0
-    i32.const 6304
-    i32.const 6352
-    local.get $3
-    select
-    local.get $4
-    i32.const 1
-    i32.shl
-    call $~lib/memory/memory.copy
-    local.get $4
     return
    end
    unreachable

--- a/tests/compiler/std/string.optimized.wat
+++ b/tests/compiler/std/string.optimized.wat
@@ -5730,8 +5730,8 @@
    return
   end
   local.get $0
-  i32.const 0
-  i32.lt_s
+  i32.const 31
+  i32.shr_u
   local.tee $1
   if
    i32.const 0
@@ -5912,8 +5912,9 @@
    return
   end
   local.get $0
-  i64.const 0
-  i64.lt_s
+  i64.const 63
+  i64.shr_u
+  i32.wrap_i64
   local.tee $1
   if
    i64.const 0

--- a/tests/compiler/std/string.optimized.wat
+++ b/tests/compiler/std/string.optimized.wat
@@ -6605,10 +6605,10 @@
   (local $3 i32)
   (local $4 i64)
   (local $5 i32)
-  (local $6 i32)
+  (local $6 i64)
   (local $7 i64)
   (local $8 i64)
-  (local $9 i64)
+  (local $9 i32)
   (local $10 i32)
   (local $11 i64)
   (local $12 i64)
@@ -6621,7 +6621,7 @@
   local.get $1
   f64.const 0
   f64.lt
-  local.tee $10
+  local.tee $9
   if (result f64)
    local.get $0
    i32.const 45
@@ -6645,7 +6645,6 @@
   local.get $5
   i32.const 0
   i32.ne
-  local.tee $6
   i64.extend_i32_u
   i64.const 52
   i64.shl
@@ -6655,18 +6654,18 @@
   i64.shl
   i64.const 1
   i64.add
-  local.tee $7
+  local.tee $6
   i64.clz
   i32.wrap_i64
   local.set $3
-  local.get $7
+  local.get $6
   local.get $3
   i64.extend_i32_s
   i64.shl
   global.set $~lib/util/number/_frc_plus
   local.get $5
   i32.const 1
-  local.get $6
+  local.get $5
   select
   i32.const 1075
   i32.sub
@@ -6682,13 +6681,13 @@
   i64.eq
   i32.const 1
   i32.add
-  local.tee $6
+  local.tee $10
   i64.extend_i32_s
   i64.shl
   i64.const 1
   i64.sub
   local.get $5
-  local.get $6
+  local.get $10
   i32.sub
   local.get $3
   i32.sub
@@ -6721,10 +6720,10 @@
   local.tee $3
   i32.const 3
   i32.shl
-  local.tee $6
+  local.tee $10
   i32.sub
   global.set $~lib/util/number/_K
-  local.get $6
+  local.get $10
   i32.const 14368
   i32.add
   i64.load
@@ -6743,7 +6742,7 @@
   local.tee $3
   i64.extend_i32_s
   i64.shl
-  local.tee $7
+  local.tee $6
   i64.const 4294967295
   i64.and
   local.tee $11
@@ -6755,14 +6754,14 @@
   i64.mul
   local.set $14
   global.get $~lib/util/number/_frc_plus
-  local.tee $8
+  local.tee $7
   i64.const 4294967295
   i64.and
   local.tee $4
   local.get $2
   i64.const 4294967295
   i64.and
-  local.tee $9
+  local.tee $8
   i64.mul
   local.set $12
   global.get $~lib/util/number/_frc_minus
@@ -6782,17 +6781,17 @@
   i64.shr_u
   local.tee $4
   i64.mul
-  local.get $9
   local.get $8
+  local.get $7
   i64.const 32
   i64.shr_u
-  local.tee $8
+  local.tee $7
   i64.mul
   local.get $12
   i64.const 32
   i64.shr_u
   i64.add
-  local.tee $9
+  local.tee $8
   i64.const 4294967295
   i64.and
   i64.add
@@ -6801,16 +6800,16 @@
   i64.const 32
   i64.shr_u
   local.get $4
-  local.get $8
+  local.get $7
   i64.mul
-  local.get $9
+  local.get $8
   i64.const 32
   i64.shr_u
   i64.add
   i64.add
   i64.const 1
   i64.sub
-  local.tee $8
+  local.tee $7
   local.get $16
   local.get $2
   i64.const 32
@@ -6821,7 +6820,7 @@
   local.get $15
   i64.const 32
   i64.shr_u
-  local.tee $9
+  local.tee $8
   i64.mul
   local.get $18
   i64.const 32
@@ -6836,7 +6835,7 @@
   i64.const 32
   i64.shr_u
   local.get $4
-  local.get $9
+  local.get $8
   i64.mul
   local.get $12
   i64.const 32
@@ -6848,7 +6847,7 @@
   i64.sub
   local.set $4
   local.get $0
-  local.get $10
+  local.get $9
   i32.const 1
   i32.shl
   i32.add
@@ -6860,10 +6859,10 @@
   local.tee $2
   i64.mul
   local.get $13
-  local.get $7
+  local.get $6
   i64.const 32
   i64.shr_u
-  local.tee $7
+  local.tee $6
   i64.mul
   local.get $14
   i64.const 32
@@ -6878,7 +6877,7 @@
   i64.const 32
   i64.shr_u
   local.get $2
-  local.get $7
+  local.get $6
   i64.mul
   local.get $11
   i64.const 32
@@ -6893,20 +6892,20 @@
   i32.add
   i32.const -64
   i32.sub
-  local.get $8
+  local.get $7
   local.get $0
   global.get $~lib/util/number/_exp
   i32.add
   i32.const -64
   i32.sub
   local.get $4
-  local.get $10
+  local.get $9
   call $~lib/util/number/genDigits
-  local.get $10
+  local.get $9
   i32.sub
   global.get $~lib/util/number/_K
   call $~lib/util/number/prettify
-  local.get $10
+  local.get $9
   i32.add
  )
  (func $~lib/util/number/dtoa (; 80 ;) (param $0 f64) (result i32)

--- a/tests/compiler/std/string.optimized.wat
+++ b/tests/compiler/std/string.optimized.wat
@@ -5784,7 +5784,7 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/decimalCount64 (; 73 ;) (param $0 i64) (result i32)
+ (func $~lib/util/number/decimalCount64High (; 73 ;) (param $0 i64) (result i32)
   local.get $0
   i64.const 100000000000
   i64.ge_u
@@ -5886,7 +5886,7 @@
    call $~lib/util/number/utoa_simple<u32>
   else
    local.get $0
-   call $~lib/util/number/decimalCount64
+   call $~lib/util/number/decimalCount64High
    local.tee $1
    i32.const 1
    i32.shl
@@ -5942,7 +5942,7 @@
    call $~lib/util/number/utoa_simple<u32>
   else
    local.get $0
-   call $~lib/util/number/decimalCount64
+   call $~lib/util/number/decimalCount64High
    local.get $1
    i32.add
    local.tee $2

--- a/tests/compiler/std/string.optimized.wat
+++ b/tests/compiler/std/string.optimized.wat
@@ -5654,44 +5654,38 @@
   local.get $0
  )
  (func $~lib/util/number/decimalCount32 (; 69 ;) (param $0 i32) (result i32)
-  i32.const 1
-  i32.const 2
   local.get $0
   i32.const 10
-  i32.lt_u
-  select
-  i32.const 3
-  i32.const 4
-  i32.const 5
+  i32.ge_u
+  i32.const 1
+  i32.add
   local.get $0
   i32.const 10000
-  i32.lt_u
-  select
+  i32.ge_u
+  i32.const 3
+  i32.add
   local.get $0
   i32.const 1000
-  i32.lt_u
-  select
+  i32.ge_u
+  i32.add
   local.get $0
   i32.const 100
   i32.lt_u
   select
-  i32.const 6
-  i32.const 7
   local.get $0
   i32.const 1000000
-  i32.lt_u
-  select
-  i32.const 8
-  i32.const 9
-  i32.const 10
+  i32.ge_u
+  i32.const 6
+  i32.add
   local.get $0
   i32.const 1000000000
-  i32.lt_u
-  select
+  i32.ge_u
+  i32.const 8
+  i32.add
   local.get $0
   i32.const 100000000
-  i32.lt_u
-  select
+  i32.ge_u
+  i32.add
   local.get $0
   i32.const 10000000
   i32.lt_u
@@ -5791,49 +5785,42 @@
   call $~lib/rt/pure/__retain
  )
  (func $~lib/util/number/decimalCount64 (; 73 ;) (param $0 i64) (result i32)
-  i32.const 10
-  i32.const 11
-  i32.const 12
   local.get $0
   i64.const 100000000000
-  i64.lt_u
-  select
+  i64.ge_u
+  i32.const 10
+  i32.add
   local.get $0
   i64.const 10000000000
-  i64.lt_u
-  select
-  i32.const 13
-  i32.const 14
-  i32.const 15
+  i64.ge_u
+  i32.add
   local.get $0
   i64.const 100000000000000
-  i64.lt_u
-  select
+  i64.ge_u
+  i32.const 13
+  i32.add
   local.get $0
   i64.const 10000000000000
-  i64.lt_u
-  select
+  i64.ge_u
+  i32.add
   local.get $0
   i64.const 1000000000000
   i64.lt_u
   select
-  i32.const 16
-  i32.const 17
   local.get $0
   i64.const 10000000000000000
-  i64.lt_u
-  select
-  i32.const 18
-  i32.const 19
-  i32.const 20
+  i64.ge_u
+  i32.const 16
+  i32.add
   local.get $0
   i64.const -8446744073709551616
-  i64.lt_u
-  select
+  i64.ge_u
+  i32.const 18
+  i32.add
   local.get $0
   i64.const 1000000000000000000
-  i64.lt_u
-  select
+  i64.ge_u
+  i32.add
   local.get $0
   i64.const 100000000000000000
   i64.lt_u

--- a/tests/compiler/std/string.untouched.wat
+++ b/tests/compiler/std/string.untouched.wat
@@ -10185,8 +10185,6 @@
   local.get $7
   i32.const 1
   local.get $7
-  i32.const 0
-  i32.ne
   select
   i32.const 1023
   i32.const 52

--- a/tests/compiler/std/string.untouched.wat
+++ b/tests/compiler/std/string.untouched.wat
@@ -8673,7 +8673,6 @@
   local.get $2
  )
  (func $~lib/util/number/decimalCount32 (; 79 ;) (param $0 i32) (result i32)
-  (local $1 i32)
   local.get $0
   i32.const 100000
   i32.lt_u
@@ -8683,26 +8682,21 @@
    i32.lt_u
    if
     i32.const 1
-    i32.const 2
     local.get $0
     i32.const 10
-    i32.lt_u
-    select
+    i32.ge_u
+    i32.add
     return
    else
-    i32.const 4
-    i32.const 5
+    i32.const 3
     local.get $0
     i32.const 10000
-    i32.lt_u
-    select
-    local.set $1
-    i32.const 3
-    local.get $1
+    i32.ge_u
+    i32.add
     local.get $0
     i32.const 1000
-    i32.lt_u
-    select
+    i32.ge_u
+    i32.add
     return
    end
    unreachable
@@ -8712,26 +8706,21 @@
    i32.lt_u
    if
     i32.const 6
-    i32.const 7
     local.get $0
     i32.const 1000000
-    i32.lt_u
-    select
+    i32.ge_u
+    i32.add
     return
    else
-    i32.const 9
-    i32.const 10
+    i32.const 8
     local.get $0
     i32.const 1000000000
-    i32.lt_u
-    select
-    local.set $1
-    i32.const 8
-    local.get $1
+    i32.ge_u
+    i32.add
     local.get $0
     i32.const 100000000
-    i32.lt_u
-    select
+    i32.ge_u
+    i32.add
     return
    end
    unreachable
@@ -8967,7 +8956,6 @@
   call $~lib/rt/pure/__retain
  )
  (func $~lib/util/number/decimalCount64 (; 83 ;) (param $0 i64) (result i32)
-  (local $1 i32)
   local.get $0
   i64.const 1000000000000000
   i64.lt_u
@@ -8976,34 +8964,26 @@
    i64.const 1000000000000
    i64.lt_u
    if
-    i32.const 11
-    i32.const 12
+    i32.const 10
     local.get $0
     i64.const 100000000000
-    i64.lt_u
-    select
-    local.set $1
-    i32.const 10
-    local.get $1
+    i64.ge_u
+    i32.add
     local.get $0
     i64.const 10000000000
-    i64.lt_u
-    select
+    i64.ge_u
+    i32.add
     return
    else
-    i32.const 14
-    i32.const 15
+    i32.const 13
     local.get $0
     i64.const 100000000000000
-    i64.lt_u
-    select
-    local.set $1
-    i32.const 13
-    local.get $1
+    i64.ge_u
+    i32.add
     local.get $0
     i64.const 10000000000000
-    i64.lt_u
-    select
+    i64.ge_u
+    i32.add
     return
    end
    unreachable
@@ -9013,26 +8993,21 @@
    i64.lt_u
    if
     i32.const 16
-    i32.const 17
     local.get $0
     i64.const 10000000000000000
-    i64.lt_u
-    select
+    i64.ge_u
+    i32.add
     return
    else
-    i32.const 19
-    i32.const 20
+    i32.const 18
     local.get $0
     i64.const -8446744073709551616
-    i64.lt_u
-    select
-    local.set $1
-    i32.const 18
-    local.get $1
+    i64.ge_u
+    i32.add
     local.get $0
     i64.const 1000000000000000000
-    i64.lt_u
-    select
+    i64.ge_u
+    i32.add
     return
    end
    unreachable

--- a/tests/compiler/std/string.untouched.wat
+++ b/tests/compiler/std/string.untouched.wat
@@ -8955,7 +8955,7 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/decimalCount64 (; 83 ;) (param $0 i64) (result i32)
+ (func $~lib/util/number/decimalCount64High (; 83 ;) (param $0 i64) (result i32)
   local.get $0
   i64.const 1000000000000000
   i64.lt_u
@@ -9181,7 +9181,7 @@
    call $~lib/util/number/utoa32_lut
   else
    local.get $0
-   call $~lib/util/number/decimalCount64
+   call $~lib/util/number/decimalCount64High
    local.set $3
    local.get $3
    i32.const 1
@@ -9261,7 +9261,7 @@
    call $~lib/util/number/utoa32_lut
   else
    local.get $0
-   call $~lib/util/number/decimalCount64
+   call $~lib/util/number/decimalCount64High
    local.get $1
    i32.add
    local.set $4

--- a/tests/compiler/std/string.untouched.wat
+++ b/tests/compiler/std/string.untouched.wat
@@ -8881,8 +8881,8 @@
    return
   end
   local.get $0
-  i32.const 0
-  i32.lt_s
+  i32.const 31
+  i32.shr_u
   local.set $1
   local.get $1
   if
@@ -9221,8 +9221,9 @@
    return
   end
   local.get $0
-  i64.const 0
-  i64.lt_s
+  i64.const 63
+  i64.shr_u
+  i32.wrap_i64
   local.set $1
   local.get $1
   if

--- a/tests/compiler/std/typedarray.optimized.wat
+++ b/tests/compiler/std/typedarray.optimized.wat
@@ -21250,12 +21250,22 @@
   i32.add
   local.set $0
   local.get $2
-  i32.const 255
-  i32.and
-  i32.eqz
+  i32.const 24
+  i32.shl
+  i32.const 24
+  i32.shr_s
+  i64.extend_i32_s
+  i64.const 10
+  i64.lt_u
   if
    local.get $0
+   local.get $2
+   i32.const 24
+   i32.shl
+   i32.const 24
+   i32.shr_s
    i32.const 48
+   i32.or
    i32.store16
    i32.const 1
    return
@@ -21685,10 +21695,16 @@
   local.get $2
   i32.const 255
   i32.and
-  i32.eqz
+  i64.extend_i32_u
+  i64.const 10
+  i64.lt_u
   if
    local.get $0
+   local.get $2
+   i32.const 255
+   i32.and
    i32.const 48
+   i32.or
    i32.store16
    i32.const 1
    return
@@ -21948,12 +21964,22 @@
   i32.add
   local.set $0
   local.get $2
-  i32.const 65535
-  i32.and
-  i32.eqz
+  i32.const 16
+  i32.shl
+  i32.const 16
+  i32.shr_s
+  i64.extend_i32_s
+  i64.const 10
+  i64.lt_u
   if
    local.get $0
+   local.get $2
+   i32.const 16
+   i32.shl
+   i32.const 16
+   i32.shr_s
    i32.const 48
+   i32.or
    i32.store16
    i32.const 1
    return
@@ -22180,10 +22206,16 @@
   local.get $2
   i32.const 65535
   i32.and
-  i32.eqz
+  i64.extend_i32_u
+  i64.const 10
+  i64.lt_u
   if
    local.get $0
+   local.get $2
+   i32.const 65535
+   i32.and
    i32.const 48
+   i32.or
    i32.store16
    i32.const 1
    return
@@ -22384,10 +22416,14 @@
   i32.add
   local.set $0
   local.get $2
-  i32.eqz
+  i64.extend_i32_s
+  i64.const 10
+  i64.lt_u
   if
    local.get $0
+   local.get $2
    i32.const 48
+   i32.or
    i32.store16
    i32.const 1
    return
@@ -22602,10 +22638,14 @@
   i32.add
   local.set $0
   local.get $2
-  i32.eqz
+  i64.extend_i32_u
+  i64.const 10
+  i64.lt_u
   if
    local.get $0
+   local.get $2
    i32.const 48
+   i32.or
    i32.store16
    i32.const 1
    return
@@ -22942,11 +22982,14 @@
   i32.add
   local.set $0
   local.get $2
-  i64.eqz
+  i64.const 10
+  i64.lt_u
   if
    local.get $0
-   i32.const 48
-   i32.store16
+   local.get $2
+   i64.const 48
+   i64.or
+   i64.store16
    i32.const 1
    return
   end
@@ -23221,11 +23264,14 @@
   i32.add
   local.set $0
   local.get $2
-  i64.eqz
+  i64.const 10
+  i64.lt_u
   if
    local.get $0
-   i32.const 48
-   i32.store16
+   local.get $2
+   i64.const 48
+   i64.or
+   i64.store16
    i32.const 1
    return
   end

--- a/tests/compiler/std/typedarray.optimized.wat
+++ b/tests/compiler/std/typedarray.optimized.wat
@@ -21202,8 +21202,8 @@
    return
   end
   local.get $0
-  i32.const 0
-  i32.lt_s
+  i32.const 31
+  i32.shr_u
   local.tee $1
   if
    i32.const 0
@@ -22879,8 +22879,9 @@
    return
   end
   local.get $0
-  i64.const 0
-  i64.lt_s
+  i64.const 63
+  i64.shr_u
+  i32.wrap_i64
   local.tee $1
   if
    i64.const 0

--- a/tests/compiler/std/typedarray.optimized.wat
+++ b/tests/compiler/std/typedarray.optimized.wat
@@ -22794,7 +22794,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/util/number/decimalCount64 (; 386 ;) (param $0 i64) (result i32)
+ (func $~lib/util/number/decimalCount64High (; 386 ;) (param $0 i64) (result i32)
   local.get $0
   i64.const 100000000000
   i64.ge_u
@@ -22909,7 +22909,7 @@
    call $~lib/util/number/utoa_simple<u32>
   else
    local.get $0
-   call $~lib/util/number/decimalCount64
+   call $~lib/util/number/decimalCount64High
    local.get $1
    i32.add
    local.tee $2
@@ -22978,7 +22978,7 @@
    local.get $0
    local.get $2
    local.get $2
-   call $~lib/util/number/decimalCount64
+   call $~lib/util/number/decimalCount64High
    local.get $1
    i32.add
    local.tee $3
@@ -23197,7 +23197,7 @@
    call $~lib/util/number/utoa_simple<u32>
   else
    local.get $0
-   call $~lib/util/number/decimalCount64
+   call $~lib/util/number/decimalCount64High
    local.tee $1
    i32.const 1
    i32.shl
@@ -23245,7 +23245,7 @@
    local.get $0
    local.get $2
    local.get $2
-   call $~lib/util/number/decimalCount64
+   call $~lib/util/number/decimalCount64High
    local.tee $1
    call $~lib/util/number/utoa_simple<u64>
   end

--- a/tests/compiler/std/typedarray.optimized.wat
+++ b/tests/compiler/std/typedarray.optimized.wat
@@ -21253,26 +21253,6 @@
   i32.shl
   i32.const 24
   i32.shr_s
-  i32.const 10
-  i32.lt_u
-  if
-   local.get $0
-   local.get $2
-   i32.const 24
-   i32.shl
-   i32.const 24
-   i32.shr_s
-   i32.const 48
-   i32.or
-   i32.store16
-   i32.const 1
-   return
-  end
-  local.get $2
-  i32.const 24
-  i32.shl
-  i32.const 24
-  i32.shr_s
   i32.const 0
   i32.lt_s
   local.tee $1
@@ -21284,6 +21264,32 @@
    local.get $2
    i32.sub
    local.set $2
+  end
+  local.get $2
+  i32.const 24
+  i32.shl
+  i32.const 24
+  i32.shr_s
+  i32.const 10
+  i32.lt_u
+  if
+   local.get $0
+   local.get $1
+   i32.const 1
+   i32.shl
+   i32.add
+   local.get $2
+   i32.const 24
+   i32.shl
+   i32.const 24
+   i32.shr_s
+   i32.const 48
+   i32.or
+   i32.store16
+   local.get $1
+   i32.const 1
+   i32.add
+   return
   end
   local.get $2
   i32.const 24
@@ -21961,26 +21967,6 @@
   i32.shl
   i32.const 16
   i32.shr_s
-  i32.const 10
-  i32.lt_u
-  if
-   local.get $0
-   local.get $2
-   i32.const 16
-   i32.shl
-   i32.const 16
-   i32.shr_s
-   i32.const 48
-   i32.or
-   i32.store16
-   i32.const 1
-   return
-  end
-  local.get $2
-  i32.const 16
-  i32.shl
-  i32.const 16
-  i32.shr_s
   i32.const 0
   i32.lt_s
   local.tee $1
@@ -21992,6 +21978,32 @@
    local.get $2
    i32.sub
    local.set $2
+  end
+  local.get $2
+  i32.const 16
+  i32.shl
+  i32.const 16
+  i32.shr_s
+  i32.const 10
+  i32.lt_u
+  if
+   local.get $0
+   local.get $1
+   i32.const 1
+   i32.shl
+   i32.add
+   local.get $2
+   i32.const 16
+   i32.shl
+   i32.const 16
+   i32.shr_s
+   i32.const 48
+   i32.or
+   i32.store16
+   local.get $1
+   i32.const 1
+   i32.add
+   return
   end
   local.get $2
   i32.const 16
@@ -22404,19 +22416,6 @@
   i32.add
   local.set $0
   local.get $2
-  i32.const 10
-  i32.lt_u
-  if
-   local.get $0
-   local.get $2
-   i32.const 48
-   i32.or
-   i32.store16
-   i32.const 1
-   return
-  end
-  local.get $0
-  local.get $2
   i32.const 0
   i32.lt_s
   local.tee $1
@@ -22429,6 +22428,25 @@
    i32.sub
    local.set $2
   end
+  local.get $2
+  i32.const 10
+  i32.lt_u
+  if
+   local.get $0
+   local.get $1
+   i32.const 1
+   i32.shl
+   i32.add
+   local.get $2
+   i32.const 48
+   i32.or
+   i32.store16
+   local.get $1
+   i32.const 1
+   i32.add
+   return
+  end
+  local.get $0
   local.get $2
   local.get $2
   call $~lib/util/number/decimalCount32
@@ -22962,31 +22980,37 @@
   i32.const 1
   i32.shl
   i32.add
-  local.set $0
-  local.get $2
-  i64.const 10
-  i64.lt_u
-  if
-   local.get $0
-   local.get $2
-   i64.const 48
-   i64.or
-   i64.store16
-   i32.const 1
-   return
-  end
+  local.set $1
   local.get $2
   i64.const 0
   i64.lt_s
-  local.tee $1
+  local.tee $0
   if
-   local.get $0
+   local.get $1
    i32.const 45
    i32.store16
    i64.const 0
    local.get $2
    i64.sub
    local.set $2
+  end
+  local.get $2
+  i64.const 10
+  i64.lt_u
+  if
+   local.get $1
+   local.get $0
+   i32.const 1
+   i32.shl
+   i32.add
+   local.get $2
+   i64.const 48
+   i64.or
+   i64.store16
+   local.get $0
+   i32.const 1
+   i32.add
+   return
   end
   local.get $2
   i64.const 4294967295
@@ -22996,24 +23020,24 @@
    i32.wrap_i64
    local.tee $3
    call $~lib/util/number/decimalCount32
-   local.get $1
-   i32.add
-   local.set $1
    local.get $0
-   local.get $3
+   i32.add
+   local.set $0
    local.get $1
+   local.get $3
+   local.get $0
    call $~lib/util/number/utoa_simple<u32>
   else
-   local.get $0
+   local.get $1
    local.get $2
    local.get $2
    call $~lib/util/number/decimalCount64High
-   local.get $1
+   local.get $0
    i32.add
-   local.tee $1
+   local.tee $0
    call $~lib/util/number/utoa_simple<u64>
   end
-  local.get $1
+  local.get $0
  )
  (func $~lib/util/string/joinIntegerArray<i64> (; 390 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)

--- a/tests/compiler/std/typedarray.optimized.wat
+++ b/tests/compiler/std/typedarray.optimized.wat
@@ -21242,7 +21242,6 @@
   i32.shr_u
  )
  (func $~lib/util/number/itoa_stream<i8> (; 357 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
   local.get $0
   local.get $1
   i32.const 1
@@ -21278,6 +21277,9 @@
   i32.lt_s
   local.tee $1
   if
+   local.get $0
+   i32.const 45
+   i32.store16
    i32.const 0
    local.get $2
    i32.sub
@@ -21288,22 +21290,16 @@
   i32.shl
   i32.const 24
   i32.shr_s
-  local.tee $3
+  local.tee $2
   call $~lib/util/number/decimalCount32
   local.get $1
   i32.add
-  local.set $2
+  local.set $1
   local.get $0
-  local.get $3
   local.get $2
+  local.get $1
   call $~lib/util/number/utoa_simple<u32>
   local.get $1
-  if
-   local.get $0
-   i32.const 45
-   i32.store16
-  end
-  local.get $2
  )
  (func $~lib/string/String#substring (; 358 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
@@ -21954,7 +21950,6 @@
   call $~lib/rt/pure/__release
  )
  (func $~lib/util/number/itoa_stream<i16> (; 370 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
   local.get $0
   local.get $1
   i32.const 1
@@ -21990,6 +21985,9 @@
   i32.lt_s
   local.tee $1
   if
+   local.get $0
+   i32.const 45
+   i32.store16
    i32.const 0
    local.get $2
    i32.sub
@@ -22000,22 +21998,16 @@
   i32.shl
   i32.const 16
   i32.shr_s
-  local.tee $3
+  local.tee $2
   call $~lib/util/number/decimalCount32
   local.get $1
   i32.add
-  local.set $2
+  local.set $1
   local.get $0
-  local.get $3
   local.get $2
+  local.get $1
   call $~lib/util/number/utoa_simple<u32>
   local.get $1
-  if
-   local.get $0
-   i32.const 45
-   i32.store16
-  end
-  local.get $2
  )
  (func $~lib/util/string/joinIntegerArray<i16> (; 371 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
@@ -22429,6 +22421,9 @@
   i32.lt_s
   local.tee $1
   if
+   local.get $0
+   i32.const 45
+   i32.store16
    i32.const 0
    local.get $2
    i32.sub
@@ -22439,15 +22434,9 @@
   call $~lib/util/number/decimalCount32
   local.get $1
   i32.add
-  local.tee $2
+  local.tee $0
   call $~lib/util/number/utoa_simple<u32>
-  local.get $1
-  if
-   local.get $0
-   i32.const 45
-   i32.store16
-  end
-  local.get $2
+  local.get $0
  )
  (func $~lib/util/string/joinIntegerArray<i32> (; 379 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
@@ -22968,7 +22957,6 @@
  )
  (func $~lib/util/number/itoa_stream<i64> (; 389 ;) (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
   (local $3 i32)
-  (local $4 i32)
   local.get $0
   local.get $1
   i32.const 1
@@ -22992,6 +22980,9 @@
   i64.lt_s
   local.tee $1
   if
+   local.get $0
+   i32.const 45
+   i32.store16
    i64.const 0
    local.get $2
    i64.sub
@@ -23003,14 +22994,14 @@
   if
    local.get $2
    i32.wrap_i64
-   local.tee $4
+   local.tee $3
    call $~lib/util/number/decimalCount32
    local.get $1
    i32.add
-   local.set $3
+   local.set $1
    local.get $0
-   local.get $4
    local.get $3
+   local.get $1
    call $~lib/util/number/utoa_simple<u32>
   else
    local.get $0
@@ -23019,16 +23010,10 @@
    call $~lib/util/number/decimalCount64High
    local.get $1
    i32.add
-   local.tee $3
+   local.tee $1
    call $~lib/util/number/utoa_simple<u64>
   end
   local.get $1
-  if
-   local.get $0
-   i32.const 45
-   i32.store16
-  end
-  local.get $3
  )
  (func $~lib/util/string/joinIntegerArray<i64> (; 390 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)

--- a/tests/compiler/std/typedarray.optimized.wat
+++ b/tests/compiler/std/typedarray.optimized.wat
@@ -21254,9 +21254,8 @@
   i32.shl
   i32.const 24
   i32.shr_s
-  i64.extend_i32_s
-  i64.const 10
-  i64.lt_u
+  i32.const 10
+  i32.lt_u
   if
    local.get $0
    local.get $2
@@ -21695,9 +21694,8 @@
   local.get $2
   i32.const 255
   i32.and
-  i64.extend_i32_u
-  i64.const 10
-  i64.lt_u
+  i32.const 10
+  i32.lt_u
   if
    local.get $0
    local.get $2
@@ -21968,9 +21966,8 @@
   i32.shl
   i32.const 16
   i32.shr_s
-  i64.extend_i32_s
-  i64.const 10
-  i64.lt_u
+  i32.const 10
+  i32.lt_u
   if
    local.get $0
    local.get $2
@@ -22206,9 +22203,8 @@
   local.get $2
   i32.const 65535
   i32.and
-  i64.extend_i32_u
-  i64.const 10
-  i64.lt_u
+  i32.const 10
+  i32.lt_u
   if
    local.get $0
    local.get $2
@@ -22416,9 +22412,8 @@
   i32.add
   local.set $0
   local.get $2
-  i64.extend_i32_s
-  i64.const 10
-  i64.lt_u
+  i32.const 10
+  i32.lt_u
   if
    local.get $0
    local.get $2
@@ -22638,9 +22633,8 @@
   i32.add
   local.set $0
   local.get $2
-  i64.extend_i32_u
-  i64.const 10
-  i64.lt_u
+  i32.const 10
+  i32.lt_u
   if
    local.get $0
    local.get $2

--- a/tests/compiler/std/typedarray.optimized.wat
+++ b/tests/compiler/std/typedarray.optimized.wat
@@ -24424,7 +24424,6 @@
   call $~lib/rt/tlsf/__free
  )
  (func $~lib/util/number/dtoa_stream (; 402 ;) (param $0 i32) (param $1 i32) (param $2 f64) (result i32)
-  (local $3 i32)
   local.get $0
   local.get $1
   i32.const 1
@@ -24472,20 +24471,25 @@
     local.get $2
     f64.const 0
     f64.lt
-    local.tee $3
+    local.tee $1
+    if
+     local.get $0
+     i32.const 45
+     i32.store16
+     local.get $0
+     i32.const 2
+     i32.add
+     local.set $0
+    end
+    local.get $0
+    i64.const 29555310648492105
+    i64.store
+    local.get $0
+    i64.const 34058970405077102
+    i64.store offset=8
+    local.get $1
     i32.const 8
     i32.add
-    local.set $1
-    local.get $0
-    i32.const 2112
-    i32.const 2160
-    local.get $3
-    select
-    local.get $1
-    i32.const 1
-    i32.shl
-    call $~lib/memory/memory.copy
-    local.get $1
     return
    end
    unreachable

--- a/tests/compiler/std/typedarray.optimized.wat
+++ b/tests/compiler/std/typedarray.optimized.wat
@@ -24068,10 +24068,10 @@
   (local $3 i32)
   (local $4 i64)
   (local $5 i32)
-  (local $6 i32)
+  (local $6 i64)
   (local $7 i64)
   (local $8 i64)
-  (local $9 i64)
+  (local $9 i32)
   (local $10 i32)
   (local $11 i64)
   (local $12 i64)
@@ -24084,7 +24084,7 @@
   local.get $1
   f64.const 0
   f64.lt
-  local.tee $10
+  local.tee $9
   if (result f64)
    local.get $0
    i32.const 45
@@ -24108,7 +24108,6 @@
   local.get $5
   i32.const 0
   i32.ne
-  local.tee $6
   i64.extend_i32_u
   i64.const 52
   i64.shl
@@ -24118,18 +24117,18 @@
   i64.shl
   i64.const 1
   i64.add
-  local.tee $7
+  local.tee $6
   i64.clz
   i32.wrap_i64
   local.set $3
-  local.get $7
+  local.get $6
   local.get $3
   i64.extend_i32_s
   i64.shl
   global.set $~lib/util/number/_frc_plus
   local.get $5
   i32.const 1
-  local.get $6
+  local.get $5
   select
   i32.const 1075
   i32.sub
@@ -24145,13 +24144,13 @@
   i64.eq
   i32.const 1
   i32.add
-  local.tee $6
+  local.tee $10
   i64.extend_i32_s
   i64.shl
   i64.const 1
   i64.sub
   local.get $5
-  local.get $6
+  local.get $10
   i32.sub
   local.get $3
   i32.sub
@@ -24184,10 +24183,10 @@
   local.tee $3
   i32.const 3
   i32.shl
-  local.tee $6
+  local.tee $10
   i32.sub
   global.set $~lib/util/number/_K
-  local.get $6
+  local.get $10
   i32.const 2192
   i32.add
   i64.load
@@ -24206,7 +24205,7 @@
   local.tee $3
   i64.extend_i32_s
   i64.shl
-  local.tee $7
+  local.tee $6
   i64.const 4294967295
   i64.and
   local.tee $11
@@ -24218,14 +24217,14 @@
   i64.mul
   local.set $14
   global.get $~lib/util/number/_frc_plus
-  local.tee $8
+  local.tee $7
   i64.const 4294967295
   i64.and
   local.tee $4
   local.get $2
   i64.const 4294967295
   i64.and
-  local.tee $9
+  local.tee $8
   i64.mul
   local.set $12
   global.get $~lib/util/number/_frc_minus
@@ -24245,17 +24244,17 @@
   i64.shr_u
   local.tee $4
   i64.mul
-  local.get $9
   local.get $8
+  local.get $7
   i64.const 32
   i64.shr_u
-  local.tee $8
+  local.tee $7
   i64.mul
   local.get $12
   i64.const 32
   i64.shr_u
   i64.add
-  local.tee $9
+  local.tee $8
   i64.const 4294967295
   i64.and
   i64.add
@@ -24264,16 +24263,16 @@
   i64.const 32
   i64.shr_u
   local.get $4
-  local.get $8
+  local.get $7
   i64.mul
-  local.get $9
+  local.get $8
   i64.const 32
   i64.shr_u
   i64.add
   i64.add
   i64.const 1
   i64.sub
-  local.tee $8
+  local.tee $7
   local.get $16
   local.get $2
   i64.const 32
@@ -24284,7 +24283,7 @@
   local.get $15
   i64.const 32
   i64.shr_u
-  local.tee $9
+  local.tee $8
   i64.mul
   local.get $18
   i64.const 32
@@ -24299,7 +24298,7 @@
   i64.const 32
   i64.shr_u
   local.get $4
-  local.get $9
+  local.get $8
   i64.mul
   local.get $12
   i64.const 32
@@ -24311,7 +24310,7 @@
   i64.sub
   local.set $4
   local.get $0
-  local.get $10
+  local.get $9
   i32.const 1
   i32.shl
   i32.add
@@ -24323,10 +24322,10 @@
   local.tee $2
   i64.mul
   local.get $13
-  local.get $7
+  local.get $6
   i64.const 32
   i64.shr_u
-  local.tee $7
+  local.tee $6
   i64.mul
   local.get $14
   i64.const 32
@@ -24341,7 +24340,7 @@
   i64.const 32
   i64.shr_u
   local.get $2
-  local.get $7
+  local.get $6
   i64.mul
   local.get $11
   i64.const 32
@@ -24356,20 +24355,20 @@
   i32.add
   i32.const -64
   i32.sub
-  local.get $8
+  local.get $7
   local.get $0
   global.get $~lib/util/number/_exp
   i32.add
   i32.const -64
   i32.sub
   local.get $4
-  local.get $10
+  local.get $9
   call $~lib/util/number/genDigits
-  local.get $10
+  local.get $9
   i32.sub
   global.get $~lib/util/number/_K
   call $~lib/util/number/prettify
-  local.get $10
+  local.get $9
   i32.add
  )
  (func $~lib/util/number/dtoa (; 401 ;) (param $0 f64) (result i32)

--- a/tests/compiler/std/typedarray.optimized.wat
+++ b/tests/compiler/std/typedarray.optimized.wat
@@ -21126,44 +21126,38 @@
   end
  )
  (func $~lib/util/number/decimalCount32 (; 353 ;) (param $0 i32) (result i32)
-  i32.const 1
-  i32.const 2
   local.get $0
   i32.const 10
-  i32.lt_u
-  select
-  i32.const 3
-  i32.const 4
-  i32.const 5
+  i32.ge_u
+  i32.const 1
+  i32.add
   local.get $0
   i32.const 10000
-  i32.lt_u
-  select
+  i32.ge_u
+  i32.const 3
+  i32.add
   local.get $0
   i32.const 1000
-  i32.lt_u
-  select
+  i32.ge_u
+  i32.add
   local.get $0
   i32.const 100
   i32.lt_u
   select
-  i32.const 6
-  i32.const 7
   local.get $0
   i32.const 1000000
-  i32.lt_u
-  select
-  i32.const 8
-  i32.const 9
-  i32.const 10
+  i32.ge_u
+  i32.const 6
+  i32.add
   local.get $0
   i32.const 1000000000
-  i32.lt_u
-  select
+  i32.ge_u
+  i32.const 8
+  i32.add
   local.get $0
   i32.const 100000000
-  i32.lt_u
-  select
+  i32.ge_u
+  i32.add
   local.get $0
   i32.const 10000000
   i32.lt_u
@@ -22801,49 +22795,42 @@
   call $~lib/rt/pure/__release
  )
  (func $~lib/util/number/decimalCount64 (; 386 ;) (param $0 i64) (result i32)
-  i32.const 10
-  i32.const 11
-  i32.const 12
   local.get $0
   i64.const 100000000000
-  i64.lt_u
-  select
+  i64.ge_u
+  i32.const 10
+  i32.add
   local.get $0
   i64.const 10000000000
-  i64.lt_u
-  select
-  i32.const 13
-  i32.const 14
-  i32.const 15
+  i64.ge_u
+  i32.add
   local.get $0
   i64.const 100000000000000
-  i64.lt_u
-  select
+  i64.ge_u
+  i32.const 13
+  i32.add
   local.get $0
   i64.const 10000000000000
-  i64.lt_u
-  select
+  i64.ge_u
+  i32.add
   local.get $0
   i64.const 1000000000000
   i64.lt_u
   select
-  i32.const 16
-  i32.const 17
   local.get $0
   i64.const 10000000000000000
-  i64.lt_u
-  select
-  i32.const 18
-  i32.const 19
-  i32.const 20
+  i64.ge_u
+  i32.const 16
+  i32.add
   local.get $0
   i64.const -8446744073709551616
-  i64.lt_u
-  select
+  i64.ge_u
+  i32.const 18
+  i32.add
   local.get $0
   i64.const 1000000000000000000
-  i64.lt_u
-  select
+  i64.ge_u
+  i32.add
   local.get $0
   i64.const 100000000000000000
   i64.lt_u

--- a/tests/compiler/std/typedarray.untouched.wat
+++ b/tests/compiler/std/typedarray.untouched.wat
@@ -34135,7 +34135,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/util/number/decimalCount64 (; 520 ;) (param $0 i64) (result i32)
+ (func $~lib/util/number/decimalCount64High (; 520 ;) (param $0 i64) (result i32)
   local.get $0
   i64.const 1000000000000000
   i64.lt_u
@@ -34375,7 +34375,7 @@
    call $~lib/util/number/utoa32_lut
   else
    local.get $0
-   call $~lib/util/number/decimalCount64
+   call $~lib/util/number/decimalCount64High
    local.get $1
    i32.add
    local.set $4
@@ -34472,7 +34472,7 @@
    call $~lib/util/number/utoa32_lut
   else
    local.get $2
-   call $~lib/util/number/decimalCount64
+   call $~lib/util/number/decimalCount64High
    local.get $4
    i32.add
    local.set $3
@@ -34772,7 +34772,7 @@
    call $~lib/util/number/utoa32_lut
   else
    local.get $0
-   call $~lib/util/number/decimalCount64
+   call $~lib/util/number/decimalCount64High
    local.set $3
    local.get $3
    i32.const 1
@@ -34847,7 +34847,7 @@
    call $~lib/util/number/utoa32_lut
   else
    local.get $2
-   call $~lib/util/number/decimalCount64
+   call $~lib/util/number/decimalCount64High
    local.set $3
    local.get $0
    local.set $6

--- a/tests/compiler/std/typedarray.untouched.wat
+++ b/tests/compiler/std/typedarray.untouched.wat
@@ -31895,8 +31895,8 @@
    return
   end
   local.get $0
-  i32.const 0
-  i32.lt_s
+  i32.const 31
+  i32.shr_u
   local.set $1
   local.get $1
   if
@@ -34335,8 +34335,9 @@
    return
   end
   local.get $0
-  i64.const 0
-  i64.lt_s
+  i64.const 63
+  i64.shr_u
+  i32.wrap_i64
   local.set $1
   local.get $1
   if

--- a/tests/compiler/std/typedarray.untouched.wat
+++ b/tests/compiler/std/typedarray.untouched.wat
@@ -31964,26 +31964,6 @@
   i32.shl
   i32.add
   local.set $0
-  local.get $2
-  i32.const 24
-  i32.shl
-  i32.const 24
-  i32.shr_s
-  i32.const 10
-  i32.lt_u
-  if
-   local.get $0
-   local.get $2
-   i32.const 24
-   i32.shl
-   i32.const 24
-   i32.shr_s
-   i32.const 48
-   i32.or
-   i32.store16
-   i32.const 1
-   return
-  end
   i32.const 0
   local.set $3
   local.get $2
@@ -31993,8 +31973,8 @@
   i32.shr_s
   i32.const 0
   i32.lt_s
-  local.set $4
-  local.get $4
+  local.set $3
+  local.get $3
   if
    i32.const 0
    local.get $2
@@ -32009,10 +31989,38 @@
   i32.shl
   i32.const 24
   i32.shr_s
-  call $~lib/util/number/decimalCount32
+  i32.const 10
+  i32.lt_u
+  if
+   local.get $0
+   local.get $3
+   i32.const 1
+   i32.shl
+   i32.add
+   local.get $2
+   i32.const 24
+   i32.shl
+   i32.const 24
+   i32.shr_s
+   i32.const 48
+   i32.or
+   i32.store16
+   i32.const 1
+   local.get $3
+   i32.add
+   return
+  end
+  local.get $3
+  local.set $4
   local.get $4
+  local.get $2
+  i32.const 24
+  i32.shl
+  i32.const 24
+  i32.shr_s
+  call $~lib/util/number/decimalCount32
   i32.add
-  local.set $3
+  local.set $4
   local.get $0
   local.set $7
   local.get $2
@@ -32021,13 +32029,13 @@
   i32.const 24
   i32.shr_s
   local.set $6
-  local.get $3
+  local.get $4
   local.set $5
   local.get $7
   local.get $6
   local.get $5
   call $~lib/util/number/utoa32_lut
-  local.get $3
+  local.get $4
  )
  (func $~lib/string/String#substring (; 479 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
@@ -32610,12 +32618,15 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
   local.get $0
   local.get $1
   i32.const 1
   i32.shl
   i32.add
   local.set $0
+  i32.const 0
+  local.set $3
   local.get $2
   i32.const 255
   i32.and
@@ -32623,6 +32634,10 @@
   i32.lt_u
   if
    local.get $0
+   local.get $3
+   i32.const 1
+   i32.shl
+   i32.add
    local.get $2
    i32.const 255
    i32.and
@@ -32630,28 +32645,32 @@
    i32.or
    i32.store16
    i32.const 1
+   local.get $3
+   i32.add
    return
   end
-  i32.const 0
-  local.set $3
+  local.get $3
+  local.set $4
+  local.get $4
   local.get $2
   i32.const 255
   i32.and
   call $~lib/util/number/decimalCount32
-  local.set $3
+  i32.add
+  local.set $4
   local.get $0
-  local.set $6
+  local.set $7
   local.get $2
   i32.const 255
   i32.and
+  local.set $6
+  local.get $4
   local.set $5
-  local.get $3
-  local.set $4
+  local.get $7
   local.get $6
   local.get $5
-  local.get $4
   call $~lib/util/number/utoa32_lut
-  local.get $3
+  local.get $4
  )
  (func $~lib/util/string/joinIntegerArray<u8> (; 489 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
@@ -32997,26 +33016,6 @@
   i32.shl
   i32.add
   local.set $0
-  local.get $2
-  i32.const 16
-  i32.shl
-  i32.const 16
-  i32.shr_s
-  i32.const 10
-  i32.lt_u
-  if
-   local.get $0
-   local.get $2
-   i32.const 16
-   i32.shl
-   i32.const 16
-   i32.shr_s
-   i32.const 48
-   i32.or
-   i32.store16
-   i32.const 1
-   return
-  end
   i32.const 0
   local.set $3
   local.get $2
@@ -33026,8 +33025,8 @@
   i32.shr_s
   i32.const 0
   i32.lt_s
-  local.set $4
-  local.get $4
+  local.set $3
+  local.get $3
   if
    i32.const 0
    local.get $2
@@ -33042,10 +33041,38 @@
   i32.shl
   i32.const 16
   i32.shr_s
-  call $~lib/util/number/decimalCount32
+  i32.const 10
+  i32.lt_u
+  if
+   local.get $0
+   local.get $3
+   i32.const 1
+   i32.shl
+   i32.add
+   local.get $2
+   i32.const 16
+   i32.shl
+   i32.const 16
+   i32.shr_s
+   i32.const 48
+   i32.or
+   i32.store16
+   i32.const 1
+   local.get $3
+   i32.add
+   return
+  end
+  local.get $3
+  local.set $4
   local.get $4
+  local.get $2
+  i32.const 16
+  i32.shl
+  i32.const 16
+  i32.shr_s
+  call $~lib/util/number/decimalCount32
   i32.add
-  local.set $3
+  local.set $4
   local.get $0
   local.set $7
   local.get $2
@@ -33054,13 +33081,13 @@
   i32.const 16
   i32.shr_s
   local.set $6
-  local.get $3
+  local.get $4
   local.set $5
   local.get $7
   local.get $6
   local.get $5
   call $~lib/util/number/utoa32_lut
-  local.get $3
+  local.get $4
  )
  (func $~lib/util/string/joinIntegerArray<i16> (; 498 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
@@ -33307,12 +33334,15 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
   local.get $0
   local.get $1
   i32.const 1
   i32.shl
   i32.add
   local.set $0
+  i32.const 0
+  local.set $3
   local.get $2
   i32.const 65535
   i32.and
@@ -33320,6 +33350,10 @@
   i32.lt_u
   if
    local.get $0
+   local.get $3
+   i32.const 1
+   i32.shl
+   i32.add
    local.get $2
    i32.const 65535
    i32.and
@@ -33327,28 +33361,32 @@
    i32.or
    i32.store16
    i32.const 1
+   local.get $3
+   i32.add
    return
   end
-  i32.const 0
-  local.set $3
+  local.get $3
+  local.set $4
+  local.get $4
   local.get $2
   i32.const 65535
   i32.and
   call $~lib/util/number/decimalCount32
-  local.set $3
+  i32.add
+  local.set $4
   local.get $0
-  local.set $6
+  local.set $7
   local.get $2
   i32.const 65535
   i32.and
+  local.set $6
+  local.get $4
   local.set $5
-  local.get $3
-  local.set $4
+  local.get $7
   local.get $6
   local.get $5
-  local.get $4
   call $~lib/util/number/utoa32_lut
-  local.get $3
+  local.get $4
  )
  (func $~lib/util/string/joinIntegerArray<u16> (; 504 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
@@ -33600,25 +33638,13 @@
   i32.shl
   i32.add
   local.set $0
-  local.get $2
-  i32.const 10
-  i32.lt_u
-  if
-   local.get $0
-   local.get $2
-   i32.const 48
-   i32.or
-   i32.store16
-   i32.const 1
-   return
-  end
   i32.const 0
   local.set $3
   local.get $2
   i32.const 0
   i32.lt_s
-  local.set $4
-  local.get $4
+  local.set $3
+  local.get $3
   if
    i32.const 0
    local.get $2
@@ -33629,21 +33655,41 @@
    i32.store16
   end
   local.get $2
-  call $~lib/util/number/decimalCount32
+  i32.const 10
+  i32.lt_u
+  if
+   local.get $0
+   local.get $3
+   i32.const 1
+   i32.shl
+   i32.add
+   local.get $2
+   i32.const 48
+   i32.or
+   i32.store16
+   i32.const 1
+   local.get $3
+   i32.add
+   return
+  end
+  local.get $3
+  local.set $4
   local.get $4
+  local.get $2
+  call $~lib/util/number/decimalCount32
   i32.add
-  local.set $3
+  local.set $4
   local.get $0
   local.set $7
   local.get $2
   local.set $6
-  local.get $3
+  local.get $4
   local.set $5
   local.get $7
   local.get $6
   local.get $5
   call $~lib/util/number/utoa32_lut
-  local.get $3
+  local.get $4
  )
  (func $~lib/util/string/joinIntegerArray<i32> (; 510 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
@@ -33888,40 +33934,51 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
   local.get $0
   local.get $1
   i32.const 1
   i32.shl
   i32.add
   local.set $0
+  i32.const 0
+  local.set $3
   local.get $2
   i32.const 10
   i32.lt_u
   if
    local.get $0
+   local.get $3
+   i32.const 1
+   i32.shl
+   i32.add
    local.get $2
    i32.const 48
    i32.or
    i32.store16
    i32.const 1
+   local.get $3
+   i32.add
    return
   end
-  i32.const 0
-  local.set $3
-  local.get $2
-  call $~lib/util/number/decimalCount32
-  local.set $3
-  local.get $0
-  local.set $6
-  local.get $2
-  local.set $5
   local.get $3
   local.set $4
+  local.get $4
+  local.get $2
+  call $~lib/util/number/decimalCount32
+  i32.add
+  local.set $4
+  local.get $0
+  local.set $7
+  local.get $2
+  local.set $6
+  local.get $4
+  local.set $5
+  local.get $7
   local.get $6
   local.get $5
-  local.get $4
   call $~lib/util/number/utoa32_lut
-  local.get $3
+  local.get $4
  )
  (func $~lib/util/string/joinIntegerArray<u32> (; 516 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
@@ -34446,25 +34503,13 @@
   i32.shl
   i32.add
   local.set $0
-  local.get $2
-  i64.const 10
-  i64.lt_u
-  if
-   local.get $0
-   local.get $2
-   i64.const 48
-   i64.or
-   i64.store16
-   i32.const 1
-   return
-  end
   i32.const 0
   local.set $3
   local.get $2
   i64.const 0
   i64.lt_s
-  local.set $4
-  local.get $4
+  local.set $3
+  local.get $3
   if
    i64.const 0
    local.get $2
@@ -34475,45 +34520,65 @@
    i32.store16
   end
   local.get $2
+  i64.const 10
+  i64.lt_u
+  if
+   local.get $0
+   local.get $3
+   i32.const 1
+   i32.shl
+   i32.add
+   local.get $2
+   i64.const 48
+   i64.or
+   i64.store16
+   i32.const 1
+   local.get $3
+   i32.add
+   return
+  end
+  local.get $3
+  local.set $4
+  local.get $2
   i64.const 4294967295
   i64.le_u
   if
    local.get $2
    i32.wrap_i64
    local.set $5
+   local.get $4
    local.get $5
    call $~lib/util/number/decimalCount32
-   local.get $4
    i32.add
-   local.set $3
+   local.set $4
    local.get $0
    local.set $8
    local.get $5
    local.set $7
-   local.get $3
+   local.get $4
    local.set $6
    local.get $8
    local.get $7
    local.get $6
    call $~lib/util/number/utoa32_lut
   else
+   local.get $4
    local.get $2
    call $~lib/util/number/decimalCount64High
-   local.get $4
    i32.add
-   local.set $3
+   local.set $4
    local.get $0
    local.set $7
    local.get $2
    local.set $9
-   local.get $3
+   local.get $4
    local.set $6
    local.get $7
    local.get $9
    local.get $6
    call $~lib/util/number/utoa64_lut
   end
-  local.get $3
+  local.get $4
  )
  (func $~lib/util/string/joinIntegerArray<i64> (; 525 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
@@ -34825,63 +34890,76 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i64)
+  (local $8 i32)
+  (local $9 i64)
   local.get $0
   local.get $1
   i32.const 1
   i32.shl
   i32.add
   local.set $0
+  i32.const 0
+  local.set $3
   local.get $2
   i64.const 10
   i64.lt_u
   if
    local.get $0
+   local.get $3
+   i32.const 1
+   i32.shl
+   i32.add
    local.get $2
    i64.const 48
    i64.or
    i64.store16
    i32.const 1
+   local.get $3
+   i32.add
    return
   end
-  i32.const 0
-  local.set $3
+  local.get $3
+  local.set $4
   local.get $2
   i64.const 4294967295
   i64.le_u
   if
    local.get $2
    i32.wrap_i64
-   local.set $4
+   local.set $5
    local.get $4
+   local.get $5
    call $~lib/util/number/decimalCount32
-   local.set $3
+   i32.add
+   local.set $4
    local.get $0
+   local.set $8
+   local.get $5
    local.set $7
    local.get $4
    local.set $6
-   local.get $3
-   local.set $5
+   local.get $8
    local.get $7
    local.get $6
-   local.get $5
    call $~lib/util/number/utoa32_lut
   else
+   local.get $4
    local.get $2
    call $~lib/util/number/decimalCount64High
-   local.set $3
+   i32.add
+   local.set $4
    local.get $0
-   local.set $6
+   local.set $7
    local.get $2
-   local.set $8
-   local.get $3
-   local.set $5
+   local.set $9
+   local.get $4
+   local.set $6
+   local.get $7
+   local.get $9
    local.get $6
-   local.get $8
-   local.get $5
    call $~lib/util/number/utoa64_lut
   end
-  local.get $3
+  local.get $4
  )
  (func $~lib/util/string/joinIntegerArray<u64> (; 532 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)

--- a/tests/compiler/std/typedarray.untouched.wat
+++ b/tests/compiler/std/typedarray.untouched.wat
@@ -31969,10 +31969,18 @@
   i32.shl
   i32.const 24
   i32.shr_s
-  i32.eqz
+  i64.extend_i32_s
+  i64.const 10
+  i64.lt_u
   if
    local.get $0
+   local.get $2
+   i32.const 24
+   i32.shl
+   i32.const 24
+   i32.shr_s
    i32.const 48
+   i32.or
    i32.store16
    i32.const 1
    return
@@ -32615,10 +32623,16 @@
   local.get $2
   i32.const 255
   i32.and
-  i32.eqz
+  i64.extend_i32_u
+  i64.const 10
+  i64.lt_u
   if
    local.get $0
+   local.get $2
+   i32.const 255
+   i32.and
    i32.const 48
+   i32.or
    i32.store16
    i32.const 1
    return
@@ -32993,10 +33007,18 @@
   i32.shl
   i32.const 16
   i32.shr_s
-  i32.eqz
+  i64.extend_i32_s
+  i64.const 10
+  i64.lt_u
   if
    local.get $0
+   local.get $2
+   i32.const 16
+   i32.shl
+   i32.const 16
+   i32.shr_s
    i32.const 48
+   i32.or
    i32.store16
    i32.const 1
    return
@@ -33303,10 +33325,16 @@
   local.get $2
   i32.const 65535
   i32.and
-  i32.eqz
+  i64.extend_i32_u
+  i64.const 10
+  i64.lt_u
   if
    local.get $0
+   local.get $2
+   i32.const 65535
+   i32.and
    i32.const 48
+   i32.or
    i32.store16
    i32.const 1
    return
@@ -33583,10 +33611,14 @@
   i32.add
   local.set $0
   local.get $2
-  i32.eqz
+  i64.extend_i32_s
+  i64.const 10
+  i64.lt_u
   if
    local.get $0
+   local.get $2
    i32.const 48
+   i32.or
    i32.store16
    i32.const 1
    return
@@ -33877,10 +33909,14 @@
   i32.add
   local.set $0
   local.get $2
-  i32.eqz
+  i64.extend_i32_u
+  i64.const 10
+  i64.lt_u
   if
    local.get $0
+   local.get $2
    i32.const 48
+   i32.or
    i32.store16
    i32.const 1
    return
@@ -34426,13 +34462,14 @@
   i32.add
   local.set $0
   local.get $2
-  i64.const 0
-  i64.ne
-  i32.eqz
+  i64.const 10
+  i64.lt_u
   if
    local.get $0
-   i32.const 48
-   i32.store16
+   local.get $2
+   i64.const 48
+   i64.or
+   i64.store16
    i32.const 1
    return
   end
@@ -34814,13 +34851,14 @@
   i32.add
   local.set $0
   local.get $2
-  i64.const 0
-  i64.ne
-  i32.eqz
+  i64.const 10
+  i64.lt_u
   if
    local.get $0
-   i32.const 48
-   i32.store16
+   local.get $2
+   i64.const 48
+   i64.or
+   i64.store16
    i32.const 1
    return
   end

--- a/tests/compiler/std/typedarray.untouched.wat
+++ b/tests/compiler/std/typedarray.untouched.wat
@@ -31969,9 +31969,8 @@
   i32.shl
   i32.const 24
   i32.shr_s
-  i64.extend_i32_s
-  i64.const 10
-  i64.lt_u
+  i32.const 10
+  i32.lt_u
   if
    local.get $0
    local.get $2
@@ -32623,9 +32622,8 @@
   local.get $2
   i32.const 255
   i32.and
-  i64.extend_i32_u
-  i64.const 10
-  i64.lt_u
+  i32.const 10
+  i32.lt_u
   if
    local.get $0
    local.get $2
@@ -33007,9 +33005,8 @@
   i32.shl
   i32.const 16
   i32.shr_s
-  i64.extend_i32_s
-  i64.const 10
-  i64.lt_u
+  i32.const 10
+  i32.lt_u
   if
    local.get $0
    local.get $2
@@ -33325,9 +33322,8 @@
   local.get $2
   i32.const 65535
   i32.and
-  i64.extend_i32_u
-  i64.const 10
-  i64.lt_u
+  i32.const 10
+  i32.lt_u
   if
    local.get $0
    local.get $2
@@ -33611,9 +33607,8 @@
   i32.add
   local.set $0
   local.get $2
-  i64.extend_i32_s
-  i64.const 10
-  i64.lt_u
+  i32.const 10
+  i32.lt_u
   if
    local.get $0
    local.get $2
@@ -33909,9 +33904,8 @@
   i32.add
   local.set $0
   local.get $2
-  i64.extend_i32_u
-  i64.const 10
-  i64.lt_u
+  i32.const 10
+  i32.lt_u
   if
    local.get $0
    local.get $2

--- a/tests/compiler/std/typedarray.untouched.wat
+++ b/tests/compiler/std/typedarray.untouched.wat
@@ -31687,7 +31687,6 @@
   end
  )
  (func $~lib/util/number/decimalCount32 (; 473 ;) (param $0 i32) (result i32)
-  (local $1 i32)
   local.get $0
   i32.const 100000
   i32.lt_u
@@ -31697,26 +31696,21 @@
    i32.lt_u
    if
     i32.const 1
-    i32.const 2
     local.get $0
     i32.const 10
-    i32.lt_u
-    select
+    i32.ge_u
+    i32.add
     return
    else
-    i32.const 4
-    i32.const 5
+    i32.const 3
     local.get $0
     i32.const 10000
-    i32.lt_u
-    select
-    local.set $1
-    i32.const 3
-    local.get $1
+    i32.ge_u
+    i32.add
     local.get $0
     i32.const 1000
-    i32.lt_u
-    select
+    i32.ge_u
+    i32.add
     return
    end
    unreachable
@@ -31726,26 +31720,21 @@
    i32.lt_u
    if
     i32.const 6
-    i32.const 7
     local.get $0
     i32.const 1000000
-    i32.lt_u
-    select
+    i32.ge_u
+    i32.add
     return
    else
-    i32.const 9
-    i32.const 10
+    i32.const 8
     local.get $0
     i32.const 1000000000
-    i32.lt_u
-    select
-    local.set $1
-    i32.const 8
-    local.get $1
+    i32.ge_u
+    i32.add
     local.get $0
     i32.const 100000000
-    i32.lt_u
-    select
+    i32.ge_u
+    i32.add
     return
    end
    unreachable
@@ -34147,7 +34136,6 @@
   call $~lib/rt/pure/__release
  )
  (func $~lib/util/number/decimalCount64 (; 520 ;) (param $0 i64) (result i32)
-  (local $1 i32)
   local.get $0
   i64.const 1000000000000000
   i64.lt_u
@@ -34156,34 +34144,26 @@
    i64.const 1000000000000
    i64.lt_u
    if
-    i32.const 11
-    i32.const 12
+    i32.const 10
     local.get $0
     i64.const 100000000000
-    i64.lt_u
-    select
-    local.set $1
-    i32.const 10
-    local.get $1
+    i64.ge_u
+    i32.add
     local.get $0
     i64.const 10000000000
-    i64.lt_u
-    select
+    i64.ge_u
+    i32.add
     return
    else
-    i32.const 14
-    i32.const 15
+    i32.const 13
     local.get $0
     i64.const 100000000000000
-    i64.lt_u
-    select
-    local.set $1
-    i32.const 13
-    local.get $1
+    i64.ge_u
+    i32.add
     local.get $0
     i64.const 10000000000000
-    i64.lt_u
-    select
+    i64.ge_u
+    i32.add
     return
    end
    unreachable
@@ -34193,26 +34173,21 @@
    i64.lt_u
    if
     i32.const 16
-    i32.const 17
     local.get $0
     i64.const 10000000000000000
-    i64.lt_u
-    select
+    i64.ge_u
+    i32.add
     return
    else
-    i32.const 19
-    i32.const 20
+    i32.const 18
     local.get $0
     i64.const -8446744073709551616
-    i64.lt_u
-    select
-    local.set $1
-    i32.const 18
-    local.get $1
+    i64.ge_u
+    i32.add
     local.get $0
     i64.const 1000000000000000000
-    i64.lt_u
-    select
+    i64.ge_u
+    i32.add
     return
    end
    unreachable

--- a/tests/compiler/std/typedarray.untouched.wat
+++ b/tests/compiler/std/typedarray.untouched.wat
@@ -32634,10 +32634,6 @@
   i32.lt_u
   if
    local.get $0
-   local.get $3
-   i32.const 1
-   i32.shl
-   i32.add
    local.get $2
    i32.const 255
    i32.and
@@ -32645,8 +32641,6 @@
    i32.or
    i32.store16
    i32.const 1
-   local.get $3
-   i32.add
    return
   end
   local.get $3
@@ -33350,10 +33344,6 @@
   i32.lt_u
   if
    local.get $0
-   local.get $3
-   i32.const 1
-   i32.shl
-   i32.add
    local.get $2
    i32.const 65535
    i32.and
@@ -33361,8 +33351,6 @@
    i32.or
    i32.store16
    i32.const 1
-   local.get $3
-   i32.add
    return
   end
   local.get $3
@@ -33948,17 +33936,11 @@
   i32.lt_u
   if
    local.get $0
-   local.get $3
-   i32.const 1
-   i32.shl
-   i32.add
    local.get $2
    i32.const 48
    i32.or
    i32.store16
    i32.const 1
-   local.get $3
-   i32.add
    return
   end
   local.get $3
@@ -34905,17 +34887,11 @@
   i64.lt_u
   if
    local.get $0
-   local.get $3
-   i32.const 1
-   i32.shl
-   i32.add
    local.get $2
    i64.const 48
    i64.or
    i64.store16
    i32.const 1
-   local.get $3
-   i32.add
    return
   end
   local.get $3

--- a/tests/compiler/std/typedarray.untouched.wat
+++ b/tests/compiler/std/typedarray.untouched.wat
@@ -36405,7 +36405,6 @@
  )
  (func $~lib/util/number/dtoa_stream (; 540 ;) (param $0 i32) (param $1 i32) (param $2 f64) (result i32)
   (local $3 i32)
-  (local $4 i32)
   local.get $0
   local.get $1
   i32.const 1
@@ -36455,20 +36454,25 @@
     f64.const 0
     f64.lt
     local.set $3
+    local.get $3
+    if
+     local.get $0
+     i32.const 45
+     i32.store16
+     local.get $0
+     i32.const 2
+     i32.add
+     local.set $0
+    end
+    local.get $0
+    i64.const 29555310648492105
+    i64.store
+    local.get $0
+    i64.const 34058970405077102
+    i64.store offset=8
     i32.const 8
     local.get $3
     i32.add
-    local.set $4
-    local.get $0
-    i32.const 2528
-    i32.const 2576
-    local.get $3
-    select
-    local.get $4
-    i32.const 1
-    i32.shl
-    call $~lib/memory/memory.copy
-    local.get $4
     return
    end
    unreachable

--- a/tests/compiler/std/typedarray.untouched.wat
+++ b/tests/compiler/std/typedarray.untouched.wat
@@ -35989,8 +35989,6 @@
   local.get $7
   i32.const 1
   local.get $7
-  i32.const 0
-  i32.ne
   select
   i32.const 1023
   i32.const 52

--- a/tests/compiler/std/typedarray.untouched.wat
+++ b/tests/compiler/std/typedarray.untouched.wat
@@ -32000,6 +32000,9 @@
    local.get $2
    i32.sub
    local.set $2
+   local.get $0
+   i32.const 45
+   i32.store16
   end
   local.get $2
   i32.const 24
@@ -32024,12 +32027,6 @@
   local.get $6
   local.get $5
   call $~lib/util/number/utoa32_lut
-  local.get $4
-  if
-   local.get $0
-   i32.const 45
-   i32.store16
-  end
   local.get $3
  )
  (func $~lib/string/String#substring (; 479 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -33036,6 +33033,9 @@
    local.get $2
    i32.sub
    local.set $2
+   local.get $0
+   i32.const 45
+   i32.store16
   end
   local.get $2
   i32.const 16
@@ -33060,12 +33060,6 @@
   local.get $6
   local.get $5
   call $~lib/util/number/utoa32_lut
-  local.get $4
-  if
-   local.get $0
-   i32.const 45
-   i32.store16
-  end
   local.get $3
  )
  (func $~lib/util/string/joinIntegerArray<i16> (; 498 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -33630,6 +33624,9 @@
    local.get $2
    i32.sub
    local.set $2
+   local.get $0
+   i32.const 45
+   i32.store16
   end
   local.get $2
   call $~lib/util/number/decimalCount32
@@ -33646,12 +33643,6 @@
   local.get $6
   local.get $5
   call $~lib/util/number/utoa32_lut
-  local.get $4
-  if
-   local.get $0
-   i32.const 45
-   i32.store16
-  end
   local.get $3
  )
  (func $~lib/util/string/joinIntegerArray<i32> (; 510 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -34479,6 +34470,9 @@
    local.get $2
    i64.sub
    local.set $2
+   local.get $0
+   i32.const 45
+   i32.store16
   end
   local.get $2
   i64.const 4294967295
@@ -34518,12 +34512,6 @@
    local.get $9
    local.get $6
    call $~lib/util/number/utoa64_lut
-  end
-  local.get $4
-  if
-   local.get $0
-   i32.const 45
-   i32.store16
   end
   local.get $3
  )


### PR DESCRIPTION
It has almost the same performance:
https://webassembly.studio/?f=kmv06wf9xw

On Chrome 80:
```
decimalCount32_old: 1113ms
decimalCount32_new: 1073ms
```
But smaller bytecode size (188 vs 200 bytes)