### PR TITLE
tsconfig can use node resolution instead of relative

### DIFF
--- a/bin/asinit
+++ b/bin/asinit
@@ -159,10 +159,9 @@ function ensureAssemblyDirectory() {
 
 function ensureTsconfigJson() {
   console.log("- Making sure that 'assembly/tsconfig.json' is set up...");
-  const base = tsconfigBase.replace(/\\/g, "/");
   if (!fs.existsSync(tsconfigFile)) {
     fs.writeFileSync(tsconfigFile, JSON.stringify({
-      "extends": base,
+      "extends": "assemblyscript/std/assembly.json",
       "include": [
         "./**/*.ts"
       ]


### PR DESCRIPTION
This way when asinit is used globally it won't point to the global definition and is less fragile.