### PR TITLE
StaticArray type fix

### DIFF
--- a/std/assembly/index.d.ts
+++ b/std/assembly/index.d.ts
@@ -1400,8 +1400,8 @@ declare class Array<T> {
   toString(): string;
 }
 
-/** Class representing a static (not resizable) sequence of values of type `T`. */
-declare abstract class StaticArray<T> {
+/** Class representing a static (not resizable) sequence of values of type `T`. This class is @sealed. */
+declare class StaticArray<T> {
   [key: number]: T;
   static fromArray<T>(source: Array<T>): StaticArray<T>;
   static concat<T>(source: StaticArray<T>, other: StaticArray<T>): StaticArray<T>;


### PR DESCRIPTION
`StaticArray`s are `@sealed`, so declaring them in the `index.d.ts` file as `abstract` causes vscode to report errors when using the `StaticArray` `constructor`.

This pull request removes the `abstract` keyword to prevent users from experiencing confusion about how `StaticArray` works.