### PR TITLE
Fix columns being off by one / implement line cache

### DIFF
--- a/src/ast.ts
+++ b/src/ast.ts
@@ -1741,16 +1741,15 @@ export class Source extends Node {
     var r = lineCache.length - 1;
     while (l < r) {
       let m = l + i32((r - l) / 2);
-      let s = lineCache[m];
+      let s = unchecked(lineCache[m]);
       if (pos < s) r = m;
-      else if (pos < lineCache[m + 1]) {
+      else if (pos < unchecked(lineCache[m + 1])) {
         this.lineColumn = pos - s + 1;
         return m + 1;
       }
       else l = m + 1;
     }
-    assert(false);
-    return 0;
+    return assert(0);
   }
 
   /** Gets the column number at the last position queried with `lineAt`. */

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -1732,15 +1732,17 @@ export class Source extends Node {
     if (!lineCache) {
       this.lineCache = lineCache = [0];
       let text = this.text;
-      for (let i = 0, k = text.length; i < k;) {
-        if (text.charCodeAt(i++) == CharCode.LINEFEED) lineCache.push(i);
+      let off = 0;
+      let end = text.length;
+      while (off < end) {
+        if (text.charCodeAt(off++) == CharCode.LINEFEED) lineCache.push(off);
       }
       lineCache.push(0x7fffffff);
     }
     var l = 0;
     var r = lineCache.length - 1;
     while (l < r) {
-      let m = l + i32((r - l) / 2);
+      let m = l + ((r - l) >> 1);
       let s = unchecked(lineCache[m]);
       if (pos < s) r = m;
       else if (pos < unchecked(lineCache[m + 1])) {

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -10091,13 +10091,15 @@ export class Compiler extends DiagnosticEmitter {
     }
 
     var filenameArg = this.ensureStaticString(codeLocation.range.source.normalizedPath);
+    var range = codeLocation.range;
+    var source = range.source;
     return module.block(null, [
       module.call(
         abortInstance.internalName, [
           messageArg,
           filenameArg,
-          module.i32(codeLocation.range.line),
-          module.i32(codeLocation.range.column)
+          module.i32(source.lineAt(range.start)),
+          module.i32(source.columnAt())
         ],
         NativeType.None
       ),

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -128,6 +128,7 @@ export class DiagnosticMessage {
   toString(): string {
     var range = this.range;
     if (range) {
+      let source = range.source;
       return (
         diagnosticCategoryToString(this.category) +
         " " +
@@ -135,11 +136,11 @@ export class DiagnosticMessage {
         ": \"" +
         this.message +
         "\" in " +
-        range.source.normalizedPath +
+        source.normalizedPath +
         ":" +
-        range.line.toString() +
+        source.lineAt(range.start).toString() +
         ":" +
-        range.column.toString()
+        source.columnAt().toString()
       );
     }
     return (
@@ -172,6 +173,7 @@ export function formatDiagnosticMessage(
   // include range information if available
   var range = message.range;
   if (range) {
+    let source = range.source;
 
     // include context information if requested
     if (showContext) {
@@ -180,26 +182,27 @@ export function formatDiagnosticMessage(
     }
     sb.push("\n");
     sb.push(" in ");
-    sb.push(range.source.normalizedPath);
+    sb.push(source.normalizedPath);
     sb.push("(");
-    sb.push(range.line.toString());
+    sb.push(source.lineAt(range.start).toString());
     sb.push(",");
-    sb.push(range.column.toString());
+    sb.push(source.columnAt().toString());
     sb.push(")");
 
     let relatedRange = message.relatedRange;
     if (relatedRange) {
+      let relatedSource = relatedRange.source;
       if (showContext) {
         sb.push("\n");
         sb.push(formatDiagnosticContext(relatedRange, useColors));
       }
       sb.push("\n");
       sb.push(" in ");
-      sb.push(relatedRange.source.normalizedPath);
+      sb.push(relatedSource.normalizedPath);
       sb.push("(");
-      sb.push(relatedRange.line.toString());
+      sb.push(relatedSource.lineAt(relatedRange.start).toString());
       sb.push(",");
-      sb.push(relatedRange.column.toString());
+      sb.push(relatedSource.columnAt().toString());
       sb.push(")");
     }
   }

--- a/src/program.ts
+++ b/src/program.ts
@@ -3106,13 +3106,14 @@ export class Function extends TypedElement {
     if (this.program.options.sourceMap) {
       let debugLocations = this.debugLocations;
       for (let i = 0, k = debugLocations.length; i < k; ++i) {
-        let debugLocation = debugLocations[i];
+        let range = debugLocations[i];
+        let source = range.source;
         module.setDebugLocation(
           ref,
-          debugLocation.debugInfoRef,
-          debugLocation.source.debugInfoIndex,
-          debugLocation.line,
-          debugLocation.column
+          range.debugInfoRef,
+          source.debugInfoIndex,
+          source.lineAt(range.start),
+          source.columnAt()
         );
       }
     }

--- a/src/tokenizer.ts
+++ b/src/tokenizer.ts
@@ -402,10 +402,7 @@ export class Range {
   source: Source;
   start: i32;
   end: i32;
-
-  // TODO: set these while tokenizing
-  // line: i32;
-  // column: i32;
+  debugInfoRef: usize = 0;
 
   constructor(source: Source, start: i32, end: i32) {
     this.source = source;
@@ -429,30 +426,9 @@ export class Range {
     return new Range(this.source, this.end, this.end);
   }
 
-  get line(): i32 {
-    var text = this.source.text;
-    var line = 1;
-    for (let pos = this.start; pos >= 0; --pos) {
-      if (text.charCodeAt(pos) == CharCode.LINEFEED) line++;
-    }
-    return line;
-  }
-
-  get column(): i32 {
-    var text = this.source.text;
-    var column = 0;
-    for (let pos = this.start - 1; pos >= 0; --pos) {
-      if (text.charCodeAt(pos) == CharCode.LINEFEED) break;
-      ++column;
-    }
-    return column;
-  }
-
   toString(): string {
     return this.source.text.substring(this.start, this.end);
   }
-
-  debugInfoRef: usize = 0;
 }
 
 /** Handler for intercepting comments while tokenizing. */

--- a/tests/compiler/abi.untouched.wat
+++ b/tests/compiler/abi.untouched.wat
@@ -37,7 +37,7 @@
    i32.const 0
    i32.const 32
    i32.const 32
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -74,7 +74,7 @@
    i32.const 0
    i32.const 32
    i32.const 45
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -103,7 +103,7 @@
    i32.const 0
    i32.const 32
    i32.const 58
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -120,7 +120,7 @@
    i32.const 0
    i32.const 32
    i32.const 65
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -135,7 +135,7 @@
    i32.const 0
    i32.const 32
    i32.const 72
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -150,7 +150,7 @@
    i32.const 0
    i32.const 32
    i32.const 74
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -163,7 +163,7 @@
    i32.const 0
    i32.const 32
    i32.const 77
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -176,7 +176,7 @@
    i32.const 0
    i32.const 32
    i32.const 79
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/assert-nonnull.optimized.wat
+++ b/tests/compiler/assert-nonnull.optimized.wat
@@ -32,7 +32,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2
-   i32.const 9
+   i32.const 10
    call $~lib/builtins/abort
    unreachable
   end
@@ -45,7 +45,7 @@
    i32.const 0
    i32.const 1040
    i32.const 11
-   i32.const 9
+   i32.const 10
    call $~lib/builtins/abort
    unreachable
   end
@@ -61,7 +61,7 @@
    i32.const 0
    i32.const 1040
    i32.const 15
-   i32.const 9
+   i32.const 10
    call $~lib/builtins/abort
    unreachable
   end
@@ -74,7 +74,7 @@
    i32.const 0
    i32.const 1040
    i32.const 19
-   i32.const 9
+   i32.const 10
    call $~lib/builtins/abort
    unreachable
   end
@@ -86,7 +86,7 @@
    i32.const 1104
    i32.const 1168
    i32.const 104
-   i32.const 41
+   i32.const 42
    call $~lib/builtins/abort
    unreachable
   end
@@ -99,7 +99,7 @@
    i32.const 1216
    i32.const 1168
    i32.const 108
-   i32.const 39
+   i32.const 40
    call $~lib/builtins/abort
    unreachable
   end
@@ -114,7 +114,7 @@
    i32.const 1104
    i32.const 1168
    i32.const 104
-   i32.const 41
+   i32.const 42
    call $~lib/builtins/abort
    unreachable
   end
@@ -131,7 +131,7 @@
    i32.const 0
    i32.const 1040
    i32.const 23
-   i32.const 9
+   i32.const 10
    call $~lib/builtins/abort
    unreachable
   end
@@ -159,7 +159,7 @@
   i32.const 0
   i32.const 1040
   i32.const 27
-  i32.const 9
+  i32.const 10
   call $~lib/builtins/abort
   unreachable
  )
@@ -185,7 +185,7 @@
   i32.const 0
   i32.const 1040
   i32.const 31
-  i32.const 9
+  i32.const 10
   call $~lib/builtins/abort
   unreachable
  )
@@ -206,7 +206,7 @@
    i32.const 0
    i32.const 1040
    i32.const 39
-   i32.const 12
+   i32.const 13
    call $~lib/builtins/abort
    unreachable
   end
@@ -228,7 +228,7 @@
    i32.const 0
    i32.const 1040
    i32.const 44
-   i32.const 9
+   i32.const 10
    call $~lib/builtins/abort
    unreachable
   end
@@ -254,7 +254,7 @@
    i32.const 0
    i32.const 1040
    i32.const 52
-   i32.const 9
+   i32.const 10
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/assert-nonnull.untouched.wat
+++ b/tests/compiler/assert-nonnull.untouched.wat
@@ -45,7 +45,7 @@
    i32.const 0
    i32.const 32
    i32.const 2
-   i32.const 9
+   i32.const 10
    call $~lib/builtins/abort
    unreachable
   end
@@ -68,7 +68,7 @@
    i32.const 0
    i32.const 32
    i32.const 11
-   i32.const 9
+   i32.const 10
    call $~lib/builtins/abort
    unreachable
   end
@@ -93,7 +93,7 @@
    i32.const 0
    i32.const 32
    i32.const 15
-   i32.const 9
+   i32.const 10
    call $~lib/builtins/abort
    unreachable
   end
@@ -123,7 +123,7 @@
    i32.const 96
    i32.const 160
    i32.const 104
-   i32.const 41
+   i32.const 42
    call $~lib/builtins/abort
    unreachable
   end
@@ -139,7 +139,7 @@
    i32.const 208
    i32.const 160
    i32.const 108
-   i32.const 39
+   i32.const 40
    call $~lib/builtins/abort
    unreachable
   end
@@ -158,7 +158,7 @@
    i32.const 0
    i32.const 32
    i32.const 19
-   i32.const 9
+   i32.const 10
    call $~lib/builtins/abort
    unreachable
   end
@@ -189,7 +189,7 @@
    i32.const 96
    i32.const 160
    i32.const 104
-   i32.const 41
+   i32.const 42
    call $~lib/builtins/abort
    unreachable
   end
@@ -214,7 +214,7 @@
    i32.const 0
    i32.const 32
    i32.const 23
-   i32.const 9
+   i32.const 10
    call $~lib/builtins/abort
    unreachable
   end
@@ -238,7 +238,7 @@
    i32.const 0
    i32.const 32
    i32.const 27
-   i32.const 9
+   i32.const 10
    call $~lib/builtins/abort
    unreachable
   end
@@ -252,7 +252,7 @@
    i32.const 0
    i32.const 32
    i32.const 27
-   i32.const 9
+   i32.const 10
    call $~lib/builtins/abort
    unreachable
   end
@@ -264,7 +264,7 @@
    i32.const 0
    i32.const 32
    i32.const 27
-   i32.const 9
+   i32.const 10
    call $~lib/builtins/abort
    unreachable
   end
@@ -290,7 +290,7 @@
    i32.const 0
    i32.const 32
    i32.const 31
-   i32.const 9
+   i32.const 10
    call $~lib/builtins/abort
    unreachable
   end
@@ -304,7 +304,7 @@
    i32.const 0
    i32.const 32
    i32.const 31
-   i32.const 9
+   i32.const 10
    call $~lib/builtins/abort
    unreachable
   end
@@ -316,7 +316,7 @@
    i32.const 0
    i32.const 32
    i32.const 31
-   i32.const 9
+   i32.const 10
    call $~lib/builtins/abort
    unreachable
   end
@@ -351,7 +351,7 @@
    i32.const 0
    i32.const 32
    i32.const 39
-   i32.const 12
+   i32.const 13
    call $~lib/builtins/abort
    unreachable
   end
@@ -377,7 +377,7 @@
    i32.const 0
    i32.const 32
    i32.const 44
-   i32.const 9
+   i32.const 10
    call $~lib/builtins/abort
    unreachable
   end
@@ -423,7 +423,7 @@
    i32.const 0
    i32.const 32
    i32.const 52
-   i32.const 9
+   i32.const 10
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/bool.untouched.wat
+++ b/tests/compiler/bool.untouched.wat
@@ -25,7 +25,7 @@
    i32.const 0
    i32.const 32
    i32.const 2
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39,7 +39,7 @@
    i32.const 0
    i32.const 32
    i32.const 4
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -53,7 +53,7 @@
    i32.const 0
    i32.const 32
    i32.const 6
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -67,7 +67,7 @@
    i32.const 0
    i32.const 32
    i32.const 8
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -81,7 +81,7 @@
    i32.const 0
    i32.const 32
    i32.const 10
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -95,7 +95,7 @@
    i32.const 0
    i32.const 32
    i32.const 12
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -109,7 +109,7 @@
    i32.const 0
    i32.const 32
    i32.const 14
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/builtins.optimized.wat
+++ b/tests/compiler/builtins.optimized.wat
@@ -530,7 +530,7 @@
    i32.const 0
    i32.const 1088
    i32.const 424
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -542,7 +542,7 @@
    i32.const 0
    i32.const 1088
    i32.const 425
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -554,7 +554,7 @@
    i32.const 0
    i32.const 1088
    i32.const 426
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -564,7 +564,7 @@
    i32.const 0
    i32.const 1088
    i32.const 427
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -576,7 +576,7 @@
    i32.const 0
    i32.const 1088
    i32.const 428
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -586,7 +586,7 @@
    i32.const 0
    i32.const 1088
    i32.const 429
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -596,7 +596,7 @@
    i32.const 0
    i32.const 1088
    i32.const 430
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -616,7 +616,7 @@
    i32.const 0
    i32.const 1088
    i32.const 447
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -628,7 +628,7 @@
    i32.const 0
    i32.const 1088
    i32.const 448
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -640,7 +640,7 @@
    i32.const 0
    i32.const 1088
    i32.const 449
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -652,7 +652,7 @@
    i32.const 0
    i32.const 1088
    i32.const 450
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -664,7 +664,7 @@
    i32.const 0
    i32.const 1088
    i32.const 451
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -676,7 +676,7 @@
    i32.const 0
    i32.const 1088
    i32.const 452
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -688,7 +688,7 @@
    i32.const 0
    i32.const 1088
    i32.const 453
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -700,7 +700,7 @@
    i32.const 0
    i32.const 1088
    i32.const 454
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -712,7 +712,7 @@
    i32.const 0
    i32.const 1088
    i32.const 455
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -724,7 +724,7 @@
    i32.const 0
    i32.const 1088
    i32.const 456
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -736,7 +736,7 @@
    i32.const 0
    i32.const 1088
    i32.const 457
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -748,7 +748,7 @@
    i32.const 0
    i32.const 1088
    i32.const 458
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -760,7 +760,7 @@
    i32.const 0
    i32.const 1088
    i32.const 459
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -772,7 +772,7 @@
    i32.const 0
    i32.const 1088
    i32.const 460
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -784,7 +784,7 @@
    i32.const 0
    i32.const 1088
    i32.const 461
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -796,7 +796,7 @@
    i32.const 0
    i32.const 1088
    i32.const 462
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -808,7 +808,7 @@
    i32.const 0
    i32.const 1088
    i32.const 463
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -820,7 +820,7 @@
    i32.const 0
    i32.const 1088
    i32.const 464
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -832,7 +832,7 @@
    i32.const 0
    i32.const 1088
    i32.const 465
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -844,7 +844,7 @@
    i32.const 0
    i32.const 1088
    i32.const 466
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/builtins.untouched.wat
+++ b/tests/compiler/builtins.untouched.wat
@@ -401,7 +401,7 @@
    i32.const 0
    i32.const 80
    i32.const 67
-   i32.const 19
+   i32.const 20
    call $~lib/builtins/abort
    unreachable
   end
@@ -422,7 +422,7 @@
    i32.const 0
    i32.const 80
    i32.const 68
-   i32.const 20
+   i32.const 21
    call $~lib/builtins/abort
    unreachable
   end
@@ -443,7 +443,7 @@
    i32.const 0
    i32.const 80
    i32.const 69
-   i32.const 20
+   i32.const 21
    call $~lib/builtins/abort
    unreachable
   end
@@ -509,7 +509,7 @@
    i32.const 0
    i32.const 80
    i32.const 85
-   i32.const 19
+   i32.const 20
    call $~lib/builtins/abort
    unreachable
   end
@@ -530,7 +530,7 @@
    i32.const 0
    i32.const 80
    i32.const 86
-   i32.const 20
+   i32.const 21
    call $~lib/builtins/abort
    unreachable
   end
@@ -551,7 +551,7 @@
    i32.const 0
    i32.const 80
    i32.const 87
-   i32.const 20
+   i32.const 21
    call $~lib/builtins/abort
    unreachable
   end
@@ -600,7 +600,7 @@
    i32.const 0
    i32.const 80
    i32.const 104
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -615,7 +615,7 @@
    i32.const 0
    i32.const 80
    i32.const 105
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -632,7 +632,7 @@
    i32.const 0
    i32.const 80
    i32.const 106
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -649,7 +649,7 @@
    i32.const 0
    i32.const 80
    i32.const 107
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -666,7 +666,7 @@
    i32.const 0
    i32.const 80
    i32.const 108
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -683,7 +683,7 @@
    i32.const 0
    i32.const 80
    i32.const 109
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -782,7 +782,7 @@
    i32.const 0
    i32.const 80
    i32.const 140
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -797,7 +797,7 @@
    i32.const 0
    i32.const 80
    i32.const 141
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -814,7 +814,7 @@
    i32.const 0
    i32.const 80
    i32.const 142
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -831,7 +831,7 @@
    i32.const 0
    i32.const 80
    i32.const 143
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -848,7 +848,7 @@
    i32.const 0
    i32.const 80
    i32.const 144
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -865,7 +865,7 @@
    i32.const 0
    i32.const 80
    i32.const 145
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1180,7 +1180,7 @@
    i32.const 0
    i32.const 80
    i32.const 296
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1193,7 +1193,7 @@
    i32.const 0
    i32.const 80
    i32.const 297
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1209,7 +1209,7 @@
    i32.const 0
    i32.const 80
    i32.const 298
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1225,7 +1225,7 @@
    i32.const 0
    i32.const 80
    i32.const 299
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1241,7 +1241,7 @@
    i32.const 0
    i32.const 80
    i32.const 300
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1257,7 +1257,7 @@
    i32.const 0
    i32.const 80
    i32.const 301
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1272,7 +1272,7 @@
    i32.const 0
    i32.const 80
    i32.const 302
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1287,7 +1287,7 @@
    i32.const 0
    i32.const 80
    i32.const 303
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1475,7 +1475,7 @@
    i32.const 0
    i32.const 80
    i32.const 424
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1488,7 +1488,7 @@
    i32.const 0
    i32.const 80
    i32.const 425
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1501,7 +1501,7 @@
    i32.const 0
    i32.const 80
    i32.const 426
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1514,7 +1514,7 @@
    i32.const 0
    i32.const 80
    i32.const 427
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1527,7 +1527,7 @@
    i32.const 0
    i32.const 80
    i32.const 428
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1540,7 +1540,7 @@
    i32.const 0
    i32.const 80
    i32.const 429
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1553,7 +1553,7 @@
    i32.const 0
    i32.const 80
    i32.const 430
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1588,7 +1588,7 @@
    i32.const 176
    i32.const 80
    i32.const 440
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1600,7 +1600,7 @@
    i32.const 0
    i32.const 80
    i32.const 441
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1612,7 +1612,7 @@
    i32.const 0
    i32.const 80
    i32.const 442
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1624,7 +1624,7 @@
    i32.const 0
    i32.const 80
    i32.const 443
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1636,7 +1636,7 @@
    i32.const 0
    i32.const 80
    i32.const 447
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1648,7 +1648,7 @@
    i32.const 0
    i32.const 80
    i32.const 448
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1660,7 +1660,7 @@
    i32.const 0
    i32.const 80
    i32.const 449
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1672,7 +1672,7 @@
    i32.const 0
    i32.const 80
    i32.const 450
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1684,7 +1684,7 @@
    i32.const 0
    i32.const 80
    i32.const 451
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1696,7 +1696,7 @@
    i32.const 0
    i32.const 80
    i32.const 452
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1708,7 +1708,7 @@
    i32.const 0
    i32.const 80
    i32.const 453
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1720,7 +1720,7 @@
    i32.const 0
    i32.const 80
    i32.const 454
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1732,7 +1732,7 @@
    i32.const 0
    i32.const 80
    i32.const 455
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1744,7 +1744,7 @@
    i32.const 0
    i32.const 80
    i32.const 456
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1756,7 +1756,7 @@
    i32.const 0
    i32.const 80
    i32.const 457
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1768,7 +1768,7 @@
    i32.const 0
    i32.const 80
    i32.const 458
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1780,7 +1780,7 @@
    i32.const 0
    i32.const 80
    i32.const 459
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1792,7 +1792,7 @@
    i32.const 0
    i32.const 80
    i32.const 460
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1804,7 +1804,7 @@
    i32.const 0
    i32.const 80
    i32.const 461
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1816,7 +1816,7 @@
    i32.const 0
    i32.const 80
    i32.const 462
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1828,7 +1828,7 @@
    i32.const 0
    i32.const 80
    i32.const 463
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1840,7 +1840,7 @@
    i32.const 0
    i32.const 80
    i32.const 464
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1852,7 +1852,7 @@
    i32.const 0
    i32.const 80
    i32.const 465
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1864,7 +1864,7 @@
    i32.const 0
    i32.const 80
    i32.const 466
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/call-inferred.untouched.wat
+++ b/tests/compiler/call-inferred.untouched.wat
@@ -54,7 +54,7 @@
    i32.const 0
    i32.const 32
    i32.const 5
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -67,7 +67,7 @@
    i32.const 0
    i32.const 32
    i32.const 6
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -80,7 +80,7 @@
    i32.const 0
    i32.const 32
    i32.const 7
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -95,7 +95,7 @@
    i32.const 0
    i32.const 32
    i32.const 13
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/call-optional.optimized.wat
+++ b/tests/compiler/call-optional.optimized.wat
@@ -55,7 +55,7 @@
    i32.const 0
    i32.const 1040
    i32.const 4
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -71,7 +71,7 @@
    i32.const 0
    i32.const 1040
    i32.const 5
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -85,7 +85,7 @@
    i32.const 0
    i32.const 1040
    i32.const 6
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -99,7 +99,7 @@
    i32.const 0
    i32.const 1040
    i32.const 9
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -115,7 +115,7 @@
    i32.const 0
    i32.const 1040
    i32.const 10
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -131,7 +131,7 @@
    i32.const 0
    i32.const 1040
    i32.const 11
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/call-optional.untouched.wat
+++ b/tests/compiler/call-optional.untouched.wat
@@ -61,7 +61,7 @@
    i32.const 0
    i32.const 32
    i32.const 4
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -78,7 +78,7 @@
    i32.const 0
    i32.const 32
    i32.const 5
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -93,7 +93,7 @@
    i32.const 0
    i32.const 32
    i32.const 6
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -111,7 +111,7 @@
    i32.const 0
    i32.const 32
    i32.const 9
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -129,7 +129,7 @@
    i32.const 0
    i32.const 32
    i32.const 10
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -147,7 +147,7 @@
    i32.const 0
    i32.const 32
    i32.const 11
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/call-super.optimized.wat
+++ b/tests/compiler/call-super.optimized.wat
@@ -121,7 +121,7 @@
    i32.const 0
    i32.const 1040
    i32.const 6
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -136,7 +136,7 @@
    i32.const 0
    i32.const 1040
    i32.const 15
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -148,7 +148,7 @@
    i32.const 0
    i32.const 1040
    i32.const 16
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -160,7 +160,7 @@
    i32.const 0
    i32.const 1040
    i32.const 22
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -172,7 +172,7 @@
    i32.const 0
    i32.const 1040
    i32.const 23
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -201,7 +201,7 @@
    i32.const 0
    i32.const 1040
    i32.const 38
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -213,7 +213,7 @@
    i32.const 0
    i32.const 1040
    i32.const 39
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -225,7 +225,7 @@
    i32.const 0
    i32.const 1040
    i32.const 45
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -237,7 +237,7 @@
    i32.const 0
    i32.const 1040
    i32.const 46
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -263,7 +263,7 @@
    i32.const 0
    i32.const 1040
    i32.const 56
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -278,7 +278,7 @@
    i32.const 0
    i32.const 1040
    i32.const 66
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -290,7 +290,7 @@
    i32.const 0
    i32.const 1040
    i32.const 67
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -319,7 +319,7 @@
    i32.const 0
    i32.const 1040
    i32.const 84
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -331,7 +331,7 @@
    i32.const 0
    i32.const 1040
    i32.const 85
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -360,7 +360,7 @@
    i32.const 0
    i32.const 1040
    i32.const 104
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -372,7 +372,7 @@
    i32.const 0
    i32.const 1040
    i32.const 105
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/call-super.untouched.wat
+++ b/tests/compiler/call-super.untouched.wat
@@ -145,7 +145,7 @@
    i32.const 0
    i32.const 32
    i32.const 6
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -175,7 +175,7 @@
    i32.const 0
    i32.const 32
    i32.const 15
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -188,7 +188,7 @@
    i32.const 0
    i32.const 32
    i32.const 16
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -211,7 +211,7 @@
    i32.const 0
    i32.const 32
    i32.const 22
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -224,7 +224,7 @@
    i32.const 0
    i32.const 32
    i32.const 23
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -270,7 +270,7 @@
    i32.const 0
    i32.const 32
    i32.const 38
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -283,7 +283,7 @@
    i32.const 0
    i32.const 32
    i32.const 39
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -303,7 +303,7 @@
    i32.const 0
    i32.const 32
    i32.const 45
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -316,7 +316,7 @@
    i32.const 0
    i32.const 32
    i32.const 46
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -345,7 +345,7 @@
    i32.const 0
    i32.const 32
    i32.const 56
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -383,7 +383,7 @@
    i32.const 0
    i32.const 32
    i32.const 66
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -396,7 +396,7 @@
    i32.const 0
    i32.const 32
    i32.const 67
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -450,7 +450,7 @@
    i32.const 0
    i32.const 32
    i32.const 84
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -463,7 +463,7 @@
    i32.const 0
    i32.const 32
    i32.const 85
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -517,7 +517,7 @@
    i32.const 0
    i32.const 32
    i32.const 104
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -530,7 +530,7 @@
    i32.const 0
    i32.const 32
    i32.const 105
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/class-static-function.untouched.wat
+++ b/tests/compiler/class-static-function.untouched.wat
@@ -36,7 +36,7 @@
    i32.const 0
    i32.const 32
    i32.const 11
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/class.untouched.wat
+++ b/tests/compiler/class.untouched.wat
@@ -453,7 +453,7 @@
    i32.const 32
    i32.const 80
    i32.const 57
-   i32.const 59
+   i32.const 60
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/comma.optimized.wat
+++ b/tests/compiler/comma.optimized.wat
@@ -25,7 +25,7 @@
    i32.const 0
    i32.const 1040
    i32.const 4
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34,7 +34,7 @@
    i32.const 0
    i32.const 1040
    i32.const 5
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -51,7 +51,7 @@
    i32.const 0
    i32.const 1040
    i32.const 8
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -62,7 +62,7 @@
    i32.const 0
    i32.const 1040
    i32.const 9
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -87,7 +87,7 @@
    i32.const 0
    i32.const 1040
    i32.const 18
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -98,7 +98,7 @@
    i32.const 0
    i32.const 1040
    i32.const 19
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -125,7 +125,7 @@
    i32.const 0
    i32.const 1040
    i32.const 22
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/comma.untouched.wat
+++ b/tests/compiler/comma.untouched.wat
@@ -29,7 +29,7 @@
    i32.const 0
    i32.const 32
    i32.const 4
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41,7 +41,7 @@
    i32.const 0
    i32.const 32
    i32.const 5
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -59,7 +59,7 @@
    i32.const 0
    i32.const 32
    i32.const 8
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -71,7 +71,7 @@
    i32.const 0
    i32.const 32
    i32.const 9
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -93,7 +93,7 @@
    i32.const 0
    i32.const 32
    i32.const 14
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -105,7 +105,7 @@
    i32.const 0
    i32.const 32
    i32.const 15
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -125,7 +125,7 @@
    i32.const 0
    i32.const 32
    i32.const 18
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -137,7 +137,7 @@
    i32.const 0
    i32.const 32
    i32.const 19
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -170,7 +170,7 @@
    i32.const 0
    i32.const 32
    i32.const 22
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/declare.optimized.wat
+++ b/tests/compiler/declare.optimized.wat
@@ -19,7 +19,7 @@
    i32.const 0
    i32.const 1040
    i32.const 5
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31,7 +31,7 @@
    i32.const 0
    i32.const 1040
    i32.const 13
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/declare.untouched.wat
+++ b/tests/compiler/declare.untouched.wat
@@ -21,7 +21,7 @@
    i32.const 0
    i32.const 32
    i32.const 5
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34,7 +34,7 @@
    i32.const 0
    i32.const 32
    i32.const 13
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/do.optimized.wat
+++ b/tests/compiler/do.optimized.wat
@@ -53,7 +53,7 @@
     i32.const 0
     i32.const 1040
     i32.const 39
-    i32.const 4
+    i32.const 5
     call $~lib/builtins/abort
     unreachable
    end
@@ -64,7 +64,7 @@
     i32.const 0
     i32.const 1040
     i32.const 40
-    i32.const 4
+    i32.const 5
     call $~lib/builtins/abort
     unreachable
    end
@@ -76,7 +76,7 @@
    i32.const 0
    i32.const 1040
    i32.const 42
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -87,7 +87,7 @@
    i32.const 0
    i32.const 1040
    i32.const 43
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -98,7 +98,7 @@
    i32.const 0
    i32.const 1040
    i32.const 44
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -120,7 +120,7 @@
    i32.const 0
    i32.const 1072
    i32.const 277
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -142,7 +142,7 @@
    i32.const 0
    i32.const 1072
    i32.const 279
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -185,7 +185,7 @@
    i32.const 0
    i32.const 1072
    i32.const 292
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -281,7 +281,7 @@
    i32.const 0
    i32.const 1072
    i32.const 205
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -295,7 +295,7 @@
    i32.const 0
    i32.const 1072
    i32.const 207
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -368,7 +368,7 @@
     i32.const 0
     i32.const 1072
     i32.const 228
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -423,7 +423,7 @@
    i32.const 0
    i32.const 1072
    i32.const 243
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -438,7 +438,7 @@
    i32.const 0
    i32.const 1072
    i32.const 244
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -486,7 +486,7 @@
    i32.const 0
    i32.const 1072
    i32.const 260
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -569,7 +569,7 @@
    i32.const 0
    i32.const 1072
    i32.const 386
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -586,7 +586,7 @@
     i32.const 0
     i32.const 1072
     i32.const 396
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -614,7 +614,7 @@
     i32.const 0
     i32.const 1072
     i32.const 408
-    i32.const 4
+    i32.const 5
     call $~lib/builtins/abort
     unreachable
    end
@@ -785,7 +785,7 @@
      i32.const 0
      i32.const 1072
      i32.const 351
-     i32.const 17
+     i32.const 18
      call $~lib/builtins/abort
      unreachable
     end
@@ -814,7 +814,7 @@
    i32.const 0
    i32.const 1072
    i32.const 501
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -884,7 +884,7 @@
      i32.const 0
      i32.const 1072
      i32.const 513
-     i32.const 19
+     i32.const 20
      call $~lib/builtins/abort
      unreachable
     end
@@ -900,7 +900,7 @@
    i32.const 0
    i32.const 1072
    i32.const 521
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1007,7 +1007,7 @@
     i32.const 0
     i32.const 1184
     i32.const 109
-    i32.const 2
+    i32.const 3
     call $~lib/builtins/abort
     unreachable
    end
@@ -1026,7 +1026,7 @@
     i32.const 0
     i32.const 1184
     i32.const 112
-    i32.const 13
+    i32.const 14
     call $~lib/builtins/abort
     unreachable
    end
@@ -1068,7 +1068,7 @@
    i32.const 0
    i32.const 1040
    i32.const 10
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1079,7 +1079,7 @@
    i32.const 0
    i32.const 1040
    i32.const 11
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1105,7 +1105,7 @@
    i32.const 0
    i32.const 1040
    i32.const 21
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1120,7 +1120,7 @@
    i32.const 0
    i32.const 1040
    i32.const 49
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1144,7 +1144,7 @@
    i32.const 0
    i32.const 1040
    i32.const 56
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1168,7 +1168,7 @@
    i32.const 0
    i32.const 1040
    i32.const 70
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1204,7 +1204,7 @@
    i32.const 0
    i32.const 1040
    i32.const 116
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1243,7 +1243,7 @@
    i32.const 0
    i32.const 1040
    i32.const 134
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1254,7 +1254,7 @@
    i32.const 0
    i32.const 1040
    i32.const 135
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1296,7 +1296,7 @@
    i32.const 0
    i32.const 1040
    i32.const 150
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1305,7 +1305,7 @@
    i32.const 0
    i32.const 1040
    i32.const 151
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1319,7 +1319,7 @@
    i32.const 0
    i32.const 1040
    i32.const 156
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1361,7 +1361,7 @@
    i32.const 0
    i32.const 1040
    i32.const 170
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1370,7 +1370,7 @@
    i32.const 0
    i32.const 1040
    i32.const 171
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1384,7 +1384,7 @@
    i32.const 0
    i32.const 1040
    i32.const 176
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1418,7 +1418,7 @@
    i32.const 0
    i32.const 1184
    i32.const 122
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1463,7 +1463,7 @@
     i32.const 0
     i32.const 1184
     i32.const 126
-    i32.const 17
+    i32.const 18
     call $~lib/builtins/abort
     unreachable
    end
@@ -1486,7 +1486,7 @@
     i32.const 0
     i32.const 1184
     i32.const 136
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end

--- a/tests/compiler/do.untouched.wat
+++ b/tests/compiler/do.untouched.wat
@@ -58,7 +58,7 @@
    i32.const 0
    i32.const 32
    i32.const 10
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -70,7 +70,7 @@
    i32.const 0
    i32.const 32
    i32.const 11
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -102,7 +102,7 @@
    i32.const 0
    i32.const 32
    i32.const 21
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -151,7 +151,7 @@
     i32.const 0
     i32.const 32
     i32.const 39
-    i32.const 4
+    i32.const 5
     call $~lib/builtins/abort
     unreachable
    end
@@ -163,7 +163,7 @@
     i32.const 0
     i32.const 32
     i32.const 40
-    i32.const 4
+    i32.const 5
     call $~lib/builtins/abort
     unreachable
    end
@@ -180,7 +180,7 @@
    i32.const 0
    i32.const 32
    i32.const 42
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -192,7 +192,7 @@
    i32.const 0
    i32.const 32
    i32.const 43
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -204,7 +204,7 @@
    i32.const 0
    i32.const 32
    i32.const 44
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -241,7 +241,7 @@
    i32.const 0
    i32.const 32
    i32.const 56
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -285,7 +285,7 @@
    i32.const 0
    i32.const 32
    i32.const 77
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -314,7 +314,7 @@
    i32.const 0
    i32.const 32
    i32.const 90
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -363,7 +363,7 @@
    i32.const 0
    i32.const 32
    i32.const 116
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -417,7 +417,7 @@
    i32.const 0
    i32.const 32
    i32.const 134
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -429,7 +429,7 @@
    i32.const 0
    i32.const 32
    i32.const 135
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -458,7 +458,7 @@
    i32.const 0
    i32.const 64
    i32.const 277
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -483,7 +483,7 @@
    i32.const 0
    i32.const 64
    i32.const 279
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -535,7 +535,7 @@
    i32.const 0
    i32.const 64
    i32.const 292
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -665,7 +665,7 @@
    i32.const 0
    i32.const 64
    i32.const 205
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -680,7 +680,7 @@
    i32.const 0
    i32.const 64
    i32.const 207
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -773,7 +773,7 @@
     i32.const 0
     i32.const 64
     i32.const 228
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -836,7 +836,7 @@
    i32.const 0
    i32.const 64
    i32.const 243
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -852,7 +852,7 @@
    i32.const 0
    i32.const 64
    i32.const 244
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -909,7 +909,7 @@
    i32.const 0
    i32.const 64
    i32.const 260
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1028,7 +1028,7 @@
    i32.const 0
    i32.const 64
    i32.const 386
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -1051,7 +1051,7 @@
     i32.const 0
     i32.const 64
     i32.const 396
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -1082,7 +1082,7 @@
     i32.const 0
     i32.const 64
     i32.const 408
-    i32.const 4
+    i32.const 5
     call $~lib/builtins/abort
     unreachable
    end
@@ -1308,7 +1308,7 @@
    i32.const 112
    i32.const 64
    i32.const 461
-   i32.const 29
+   i32.const 30
    call $~lib/builtins/abort
    unreachable
   end
@@ -1402,7 +1402,7 @@
    i32.const 0
    i32.const 64
    i32.const 338
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1465,7 +1465,7 @@
      i32.const 0
      i32.const 64
      i32.const 351
-     i32.const 17
+     i32.const 18
      call $~lib/builtins/abort
      unreachable
     end
@@ -1610,7 +1610,7 @@
    i32.const 0
    i32.const 64
    i32.const 365
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1699,7 +1699,7 @@
    i32.const 0
    i32.const 64
    i32.const 501
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1740,7 +1740,7 @@
       i32.const 0
       i32.const 64
       i32.const 513
-      i32.const 19
+      i32.const 20
       call $~lib/builtins/abort
       unreachable
      end
@@ -1759,7 +1759,7 @@
      i32.const 0
      i32.const 64
      i32.const 518
-     i32.const 17
+     i32.const 18
      call $~lib/builtins/abort
      unreachable
     end
@@ -1776,7 +1776,7 @@
    i32.const 0
    i32.const 64
    i32.const 521
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1827,7 +1827,7 @@
    i32.const 0
    i32.const 176
    i32.const 109
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1848,7 +1848,7 @@
    i32.const 0
    i32.const 176
    i32.const 112
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1942,7 +1942,7 @@
    i32.const 0
    i32.const 32
    i32.const 150
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1953,7 +1953,7 @@
    i32.const 0
    i32.const 32
    i32.const 151
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2018,7 +2018,7 @@
    i32.const 0
    i32.const 32
    i32.const 170
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2029,7 +2029,7 @@
    i32.const 0
    i32.const 32
    i32.const 171
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2048,7 +2048,7 @@
    i32.const 0
    i32.const 32
    i32.const 16
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2061,7 +2061,7 @@
    i32.const 0
    i32.const 32
    i32.const 26
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2074,7 +2074,7 @@
    i32.const 0
    i32.const 32
    i32.const 49
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2087,7 +2087,7 @@
    i32.const 0
    i32.const 32
    i32.const 61
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2099,7 +2099,7 @@
    i32.const 0
    i32.const 32
    i32.const 70
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2112,7 +2112,7 @@
    i32.const 0
    i32.const 32
    i32.const 82
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2125,7 +2125,7 @@
    i32.const 0
    i32.const 32
    i32.const 95
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2138,7 +2138,7 @@
    i32.const 0
    i32.const 32
    i32.const 108
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2151,7 +2151,7 @@
    i32.const 0
    i32.const 32
    i32.const 121
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2164,7 +2164,7 @@
    i32.const 0
    i32.const 32
    i32.const 140
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2177,7 +2177,7 @@
    i32.const 0
    i32.const 32
    i32.const 156
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2190,7 +2190,7 @@
    i32.const 0
    i32.const 32
    i32.const 176
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2246,7 +2246,7 @@
    i32.const 0
    i32.const 176
    i32.const 122
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -2268,7 +2268,7 @@
     i32.const 0
     i32.const 176
     i32.const 126
-    i32.const 17
+    i32.const 18
     call $~lib/builtins/abort
     unreachable
    end
@@ -2284,7 +2284,7 @@
     i32.const 0
     i32.const 176
     i32.const 136
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -2316,7 +2316,7 @@
    i32.const 0
    i32.const 176
    i32.const 69
-   i32.const 15
+   i32.const 16
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/extends-baseaggregate.optimized.wat
+++ b/tests/compiler/extends-baseaggregate.optimized.wat
@@ -45,7 +45,7 @@
    i32.const 0
    i32.const 1136
    i32.const 277
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -67,7 +67,7 @@
    i32.const 0
    i32.const 1136
    i32.const 279
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -110,7 +110,7 @@
    i32.const 0
    i32.const 1136
    i32.const 292
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -206,7 +206,7 @@
    i32.const 0
    i32.const 1136
    i32.const 205
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -220,7 +220,7 @@
    i32.const 0
    i32.const 1136
    i32.const 207
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -293,7 +293,7 @@
     i32.const 0
     i32.const 1136
     i32.const 228
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -348,7 +348,7 @@
    i32.const 0
    i32.const 1136
    i32.const 243
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -363,7 +363,7 @@
    i32.const 0
    i32.const 1136
    i32.const 244
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -411,7 +411,7 @@
    i32.const 0
    i32.const 1136
    i32.const 260
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -494,7 +494,7 @@
    i32.const 0
    i32.const 1136
    i32.const 386
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -511,7 +511,7 @@
     i32.const 0
     i32.const 1136
     i32.const 396
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -539,7 +539,7 @@
     i32.const 0
     i32.const 1136
     i32.const 408
-    i32.const 4
+    i32.const 5
     call $~lib/builtins/abort
     unreachable
    end
@@ -680,7 +680,7 @@
    i32.const 1184
    i32.const 1136
    i32.const 461
-   i32.const 29
+   i32.const 30
    call $~lib/builtins/abort
    unreachable
   end
@@ -753,7 +753,7 @@
    i32.const 0
    i32.const 1136
    i32.const 338
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -805,7 +805,7 @@
      i32.const 0
      i32.const 1136
      i32.const 351
-     i32.const 17
+     i32.const 18
      call $~lib/builtins/abort
      unreachable
     end
@@ -838,7 +838,7 @@
    i32.const 0
    i32.const 1136
    i32.const 365
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -909,7 +909,7 @@
    i32.const 0
    i32.const 1136
    i32.const 501
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1001,7 +1001,7 @@
      i32.const 0
      i32.const 1136
      i32.const 513
-     i32.const 19
+     i32.const 20
      call $~lib/builtins/abort
      unreachable
     end
@@ -1017,7 +1017,7 @@
    i32.const 0
    i32.const 1136
    i32.const 521
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1072,7 +1072,7 @@
     i32.const 0
     i32.const 1248
     i32.const 109
-    i32.const 2
+    i32.const 3
     call $~lib/builtins/abort
     unreachable
    end
@@ -1089,7 +1089,7 @@
     i32.const 0
     i32.const 1248
     i32.const 112
-    i32.const 13
+    i32.const 14
     call $~lib/builtins/abort
     unreachable
    end
@@ -1132,7 +1132,7 @@
    i32.const 0
    i32.const 1136
    i32.const 581
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1632,7 +1632,7 @@
     i32.const 1296
     i32.const 1344
     i32.const 14
-    i32.const 47
+    i32.const 48
     call $~lib/builtins/abort
     unreachable
    end
@@ -1940,7 +1940,7 @@
    i32.const 0
    i32.const 1248
    i32.const 122
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1973,7 +1973,7 @@
     i32.const 0
     i32.const 1248
     i32.const 136
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -1987,7 +1987,7 @@
     i32.const 1392
     i32.const 1456
     i32.const 22
-    i32.const 27
+    i32.const 28
     call $~lib/builtins/abort
     unreachable
    end
@@ -2118,7 +2118,7 @@
         i32.const 0
         i32.const 1248
         i32.const 79
-        i32.const 19
+        i32.const 20
         call $~lib/builtins/abort
         unreachable
        end
@@ -2151,7 +2151,7 @@
       i32.const 0
       i32.const 1248
       i32.const 90
-      i32.const 8
+      i32.const 9
       call $~lib/builtins/abort
       unreachable
      end
@@ -2176,7 +2176,7 @@
    i32.const 0
    i32.const 1248
    i32.const 101
-   i32.const 26
+   i32.const 27
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/extends-baseaggregate.untouched.wat
+++ b/tests/compiler/extends-baseaggregate.untouched.wat
@@ -59,7 +59,7 @@
    i32.const 0
    i32.const 128
    i32.const 277
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -84,7 +84,7 @@
    i32.const 0
    i32.const 128
    i32.const 279
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -136,7 +136,7 @@
    i32.const 0
    i32.const 128
    i32.const 292
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -266,7 +266,7 @@
    i32.const 0
    i32.const 128
    i32.const 205
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -281,7 +281,7 @@
    i32.const 0
    i32.const 128
    i32.const 207
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -374,7 +374,7 @@
     i32.const 0
     i32.const 128
     i32.const 228
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -437,7 +437,7 @@
    i32.const 0
    i32.const 128
    i32.const 243
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -453,7 +453,7 @@
    i32.const 0
    i32.const 128
    i32.const 244
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -510,7 +510,7 @@
    i32.const 0
    i32.const 128
    i32.const 260
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -629,7 +629,7 @@
    i32.const 0
    i32.const 128
    i32.const 386
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -652,7 +652,7 @@
     i32.const 0
     i32.const 128
     i32.const 396
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -683,7 +683,7 @@
     i32.const 0
     i32.const 128
     i32.const 408
-    i32.const 4
+    i32.const 5
     call $~lib/builtins/abort
     unreachable
    end
@@ -909,7 +909,7 @@
    i32.const 176
    i32.const 128
    i32.const 461
-   i32.const 29
+   i32.const 30
    call $~lib/builtins/abort
    unreachable
   end
@@ -1003,7 +1003,7 @@
    i32.const 0
    i32.const 128
    i32.const 338
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1066,7 +1066,7 @@
      i32.const 0
      i32.const 128
      i32.const 351
-     i32.const 17
+     i32.const 18
      call $~lib/builtins/abort
      unreachable
     end
@@ -1211,7 +1211,7 @@
    i32.const 0
    i32.const 128
    i32.const 365
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1300,7 +1300,7 @@
    i32.const 0
    i32.const 128
    i32.const 501
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1341,7 +1341,7 @@
       i32.const 0
       i32.const 128
       i32.const 513
-      i32.const 19
+      i32.const 20
       call $~lib/builtins/abort
       unreachable
      end
@@ -1360,7 +1360,7 @@
      i32.const 0
      i32.const 128
      i32.const 518
-     i32.const 17
+     i32.const 18
      call $~lib/builtins/abort
      unreachable
     end
@@ -1377,7 +1377,7 @@
    i32.const 0
    i32.const 128
    i32.const 521
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1426,7 +1426,7 @@
    i32.const 0
    i32.const 240
    i32.const 109
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1445,7 +1445,7 @@
    i32.const 0
    i32.const 240
    i32.const 112
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1538,7 +1538,7 @@
    i32.const 0
    i32.const 128
    i32.const 581
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3159,7 +3159,7 @@
     i32.const 288
     i32.const 336
     i32.const 14
-    i32.const 47
+    i32.const 48
     call $~lib/builtins/abort
     unreachable
    end
@@ -3532,7 +3532,7 @@
    i32.const 384
    i32.const 448
    i32.const 22
-   i32.const 27
+   i32.const 28
    call $~lib/builtins/abort
    unreachable
   end
@@ -3641,7 +3641,7 @@
    i32.const 0
    i32.const 240
    i32.const 122
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -3680,7 +3680,7 @@
     i32.const 0
     i32.const 240
     i32.const 136
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -3782,7 +3782,7 @@
         i32.const 0
         i32.const 240
         i32.const 79
-        i32.const 19
+        i32.const 20
         call $~lib/builtins/abort
         unreachable
        end
@@ -3817,7 +3817,7 @@
       i32.const 0
       i32.const 240
       i32.const 90
-      i32.const 8
+      i32.const 9
       call $~lib/builtins/abort
       unreachable
      end
@@ -3847,7 +3847,7 @@
     i32.const 0
     i32.const 240
     i32.const 101
-    i32.const 26
+    i32.const 27
     call $~lib/builtins/abort
     unreachable
    end

--- a/tests/compiler/features/js-bigint-integration.optimized.wat
+++ b/tests/compiler/features/js-bigint-integration.optimized.wat
@@ -31,7 +31,7 @@
    i32.const 0
    i32.const 1040
    i32.const 4
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42,7 +42,7 @@
    i32.const 0
    i32.const 1040
    i32.const 5
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/features/js-bigint-integration.untouched.wat
+++ b/tests/compiler/features/js-bigint-integration.untouched.wat
@@ -23,7 +23,7 @@
    i32.const 0
    i32.const 32
    i32.const 4
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35,7 +35,7 @@
    i32.const 0
    i32.const 32
    i32.const 5
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/features/mutable-globals.optimized.wat
+++ b/tests/compiler/features/mutable-globals.optimized.wat
@@ -26,7 +26,7 @@
    i32.const 0
    i32.const 1040
    i32.const 5
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37,7 +37,7 @@
    i32.const 0
    i32.const 1040
    i32.const 6
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -56,7 +56,7 @@
    i32.const 0
    i32.const 1040
    i32.const 11
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -67,7 +67,7 @@
    i32.const 0
    i32.const 1040
    i32.const 12
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/features/mutable-globals.untouched.wat
+++ b/tests/compiler/features/mutable-globals.untouched.wat
@@ -21,7 +21,7 @@
    i32.const 0
    i32.const 32
    i32.const 5
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33,7 +33,7 @@
    i32.const 0
    i32.const 32
    i32.const 6
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -53,7 +53,7 @@
    i32.const 0
    i32.const 32
    i32.const 11
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -65,7 +65,7 @@
    i32.const 0
    i32.const 32
    i32.const 12
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/features/reference-types.optimized.wat
+++ b/tests/compiler/features/reference-types.optimized.wat
@@ -39,7 +39,7 @@
    i32.const 0
    i32.const 1040
    i32.const 19
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -58,7 +58,7 @@
    i32.const 0
    i32.const 1040
    i32.const 32
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/features/reference-types.untouched.wat
+++ b/tests/compiler/features/reference-types.untouched.wat
@@ -38,7 +38,7 @@
    i32.const 0
    i32.const 32
    i32.const 19
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -59,7 +59,7 @@
    i32.const 0
    i32.const 32
    i32.const 32
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -74,7 +74,7 @@
    i32.const 0
    i32.const 32
    i32.const 34
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -89,7 +89,7 @@
    i32.const 0
    i32.const 32
    i32.const 36
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -102,7 +102,7 @@
    i32.const 0
    i32.const 32
    i32.const 39
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -117,7 +117,7 @@
    i32.const 0
    i32.const 32
    i32.const 41
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -132,7 +132,7 @@
    i32.const 0
    i32.const 32
    i32.const 43
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/features/simd.optimized.wat
+++ b/tests/compiler/features/simd.optimized.wat
@@ -89,7 +89,7 @@
    i32.const 0
    i32.const 1040
    i32.const 70
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -104,7 +104,7 @@
    i32.const 0
    i32.const 1040
    i32.const 72
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/features/simd.untouched.wat
+++ b/tests/compiler/features/simd.untouched.wat
@@ -144,7 +144,7 @@
    i32.const 0
    i32.const 32
    i32.const 70
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -161,7 +161,7 @@
    i32.const 0
    i32.const 32
    i32.const 72
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -210,7 +210,7 @@
    i32.const 0
    i32.const 80
    i32.const 61
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -228,7 +228,7 @@
    i32.const 0
    i32.const 80
    i32.const 63
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -247,7 +247,7 @@
    i32.const 0
    i32.const 80
    i32.const 65
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -264,7 +264,7 @@
    i32.const 0
    i32.const 80
    i32.const 66
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -281,7 +281,7 @@
    i32.const 0
    i32.const 80
    i32.const 67
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -297,7 +297,7 @@
    i32.const 0
    i32.const 80
    i32.const 108
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -314,7 +314,7 @@
    i32.const 0
    i32.const 80
    i32.const 113
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -331,7 +331,7 @@
    i32.const 0
    i32.const 80
    i32.const 114
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -346,7 +346,7 @@
    i32.const 0
    i32.const 80
    i32.const 115
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -363,7 +363,7 @@
    i32.const 0
    i32.const 80
    i32.const 116
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -380,7 +380,7 @@
    i32.const 0
    i32.const 80
    i32.const 121
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -412,7 +412,7 @@
    i32.const 0
    i32.const 80
    i32.const 159
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -429,7 +429,7 @@
    i32.const 0
    i32.const 80
    i32.const 160
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -446,7 +446,7 @@
    i32.const 0
    i32.const 80
    i32.const 161
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -463,7 +463,7 @@
    i32.const 0
    i32.const 80
    i32.const 162
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -480,7 +480,7 @@
    i32.const 0
    i32.const 80
    i32.const 163
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -497,7 +497,7 @@
    i32.const 0
    i32.const 80
    i32.const 164
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -514,7 +514,7 @@
    i32.const 0
    i32.const 80
    i32.const 165
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -531,7 +531,7 @@
    i32.const 0
    i32.const 80
    i32.const 166
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -548,7 +548,7 @@
    i32.const 0
    i32.const 80
    i32.const 167
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -565,7 +565,7 @@
    i32.const 0
    i32.const 80
    i32.const 168
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -591,7 +591,7 @@
    i32.const 0
    i32.const 80
    i32.const 175
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -609,7 +609,7 @@
    i32.const 0
    i32.const 80
    i32.const 177
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -628,7 +628,7 @@
    i32.const 0
    i32.const 80
    i32.const 179
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -645,7 +645,7 @@
    i32.const 0
    i32.const 80
    i32.const 180
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -662,7 +662,7 @@
    i32.const 0
    i32.const 80
    i32.const 181
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -678,7 +678,7 @@
    i32.const 0
    i32.const 80
    i32.const 222
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -695,7 +695,7 @@
    i32.const 0
    i32.const 80
    i32.const 227
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -712,7 +712,7 @@
    i32.const 0
    i32.const 80
    i32.const 228
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -727,7 +727,7 @@
    i32.const 0
    i32.const 80
    i32.const 229
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -744,7 +744,7 @@
    i32.const 0
    i32.const 80
    i32.const 230
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -761,7 +761,7 @@
    i32.const 0
    i32.const 80
    i32.const 235
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -793,7 +793,7 @@
    i32.const 0
    i32.const 80
    i32.const 273
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -810,7 +810,7 @@
    i32.const 0
    i32.const 80
    i32.const 274
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -827,7 +827,7 @@
    i32.const 0
    i32.const 80
    i32.const 275
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -844,7 +844,7 @@
    i32.const 0
    i32.const 80
    i32.const 276
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -861,7 +861,7 @@
    i32.const 0
    i32.const 80
    i32.const 277
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -878,7 +878,7 @@
    i32.const 0
    i32.const 80
    i32.const 278
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -895,7 +895,7 @@
    i32.const 0
    i32.const 80
    i32.const 279
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -912,7 +912,7 @@
    i32.const 0
    i32.const 80
    i32.const 280
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -929,7 +929,7 @@
    i32.const 0
    i32.const 80
    i32.const 281
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -946,7 +946,7 @@
    i32.const 0
    i32.const 80
    i32.const 282
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -972,7 +972,7 @@
    i32.const 0
    i32.const 80
    i32.const 316
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -990,7 +990,7 @@
    i32.const 0
    i32.const 80
    i32.const 318
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1009,7 +1009,7 @@
    i32.const 0
    i32.const 80
    i32.const 320
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1026,7 +1026,7 @@
    i32.const 0
    i32.const 80
    i32.const 321
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1043,7 +1043,7 @@
    i32.const 0
    i32.const 80
    i32.const 322
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1059,7 +1059,7 @@
    i32.const 0
    i32.const 80
    i32.const 363
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1072,7 +1072,7 @@
    i32.const 0
    i32.const 80
    i32.const 368
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1085,7 +1085,7 @@
    i32.const 0
    i32.const 80
    i32.const 369
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1102,7 +1102,7 @@
    i32.const 0
    i32.const 80
    i32.const 370
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1119,7 +1119,7 @@
    i32.const 0
    i32.const 80
    i32.const 375
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1151,7 +1151,7 @@
    i32.const 0
    i32.const 80
    i32.const 389
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1168,7 +1168,7 @@
    i32.const 0
    i32.const 80
    i32.const 390
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1185,7 +1185,7 @@
    i32.const 0
    i32.const 80
    i32.const 391
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1202,7 +1202,7 @@
    i32.const 0
    i32.const 80
    i32.const 392
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1219,7 +1219,7 @@
    i32.const 0
    i32.const 80
    i32.const 393
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1236,7 +1236,7 @@
    i32.const 0
    i32.const 80
    i32.const 394
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1253,7 +1253,7 @@
    i32.const 0
    i32.const 80
    i32.const 395
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1270,7 +1270,7 @@
    i32.const 0
    i32.const 80
    i32.const 396
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1287,7 +1287,7 @@
    i32.const 0
    i32.const 80
    i32.const 397
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1304,7 +1304,7 @@
    i32.const 0
    i32.const 80
    i32.const 398
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1326,7 +1326,7 @@
    i32.const 0
    i32.const 80
    i32.const 436
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1344,7 +1344,7 @@
    i32.const 0
    i32.const 80
    i32.const 438
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1363,7 +1363,7 @@
    i32.const 0
    i32.const 80
    i32.const 440
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1380,7 +1380,7 @@
    i32.const 0
    i32.const 80
    i32.const 441
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1396,7 +1396,7 @@
    i32.const 0
    i32.const 80
    i32.const 442
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1409,7 +1409,7 @@
    i32.const 0
    i32.const 80
    i32.const 447
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1422,7 +1422,7 @@
    i32.const 0
    i32.const 80
    i32.const 448
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1439,7 +1439,7 @@
    i32.const 0
    i32.const 80
    i32.const 449
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1456,7 +1456,7 @@
    i32.const 0
    i32.const 80
    i32.const 454
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1483,7 +1483,7 @@
    i32.const 0
    i32.const 80
    i32.const 495
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1501,7 +1501,7 @@
    i32.const 0
    i32.const 80
    i32.const 497
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1520,7 +1520,7 @@
    i32.const 0
    i32.const 80
    i32.const 499
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1537,7 +1537,7 @@
    i32.const 0
    i32.const 80
    i32.const 500
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1554,7 +1554,7 @@
    i32.const 0
    i32.const 80
    i32.const 501
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1575,7 +1575,7 @@
    i32.const 0
    i32.const 80
    i32.const 503
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1592,7 +1592,7 @@
    i32.const 0
    i32.const 80
    i32.const 504
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1608,7 +1608,7 @@
    i32.const 0
    i32.const 80
    i32.const 505
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1621,7 +1621,7 @@
    i32.const 0
    i32.const 80
    i32.const 506
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1634,7 +1634,7 @@
    i32.const 0
    i32.const 80
    i32.const 507
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1651,7 +1651,7 @@
    i32.const 0
    i32.const 80
    i32.const 508
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1668,7 +1668,7 @@
    i32.const 0
    i32.const 80
    i32.const 513
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1699,7 +1699,7 @@
    i32.const 0
    i32.const 80
    i32.const 522
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1716,7 +1716,7 @@
    i32.const 0
    i32.const 80
    i32.const 523
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1733,7 +1733,7 @@
    i32.const 0
    i32.const 80
    i32.const 524
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1750,7 +1750,7 @@
    i32.const 0
    i32.const 80
    i32.const 525
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1767,7 +1767,7 @@
    i32.const 0
    i32.const 80
    i32.const 526
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1784,7 +1784,7 @@
    i32.const 0
    i32.const 80
    i32.const 527
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1801,7 +1801,7 @@
    i32.const 0
    i32.const 80
    i32.const 528
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1818,7 +1818,7 @@
    i32.const 0
    i32.const 80
    i32.const 529
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1834,7 +1834,7 @@
    i32.const 0
    i32.const 80
    i32.const 530
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1861,7 +1861,7 @@
    i32.const 0
    i32.const 80
    i32.const 557
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1879,7 +1879,7 @@
    i32.const 0
    i32.const 80
    i32.const 559
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1898,7 +1898,7 @@
    i32.const 0
    i32.const 80
    i32.const 561
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1915,7 +1915,7 @@
    i32.const 0
    i32.const 80
    i32.const 562
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1932,7 +1932,7 @@
    i32.const 0
    i32.const 80
    i32.const 563
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1953,7 +1953,7 @@
    i32.const 0
    i32.const 80
    i32.const 565
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1970,7 +1970,7 @@
    i32.const 0
    i32.const 80
    i32.const 566
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1986,7 +1986,7 @@
    i32.const 0
    i32.const 80
    i32.const 567
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1999,7 +1999,7 @@
    i32.const 0
    i32.const 80
    i32.const 568
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2012,7 +2012,7 @@
    i32.const 0
    i32.const 80
    i32.const 569
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2029,7 +2029,7 @@
    i32.const 0
    i32.const 80
    i32.const 570
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2046,7 +2046,7 @@
    i32.const 0
    i32.const 80
    i32.const 575
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2077,7 +2077,7 @@
    i32.const 0
    i32.const 80
    i32.const 584
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2094,7 +2094,7 @@
    i32.const 0
    i32.const 80
    i32.const 585
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2111,7 +2111,7 @@
    i32.const 0
    i32.const 80
    i32.const 586
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2128,7 +2128,7 @@
    i32.const 0
    i32.const 80
    i32.const 587
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2145,7 +2145,7 @@
    i32.const 0
    i32.const 80
    i32.const 588
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2162,7 +2162,7 @@
    i32.const 0
    i32.const 80
    i32.const 589
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2179,7 +2179,7 @@
    i32.const 0
    i32.const 80
    i32.const 590
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2196,7 +2196,7 @@
    i32.const 0
    i32.const 80
    i32.const 591
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2212,7 +2212,7 @@
    i32.const 0
    i32.const 80
    i32.const 592
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2238,7 +2238,7 @@
    i32.const 0
    i32.const 80
    i32.const 620
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2257,7 +2257,7 @@
    i32.const 0
    i32.const 80
    i32.const 626
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/for.optimized.wat
+++ b/tests/compiler/for.optimized.wat
@@ -73,7 +73,7 @@
    i32.const 0
    i32.const 1040
    i32.const 120
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -84,7 +84,7 @@
    i32.const 0
    i32.const 1040
    i32.const 121
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -95,7 +95,7 @@
    i32.const 0
    i32.const 1040
    i32.const 122
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -117,7 +117,7 @@
    i32.const 0
    i32.const 1072
    i32.const 277
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -139,7 +139,7 @@
    i32.const 0
    i32.const 1072
    i32.const 279
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -182,7 +182,7 @@
    i32.const 0
    i32.const 1072
    i32.const 292
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -278,7 +278,7 @@
    i32.const 0
    i32.const 1072
    i32.const 205
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -292,7 +292,7 @@
    i32.const 0
    i32.const 1072
    i32.const 207
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -365,7 +365,7 @@
     i32.const 0
     i32.const 1072
     i32.const 228
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -420,7 +420,7 @@
    i32.const 0
    i32.const 1072
    i32.const 243
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -435,7 +435,7 @@
    i32.const 0
    i32.const 1072
    i32.const 244
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -483,7 +483,7 @@
    i32.const 0
    i32.const 1072
    i32.const 260
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -566,7 +566,7 @@
    i32.const 0
    i32.const 1072
    i32.const 386
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -583,7 +583,7 @@
     i32.const 0
     i32.const 1072
     i32.const 396
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -611,7 +611,7 @@
     i32.const 0
     i32.const 1072
     i32.const 408
-    i32.const 4
+    i32.const 5
     call $~lib/builtins/abort
     unreachable
    end
@@ -782,7 +782,7 @@
      i32.const 0
      i32.const 1072
      i32.const 351
-     i32.const 17
+     i32.const 18
      call $~lib/builtins/abort
      unreachable
     end
@@ -811,7 +811,7 @@
    i32.const 0
    i32.const 1072
    i32.const 501
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -881,7 +881,7 @@
      i32.const 0
      i32.const 1072
      i32.const 513
-     i32.const 19
+     i32.const 20
      call $~lib/builtins/abort
      unreachable
     end
@@ -897,7 +897,7 @@
    i32.const 0
    i32.const 1072
    i32.const 521
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1004,7 +1004,7 @@
     i32.const 0
     i32.const 1184
     i32.const 109
-    i32.const 2
+    i32.const 3
     call $~lib/builtins/abort
     unreachable
    end
@@ -1023,7 +1023,7 @@
     i32.const 0
     i32.const 1184
     i32.const 112
-    i32.const 13
+    i32.const 14
     call $~lib/builtins/abort
     unreachable
    end
@@ -1067,7 +1067,7 @@
    i32.const 0
    i32.const 1040
    i32.const 8
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1096,7 +1096,7 @@
    i32.const 0
    i32.const 1040
    i32.const 19
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1123,7 +1123,7 @@
    i32.const 0
    i32.const 1040
    i32.const 29
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1152,7 +1152,7 @@
    i32.const 0
    i32.const 1040
    i32.const 39
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1174,7 +1174,7 @@
    i32.const 0
    i32.const 1040
    i32.const 49
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1200,7 +1200,7 @@
    i32.const 0
    i32.const 1040
    i32.const 61
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1233,7 +1233,7 @@
    i32.const 0
    i32.const 1040
    i32.const 80
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1256,7 +1256,7 @@
    i32.const 0
    i32.const 1040
    i32.const 127
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1299,7 +1299,7 @@
    i32.const 0
    i32.const 1040
    i32.const 137
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1308,7 +1308,7 @@
    i32.const 0
    i32.const 1040
    i32.const 138
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1322,7 +1322,7 @@
    i32.const 0
    i32.const 1040
    i32.const 143
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1370,7 +1370,7 @@
    i32.const 0
    i32.const 1040
    i32.const 157
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1379,7 +1379,7 @@
    i32.const 0
    i32.const 1040
    i32.const 158
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1393,7 +1393,7 @@
    i32.const 0
    i32.const 1040
    i32.const 163
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1427,7 +1427,7 @@
    i32.const 0
    i32.const 1184
    i32.const 122
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1472,7 +1472,7 @@
     i32.const 0
     i32.const 1184
     i32.const 126
-    i32.const 17
+    i32.const 18
     call $~lib/builtins/abort
     unreachable
    end
@@ -1495,7 +1495,7 @@
     i32.const 0
     i32.const 1184
     i32.const 136
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end

--- a/tests/compiler/for.untouched.wat
+++ b/tests/compiler/for.untouched.wat
@@ -55,7 +55,7 @@
    i32.const 0
    i32.const 32
    i32.const 8
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -89,7 +89,7 @@
    i32.const 0
    i32.const 32
    i32.const 19
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -124,7 +124,7 @@
    i32.const 0
    i32.const 32
    i32.const 29
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -164,7 +164,7 @@
    i32.const 0
    i32.const 32
    i32.const 39
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -203,7 +203,7 @@
    i32.const 0
    i32.const 32
    i32.const 49
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -242,7 +242,7 @@
    i32.const 0
    i32.const 32
    i32.const 61
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -283,7 +283,7 @@
    i32.const 0
    i32.const 32
    i32.const 80
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -315,7 +315,7 @@
    i32.const 0
    i32.const 32
    i32.const 89
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -345,7 +345,7 @@
    i32.const 0
    i32.const 32
    i32.const 101
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -420,7 +420,7 @@
    i32.const 0
    i32.const 32
    i32.const 120
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -432,7 +432,7 @@
    i32.const 0
    i32.const 32
    i32.const 121
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -444,7 +444,7 @@
    i32.const 0
    i32.const 32
    i32.const 122
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -473,7 +473,7 @@
    i32.const 0
    i32.const 64
    i32.const 277
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -498,7 +498,7 @@
    i32.const 0
    i32.const 64
    i32.const 279
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -550,7 +550,7 @@
    i32.const 0
    i32.const 64
    i32.const 292
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -680,7 +680,7 @@
    i32.const 0
    i32.const 64
    i32.const 205
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -695,7 +695,7 @@
    i32.const 0
    i32.const 64
    i32.const 207
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -788,7 +788,7 @@
     i32.const 0
     i32.const 64
     i32.const 228
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -851,7 +851,7 @@
    i32.const 0
    i32.const 64
    i32.const 243
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -867,7 +867,7 @@
    i32.const 0
    i32.const 64
    i32.const 244
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -924,7 +924,7 @@
    i32.const 0
    i32.const 64
    i32.const 260
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1043,7 +1043,7 @@
    i32.const 0
    i32.const 64
    i32.const 386
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -1066,7 +1066,7 @@
     i32.const 0
     i32.const 64
     i32.const 396
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -1097,7 +1097,7 @@
     i32.const 0
     i32.const 64
     i32.const 408
-    i32.const 4
+    i32.const 5
     call $~lib/builtins/abort
     unreachable
    end
@@ -1323,7 +1323,7 @@
    i32.const 112
    i32.const 64
    i32.const 461
-   i32.const 29
+   i32.const 30
    call $~lib/builtins/abort
    unreachable
   end
@@ -1417,7 +1417,7 @@
    i32.const 0
    i32.const 64
    i32.const 338
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1480,7 +1480,7 @@
      i32.const 0
      i32.const 64
      i32.const 351
-     i32.const 17
+     i32.const 18
      call $~lib/builtins/abort
      unreachable
     end
@@ -1625,7 +1625,7 @@
    i32.const 0
    i32.const 64
    i32.const 365
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1714,7 +1714,7 @@
    i32.const 0
    i32.const 64
    i32.const 501
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1755,7 +1755,7 @@
       i32.const 0
       i32.const 64
       i32.const 513
-      i32.const 19
+      i32.const 20
       call $~lib/builtins/abort
       unreachable
      end
@@ -1774,7 +1774,7 @@
      i32.const 0
      i32.const 64
      i32.const 518
-     i32.const 17
+     i32.const 18
      call $~lib/builtins/abort
      unreachable
     end
@@ -1791,7 +1791,7 @@
    i32.const 0
    i32.const 64
    i32.const 521
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1842,7 +1842,7 @@
    i32.const 0
    i32.const 176
    i32.const 109
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1863,7 +1863,7 @@
    i32.const 0
    i32.const 176
    i32.const 112
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1960,7 +1960,7 @@
    i32.const 0
    i32.const 32
    i32.const 137
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1971,7 +1971,7 @@
    i32.const 0
    i32.const 32
    i32.const 138
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2051,7 +2051,7 @@
    i32.const 0
    i32.const 32
    i32.const 157
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2062,7 +2062,7 @@
    i32.const 0
    i32.const 32
    i32.const 158
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2081,7 +2081,7 @@
    i32.const 0
    i32.const 32
    i32.const 13
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2094,7 +2094,7 @@
    i32.const 0
    i32.const 32
    i32.const 24
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2107,7 +2107,7 @@
    i32.const 0
    i32.const 32
    i32.const 34
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2120,7 +2120,7 @@
    i32.const 0
    i32.const 32
    i32.const 44
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2133,7 +2133,7 @@
    i32.const 0
    i32.const 32
    i32.const 54
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2146,7 +2146,7 @@
    i32.const 0
    i32.const 32
    i32.const 66
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2159,7 +2159,7 @@
    i32.const 0
    i32.const 32
    i32.const 76
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2172,7 +2172,7 @@
    i32.const 0
    i32.const 32
    i32.const 85
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2185,7 +2185,7 @@
    i32.const 0
    i32.const 32
    i32.const 94
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2198,7 +2198,7 @@
    i32.const 0
    i32.const 32
    i32.const 105
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2211,7 +2211,7 @@
    i32.const 0
    i32.const 32
    i32.const 127
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2224,7 +2224,7 @@
    i32.const 0
    i32.const 32
    i32.const 143
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2237,7 +2237,7 @@
    i32.const 0
    i32.const 32
    i32.const 163
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2293,7 +2293,7 @@
    i32.const 0
    i32.const 176
    i32.const 122
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -2315,7 +2315,7 @@
     i32.const 0
     i32.const 176
     i32.const 126
-    i32.const 17
+    i32.const 18
     call $~lib/builtins/abort
     unreachable
    end
@@ -2331,7 +2331,7 @@
     i32.const 0
     i32.const 176
     i32.const 136
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -2363,7 +2363,7 @@
    i32.const 0
    i32.const 176
    i32.const 69
-   i32.const 15
+   i32.const 16
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/function-expression.optimized.wat
+++ b/tests/compiler/function-expression.optimized.wat
@@ -63,7 +63,7 @@
    i32.const 0
    i32.const 1040
    i32.const 21
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -75,7 +75,7 @@
    i32.const 0
    i32.const 1040
    i32.const 22
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -87,7 +87,7 @@
    i32.const 0
    i32.const 1040
    i32.const 23
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/function-expression.untouched.wat
+++ b/tests/compiler/function-expression.untouched.wat
@@ -100,7 +100,7 @@
    i32.const 0
    i32.const 32
    i32.const 4
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -116,7 +116,7 @@
    i32.const 0
    i32.const 32
    i32.const 9
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -135,7 +135,7 @@
    i32.const 0
    i32.const 32
    i32.const 16
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -148,7 +148,7 @@
    i32.const 0
    i32.const 32
    i32.const 21
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -161,7 +161,7 @@
    i32.const 0
    i32.const 32
    i32.const 22
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -174,7 +174,7 @@
    i32.const 0
    i32.const 32
    i32.const 23
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -191,7 +191,7 @@
    i32.const 0
    i32.const 32
    i32.const 34
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -208,7 +208,7 @@
    i32.const 0
    i32.const 32
    i32.const 35
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -225,7 +225,7 @@
    i32.const 0
    i32.const 32
    i32.const 36
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -238,7 +238,7 @@
    i32.const 0
    i32.const 32
    i32.const 45
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/function-types.optimized.wat
+++ b/tests/compiler/function-types.optimized.wat
@@ -65,7 +65,7 @@
    i32.const 0
    i32.const 1040
    i32.const 23
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -81,7 +81,7 @@
    i32.const 0
    i32.const 1040
    i32.const 35
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -97,7 +97,7 @@
    i32.const 0
    i32.const 1040
    i32.const 41
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -111,7 +111,7 @@
    i32.const 0
    i32.const 1040
    i32.const 42
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/function-types.untouched.wat
+++ b/tests/compiler/function-types.untouched.wat
@@ -110,7 +110,7 @@
    i32.const 0
    i32.const 32
    i32.const 11
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -129,7 +129,7 @@
    i32.const 0
    i32.const 32
    i32.const 15
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -146,7 +146,7 @@
    i32.const 0
    i32.const 32
    i32.const 17
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -161,7 +161,7 @@
    i32.const 0
    i32.const 32
    i32.const 23
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -175,7 +175,7 @@
    i32.const 0
    i32.const 32
    i32.const 29
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -190,7 +190,7 @@
    i32.const 0
    i32.const 32
    i32.const 35
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -207,7 +207,7 @@
    i32.const 0
    i32.const 32
    i32.const 41
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -222,7 +222,7 @@
    i32.const 0
    i32.const 32
    i32.const 42
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/getter-setter.optimized.wat
+++ b/tests/compiler/getter-setter.optimized.wat
@@ -13,7 +13,7 @@
    i32.const 0
    i32.const 1040
    i32.const 13
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/getter-setter.untouched.wat
+++ b/tests/compiler/getter-setter.untouched.wat
@@ -26,7 +26,7 @@
    i32.const 0
    i32.const 32
    i32.const 13
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40,7 +40,7 @@
    i32.const 0
    i32.const 32
    i32.const 15
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -54,7 +54,7 @@
    i32.const 0
    i32.const 32
    i32.const 16
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/if.optimized.wat
+++ b/tests/compiler/if.optimized.wat
@@ -34,7 +34,7 @@
    i32.const 1072
    i32.const 1040
    i32.const 37
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -46,7 +46,7 @@
    i32.const 0
    i32.const 1040
    i32.const 17
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -58,7 +58,7 @@
    i32.const 0
    i32.const 1040
    i32.const 18
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/if.untouched.wat
+++ b/tests/compiler/if.untouched.wat
@@ -53,7 +53,7 @@
    i32.const 0
    i32.const 32
    i32.const 8
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -66,7 +66,7 @@
    i32.const 0
    i32.const 32
    i32.const 9
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -79,7 +79,7 @@
    i32.const 0
    i32.const 32
    i32.const 17
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -92,7 +92,7 @@
    i32.const 0
    i32.const 32
    i32.const 18
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -105,7 +105,7 @@
    i32.const 0
    i32.const 32
    i32.const 30
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -118,7 +118,7 @@
    i32.const 0
    i32.const 32
    i32.const 31
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -132,7 +132,7 @@
    i32.const 64
    i32.const 32
    i32.const 37
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/implicit-getter-setter.optimized.wat
+++ b/tests/compiler/implicit-getter-setter.optimized.wat
@@ -52,7 +52,7 @@
    i32.const 0
    i32.const 1040
    i32.const 277
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -74,7 +74,7 @@
    i32.const 0
    i32.const 1040
    i32.const 279
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -117,7 +117,7 @@
    i32.const 0
    i32.const 1040
    i32.const 292
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -213,7 +213,7 @@
    i32.const 0
    i32.const 1040
    i32.const 205
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -227,7 +227,7 @@
    i32.const 0
    i32.const 1040
    i32.const 207
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -300,7 +300,7 @@
     i32.const 0
     i32.const 1040
     i32.const 228
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -355,7 +355,7 @@
    i32.const 0
    i32.const 1040
    i32.const 243
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -370,7 +370,7 @@
    i32.const 0
    i32.const 1040
    i32.const 244
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -418,7 +418,7 @@
    i32.const 0
    i32.const 1040
    i32.const 260
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -501,7 +501,7 @@
    i32.const 0
    i32.const 1040
    i32.const 386
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -518,7 +518,7 @@
     i32.const 0
     i32.const 1040
     i32.const 396
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -546,7 +546,7 @@
     i32.const 0
     i32.const 1040
     i32.const 408
-    i32.const 4
+    i32.const 5
     call $~lib/builtins/abort
     unreachable
    end
@@ -736,7 +736,7 @@
    i32.const 0
    i32.const 1040
    i32.const 338
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -788,7 +788,7 @@
      i32.const 0
      i32.const 1040
      i32.const 351
-     i32.const 17
+     i32.const 18
      call $~lib/builtins/abort
      unreachable
     end
@@ -821,7 +821,7 @@
    i32.const 0
    i32.const 1040
    i32.const 365
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -892,7 +892,7 @@
    i32.const 0
    i32.const 1040
    i32.const 501
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -903,7 +903,7 @@
    i32.const 1088
    i32.const 1040
    i32.const 461
-   i32.const 29
+   i32.const 30
    call $~lib/builtins/abort
    unreachable
   end
@@ -1003,7 +1003,7 @@
      i32.const 0
      i32.const 1040
      i32.const 513
-     i32.const 19
+     i32.const 20
      call $~lib/builtins/abort
      unreachable
     end
@@ -1019,7 +1019,7 @@
    i32.const 0
    i32.const 1040
    i32.const 521
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1076,7 +1076,7 @@
     i32.const 0
     i32.const 1152
     i32.const 109
-    i32.const 2
+    i32.const 3
     call $~lib/builtins/abort
     unreachable
    end
@@ -1095,7 +1095,7 @@
     i32.const 0
     i32.const 1152
     i32.const 112
-    i32.const 13
+    i32.const 14
     call $~lib/builtins/abort
     unreachable
    end
@@ -1199,7 +1199,7 @@
    i32.const 0
    i32.const 1152
    i32.const 122
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1244,7 +1244,7 @@
     i32.const 0
     i32.const 1152
     i32.const 126
-    i32.const 17
+    i32.const 18
     call $~lib/builtins/abort
     unreachable
    end
@@ -1267,7 +1267,7 @@
     i32.const 0
     i32.const 1152
     i32.const 136
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end

--- a/tests/compiler/implicit-getter-setter.untouched.wat
+++ b/tests/compiler/implicit-getter-setter.untouched.wat
@@ -63,7 +63,7 @@
    i32.const 0
    i32.const 32
    i32.const 277
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -88,7 +88,7 @@
    i32.const 0
    i32.const 32
    i32.const 279
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -140,7 +140,7 @@
    i32.const 0
    i32.const 32
    i32.const 292
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -270,7 +270,7 @@
    i32.const 0
    i32.const 32
    i32.const 205
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -285,7 +285,7 @@
    i32.const 0
    i32.const 32
    i32.const 207
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -378,7 +378,7 @@
     i32.const 0
     i32.const 32
     i32.const 228
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -441,7 +441,7 @@
    i32.const 0
    i32.const 32
    i32.const 243
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -457,7 +457,7 @@
    i32.const 0
    i32.const 32
    i32.const 244
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -514,7 +514,7 @@
    i32.const 0
    i32.const 32
    i32.const 260
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -633,7 +633,7 @@
    i32.const 0
    i32.const 32
    i32.const 386
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -656,7 +656,7 @@
     i32.const 0
     i32.const 32
     i32.const 396
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -687,7 +687,7 @@
     i32.const 0
     i32.const 32
     i32.const 408
-    i32.const 4
+    i32.const 5
     call $~lib/builtins/abort
     unreachable
    end
@@ -913,7 +913,7 @@
    i32.const 80
    i32.const 32
    i32.const 461
-   i32.const 29
+   i32.const 30
    call $~lib/builtins/abort
    unreachable
   end
@@ -1007,7 +1007,7 @@
    i32.const 0
    i32.const 32
    i32.const 338
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1070,7 +1070,7 @@
      i32.const 0
      i32.const 32
      i32.const 351
-     i32.const 17
+     i32.const 18
      call $~lib/builtins/abort
      unreachable
     end
@@ -1215,7 +1215,7 @@
    i32.const 0
    i32.const 32
    i32.const 365
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1304,7 +1304,7 @@
    i32.const 0
    i32.const 32
    i32.const 501
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1345,7 +1345,7 @@
       i32.const 0
       i32.const 32
       i32.const 513
-      i32.const 19
+      i32.const 20
       call $~lib/builtins/abort
       unreachable
      end
@@ -1364,7 +1364,7 @@
      i32.const 0
      i32.const 32
      i32.const 518
-     i32.const 17
+     i32.const 18
      call $~lib/builtins/abort
      unreachable
     end
@@ -1381,7 +1381,7 @@
    i32.const 0
    i32.const 32
    i32.const 521
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1432,7 +1432,7 @@
    i32.const 0
    i32.const 144
    i32.const 109
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1453,7 +1453,7 @@
    i32.const 0
    i32.const 144
    i32.const 112
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1590,7 +1590,7 @@
    i32.const 0
    i32.const 144
    i32.const 122
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1612,7 +1612,7 @@
     i32.const 0
     i32.const 144
     i32.const 126
-    i32.const 17
+    i32.const 18
     call $~lib/builtins/abort
     unreachable
    end
@@ -1628,7 +1628,7 @@
     i32.const 0
     i32.const 144
     i32.const 136
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -1660,7 +1660,7 @@
    i32.const 0
    i32.const 144
    i32.const 69
-   i32.const 15
+   i32.const 16
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/infer-array.optimized.wat
+++ b/tests/compiler/infer-array.optimized.wat
@@ -363,7 +363,7 @@
     i32.const 0
     i32.const 1264
     i32.const 14
-    i32.const 2
+    i32.const 3
     call $~lib/builtins/abort
     unreachable
    end
@@ -498,7 +498,7 @@
   i32.const 1072
   i32.const 1136
   i32.const 104
-  i32.const 41
+  i32.const 42
   call $~lib/builtins/abort
   unreachable
  )

--- a/tests/compiler/infer-array.untouched.wat
+++ b/tests/compiler/infer-array.untouched.wat
@@ -1455,7 +1455,7 @@
    i32.const 64
    i32.const 128
    i32.const 104
-   i32.const 41
+   i32.const 42
    call $~lib/builtins/abort
    unreachable
   end
@@ -1487,7 +1487,7 @@
    i32.const 64
    i32.const 128
    i32.const 104
-   i32.const 41
+   i32.const 42
    call $~lib/builtins/abort
    unreachable
   end
@@ -1516,7 +1516,7 @@
    i32.const 64
    i32.const 128
    i32.const 104
-   i32.const 41
+   i32.const 42
    call $~lib/builtins/abort
    unreachable
   end
@@ -1545,7 +1545,7 @@
    i32.const 64
    i32.const 128
    i32.const 104
-   i32.const 41
+   i32.const 42
    call $~lib/builtins/abort
    unreachable
   end
@@ -1587,7 +1587,7 @@
    i32.const 64
    i32.const 128
    i32.const 104
-   i32.const 41
+   i32.const 42
    call $~lib/builtins/abort
    unreachable
   end
@@ -1617,7 +1617,7 @@
    i32.const 64
    i32.const 128
    i32.const 104
-   i32.const 41
+   i32.const 42
    call $~lib/builtins/abort
    unreachable
   end
@@ -1646,7 +1646,7 @@
    i32.const 64
    i32.const 128
    i32.const 104
-   i32.const 41
+   i32.const 42
    call $~lib/builtins/abort
    unreachable
   end
@@ -1676,7 +1676,7 @@
    i32.const 64
    i32.const 128
    i32.const 104
-   i32.const 41
+   i32.const 42
    call $~lib/builtins/abort
    unreachable
   end
@@ -1692,7 +1692,7 @@
    i32.const 640
    i32.const 128
    i32.const 108
-   i32.const 39
+   i32.const 40
    call $~lib/builtins/abort
    unreachable
   end
@@ -1749,7 +1749,7 @@
    i32.const 0
    i32.const 256
    i32.const 14
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/infer-generic.untouched.wat
+++ b/tests/compiler/infer-generic.untouched.wat
@@ -119,7 +119,7 @@
    i32.const 0
    i32.const 32
    i32.const 46
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/inlining-blocklocals.optimized.wat
+++ b/tests/compiler/inlining-blocklocals.optimized.wat
@@ -30,7 +30,7 @@
    i32.const 0
    i32.const 1040
    i32.const 19
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -41,7 +41,7 @@
    i32.const 0
    i32.const 1040
    i32.const 20
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/inlining-blocklocals.untouched.wat
+++ b/tests/compiler/inlining-blocklocals.untouched.wat
@@ -51,7 +51,7 @@
    i32.const 0
    i32.const 32
    i32.const 18
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -63,7 +63,7 @@
    i32.const 0
    i32.const 32
    i32.const 19
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -75,7 +75,7 @@
    i32.const 0
    i32.const 32
    i32.const 20
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -87,7 +87,7 @@
    i32.const 0
    i32.const 32
    i32.const 21
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/inlining.optimized.wat
+++ b/tests/compiler/inlining.optimized.wat
@@ -144,7 +144,7 @@
    i32.const 0
    i32.const 1040
    i32.const 95
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -156,7 +156,7 @@
    i32.const 0
    i32.const 1040
    i32.const 96
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -168,7 +168,7 @@
    i32.const 0
    i32.const 1040
    i32.const 97
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -180,7 +180,7 @@
    i32.const 0
    i32.const 1040
    i32.const 98
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/inlining.untouched.wat
+++ b/tests/compiler/inlining.untouched.wat
@@ -76,7 +76,7 @@
    i32.const 0
    i32.const 32
    i32.const 60
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -106,7 +106,7 @@
    i32.const 0
    i32.const 32
    i32.const 61
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -136,7 +136,7 @@
    i32.const 0
    i32.const 32
    i32.const 62
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -150,7 +150,7 @@
    i32.const 0
    i32.const 32
    i32.const 63
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -164,7 +164,7 @@
    i32.const 0
    i32.const 32
    i32.const 64
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -188,7 +188,7 @@
    i32.const 0
    i32.const 32
    i32.const 65
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -212,7 +212,7 @@
    i32.const 0
    i32.const 32
    i32.const 66
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -230,7 +230,7 @@
    i32.const 0
    i32.const 32
    i32.const 68
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -248,7 +248,7 @@
    i32.const 0
    i32.const 32
    i32.const 69
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -271,7 +271,7 @@
    i32.const 0
    i32.const 32
    i32.const 71
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -449,7 +449,7 @@
    i32.const 0
    i32.const 32
    i32.const 95
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -462,7 +462,7 @@
    i32.const 0
    i32.const 32
    i32.const 96
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -475,7 +475,7 @@
    i32.const 0
    i32.const 32
    i32.const 97
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -488,7 +488,7 @@
    i32.const 0
    i32.const 32
    i32.const 98
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -504,7 +504,7 @@
    i32.const 0
    i32.const 32
    i32.const 10
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/instanceof-class.optimized.wat
+++ b/tests/compiler/instanceof-class.optimized.wat
@@ -133,7 +133,7 @@
    i32.const 0
    i32.const 1040
    i32.const 17
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/instanceof-class.untouched.wat
+++ b/tests/compiler/instanceof-class.untouched.wat
@@ -205,7 +205,7 @@
    i32.const 0
    i32.const 32
    i32.const 17
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/instanceof.optimized.wat
+++ b/tests/compiler/instanceof.optimized.wat
@@ -13,7 +13,7 @@
    i32.const 0
    i32.const 1040
    i32.const 68
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/instanceof.untouched.wat
+++ b/tests/compiler/instanceof.untouched.wat
@@ -49,7 +49,7 @@
    i32.const 0
    i32.const 32
    i32.const 62
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -61,7 +61,7 @@
    i32.const 0
    i32.const 32
    i32.const 63
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -73,7 +73,7 @@
    i32.const 0
    i32.const 32
    i32.const 64
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -85,7 +85,7 @@
    i32.const 0
    i32.const 32
    i32.const 65
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -98,7 +98,7 @@
    i32.const 0
    i32.const 32
    i32.const 68
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -124,7 +124,7 @@
    i32.const 0
    i32.const 32
    i32.const 71
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/issues/1095.optimized.wat
+++ b/tests/compiler/issues/1095.optimized.wat
@@ -36,7 +36,7 @@
    i32.const 0
    i32.const 1040
    i32.const 277
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -58,7 +58,7 @@
    i32.const 0
    i32.const 1040
    i32.const 279
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -101,7 +101,7 @@
    i32.const 0
    i32.const 1040
    i32.const 292
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -197,7 +197,7 @@
    i32.const 0
    i32.const 1040
    i32.const 205
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -211,7 +211,7 @@
    i32.const 0
    i32.const 1040
    i32.const 207
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -284,7 +284,7 @@
     i32.const 0
     i32.const 1040
     i32.const 228
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -339,7 +339,7 @@
    i32.const 0
    i32.const 1040
    i32.const 243
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -354,7 +354,7 @@
    i32.const 0
    i32.const 1040
    i32.const 244
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -402,7 +402,7 @@
    i32.const 0
    i32.const 1040
    i32.const 260
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -485,7 +485,7 @@
    i32.const 0
    i32.const 1040
    i32.const 386
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -502,7 +502,7 @@
     i32.const 0
     i32.const 1040
     i32.const 396
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -530,7 +530,7 @@
     i32.const 0
     i32.const 1040
     i32.const 408
-    i32.const 4
+    i32.const 5
     call $~lib/builtins/abort
     unreachable
    end
@@ -701,7 +701,7 @@
      i32.const 0
      i32.const 1040
      i32.const 351
-     i32.const 17
+     i32.const 18
      call $~lib/builtins/abort
      unreachable
     end
@@ -730,7 +730,7 @@
    i32.const 0
    i32.const 1040
    i32.const 501
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -800,7 +800,7 @@
      i32.const 0
      i32.const 1040
      i32.const 513
-     i32.const 19
+     i32.const 20
      call $~lib/builtins/abort
      unreachable
     end
@@ -816,7 +816,7 @@
    i32.const 0
    i32.const 1040
    i32.const 521
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -918,7 +918,7 @@
     i32.const 0
     i32.const 1152
     i32.const 109
-    i32.const 2
+    i32.const 3
     call $~lib/builtins/abort
     unreachable
    end
@@ -937,7 +937,7 @@
     i32.const 0
     i32.const 1152
     i32.const 112
-    i32.const 13
+    i32.const 14
     call $~lib/builtins/abort
     unreachable
    end
@@ -975,7 +975,7 @@
    i32.const 0
    i32.const 1232
    i32.const 8
-   i32.const 12
+   i32.const 13
    call $~lib/builtins/abort
    unreachable
   end
@@ -1016,7 +1016,7 @@
    i32.const 0
    i32.const 1152
    i32.const 122
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1061,7 +1061,7 @@
     i32.const 0
     i32.const 1152
     i32.const 126
-    i32.const 17
+    i32.const 18
     call $~lib/builtins/abort
     unreachable
    end
@@ -1084,7 +1084,7 @@
     i32.const 0
     i32.const 1152
     i32.const 136
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end

--- a/tests/compiler/issues/1095.untouched.wat
+++ b/tests/compiler/issues/1095.untouched.wat
@@ -49,7 +49,7 @@
    i32.const 0
    i32.const 32
    i32.const 277
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -74,7 +74,7 @@
    i32.const 0
    i32.const 32
    i32.const 279
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -126,7 +126,7 @@
    i32.const 0
    i32.const 32
    i32.const 292
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -256,7 +256,7 @@
    i32.const 0
    i32.const 32
    i32.const 205
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -271,7 +271,7 @@
    i32.const 0
    i32.const 32
    i32.const 207
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -364,7 +364,7 @@
     i32.const 0
     i32.const 32
     i32.const 228
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -427,7 +427,7 @@
    i32.const 0
    i32.const 32
    i32.const 243
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -443,7 +443,7 @@
    i32.const 0
    i32.const 32
    i32.const 244
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -500,7 +500,7 @@
    i32.const 0
    i32.const 32
    i32.const 260
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -619,7 +619,7 @@
    i32.const 0
    i32.const 32
    i32.const 386
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -642,7 +642,7 @@
     i32.const 0
     i32.const 32
     i32.const 396
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -673,7 +673,7 @@
     i32.const 0
     i32.const 32
     i32.const 408
-    i32.const 4
+    i32.const 5
     call $~lib/builtins/abort
     unreachable
    end
@@ -899,7 +899,7 @@
    i32.const 80
    i32.const 32
    i32.const 461
-   i32.const 29
+   i32.const 30
    call $~lib/builtins/abort
    unreachable
   end
@@ -993,7 +993,7 @@
    i32.const 0
    i32.const 32
    i32.const 338
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1056,7 +1056,7 @@
      i32.const 0
      i32.const 32
      i32.const 351
-     i32.const 17
+     i32.const 18
      call $~lib/builtins/abort
      unreachable
     end
@@ -1201,7 +1201,7 @@
    i32.const 0
    i32.const 32
    i32.const 365
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1290,7 +1290,7 @@
    i32.const 0
    i32.const 32
    i32.const 501
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1331,7 +1331,7 @@
       i32.const 0
       i32.const 32
       i32.const 513
-      i32.const 19
+      i32.const 20
       call $~lib/builtins/abort
       unreachable
      end
@@ -1350,7 +1350,7 @@
      i32.const 0
      i32.const 32
      i32.const 518
-     i32.const 17
+     i32.const 18
      call $~lib/builtins/abort
      unreachable
     end
@@ -1367,7 +1367,7 @@
    i32.const 0
    i32.const 32
    i32.const 521
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1418,7 +1418,7 @@
    i32.const 0
    i32.const 144
    i32.const 109
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1439,7 +1439,7 @@
    i32.const 0
    i32.const 144
    i32.const 112
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1500,7 +1500,7 @@
    i32.const 0
    i32.const 224
    i32.const 8
-   i32.const 12
+   i32.const 13
    call $~lib/builtins/abort
    unreachable
   end
@@ -1574,7 +1574,7 @@
    i32.const 0
    i32.const 144
    i32.const 122
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1596,7 +1596,7 @@
     i32.const 0
     i32.const 144
     i32.const 126
-    i32.const 17
+    i32.const 18
     call $~lib/builtins/abort
     unreachable
    end
@@ -1612,7 +1612,7 @@
     i32.const 0
     i32.const 144
     i32.const 136
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -1644,7 +1644,7 @@
    i32.const 0
    i32.const 144
    i32.const 69
-   i32.const 15
+   i32.const 16
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/logical.untouched.wat
+++ b/tests/compiler/logical.untouched.wat
@@ -136,7 +136,7 @@
    i32.const 0
    i32.const 32
    i32.const 12
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -155,7 +155,7 @@
    i32.const 0
    i32.const 32
    i32.const 15
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -176,7 +176,7 @@
    i32.const 0
    i32.const 32
    i32.const 20
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -197,7 +197,7 @@
    i32.const 0
    i32.const 32
    i32.const 23
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -223,7 +223,7 @@
    i32.const 0
    i32.const 32
    i32.const 28
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -249,7 +249,7 @@
    i32.const 0
    i32.const 32
    i32.const 31
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -275,7 +275,7 @@
    i32.const 0
    i32.const 32
    i32.const 36
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -301,7 +301,7 @@
    i32.const 0
    i32.const 32
    i32.const 39
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -327,7 +327,7 @@
    i32.const 0
    i32.const 32
    i32.const 44
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -353,7 +353,7 @@
    i32.const 0
    i32.const 32
    i32.const 47
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -379,7 +379,7 @@
    i32.const 0
    i32.const 32
    i32.const 50
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -405,7 +405,7 @@
    i32.const 0
    i32.const 32
    i32.const 53
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -432,7 +432,7 @@
    i32.const 0
    i32.const 32
    i32.const 56
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -459,7 +459,7 @@
    i32.const 0
    i32.const 32
    i32.const 59
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -486,7 +486,7 @@
    i32.const 0
    i32.const 32
    i32.const 62
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -513,7 +513,7 @@
    i32.const 0
    i32.const 32
    i32.const 65
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -525,7 +525,7 @@
    i32.const 0
    i32.const 32
    i32.const 76
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -537,7 +537,7 @@
    i32.const 0
    i32.const 32
    i32.const 77
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/loop-flow.optimized.wat
+++ b/tests/compiler/loop-flow.optimized.wat
@@ -41,7 +41,7 @@
     i32.const 1088
     i32.const 1040
     i32.const 24
-    i32.const 21
+    i32.const 22
     call $~lib/builtins/abort
     unreachable
    end
@@ -65,7 +65,7 @@
      i32.const 1088
      i32.const 1040
      i32.const 54
-     i32.const 21
+     i32.const 22
      call $~lib/builtins/abort
      unreachable
     end
@@ -91,7 +91,7 @@
     i32.const 1088
     i32.const 1040
     i32.const 78
-    i32.const 21
+    i32.const 22
     call $~lib/builtins/abort
     unreachable
    end
@@ -101,7 +101,7 @@
   i32.const 1088
   i32.const 1040
   i32.const 11
-  i32.const 4
+  i32.const 5
   call $~lib/builtins/abort
   unreachable
  )
@@ -115,7 +115,7 @@
   i32.const 1088
   i32.const 1040
   i32.const 41
-  i32.const 4
+  i32.const 5
   call $~lib/builtins/abort
   unreachable
  )
@@ -123,7 +123,7 @@
   i32.const 1088
   i32.const 1040
   i32.const 71
-  i32.const 4
+  i32.const 5
   call $~lib/builtins/abort
   unreachable
  )
@@ -136,7 +136,7 @@
    i32.const 0
    i32.const 1040
    i32.const 29
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -148,7 +148,7 @@
    i32.const 0
    i32.const 1040
    i32.const 59
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -160,7 +160,7 @@
    i32.const 0
    i32.const 1040
    i32.const 83
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/loop-flow.untouched.wat
+++ b/tests/compiler/loop-flow.untouched.wat
@@ -55,7 +55,7 @@
       i32.const 80
       i32.const 32
       i32.const 24
-      i32.const 21
+      i32.const 22
       call $~lib/builtins/abort
       unreachable
      else
@@ -103,7 +103,7 @@
        i32.const 80
        i32.const 32
        i32.const 54
-       i32.const 21
+       i32.const 22
        call $~lib/builtins/abort
        unreachable
       else
@@ -141,7 +141,7 @@
      i32.const 80
      i32.const 32
      i32.const 78
-     i32.const 21
+     i32.const 22
      call $~lib/builtins/abort
      unreachable
     else
@@ -162,7 +162,7 @@
    i32.const 0
    i32.const 32
    i32.const 7
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -175,7 +175,7 @@
    i32.const 0
    i32.const 32
    i32.const 29
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -187,7 +187,7 @@
    i32.const 0
    i32.const 32
    i32.const 37
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -200,7 +200,7 @@
    i32.const 0
    i32.const 32
    i32.const 59
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -212,7 +212,7 @@
    i32.const 0
    i32.const 32
    i32.const 67
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -225,7 +225,7 @@
    i32.const 0
    i32.const 32
    i32.const 83
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -240,7 +240,7 @@
     i32.const 80
     i32.const 32
     i32.const 11
-    i32.const 4
+    i32.const 5
     call $~lib/builtins/abort
     unreachable
    end
@@ -269,7 +269,7 @@
     i32.const 80
     i32.const 32
     i32.const 41
-    i32.const 4
+    i32.const 5
     call $~lib/builtins/abort
     unreachable
    end
@@ -296,7 +296,7 @@
    i32.const 80
    i32.const 32
    i32.const 71
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/managed-cast.optimized.wat
+++ b/tests/compiler/managed-cast.optimized.wat
@@ -38,7 +38,7 @@
    i32.const 0
    i32.const 1040
    i32.const 277
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -60,7 +60,7 @@
    i32.const 0
    i32.const 1040
    i32.const 279
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -103,7 +103,7 @@
    i32.const 0
    i32.const 1040
    i32.const 292
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -199,7 +199,7 @@
    i32.const 0
    i32.const 1040
    i32.const 205
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -213,7 +213,7 @@
    i32.const 0
    i32.const 1040
    i32.const 207
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -286,7 +286,7 @@
     i32.const 0
     i32.const 1040
     i32.const 228
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -341,7 +341,7 @@
    i32.const 0
    i32.const 1040
    i32.const 243
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -356,7 +356,7 @@
    i32.const 0
    i32.const 1040
    i32.const 244
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -404,7 +404,7 @@
    i32.const 0
    i32.const 1040
    i32.const 260
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -487,7 +487,7 @@
    i32.const 0
    i32.const 1040
    i32.const 386
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -504,7 +504,7 @@
     i32.const 0
     i32.const 1040
     i32.const 396
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -532,7 +532,7 @@
     i32.const 0
     i32.const 1040
     i32.const 408
-    i32.const 4
+    i32.const 5
     call $~lib/builtins/abort
     unreachable
    end
@@ -703,7 +703,7 @@
      i32.const 0
      i32.const 1040
      i32.const 351
-     i32.const 17
+     i32.const 18
      call $~lib/builtins/abort
      unreachable
     end
@@ -731,7 +731,7 @@
    i32.const 0
    i32.const 1040
    i32.const 501
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -801,7 +801,7 @@
      i32.const 0
      i32.const 1040
      i32.const 513
-     i32.const 19
+     i32.const 20
      call $~lib/builtins/abort
      unreachable
     end
@@ -817,7 +817,7 @@
    i32.const 0
    i32.const 1040
    i32.const 521
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -926,7 +926,7 @@
     i32.const 0
     i32.const 1152
     i32.const 109
-    i32.const 2
+    i32.const 3
     call $~lib/builtins/abort
     unreachable
    end
@@ -945,7 +945,7 @@
     i32.const 0
     i32.const 1152
     i32.const 112
-    i32.const 13
+    i32.const 14
     call $~lib/builtins/abort
     unreachable
    end
@@ -1032,7 +1032,7 @@
    i32.const 0
    i32.const 1200
    i32.const 14
-   i32.const 11
+   i32.const 12
    call $~lib/builtins/abort
    unreachable
   end
@@ -1048,7 +1048,7 @@
    i32.const 0
    i32.const 1200
    i32.const 31
-   i32.const 8
+   i32.const 9
    call $~lib/builtins/abort
    unreachable
   end
@@ -1069,7 +1069,7 @@
    i32.const 0
    i32.const 1200
    i32.const 36
-   i32.const 8
+   i32.const 9
    call $~lib/builtins/abort
    unreachable
   end
@@ -1081,7 +1081,7 @@
    i32.const 0
    i32.const 1200
    i32.const 41
-   i32.const 29
+   i32.const 30
    call $~lib/builtins/abort
    unreachable
   end
@@ -1093,7 +1093,7 @@
    i32.const 0
    i32.const 1200
    i32.const 47
-   i32.const 29
+   i32.const 30
    call $~lib/builtins/abort
    unreachable
   end
@@ -1132,7 +1132,7 @@
    i32.const 0
    i32.const 1152
    i32.const 122
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1177,7 +1177,7 @@
     i32.const 0
     i32.const 1152
     i32.const 126
-    i32.const 17
+    i32.const 18
     call $~lib/builtins/abort
     unreachable
    end
@@ -1200,7 +1200,7 @@
     i32.const 0
     i32.const 1152
     i32.const 136
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end

--- a/tests/compiler/managed-cast.untouched.wat
+++ b/tests/compiler/managed-cast.untouched.wat
@@ -51,7 +51,7 @@
    i32.const 0
    i32.const 32
    i32.const 277
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -76,7 +76,7 @@
    i32.const 0
    i32.const 32
    i32.const 279
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -128,7 +128,7 @@
    i32.const 0
    i32.const 32
    i32.const 292
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -258,7 +258,7 @@
    i32.const 0
    i32.const 32
    i32.const 205
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -273,7 +273,7 @@
    i32.const 0
    i32.const 32
    i32.const 207
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -366,7 +366,7 @@
     i32.const 0
     i32.const 32
     i32.const 228
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -429,7 +429,7 @@
    i32.const 0
    i32.const 32
    i32.const 243
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -445,7 +445,7 @@
    i32.const 0
    i32.const 32
    i32.const 244
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -502,7 +502,7 @@
    i32.const 0
    i32.const 32
    i32.const 260
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -621,7 +621,7 @@
    i32.const 0
    i32.const 32
    i32.const 386
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -644,7 +644,7 @@
     i32.const 0
     i32.const 32
     i32.const 396
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -675,7 +675,7 @@
     i32.const 0
     i32.const 32
     i32.const 408
-    i32.const 4
+    i32.const 5
     call $~lib/builtins/abort
     unreachable
    end
@@ -901,7 +901,7 @@
    i32.const 80
    i32.const 32
    i32.const 461
-   i32.const 29
+   i32.const 30
    call $~lib/builtins/abort
    unreachable
   end
@@ -995,7 +995,7 @@
    i32.const 0
    i32.const 32
    i32.const 338
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1058,7 +1058,7 @@
      i32.const 0
      i32.const 32
      i32.const 351
-     i32.const 17
+     i32.const 18
      call $~lib/builtins/abort
      unreachable
     end
@@ -1203,7 +1203,7 @@
    i32.const 0
    i32.const 32
    i32.const 365
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1292,7 +1292,7 @@
    i32.const 0
    i32.const 32
    i32.const 501
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1333,7 +1333,7 @@
       i32.const 0
       i32.const 32
       i32.const 513
-      i32.const 19
+      i32.const 20
       call $~lib/builtins/abort
       unreachable
      end
@@ -1352,7 +1352,7 @@
      i32.const 0
      i32.const 32
      i32.const 518
-     i32.const 17
+     i32.const 18
      call $~lib/builtins/abort
      unreachable
     end
@@ -1369,7 +1369,7 @@
    i32.const 0
    i32.const 32
    i32.const 521
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1420,7 +1420,7 @@
    i32.const 0
    i32.const 144
    i32.const 109
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1441,7 +1441,7 @@
    i32.const 0
    i32.const 144
    i32.const 112
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1521,7 +1521,7 @@
    i32.const 0
    i32.const 192
    i32.const 14
-   i32.const 11
+   i32.const 12
    call $~lib/builtins/abort
    unreachable
   end
@@ -1623,7 +1623,7 @@
    i32.const 0
    i32.const 192
    i32.const 31
-   i32.const 8
+   i32.const 9
    call $~lib/builtins/abort
    unreachable
   end
@@ -1644,7 +1644,7 @@
    i32.const 0
    i32.const 192
    i32.const 36
-   i32.const 8
+   i32.const 9
    call $~lib/builtins/abort
    unreachable
   end
@@ -1657,7 +1657,7 @@
    i32.const 0
    i32.const 192
    i32.const 36
-   i32.const 8
+   i32.const 9
    call $~lib/builtins/abort
    unreachable
   end
@@ -1681,7 +1681,7 @@
    i32.const 0
    i32.const 192
    i32.const 41
-   i32.const 29
+   i32.const 30
    call $~lib/builtins/abort
    unreachable
   end
@@ -1713,7 +1713,7 @@
    i32.const 0
    i32.const 192
    i32.const 47
-   i32.const 29
+   i32.const 30
    call $~lib/builtins/abort
    unreachable
   end
@@ -1838,7 +1838,7 @@
    i32.const 0
    i32.const 144
    i32.const 122
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1860,7 +1860,7 @@
     i32.const 0
     i32.const 144
     i32.const 126
-    i32.const 17
+    i32.const 18
     call $~lib/builtins/abort
     unreachable
    end
@@ -1876,7 +1876,7 @@
     i32.const 0
     i32.const 144
     i32.const 136
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -1908,7 +1908,7 @@
    i32.const 0
    i32.const 144
    i32.const 69
-   i32.const 15
+   i32.const 16
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/many-locals.optimized.wat
+++ b/tests/compiler/many-locals.optimized.wat
@@ -28,7 +28,7 @@
    i32.const 0
    i32.const 1040
    i32.const 267
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/many-locals.untouched.wat
+++ b/tests/compiler/many-locals.untouched.wat
@@ -798,7 +798,7 @@
    i32.const 0
    i32.const 32
    i32.const 133
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -811,7 +811,7 @@
    i32.const 0
    i32.const 32
    i32.const 267
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/memcpy.optimized.wat
+++ b/tests/compiler/memcpy.optimized.wat
@@ -886,7 +886,7 @@
    i32.const 0
    i32.const 1040
    i32.const 151
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -898,7 +898,7 @@
    i32.const 0
    i32.const 1040
    i32.const 152
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -914,7 +914,7 @@
    i32.const 0
    i32.const 1040
    i32.const 155
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -926,7 +926,7 @@
    i32.const 0
    i32.const 1040
    i32.const 156
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -938,7 +938,7 @@
    i32.const 0
    i32.const 1040
    i32.const 157
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -950,7 +950,7 @@
    i32.const 0
    i32.const 1040
    i32.const 158
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -962,7 +962,7 @@
    i32.const 0
    i32.const 1040
    i32.const 159
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -979,7 +979,7 @@
    i32.const 0
    i32.const 1040
    i32.const 162
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -996,7 +996,7 @@
    i32.const 0
    i32.const 1040
    i32.const 165
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1008,7 +1008,7 @@
    i32.const 0
    i32.const 1040
    i32.const 166
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1020,7 +1020,7 @@
    i32.const 0
    i32.const 1040
    i32.const 167
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1032,7 +1032,7 @@
    i32.const 0
    i32.const 1040
    i32.const 168
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/memcpy.untouched.wat
+++ b/tests/compiler/memcpy.untouched.wat
@@ -1076,7 +1076,7 @@
    i32.const 0
    i32.const 32
    i32.const 151
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1089,7 +1089,7 @@
    i32.const 0
    i32.const 32
    i32.const 152
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1106,7 +1106,7 @@
    i32.const 0
    i32.const 32
    i32.const 155
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1119,7 +1119,7 @@
    i32.const 0
    i32.const 32
    i32.const 156
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1132,7 +1132,7 @@
    i32.const 0
    i32.const 32
    i32.const 157
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1145,7 +1145,7 @@
    i32.const 0
    i32.const 32
    i32.const 158
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1158,7 +1158,7 @@
    i32.const 0
    i32.const 32
    i32.const 159
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1180,7 +1180,7 @@
    i32.const 0
    i32.const 32
    i32.const 162
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1202,7 +1202,7 @@
    i32.const 0
    i32.const 32
    i32.const 165
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1215,7 +1215,7 @@
    i32.const 0
    i32.const 32
    i32.const 166
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1228,7 +1228,7 @@
    i32.const 0
    i32.const 32
    i32.const 167
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1241,7 +1241,7 @@
    i32.const 0
    i32.const 32
    i32.const 168
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/memmove.optimized.wat
+++ b/tests/compiler/memmove.optimized.wat
@@ -215,7 +215,7 @@
    i32.const 0
    i32.const 1040
    i32.const 55
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -227,7 +227,7 @@
    i32.const 0
    i32.const 1040
    i32.const 56
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -243,7 +243,7 @@
    i32.const 0
    i32.const 1040
    i32.const 59
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -255,7 +255,7 @@
    i32.const 0
    i32.const 1040
    i32.const 60
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -267,7 +267,7 @@
    i32.const 0
    i32.const 1040
    i32.const 61
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -279,7 +279,7 @@
    i32.const 0
    i32.const 1040
    i32.const 62
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -291,7 +291,7 @@
    i32.const 0
    i32.const 1040
    i32.const 63
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -308,7 +308,7 @@
    i32.const 0
    i32.const 1040
    i32.const 66
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -325,7 +325,7 @@
    i32.const 0
    i32.const 1040
    i32.const 69
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -337,7 +337,7 @@
    i32.const 0
    i32.const 1040
    i32.const 70
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -349,7 +349,7 @@
    i32.const 0
    i32.const 1040
    i32.const 71
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -361,7 +361,7 @@
    i32.const 0
    i32.const 1040
    i32.const 72
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/memmove.untouched.wat
+++ b/tests/compiler/memmove.untouched.wat
@@ -241,7 +241,7 @@
    i32.const 0
    i32.const 32
    i32.const 55
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -254,7 +254,7 @@
    i32.const 0
    i32.const 32
    i32.const 56
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -271,7 +271,7 @@
    i32.const 0
    i32.const 32
    i32.const 59
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -284,7 +284,7 @@
    i32.const 0
    i32.const 32
    i32.const 60
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -297,7 +297,7 @@
    i32.const 0
    i32.const 32
    i32.const 61
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -310,7 +310,7 @@
    i32.const 0
    i32.const 32
    i32.const 62
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -323,7 +323,7 @@
    i32.const 0
    i32.const 32
    i32.const 63
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -345,7 +345,7 @@
    i32.const 0
    i32.const 32
    i32.const 66
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -367,7 +367,7 @@
    i32.const 0
    i32.const 32
    i32.const 69
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -380,7 +380,7 @@
    i32.const 0
    i32.const 32
    i32.const 70
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -393,7 +393,7 @@
    i32.const 0
    i32.const 32
    i32.const 71
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -406,7 +406,7 @@
    i32.const 0
    i32.const 32
    i32.const 72
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/memset.optimized.wat
+++ b/tests/compiler/memset.optimized.wat
@@ -222,7 +222,7 @@
    i32.const 0
    i32.const 1040
    i32.const 72
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -236,7 +236,7 @@
    i32.const 0
    i32.const 1040
    i32.const 73
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -254,7 +254,7 @@
    i32.const 0
    i32.const 1040
    i32.const 77
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -268,7 +268,7 @@
    i32.const 0
    i32.const 1040
    i32.const 78
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -282,7 +282,7 @@
    i32.const 0
    i32.const 1040
    i32.const 79
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -296,7 +296,7 @@
    i32.const 0
    i32.const 1040
    i32.const 80
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/memset.untouched.wat
+++ b/tests/compiler/memset.untouched.wat
@@ -290,7 +290,7 @@
    i32.const 0
    i32.const 32
    i32.const 72
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -305,7 +305,7 @@
    i32.const 0
    i32.const 32
    i32.const 73
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -325,7 +325,7 @@
    i32.const 0
    i32.const 32
    i32.const 77
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -340,7 +340,7 @@
    i32.const 0
    i32.const 32
    i32.const 78
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -355,7 +355,7 @@
    i32.const 0
    i32.const 32
    i32.const 79
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -370,7 +370,7 @@
    i32.const 0
    i32.const 32
    i32.const 80
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/number.optimized.wat
+++ b/tests/compiler/number.optimized.wat
@@ -1378,7 +1378,7 @@
    i32.const 0
    i32.const 2288
    i32.const 70
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1393,7 +1393,7 @@
    i32.const 0
    i32.const 2288
    i32.const 72
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1476,7 +1476,7 @@
    i32.const 0
    i32.const 1104
    i32.const 5
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1488,7 +1488,7 @@
    i32.const 0
    i32.const 1104
    i32.const 7
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1501,7 +1501,7 @@
    i32.const 0
    i32.const 1104
    i32.const 8
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1514,7 +1514,7 @@
    i32.const 0
    i32.const 1104
    i32.const 10
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1527,7 +1527,7 @@
    i32.const 0
    i32.const 1104
    i32.const 11
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1544,7 +1544,7 @@
    i32.const 0
    i32.const 1104
    i32.const 12
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1561,7 +1561,7 @@
    i32.const 0
    i32.const 1104
    i32.const 13
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1573,7 +1573,7 @@
    i32.const 0
    i32.const 1104
    i32.const 14
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1585,7 +1585,7 @@
    i32.const 0
    i32.const 1104
    i32.const 15
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1603,7 +1603,7 @@
    i32.const 0
    i32.const 1104
    i32.const 18
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1621,7 +1621,7 @@
    i32.const 0
    i32.const 1104
    i32.const 19
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1631,7 +1631,7 @@
    i32.const 0
    i32.const 1104
    i32.const 25
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1643,7 +1643,7 @@
    i32.const 0
    i32.const 1104
    i32.const 26
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1655,7 +1655,7 @@
    i32.const 0
    i32.const 1104
    i32.const 27
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1667,7 +1667,7 @@
    i32.const 0
    i32.const 1104
    i32.const 28
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1677,7 +1677,7 @@
    i32.const 0
    i32.const 1104
    i32.const 29
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1687,7 +1687,7 @@
    i32.const 0
    i32.const 1104
    i32.const 30
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1699,7 +1699,7 @@
    i32.const 0
    i32.const 1104
    i32.const 31
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1709,7 +1709,7 @@
    i32.const 0
    i32.const 1104
    i32.const 32
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1719,7 +1719,7 @@
    i32.const 0
    i32.const 1104
    i32.const 33
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1731,7 +1731,7 @@
    i32.const 0
    i32.const 1104
    i32.const 34
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1743,7 +1743,7 @@
    i32.const 0
    i32.const 1104
    i32.const 35
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1753,7 +1753,7 @@
    i32.const 0
    i32.const 1104
    i32.const 36
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1763,7 +1763,7 @@
    i32.const 0
    i32.const 1104
    i32.const 37
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1773,7 +1773,7 @@
    i32.const 0
    i32.const 1104
    i32.const 38
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1785,7 +1785,7 @@
    i32.const 0
    i32.const 1104
    i32.const 39
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1797,7 +1797,7 @@
    i32.const 0
    i32.const 1104
    i32.const 40
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1809,7 +1809,7 @@
    i32.const 0
    i32.const 1104
    i32.const 41
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1821,7 +1821,7 @@
    i32.const 0
    i32.const 1104
    i32.const 42
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1831,7 +1831,7 @@
    i32.const 0
    i32.const 1104
    i32.const 43
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1841,7 +1841,7 @@
    i32.const 0
    i32.const 1104
    i32.const 44
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1851,7 +1851,7 @@
    i32.const 0
    i32.const 1104
    i32.const 48
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1863,7 +1863,7 @@
    i32.const 0
    i32.const 1104
    i32.const 49
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1875,7 +1875,7 @@
    i32.const 0
    i32.const 1104
    i32.const 50
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1887,7 +1887,7 @@
    i32.const 0
    i32.const 1104
    i32.const 51
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1897,7 +1897,7 @@
    i32.const 0
    i32.const 1104
    i32.const 52
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1907,7 +1907,7 @@
    i32.const 0
    i32.const 1104
    i32.const 53
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1919,7 +1919,7 @@
    i32.const 0
    i32.const 1104
    i32.const 54
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1929,7 +1929,7 @@
    i32.const 0
    i32.const 1104
    i32.const 55
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1939,7 +1939,7 @@
    i32.const 0
    i32.const 1104
    i32.const 56
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1951,7 +1951,7 @@
    i32.const 0
    i32.const 1104
    i32.const 57
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1963,7 +1963,7 @@
    i32.const 0
    i32.const 1104
    i32.const 58
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1973,7 +1973,7 @@
    i32.const 0
    i32.const 1104
    i32.const 59
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1983,7 +1983,7 @@
    i32.const 0
    i32.const 1104
    i32.const 60
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1993,7 +1993,7 @@
    i32.const 0
    i32.const 1104
    i32.const 61
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2005,7 +2005,7 @@
    i32.const 0
    i32.const 1104
    i32.const 62
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2017,7 +2017,7 @@
    i32.const 0
    i32.const 1104
    i32.const 63
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2029,7 +2029,7 @@
    i32.const 0
    i32.const 1104
    i32.const 64
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2041,7 +2041,7 @@
    i32.const 0
    i32.const 1104
    i32.const 65
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2051,7 +2051,7 @@
    i32.const 0
    i32.const 1104
    i32.const 66
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2061,7 +2061,7 @@
    i32.const 0
    i32.const 1104
    i32.const 67
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/number.untouched.wat
+++ b/tests/compiler/number.untouched.wat
@@ -3245,7 +3245,7 @@
    i32.const 0
    i32.const 1696
    i32.const 70
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3262,7 +3262,7 @@
    i32.const 0
    i32.const 1696
    i32.const 72
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -3442,7 +3442,7 @@
    i32.const 0
    i32.const 512
    i32.const 5
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3457,7 +3457,7 @@
    i32.const 0
    i32.const 512
    i32.const 7
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3471,7 +3471,7 @@
    i32.const 0
    i32.const 512
    i32.const 8
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3485,7 +3485,7 @@
    i32.const 0
    i32.const 512
    i32.const 10
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3499,7 +3499,7 @@
    i32.const 0
    i32.const 512
    i32.const 11
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3517,7 +3517,7 @@
    i32.const 0
    i32.const 512
    i32.const 12
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3535,7 +3535,7 @@
    i32.const 0
    i32.const 512
    i32.const 13
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3549,7 +3549,7 @@
    i32.const 0
    i32.const 512
    i32.const 14
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3563,7 +3563,7 @@
    i32.const 0
    i32.const 512
    i32.const 15
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3582,7 +3582,7 @@
    i32.const 0
    i32.const 512
    i32.const 18
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3601,7 +3601,7 @@
    i32.const 0
    i32.const 512
    i32.const 19
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3614,7 +3614,7 @@
    i32.const 0
    i32.const 512
    i32.const 23
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3627,7 +3627,7 @@
    i32.const 0
    i32.const 512
    i32.const 25
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3640,7 +3640,7 @@
    i32.const 0
    i32.const 512
    i32.const 26
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3653,7 +3653,7 @@
    i32.const 0
    i32.const 512
    i32.const 27
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3666,7 +3666,7 @@
    i32.const 0
    i32.const 512
    i32.const 28
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3679,7 +3679,7 @@
    i32.const 0
    i32.const 512
    i32.const 29
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3692,7 +3692,7 @@
    i32.const 0
    i32.const 512
    i32.const 30
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3705,7 +3705,7 @@
    i32.const 0
    i32.const 512
    i32.const 31
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3718,7 +3718,7 @@
    i32.const 0
    i32.const 512
    i32.const 32
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3731,7 +3731,7 @@
    i32.const 0
    i32.const 512
    i32.const 33
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3744,7 +3744,7 @@
    i32.const 0
    i32.const 512
    i32.const 34
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3757,7 +3757,7 @@
    i32.const 0
    i32.const 512
    i32.const 35
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3770,7 +3770,7 @@
    i32.const 0
    i32.const 512
    i32.const 36
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3783,7 +3783,7 @@
    i32.const 0
    i32.const 512
    i32.const 37
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3796,7 +3796,7 @@
    i32.const 0
    i32.const 512
    i32.const 38
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3809,7 +3809,7 @@
    i32.const 0
    i32.const 512
    i32.const 39
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3822,7 +3822,7 @@
    i32.const 0
    i32.const 512
    i32.const 40
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3835,7 +3835,7 @@
    i32.const 0
    i32.const 512
    i32.const 41
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3848,7 +3848,7 @@
    i32.const 0
    i32.const 512
    i32.const 42
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3861,7 +3861,7 @@
    i32.const 0
    i32.const 512
    i32.const 43
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3874,7 +3874,7 @@
    i32.const 0
    i32.const 512
    i32.const 44
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3887,7 +3887,7 @@
    i32.const 0
    i32.const 512
    i32.const 46
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3900,7 +3900,7 @@
    i32.const 0
    i32.const 512
    i32.const 48
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3913,7 +3913,7 @@
    i32.const 0
    i32.const 512
    i32.const 49
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3926,7 +3926,7 @@
    i32.const 0
    i32.const 512
    i32.const 50
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3939,7 +3939,7 @@
    i32.const 0
    i32.const 512
    i32.const 51
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3952,7 +3952,7 @@
    i32.const 0
    i32.const 512
    i32.const 52
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3965,7 +3965,7 @@
    i32.const 0
    i32.const 512
    i32.const 53
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3978,7 +3978,7 @@
    i32.const 0
    i32.const 512
    i32.const 54
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3991,7 +3991,7 @@
    i32.const 0
    i32.const 512
    i32.const 55
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -4004,7 +4004,7 @@
    i32.const 0
    i32.const 512
    i32.const 56
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -4017,7 +4017,7 @@
    i32.const 0
    i32.const 512
    i32.const 57
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -4030,7 +4030,7 @@
    i32.const 0
    i32.const 512
    i32.const 58
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -4043,7 +4043,7 @@
    i32.const 0
    i32.const 512
    i32.const 59
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -4056,7 +4056,7 @@
    i32.const 0
    i32.const 512
    i32.const 60
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -4069,7 +4069,7 @@
    i32.const 0
    i32.const 512
    i32.const 61
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -4082,7 +4082,7 @@
    i32.const 0
    i32.const 512
    i32.const 62
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -4095,7 +4095,7 @@
    i32.const 0
    i32.const 512
    i32.const 63
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -4108,7 +4108,7 @@
    i32.const 0
    i32.const 512
    i32.const 64
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -4121,7 +4121,7 @@
    i32.const 0
    i32.const 512
    i32.const 65
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -4134,7 +4134,7 @@
    i32.const 0
    i32.const 512
    i32.const 66
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -4147,7 +4147,7 @@
    i32.const 0
    i32.const 512
    i32.const 67
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/overflow.untouched.wat
+++ b/tests/compiler/overflow.untouched.wat
@@ -29,7 +29,7 @@
    i32.const 0
    i32.const 32
    i32.const 10
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -49,7 +49,7 @@
    i32.const 0
    i32.const 32
    i32.const 13
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -72,7 +72,7 @@
    i32.const 0
    i32.const 32
    i32.const 16
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -95,7 +95,7 @@
    i32.const 0
    i32.const 32
    i32.const 19
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -115,7 +115,7 @@
    i32.const 0
    i32.const 32
    i32.const 22
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -135,7 +135,7 @@
    i32.const 0
    i32.const 32
    i32.const 25
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -156,7 +156,7 @@
    i32.const 0
    i32.const 32
    i32.const 28
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -177,7 +177,7 @@
    i32.const 0
    i32.const 32
    i32.const 31
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -195,7 +195,7 @@
    i32.const 0
    i32.const 32
    i32.const 33
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -217,7 +217,7 @@
    i32.const 0
    i32.const 32
    i32.const 42
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -237,7 +237,7 @@
    i32.const 0
    i32.const 32
    i32.const 45
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -260,7 +260,7 @@
    i32.const 0
    i32.const 32
    i32.const 48
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -283,7 +283,7 @@
    i32.const 0
    i32.const 32
    i32.const 51
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -303,7 +303,7 @@
    i32.const 0
    i32.const 32
    i32.const 54
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -323,7 +323,7 @@
    i32.const 0
    i32.const 32
    i32.const 57
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -344,7 +344,7 @@
    i32.const 0
    i32.const 32
    i32.const 60
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -365,7 +365,7 @@
    i32.const 0
    i32.const 32
    i32.const 63
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -383,7 +383,7 @@
    i32.const 0
    i32.const 32
    i32.const 65
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -403,7 +403,7 @@
    i32.const 0
    i32.const 32
    i32.const 74
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -421,7 +421,7 @@
    i32.const 0
    i32.const 32
    i32.const 77
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -442,7 +442,7 @@
    i32.const 0
    i32.const 32
    i32.const 80
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -463,7 +463,7 @@
    i32.const 0
    i32.const 32
    i32.const 83
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -481,7 +481,7 @@
    i32.const 0
    i32.const 32
    i32.const 86
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -499,7 +499,7 @@
    i32.const 0
    i32.const 32
    i32.const 89
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -518,7 +518,7 @@
    i32.const 0
    i32.const 32
    i32.const 92
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -537,7 +537,7 @@
    i32.const 0
    i32.const 32
    i32.const 95
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -553,7 +553,7 @@
    i32.const 0
    i32.const 32
    i32.const 97
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -573,7 +573,7 @@
    i32.const 0
    i32.const 32
    i32.const 106
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -591,7 +591,7 @@
    i32.const 0
    i32.const 32
    i32.const 109
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -612,7 +612,7 @@
    i32.const 0
    i32.const 32
    i32.const 112
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -633,7 +633,7 @@
    i32.const 0
    i32.const 32
    i32.const 115
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -651,7 +651,7 @@
    i32.const 0
    i32.const 32
    i32.const 118
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -669,7 +669,7 @@
    i32.const 0
    i32.const 32
    i32.const 121
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -688,7 +688,7 @@
    i32.const 0
    i32.const 32
    i32.const 124
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -707,7 +707,7 @@
    i32.const 0
    i32.const 32
    i32.const 127
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -723,7 +723,7 @@
    i32.const 0
    i32.const 32
    i32.const 129
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/portable-conversions.untouched.wat
+++ b/tests/compiler/portable-conversions.untouched.wat
@@ -22,7 +22,7 @@
    i32.const 0
    i32.const 32
    i32.const 6
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37,7 +37,7 @@
    i32.const 0
    i32.const 32
    i32.const 7
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -52,7 +52,7 @@
    i32.const 0
    i32.const 32
    i32.const 8
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -67,7 +67,7 @@
    i32.const 0
    i32.const 32
    i32.const 9
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -81,7 +81,7 @@
    i32.const 0
    i32.const 32
    i32.const 11
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -96,7 +96,7 @@
    i32.const 0
    i32.const 32
    i32.const 12
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -111,7 +111,7 @@
    i32.const 0
    i32.const 32
    i32.const 13
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -126,7 +126,7 @@
    i32.const 0
    i32.const 32
    i32.const 14
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -136,7 +136,7 @@
    i32.const 0
    i32.const 32
    i32.const 16
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -147,7 +147,7 @@
    i32.const 0
    i32.const 32
    i32.const 17
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -158,7 +158,7 @@
    i32.const 0
    i32.const 32
    i32.const 18
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -169,7 +169,7 @@
    i32.const 0
    i32.const 32
    i32.const 19
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -180,7 +180,7 @@
    i32.const 0
    i32.const 32
    i32.const 21
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -190,7 +190,7 @@
    i32.const 0
    i32.const 32
    i32.const 22
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -201,7 +201,7 @@
    i32.const 0
    i32.const 32
    i32.const 23
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -212,7 +212,7 @@
    i32.const 0
    i32.const 32
    i32.const 24
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -222,7 +222,7 @@
    i32.const 0
    i32.const 32
    i32.const 26
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -233,7 +233,7 @@
    i32.const 0
    i32.const 32
    i32.const 27
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -244,7 +244,7 @@
    i32.const 0
    i32.const 32
    i32.const 28
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -255,7 +255,7 @@
    i32.const 0
    i32.const 32
    i32.const 29
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -267,7 +267,7 @@
    i32.const 0
    i32.const 32
    i32.const 31
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -280,7 +280,7 @@
    i32.const 0
    i32.const 32
    i32.const 32
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -293,7 +293,7 @@
    i32.const 0
    i32.const 32
    i32.const 33
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -306,7 +306,7 @@
    i32.const 0
    i32.const 32
    i32.const 34
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -318,7 +318,7 @@
    i32.const 0
    i32.const 32
    i32.const 36
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -331,7 +331,7 @@
    i32.const 0
    i32.const 32
    i32.const 37
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -344,7 +344,7 @@
    i32.const 0
    i32.const 32
    i32.const 38
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -357,7 +357,7 @@
    i32.const 0
    i32.const 32
    i32.const 39
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -367,7 +367,7 @@
    i32.const 0
    i32.const 32
    i32.const 41
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -378,7 +378,7 @@
    i32.const 0
    i32.const 32
    i32.const 42
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -389,7 +389,7 @@
    i32.const 0
    i32.const 32
    i32.const 43
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -400,7 +400,7 @@
    i32.const 0
    i32.const 32
    i32.const 44
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -411,7 +411,7 @@
    i32.const 0
    i32.const 32
    i32.const 46
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -421,7 +421,7 @@
    i32.const 0
    i32.const 32
    i32.const 47
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -432,7 +432,7 @@
    i32.const 0
    i32.const 32
    i32.const 48
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -443,7 +443,7 @@
    i32.const 0
    i32.const 32
    i32.const 49
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -453,7 +453,7 @@
    i32.const 0
    i32.const 32
    i32.const 51
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -464,7 +464,7 @@
    i32.const 0
    i32.const 32
    i32.const 52
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -475,7 +475,7 @@
    i32.const 0
    i32.const 32
    i32.const 53
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -486,7 +486,7 @@
    i32.const 0
    i32.const 32
    i32.const 54
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -498,7 +498,7 @@
    i32.const 0
    i32.const 32
    i32.const 56
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -510,7 +510,7 @@
    i32.const 0
    i32.const 32
    i32.const 57
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -522,7 +522,7 @@
    i32.const 0
    i32.const 32
    i32.const 58
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -534,7 +534,7 @@
    i32.const 0
    i32.const 32
    i32.const 59
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -546,7 +546,7 @@
    i32.const 0
    i32.const 32
    i32.const 61
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -558,7 +558,7 @@
    i32.const 0
    i32.const 32
    i32.const 62
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -569,7 +569,7 @@
    i32.const 0
    i32.const 32
    i32.const 63
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -581,7 +581,7 @@
    i32.const 0
    i32.const 32
    i32.const 64
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -593,7 +593,7 @@
    i32.const 0
    i32.const 32
    i32.const 66
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -605,7 +605,7 @@
    i32.const 0
    i32.const 32
    i32.const 67
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -617,7 +617,7 @@
    i32.const 0
    i32.const 32
    i32.const 68
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -628,7 +628,7 @@
    i32.const 0
    i32.const 32
    i32.const 69
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/rc/global-init.untouched.wat
+++ b/tests/compiler/rc/global-init.untouched.wat
@@ -42,7 +42,7 @@
    i32.const 0
    i32.const 48
    i32.const 109
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -63,7 +63,7 @@
    i32.const 0
    i32.const 48
    i32.const 112
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -152,7 +152,7 @@
    i32.const 0
    i32.const 96
    i32.const 277
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -177,7 +177,7 @@
    i32.const 0
    i32.const 96
    i32.const 279
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -229,7 +229,7 @@
    i32.const 0
    i32.const 96
    i32.const 292
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -359,7 +359,7 @@
    i32.const 0
    i32.const 96
    i32.const 205
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -374,7 +374,7 @@
    i32.const 0
    i32.const 96
    i32.const 207
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -467,7 +467,7 @@
     i32.const 0
     i32.const 96
     i32.const 228
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -530,7 +530,7 @@
    i32.const 0
    i32.const 96
    i32.const 243
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -546,7 +546,7 @@
    i32.const 0
    i32.const 96
    i32.const 244
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -603,7 +603,7 @@
    i32.const 0
    i32.const 96
    i32.const 260
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -728,7 +728,7 @@
    i32.const 0
    i32.const 48
    i32.const 122
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -750,7 +750,7 @@
     i32.const 0
     i32.const 48
     i32.const 126
-    i32.const 17
+    i32.const 18
     call $~lib/builtins/abort
     unreachable
    end
@@ -766,7 +766,7 @@
     i32.const 0
     i32.const 48
     i32.const 136
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -798,7 +798,7 @@
    i32.const 0
    i32.const 48
    i32.const 69
-   i32.const 15
+   i32.const 16
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/rc/local-init.optimized.wat
+++ b/tests/compiler/rc/local-init.optimized.wat
@@ -35,7 +35,7 @@
    i32.const 0
    i32.const 1056
    i32.const 277
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -57,7 +57,7 @@
    i32.const 0
    i32.const 1056
    i32.const 279
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -100,7 +100,7 @@
    i32.const 0
    i32.const 1056
    i32.const 292
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -196,7 +196,7 @@
    i32.const 0
    i32.const 1056
    i32.const 205
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -210,7 +210,7 @@
    i32.const 0
    i32.const 1056
    i32.const 207
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -283,7 +283,7 @@
     i32.const 0
     i32.const 1056
     i32.const 228
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -338,7 +338,7 @@
    i32.const 0
    i32.const 1056
    i32.const 243
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -353,7 +353,7 @@
    i32.const 0
    i32.const 1056
    i32.const 244
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -401,7 +401,7 @@
    i32.const 0
    i32.const 1056
    i32.const 260
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -484,7 +484,7 @@
    i32.const 0
    i32.const 1056
    i32.const 386
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -501,7 +501,7 @@
     i32.const 0
     i32.const 1056
     i32.const 396
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -529,7 +529,7 @@
     i32.const 0
     i32.const 1056
     i32.const 408
-    i32.const 4
+    i32.const 5
     call $~lib/builtins/abort
     unreachable
    end
@@ -700,7 +700,7 @@
      i32.const 0
      i32.const 1056
      i32.const 351
-     i32.const 17
+     i32.const 18
      call $~lib/builtins/abort
      unreachable
     end
@@ -729,7 +729,7 @@
    i32.const 0
    i32.const 1056
    i32.const 501
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -799,7 +799,7 @@
      i32.const 0
      i32.const 1056
      i32.const 513
-     i32.const 19
+     i32.const 20
      call $~lib/builtins/abort
      unreachable
     end
@@ -815,7 +815,7 @@
    i32.const 0
    i32.const 1056
    i32.const 521
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -922,7 +922,7 @@
     i32.const 0
     i32.const 1168
     i32.const 109
-    i32.const 2
+    i32.const 3
     call $~lib/builtins/abort
     unreachable
    end
@@ -941,7 +941,7 @@
     i32.const 0
     i32.const 1168
     i32.const 112
-    i32.const 13
+    i32.const 14
     call $~lib/builtins/abort
     unreachable
    end
@@ -975,7 +975,7 @@
    i32.const 0
    i32.const 1168
    i32.const 122
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1020,7 +1020,7 @@
     i32.const 0
     i32.const 1168
     i32.const 126
-    i32.const 17
+    i32.const 18
     call $~lib/builtins/abort
     unreachable
    end
@@ -1043,7 +1043,7 @@
     i32.const 0
     i32.const 1168
     i32.const 136
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end

--- a/tests/compiler/rc/local-init.untouched.wat
+++ b/tests/compiler/rc/local-init.untouched.wat
@@ -62,7 +62,7 @@
    i32.const 0
    i32.const 48
    i32.const 277
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -87,7 +87,7 @@
    i32.const 0
    i32.const 48
    i32.const 279
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -139,7 +139,7 @@
    i32.const 0
    i32.const 48
    i32.const 292
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -269,7 +269,7 @@
    i32.const 0
    i32.const 48
    i32.const 205
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -284,7 +284,7 @@
    i32.const 0
    i32.const 48
    i32.const 207
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -377,7 +377,7 @@
     i32.const 0
     i32.const 48
     i32.const 228
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -440,7 +440,7 @@
    i32.const 0
    i32.const 48
    i32.const 243
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -456,7 +456,7 @@
    i32.const 0
    i32.const 48
    i32.const 244
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -513,7 +513,7 @@
    i32.const 0
    i32.const 48
    i32.const 260
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -632,7 +632,7 @@
    i32.const 0
    i32.const 48
    i32.const 386
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -655,7 +655,7 @@
     i32.const 0
     i32.const 48
     i32.const 396
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -686,7 +686,7 @@
     i32.const 0
     i32.const 48
     i32.const 408
-    i32.const 4
+    i32.const 5
     call $~lib/builtins/abort
     unreachable
    end
@@ -912,7 +912,7 @@
    i32.const 96
    i32.const 48
    i32.const 461
-   i32.const 29
+   i32.const 30
    call $~lib/builtins/abort
    unreachable
   end
@@ -1006,7 +1006,7 @@
    i32.const 0
    i32.const 48
    i32.const 338
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1069,7 +1069,7 @@
      i32.const 0
      i32.const 48
      i32.const 351
-     i32.const 17
+     i32.const 18
      call $~lib/builtins/abort
      unreachable
     end
@@ -1214,7 +1214,7 @@
    i32.const 0
    i32.const 48
    i32.const 365
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1303,7 +1303,7 @@
    i32.const 0
    i32.const 48
    i32.const 501
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1344,7 +1344,7 @@
       i32.const 0
       i32.const 48
       i32.const 513
-      i32.const 19
+      i32.const 20
       call $~lib/builtins/abort
       unreachable
      end
@@ -1363,7 +1363,7 @@
      i32.const 0
      i32.const 48
      i32.const 518
-     i32.const 17
+     i32.const 18
      call $~lib/builtins/abort
      unreachable
     end
@@ -1380,7 +1380,7 @@
    i32.const 0
    i32.const 48
    i32.const 521
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1431,7 +1431,7 @@
    i32.const 0
    i32.const 160
    i32.const 109
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1452,7 +1452,7 @@
    i32.const 0
    i32.const 160
    i32.const 112
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1538,7 +1538,7 @@
    i32.const 0
    i32.const 160
    i32.const 122
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1560,7 +1560,7 @@
     i32.const 0
     i32.const 160
     i32.const 126
-    i32.const 17
+    i32.const 18
     call $~lib/builtins/abort
     unreachable
    end
@@ -1576,7 +1576,7 @@
     i32.const 0
     i32.const 160
     i32.const 136
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -1611,7 +1611,7 @@
    i32.const 0
    i32.const 160
    i32.const 69
-   i32.const 15
+   i32.const 16
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/rc/logical-and-mismatch.optimized.wat
+++ b/tests/compiler/rc/logical-and-mismatch.optimized.wat
@@ -35,7 +35,7 @@
    i32.const 0
    i32.const 1040
    i32.const 277
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -57,7 +57,7 @@
    i32.const 0
    i32.const 1040
    i32.const 279
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -100,7 +100,7 @@
    i32.const 0
    i32.const 1040
    i32.const 292
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -196,7 +196,7 @@
    i32.const 0
    i32.const 1040
    i32.const 205
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -210,7 +210,7 @@
    i32.const 0
    i32.const 1040
    i32.const 207
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -283,7 +283,7 @@
     i32.const 0
     i32.const 1040
     i32.const 228
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -338,7 +338,7 @@
    i32.const 0
    i32.const 1040
    i32.const 243
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -353,7 +353,7 @@
    i32.const 0
    i32.const 1040
    i32.const 244
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -401,7 +401,7 @@
    i32.const 0
    i32.const 1040
    i32.const 260
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -484,7 +484,7 @@
    i32.const 0
    i32.const 1040
    i32.const 386
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -501,7 +501,7 @@
     i32.const 0
     i32.const 1040
     i32.const 396
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -529,7 +529,7 @@
     i32.const 0
     i32.const 1040
     i32.const 408
-    i32.const 4
+    i32.const 5
     call $~lib/builtins/abort
     unreachable
    end
@@ -700,7 +700,7 @@
      i32.const 0
      i32.const 1040
      i32.const 351
-     i32.const 17
+     i32.const 18
      call $~lib/builtins/abort
      unreachable
     end
@@ -729,7 +729,7 @@
    i32.const 0
    i32.const 1040
    i32.const 501
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -799,7 +799,7 @@
      i32.const 0
      i32.const 1040
      i32.const 513
-     i32.const 19
+     i32.const 20
      call $~lib/builtins/abort
      unreachable
     end
@@ -815,7 +815,7 @@
    i32.const 0
    i32.const 1040
    i32.const 521
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -917,7 +917,7 @@
     i32.const 0
     i32.const 1152
     i32.const 109
-    i32.const 2
+    i32.const 3
     call $~lib/builtins/abort
     unreachable
    end
@@ -936,7 +936,7 @@
     i32.const 0
     i32.const 1152
     i32.const 112
-    i32.const 13
+    i32.const 14
     call $~lib/builtins/abort
     unreachable
    end
@@ -1017,7 +1017,7 @@
    i32.const 0
    i32.const 1152
    i32.const 122
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1062,7 +1062,7 @@
     i32.const 0
     i32.const 1152
     i32.const 126
-    i32.const 17
+    i32.const 18
     call $~lib/builtins/abort
     unreachable
    end
@@ -1085,7 +1085,7 @@
     i32.const 0
     i32.const 1152
     i32.const 136
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end

--- a/tests/compiler/rc/logical-and-mismatch.untouched.wat
+++ b/tests/compiler/rc/logical-and-mismatch.untouched.wat
@@ -48,7 +48,7 @@
    i32.const 0
    i32.const 32
    i32.const 277
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -73,7 +73,7 @@
    i32.const 0
    i32.const 32
    i32.const 279
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -125,7 +125,7 @@
    i32.const 0
    i32.const 32
    i32.const 292
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -255,7 +255,7 @@
    i32.const 0
    i32.const 32
    i32.const 205
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -270,7 +270,7 @@
    i32.const 0
    i32.const 32
    i32.const 207
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -363,7 +363,7 @@
     i32.const 0
     i32.const 32
     i32.const 228
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -426,7 +426,7 @@
    i32.const 0
    i32.const 32
    i32.const 243
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -442,7 +442,7 @@
    i32.const 0
    i32.const 32
    i32.const 244
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -499,7 +499,7 @@
    i32.const 0
    i32.const 32
    i32.const 260
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -618,7 +618,7 @@
    i32.const 0
    i32.const 32
    i32.const 386
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -641,7 +641,7 @@
     i32.const 0
     i32.const 32
     i32.const 396
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -672,7 +672,7 @@
     i32.const 0
     i32.const 32
     i32.const 408
-    i32.const 4
+    i32.const 5
     call $~lib/builtins/abort
     unreachable
    end
@@ -898,7 +898,7 @@
    i32.const 80
    i32.const 32
    i32.const 461
-   i32.const 29
+   i32.const 30
    call $~lib/builtins/abort
    unreachable
   end
@@ -992,7 +992,7 @@
    i32.const 0
    i32.const 32
    i32.const 338
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1055,7 +1055,7 @@
      i32.const 0
      i32.const 32
      i32.const 351
-     i32.const 17
+     i32.const 18
      call $~lib/builtins/abort
      unreachable
     end
@@ -1200,7 +1200,7 @@
    i32.const 0
    i32.const 32
    i32.const 365
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1289,7 +1289,7 @@
    i32.const 0
    i32.const 32
    i32.const 501
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1330,7 +1330,7 @@
       i32.const 0
       i32.const 32
       i32.const 513
-      i32.const 19
+      i32.const 20
       call $~lib/builtins/abort
       unreachable
      end
@@ -1349,7 +1349,7 @@
      i32.const 0
      i32.const 32
      i32.const 518
-     i32.const 17
+     i32.const 18
      call $~lib/builtins/abort
      unreachable
     end
@@ -1366,7 +1366,7 @@
    i32.const 0
    i32.const 32
    i32.const 521
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1417,7 +1417,7 @@
    i32.const 0
    i32.const 144
    i32.const 109
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1438,7 +1438,7 @@
    i32.const 0
    i32.const 144
    i32.const 112
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1581,7 +1581,7 @@
    i32.const 0
    i32.const 144
    i32.const 122
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1603,7 +1603,7 @@
     i32.const 0
     i32.const 144
     i32.const 126
-    i32.const 17
+    i32.const 18
     call $~lib/builtins/abort
     unreachable
    end
@@ -1619,7 +1619,7 @@
     i32.const 0
     i32.const 144
     i32.const 136
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -1651,7 +1651,7 @@
    i32.const 0
    i32.const 144
    i32.const 69
-   i32.const 15
+   i32.const 16
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/rc/logical-or-mismatch.optimized.wat
+++ b/tests/compiler/rc/logical-or-mismatch.optimized.wat
@@ -35,7 +35,7 @@
    i32.const 0
    i32.const 1040
    i32.const 277
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -57,7 +57,7 @@
    i32.const 0
    i32.const 1040
    i32.const 279
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -100,7 +100,7 @@
    i32.const 0
    i32.const 1040
    i32.const 292
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -196,7 +196,7 @@
    i32.const 0
    i32.const 1040
    i32.const 205
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -210,7 +210,7 @@
    i32.const 0
    i32.const 1040
    i32.const 207
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -283,7 +283,7 @@
     i32.const 0
     i32.const 1040
     i32.const 228
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -338,7 +338,7 @@
    i32.const 0
    i32.const 1040
    i32.const 243
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -353,7 +353,7 @@
    i32.const 0
    i32.const 1040
    i32.const 244
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -401,7 +401,7 @@
    i32.const 0
    i32.const 1040
    i32.const 260
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -484,7 +484,7 @@
    i32.const 0
    i32.const 1040
    i32.const 386
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -501,7 +501,7 @@
     i32.const 0
     i32.const 1040
     i32.const 396
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -529,7 +529,7 @@
     i32.const 0
     i32.const 1040
     i32.const 408
-    i32.const 4
+    i32.const 5
     call $~lib/builtins/abort
     unreachable
    end
@@ -700,7 +700,7 @@
      i32.const 0
      i32.const 1040
      i32.const 351
-     i32.const 17
+     i32.const 18
      call $~lib/builtins/abort
      unreachable
     end
@@ -729,7 +729,7 @@
    i32.const 0
    i32.const 1040
    i32.const 501
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -799,7 +799,7 @@
      i32.const 0
      i32.const 1040
      i32.const 513
-     i32.const 19
+     i32.const 20
      call $~lib/builtins/abort
      unreachable
     end
@@ -815,7 +815,7 @@
    i32.const 0
    i32.const 1040
    i32.const 521
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -917,7 +917,7 @@
     i32.const 0
     i32.const 1152
     i32.const 109
-    i32.const 2
+    i32.const 3
     call $~lib/builtins/abort
     unreachable
    end
@@ -936,7 +936,7 @@
     i32.const 0
     i32.const 1152
     i32.const 112
-    i32.const 13
+    i32.const 14
     call $~lib/builtins/abort
     unreachable
    end
@@ -1019,7 +1019,7 @@
    i32.const 0
    i32.const 1152
    i32.const 122
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1064,7 +1064,7 @@
     i32.const 0
     i32.const 1152
     i32.const 126
-    i32.const 17
+    i32.const 18
     call $~lib/builtins/abort
     unreachable
    end
@@ -1087,7 +1087,7 @@
     i32.const 0
     i32.const 1152
     i32.const 136
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end

--- a/tests/compiler/rc/logical-or-mismatch.untouched.wat
+++ b/tests/compiler/rc/logical-or-mismatch.untouched.wat
@@ -48,7 +48,7 @@
    i32.const 0
    i32.const 32
    i32.const 277
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -73,7 +73,7 @@
    i32.const 0
    i32.const 32
    i32.const 279
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -125,7 +125,7 @@
    i32.const 0
    i32.const 32
    i32.const 292
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -255,7 +255,7 @@
    i32.const 0
    i32.const 32
    i32.const 205
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -270,7 +270,7 @@
    i32.const 0
    i32.const 32
    i32.const 207
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -363,7 +363,7 @@
     i32.const 0
     i32.const 32
     i32.const 228
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -426,7 +426,7 @@
    i32.const 0
    i32.const 32
    i32.const 243
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -442,7 +442,7 @@
    i32.const 0
    i32.const 32
    i32.const 244
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -499,7 +499,7 @@
    i32.const 0
    i32.const 32
    i32.const 260
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -618,7 +618,7 @@
    i32.const 0
    i32.const 32
    i32.const 386
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -641,7 +641,7 @@
     i32.const 0
     i32.const 32
     i32.const 396
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -672,7 +672,7 @@
     i32.const 0
     i32.const 32
     i32.const 408
-    i32.const 4
+    i32.const 5
     call $~lib/builtins/abort
     unreachable
    end
@@ -898,7 +898,7 @@
    i32.const 80
    i32.const 32
    i32.const 461
-   i32.const 29
+   i32.const 30
    call $~lib/builtins/abort
    unreachable
   end
@@ -992,7 +992,7 @@
    i32.const 0
    i32.const 32
    i32.const 338
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1055,7 +1055,7 @@
      i32.const 0
      i32.const 32
      i32.const 351
-     i32.const 17
+     i32.const 18
      call $~lib/builtins/abort
      unreachable
     end
@@ -1200,7 +1200,7 @@
    i32.const 0
    i32.const 32
    i32.const 365
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1289,7 +1289,7 @@
    i32.const 0
    i32.const 32
    i32.const 501
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1330,7 +1330,7 @@
       i32.const 0
       i32.const 32
       i32.const 513
-      i32.const 19
+      i32.const 20
       call $~lib/builtins/abort
       unreachable
      end
@@ -1349,7 +1349,7 @@
      i32.const 0
      i32.const 32
      i32.const 518
-     i32.const 17
+     i32.const 18
      call $~lib/builtins/abort
      unreachable
     end
@@ -1366,7 +1366,7 @@
    i32.const 0
    i32.const 32
    i32.const 521
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1417,7 +1417,7 @@
    i32.const 0
    i32.const 144
    i32.const 109
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1438,7 +1438,7 @@
    i32.const 0
    i32.const 144
    i32.const 112
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1581,7 +1581,7 @@
    i32.const 0
    i32.const 144
    i32.const 122
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1603,7 +1603,7 @@
     i32.const 0
     i32.const 144
     i32.const 126
-    i32.const 17
+    i32.const 18
     call $~lib/builtins/abort
     unreachable
    end
@@ -1619,7 +1619,7 @@
     i32.const 0
     i32.const 144
     i32.const 136
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -1651,7 +1651,7 @@
    i32.const 0
    i32.const 144
    i32.const 69
-   i32.const 15
+   i32.const 16
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/rc/optimize.optimized.wat
+++ b/tests/compiler/rc/optimize.optimized.wat
@@ -84,7 +84,7 @@
     i32.const 0
     i32.const 1040
     i32.const 109
-    i32.const 2
+    i32.const 3
     call $~lib/builtins/abort
     unreachable
    end
@@ -103,7 +103,7 @@
     i32.const 0
     i32.const 1040
     i32.const 112
-    i32.const 13
+    i32.const 14
     call $~lib/builtins/abort
     unreachable
    end
@@ -125,7 +125,7 @@
    i32.const 0
    i32.const 1088
    i32.const 277
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -147,7 +147,7 @@
    i32.const 0
    i32.const 1088
    i32.const 279
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -190,7 +190,7 @@
    i32.const 0
    i32.const 1088
    i32.const 292
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -286,7 +286,7 @@
    i32.const 0
    i32.const 1088
    i32.const 205
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -300,7 +300,7 @@
    i32.const 0
    i32.const 1088
    i32.const 207
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -373,7 +373,7 @@
     i32.const 0
     i32.const 1088
     i32.const 228
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -428,7 +428,7 @@
    i32.const 0
    i32.const 1088
    i32.const 243
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -443,7 +443,7 @@
    i32.const 0
    i32.const 1088
    i32.const 244
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -491,7 +491,7 @@
    i32.const 0
    i32.const 1088
    i32.const 260
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -574,7 +574,7 @@
    i32.const 0
    i32.const 1088
    i32.const 386
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -591,7 +591,7 @@
     i32.const 0
     i32.const 1088
     i32.const 396
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -619,7 +619,7 @@
     i32.const 0
     i32.const 1088
     i32.const 408
-    i32.const 4
+    i32.const 5
     call $~lib/builtins/abort
     unreachable
    end
@@ -790,7 +790,7 @@
      i32.const 0
      i32.const 1088
      i32.const 351
-     i32.const 17
+     i32.const 18
      call $~lib/builtins/abort
      unreachable
     end
@@ -819,7 +819,7 @@
    i32.const 0
    i32.const 1088
    i32.const 501
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -889,7 +889,7 @@
      i32.const 0
      i32.const 1088
      i32.const 513
-     i32.const 19
+     i32.const 20
      call $~lib/builtins/abort
      unreachable
     end
@@ -905,7 +905,7 @@
    i32.const 0
    i32.const 1088
    i32.const 521
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1070,7 +1070,7 @@
    i32.const 0
    i32.const 1040
    i32.const 122
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1115,7 +1115,7 @@
     i32.const 0
     i32.const 1040
     i32.const 126
-    i32.const 17
+    i32.const 18
     call $~lib/builtins/abort
     unreachable
    end
@@ -1138,7 +1138,7 @@
     i32.const 0
     i32.const 1040
     i32.const 136
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end

--- a/tests/compiler/rc/optimize.untouched.wat
+++ b/tests/compiler/rc/optimize.untouched.wat
@@ -83,7 +83,7 @@
    i32.const 0
    i32.const 32
    i32.const 109
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -104,7 +104,7 @@
    i32.const 0
    i32.const 32
    i32.const 112
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -143,7 +143,7 @@
    i32.const 0
    i32.const 80
    i32.const 277
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -168,7 +168,7 @@
    i32.const 0
    i32.const 80
    i32.const 279
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -220,7 +220,7 @@
    i32.const 0
    i32.const 80
    i32.const 292
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -350,7 +350,7 @@
    i32.const 0
    i32.const 80
    i32.const 205
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -365,7 +365,7 @@
    i32.const 0
    i32.const 80
    i32.const 207
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -458,7 +458,7 @@
     i32.const 0
     i32.const 80
     i32.const 228
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -521,7 +521,7 @@
    i32.const 0
    i32.const 80
    i32.const 243
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -537,7 +537,7 @@
    i32.const 0
    i32.const 80
    i32.const 244
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -594,7 +594,7 @@
    i32.const 0
    i32.const 80
    i32.const 260
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -713,7 +713,7 @@
    i32.const 0
    i32.const 80
    i32.const 386
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -736,7 +736,7 @@
     i32.const 0
     i32.const 80
     i32.const 396
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -767,7 +767,7 @@
     i32.const 0
     i32.const 80
     i32.const 408
-    i32.const 4
+    i32.const 5
     call $~lib/builtins/abort
     unreachable
    end
@@ -993,7 +993,7 @@
    i32.const 128
    i32.const 80
    i32.const 461
-   i32.const 29
+   i32.const 30
    call $~lib/builtins/abort
    unreachable
   end
@@ -1087,7 +1087,7 @@
    i32.const 0
    i32.const 80
    i32.const 338
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1150,7 +1150,7 @@
      i32.const 0
      i32.const 80
      i32.const 351
-     i32.const 17
+     i32.const 18
      call $~lib/builtins/abort
      unreachable
     end
@@ -1295,7 +1295,7 @@
    i32.const 0
    i32.const 80
    i32.const 365
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1384,7 +1384,7 @@
    i32.const 0
    i32.const 80
    i32.const 501
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1425,7 +1425,7 @@
       i32.const 0
       i32.const 80
       i32.const 513
-      i32.const 19
+      i32.const 20
       call $~lib/builtins/abort
       unreachable
      end
@@ -1444,7 +1444,7 @@
      i32.const 0
      i32.const 80
      i32.const 518
-     i32.const 17
+     i32.const 18
      call $~lib/builtins/abort
      unreachable
     end
@@ -1461,7 +1461,7 @@
    i32.const 0
    i32.const 80
    i32.const 521
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1833,7 +1833,7 @@
    i32.const 0
    i32.const 32
    i32.const 122
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1855,7 +1855,7 @@
     i32.const 0
     i32.const 32
     i32.const 126
-    i32.const 17
+    i32.const 18
     call $~lib/builtins/abort
     unreachable
    end
@@ -1871,7 +1871,7 @@
     i32.const 0
     i32.const 32
     i32.const 136
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -1903,7 +1903,7 @@
    i32.const 0
    i32.const 32
    i32.const 69
-   i32.const 15
+   i32.const 16
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/rc/rereturn.optimized.wat
+++ b/tests/compiler/rc/rereturn.optimized.wat
@@ -38,7 +38,7 @@
    i32.const 0
    i32.const 1040
    i32.const 277
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -60,7 +60,7 @@
    i32.const 0
    i32.const 1040
    i32.const 279
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -103,7 +103,7 @@
    i32.const 0
    i32.const 1040
    i32.const 292
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -199,7 +199,7 @@
    i32.const 0
    i32.const 1040
    i32.const 205
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -213,7 +213,7 @@
    i32.const 0
    i32.const 1040
    i32.const 207
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -286,7 +286,7 @@
     i32.const 0
     i32.const 1040
     i32.const 228
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -341,7 +341,7 @@
    i32.const 0
    i32.const 1040
    i32.const 243
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -356,7 +356,7 @@
    i32.const 0
    i32.const 1040
    i32.const 244
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -404,7 +404,7 @@
    i32.const 0
    i32.const 1040
    i32.const 260
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -487,7 +487,7 @@
    i32.const 0
    i32.const 1040
    i32.const 386
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -504,7 +504,7 @@
     i32.const 0
     i32.const 1040
     i32.const 396
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -532,7 +532,7 @@
     i32.const 0
     i32.const 1040
     i32.const 408
-    i32.const 4
+    i32.const 5
     call $~lib/builtins/abort
     unreachable
    end
@@ -722,7 +722,7 @@
    i32.const 0
    i32.const 1040
    i32.const 338
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -774,7 +774,7 @@
      i32.const 0
      i32.const 1040
      i32.const 351
-     i32.const 17
+     i32.const 18
      call $~lib/builtins/abort
      unreachable
     end
@@ -807,7 +807,7 @@
    i32.const 0
    i32.const 1040
    i32.const 365
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -878,7 +878,7 @@
    i32.const 0
    i32.const 1040
    i32.const 501
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -889,7 +889,7 @@
    i32.const 1088
    i32.const 1040
    i32.const 461
-   i32.const 29
+   i32.const 30
    call $~lib/builtins/abort
    unreachable
   end
@@ -989,7 +989,7 @@
      i32.const 0
      i32.const 1040
      i32.const 513
-     i32.const 19
+     i32.const 20
      call $~lib/builtins/abort
      unreachable
     end
@@ -1005,7 +1005,7 @@
    i32.const 0
    i32.const 1040
    i32.const 521
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1060,7 +1060,7 @@
     i32.const 0
     i32.const 1152
     i32.const 109
-    i32.const 2
+    i32.const 3
     call $~lib/builtins/abort
     unreachable
    end
@@ -1077,7 +1077,7 @@
     i32.const 0
     i32.const 1152
     i32.const 112
-    i32.const 13
+    i32.const 14
     call $~lib/builtins/abort
     unreachable
    end
@@ -1115,7 +1115,7 @@
    i32.const 0
    i32.const 1152
    i32.const 122
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1160,7 +1160,7 @@
     i32.const 0
     i32.const 1152
     i32.const 126
-    i32.const 17
+    i32.const 18
     call $~lib/builtins/abort
     unreachable
    end
@@ -1181,7 +1181,7 @@
     i32.const 0
     i32.const 1152
     i32.const 136
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end

--- a/tests/compiler/rc/rereturn.untouched.wat
+++ b/tests/compiler/rc/rereturn.untouched.wat
@@ -50,7 +50,7 @@
    i32.const 0
    i32.const 32
    i32.const 277
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -75,7 +75,7 @@
    i32.const 0
    i32.const 32
    i32.const 279
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -127,7 +127,7 @@
    i32.const 0
    i32.const 32
    i32.const 292
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -257,7 +257,7 @@
    i32.const 0
    i32.const 32
    i32.const 205
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -272,7 +272,7 @@
    i32.const 0
    i32.const 32
    i32.const 207
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -365,7 +365,7 @@
     i32.const 0
     i32.const 32
     i32.const 228
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -428,7 +428,7 @@
    i32.const 0
    i32.const 32
    i32.const 243
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -444,7 +444,7 @@
    i32.const 0
    i32.const 32
    i32.const 244
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -501,7 +501,7 @@
    i32.const 0
    i32.const 32
    i32.const 260
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -620,7 +620,7 @@
    i32.const 0
    i32.const 32
    i32.const 386
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -643,7 +643,7 @@
     i32.const 0
     i32.const 32
     i32.const 396
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -674,7 +674,7 @@
     i32.const 0
     i32.const 32
     i32.const 408
-    i32.const 4
+    i32.const 5
     call $~lib/builtins/abort
     unreachable
    end
@@ -900,7 +900,7 @@
    i32.const 80
    i32.const 32
    i32.const 461
-   i32.const 29
+   i32.const 30
    call $~lib/builtins/abort
    unreachable
   end
@@ -994,7 +994,7 @@
    i32.const 0
    i32.const 32
    i32.const 338
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1057,7 +1057,7 @@
      i32.const 0
      i32.const 32
      i32.const 351
-     i32.const 17
+     i32.const 18
      call $~lib/builtins/abort
      unreachable
     end
@@ -1202,7 +1202,7 @@
    i32.const 0
    i32.const 32
    i32.const 365
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1291,7 +1291,7 @@
    i32.const 0
    i32.const 32
    i32.const 501
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1332,7 +1332,7 @@
       i32.const 0
       i32.const 32
       i32.const 513
-      i32.const 19
+      i32.const 20
       call $~lib/builtins/abort
       unreachable
      end
@@ -1351,7 +1351,7 @@
      i32.const 0
      i32.const 32
      i32.const 518
-     i32.const 17
+     i32.const 18
      call $~lib/builtins/abort
      unreachable
     end
@@ -1368,7 +1368,7 @@
    i32.const 0
    i32.const 32
    i32.const 521
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1417,7 +1417,7 @@
    i32.const 0
    i32.const 144
    i32.const 109
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1436,7 +1436,7 @@
    i32.const 0
    i32.const 144
    i32.const 112
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1527,7 +1527,7 @@
    i32.const 0
    i32.const 144
    i32.const 122
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1549,7 +1549,7 @@
     i32.const 0
     i32.const 144
     i32.const 126
-    i32.const 17
+    i32.const 18
     call $~lib/builtins/abort
     unreachable
    end
@@ -1565,7 +1565,7 @@
     i32.const 0
     i32.const 144
     i32.const 136
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -1597,7 +1597,7 @@
    i32.const 0
    i32.const 144
    i32.const 69
-   i32.const 15
+   i32.const 16
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/rc/ternary-mismatch.optimized.wat
+++ b/tests/compiler/rc/ternary-mismatch.optimized.wat
@@ -37,7 +37,7 @@
    i32.const 0
    i32.const 1040
    i32.const 277
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -59,7 +59,7 @@
    i32.const 0
    i32.const 1040
    i32.const 279
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -102,7 +102,7 @@
    i32.const 0
    i32.const 1040
    i32.const 292
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -198,7 +198,7 @@
    i32.const 0
    i32.const 1040
    i32.const 205
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -212,7 +212,7 @@
    i32.const 0
    i32.const 1040
    i32.const 207
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -285,7 +285,7 @@
     i32.const 0
     i32.const 1040
     i32.const 228
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -340,7 +340,7 @@
    i32.const 0
    i32.const 1040
    i32.const 243
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -355,7 +355,7 @@
    i32.const 0
    i32.const 1040
    i32.const 244
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -403,7 +403,7 @@
    i32.const 0
    i32.const 1040
    i32.const 260
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -486,7 +486,7 @@
    i32.const 0
    i32.const 1040
    i32.const 386
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -503,7 +503,7 @@
     i32.const 0
     i32.const 1040
     i32.const 396
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -531,7 +531,7 @@
     i32.const 0
     i32.const 1040
     i32.const 408
-    i32.const 4
+    i32.const 5
     call $~lib/builtins/abort
     unreachable
    end
@@ -702,7 +702,7 @@
      i32.const 0
      i32.const 1040
      i32.const 351
-     i32.const 17
+     i32.const 18
      call $~lib/builtins/abort
      unreachable
     end
@@ -731,7 +731,7 @@
    i32.const 0
    i32.const 1040
    i32.const 501
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -801,7 +801,7 @@
      i32.const 0
      i32.const 1040
      i32.const 513
-     i32.const 19
+     i32.const 20
      call $~lib/builtins/abort
      unreachable
     end
@@ -817,7 +817,7 @@
    i32.const 0
    i32.const 1040
    i32.const 521
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -919,7 +919,7 @@
     i32.const 0
     i32.const 1152
     i32.const 109
-    i32.const 2
+    i32.const 3
     call $~lib/builtins/abort
     unreachable
    end
@@ -938,7 +938,7 @@
     i32.const 0
     i32.const 1152
     i32.const 112
-    i32.const 13
+    i32.const 14
     call $~lib/builtins/abort
     unreachable
    end
@@ -1018,7 +1018,7 @@
    i32.const 0
    i32.const 1152
    i32.const 122
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1063,7 +1063,7 @@
     i32.const 0
     i32.const 1152
     i32.const 126
-    i32.const 17
+    i32.const 18
     call $~lib/builtins/abort
     unreachable
    end
@@ -1086,7 +1086,7 @@
     i32.const 0
     i32.const 1152
     i32.const 136
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end

--- a/tests/compiler/rc/ternary-mismatch.untouched.wat
+++ b/tests/compiler/rc/ternary-mismatch.untouched.wat
@@ -50,7 +50,7 @@
    i32.const 0
    i32.const 32
    i32.const 277
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -75,7 +75,7 @@
    i32.const 0
    i32.const 32
    i32.const 279
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -127,7 +127,7 @@
    i32.const 0
    i32.const 32
    i32.const 292
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -257,7 +257,7 @@
    i32.const 0
    i32.const 32
    i32.const 205
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -272,7 +272,7 @@
    i32.const 0
    i32.const 32
    i32.const 207
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -365,7 +365,7 @@
     i32.const 0
     i32.const 32
     i32.const 228
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -428,7 +428,7 @@
    i32.const 0
    i32.const 32
    i32.const 243
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -444,7 +444,7 @@
    i32.const 0
    i32.const 32
    i32.const 244
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -501,7 +501,7 @@
    i32.const 0
    i32.const 32
    i32.const 260
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -620,7 +620,7 @@
    i32.const 0
    i32.const 32
    i32.const 386
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -643,7 +643,7 @@
     i32.const 0
     i32.const 32
     i32.const 396
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -674,7 +674,7 @@
     i32.const 0
     i32.const 32
     i32.const 408
-    i32.const 4
+    i32.const 5
     call $~lib/builtins/abort
     unreachable
    end
@@ -900,7 +900,7 @@
    i32.const 80
    i32.const 32
    i32.const 461
-   i32.const 29
+   i32.const 30
    call $~lib/builtins/abort
    unreachable
   end
@@ -994,7 +994,7 @@
    i32.const 0
    i32.const 32
    i32.const 338
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1057,7 +1057,7 @@
      i32.const 0
      i32.const 32
      i32.const 351
-     i32.const 17
+     i32.const 18
      call $~lib/builtins/abort
      unreachable
     end
@@ -1202,7 +1202,7 @@
    i32.const 0
    i32.const 32
    i32.const 365
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1291,7 +1291,7 @@
    i32.const 0
    i32.const 32
    i32.const 501
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1332,7 +1332,7 @@
       i32.const 0
       i32.const 32
       i32.const 513
-      i32.const 19
+      i32.const 20
       call $~lib/builtins/abort
       unreachable
      end
@@ -1351,7 +1351,7 @@
      i32.const 0
      i32.const 32
      i32.const 518
-     i32.const 17
+     i32.const 18
      call $~lib/builtins/abort
      unreachable
     end
@@ -1368,7 +1368,7 @@
    i32.const 0
    i32.const 32
    i32.const 521
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1419,7 +1419,7 @@
    i32.const 0
    i32.const 144
    i32.const 109
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1440,7 +1440,7 @@
    i32.const 0
    i32.const 144
    i32.const 112
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1565,7 +1565,7 @@
    i32.const 0
    i32.const 144
    i32.const 122
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1587,7 +1587,7 @@
     i32.const 0
     i32.const 144
     i32.const 126
-    i32.const 17
+    i32.const 18
     call $~lib/builtins/abort
     unreachable
    end
@@ -1603,7 +1603,7 @@
     i32.const 0
     i32.const 144
     i32.const 136
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -1635,7 +1635,7 @@
    i32.const 0
    i32.const 144
    i32.const 69
-   i32.const 15
+   i32.const 16
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/resolve-access.optimized.wat
+++ b/tests/compiler/resolve-access.optimized.wat
@@ -486,7 +486,7 @@
    i32.const 1072
    i32.const 1136
    i32.const 104
-   i32.const 41
+   i32.const 42
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/resolve-access.untouched.wat
+++ b/tests/compiler/resolve-access.untouched.wat
@@ -1449,7 +1449,7 @@
    i32.const 64
    i32.const 128
    i32.const 104
-   i32.const 41
+   i32.const 42
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/resolve-binary.optimized.wat
+++ b/tests/compiler/resolve-binary.optimized.wat
@@ -1398,7 +1398,7 @@
    i32.const 0
    i32.const 2432
    i32.const 70
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1413,7 +1413,7 @@
    i32.const 0
    i32.const 2432
    i32.const 72
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1437,7 +1437,7 @@
    i32.const 0
    i32.const 1104
    i32.const 2
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1449,7 +1449,7 @@
    i32.const 0
    i32.const 1104
    i32.const 7
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1461,7 +1461,7 @@
    i32.const 0
    i32.const 1104
    i32.const 12
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1473,7 +1473,7 @@
    i32.const 0
    i32.const 1104
    i32.const 17
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1485,7 +1485,7 @@
    i32.const 0
    i32.const 1104
    i32.const 22
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1497,7 +1497,7 @@
    i32.const 0
    i32.const 1104
    i32.const 27
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1509,7 +1509,7 @@
    i32.const 0
    i32.const 1104
    i32.const 34
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1521,7 +1521,7 @@
    i32.const 0
    i32.const 1104
    i32.const 39
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1540,7 +1540,7 @@
    i32.const 0
    i32.const 1104
    i32.const 48
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1557,7 +1557,7 @@
    i32.const 0
    i32.const 1104
    i32.const 53
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1574,7 +1574,7 @@
    i32.const 0
    i32.const 1104
    i32.const 58
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1591,7 +1591,7 @@
    i32.const 0
    i32.const 1104
    i32.const 63
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1607,7 +1607,7 @@
    i32.const 0
    i32.const 1104
    i32.const 69
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1624,7 +1624,7 @@
    i32.const 0
    i32.const 1104
    i32.const 75
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1641,7 +1641,7 @@
    i32.const 0
    i32.const 1104
    i32.const 80
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1658,7 +1658,7 @@
    i32.const 0
    i32.const 1104
    i32.const 85
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1675,7 +1675,7 @@
    i32.const 0
    i32.const 1104
    i32.const 90
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1692,7 +1692,7 @@
    i32.const 0
    i32.const 1104
    i32.const 95
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1709,7 +1709,7 @@
    i32.const 0
    i32.const 1104
    i32.const 100
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1726,7 +1726,7 @@
    i32.const 0
    i32.const 1104
    i32.const 105
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1743,7 +1743,7 @@
    i32.const 0
    i32.const 1104
    i32.const 110
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1756,7 +1756,7 @@
    i32.const 0
    i32.const 1104
    i32.const 117
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1769,7 +1769,7 @@
    i32.const 0
    i32.const 1104
    i32.const 122
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1782,7 +1782,7 @@
    i32.const 0
    i32.const 1104
    i32.const 127
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1795,7 +1795,7 @@
    i32.const 0
    i32.const 1104
    i32.const 132
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1808,7 +1808,7 @@
    i32.const 0
    i32.const 1104
    i32.const 137
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1820,7 +1820,7 @@
    i32.const 0
    i32.const 1104
    i32.const 144
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1833,7 +1833,7 @@
    i32.const 0
    i32.const 1104
    i32.const 151
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1846,7 +1846,7 @@
    i32.const 0
    i32.const 1104
    i32.const 156
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1859,7 +1859,7 @@
    i32.const 0
    i32.const 1104
    i32.const 161
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1872,7 +1872,7 @@
    i32.const 0
    i32.const 1104
    i32.const 168
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1885,7 +1885,7 @@
    i32.const 0
    i32.const 1104
    i32.const 173
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1898,7 +1898,7 @@
    i32.const 0
    i32.const 1104
    i32.const 178
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1911,7 +1911,7 @@
    i32.const 0
    i32.const 1104
    i32.const 185
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1924,7 +1924,7 @@
    i32.const 0
    i32.const 1104
    i32.const 190
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1937,7 +1937,7 @@
    i32.const 0
    i32.const 1104
    i32.const 195
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1950,7 +1950,7 @@
    i32.const 0
    i32.const 1104
    i32.const 200
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1966,7 +1966,7 @@
    i32.const 0
    i32.const 1104
    i32.const 261
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1978,7 +1978,7 @@
    i32.const 0
    i32.const 1104
    i32.const 266
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1990,7 +1990,7 @@
    i32.const 0
    i32.const 1104
    i32.const 271
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2002,7 +2002,7 @@
    i32.const 0
    i32.const 1104
    i32.const 276
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2014,7 +2014,7 @@
    i32.const 0
    i32.const 1104
    i32.const 281
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2026,7 +2026,7 @@
    i32.const 0
    i32.const 1104
    i32.const 286
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2038,7 +2038,7 @@
    i32.const 0
    i32.const 1104
    i32.const 291
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2050,7 +2050,7 @@
    i32.const 0
    i32.const 1104
    i32.const 296
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2062,7 +2062,7 @@
    i32.const 0
    i32.const 1104
    i32.const 301
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2074,7 +2074,7 @@
    i32.const 0
    i32.const 1104
    i32.const 306
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2086,7 +2086,7 @@
    i32.const 0
    i32.const 1104
    i32.const 311
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2098,7 +2098,7 @@
    i32.const 0
    i32.const 1104
    i32.const 316
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2119,7 +2119,7 @@
    i32.const 0
    i32.const 1104
    i32.const 334
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2130,7 +2130,7 @@
    i32.const 0
    i32.const 1104
    i32.const 339
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/resolve-binary.untouched.wat
+++ b/tests/compiler/resolve-binary.untouched.wat
@@ -4225,7 +4225,7 @@
    i32.const 0
    i32.const 8016
    i32.const 70
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4242,7 +4242,7 @@
    i32.const 0
    i32.const 8016
    i32.const 72
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -4572,7 +4572,7 @@
    i32.const 0
    i32.const 96
    i32.const 2
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -4586,7 +4586,7 @@
    i32.const 0
    i32.const 96
    i32.const 7
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -4600,7 +4600,7 @@
    i32.const 0
    i32.const 96
    i32.const 12
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -4614,7 +4614,7 @@
    i32.const 0
    i32.const 96
    i32.const 17
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -4628,7 +4628,7 @@
    i32.const 0
    i32.const 96
    i32.const 22
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -4642,7 +4642,7 @@
    i32.const 0
    i32.const 96
    i32.const 27
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -4656,7 +4656,7 @@
    i32.const 0
    i32.const 96
    i32.const 34
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -4670,7 +4670,7 @@
    i32.const 0
    i32.const 96
    i32.const 39
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -4696,7 +4696,7 @@
    i32.const 0
    i32.const 96
    i32.const 48
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -4714,7 +4714,7 @@
    i32.const 0
    i32.const 96
    i32.const 53
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -4732,7 +4732,7 @@
    i32.const 0
    i32.const 96
    i32.const 58
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -4750,7 +4750,7 @@
    i32.const 0
    i32.const 96
    i32.const 63
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -4771,7 +4771,7 @@
    i32.const 0
    i32.const 96
    i32.const 69
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -4791,7 +4791,7 @@
    i32.const 0
    i32.const 96
    i32.const 75
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -4809,7 +4809,7 @@
    i32.const 0
    i32.const 96
    i32.const 80
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -4827,7 +4827,7 @@
    i32.const 0
    i32.const 96
    i32.const 85
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -4845,7 +4845,7 @@
    i32.const 0
    i32.const 96
    i32.const 90
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -4863,7 +4863,7 @@
    i32.const 0
    i32.const 96
    i32.const 95
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -4881,7 +4881,7 @@
    i32.const 0
    i32.const 96
    i32.const 100
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -4899,7 +4899,7 @@
    i32.const 0
    i32.const 96
    i32.const 105
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -4917,7 +4917,7 @@
    i32.const 0
    i32.const 96
    i32.const 110
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -4931,7 +4931,7 @@
    i32.const 0
    i32.const 96
    i32.const 117
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -4945,7 +4945,7 @@
    i32.const 0
    i32.const 96
    i32.const 122
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -4959,7 +4959,7 @@
    i32.const 0
    i32.const 96
    i32.const 127
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -4973,7 +4973,7 @@
    i32.const 0
    i32.const 96
    i32.const 132
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -4987,7 +4987,7 @@
    i32.const 0
    i32.const 96
    i32.const 137
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -5004,7 +5004,7 @@
    i32.const 0
    i32.const 96
    i32.const 144
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -5018,7 +5018,7 @@
    i32.const 0
    i32.const 96
    i32.const 151
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -5032,7 +5032,7 @@
    i32.const 0
    i32.const 96
    i32.const 156
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -5046,7 +5046,7 @@
    i32.const 0
    i32.const 96
    i32.const 161
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -5060,7 +5060,7 @@
    i32.const 0
    i32.const 96
    i32.const 168
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -5074,7 +5074,7 @@
    i32.const 0
    i32.const 96
    i32.const 173
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -5088,7 +5088,7 @@
    i32.const 0
    i32.const 96
    i32.const 178
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -5102,7 +5102,7 @@
    i32.const 0
    i32.const 96
    i32.const 185
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -5116,7 +5116,7 @@
    i32.const 0
    i32.const 96
    i32.const 190
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -5130,7 +5130,7 @@
    i32.const 0
    i32.const 96
    i32.const 195
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -5144,7 +5144,7 @@
    i32.const 0
    i32.const 96
    i32.const 200
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -5164,7 +5164,7 @@
    i32.const 0
    i32.const 96
    i32.const 261
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -5181,7 +5181,7 @@
    i32.const 0
    i32.const 96
    i32.const 266
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -5198,7 +5198,7 @@
    i32.const 0
    i32.const 96
    i32.const 271
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -5215,7 +5215,7 @@
    i32.const 0
    i32.const 96
    i32.const 276
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -5232,7 +5232,7 @@
    i32.const 0
    i32.const 96
    i32.const 281
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -5249,7 +5249,7 @@
    i32.const 0
    i32.const 96
    i32.const 286
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -5266,7 +5266,7 @@
    i32.const 0
    i32.const 96
    i32.const 291
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -5283,7 +5283,7 @@
    i32.const 0
    i32.const 96
    i32.const 296
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -5300,7 +5300,7 @@
    i32.const 0
    i32.const 96
    i32.const 301
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -5317,7 +5317,7 @@
    i32.const 0
    i32.const 96
    i32.const 306
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -5334,7 +5334,7 @@
    i32.const 0
    i32.const 96
    i32.const 311
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -5351,7 +5351,7 @@
    i32.const 0
    i32.const 96
    i32.const 316
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -5388,7 +5388,7 @@
    i32.const 0
    i32.const 96
    i32.const 334
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -5400,7 +5400,7 @@
    i32.const 0
    i32.const 96
    i32.const 339
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/resolve-elementaccess.optimized.wat
+++ b/tests/compiler/resolve-elementaccess.optimized.wat
@@ -299,7 +299,7 @@
    i32.const 1040
    i32.const 1088
    i32.const 23
-   i32.const 56
+   i32.const 57
    call $~lib/builtins/abort
    unreachable
   end
@@ -354,7 +354,7 @@
    i32.const 1152
    i32.const 1216
    i32.const 1187
-   i32.const 63
+   i32.const 64
    call $~lib/builtins/abort
    unreachable
   end
@@ -378,7 +378,7 @@
    i32.const 1152
    i32.const 1216
    i32.const 1176
-   i32.const 63
+   i32.const 64
    call $~lib/builtins/abort
    unreachable
   end
@@ -1700,7 +1700,7 @@
    i32.const 0
    i32.const 2416
    i32.const 70
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1715,7 +1715,7 @@
    i32.const 0
    i32.const 2416
    i32.const 72
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1847,7 +1847,7 @@
    i32.const 1152
    i32.const 1216
    i32.const 163
-   i32.const 44
+   i32.const 45
    call $~lib/builtins/abort
    unreachable
   end
@@ -1867,7 +1867,7 @@
    i32.const 1152
    i32.const 1216
    i32.const 152
-   i32.const 44
+   i32.const 45
    call $~lib/builtins/abort
    unreachable
   end
@@ -1937,7 +1937,7 @@
    i32.const 0
    i32.const 2496
    i32.const 5
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1953,7 +1953,7 @@
    i32.const 0
    i32.const 2496
    i32.const 10
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1978,7 +1978,7 @@
    i32.const 0
    i32.const 2496
    i32.const 15
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1999,7 +1999,7 @@
    i32.const 0
    i32.const 2496
    i32.const 21
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2037,7 +2037,7 @@
    i32.const 0
    i32.const 2496
    i32.const 28
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2052,7 +2052,7 @@
    i32.const 0
    i32.const 2496
    i32.const 33
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2076,7 +2076,7 @@
    i32.const 0
    i32.const 2496
    i32.const 38
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2097,7 +2097,7 @@
    i32.const 0
    i32.const 2496
    i32.const 44
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/resolve-elementaccess.untouched.wat
+++ b/tests/compiler/resolve-elementaccess.untouched.wat
@@ -388,7 +388,7 @@
    i32.const 32
    i32.const 80
    i32.const 23
-   i32.const 56
+   i32.const 57
    call $~lib/builtins/abort
    unreachable
   end
@@ -473,7 +473,7 @@
    i32.const 144
    i32.const 208
    i32.const 1187
-   i32.const 63
+   i32.const 64
    call $~lib/builtins/abort
    unreachable
   end
@@ -497,7 +497,7 @@
    i32.const 144
    i32.const 208
    i32.const 1176
-   i32.const 63
+   i32.const 64
    call $~lib/builtins/abort
    unreachable
   end
@@ -3327,7 +3327,7 @@
    i32.const 0
    i32.const 1824
    i32.const 70
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3344,7 +3344,7 @@
    i32.const 0
    i32.const 1824
    i32.const 72
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -3661,7 +3661,7 @@
    i32.const 144
    i32.const 208
    i32.const 163
-   i32.const 44
+   i32.const 45
    call $~lib/builtins/abort
    unreachable
   end
@@ -3681,7 +3681,7 @@
    i32.const 144
    i32.const 208
    i32.const 152
-   i32.const 44
+   i32.const 45
    call $~lib/builtins/abort
    unreachable
   end
@@ -3777,7 +3777,7 @@
    i32.const 0
    i32.const 1904
    i32.const 5
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3793,7 +3793,7 @@
    i32.const 0
    i32.const 1904
    i32.const 10
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3819,7 +3819,7 @@
    i32.const 0
    i32.const 1904
    i32.const 15
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3841,7 +3841,7 @@
    i32.const 0
    i32.const 1904
    i32.const 21
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3869,7 +3869,7 @@
    i32.const 0
    i32.const 1904
    i32.const 28
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3885,7 +3885,7 @@
    i32.const 0
    i32.const 1904
    i32.const 33
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3911,7 +3911,7 @@
    i32.const 0
    i32.const 1904
    i32.const 38
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3933,7 +3933,7 @@
    i32.const 0
    i32.const 1904
    i32.const 44
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/resolve-function-expression.optimized.wat
+++ b/tests/compiler/resolve-function-expression.optimized.wat
@@ -248,7 +248,7 @@
    i32.const 0
    i32.const 1040
    i32.const 11
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/resolve-function-expression.untouched.wat
+++ b/tests/compiler/resolve-function-expression.untouched.wat
@@ -629,7 +629,7 @@
    i32.const 0
    i32.const 32
    i32.const 1
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -645,7 +645,7 @@
    i32.const 0
    i32.const 32
    i32.const 6
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -673,7 +673,7 @@
    i32.const 0
    i32.const 32
    i32.const 11
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/resolve-propertyaccess.optimized.wat
+++ b/tests/compiler/resolve-propertyaccess.optimized.wat
@@ -340,7 +340,7 @@
    i32.const 0
    i32.const 1104
    i32.const 6
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -353,7 +353,7 @@
    i32.const 0
    i32.const 1104
    i32.const 12
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -366,7 +366,7 @@
    i32.const 0
    i32.const 1104
    i32.const 24
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -379,7 +379,7 @@
    i32.const 0
    i32.const 1104
    i32.const 30
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -392,7 +392,7 @@
    i32.const 0
    i32.const 1104
    i32.const 42
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -405,7 +405,7 @@
    i32.const 0
    i32.const 1104
    i32.const 48
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -418,7 +418,7 @@
    i32.const 0
    i32.const 1104
    i32.const 58
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -431,7 +431,7 @@
    i32.const 0
    i32.const 1104
    i32.const 70
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -444,7 +444,7 @@
    i32.const 0
    i32.const 1104
    i32.const 76
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -464,7 +464,7 @@
    i32.const 0
    i32.const 1104
    i32.const 84
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/resolve-propertyaccess.untouched.wat
+++ b/tests/compiler/resolve-propertyaccess.untouched.wat
@@ -658,7 +658,7 @@
    i32.const 0
    i32.const 512
    i32.const 6
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -672,7 +672,7 @@
    i32.const 0
    i32.const 512
    i32.const 12
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -686,7 +686,7 @@
    i32.const 0
    i32.const 512
    i32.const 24
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -700,7 +700,7 @@
    i32.const 0
    i32.const 512
    i32.const 30
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -714,7 +714,7 @@
    i32.const 0
    i32.const 512
    i32.const 42
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -728,7 +728,7 @@
    i32.const 0
    i32.const 512
    i32.const 48
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -742,7 +742,7 @@
    i32.const 0
    i32.const 512
    i32.const 58
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -756,7 +756,7 @@
    i32.const 0
    i32.const 512
    i32.const 70
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -770,7 +770,7 @@
    i32.const 0
    i32.const 512
    i32.const 76
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -788,7 +788,7 @@
    i32.const 0
    i32.const 512
    i32.const 84
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/resolve-ternary.optimized.wat
+++ b/tests/compiler/resolve-ternary.optimized.wat
@@ -60,7 +60,7 @@
    i32.const 0
    i32.const 1040
    i32.const 277
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -82,7 +82,7 @@
    i32.const 0
    i32.const 1040
    i32.const 279
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -125,7 +125,7 @@
    i32.const 0
    i32.const 1040
    i32.const 292
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -221,7 +221,7 @@
    i32.const 0
    i32.const 1040
    i32.const 205
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -235,7 +235,7 @@
    i32.const 0
    i32.const 1040
    i32.const 207
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -308,7 +308,7 @@
     i32.const 0
     i32.const 1040
     i32.const 228
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -363,7 +363,7 @@
    i32.const 0
    i32.const 1040
    i32.const 243
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -378,7 +378,7 @@
    i32.const 0
    i32.const 1040
    i32.const 244
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -426,7 +426,7 @@
    i32.const 0
    i32.const 1040
    i32.const 260
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -509,7 +509,7 @@
    i32.const 0
    i32.const 1040
    i32.const 386
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -526,7 +526,7 @@
     i32.const 0
     i32.const 1040
     i32.const 396
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -554,7 +554,7 @@
     i32.const 0
     i32.const 1040
     i32.const 408
-    i32.const 4
+    i32.const 5
     call $~lib/builtins/abort
     unreachable
    end
@@ -744,7 +744,7 @@
    i32.const 0
    i32.const 1040
    i32.const 338
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -796,7 +796,7 @@
      i32.const 0
      i32.const 1040
      i32.const 351
-     i32.const 17
+     i32.const 18
      call $~lib/builtins/abort
      unreachable
     end
@@ -829,7 +829,7 @@
    i32.const 0
    i32.const 1040
    i32.const 365
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -900,7 +900,7 @@
    i32.const 0
    i32.const 1040
    i32.const 501
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -911,7 +911,7 @@
    i32.const 1088
    i32.const 1040
    i32.const 461
-   i32.const 29
+   i32.const 30
    call $~lib/builtins/abort
    unreachable
   end
@@ -1011,7 +1011,7 @@
      i32.const 0
      i32.const 1040
      i32.const 513
-     i32.const 19
+     i32.const 20
      call $~lib/builtins/abort
      unreachable
     end
@@ -1027,7 +1027,7 @@
    i32.const 0
    i32.const 1040
    i32.const 521
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1082,7 +1082,7 @@
     i32.const 0
     i32.const 1152
     i32.const 109
-    i32.const 2
+    i32.const 3
     call $~lib/builtins/abort
     unreachable
    end
@@ -1099,7 +1099,7 @@
     i32.const 0
     i32.const 1152
     i32.const 112
-    i32.const 13
+    i32.const 14
     call $~lib/builtins/abort
     unreachable
    end
@@ -2350,7 +2350,7 @@
    i32.const 0
    i32.const 1264
    i32.const 5
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2408,7 +2408,7 @@
     i32.const 0
     i32.const 1040
     i32.const 581
-    i32.const 2
+    i32.const 3
     call $~lib/builtins/abort
     unreachable
    end
@@ -2423,7 +2423,7 @@
    i32.const 0
    i32.const 1264
    i32.const 13
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2461,7 +2461,7 @@
    i32.const 0
    i32.const 1152
    i32.const 122
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -2506,7 +2506,7 @@
     i32.const 0
     i32.const 1152
     i32.const 126
-    i32.const 17
+    i32.const 18
     call $~lib/builtins/abort
     unreachable
    end
@@ -2521,7 +2521,7 @@
     i32.const 0
     i32.const 1152
     i32.const 136
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end

--- a/tests/compiler/resolve-ternary.untouched.wat
+++ b/tests/compiler/resolve-ternary.untouched.wat
@@ -81,7 +81,7 @@
    i32.const 0
    i32.const 32
    i32.const 277
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -106,7 +106,7 @@
    i32.const 0
    i32.const 32
    i32.const 279
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -158,7 +158,7 @@
    i32.const 0
    i32.const 32
    i32.const 292
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -288,7 +288,7 @@
    i32.const 0
    i32.const 32
    i32.const 205
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -303,7 +303,7 @@
    i32.const 0
    i32.const 32
    i32.const 207
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -396,7 +396,7 @@
     i32.const 0
     i32.const 32
     i32.const 228
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -459,7 +459,7 @@
    i32.const 0
    i32.const 32
    i32.const 243
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -475,7 +475,7 @@
    i32.const 0
    i32.const 32
    i32.const 244
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -532,7 +532,7 @@
    i32.const 0
    i32.const 32
    i32.const 260
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -651,7 +651,7 @@
    i32.const 0
    i32.const 32
    i32.const 386
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -674,7 +674,7 @@
     i32.const 0
     i32.const 32
     i32.const 396
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -705,7 +705,7 @@
     i32.const 0
     i32.const 32
     i32.const 408
-    i32.const 4
+    i32.const 5
     call $~lib/builtins/abort
     unreachable
    end
@@ -931,7 +931,7 @@
    i32.const 80
    i32.const 32
    i32.const 461
-   i32.const 29
+   i32.const 30
    call $~lib/builtins/abort
    unreachable
   end
@@ -1025,7 +1025,7 @@
    i32.const 0
    i32.const 32
    i32.const 338
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1088,7 +1088,7 @@
      i32.const 0
      i32.const 32
      i32.const 351
-     i32.const 17
+     i32.const 18
      call $~lib/builtins/abort
      unreachable
     end
@@ -1233,7 +1233,7 @@
    i32.const 0
    i32.const 32
    i32.const 365
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1322,7 +1322,7 @@
    i32.const 0
    i32.const 32
    i32.const 501
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1363,7 +1363,7 @@
       i32.const 0
       i32.const 32
       i32.const 513
-      i32.const 19
+      i32.const 20
       call $~lib/builtins/abort
       unreachable
      end
@@ -1382,7 +1382,7 @@
      i32.const 0
      i32.const 32
      i32.const 518
-     i32.const 17
+     i32.const 18
      call $~lib/builtins/abort
      unreachable
     end
@@ -1399,7 +1399,7 @@
    i32.const 0
    i32.const 32
    i32.const 521
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1448,7 +1448,7 @@
    i32.const 0
    i32.const 144
    i32.const 109
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1467,7 +1467,7 @@
    i32.const 0
    i32.const 144
    i32.const 112
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -4593,7 +4593,7 @@
    i32.const 0
    i32.const 32
    i32.const 581
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4726,7 +4726,7 @@
    i32.const 0
    i32.const 672
    i32.const 5
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -4746,7 +4746,7 @@
    i32.const 0
    i32.const 672
    i32.const 13
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -4767,7 +4767,7 @@
    i32.const 0
    i32.const 672
    i32.const 24
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -4788,7 +4788,7 @@
    i32.const 0
    i32.const 672
    i32.const 35
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -4809,7 +4809,7 @@
    i32.const 0
    i32.const 672
    i32.const 43
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -4844,7 +4844,7 @@
    i32.const 0
    i32.const 144
    i32.const 122
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -4866,7 +4866,7 @@
     i32.const 0
     i32.const 144
     i32.const 126
-    i32.const 17
+    i32.const 18
     call $~lib/builtins/abort
     unreachable
    end
@@ -4882,7 +4882,7 @@
     i32.const 0
     i32.const 144
     i32.const 136
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -4914,7 +4914,7 @@
    i32.const 0
    i32.const 144
    i32.const 69
-   i32.const 15
+   i32.const 16
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/resolve-unary.optimized.wat
+++ b/tests/compiler/resolve-unary.optimized.wat
@@ -348,7 +348,7 @@
    i32.const 0
    i32.const 1104
    i32.const 2
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -361,7 +361,7 @@
    i32.const 0
    i32.const 1104
    i32.const 7
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -378,7 +378,7 @@
    i32.const 0
    i32.const 1104
    i32.const 13
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -395,7 +395,7 @@
    i32.const 0
    i32.const 1104
    i32.const 18
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -410,7 +410,7 @@
    i32.const 0
    i32.const 1104
    i32.const 23
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -425,7 +425,7 @@
    i32.const 0
    i32.const 1104
    i32.const 28
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -440,7 +440,7 @@
    i32.const 0
    i32.const 1104
    i32.const 33
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -458,7 +458,7 @@
    i32.const 0
    i32.const 1104
    i32.const 41
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -476,7 +476,7 @@
    i32.const 0
    i32.const 1104
    i32.const 46
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -492,7 +492,7 @@
    i32.const 0
    i32.const 1104
    i32.const 91
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -504,7 +504,7 @@
    i32.const 0
    i32.const 1104
    i32.const 96
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -516,7 +516,7 @@
    i32.const 0
    i32.const 1104
    i32.const 111
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -528,7 +528,7 @@
    i32.const 0
    i32.const 1104
    i32.const 116
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -542,7 +542,7 @@
    i32.const 0
    i32.const 1104
    i32.const 121
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -556,7 +556,7 @@
    i32.const 0
    i32.const 1104
    i32.const 126
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -572,7 +572,7 @@
    i32.const 0
    i32.const 1104
    i32.const 151
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -584,7 +584,7 @@
    i32.const 0
    i32.const 1104
    i32.const 156
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -596,7 +596,7 @@
    i32.const 0
    i32.const 1104
    i32.const 161
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -608,7 +608,7 @@
    i32.const 0
    i32.const 1104
    i32.const 166
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/resolve-unary.untouched.wat
+++ b/tests/compiler/resolve-unary.untouched.wat
@@ -776,7 +776,7 @@
    i32.const 0
    i32.const 512
    i32.const 2
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -790,7 +790,7 @@
    i32.const 0
    i32.const 512
    i32.const 7
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -808,7 +808,7 @@
    i32.const 0
    i32.const 512
    i32.const 13
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -826,7 +826,7 @@
    i32.const 0
    i32.const 512
    i32.const 18
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -841,7 +841,7 @@
    i32.const 0
    i32.const 512
    i32.const 23
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -857,7 +857,7 @@
    i32.const 0
    i32.const 512
    i32.const 28
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -873,7 +873,7 @@
    i32.const 0
    i32.const 512
    i32.const 33
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -892,7 +892,7 @@
    i32.const 0
    i32.const 512
    i32.const 41
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -911,7 +911,7 @@
    i32.const 0
    i32.const 512
    i32.const 46
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -930,7 +930,7 @@
    i32.const 0
    i32.const 512
    i32.const 91
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -946,7 +946,7 @@
    i32.const 0
    i32.const 512
    i32.const 96
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -976,7 +976,7 @@
    i32.const 0
    i32.const 512
    i32.const 101
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1006,7 +1006,7 @@
    i32.const 0
    i32.const 512
    i32.const 106
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1022,7 +1022,7 @@
    i32.const 0
    i32.const 512
    i32.const 111
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1038,7 +1038,7 @@
    i32.const 0
    i32.const 512
    i32.const 116
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1069,7 +1069,7 @@
    i32.const 0
    i32.const 512
    i32.const 121
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1100,7 +1100,7 @@
    i32.const 0
    i32.const 512
    i32.const 126
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1119,7 +1119,7 @@
    i32.const 0
    i32.const 512
    i32.const 151
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1135,7 +1135,7 @@
    i32.const 0
    i32.const 512
    i32.const 156
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1151,7 +1151,7 @@
    i32.const 0
    i32.const 512
    i32.const 161
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1167,7 +1167,7 @@
    i32.const 0
    i32.const 512
    i32.const 166
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/retain-i32.untouched.wat
+++ b/tests/compiler/retain-i32.untouched.wat
@@ -41,7 +41,7 @@
    i32.const 0
    i32.const 32
    i32.const 4
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -65,7 +65,7 @@
    i32.const 0
    i32.const 32
    i32.const 5
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -89,7 +89,7 @@
    i32.const 0
    i32.const 32
    i32.const 6
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -113,7 +113,7 @@
    i32.const 0
    i32.const 32
    i32.const 7
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -137,7 +137,7 @@
    i32.const 0
    i32.const 32
    i32.const 8
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -161,7 +161,7 @@
    i32.const 0
    i32.const 32
    i32.const 9
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -185,7 +185,7 @@
    i32.const 0
    i32.const 32
    i32.const 10
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -205,7 +205,7 @@
    i32.const 0
    i32.const 32
    i32.const 13
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -225,7 +225,7 @@
    i32.const 0
    i32.const 32
    i32.const 14
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -245,7 +245,7 @@
    i32.const 0
    i32.const 32
    i32.const 15
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -265,7 +265,7 @@
    i32.const 0
    i32.const 32
    i32.const 16
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -285,7 +285,7 @@
    i32.const 0
    i32.const 32
    i32.const 17
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -305,7 +305,7 @@
    i32.const 0
    i32.const 32
    i32.const 18
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -325,7 +325,7 @@
    i32.const 0
    i32.const 32
    i32.const 19
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -478,7 +478,7 @@
    i32.const 0
    i32.const 32
    i32.const 78
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -500,7 +500,7 @@
    i32.const 0
    i32.const 32
    i32.const 81
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -520,7 +520,7 @@
    i32.const 0
    i32.const 32
    i32.const 84
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -540,7 +540,7 @@
    i32.const 0
    i32.const 32
    i32.const 87
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -560,7 +560,7 @@
    i32.const 0
    i32.const 32
    i32.const 90
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -580,7 +580,7 @@
    i32.const 0
    i32.const 32
    i32.const 93
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -600,7 +600,7 @@
    i32.const 0
    i32.const 32
    i32.const 96
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -616,7 +616,7 @@
    i32.const 0
    i32.const 32
    i32.const 99
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -632,7 +632,7 @@
    i32.const 0
    i32.const 32
    i32.const 102
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -648,7 +648,7 @@
    i32.const 0
    i32.const 32
    i32.const 105
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -664,7 +664,7 @@
    i32.const 0
    i32.const 32
    i32.const 108
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -684,7 +684,7 @@
    i32.const 0
    i32.const 32
    i32.const 113
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -704,7 +704,7 @@
    i32.const 0
    i32.const 32
    i32.const 116
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -722,7 +722,7 @@
    i32.const 0
    i32.const 32
    i32.const 119
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -740,7 +740,7 @@
    i32.const 0
    i32.const 32
    i32.const 122
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -756,7 +756,7 @@
    i32.const 0
    i32.const 32
    i32.const 125
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -772,7 +772,7 @@
    i32.const 0
    i32.const 32
    i32.const 128
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -788,7 +788,7 @@
    i32.const 0
    i32.const 32
    i32.const 131
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/retain-release-sanity.optimized.wat
+++ b/tests/compiler/retain-release-sanity.optimized.wat
@@ -51,7 +51,7 @@
    i32.const 0
    i32.const 1136
    i32.const 277
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -73,7 +73,7 @@
    i32.const 0
    i32.const 1136
    i32.const 279
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -116,7 +116,7 @@
    i32.const 0
    i32.const 1136
    i32.const 292
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -212,7 +212,7 @@
    i32.const 0
    i32.const 1136
    i32.const 205
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -226,7 +226,7 @@
    i32.const 0
    i32.const 1136
    i32.const 207
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -299,7 +299,7 @@
     i32.const 0
     i32.const 1136
     i32.const 228
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -354,7 +354,7 @@
    i32.const 0
    i32.const 1136
    i32.const 243
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -369,7 +369,7 @@
    i32.const 0
    i32.const 1136
    i32.const 244
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -417,7 +417,7 @@
    i32.const 0
    i32.const 1136
    i32.const 260
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -500,7 +500,7 @@
    i32.const 0
    i32.const 1136
    i32.const 386
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -517,7 +517,7 @@
     i32.const 0
     i32.const 1136
     i32.const 396
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -545,7 +545,7 @@
     i32.const 0
     i32.const 1136
     i32.const 408
-    i32.const 4
+    i32.const 5
     call $~lib/builtins/abort
     unreachable
    end
@@ -686,7 +686,7 @@
    i32.const 1184
    i32.const 1136
    i32.const 461
-   i32.const 29
+   i32.const 30
    call $~lib/builtins/abort
    unreachable
   end
@@ -759,7 +759,7 @@
    i32.const 0
    i32.const 1136
    i32.const 338
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -811,7 +811,7 @@
      i32.const 0
      i32.const 1136
      i32.const 351
-     i32.const 17
+     i32.const 18
      call $~lib/builtins/abort
      unreachable
     end
@@ -844,7 +844,7 @@
    i32.const 0
    i32.const 1136
    i32.const 365
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -915,7 +915,7 @@
    i32.const 0
    i32.const 1136
    i32.const 501
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1007,7 +1007,7 @@
      i32.const 0
      i32.const 1136
      i32.const 513
-     i32.const 19
+     i32.const 20
      call $~lib/builtins/abort
      unreachable
     end
@@ -1023,7 +1023,7 @@
    i32.const 0
    i32.const 1136
    i32.const 521
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1238,7 +1238,7 @@
     i32.const 0
     i32.const 1248
     i32.const 109
-    i32.const 2
+    i32.const 3
     call $~lib/builtins/abort
     unreachable
    end
@@ -1257,7 +1257,7 @@
     i32.const 0
     i32.const 1248
     i32.const 112
-    i32.const 13
+    i32.const 14
     call $~lib/builtins/abort
     unreachable
    end
@@ -1311,7 +1311,7 @@
    i32.const 0
    i32.const 1136
    i32.const 581
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1625,7 +1625,7 @@
     i32.const 1040
     i32.const 1088
     i32.const 14
-    i32.const 47
+    i32.const 48
     call $~lib/builtins/abort
     unreachable
    end
@@ -1827,7 +1827,7 @@
    i32.const 1296
    i32.const 1088
    i32.const 299
-   i32.const 20
+   i32.const 21
    call $~lib/builtins/abort
    unreachable
   end
@@ -2365,7 +2365,7 @@
    i32.const 0
    i32.const 1248
    i32.const 122
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -2398,7 +2398,7 @@
     i32.const 0
     i32.const 1248
     i32.const 136
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -2412,7 +2412,7 @@
     i32.const 1488
     i32.const 1552
     i32.const 22
-    i32.const 27
+    i32.const 28
     call $~lib/builtins/abort
     unreachable
    end
@@ -2551,7 +2551,7 @@
         i32.const 0
         i32.const 1248
         i32.const 79
-        i32.const 19
+        i32.const 20
         call $~lib/builtins/abort
         unreachable
        end
@@ -2584,7 +2584,7 @@
       i32.const 0
       i32.const 1248
       i32.const 90
-      i32.const 8
+      i32.const 9
       call $~lib/builtins/abort
       unreachable
      end
@@ -2609,7 +2609,7 @@
    i32.const 0
    i32.const 1248
    i32.const 101
-   i32.const 26
+   i32.const 27
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/retain-release-sanity.untouched.wat
+++ b/tests/compiler/retain-release-sanity.untouched.wat
@@ -64,7 +64,7 @@
    i32.const 0
    i32.const 128
    i32.const 277
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -89,7 +89,7 @@
    i32.const 0
    i32.const 128
    i32.const 279
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -141,7 +141,7 @@
    i32.const 0
    i32.const 128
    i32.const 292
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -271,7 +271,7 @@
    i32.const 0
    i32.const 128
    i32.const 205
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -286,7 +286,7 @@
    i32.const 0
    i32.const 128
    i32.const 207
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -379,7 +379,7 @@
     i32.const 0
     i32.const 128
     i32.const 228
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -442,7 +442,7 @@
    i32.const 0
    i32.const 128
    i32.const 243
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -458,7 +458,7 @@
    i32.const 0
    i32.const 128
    i32.const 244
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -515,7 +515,7 @@
    i32.const 0
    i32.const 128
    i32.const 260
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -634,7 +634,7 @@
    i32.const 0
    i32.const 128
    i32.const 386
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -657,7 +657,7 @@
     i32.const 0
     i32.const 128
     i32.const 396
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -688,7 +688,7 @@
     i32.const 0
     i32.const 128
     i32.const 408
-    i32.const 4
+    i32.const 5
     call $~lib/builtins/abort
     unreachable
    end
@@ -914,7 +914,7 @@
    i32.const 176
    i32.const 128
    i32.const 461
-   i32.const 29
+   i32.const 30
    call $~lib/builtins/abort
    unreachable
   end
@@ -1008,7 +1008,7 @@
    i32.const 0
    i32.const 128
    i32.const 338
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1071,7 +1071,7 @@
      i32.const 0
      i32.const 128
      i32.const 351
-     i32.const 17
+     i32.const 18
      call $~lib/builtins/abort
      unreachable
     end
@@ -1216,7 +1216,7 @@
    i32.const 0
    i32.const 128
    i32.const 365
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1305,7 +1305,7 @@
    i32.const 0
    i32.const 128
    i32.const 501
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1346,7 +1346,7 @@
       i32.const 0
       i32.const 128
       i32.const 513
-      i32.const 19
+      i32.const 20
       call $~lib/builtins/abort
       unreachable
      end
@@ -1365,7 +1365,7 @@
      i32.const 0
      i32.const 128
      i32.const 518
-     i32.const 17
+     i32.const 18
      call $~lib/builtins/abort
      unreachable
     end
@@ -1382,7 +1382,7 @@
    i32.const 0
    i32.const 128
    i32.const 521
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1642,7 +1642,7 @@
    i32.const 0
    i32.const 240
    i32.const 109
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1663,7 +1663,7 @@
    i32.const 0
    i32.const 240
    i32.const 112
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1704,7 +1704,7 @@
    i32.const 32
    i32.const 80
    i32.const 57
-   i32.const 59
+   i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
@@ -1809,7 +1809,7 @@
    i32.const 0
    i32.const 128
    i32.const 581
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3226,7 +3226,7 @@
     i32.const 32
     i32.const 80
     i32.const 14
-    i32.const 47
+    i32.const 48
     call $~lib/builtins/abort
     unreachable
    end
@@ -3305,7 +3305,7 @@
    i32.const 288
    i32.const 80
    i32.const 299
-   i32.const 20
+   i32.const 21
    call $~lib/builtins/abort
    unreachable
   end
@@ -3338,7 +3338,7 @@
    i32.const 32
    i32.const 80
    i32.const 57
-   i32.const 59
+   i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
@@ -3416,7 +3416,7 @@
    i32.const 32
    i32.const 80
    i32.const 57
-   i32.const 59
+   i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
@@ -4136,7 +4136,7 @@
    i32.const 480
    i32.const 544
    i32.const 22
-   i32.const 27
+   i32.const 28
    call $~lib/builtins/abort
    unreachable
   end
@@ -4255,7 +4255,7 @@
    i32.const 0
    i32.const 240
    i32.const 122
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -4294,7 +4294,7 @@
     i32.const 0
     i32.const 240
     i32.const 136
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -4396,7 +4396,7 @@
         i32.const 0
         i32.const 240
         i32.const 79
-        i32.const 19
+        i32.const 20
         call $~lib/builtins/abort
         unreachable
        end
@@ -4431,7 +4431,7 @@
       i32.const 0
       i32.const 240
       i32.const 90
-      i32.const 8
+      i32.const 9
       call $~lib/builtins/abort
       unreachable
      end
@@ -4461,7 +4461,7 @@
     i32.const 0
     i32.const 240
     i32.const 101
-    i32.const 26
+    i32.const 27
     call $~lib/builtins/abort
     unreachable
    end

--- a/tests/compiler/retain-release.optimized.wat
+++ b/tests/compiler/retain-release.optimized.wat
@@ -210,7 +210,7 @@
    i32.const 1040
    i32.const 1072
    i32.const 367
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/retain-release.untouched.wat
+++ b/tests/compiler/retain-release.untouched.wat
@@ -721,7 +721,7 @@
     i32.const 32
     i32.const 64
     i32.const 367
-    i32.const 4
+    i32.const 5
     call $~lib/builtins/abort
     unreachable
    end

--- a/tests/compiler/retain-return.optimized.wat
+++ b/tests/compiler/retain-return.optimized.wat
@@ -34,7 +34,7 @@
    i32.const 0
    i32.const 1040
    i32.const 277
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -56,7 +56,7 @@
    i32.const 0
    i32.const 1040
    i32.const 279
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -99,7 +99,7 @@
    i32.const 0
    i32.const 1040
    i32.const 292
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -195,7 +195,7 @@
    i32.const 0
    i32.const 1040
    i32.const 205
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -209,7 +209,7 @@
    i32.const 0
    i32.const 1040
    i32.const 207
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -282,7 +282,7 @@
     i32.const 0
     i32.const 1040
     i32.const 228
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -337,7 +337,7 @@
    i32.const 0
    i32.const 1040
    i32.const 243
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -352,7 +352,7 @@
    i32.const 0
    i32.const 1040
    i32.const 244
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -400,7 +400,7 @@
    i32.const 0
    i32.const 1040
    i32.const 260
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -483,7 +483,7 @@
    i32.const 0
    i32.const 1040
    i32.const 386
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -500,7 +500,7 @@
     i32.const 0
     i32.const 1040
     i32.const 396
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -528,7 +528,7 @@
     i32.const 0
     i32.const 1040
     i32.const 408
-    i32.const 4
+    i32.const 5
     call $~lib/builtins/abort
     unreachable
    end
@@ -699,7 +699,7 @@
      i32.const 0
      i32.const 1040
      i32.const 351
-     i32.const 17
+     i32.const 18
      call $~lib/builtins/abort
      unreachable
     end
@@ -728,7 +728,7 @@
    i32.const 0
    i32.const 1040
    i32.const 501
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -798,7 +798,7 @@
      i32.const 0
      i32.const 1040
      i32.const 513
-     i32.const 19
+     i32.const 20
      call $~lib/builtins/abort
      unreachable
     end
@@ -814,7 +814,7 @@
    i32.const 0
    i32.const 1040
    i32.const 521
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -914,7 +914,7 @@
     i32.const 0
     i32.const 1152
     i32.const 109
-    i32.const 2
+    i32.const 3
     call $~lib/builtins/abort
     unreachable
    end
@@ -931,7 +931,7 @@
     i32.const 0
     i32.const 1152
     i32.const 112
-    i32.const 13
+    i32.const 14
     call $~lib/builtins/abort
     unreachable
    end
@@ -1041,7 +1041,7 @@
    i32.const 0
    i32.const 1152
    i32.const 122
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1086,7 +1086,7 @@
     i32.const 0
     i32.const 1152
     i32.const 126
-    i32.const 17
+    i32.const 18
     call $~lib/builtins/abort
     unreachable
    end
@@ -1107,7 +1107,7 @@
     i32.const 0
     i32.const 1152
     i32.const 136
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end

--- a/tests/compiler/retain-return.untouched.wat
+++ b/tests/compiler/retain-return.untouched.wat
@@ -54,7 +54,7 @@
    i32.const 0
    i32.const 32
    i32.const 277
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -79,7 +79,7 @@
    i32.const 0
    i32.const 32
    i32.const 279
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -131,7 +131,7 @@
    i32.const 0
    i32.const 32
    i32.const 292
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -261,7 +261,7 @@
    i32.const 0
    i32.const 32
    i32.const 205
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -276,7 +276,7 @@
    i32.const 0
    i32.const 32
    i32.const 207
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -369,7 +369,7 @@
     i32.const 0
     i32.const 32
     i32.const 228
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -432,7 +432,7 @@
    i32.const 0
    i32.const 32
    i32.const 243
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -448,7 +448,7 @@
    i32.const 0
    i32.const 32
    i32.const 244
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -505,7 +505,7 @@
    i32.const 0
    i32.const 32
    i32.const 260
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -624,7 +624,7 @@
    i32.const 0
    i32.const 32
    i32.const 386
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -647,7 +647,7 @@
     i32.const 0
     i32.const 32
     i32.const 396
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -678,7 +678,7 @@
     i32.const 0
     i32.const 32
     i32.const 408
-    i32.const 4
+    i32.const 5
     call $~lib/builtins/abort
     unreachable
    end
@@ -904,7 +904,7 @@
    i32.const 80
    i32.const 32
    i32.const 461
-   i32.const 29
+   i32.const 30
    call $~lib/builtins/abort
    unreachable
   end
@@ -998,7 +998,7 @@
    i32.const 0
    i32.const 32
    i32.const 338
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1061,7 +1061,7 @@
      i32.const 0
      i32.const 32
      i32.const 351
-     i32.const 17
+     i32.const 18
      call $~lib/builtins/abort
      unreachable
     end
@@ -1206,7 +1206,7 @@
    i32.const 0
    i32.const 32
    i32.const 365
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1295,7 +1295,7 @@
    i32.const 0
    i32.const 32
    i32.const 501
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1336,7 +1336,7 @@
       i32.const 0
       i32.const 32
       i32.const 513
-      i32.const 19
+      i32.const 20
       call $~lib/builtins/abort
       unreachable
      end
@@ -1355,7 +1355,7 @@
      i32.const 0
      i32.const 32
      i32.const 518
-     i32.const 17
+     i32.const 18
      call $~lib/builtins/abort
      unreachable
     end
@@ -1372,7 +1372,7 @@
    i32.const 0
    i32.const 32
    i32.const 521
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1421,7 +1421,7 @@
    i32.const 0
    i32.const 144
    i32.const 109
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1440,7 +1440,7 @@
    i32.const 0
    i32.const 144
    i32.const 112
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1670,7 +1670,7 @@
    i32.const 0
    i32.const 144
    i32.const 122
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1692,7 +1692,7 @@
     i32.const 0
     i32.const 144
     i32.const 126
-    i32.const 17
+    i32.const 18
     call $~lib/builtins/abort
     unreachable
    end
@@ -1708,7 +1708,7 @@
     i32.const 0
     i32.const 144
     i32.const 136
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -1740,7 +1740,7 @@
    i32.const 0
    i32.const 144
    i32.const 69
-   i32.const 15
+   i32.const 16
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/rt/flags.optimized.wat
+++ b/tests/compiler/rt/flags.optimized.wat
@@ -23,7 +23,7 @@
    i32.const 1040
    i32.const 1104
    i32.const 22
-   i32.const 27
+   i32.const 28
    call $~lib/builtins/abort
    unreachable
   end
@@ -324,7 +324,7 @@
   i32.const 0
   i32.const 1152
   i32.const 6
-  i32.const 2
+  i32.const 3
   call $~lib/builtins/abort
   unreachable
  )

--- a/tests/compiler/rt/flags.untouched.wat
+++ b/tests/compiler/rt/flags.untouched.wat
@@ -27,7 +27,7 @@
    i32.const 32
    i32.const 96
    i32.const 22
-   i32.const 27
+   i32.const 28
    call $~lib/builtins/abort
    unreachable
   end
@@ -50,7 +50,7 @@
    i32.const 0
    i32.const 144
    i32.const 6
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -65,7 +65,7 @@
    i32.const 0
    i32.const 144
    i32.const 6
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -80,7 +80,7 @@
    i32.const 0
    i32.const 144
    i32.const 6
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -95,7 +95,7 @@
    i32.const 0
    i32.const 144
    i32.const 6
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -110,7 +110,7 @@
    i32.const 0
    i32.const 144
    i32.const 6
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -125,7 +125,7 @@
    i32.const 0
    i32.const 144
    i32.const 6
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -140,7 +140,7 @@
    i32.const 0
    i32.const 144
    i32.const 6
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -155,7 +155,7 @@
    i32.const 0
    i32.const 144
    i32.const 6
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -170,7 +170,7 @@
    i32.const 0
    i32.const 144
    i32.const 6
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -185,7 +185,7 @@
    i32.const 0
    i32.const 144
    i32.const 6
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -200,7 +200,7 @@
    i32.const 0
    i32.const 144
    i32.const 6
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -215,7 +215,7 @@
    i32.const 0
    i32.const 144
    i32.const 6
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -230,7 +230,7 @@
    i32.const 0
    i32.const 144
    i32.const 6
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -245,7 +245,7 @@
    i32.const 0
    i32.const 144
    i32.const 6
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -260,7 +260,7 @@
    i32.const 0
    i32.const 144
    i32.const 6
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -275,7 +275,7 @@
    i32.const 0
    i32.const 144
    i32.const 6
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -290,7 +290,7 @@
    i32.const 0
    i32.const 144
    i32.const 6
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -305,7 +305,7 @@
    i32.const 0
    i32.const 144
    i32.const 6
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -320,7 +320,7 @@
    i32.const 0
    i32.const 144
    i32.const 6
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -335,7 +335,7 @@
    i32.const 0
    i32.const 144
    i32.const 6
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -350,7 +350,7 @@
    i32.const 0
    i32.const 144
    i32.const 6
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -365,7 +365,7 @@
    i32.const 0
    i32.const 144
    i32.const 6
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -380,7 +380,7 @@
    i32.const 0
    i32.const 144
    i32.const 6
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -395,7 +395,7 @@
    i32.const 0
    i32.const 144
    i32.const 6
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -410,7 +410,7 @@
    i32.const 0
    i32.const 144
    i32.const 6
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -425,7 +425,7 @@
    i32.const 0
    i32.const 144
    i32.const 6
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -440,7 +440,7 @@
    i32.const 0
    i32.const 144
    i32.const 6
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -455,7 +455,7 @@
    i32.const 0
    i32.const 144
    i32.const 6
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -470,7 +470,7 @@
    i32.const 0
    i32.const 144
    i32.const 6
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -485,7 +485,7 @@
    i32.const 0
    i32.const 144
    i32.const 6
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -500,7 +500,7 @@
    i32.const 0
    i32.const 144
    i32.const 6
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -515,7 +515,7 @@
    i32.const 0
    i32.const 144
    i32.const 6
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -530,7 +530,7 @@
    i32.const 0
    i32.const 144
    i32.const 6
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -545,7 +545,7 @@
    i32.const 0
    i32.const 144
    i32.const 6
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -560,7 +560,7 @@
    i32.const 0
    i32.const 144
    i32.const 6
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -575,7 +575,7 @@
    i32.const 0
    i32.const 144
    i32.const 6
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -590,7 +590,7 @@
    i32.const 0
    i32.const 144
    i32.const 6
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -605,7 +605,7 @@
    i32.const 0
    i32.const 144
    i32.const 6
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -620,7 +620,7 @@
    i32.const 0
    i32.const 144
    i32.const 6
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -635,7 +635,7 @@
    i32.const 0
    i32.const 144
    i32.const 6
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -650,7 +650,7 @@
    i32.const 0
    i32.const 144
    i32.const 6
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -665,7 +665,7 @@
    i32.const 0
    i32.const 144
    i32.const 6
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -680,7 +680,7 @@
    i32.const 0
    i32.const 144
    i32.const 6
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -695,7 +695,7 @@
    i32.const 0
    i32.const 144
    i32.const 6
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -710,7 +710,7 @@
    i32.const 0
    i32.const 144
    i32.const 6
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -725,7 +725,7 @@
    i32.const 0
    i32.const 144
    i32.const 6
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -740,7 +740,7 @@
    i32.const 0
    i32.const 144
    i32.const 6
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -755,7 +755,7 @@
    i32.const 0
    i32.const 144
    i32.const 6
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -770,7 +770,7 @@
    i32.const 0
    i32.const 144
    i32.const 6
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -785,7 +785,7 @@
    i32.const 0
    i32.const 144
    i32.const 6
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -800,7 +800,7 @@
    i32.const 0
    i32.const 144
    i32.const 6
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -815,7 +815,7 @@
    i32.const 0
    i32.const 144
    i32.const 6
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -830,7 +830,7 @@
    i32.const 0
    i32.const 144
    i32.const 6
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -845,7 +845,7 @@
    i32.const 0
    i32.const 144
    i32.const 6
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -860,7 +860,7 @@
    i32.const 0
    i32.const 144
    i32.const 6
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -875,7 +875,7 @@
    i32.const 0
    i32.const 144
    i32.const 6
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -890,7 +890,7 @@
    i32.const 0
    i32.const 144
    i32.const 6
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -905,7 +905,7 @@
    i32.const 0
    i32.const 144
    i32.const 6
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -920,7 +920,7 @@
    i32.const 0
    i32.const 144
    i32.const 6
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/rt/instanceof.optimized.wat
+++ b/tests/compiler/rt/instanceof.optimized.wat
@@ -164,7 +164,7 @@
    i32.const 0
    i32.const 1040
    i32.const 10
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -181,7 +181,7 @@
    i32.const 0
    i32.const 1040
    i32.const 11
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -199,7 +199,7 @@
    i32.const 0
    i32.const 1040
    i32.const 14
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -216,7 +216,7 @@
    i32.const 0
    i32.const 1040
    i32.const 15
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -234,7 +234,7 @@
    i32.const 0
    i32.const 1040
    i32.const 18
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -252,7 +252,7 @@
    i32.const 0
    i32.const 1040
    i32.const 19
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -272,7 +272,7 @@
    i32.const 0
    i32.const 1040
    i32.const 25
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -289,7 +289,7 @@
    i32.const 0
    i32.const 1040
    i32.const 26
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -306,7 +306,7 @@
    i32.const 0
    i32.const 1040
    i32.const 27
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -316,7 +316,7 @@
    i32.const 0
    i32.const 1040
    i32.const 29
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -334,7 +334,7 @@
    i32.const 0
    i32.const 1040
    i32.const 30
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -351,7 +351,7 @@
    i32.const 0
    i32.const 1040
    i32.const 31
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -361,7 +361,7 @@
    i32.const 0
    i32.const 1040
    i32.const 33
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -379,7 +379,7 @@
    i32.const 0
    i32.const 1040
    i32.const 34
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -397,7 +397,7 @@
    i32.const 0
    i32.const 1040
    i32.const 35
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/rt/instanceof.untouched.wat
+++ b/tests/compiler/rt/instanceof.untouched.wat
@@ -254,7 +254,7 @@
    i32.const 0
    i32.const 32
    i32.const 10
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -274,7 +274,7 @@
    i32.const 0
    i32.const 32
    i32.const 11
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -293,7 +293,7 @@
    i32.const 0
    i32.const 32
    i32.const 14
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -313,7 +313,7 @@
    i32.const 0
    i32.const 32
    i32.const 15
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -332,7 +332,7 @@
    i32.const 0
    i32.const 32
    i32.const 18
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -351,7 +351,7 @@
    i32.const 0
    i32.const 32
    i32.const 19
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -372,7 +372,7 @@
    i32.const 0
    i32.const 32
    i32.const 25
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -392,7 +392,7 @@
    i32.const 0
    i32.const 32
    i32.const 26
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -412,7 +412,7 @@
    i32.const 0
    i32.const 32
    i32.const 27
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -424,7 +424,7 @@
    i32.const 0
    i32.const 32
    i32.const 29
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -443,7 +443,7 @@
    i32.const 0
    i32.const 32
    i32.const 30
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -463,7 +463,7 @@
    i32.const 0
    i32.const 32
    i32.const 31
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -475,7 +475,7 @@
    i32.const 0
    i32.const 32
    i32.const 33
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -494,7 +494,7 @@
    i32.const 0
    i32.const 32
    i32.const 34
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -513,7 +513,7 @@
    i32.const 0
    i32.const 32
    i32.const 35
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -526,7 +526,7 @@
    i32.const 0
    i32.const 32
    i32.const 41
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -546,7 +546,7 @@
    i32.const 0
    i32.const 32
    i32.const 42
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -566,7 +566,7 @@
    i32.const 0
    i32.const 32
    i32.const 43
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -579,7 +579,7 @@
    i32.const 0
    i32.const 32
    i32.const 45
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -599,7 +599,7 @@
    i32.const 0
    i32.const 32
    i32.const 46
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -619,7 +619,7 @@
    i32.const 0
    i32.const 32
    i32.const 47
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -632,7 +632,7 @@
    i32.const 0
    i32.const 32
    i32.const 49
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -652,7 +652,7 @@
    i32.const 0
    i32.const 32
    i32.const 50
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -672,7 +672,7 @@
    i32.const 0
    i32.const 32
    i32.const 51
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/rt/stub-realloc.optimized.wat
+++ b/tests/compiler/rt/stub-realloc.optimized.wat
@@ -315,7 +315,7 @@
    i32.const 0
    i32.const 1040
    i32.const 43
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -333,7 +333,7 @@
    i32.const 0
    i32.const 1040
    i32.const 46
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -429,7 +429,7 @@
    i32.const 0
    i32.const 1088
    i32.const 7
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -444,7 +444,7 @@
    i32.const 0
    i32.const 1088
    i32.const 10
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -459,7 +459,7 @@
    i32.const 0
    i32.const 1088
    i32.const 13
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -480,7 +480,7 @@
    i32.const 0
    i32.const 1088
    i32.const 18
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -495,7 +495,7 @@
    i32.const 0
    i32.const 1088
    i32.const 21
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -510,7 +510,7 @@
    i32.const 0
    i32.const 1088
    i32.const 24
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -525,7 +525,7 @@
    i32.const 0
    i32.const 1088
    i32.const 27
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -542,7 +542,7 @@
    i32.const 0
    i32.const 1040
    i32.const 70
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -557,7 +557,7 @@
    i32.const 0
    i32.const 1040
    i32.const 72
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -580,7 +580,7 @@
    i32.const 0
    i32.const 1088
    i32.const 30
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/rt/stub-realloc.untouched.wat
+++ b/tests/compiler/rt/stub-realloc.untouched.wat
@@ -1415,7 +1415,7 @@
    i32.const 0
    i32.const 32
    i32.const 43
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1435,7 +1435,7 @@
    i32.const 0
    i32.const 32
    i32.const 46
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1533,7 +1533,7 @@
    i32.const 0
    i32.const 32
    i32.const 70
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1550,7 +1550,7 @@
    i32.const 0
    i32.const 32
    i32.const 72
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1584,7 +1584,7 @@
    i32.const 0
    i32.const 80
    i32.const 7
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1600,7 +1600,7 @@
    i32.const 0
    i32.const 80
    i32.const 10
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1616,7 +1616,7 @@
    i32.const 0
    i32.const 80
    i32.const 13
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1640,7 +1640,7 @@
    i32.const 0
    i32.const 80
    i32.const 18
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1656,7 +1656,7 @@
    i32.const 0
    i32.const 80
    i32.const 21
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1672,7 +1672,7 @@
    i32.const 0
    i32.const 80
    i32.const 24
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1688,7 +1688,7 @@
    i32.const 0
    i32.const 80
    i32.const 27
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1704,7 +1704,7 @@
    i32.const 0
    i32.const 80
    i32.const 30
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/runtime-full.optimized.wat
+++ b/tests/compiler/runtime-full.optimized.wat
@@ -38,7 +38,7 @@
    i32.const 0
    i32.const 1040
    i32.const 277
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -60,7 +60,7 @@
    i32.const 0
    i32.const 1040
    i32.const 279
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -103,7 +103,7 @@
    i32.const 0
    i32.const 1040
    i32.const 292
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -199,7 +199,7 @@
    i32.const 0
    i32.const 1040
    i32.const 205
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -213,7 +213,7 @@
    i32.const 0
    i32.const 1040
    i32.const 207
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -286,7 +286,7 @@
     i32.const 0
     i32.const 1040
     i32.const 228
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -341,7 +341,7 @@
    i32.const 0
    i32.const 1040
    i32.const 243
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -356,7 +356,7 @@
    i32.const 0
    i32.const 1040
    i32.const 244
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -404,7 +404,7 @@
    i32.const 0
    i32.const 1040
    i32.const 260
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -487,7 +487,7 @@
    i32.const 0
    i32.const 1040
    i32.const 386
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -504,7 +504,7 @@
     i32.const 0
     i32.const 1040
     i32.const 396
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -532,7 +532,7 @@
     i32.const 0
     i32.const 1040
     i32.const 408
-    i32.const 4
+    i32.const 5
     call $~lib/builtins/abort
     unreachable
    end
@@ -722,7 +722,7 @@
    i32.const 0
    i32.const 1040
    i32.const 338
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -774,7 +774,7 @@
      i32.const 0
      i32.const 1040
      i32.const 351
-     i32.const 17
+     i32.const 18
      call $~lib/builtins/abort
      unreachable
     end
@@ -807,7 +807,7 @@
    i32.const 0
    i32.const 1040
    i32.const 365
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -878,7 +878,7 @@
    i32.const 0
    i32.const 1040
    i32.const 501
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -889,7 +889,7 @@
    i32.const 1088
    i32.const 1040
    i32.const 461
-   i32.const 29
+   i32.const 30
    call $~lib/builtins/abort
    unreachable
   end
@@ -989,7 +989,7 @@
      i32.const 0
      i32.const 1040
      i32.const 513
-     i32.const 19
+     i32.const 20
      call $~lib/builtins/abort
      unreachable
     end
@@ -1005,7 +1005,7 @@
    i32.const 0
    i32.const 1040
    i32.const 521
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1060,7 +1060,7 @@
     i32.const 0
     i32.const 1152
     i32.const 109
-    i32.const 2
+    i32.const 3
     call $~lib/builtins/abort
     unreachable
    end
@@ -1077,7 +1077,7 @@
     i32.const 0
     i32.const 1152
     i32.const 112
-    i32.const 13
+    i32.const 14
     call $~lib/builtins/abort
     unreachable
    end
@@ -1115,7 +1115,7 @@
    i32.const 0
    i32.const 1152
    i32.const 122
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1160,7 +1160,7 @@
     i32.const 0
     i32.const 1152
     i32.const 126
-    i32.const 17
+    i32.const 18
     call $~lib/builtins/abort
     unreachable
    end
@@ -1181,7 +1181,7 @@
     i32.const 0
     i32.const 1152
     i32.const 136
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end

--- a/tests/compiler/runtime-full.untouched.wat
+++ b/tests/compiler/runtime-full.untouched.wat
@@ -49,7 +49,7 @@
    i32.const 0
    i32.const 32
    i32.const 277
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -74,7 +74,7 @@
    i32.const 0
    i32.const 32
    i32.const 279
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -126,7 +126,7 @@
    i32.const 0
    i32.const 32
    i32.const 292
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -256,7 +256,7 @@
    i32.const 0
    i32.const 32
    i32.const 205
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -271,7 +271,7 @@
    i32.const 0
    i32.const 32
    i32.const 207
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -364,7 +364,7 @@
     i32.const 0
     i32.const 32
     i32.const 228
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -427,7 +427,7 @@
    i32.const 0
    i32.const 32
    i32.const 243
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -443,7 +443,7 @@
    i32.const 0
    i32.const 32
    i32.const 244
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -500,7 +500,7 @@
    i32.const 0
    i32.const 32
    i32.const 260
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -619,7 +619,7 @@
    i32.const 0
    i32.const 32
    i32.const 386
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -642,7 +642,7 @@
     i32.const 0
     i32.const 32
     i32.const 396
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -673,7 +673,7 @@
     i32.const 0
     i32.const 32
     i32.const 408
-    i32.const 4
+    i32.const 5
     call $~lib/builtins/abort
     unreachable
    end
@@ -899,7 +899,7 @@
    i32.const 80
    i32.const 32
    i32.const 461
-   i32.const 29
+   i32.const 30
    call $~lib/builtins/abort
    unreachable
   end
@@ -993,7 +993,7 @@
    i32.const 0
    i32.const 32
    i32.const 338
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1056,7 +1056,7 @@
      i32.const 0
      i32.const 32
      i32.const 351
-     i32.const 17
+     i32.const 18
      call $~lib/builtins/abort
      unreachable
     end
@@ -1201,7 +1201,7 @@
    i32.const 0
    i32.const 32
    i32.const 365
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1290,7 +1290,7 @@
    i32.const 0
    i32.const 32
    i32.const 501
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1331,7 +1331,7 @@
       i32.const 0
       i32.const 32
       i32.const 513
-      i32.const 19
+      i32.const 20
       call $~lib/builtins/abort
       unreachable
      end
@@ -1350,7 +1350,7 @@
      i32.const 0
      i32.const 32
      i32.const 518
-     i32.const 17
+     i32.const 18
      call $~lib/builtins/abort
      unreachable
     end
@@ -1367,7 +1367,7 @@
    i32.const 0
    i32.const 32
    i32.const 521
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1416,7 +1416,7 @@
    i32.const 0
    i32.const 144
    i32.const 109
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1435,7 +1435,7 @@
    i32.const 0
    i32.const 144
    i32.const 112
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1500,7 +1500,7 @@
    i32.const 0
    i32.const 144
    i32.const 122
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1522,7 +1522,7 @@
     i32.const 0
     i32.const 144
     i32.const 126
-    i32.const 17
+    i32.const 18
     call $~lib/builtins/abort
     unreachable
    end
@@ -1538,7 +1538,7 @@
     i32.const 0
     i32.const 144
     i32.const 136
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -1570,7 +1570,7 @@
    i32.const 0
    i32.const 144
    i32.const 69
-   i32.const 15
+   i32.const 16
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/static-this.untouched.wat
+++ b/tests/compiler/static-this.untouched.wat
@@ -21,7 +21,7 @@
    i32.const 0
    i32.const 32
    i32.const 8
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/std/array-access.optimized.wat
+++ b/tests/compiler/std/array-access.optimized.wat
@@ -25,7 +25,7 @@
    i32.const 1040
    i32.const 1104
    i32.const 104
-   i32.const 41
+   i32.const 42
    call $~lib/builtins/abort
    unreachable
   end
@@ -42,7 +42,7 @@
    i32.const 1152
    i32.const 1104
    i32.const 108
-   i32.const 39
+   i32.const 40
    call $~lib/builtins/abort
    unreachable
   end
@@ -60,7 +60,7 @@
    i32.const 1040
    i32.const 1104
    i32.const 104
-   i32.const 41
+   i32.const 42
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/std/array-access.untouched.wat
+++ b/tests/compiler/std/array-access.untouched.wat
@@ -46,7 +46,7 @@
    i32.const 32
    i32.const 96
    i32.const 104
-   i32.const 41
+   i32.const 42
    call $~lib/builtins/abort
    unreachable
   end
@@ -62,7 +62,7 @@
    i32.const 144
    i32.const 96
    i32.const 108
-   i32.const 39
+   i32.const 40
    call $~lib/builtins/abort
    unreachable
   end
@@ -87,7 +87,7 @@
    i32.const 32
    i32.const 96
    i32.const 104
-   i32.const 41
+   i32.const 42
    call $~lib/builtins/abort
    unreachable
   end
@@ -136,7 +136,7 @@
    i32.const 32
    i32.const 96
    i32.const 104
-   i32.const 41
+   i32.const 42
    call $~lib/builtins/abort
    unreachable
   end
@@ -152,7 +152,7 @@
    i32.const 144
    i32.const 96
    i32.const 108
-   i32.const 39
+   i32.const 40
    call $~lib/builtins/abort
    unreachable
   end
@@ -421,7 +421,7 @@
    i32.const 32
    i32.const 96
    i32.const 104
-   i32.const 41
+   i32.const 42
    call $~lib/builtins/abort
    unreachable
   end
@@ -437,7 +437,7 @@
    i32.const 144
    i32.const 96
    i32.const 108
-   i32.const 39
+   i32.const 40
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/std/array-literal.optimized.wat
+++ b/tests/compiler/std/array-literal.optimized.wat
@@ -44,7 +44,7 @@
    i32.const 1168
    i32.const 1232
    i32.const 104
-   i32.const 41
+   i32.const 42
    call $~lib/builtins/abort
    unreachable
   end
@@ -63,7 +63,7 @@
    i32.const 1168
    i32.const 1232
    i32.const 104
-   i32.const 41
+   i32.const 42
    call $~lib/builtins/abort
    unreachable
   end
@@ -90,7 +90,7 @@
    i32.const 0
    i32.const 1392
    i32.const 277
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -112,7 +112,7 @@
    i32.const 0
    i32.const 1392
    i32.const 279
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -155,7 +155,7 @@
    i32.const 0
    i32.const 1392
    i32.const 292
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -251,7 +251,7 @@
    i32.const 0
    i32.const 1392
    i32.const 205
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -265,7 +265,7 @@
    i32.const 0
    i32.const 1392
    i32.const 207
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -338,7 +338,7 @@
     i32.const 0
     i32.const 1392
     i32.const 228
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -393,7 +393,7 @@
    i32.const 0
    i32.const 1392
    i32.const 243
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -408,7 +408,7 @@
    i32.const 0
    i32.const 1392
    i32.const 244
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -456,7 +456,7 @@
    i32.const 0
    i32.const 1392
    i32.const 260
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -539,7 +539,7 @@
    i32.const 0
    i32.const 1392
    i32.const 386
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -556,7 +556,7 @@
     i32.const 0
     i32.const 1392
     i32.const 396
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -584,7 +584,7 @@
     i32.const 0
     i32.const 1392
     i32.const 408
-    i32.const 4
+    i32.const 5
     call $~lib/builtins/abort
     unreachable
    end
@@ -774,7 +774,7 @@
    i32.const 0
    i32.const 1392
    i32.const 338
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -826,7 +826,7 @@
      i32.const 0
      i32.const 1392
      i32.const 351
-     i32.const 17
+     i32.const 18
      call $~lib/builtins/abort
      unreachable
     end
@@ -859,7 +859,7 @@
    i32.const 0
    i32.const 1392
    i32.const 365
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -930,7 +930,7 @@
    i32.const 0
    i32.const 1392
    i32.const 501
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -941,7 +941,7 @@
    i32.const 1440
    i32.const 1392
    i32.const 461
-   i32.const 29
+   i32.const 30
    call $~lib/builtins/abort
    unreachable
   end
@@ -1041,7 +1041,7 @@
      i32.const 0
      i32.const 1392
      i32.const 513
-     i32.const 19
+     i32.const 20
      call $~lib/builtins/abort
      unreachable
     end
@@ -1057,7 +1057,7 @@
    i32.const 0
    i32.const 1392
    i32.const 521
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1114,7 +1114,7 @@
     i32.const 0
     i32.const 1504
     i32.const 109
-    i32.const 2
+    i32.const 3
     call $~lib/builtins/abort
     unreachable
    end
@@ -1133,7 +1133,7 @@
     i32.const 0
     i32.const 1504
     i32.const 112
-    i32.const 13
+    i32.const 14
     call $~lib/builtins/abort
     unreachable
    end
@@ -1188,7 +1188,7 @@
    i32.const 0
    i32.const 1104
    i32.const 2
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1199,7 +1199,7 @@
    i32.const 0
    i32.const 1104
    i32.const 3
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1212,7 +1212,7 @@
    i32.const 0
    i32.const 1104
    i32.const 4
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1225,7 +1225,7 @@
    i32.const 0
    i32.const 1104
    i32.const 5
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1237,7 +1237,7 @@
    i32.const 0
    i32.const 1104
    i32.const 8
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1248,7 +1248,7 @@
    i32.const 0
    i32.const 1104
    i32.const 9
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1261,7 +1261,7 @@
    i32.const 0
    i32.const 1104
    i32.const 10
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1274,7 +1274,7 @@
    i32.const 0
    i32.const 1104
    i32.const 11
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1284,7 +1284,7 @@
    i32.const 0
    i32.const 1104
    i32.const 14
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1322,7 +1322,7 @@
    i32.const 0
    i32.const 1104
    i32.const 19
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1333,7 +1333,7 @@
    i32.const 0
    i32.const 1104
    i32.const 20
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1346,7 +1346,7 @@
    i32.const 0
    i32.const 1104
    i32.const 21
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1359,7 +1359,7 @@
    i32.const 0
    i32.const 1104
    i32.const 22
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1399,7 +1399,7 @@
    i32.const 0
    i32.const 1104
    i32.const 27
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1410,7 +1410,7 @@
    i32.const 0
    i32.const 1104
    i32.const 28
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1423,7 +1423,7 @@
    i32.const 0
    i32.const 1104
    i32.const 29
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1436,7 +1436,7 @@
    i32.const 0
    i32.const 1104
    i32.const 30
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1475,7 +1475,7 @@
    i32.const 0
    i32.const 1104
    i32.const 34
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1514,7 +1514,7 @@
    i32.const 0
    i32.const 1104
    i32.const 38
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1563,7 +1563,7 @@
    i32.const 0
    i32.const 1504
    i32.const 122
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1623,7 +1623,7 @@
     i32.const 0
     i32.const 1504
     i32.const 126
-    i32.const 17
+    i32.const 18
     call $~lib/builtins/abort
     unreachable
    end
@@ -1646,7 +1646,7 @@
     i32.const 0
     i32.const 1504
     i32.const 136
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end

--- a/tests/compiler/std/array-literal.untouched.wat
+++ b/tests/compiler/std/array-literal.untouched.wat
@@ -67,7 +67,7 @@
    i32.const 160
    i32.const 224
    i32.const 104
-   i32.const 41
+   i32.const 42
    call $~lib/builtins/abort
    unreachable
   end
@@ -100,7 +100,7 @@
    i32.const 160
    i32.const 224
    i32.const 104
-   i32.const 41
+   i32.const 42
    call $~lib/builtins/abort
    unreachable
   end
@@ -132,7 +132,7 @@
    i32.const 0
    i32.const 384
    i32.const 277
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -157,7 +157,7 @@
    i32.const 0
    i32.const 384
    i32.const 279
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -209,7 +209,7 @@
    i32.const 0
    i32.const 384
    i32.const 292
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -339,7 +339,7 @@
    i32.const 0
    i32.const 384
    i32.const 205
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -354,7 +354,7 @@
    i32.const 0
    i32.const 384
    i32.const 207
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -447,7 +447,7 @@
     i32.const 0
     i32.const 384
     i32.const 228
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -510,7 +510,7 @@
    i32.const 0
    i32.const 384
    i32.const 243
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -526,7 +526,7 @@
    i32.const 0
    i32.const 384
    i32.const 244
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -583,7 +583,7 @@
    i32.const 0
    i32.const 384
    i32.const 260
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -702,7 +702,7 @@
    i32.const 0
    i32.const 384
    i32.const 386
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -725,7 +725,7 @@
     i32.const 0
     i32.const 384
     i32.const 396
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -756,7 +756,7 @@
     i32.const 0
     i32.const 384
     i32.const 408
-    i32.const 4
+    i32.const 5
     call $~lib/builtins/abort
     unreachable
    end
@@ -982,7 +982,7 @@
    i32.const 432
    i32.const 384
    i32.const 461
-   i32.const 29
+   i32.const 30
    call $~lib/builtins/abort
    unreachable
   end
@@ -1076,7 +1076,7 @@
    i32.const 0
    i32.const 384
    i32.const 338
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1139,7 +1139,7 @@
      i32.const 0
      i32.const 384
      i32.const 351
-     i32.const 17
+     i32.const 18
      call $~lib/builtins/abort
      unreachable
     end
@@ -1284,7 +1284,7 @@
    i32.const 0
    i32.const 384
    i32.const 365
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1373,7 +1373,7 @@
    i32.const 0
    i32.const 384
    i32.const 501
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1414,7 +1414,7 @@
       i32.const 0
       i32.const 384
       i32.const 513
-      i32.const 19
+      i32.const 20
       call $~lib/builtins/abort
       unreachable
      end
@@ -1433,7 +1433,7 @@
      i32.const 0
      i32.const 384
      i32.const 518
-     i32.const 17
+     i32.const 18
      call $~lib/builtins/abort
      unreachable
     end
@@ -1450,7 +1450,7 @@
    i32.const 0
    i32.const 384
    i32.const 521
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -2760,7 +2760,7 @@
    i32.const 0
    i32.const 496
    i32.const 109
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2781,7 +2781,7 @@
    i32.const 0
    i32.const 496
    i32.const 112
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -2892,7 +2892,7 @@
    i32.const 0
    i32.const 96
    i32.const 2
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2906,7 +2906,7 @@
    i32.const 0
    i32.const 96
    i32.const 3
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2920,7 +2920,7 @@
    i32.const 0
    i32.const 96
    i32.const 4
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2934,7 +2934,7 @@
    i32.const 0
    i32.const 96
    i32.const 5
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2947,7 +2947,7 @@
    i32.const 0
    i32.const 96
    i32.const 8
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2961,7 +2961,7 @@
    i32.const 0
    i32.const 96
    i32.const 9
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2975,7 +2975,7 @@
    i32.const 0
    i32.const 96
    i32.const 10
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2989,7 +2989,7 @@
    i32.const 0
    i32.const 96
    i32.const 11
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3002,7 +3002,7 @@
    i32.const 0
    i32.const 96
    i32.const 14
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3044,7 +3044,7 @@
    i32.const 0
    i32.const 96
    i32.const 19
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3058,7 +3058,7 @@
    i32.const 0
    i32.const 96
    i32.const 20
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3072,7 +3072,7 @@
    i32.const 0
    i32.const 96
    i32.const 21
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3086,7 +3086,7 @@
    i32.const 0
    i32.const 96
    i32.const 22
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3130,7 +3130,7 @@
    i32.const 0
    i32.const 96
    i32.const 27
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3144,7 +3144,7 @@
    i32.const 0
    i32.const 96
    i32.const 28
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3158,7 +3158,7 @@
    i32.const 0
    i32.const 96
    i32.const 29
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3172,7 +3172,7 @@
    i32.const 0
    i32.const 96
    i32.const 30
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3209,7 +3209,7 @@
    i32.const 0
    i32.const 96
    i32.const 34
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3246,7 +3246,7 @@
    i32.const 0
    i32.const 96
    i32.const 38
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3324,7 +3324,7 @@
    i32.const 0
    i32.const 496
    i32.const 122
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -3346,7 +3346,7 @@
     i32.const 0
     i32.const 496
     i32.const 126
-    i32.const 17
+    i32.const 18
     call $~lib/builtins/abort
     unreachable
    end
@@ -3362,7 +3362,7 @@
     i32.const 0
     i32.const 496
     i32.const 136
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -3394,7 +3394,7 @@
    i32.const 0
    i32.const 496
    i32.const 69
-   i32.const 15
+   i32.const 16
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/std/array.optimized.wat
+++ b/tests/compiler/std/array.optimized.wat
@@ -251,7 +251,7 @@
    i32.const 0
    i32.const 1136
    i32.const 277
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -273,7 +273,7 @@
    i32.const 0
    i32.const 1136
    i32.const 279
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -316,7 +316,7 @@
    i32.const 0
    i32.const 1136
    i32.const 292
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -412,7 +412,7 @@
    i32.const 0
    i32.const 1136
    i32.const 205
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -426,7 +426,7 @@
    i32.const 0
    i32.const 1136
    i32.const 207
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -499,7 +499,7 @@
     i32.const 0
     i32.const 1136
     i32.const 228
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -554,7 +554,7 @@
    i32.const 0
    i32.const 1136
    i32.const 243
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -569,7 +569,7 @@
    i32.const 0
    i32.const 1136
    i32.const 244
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -617,7 +617,7 @@
    i32.const 0
    i32.const 1136
    i32.const 260
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -700,7 +700,7 @@
    i32.const 0
    i32.const 1136
    i32.const 386
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -717,7 +717,7 @@
     i32.const 0
     i32.const 1136
     i32.const 396
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -745,7 +745,7 @@
     i32.const 0
     i32.const 1136
     i32.const 408
-    i32.const 4
+    i32.const 5
     call $~lib/builtins/abort
     unreachable
    end
@@ -886,7 +886,7 @@
    i32.const 1184
    i32.const 1136
    i32.const 461
-   i32.const 29
+   i32.const 30
    call $~lib/builtins/abort
    unreachable
   end
@@ -959,7 +959,7 @@
    i32.const 0
    i32.const 1136
    i32.const 338
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1011,7 +1011,7 @@
      i32.const 0
      i32.const 1136
      i32.const 351
-     i32.const 17
+     i32.const 18
      call $~lib/builtins/abort
      unreachable
     end
@@ -1044,7 +1044,7 @@
    i32.const 0
    i32.const 1136
    i32.const 365
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1115,7 +1115,7 @@
    i32.const 0
    i32.const 1136
    i32.const 501
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1206,7 +1206,7 @@
      i32.const 0
      i32.const 1136
      i32.const 513
-     i32.const 19
+     i32.const 20
      call $~lib/builtins/abort
      unreachable
     end
@@ -1222,7 +1222,7 @@
    i32.const 0
    i32.const 1136
    i32.const 521
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1452,7 +1452,7 @@
     i32.const 0
     i32.const 1248
     i32.const 109
-    i32.const 2
+    i32.const 3
     call $~lib/builtins/abort
     unreachable
    end
@@ -1471,7 +1471,7 @@
     i32.const 0
     i32.const 1248
     i32.const 112
-    i32.const 13
+    i32.const 14
     call $~lib/builtins/abort
     unreachable
    end
@@ -1502,7 +1502,7 @@
    i32.const 1040
    i32.const 1088
    i32.const 57
-   i32.const 59
+   i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
@@ -1858,7 +1858,7 @@
    i32.const 1504
    i32.const 1088
    i32.const 104
-   i32.const 41
+   i32.const 42
    call $~lib/builtins/abort
    unreachable
   end
@@ -1997,7 +1997,7 @@
    i32.const 1504
    i32.const 1088
    i32.const 104
-   i32.const 41
+   i32.const 42
    call $~lib/builtins/abort
    unreachable
   end
@@ -2102,7 +2102,7 @@
    i32.const 0
    i32.const 1136
    i32.const 581
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2243,7 +2243,7 @@
     i32.const 1040
     i32.const 1088
     i32.const 14
-    i32.const 47
+    i32.const 48
     call $~lib/builtins/abort
     unreachable
    end
@@ -2319,7 +2319,7 @@
    i32.const 1984
    i32.const 1088
    i32.const 299
-   i32.const 20
+   i32.const 21
    call $~lib/builtins/abort
    unreachable
   end
@@ -2359,7 +2359,7 @@
    i32.const 1040
    i32.const 1088
    i32.const 229
-   i32.const 59
+   i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
@@ -2793,7 +2793,7 @@
    i32.const 1504
    i32.const 1088
    i32.const 104
-   i32.const 41
+   i32.const 42
    call $~lib/builtins/abort
    unreachable
   end
@@ -2808,7 +2808,7 @@
    i32.const 4928
    i32.const 1088
    i32.const 108
-   i32.const 39
+   i32.const 40
    call $~lib/builtins/abort
    unreachable
   end
@@ -2901,7 +2901,7 @@
    i32.const 1504
    i32.const 1088
    i32.const 104
-   i32.const 41
+   i32.const 42
    call $~lib/builtins/abort
    unreachable
   end
@@ -2923,7 +2923,7 @@
     i32.const 1504
     i32.const 1088
     i32.const 120
-    i32.const 21
+    i32.const 22
     call $~lib/builtins/abort
     unreachable
    end
@@ -3329,7 +3329,7 @@
     i32.const 0
     i32.const 1296
     i32.const 625
-    i32.const 6
+    i32.const 7
     call $~lib/builtins/abort
     unreachable
    end
@@ -3348,7 +3348,7 @@
    i32.const 1504
    i32.const 1088
    i32.const 104
-   i32.const 41
+   i32.const 42
    call $~lib/builtins/abort
    unreachable
   end
@@ -3749,7 +3749,7 @@
    i32.const 0
    i32.const 5040
    i32.const 1406
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -4659,7 +4659,7 @@
    i32.const 1504
    i32.const 1088
    i32.const 104
-   i32.const 41
+   i32.const 42
    call $~lib/builtins/abort
    unreachable
   end
@@ -5237,7 +5237,7 @@
    i32.const 0
    i32.const 1296
    i32.const 887
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -5263,7 +5263,7 @@
     i32.const 1504
     i32.const 1088
     i32.const 120
-    i32.const 21
+    i32.const 22
     call $~lib/builtins/abort
     unreachable
    end
@@ -5506,7 +5506,7 @@
    i32.const 0
    i32.const 1296
    i32.const 887
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -5819,7 +5819,7 @@
    i32.const 0
    i32.const 1296
    i32.const 887
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -9954,7 +9954,7 @@
    i32.const 0
    i32.const 1296
    i32.const 52
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -9987,7 +9987,7 @@
    i32.const 0
    i32.const 1296
    i32.const 60
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10011,7 +10011,7 @@
    i32.const 0
    i32.const 1296
    i32.const 63
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10035,7 +10035,7 @@
    i32.const 0
    i32.const 1296
    i32.const 66
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10059,7 +10059,7 @@
    i32.const 0
    i32.const 1296
    i32.const 69
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10083,7 +10083,7 @@
    i32.const 0
    i32.const 1296
    i32.const 72
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10126,7 +10126,7 @@
    i32.const 0
    i32.const 1296
    i32.const 79
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10151,7 +10151,7 @@
    i32.const 0
    i32.const 1296
    i32.const 82
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10176,7 +10176,7 @@
    i32.const 0
    i32.const 1296
    i32.const 85
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10201,7 +10201,7 @@
    i32.const 0
    i32.const 1296
    i32.const 88
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10226,7 +10226,7 @@
    i32.const 0
    i32.const 1296
    i32.const 91
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10248,7 +10248,7 @@
    i32.const 0
    i32.const 1296
    i32.const 97
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10258,7 +10258,7 @@
    i32.const 0
    i32.const 1296
    i32.const 98
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10274,7 +10274,7 @@
    i32.const 0
    i32.const 1296
    i32.const 102
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10286,7 +10286,7 @@
    i32.const 0
    i32.const 1296
    i32.const 103
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10298,7 +10298,7 @@
    i32.const 0
    i32.const 1296
    i32.const 104
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10310,7 +10310,7 @@
    i32.const 0
    i32.const 1296
    i32.const 108
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10320,7 +10320,7 @@
    i32.const 0
    i32.const 1296
    i32.const 109
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10332,7 +10332,7 @@
    i32.const 0
    i32.const 1296
    i32.const 110
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10347,7 +10347,7 @@
    i32.const 0
    i32.const 1296
    i32.const 114
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10359,7 +10359,7 @@
    i32.const 0
    i32.const 1296
    i32.const 115
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10372,7 +10372,7 @@
    i32.const 0
    i32.const 1296
    i32.const 116
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10387,7 +10387,7 @@
    i32.const 0
    i32.const 1296
    i32.const 120
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10399,7 +10399,7 @@
    i32.const 0
    i32.const 1296
    i32.const 121
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10412,7 +10412,7 @@
    i32.const 0
    i32.const 1296
    i32.const 122
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10425,7 +10425,7 @@
    i32.const 0
    i32.const 1296
    i32.const 123
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10440,7 +10440,7 @@
    i32.const 0
    i32.const 1296
    i32.const 127
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10452,7 +10452,7 @@
    i32.const 0
    i32.const 1296
    i32.const 128
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10465,7 +10465,7 @@
    i32.const 0
    i32.const 1296
    i32.const 129
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10478,7 +10478,7 @@
    i32.const 0
    i32.const 1296
    i32.const 130
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10491,7 +10491,7 @@
    i32.const 0
    i32.const 1296
    i32.const 131
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10551,7 +10551,7 @@
    i32.const 0
    i32.const 1296
    i32.const 139
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10572,7 +10572,7 @@
    i32.const 0
    i32.const 1296
    i32.const 148
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10584,7 +10584,7 @@
    i32.const 0
    i32.const 1296
    i32.const 149
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10596,7 +10596,7 @@
    i32.const 0
    i32.const 1296
    i32.const 150
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10618,7 +10618,7 @@
    i32.const 0
    i32.const 1296
    i32.const 153
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10631,7 +10631,7 @@
    i32.const 0
    i32.const 1296
    i32.const 155
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10644,7 +10644,7 @@
    i32.const 0
    i32.const 1296
    i32.const 156
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10657,7 +10657,7 @@
    i32.const 0
    i32.const 1296
    i32.const 157
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10681,7 +10681,7 @@
    i32.const 0
    i32.const 1296
    i32.const 164
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10693,7 +10693,7 @@
    i32.const 0
    i32.const 1296
    i32.const 165
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10705,7 +10705,7 @@
    i32.const 0
    i32.const 1296
    i32.const 166
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10718,7 +10718,7 @@
    i32.const 0
    i32.const 1296
    i32.const 167
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10731,7 +10731,7 @@
    i32.const 0
    i32.const 1296
    i32.const 168
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10744,7 +10744,7 @@
    i32.const 0
    i32.const 1296
    i32.const 169
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10757,7 +10757,7 @@
    i32.const 0
    i32.const 1296
    i32.const 170
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10770,7 +10770,7 @@
    i32.const 0
    i32.const 1296
    i32.const 171
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10785,7 +10785,7 @@
    i32.const 0
    i32.const 1296
    i32.const 174
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10801,7 +10801,7 @@
    i32.const 0
    i32.const 1296
    i32.const 182
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10819,7 +10819,7 @@
    i32.const 0
    i32.const 1296
    i32.const 184
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10829,7 +10829,7 @@
    i32.const 0
    i32.const 1296
    i32.const 185
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10867,7 +10867,7 @@
    i32.const 0
    i32.const 1296
    i32.const 192
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10900,7 +10900,7 @@
    i32.const 0
    i32.const 1296
    i32.const 194
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10932,7 +10932,7 @@
    i32.const 0
    i32.const 1296
    i32.const 196
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10964,7 +10964,7 @@
    i32.const 0
    i32.const 1296
    i32.const 198
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10996,7 +10996,7 @@
    i32.const 0
    i32.const 1296
    i32.const 200
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11028,7 +11028,7 @@
    i32.const 0
    i32.const 1296
    i32.const 202
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11060,7 +11060,7 @@
    i32.const 0
    i32.const 1296
    i32.const 204
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11092,7 +11092,7 @@
    i32.const 0
    i32.const 1296
    i32.const 206
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11124,7 +11124,7 @@
    i32.const 0
    i32.const 1296
    i32.const 208
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11156,7 +11156,7 @@
    i32.const 0
    i32.const 1296
    i32.const 210
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11189,7 +11189,7 @@
    i32.const 0
    i32.const 1296
    i32.const 212
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11222,7 +11222,7 @@
    i32.const 0
    i32.const 1296
    i32.const 214
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11287,7 +11287,7 @@
    i32.const 0
    i32.const 1296
    i32.const 222
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11299,7 +11299,7 @@
    i32.const 0
    i32.const 1296
    i32.const 223
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11312,7 +11312,7 @@
    i32.const 0
    i32.const 1296
    i32.const 224
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11325,7 +11325,7 @@
    i32.const 0
    i32.const 1296
    i32.const 225
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11338,7 +11338,7 @@
    i32.const 0
    i32.const 1296
    i32.const 226
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11351,7 +11351,7 @@
    i32.const 0
    i32.const 1296
    i32.const 227
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11366,7 +11366,7 @@
    i32.const 0
    i32.const 1296
    i32.const 231
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11378,7 +11378,7 @@
    i32.const 0
    i32.const 1296
    i32.const 232
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11391,7 +11391,7 @@
    i32.const 0
    i32.const 1296
    i32.const 233
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11404,7 +11404,7 @@
    i32.const 0
    i32.const 1296
    i32.const 234
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11417,7 +11417,7 @@
    i32.const 0
    i32.const 1296
    i32.const 235
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11430,7 +11430,7 @@
    i32.const 0
    i32.const 1296
    i32.const 236
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11443,7 +11443,7 @@
    i32.const 0
    i32.const 1296
    i32.const 237
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11457,7 +11457,7 @@
    i32.const 1984
    i32.const 1088
    i32.const 360
-   i32.const 20
+   i32.const 21
    call $~lib/builtins/abort
    unreachable
   end
@@ -11493,7 +11493,7 @@
    i32.const 0
    i32.const 1296
    i32.const 246
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11505,7 +11505,7 @@
    i32.const 0
    i32.const 1296
    i32.const 247
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11517,7 +11517,7 @@
    i32.const 0
    i32.const 1296
    i32.const 248
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11530,7 +11530,7 @@
    i32.const 0
    i32.const 1296
    i32.const 249
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11543,7 +11543,7 @@
    i32.const 0
    i32.const 1296
    i32.const 250
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11556,7 +11556,7 @@
    i32.const 0
    i32.const 1296
    i32.const 251
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11569,7 +11569,7 @@
    i32.const 0
    i32.const 1296
    i32.const 252
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11583,7 +11583,7 @@
    i32.const 0
    i32.const 1296
    i32.const 256
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11595,7 +11595,7 @@
    i32.const 0
    i32.const 1296
    i32.const 257
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11607,7 +11607,7 @@
    i32.const 0
    i32.const 1296
    i32.const 258
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11620,7 +11620,7 @@
    i32.const 0
    i32.const 1296
    i32.const 259
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11633,7 +11633,7 @@
    i32.const 0
    i32.const 1296
    i32.const 260
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11646,7 +11646,7 @@
    i32.const 0
    i32.const 1296
    i32.const 261
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11702,7 +11702,7 @@
    i32.const 0
    i32.const 1296
    i32.const 269
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11714,7 +11714,7 @@
    i32.const 0
    i32.const 1296
    i32.const 270
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11727,7 +11727,7 @@
    i32.const 0
    i32.const 1296
    i32.const 271
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11740,7 +11740,7 @@
    i32.const 0
    i32.const 1296
    i32.const 272
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11753,7 +11753,7 @@
    i32.const 0
    i32.const 1296
    i32.const 273
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11773,7 +11773,7 @@
    i32.const 0
    i32.const 1296
    i32.const 283
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11789,7 +11789,7 @@
    i32.const 0
    i32.const 1296
    i32.const 286
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11805,7 +11805,7 @@
    i32.const 0
    i32.const 1296
    i32.const 289
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11821,7 +11821,7 @@
    i32.const 0
    i32.const 1296
    i32.const 292
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11837,7 +11837,7 @@
    i32.const 0
    i32.const 1296
    i32.const 295
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11853,7 +11853,7 @@
    i32.const 0
    i32.const 1296
    i32.const 298
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11869,7 +11869,7 @@
    i32.const 0
    i32.const 1296
    i32.const 301
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11885,7 +11885,7 @@
    i32.const 0
    i32.const 1296
    i32.const 304
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11901,7 +11901,7 @@
    i32.const 0
    i32.const 1296
    i32.const 307
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11917,7 +11917,7 @@
    i32.const 0
    i32.const 1296
    i32.const 310
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11981,7 +11981,7 @@
    i32.const 0
    i32.const 1296
    i32.const 312
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12045,7 +12045,7 @@
    i32.const 0
    i32.const 1296
    i32.const 313
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12063,7 +12063,7 @@
    i32.const 0
    i32.const 1296
    i32.const 320
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12077,7 +12077,7 @@
    i32.const 0
    i32.const 1296
    i32.const 323
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12089,7 +12089,7 @@
    i32.const 0
    i32.const 1296
    i32.const 326
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12101,7 +12101,7 @@
    i32.const 0
    i32.const 1296
    i32.const 329
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12115,7 +12115,7 @@
    i32.const 0
    i32.const 1296
    i32.const 332
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12129,7 +12129,7 @@
    i32.const 0
    i32.const 1296
    i32.const 335
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12143,7 +12143,7 @@
    i32.const 0
    i32.const 1296
    i32.const 338
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12157,7 +12157,7 @@
    i32.const 0
    i32.const 1296
    i32.const 341
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12171,7 +12171,7 @@
    i32.const 0
    i32.const 1296
    i32.const 344
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12185,7 +12185,7 @@
    i32.const 0
    i32.const 1296
    i32.const 347
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12252,7 +12252,7 @@
    i32.const 0
    i32.const 1296
    i32.const 349
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12319,7 +12319,7 @@
    i32.const 0
    i32.const 1296
    i32.const 350
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12336,7 +12336,7 @@
    i32.const 0
    i32.const 1296
    i32.const 354
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12348,7 +12348,7 @@
    i32.const 0
    i32.const 1296
    i32.const 355
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12361,7 +12361,7 @@
    i32.const 0
    i32.const 1296
    i32.const 356
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12374,7 +12374,7 @@
    i32.const 0
    i32.const 1296
    i32.const 357
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12407,7 +12407,7 @@
    i32.const 0
    i32.const 1296
    i32.const 364
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12426,7 +12426,7 @@
    i32.const 0
    i32.const 1296
    i32.const 365
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12458,7 +12458,7 @@
    i32.const 0
    i32.const 1296
    i32.const 368
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12477,7 +12477,7 @@
    i32.const 0
    i32.const 1296
    i32.const 369
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12509,7 +12509,7 @@
    i32.const 0
    i32.const 1296
    i32.const 372
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12528,7 +12528,7 @@
    i32.const 0
    i32.const 1296
    i32.const 373
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12560,7 +12560,7 @@
    i32.const 0
    i32.const 1296
    i32.const 376
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12579,7 +12579,7 @@
    i32.const 0
    i32.const 1296
    i32.const 377
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12610,7 +12610,7 @@
    i32.const 0
    i32.const 1296
    i32.const 380
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12629,7 +12629,7 @@
    i32.const 0
    i32.const 1296
    i32.const 381
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12660,7 +12660,7 @@
    i32.const 0
    i32.const 1296
    i32.const 384
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12679,7 +12679,7 @@
    i32.const 0
    i32.const 1296
    i32.const 385
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12710,7 +12710,7 @@
    i32.const 0
    i32.const 1296
    i32.const 388
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12729,7 +12729,7 @@
    i32.const 0
    i32.const 1296
    i32.const 389
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12760,7 +12760,7 @@
    i32.const 0
    i32.const 1296
    i32.const 392
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12779,7 +12779,7 @@
    i32.const 0
    i32.const 1296
    i32.const 393
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12810,7 +12810,7 @@
    i32.const 0
    i32.const 1296
    i32.const 396
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12829,7 +12829,7 @@
    i32.const 0
    i32.const 1296
    i32.const 397
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12860,7 +12860,7 @@
    i32.const 0
    i32.const 1296
    i32.const 400
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12879,7 +12879,7 @@
    i32.const 0
    i32.const 1296
    i32.const 401
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12910,7 +12910,7 @@
    i32.const 0
    i32.const 1296
    i32.const 404
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12929,7 +12929,7 @@
    i32.const 0
    i32.const 1296
    i32.const 405
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12960,7 +12960,7 @@
    i32.const 0
    i32.const 1296
    i32.const 408
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12979,7 +12979,7 @@
    i32.const 0
    i32.const 1296
    i32.const 409
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13011,7 +13011,7 @@
    i32.const 0
    i32.const 1296
    i32.const 412
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13030,7 +13030,7 @@
    i32.const 0
    i32.const 1296
    i32.const 413
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13062,7 +13062,7 @@
    i32.const 0
    i32.const 1296
    i32.const 416
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13081,7 +13081,7 @@
    i32.const 0
    i32.const 1296
    i32.const 417
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13100,7 +13100,7 @@
    i32.const 0
    i32.const 1296
    i32.const 421
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13110,7 +13110,7 @@
    i32.const 0
    i32.const 1296
    i32.const 422
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13158,7 +13158,7 @@
    i32.const 0
    i32.const 1296
    i32.const 427
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13173,7 +13173,7 @@
    i32.const 0
    i32.const 1296
    i32.const 428
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13188,7 +13188,7 @@
    i32.const 0
    i32.const 1296
    i32.const 429
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13200,7 +13200,7 @@
    i32.const 0
    i32.const 1296
    i32.const 431
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13215,7 +13215,7 @@
    i32.const 0
    i32.const 1296
    i32.const 432
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13230,7 +13230,7 @@
    i32.const 0
    i32.const 1296
    i32.const 433
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13245,7 +13245,7 @@
    i32.const 0
    i32.const 1296
    i32.const 434
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13278,7 +13278,7 @@
    i32.const 0
    i32.const 1296
    i32.const 439
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13292,7 +13292,7 @@
    i32.const 0
    i32.const 1296
    i32.const 440
-   i32.const 9
+   i32.const 10
    call $~lib/builtins/abort
    unreachable
   end
@@ -13303,7 +13303,7 @@
    i32.const 0
    i32.const 1296
    i32.const 440
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13315,7 +13315,7 @@
    i32.const 0
    i32.const 1296
    i32.const 442
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13327,7 +13327,7 @@
    i32.const 0
    i32.const 1296
    i32.const 443
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13341,7 +13341,7 @@
    i32.const 0
    i32.const 1296
    i32.const 444
-   i32.const 9
+   i32.const 10
    call $~lib/builtins/abort
    unreachable
   end
@@ -13352,7 +13352,7 @@
    i32.const 0
    i32.const 1296
    i32.const 444
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13483,7 +13483,7 @@
    i32.const 0
    i32.const 1296
    i32.const 457
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13498,7 +13498,7 @@
    i32.const 0
    i32.const 1296
    i32.const 460
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13513,7 +13513,7 @@
    i32.const 0
    i32.const 1296
    i32.const 463
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13528,7 +13528,7 @@
    i32.const 0
    i32.const 1296
    i32.const 471
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13540,7 +13540,7 @@
    i32.const 0
    i32.const 1296
    i32.const 472
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13555,7 +13555,7 @@
    i32.const 0
    i32.const 1296
    i32.const 474
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13582,7 +13582,7 @@
    i32.const 0
    i32.const 1296
    i32.const 487
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13594,7 +13594,7 @@
    i32.const 0
    i32.const 1296
    i32.const 488
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13613,7 +13613,7 @@
    i32.const 0
    i32.const 1296
    i32.const 498
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13624,7 +13624,7 @@
    i32.const 0
    i32.const 1296
    i32.const 501
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13637,7 +13637,7 @@
    i32.const 0
    i32.const 1296
    i32.const 509
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13649,7 +13649,7 @@
    i32.const 0
    i32.const 1296
    i32.const 510
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13660,7 +13660,7 @@
    i32.const 0
    i32.const 1296
    i32.const 512
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13685,7 +13685,7 @@
    i32.const 0
    i32.const 1296
    i32.const 525
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13697,7 +13697,7 @@
    i32.const 0
    i32.const 1296
    i32.const 526
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13716,7 +13716,7 @@
    i32.const 0
    i32.const 1296
    i32.const 536
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13727,7 +13727,7 @@
    i32.const 0
    i32.const 1296
    i32.const 539
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13738,7 +13738,7 @@
    i32.const 0
    i32.const 1296
    i32.const 547
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13750,7 +13750,7 @@
    i32.const 0
    i32.const 1296
    i32.const 548
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13763,7 +13763,7 @@
    i32.const 0
    i32.const 1296
    i32.const 550
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13786,7 +13786,7 @@
    i32.const 0
    i32.const 1296
    i32.const 563
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13798,7 +13798,7 @@
    i32.const 0
    i32.const 1296
    i32.const 564
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13820,7 +13820,7 @@
    i32.const 0
    i32.const 1296
    i32.const 575
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13836,7 +13836,7 @@
    i32.const 0
    i32.const 1296
    i32.const 584
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13848,7 +13848,7 @@
    i32.const 0
    i32.const 1296
    i32.const 585
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13864,7 +13864,7 @@
    i32.const 0
    i32.const 1296
    i32.const 588
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13892,7 +13892,7 @@
    i32.const 0
    i32.const 1296
    i32.const 602
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13904,7 +13904,7 @@
    i32.const 0
    i32.const 1296
    i32.const 603
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13925,7 +13925,7 @@
    i32.const 0
    i32.const 1296
    i32.const 628
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14014,7 +14014,7 @@
    i32.const 0
    i32.const 1296
    i32.const 642
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14030,7 +14030,7 @@
    i32.const 0
    i32.const 1296
    i32.const 643
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14047,7 +14047,7 @@
    i32.const 0
    i32.const 1296
    i32.const 652
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14059,7 +14059,7 @@
    i32.const 0
    i32.const 1296
    i32.const 653
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14076,7 +14076,7 @@
    i32.const 0
    i32.const 1296
    i32.const 660
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14105,7 +14105,7 @@
    i32.const 0
    i32.const 1296
    i32.const 675
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14117,7 +14117,7 @@
    i32.const 0
    i32.const 1296
    i32.const 676
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14140,7 +14140,7 @@
    i32.const 0
    i32.const 1296
    i32.const 686
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14157,7 +14157,7 @@
    i32.const 0
    i32.const 1296
    i32.const 695
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14169,7 +14169,7 @@
    i32.const 0
    i32.const 1296
    i32.const 696
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14186,7 +14186,7 @@
    i32.const 0
    i32.const 1296
    i32.const 703
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14215,7 +14215,7 @@
    i32.const 0
    i32.const 1296
    i32.const 718
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14227,7 +14227,7 @@
    i32.const 0
    i32.const 1296
    i32.const 719
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14251,7 +14251,7 @@
    i32.const 0
    i32.const 1296
    i32.const 729
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14267,7 +14267,7 @@
    i32.const 0
    i32.const 1296
    i32.const 733
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14283,7 +14283,7 @@
    i32.const 0
    i32.const 1296
    i32.const 736
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14295,7 +14295,7 @@
    i32.const 0
    i32.const 1296
    i32.const 739
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14311,7 +14311,7 @@
    i32.const 0
    i32.const 1296
    i32.const 747
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14323,7 +14323,7 @@
    i32.const 0
    i32.const 1296
    i32.const 748
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14339,7 +14339,7 @@
    i32.const 0
    i32.const 1296
    i32.const 750
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14367,7 +14367,7 @@
    i32.const 0
    i32.const 1296
    i32.const 763
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14379,7 +14379,7 @@
    i32.const 0
    i32.const 1296
    i32.const 764
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14401,7 +14401,7 @@
    i32.const 0
    i32.const 1296
    i32.const 774
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14417,7 +14417,7 @@
    i32.const 0
    i32.const 1296
    i32.const 778
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14433,7 +14433,7 @@
    i32.const 0
    i32.const 1296
    i32.const 781
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14445,7 +14445,7 @@
    i32.const 0
    i32.const 1296
    i32.const 784
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14461,7 +14461,7 @@
    i32.const 0
    i32.const 1296
    i32.const 792
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14473,7 +14473,7 @@
    i32.const 0
    i32.const 1296
    i32.const 793
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14489,7 +14489,7 @@
    i32.const 0
    i32.const 1296
    i32.const 795
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14517,7 +14517,7 @@
    i32.const 0
    i32.const 1296
    i32.const 808
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14527,7 +14527,7 @@
    i32.const 0
    i32.const 1296
    i32.const 809
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14631,7 +14631,7 @@
    i32.const 0
    i32.const 1296
    i32.const 898
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14720,7 +14720,7 @@
    i32.const 0
    i32.const 1296
    i32.const 902
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14752,7 +14752,7 @@
    i32.const 0
    i32.const 1296
    i32.const 906
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14784,7 +14784,7 @@
    i32.const 0
    i32.const 1296
    i32.const 910
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14859,7 +14859,7 @@
    i32.const 0
    i32.const 1296
    i32.const 930
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14881,7 +14881,7 @@
    i32.const 0
    i32.const 1296
    i32.const 933
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14897,7 +14897,7 @@
    i32.const 0
    i32.const 1296
    i32.const 936
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14913,7 +14913,7 @@
    i32.const 0
    i32.const 1296
    i32.const 939
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14929,7 +14929,7 @@
    i32.const 0
    i32.const 1296
    i32.const 942
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14945,7 +14945,7 @@
    i32.const 0
    i32.const 1296
    i32.const 945
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14961,7 +14961,7 @@
    i32.const 0
    i32.const 1296
    i32.const 948
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -15119,7 +15119,7 @@
    i32.const 0
    i32.const 1296
    i32.const 985
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -15156,7 +15156,7 @@
    i32.const 0
    i32.const 1296
    i32.const 994
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -15177,7 +15177,7 @@
    i32.const 0
    i32.const 1296
    i32.const 995
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -15198,7 +15198,7 @@
    i32.const 0
    i32.const 1296
    i32.const 996
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -15219,7 +15219,7 @@
    i32.const 0
    i32.const 1296
    i32.const 997
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -15244,7 +15244,7 @@
    i32.const 0
    i32.const 1296
    i32.const 998
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -15265,7 +15265,7 @@
    i32.const 0
    i32.const 1296
    i32.const 999
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -15298,7 +15298,7 @@
    i32.const 0
    i32.const 1296
    i32.const 1001
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -15328,7 +15328,7 @@
    i32.const 0
    i32.const 1296
    i32.const 1004
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -15403,7 +15403,7 @@
    i32.const 0
    i32.const 1296
    i32.const 1014
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -15420,7 +15420,7 @@
    i32.const 0
    i32.const 1296
    i32.const 1015
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -15437,7 +15437,7 @@
    i32.const 0
    i32.const 1296
    i32.const 1016
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -15454,7 +15454,7 @@
    i32.const 0
    i32.const 1296
    i32.const 1017
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -15479,7 +15479,7 @@
    i32.const 0
    i32.const 1296
    i32.const 1019
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -15504,7 +15504,7 @@
    i32.const 0
    i32.const 1296
    i32.const 1020
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -15529,7 +15529,7 @@
    i32.const 0
    i32.const 1296
    i32.const 1021
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -15554,7 +15554,7 @@
    i32.const 0
    i32.const 1296
    i32.const 1022
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -15577,7 +15577,7 @@
    i32.const 0
    i32.const 1296
    i32.const 1026
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -15600,7 +15600,7 @@
    i32.const 0
    i32.const 1296
    i32.const 1027
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -15643,7 +15643,7 @@
    i32.const 0
    i32.const 1296
    i32.const 1030
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -15686,7 +15686,7 @@
    i32.const 0
    i32.const 1296
    i32.const 1033
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -15730,7 +15730,7 @@
    i32.const 0
    i32.const 1296
    i32.const 1036
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -15828,7 +15828,7 @@
    i32.const 0
    i32.const 1248
    i32.const 122
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -15905,7 +15905,7 @@
     i32.const 0
     i32.const 1248
     i32.const 126
-    i32.const 17
+    i32.const 18
     call $~lib/builtins/abort
     unreachable
    end
@@ -15920,7 +15920,7 @@
     i32.const 0
     i32.const 1248
     i32.const 136
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end

--- a/tests/compiler/std/array.untouched.wat
+++ b/tests/compiler/std/array.untouched.wat
@@ -265,7 +265,7 @@
    i32.const 0
    i32.const 128
    i32.const 277
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -290,7 +290,7 @@
    i32.const 0
    i32.const 128
    i32.const 279
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -342,7 +342,7 @@
    i32.const 0
    i32.const 128
    i32.const 292
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -472,7 +472,7 @@
    i32.const 0
    i32.const 128
    i32.const 205
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -487,7 +487,7 @@
    i32.const 0
    i32.const 128
    i32.const 207
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -580,7 +580,7 @@
     i32.const 0
     i32.const 128
     i32.const 228
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -643,7 +643,7 @@
    i32.const 0
    i32.const 128
    i32.const 243
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -659,7 +659,7 @@
    i32.const 0
    i32.const 128
    i32.const 244
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -716,7 +716,7 @@
    i32.const 0
    i32.const 128
    i32.const 260
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -835,7 +835,7 @@
    i32.const 0
    i32.const 128
    i32.const 386
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -858,7 +858,7 @@
     i32.const 0
     i32.const 128
     i32.const 396
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -889,7 +889,7 @@
     i32.const 0
     i32.const 128
     i32.const 408
-    i32.const 4
+    i32.const 5
     call $~lib/builtins/abort
     unreachable
    end
@@ -1115,7 +1115,7 @@
    i32.const 176
    i32.const 128
    i32.const 461
-   i32.const 29
+   i32.const 30
    call $~lib/builtins/abort
    unreachable
   end
@@ -1209,7 +1209,7 @@
    i32.const 0
    i32.const 128
    i32.const 338
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1272,7 +1272,7 @@
      i32.const 0
      i32.const 128
      i32.const 351
-     i32.const 17
+     i32.const 18
      call $~lib/builtins/abort
      unreachable
     end
@@ -1417,7 +1417,7 @@
    i32.const 0
    i32.const 128
    i32.const 365
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1506,7 +1506,7 @@
    i32.const 0
    i32.const 128
    i32.const 501
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1547,7 +1547,7 @@
       i32.const 0
       i32.const 128
       i32.const 513
-      i32.const 19
+      i32.const 20
       call $~lib/builtins/abort
       unreachable
      end
@@ -1566,7 +1566,7 @@
      i32.const 0
      i32.const 128
      i32.const 518
-     i32.const 17
+     i32.const 18
      call $~lib/builtins/abort
      unreachable
     end
@@ -1583,7 +1583,7 @@
    i32.const 0
    i32.const 128
    i32.const 521
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1843,7 +1843,7 @@
    i32.const 0
    i32.const 240
    i32.const 109
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1864,7 +1864,7 @@
    i32.const 0
    i32.const 240
    i32.const 112
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1905,7 +1905,7 @@
    i32.const 32
    i32.const 80
    i32.const 57
-   i32.const 59
+   i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
@@ -2035,7 +2035,7 @@
    i32.const 32
    i32.const 336
    i32.const 23
-   i32.const 56
+   i32.const 57
    call $~lib/builtins/abort
    unreachable
   end
@@ -3557,7 +3557,7 @@
    i32.const 496
    i32.const 80
    i32.const 104
-   i32.const 41
+   i32.const 42
    call $~lib/builtins/abort
    unreachable
   end
@@ -3760,7 +3760,7 @@
    i32.const 496
    i32.const 80
    i32.const 104
-   i32.const 41
+   i32.const 42
    call $~lib/builtins/abort
    unreachable
   end
@@ -3926,7 +3926,7 @@
    i32.const 0
    i32.const 128
    i32.const 581
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4099,7 +4099,7 @@
     i32.const 32
     i32.const 80
     i32.const 14
-    i32.const 47
+    i32.const 48
     call $~lib/builtins/abort
     unreachable
    end
@@ -4184,7 +4184,7 @@
    i32.const 496
    i32.const 80
    i32.const 104
-   i32.const 41
+   i32.const 42
    call $~lib/builtins/abort
    unreachable
   end
@@ -4207,7 +4207,7 @@
    i32.const 976
    i32.const 80
    i32.const 299
-   i32.const 20
+   i32.const 21
    call $~lib/builtins/abort
    unreachable
   end
@@ -4318,7 +4318,7 @@
    i32.const 32
    i32.const 80
    i32.const 229
-   i32.const 59
+   i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
@@ -4618,7 +4618,7 @@
    i32.const 976
    i32.const 80
    i32.const 360
-   i32.const 20
+   i32.const 21
    call $~lib/builtins/abort
    unreachable
   end
@@ -5325,7 +5325,7 @@
    i32.const 496
    i32.const 80
    i32.const 104
-   i32.const 41
+   i32.const 42
    call $~lib/builtins/abort
    unreachable
   end
@@ -5341,7 +5341,7 @@
    i32.const 3920
    i32.const 80
    i32.const 108
-   i32.const 39
+   i32.const 40
    call $~lib/builtins/abort
    unreachable
   end
@@ -5479,7 +5479,7 @@
    i32.const 496
    i32.const 80
    i32.const 104
-   i32.const 41
+   i32.const 42
    call $~lib/builtins/abort
    unreachable
   end
@@ -5512,7 +5512,7 @@
     i32.const 496
     i32.const 80
     i32.const 120
-    i32.const 21
+    i32.const 22
     call $~lib/builtins/abort
     unreachable
    end
@@ -6122,7 +6122,7 @@
     i32.const 0
     i32.const 288
     i32.const 625
-    i32.const 6
+    i32.const 7
     call $~lib/builtins/abort
     unreachable
    end
@@ -6233,7 +6233,7 @@
    i32.const 496
    i32.const 80
    i32.const 104
-   i32.const 41
+   i32.const 42
    call $~lib/builtins/abort
    unreachable
   end
@@ -7011,7 +7011,7 @@
    i32.const 0
    i32.const 4032
    i32.const 1406
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -8164,7 +8164,7 @@
    i32.const 496
    i32.const 80
    i32.const 104
-   i32.const 41
+   i32.const 42
    call $~lib/builtins/abort
    unreachable
   end
@@ -9433,7 +9433,7 @@
    i32.const 0
    i32.const 288
    i32.const 887
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -9488,7 +9488,7 @@
    i32.const 32
    i32.const 80
    i32.const 57
-   i32.const 59
+   i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
@@ -9601,7 +9601,7 @@
     i32.const 496
     i32.const 80
     i32.const 120
-    i32.const 21
+    i32.const 22
     call $~lib/builtins/abort
     unreachable
    end
@@ -9884,7 +9884,7 @@
    i32.const 496
    i32.const 80
    i32.const 104
-   i32.const 41
+   i32.const 42
    call $~lib/builtins/abort
    unreachable
   end
@@ -9900,7 +9900,7 @@
    i32.const 3920
    i32.const 80
    i32.const 108
-   i32.const 39
+   i32.const 40
    call $~lib/builtins/abort
    unreachable
   end
@@ -9989,7 +9989,7 @@
    i32.const 0
    i32.const 288
    i32.const 887
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10011,7 +10011,7 @@
    i32.const 32
    i32.const 80
    i32.const 57
-   i32.const 59
+   i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
@@ -10139,7 +10139,7 @@
     i32.const 496
     i32.const 80
     i32.const 120
-    i32.const 21
+    i32.const 22
     call $~lib/builtins/abort
     unreachable
    end
@@ -10415,7 +10415,7 @@
    i32.const 496
    i32.const 80
    i32.const 104
-   i32.const 41
+   i32.const 42
    call $~lib/builtins/abort
    unreachable
   end
@@ -10431,7 +10431,7 @@
    i32.const 3920
    i32.const 80
    i32.const 108
-   i32.const 39
+   i32.const 40
    call $~lib/builtins/abort
    unreachable
   end
@@ -10520,7 +10520,7 @@
    i32.const 0
    i32.const 288
    i32.const 887
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10722,7 +10722,7 @@
    i32.const 496
    i32.const 80
    i32.const 104
-   i32.const 41
+   i32.const 42
    call $~lib/builtins/abort
    unreachable
   end
@@ -10815,7 +10815,7 @@
    i32.const 0
    i32.const 288
    i32.const 887
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11283,7 +11283,7 @@
    i32.const 32
    i32.const 80
    i32.const 57
-   i32.const 59
+   i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
@@ -11582,7 +11582,7 @@
     i32.const 496
     i32.const 80
     i32.const 120
-    i32.const 21
+    i32.const 22
     call $~lib/builtins/abort
     unreachable
    end
@@ -11836,7 +11836,7 @@
    i32.const 496
    i32.const 80
    i32.const 104
-   i32.const 41
+   i32.const 42
    call $~lib/builtins/abort
    unreachable
   end
@@ -11852,7 +11852,7 @@
    i32.const 3920
    i32.const 80
    i32.const 108
-   i32.const 39
+   i32.const 40
    call $~lib/builtins/abort
    unreachable
   end
@@ -11941,7 +11941,7 @@
    i32.const 0
    i32.const 288
    i32.const 887
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -18012,7 +18012,7 @@
    i32.const 0
    i32.const 288
    i32.const 46
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -18027,7 +18027,7 @@
    i32.const 0
    i32.const 288
    i32.const 47
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -18042,7 +18042,7 @@
    i32.const 0
    i32.const 288
    i32.const 48
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -18054,7 +18054,7 @@
    i32.const 0
    i32.const 288
    i32.const 49
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -18066,7 +18066,7 @@
    i32.const 0
    i32.const 288
    i32.const 50
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -18077,7 +18077,7 @@
    i32.const 0
    i32.const 288
    i32.const 52
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -18113,7 +18113,7 @@
    i32.const 0
    i32.const 288
    i32.const 60
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -18138,7 +18138,7 @@
    i32.const 0
    i32.const 288
    i32.const 63
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -18163,7 +18163,7 @@
    i32.const 0
    i32.const 288
    i32.const 66
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -18188,7 +18188,7 @@
    i32.const 0
    i32.const 288
    i32.const 69
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -18213,7 +18213,7 @@
    i32.const 0
    i32.const 288
    i32.const 72
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -18257,7 +18257,7 @@
    i32.const 0
    i32.const 288
    i32.const 79
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -18282,7 +18282,7 @@
    i32.const 0
    i32.const 288
    i32.const 82
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -18307,7 +18307,7 @@
    i32.const 0
    i32.const 288
    i32.const 85
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -18332,7 +18332,7 @@
    i32.const 0
    i32.const 288
    i32.const 88
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -18357,7 +18357,7 @@
    i32.const 0
    i32.const 288
    i32.const 91
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -18382,7 +18382,7 @@
    i32.const 0
    i32.const 288
    i32.const 97
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -18395,7 +18395,7 @@
    i32.const 0
    i32.const 288
    i32.const 98
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -18413,7 +18413,7 @@
    i32.const 0
    i32.const 288
    i32.const 102
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -18426,7 +18426,7 @@
    i32.const 0
    i32.const 288
    i32.const 103
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -18439,7 +18439,7 @@
    i32.const 0
    i32.const 288
    i32.const 104
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -18454,7 +18454,7 @@
    i32.const 0
    i32.const 288
    i32.const 108
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -18467,7 +18467,7 @@
    i32.const 0
    i32.const 288
    i32.const 109
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -18480,7 +18480,7 @@
    i32.const 0
    i32.const 288
    i32.const 110
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -18497,7 +18497,7 @@
    i32.const 0
    i32.const 288
    i32.const 114
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -18510,7 +18510,7 @@
    i32.const 0
    i32.const 288
    i32.const 115
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -18524,7 +18524,7 @@
    i32.const 0
    i32.const 288
    i32.const 116
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -18541,7 +18541,7 @@
    i32.const 0
    i32.const 288
    i32.const 120
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -18554,7 +18554,7 @@
    i32.const 0
    i32.const 288
    i32.const 121
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -18568,7 +18568,7 @@
    i32.const 0
    i32.const 288
    i32.const 122
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -18582,7 +18582,7 @@
    i32.const 0
    i32.const 288
    i32.const 123
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -18599,7 +18599,7 @@
    i32.const 0
    i32.const 288
    i32.const 127
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -18612,7 +18612,7 @@
    i32.const 0
    i32.const 288
    i32.const 128
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -18626,7 +18626,7 @@
    i32.const 0
    i32.const 288
    i32.const 129
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -18640,7 +18640,7 @@
    i32.const 0
    i32.const 288
    i32.const 130
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -18654,7 +18654,7 @@
    i32.const 0
    i32.const 288
    i32.const 131
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -18692,7 +18692,7 @@
    i32.const 0
    i32.const 288
    i32.const 139
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -18715,7 +18715,7 @@
    i32.const 0
    i32.const 288
    i32.const 148
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -18728,7 +18728,7 @@
    i32.const 0
    i32.const 288
    i32.const 149
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -18741,7 +18741,7 @@
    i32.const 0
    i32.const 288
    i32.const 150
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -18764,7 +18764,7 @@
    i32.const 0
    i32.const 288
    i32.const 153
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -18778,7 +18778,7 @@
    i32.const 0
    i32.const 288
    i32.const 155
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -18792,7 +18792,7 @@
    i32.const 0
    i32.const 288
    i32.const 156
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -18806,7 +18806,7 @@
    i32.const 0
    i32.const 288
    i32.const 157
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -18835,7 +18835,7 @@
    i32.const 0
    i32.const 288
    i32.const 164
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -18848,7 +18848,7 @@
    i32.const 0
    i32.const 288
    i32.const 165
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -18861,7 +18861,7 @@
    i32.const 0
    i32.const 288
    i32.const 166
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -18875,7 +18875,7 @@
    i32.const 0
    i32.const 288
    i32.const 167
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -18889,7 +18889,7 @@
    i32.const 0
    i32.const 288
    i32.const 168
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -18903,7 +18903,7 @@
    i32.const 0
    i32.const 288
    i32.const 169
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -18917,7 +18917,7 @@
    i32.const 0
    i32.const 288
    i32.const 170
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -18931,7 +18931,7 @@
    i32.const 0
    i32.const 288
    i32.const 171
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -18947,7 +18947,7 @@
    i32.const 0
    i32.const 288
    i32.const 174
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -18967,7 +18967,7 @@
    i32.const 0
    i32.const 288
    i32.const 182
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -18988,7 +18988,7 @@
    i32.const 0
    i32.const 288
    i32.const 184
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -19001,7 +19001,7 @@
    i32.const 0
    i32.const 288
    i32.const 185
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -19040,7 +19040,7 @@
    i32.const 0
    i32.const 288
    i32.const 192
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -19075,7 +19075,7 @@
    i32.const 0
    i32.const 288
    i32.const 194
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -19110,7 +19110,7 @@
    i32.const 0
    i32.const 288
    i32.const 196
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -19145,7 +19145,7 @@
    i32.const 0
    i32.const 288
    i32.const 198
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -19180,7 +19180,7 @@
    i32.const 0
    i32.const 288
    i32.const 200
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -19215,7 +19215,7 @@
    i32.const 0
    i32.const 288
    i32.const 202
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -19250,7 +19250,7 @@
    i32.const 0
    i32.const 288
    i32.const 204
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -19285,7 +19285,7 @@
    i32.const 0
    i32.const 288
    i32.const 206
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -19320,7 +19320,7 @@
    i32.const 0
    i32.const 288
    i32.const 208
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -19355,7 +19355,7 @@
    i32.const 0
    i32.const 288
    i32.const 210
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -19390,7 +19390,7 @@
    i32.const 0
    i32.const 288
    i32.const 212
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -19425,7 +19425,7 @@
    i32.const 0
    i32.const 288
    i32.const 214
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -19492,7 +19492,7 @@
    i32.const 0
    i32.const 288
    i32.const 222
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -19505,7 +19505,7 @@
    i32.const 0
    i32.const 288
    i32.const 223
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -19519,7 +19519,7 @@
    i32.const 0
    i32.const 288
    i32.const 224
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -19533,7 +19533,7 @@
    i32.const 0
    i32.const 288
    i32.const 225
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -19547,7 +19547,7 @@
    i32.const 0
    i32.const 288
    i32.const 226
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -19561,7 +19561,7 @@
    i32.const 0
    i32.const 288
    i32.const 227
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -19578,7 +19578,7 @@
    i32.const 0
    i32.const 288
    i32.const 231
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -19591,7 +19591,7 @@
    i32.const 0
    i32.const 288
    i32.const 232
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -19605,7 +19605,7 @@
    i32.const 0
    i32.const 288
    i32.const 233
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -19619,7 +19619,7 @@
    i32.const 0
    i32.const 288
    i32.const 234
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -19633,7 +19633,7 @@
    i32.const 0
    i32.const 288
    i32.const 235
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -19647,7 +19647,7 @@
    i32.const 0
    i32.const 288
    i32.const 236
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -19661,7 +19661,7 @@
    i32.const 0
    i32.const 288
    i32.const 237
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -19676,7 +19676,7 @@
    i32.const 0
    i32.const 288
    i32.const 246
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -19689,7 +19689,7 @@
    i32.const 0
    i32.const 288
    i32.const 247
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -19702,7 +19702,7 @@
    i32.const 0
    i32.const 288
    i32.const 248
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -19716,7 +19716,7 @@
    i32.const 0
    i32.const 288
    i32.const 249
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -19730,7 +19730,7 @@
    i32.const 0
    i32.const 288
    i32.const 250
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -19744,7 +19744,7 @@
    i32.const 0
    i32.const 288
    i32.const 251
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -19758,7 +19758,7 @@
    i32.const 0
    i32.const 288
    i32.const 252
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -19773,7 +19773,7 @@
    i32.const 0
    i32.const 288
    i32.const 256
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -19786,7 +19786,7 @@
    i32.const 0
    i32.const 288
    i32.const 257
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -19799,7 +19799,7 @@
    i32.const 0
    i32.const 288
    i32.const 258
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -19813,7 +19813,7 @@
    i32.const 0
    i32.const 288
    i32.const 259
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -19827,7 +19827,7 @@
    i32.const 0
    i32.const 288
    i32.const 260
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -19841,7 +19841,7 @@
    i32.const 0
    i32.const 288
    i32.const 261
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -19857,7 +19857,7 @@
    i32.const 0
    i32.const 288
    i32.const 269
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -19870,7 +19870,7 @@
    i32.const 0
    i32.const 288
    i32.const 270
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -19884,7 +19884,7 @@
    i32.const 0
    i32.const 288
    i32.const 271
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -19898,7 +19898,7 @@
    i32.const 0
    i32.const 288
    i32.const 272
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -19912,7 +19912,7 @@
    i32.const 0
    i32.const 288
    i32.const 273
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -19937,7 +19937,7 @@
    i32.const 0
    i32.const 288
    i32.const 283
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -19954,7 +19954,7 @@
    i32.const 0
    i32.const 288
    i32.const 286
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -19971,7 +19971,7 @@
    i32.const 0
    i32.const 288
    i32.const 289
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -19988,7 +19988,7 @@
    i32.const 0
    i32.const 288
    i32.const 292
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -20005,7 +20005,7 @@
    i32.const 0
    i32.const 288
    i32.const 295
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -20022,7 +20022,7 @@
    i32.const 0
    i32.const 288
    i32.const 298
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -20039,7 +20039,7 @@
    i32.const 0
    i32.const 288
    i32.const 301
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -20056,7 +20056,7 @@
    i32.const 0
    i32.const 288
    i32.const 304
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -20073,7 +20073,7 @@
    i32.const 0
    i32.const 288
    i32.const 307
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -20090,7 +20090,7 @@
    i32.const 0
    i32.const 288
    i32.const 310
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -20111,7 +20111,7 @@
    i32.const 0
    i32.const 288
    i32.const 312
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -20132,7 +20132,7 @@
    i32.const 0
    i32.const 288
    i32.const 313
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -20153,7 +20153,7 @@
    i32.const 0
    i32.const 288
    i32.const 320
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -20170,7 +20170,7 @@
    i32.const 0
    i32.const 288
    i32.const 323
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -20187,7 +20187,7 @@
    i32.const 0
    i32.const 288
    i32.const 326
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -20204,7 +20204,7 @@
    i32.const 0
    i32.const 288
    i32.const 329
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -20221,7 +20221,7 @@
    i32.const 0
    i32.const 288
    i32.const 332
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -20238,7 +20238,7 @@
    i32.const 0
    i32.const 288
    i32.const 335
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -20255,7 +20255,7 @@
    i32.const 0
    i32.const 288
    i32.const 338
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -20272,7 +20272,7 @@
    i32.const 0
    i32.const 288
    i32.const 341
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -20289,7 +20289,7 @@
    i32.const 0
    i32.const 288
    i32.const 344
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -20306,7 +20306,7 @@
    i32.const 0
    i32.const 288
    i32.const 347
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -20325,7 +20325,7 @@
    i32.const 0
    i32.const 288
    i32.const 349
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -20344,7 +20344,7 @@
    i32.const 0
    i32.const 288
    i32.const 350
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -20362,7 +20362,7 @@
    i32.const 0
    i32.const 288
    i32.const 354
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -20375,7 +20375,7 @@
    i32.const 0
    i32.const 288
    i32.const 355
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -20389,7 +20389,7 @@
    i32.const 0
    i32.const 288
    i32.const 356
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -20403,7 +20403,7 @@
    i32.const 0
    i32.const 288
    i32.const 357
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -20437,7 +20437,7 @@
    i32.const 0
    i32.const 288
    i32.const 364
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -20456,7 +20456,7 @@
    i32.const 0
    i32.const 288
    i32.const 365
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -20490,7 +20490,7 @@
    i32.const 0
    i32.const 288
    i32.const 368
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -20509,7 +20509,7 @@
    i32.const 0
    i32.const 288
    i32.const 369
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -20543,7 +20543,7 @@
    i32.const 0
    i32.const 288
    i32.const 372
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -20562,7 +20562,7 @@
    i32.const 0
    i32.const 288
    i32.const 373
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -20596,7 +20596,7 @@
    i32.const 0
    i32.const 288
    i32.const 376
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -20615,7 +20615,7 @@
    i32.const 0
    i32.const 288
    i32.const 377
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -20649,7 +20649,7 @@
    i32.const 0
    i32.const 288
    i32.const 380
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -20668,7 +20668,7 @@
    i32.const 0
    i32.const 288
    i32.const 381
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -20702,7 +20702,7 @@
    i32.const 0
    i32.const 288
    i32.const 384
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -20721,7 +20721,7 @@
    i32.const 0
    i32.const 288
    i32.const 385
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -20755,7 +20755,7 @@
    i32.const 0
    i32.const 288
    i32.const 388
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -20774,7 +20774,7 @@
    i32.const 0
    i32.const 288
    i32.const 389
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -20808,7 +20808,7 @@
    i32.const 0
    i32.const 288
    i32.const 392
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -20827,7 +20827,7 @@
    i32.const 0
    i32.const 288
    i32.const 393
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -20861,7 +20861,7 @@
    i32.const 0
    i32.const 288
    i32.const 396
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -20880,7 +20880,7 @@
    i32.const 0
    i32.const 288
    i32.const 397
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -20914,7 +20914,7 @@
    i32.const 0
    i32.const 288
    i32.const 400
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -20933,7 +20933,7 @@
    i32.const 0
    i32.const 288
    i32.const 401
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -20967,7 +20967,7 @@
    i32.const 0
    i32.const 288
    i32.const 404
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -20986,7 +20986,7 @@
    i32.const 0
    i32.const 288
    i32.const 405
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -21020,7 +21020,7 @@
    i32.const 0
    i32.const 288
    i32.const 408
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -21039,7 +21039,7 @@
    i32.const 0
    i32.const 288
    i32.const 409
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -21073,7 +21073,7 @@
    i32.const 0
    i32.const 288
    i32.const 412
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -21092,7 +21092,7 @@
    i32.const 0
    i32.const 288
    i32.const 413
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -21126,7 +21126,7 @@
    i32.const 0
    i32.const 288
    i32.const 416
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -21145,7 +21145,7 @@
    i32.const 0
    i32.const 288
    i32.const 417
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -21170,7 +21170,7 @@
    i32.const 0
    i32.const 288
    i32.const 421
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -21183,7 +21183,7 @@
    i32.const 0
    i32.const 288
    i32.const 422
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -21246,7 +21246,7 @@
    i32.const 0
    i32.const 288
    i32.const 427
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -21262,7 +21262,7 @@
    i32.const 0
    i32.const 288
    i32.const 428
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -21278,7 +21278,7 @@
    i32.const 0
    i32.const 288
    i32.const 429
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -21291,7 +21291,7 @@
    i32.const 0
    i32.const 288
    i32.const 431
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -21307,7 +21307,7 @@
    i32.const 0
    i32.const 288
    i32.const 432
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -21323,7 +21323,7 @@
    i32.const 0
    i32.const 288
    i32.const 433
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -21339,7 +21339,7 @@
    i32.const 0
    i32.const 288
    i32.const 434
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -21383,7 +21383,7 @@
    i32.const 0
    i32.const 288
    i32.const 439
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -21398,7 +21398,7 @@
    i32.const 0
    i32.const 288
    i32.const 440
-   i32.const 9
+   i32.const 10
    call $~lib/builtins/abort
    unreachable
   end
@@ -21410,7 +21410,7 @@
    i32.const 0
    i32.const 288
    i32.const 440
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -21423,7 +21423,7 @@
    i32.const 0
    i32.const 288
    i32.const 442
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -21438,7 +21438,7 @@
    i32.const 0
    i32.const 288
    i32.const 443
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -21453,7 +21453,7 @@
    i32.const 0
    i32.const 288
    i32.const 444
-   i32.const 9
+   i32.const 10
    call $~lib/builtins/abort
    unreachable
   end
@@ -21465,7 +21465,7 @@
    i32.const 0
    i32.const 288
    i32.const 444
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -21599,7 +21599,7 @@
    i32.const 0
    i32.const 288
    i32.const 457
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -21615,7 +21615,7 @@
    i32.const 0
    i32.const 288
    i32.const 460
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -21631,7 +21631,7 @@
    i32.const 0
    i32.const 288
    i32.const 463
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -21647,7 +21647,7 @@
    i32.const 0
    i32.const 288
    i32.const 471
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -21660,7 +21660,7 @@
    i32.const 0
    i32.const 288
    i32.const 472
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -21676,7 +21676,7 @@
    i32.const 0
    i32.const 288
    i32.const 474
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -21704,7 +21704,7 @@
    i32.const 0
    i32.const 288
    i32.const 487
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -21717,7 +21717,7 @@
    i32.const 0
    i32.const 288
    i32.const 488
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -21741,7 +21741,7 @@
    i32.const 0
    i32.const 288
    i32.const 498
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -21757,7 +21757,7 @@
    i32.const 0
    i32.const 288
    i32.const 501
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -21773,7 +21773,7 @@
    i32.const 0
    i32.const 288
    i32.const 509
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -21786,7 +21786,7 @@
    i32.const 0
    i32.const 288
    i32.const 510
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -21802,7 +21802,7 @@
    i32.const 0
    i32.const 288
    i32.const 512
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -21830,7 +21830,7 @@
    i32.const 0
    i32.const 288
    i32.const 525
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -21843,7 +21843,7 @@
    i32.const 0
    i32.const 288
    i32.const 526
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -21867,7 +21867,7 @@
    i32.const 0
    i32.const 288
    i32.const 536
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -21883,7 +21883,7 @@
    i32.const 0
    i32.const 288
    i32.const 539
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -21899,7 +21899,7 @@
    i32.const 0
    i32.const 288
    i32.const 547
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -21912,7 +21912,7 @@
    i32.const 0
    i32.const 288
    i32.const 548
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -21928,7 +21928,7 @@
    i32.const 0
    i32.const 288
    i32.const 550
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -21956,7 +21956,7 @@
    i32.const 0
    i32.const 288
    i32.const 563
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -21969,7 +21969,7 @@
    i32.const 0
    i32.const 288
    i32.const 564
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -21994,7 +21994,7 @@
    i32.const 0
    i32.const 288
    i32.const 575
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -22011,7 +22011,7 @@
    i32.const 0
    i32.const 288
    i32.const 584
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -22024,7 +22024,7 @@
    i32.const 0
    i32.const 288
    i32.const 585
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -22041,7 +22041,7 @@
    i32.const 0
    i32.const 288
    i32.const 588
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -22070,7 +22070,7 @@
    i32.const 0
    i32.const 288
    i32.const 602
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -22083,7 +22083,7 @@
    i32.const 0
    i32.const 288
    i32.const 603
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -22107,7 +22107,7 @@
    i32.const 0
    i32.const 288
    i32.const 628
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -22159,7 +22159,7 @@
    i32.const 0
    i32.const 288
    i32.const 642
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -22176,7 +22176,7 @@
    i32.const 0
    i32.const 288
    i32.const 643
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -22194,7 +22194,7 @@
    i32.const 0
    i32.const 288
    i32.const 652
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -22207,7 +22207,7 @@
    i32.const 0
    i32.const 288
    i32.const 653
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -22225,7 +22225,7 @@
    i32.const 0
    i32.const 288
    i32.const 660
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -22255,7 +22255,7 @@
    i32.const 0
    i32.const 288
    i32.const 675
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -22268,7 +22268,7 @@
    i32.const 0
    i32.const 288
    i32.const 676
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -22295,7 +22295,7 @@
    i32.const 0
    i32.const 288
    i32.const 686
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -22313,7 +22313,7 @@
    i32.const 0
    i32.const 288
    i32.const 695
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -22326,7 +22326,7 @@
    i32.const 0
    i32.const 288
    i32.const 696
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -22344,7 +22344,7 @@
    i32.const 0
    i32.const 288
    i32.const 703
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -22374,7 +22374,7 @@
    i32.const 0
    i32.const 288
    i32.const 718
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -22387,7 +22387,7 @@
    i32.const 0
    i32.const 288
    i32.const 719
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -22414,7 +22414,7 @@
    i32.const 0
    i32.const 288
    i32.const 729
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -22431,7 +22431,7 @@
    i32.const 0
    i32.const 288
    i32.const 733
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -22450,7 +22450,7 @@
    i32.const 0
    i32.const 288
    i32.const 736
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -22469,7 +22469,7 @@
    i32.const 0
    i32.const 288
    i32.const 739
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -22486,7 +22486,7 @@
    i32.const 0
    i32.const 288
    i32.const 747
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -22499,7 +22499,7 @@
    i32.const 0
    i32.const 288
    i32.const 748
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -22516,7 +22516,7 @@
    i32.const 0
    i32.const 288
    i32.const 750
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -22545,7 +22545,7 @@
    i32.const 0
    i32.const 288
    i32.const 763
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -22558,7 +22558,7 @@
    i32.const 0
    i32.const 288
    i32.const 764
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -22583,7 +22583,7 @@
    i32.const 0
    i32.const 288
    i32.const 774
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -22600,7 +22600,7 @@
    i32.const 0
    i32.const 288
    i32.const 778
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -22619,7 +22619,7 @@
    i32.const 0
    i32.const 288
    i32.const 781
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -22638,7 +22638,7 @@
    i32.const 0
    i32.const 288
    i32.const 784
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -22655,7 +22655,7 @@
    i32.const 0
    i32.const 288
    i32.const 792
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -22668,7 +22668,7 @@
    i32.const 0
    i32.const 288
    i32.const 793
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -22685,7 +22685,7 @@
    i32.const 0
    i32.const 288
    i32.const 795
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -22714,7 +22714,7 @@
    i32.const 0
    i32.const 288
    i32.const 808
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -22727,7 +22727,7 @@
    i32.const 0
    i32.const 288
    i32.const 809
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -22778,7 +22778,7 @@
    i32.const 0
    i32.const 288
    i32.const 898
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -22810,7 +22810,7 @@
    i32.const 0
    i32.const 288
    i32.const 902
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -22842,7 +22842,7 @@
    i32.const 0
    i32.const 288
    i32.const 906
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -22874,7 +22874,7 @@
    i32.const 0
    i32.const 288
    i32.const 910
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -22947,7 +22947,7 @@
    i32.const 0
    i32.const 288
    i32.const 930
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -22968,7 +22968,7 @@
    i32.const 0
    i32.const 288
    i32.const 933
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -22983,7 +22983,7 @@
    i32.const 0
    i32.const 288
    i32.const 936
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -22998,7 +22998,7 @@
    i32.const 0
    i32.const 288
    i32.const 939
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -23013,7 +23013,7 @@
    i32.const 0
    i32.const 288
    i32.const 942
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -23028,7 +23028,7 @@
    i32.const 0
    i32.const 288
    i32.const 945
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -23043,7 +23043,7 @@
    i32.const 0
    i32.const 288
    i32.const 948
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -23155,7 +23155,7 @@
    i32.const 0
    i32.const 288
    i32.const 985
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -23190,7 +23190,7 @@
    i32.const 0
    i32.const 288
    i32.const 994
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -23211,7 +23211,7 @@
    i32.const 0
    i32.const 288
    i32.const 995
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -23232,7 +23232,7 @@
    i32.const 0
    i32.const 288
    i32.const 996
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -23253,7 +23253,7 @@
    i32.const 0
    i32.const 288
    i32.const 997
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -23274,7 +23274,7 @@
    i32.const 0
    i32.const 288
    i32.const 998
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -23295,7 +23295,7 @@
    i32.const 0
    i32.const 288
    i32.const 999
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -23336,7 +23336,7 @@
    i32.const 0
    i32.const 288
    i32.const 1001
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -23373,7 +23373,7 @@
    i32.const 0
    i32.const 288
    i32.const 1004
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -23447,7 +23447,7 @@
    i32.const 0
    i32.const 288
    i32.const 1014
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -23461,7 +23461,7 @@
    i32.const 0
    i32.const 288
    i32.const 1015
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -23475,7 +23475,7 @@
    i32.const 0
    i32.const 288
    i32.const 1016
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -23489,7 +23489,7 @@
    i32.const 0
    i32.const 288
    i32.const 1017
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -23509,7 +23509,7 @@
    i32.const 0
    i32.const 288
    i32.const 1019
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -23529,7 +23529,7 @@
    i32.const 0
    i32.const 288
    i32.const 1020
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -23549,7 +23549,7 @@
    i32.const 0
    i32.const 288
    i32.const 1021
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -23569,7 +23569,7 @@
    i32.const 0
    i32.const 288
    i32.const 1022
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -23590,7 +23590,7 @@
    i32.const 0
    i32.const 288
    i32.const 1026
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -23610,7 +23610,7 @@
    i32.const 0
    i32.const 288
    i32.const 1027
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -23652,7 +23652,7 @@
    i32.const 0
    i32.const 288
    i32.const 1030
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -23694,7 +23694,7 @@
    i32.const 0
    i32.const 288
    i32.const 1033
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -23741,7 +23741,7 @@
    i32.const 0
    i32.const 288
    i32.const 1036
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -23843,7 +23843,7 @@
    i32.const 0
    i32.const 240
    i32.const 122
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -23865,7 +23865,7 @@
     i32.const 0
     i32.const 240
     i32.const 126
-    i32.const 17
+    i32.const 18
     call $~lib/builtins/abort
     unreachable
    end
@@ -23881,7 +23881,7 @@
     i32.const 0
     i32.const 240
     i32.const 136
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -23913,7 +23913,7 @@
    i32.const 0
    i32.const 240
    i32.const 69
-   i32.const 15
+   i32.const 16
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/std/arraybuffer.optimized.wat
+++ b/tests/compiler/std/arraybuffer.optimized.wat
@@ -43,7 +43,7 @@
    i32.const 0
    i32.const 1152
    i32.const 277
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -65,7 +65,7 @@
    i32.const 0
    i32.const 1152
    i32.const 279
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -108,7 +108,7 @@
    i32.const 0
    i32.const 1152
    i32.const 292
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -204,7 +204,7 @@
    i32.const 0
    i32.const 1152
    i32.const 205
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -218,7 +218,7 @@
    i32.const 0
    i32.const 1152
    i32.const 207
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -291,7 +291,7 @@
     i32.const 0
     i32.const 1152
     i32.const 228
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -346,7 +346,7 @@
    i32.const 0
    i32.const 1152
    i32.const 243
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -361,7 +361,7 @@
    i32.const 0
    i32.const 1152
    i32.const 244
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -409,7 +409,7 @@
    i32.const 0
    i32.const 1152
    i32.const 260
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -492,7 +492,7 @@
    i32.const 0
    i32.const 1152
    i32.const 386
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -509,7 +509,7 @@
     i32.const 0
     i32.const 1152
     i32.const 396
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -537,7 +537,7 @@
     i32.const 0
     i32.const 1152
     i32.const 408
-    i32.const 4
+    i32.const 5
     call $~lib/builtins/abort
     unreachable
    end
@@ -727,7 +727,7 @@
    i32.const 0
    i32.const 1152
    i32.const 338
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -779,7 +779,7 @@
      i32.const 0
      i32.const 1152
      i32.const 351
-     i32.const 17
+     i32.const 18
      call $~lib/builtins/abort
      unreachable
     end
@@ -812,7 +812,7 @@
    i32.const 0
    i32.const 1152
    i32.const 365
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -883,7 +883,7 @@
    i32.const 0
    i32.const 1152
    i32.const 501
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -894,7 +894,7 @@
    i32.const 1200
    i32.const 1152
    i32.const 461
-   i32.const 29
+   i32.const 30
    call $~lib/builtins/abort
    unreachable
   end
@@ -994,7 +994,7 @@
      i32.const 0
      i32.const 1152
      i32.const 513
-     i32.const 19
+     i32.const 20
      call $~lib/builtins/abort
      unreachable
     end
@@ -1010,7 +1010,7 @@
    i32.const 0
    i32.const 1152
    i32.const 521
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1225,7 +1225,7 @@
     i32.const 0
     i32.const 1264
     i32.const 109
-    i32.const 2
+    i32.const 3
     call $~lib/builtins/abort
     unreachable
    end
@@ -1244,7 +1244,7 @@
     i32.const 0
     i32.const 1264
     i32.const 112
-    i32.const 13
+    i32.const 14
     call $~lib/builtins/abort
     unreachable
    end
@@ -1518,7 +1518,7 @@
    i32.const 1040
    i32.const 1088
    i32.const 23
-   i32.const 56
+   i32.const 57
    call $~lib/builtins/abort
    unreachable
   end
@@ -1610,7 +1610,7 @@
    i32.const 1040
    i32.const 1408
    i32.const 25
-   i32.const 6
+   i32.const 7
    call $~lib/builtins/abort
    unreachable
   end
@@ -1681,7 +1681,7 @@
    i32.const 0
    i32.const 1312
    i32.const 4
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1699,7 +1699,7 @@
    i32.const 0
    i32.const 1312
    i32.const 8
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1710,7 +1710,7 @@
    i32.const 0
    i32.const 1312
    i32.const 9
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1730,7 +1730,7 @@
    i32.const 0
    i32.const 1312
    i32.const 13
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1750,7 +1750,7 @@
    i32.const 0
    i32.const 1312
    i32.const 17
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1770,7 +1770,7 @@
    i32.const 0
    i32.const 1312
    i32.const 21
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1790,7 +1790,7 @@
    i32.const 0
    i32.const 1312
    i32.const 25
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1811,7 +1811,7 @@
    i32.const 0
    i32.const 1312
    i32.const 29
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1832,7 +1832,7 @@
    i32.const 0
    i32.const 1312
    i32.const 33
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1851,7 +1851,7 @@
    i32.const 0
    i32.const 1312
    i32.const 37
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1861,7 +1861,7 @@
    i32.const 0
    i32.const 1312
    i32.const 38
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1945,7 +1945,7 @@
    i32.const 0
    i32.const 1264
    i32.const 122
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1989,7 +1989,7 @@
     i32.const 0
     i32.const 1264
     i32.const 126
-    i32.const 17
+    i32.const 18
     call $~lib/builtins/abort
     unreachable
    end
@@ -2012,7 +2012,7 @@
     i32.const 0
     i32.const 1264
     i32.const 136
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end

--- a/tests/compiler/std/arraybuffer.untouched.wat
+++ b/tests/compiler/std/arraybuffer.untouched.wat
@@ -56,7 +56,7 @@
    i32.const 0
    i32.const 144
    i32.const 277
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -81,7 +81,7 @@
    i32.const 0
    i32.const 144
    i32.const 279
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -133,7 +133,7 @@
    i32.const 0
    i32.const 144
    i32.const 292
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -263,7 +263,7 @@
    i32.const 0
    i32.const 144
    i32.const 205
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -278,7 +278,7 @@
    i32.const 0
    i32.const 144
    i32.const 207
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -371,7 +371,7 @@
     i32.const 0
     i32.const 144
     i32.const 228
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -434,7 +434,7 @@
    i32.const 0
    i32.const 144
    i32.const 243
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -450,7 +450,7 @@
    i32.const 0
    i32.const 144
    i32.const 244
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -507,7 +507,7 @@
    i32.const 0
    i32.const 144
    i32.const 260
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -626,7 +626,7 @@
    i32.const 0
    i32.const 144
    i32.const 386
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -649,7 +649,7 @@
     i32.const 0
     i32.const 144
     i32.const 396
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -680,7 +680,7 @@
     i32.const 0
     i32.const 144
     i32.const 408
-    i32.const 4
+    i32.const 5
     call $~lib/builtins/abort
     unreachable
    end
@@ -906,7 +906,7 @@
    i32.const 192
    i32.const 144
    i32.const 461
-   i32.const 29
+   i32.const 30
    call $~lib/builtins/abort
    unreachable
   end
@@ -1000,7 +1000,7 @@
    i32.const 0
    i32.const 144
    i32.const 338
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1063,7 +1063,7 @@
      i32.const 0
      i32.const 144
      i32.const 351
-     i32.const 17
+     i32.const 18
      call $~lib/builtins/abort
      unreachable
     end
@@ -1208,7 +1208,7 @@
    i32.const 0
    i32.const 144
    i32.const 365
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1297,7 +1297,7 @@
    i32.const 0
    i32.const 144
    i32.const 501
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1338,7 +1338,7 @@
       i32.const 0
       i32.const 144
       i32.const 513
-      i32.const 19
+      i32.const 20
       call $~lib/builtins/abort
       unreachable
      end
@@ -1357,7 +1357,7 @@
      i32.const 0
      i32.const 144
      i32.const 518
-     i32.const 17
+     i32.const 18
      call $~lib/builtins/abort
      unreachable
     end
@@ -1374,7 +1374,7 @@
    i32.const 0
    i32.const 144
    i32.const 521
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1634,7 +1634,7 @@
    i32.const 0
    i32.const 256
    i32.const 109
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1655,7 +1655,7 @@
    i32.const 0
    i32.const 256
    i32.const 112
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1681,7 +1681,7 @@
    i32.const 32
    i32.const 80
    i32.const 54
-   i32.const 42
+   i32.const 43
    call $~lib/builtins/abort
    unreachable
   end
@@ -3148,7 +3148,7 @@
    i32.const 32
    i32.const 80
    i32.const 23
-   i32.const 56
+   i32.const 57
    call $~lib/builtins/abort
    unreachable
   end
@@ -3344,7 +3344,7 @@
    i32.const 32
    i32.const 400
    i32.const 25
-   i32.const 6
+   i32.const 7
    call $~lib/builtins/abort
    unreachable
   end
@@ -3458,7 +3458,7 @@
    i32.const 0
    i32.const 304
    i32.const 4
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3476,7 +3476,7 @@
    i32.const 0
    i32.const 304
    i32.const 8
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3488,7 +3488,7 @@
    i32.const 0
    i32.const 304
    i32.const 9
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3510,7 +3510,7 @@
    i32.const 0
    i32.const 304
    i32.const 13
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3532,7 +3532,7 @@
    i32.const 0
    i32.const 304
    i32.const 17
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3554,7 +3554,7 @@
    i32.const 0
    i32.const 304
    i32.const 21
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3576,7 +3576,7 @@
    i32.const 0
    i32.const 304
    i32.const 25
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3598,7 +3598,7 @@
    i32.const 0
    i32.const 304
    i32.const 29
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3620,7 +3620,7 @@
    i32.const 0
    i32.const 304
    i32.const 33
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3642,7 +3642,7 @@
    i32.const 0
    i32.const 304
    i32.const 37
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3654,7 +3654,7 @@
    i32.const 0
    i32.const 304
    i32.const 38
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3666,7 +3666,7 @@
    i32.const 0
    i32.const 304
    i32.const 40
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3678,7 +3678,7 @@
    i32.const 0
    i32.const 304
    i32.const 41
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3690,7 +3690,7 @@
    i32.const 0
    i32.const 304
    i32.const 42
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3702,7 +3702,7 @@
    i32.const 0
    i32.const 304
    i32.const 43
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3714,7 +3714,7 @@
    i32.const 0
    i32.const 304
    i32.const 44
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3726,7 +3726,7 @@
    i32.const 0
    i32.const 304
    i32.const 45
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3748,7 +3748,7 @@
    i32.const 0
    i32.const 304
    i32.const 48
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3759,7 +3759,7 @@
    i32.const 0
    i32.const 304
    i32.const 49
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3773,7 +3773,7 @@
    i32.const 0
    i32.const 304
    i32.const 50
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3792,7 +3792,7 @@
    i32.const 0
    i32.const 304
    i32.const 51
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3853,7 +3853,7 @@
    i32.const 0
    i32.const 256
    i32.const 122
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -3875,7 +3875,7 @@
     i32.const 0
     i32.const 256
     i32.const 126
-    i32.const 17
+    i32.const 18
     call $~lib/builtins/abort
     unreachable
    end
@@ -3891,7 +3891,7 @@
     i32.const 0
     i32.const 256
     i32.const 136
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -3923,7 +3923,7 @@
    i32.const 0
    i32.const 256
    i32.const 69
-   i32.const 15
+   i32.const 16
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/std/dataview.optimized.wat
+++ b/tests/compiler/std/dataview.optimized.wat
@@ -51,7 +51,7 @@
    i32.const 0
    i32.const 1152
    i32.const 277
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -73,7 +73,7 @@
    i32.const 0
    i32.const 1152
    i32.const 279
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -116,7 +116,7 @@
    i32.const 0
    i32.const 1152
    i32.const 292
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -212,7 +212,7 @@
    i32.const 0
    i32.const 1152
    i32.const 205
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -226,7 +226,7 @@
    i32.const 0
    i32.const 1152
    i32.const 207
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -299,7 +299,7 @@
     i32.const 0
     i32.const 1152
     i32.const 228
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -354,7 +354,7 @@
    i32.const 0
    i32.const 1152
    i32.const 243
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -369,7 +369,7 @@
    i32.const 0
    i32.const 1152
    i32.const 244
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -417,7 +417,7 @@
    i32.const 0
    i32.const 1152
    i32.const 260
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -500,7 +500,7 @@
    i32.const 0
    i32.const 1152
    i32.const 386
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -517,7 +517,7 @@
     i32.const 0
     i32.const 1152
     i32.const 396
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -545,7 +545,7 @@
     i32.const 0
     i32.const 1152
     i32.const 408
-    i32.const 4
+    i32.const 5
     call $~lib/builtins/abort
     unreachable
    end
@@ -735,7 +735,7 @@
    i32.const 0
    i32.const 1152
    i32.const 338
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -787,7 +787,7 @@
      i32.const 0
      i32.const 1152
      i32.const 351
-     i32.const 17
+     i32.const 18
      call $~lib/builtins/abort
      unreachable
     end
@@ -820,7 +820,7 @@
    i32.const 0
    i32.const 1152
    i32.const 365
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -891,7 +891,7 @@
    i32.const 0
    i32.const 1152
    i32.const 501
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -902,7 +902,7 @@
    i32.const 1200
    i32.const 1152
    i32.const 461
-   i32.const 29
+   i32.const 30
    call $~lib/builtins/abort
    unreachable
   end
@@ -1002,7 +1002,7 @@
      i32.const 0
      i32.const 1152
      i32.const 513
-     i32.const 19
+     i32.const 20
      call $~lib/builtins/abort
      unreachable
     end
@@ -1018,7 +1018,7 @@
    i32.const 0
    i32.const 1152
    i32.const 521
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1075,7 +1075,7 @@
     i32.const 0
     i32.const 1264
     i32.const 109
-    i32.const 2
+    i32.const 3
     call $~lib/builtins/abort
     unreachable
    end
@@ -1094,7 +1094,7 @@
     i32.const 0
     i32.const 1264
     i32.const 112
-    i32.const 13
+    i32.const 14
     call $~lib/builtins/abort
     unreachable
    end
@@ -1198,7 +1198,7 @@
    i32.const 1312
    i32.const 1376
    i32.const 163
-   i32.const 44
+   i32.const 45
    call $~lib/builtins/abort
    unreachable
   end
@@ -1229,7 +1229,7 @@
    i32.const 1040
    i32.const 1440
    i32.const 25
-   i32.const 6
+   i32.const 7
    call $~lib/builtins/abort
    unreachable
   end
@@ -1308,7 +1308,7 @@
    i32.const 1312
    i32.const 1440
    i32.const 35
-   i32.const 6
+   i32.const 7
    call $~lib/builtins/abort
    unreachable
   end
@@ -1364,7 +1364,7 @@
    i32.const 1312
    i32.const 1440
    i32.const 48
-   i32.const 6
+   i32.const 7
    call $~lib/builtins/abort
    unreachable
   end
@@ -1390,7 +1390,7 @@
    i32.const 1312
    i32.const 1440
    i32.const 59
-   i32.const 49
+   i32.const 50
    call $~lib/builtins/abort
    unreachable
   end
@@ -1428,7 +1428,7 @@
    i32.const 1312
    i32.const 1440
    i32.const 66
-   i32.const 6
+   i32.const 7
    call $~lib/builtins/abort
    unreachable
   end
@@ -1462,7 +1462,7 @@
    i32.const 1312
    i32.const 1440
    i32.const 74
-   i32.const 6
+   i32.const 7
    call $~lib/builtins/abort
    unreachable
   end
@@ -1491,7 +1491,7 @@
    i32.const 1312
    i32.const 1440
    i32.const 159
-   i32.const 6
+   i32.const 7
    call $~lib/builtins/abort
    unreachable
   end
@@ -1516,7 +1516,7 @@
    i32.const 1312
    i32.const 1440
    i32.const 80
-   i32.const 49
+   i32.const 50
    call $~lib/builtins/abort
    unreachable
   end
@@ -1552,7 +1552,7 @@
    i32.const 1312
    i32.const 1440
    i32.const 87
-   i32.const 6
+   i32.const 7
    call $~lib/builtins/abort
    unreachable
   end
@@ -1586,7 +1586,7 @@
    i32.const 1312
    i32.const 1440
    i32.const 95
-   i32.const 6
+   i32.const 7
    call $~lib/builtins/abort
    unreachable
   end
@@ -1615,7 +1615,7 @@
    i32.const 1312
    i32.const 1440
    i32.const 167
-   i32.const 6
+   i32.const 7
    call $~lib/builtins/abort
    unreachable
   end
@@ -1640,7 +1640,7 @@
    i32.const 1312
    i32.const 1440
    i32.const 103
-   i32.const 6
+   i32.const 7
    call $~lib/builtins/abort
    unreachable
   end
@@ -1668,7 +1668,7 @@
    i32.const 1312
    i32.const 1440
    i32.const 111
-   i32.const 6
+   i32.const 7
    call $~lib/builtins/abort
    unreachable
   end
@@ -1696,7 +1696,7 @@
    i32.const 1312
    i32.const 1440
    i32.const 124
-   i32.const 6
+   i32.const 7
    call $~lib/builtins/abort
    unreachable
   end
@@ -1720,7 +1720,7 @@
    i32.const 1312
    i32.const 1440
    i32.const 131
-   i32.const 6
+   i32.const 7
    call $~lib/builtins/abort
    unreachable
   end
@@ -1744,7 +1744,7 @@
    i32.const 1312
    i32.const 1440
    i32.const 175
-   i32.const 6
+   i32.const 7
    call $~lib/builtins/abort
    unreachable
   end
@@ -1768,7 +1768,7 @@
    i32.const 1312
    i32.const 1440
    i32.const 143
-   i32.const 6
+   i32.const 7
    call $~lib/builtins/abort
    unreachable
   end
@@ -1792,7 +1792,7 @@
    i32.const 1312
    i32.const 1440
    i32.const 150
-   i32.const 6
+   i32.const 7
    call $~lib/builtins/abort
    unreachable
   end
@@ -1816,7 +1816,7 @@
    i32.const 1312
    i32.const 1440
    i32.const 182
-   i32.const 6
+   i32.const 7
    call $~lib/builtins/abort
    unreachable
   end
@@ -1893,7 +1893,7 @@
    i32.const 0
    i32.const 1488
    i32.const 15
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1907,7 +1907,7 @@
    i32.const 0
    i32.const 1488
    i32.const 16
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1921,7 +1921,7 @@
    i32.const 0
    i32.const 1488
    i32.const 17
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1935,7 +1935,7 @@
    i32.const 0
    i32.const 1488
    i32.const 18
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1949,7 +1949,7 @@
    i32.const 0
    i32.const 1488
    i32.const 19
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1963,7 +1963,7 @@
    i32.const 0
    i32.const 1488
    i32.const 21
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1977,7 +1977,7 @@
    i32.const 0
    i32.const 1488
    i32.const 22
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1991,7 +1991,7 @@
    i32.const 0
    i32.const 1488
    i32.const 23
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2005,7 +2005,7 @@
    i32.const 0
    i32.const 1488
    i32.const 24
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2019,7 +2019,7 @@
    i32.const 0
    i32.const 1488
    i32.const 25
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2032,7 +2032,7 @@
    i32.const 0
    i32.const 1488
    i32.const 27
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2045,7 +2045,7 @@
    i32.const 0
    i32.const 1488
    i32.const 28
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2058,7 +2058,7 @@
    i32.const 0
    i32.const 1488
    i32.const 30
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2071,7 +2071,7 @@
    i32.const 0
    i32.const 1488
    i32.const 31
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2084,7 +2084,7 @@
    i32.const 0
    i32.const 1488
    i32.const 32
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2097,7 +2097,7 @@
    i32.const 0
    i32.const 1488
    i32.const 33
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2110,7 +2110,7 @@
    i32.const 0
    i32.const 1488
    i32.const 34
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2123,7 +2123,7 @@
    i32.const 0
    i32.const 1488
    i32.const 35
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2136,7 +2136,7 @@
    i32.const 0
    i32.const 1488
    i32.const 36
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2149,7 +2149,7 @@
    i32.const 0
    i32.const 1488
    i32.const 37
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2165,7 +2165,7 @@
    i32.const 0
    i32.const 1488
    i32.const 39
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2181,7 +2181,7 @@
    i32.const 0
    i32.const 1488
    i32.const 40
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2197,7 +2197,7 @@
    i32.const 0
    i32.const 1488
    i32.const 41
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2213,7 +2213,7 @@
    i32.const 0
    i32.const 1488
    i32.const 42
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2229,7 +2229,7 @@
    i32.const 0
    i32.const 1488
    i32.const 43
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2245,7 +2245,7 @@
    i32.const 0
    i32.const 1488
    i32.const 44
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2261,7 +2261,7 @@
    i32.const 0
    i32.const 1488
    i32.const 45
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2277,7 +2277,7 @@
    i32.const 0
    i32.const 1488
    i32.const 47
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2293,7 +2293,7 @@
    i32.const 0
    i32.const 1488
    i32.const 48
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2309,7 +2309,7 @@
    i32.const 0
    i32.const 1488
    i32.const 49
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2325,7 +2325,7 @@
    i32.const 0
    i32.const 1488
    i32.const 50
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2341,7 +2341,7 @@
    i32.const 0
    i32.const 1488
    i32.const 51
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2357,7 +2357,7 @@
    i32.const 0
    i32.const 1488
    i32.const 52
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2373,7 +2373,7 @@
    i32.const 0
    i32.const 1488
    i32.const 53
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2387,7 +2387,7 @@
    i32.const 0
    i32.const 1488
    i32.const 55
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2401,7 +2401,7 @@
    i32.const 0
    i32.const 1488
    i32.const 56
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2415,7 +2415,7 @@
    i32.const 0
    i32.const 1488
    i32.const 57
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2429,7 +2429,7 @@
    i32.const 0
    i32.const 1488
    i32.const 58
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2443,7 +2443,7 @@
    i32.const 0
    i32.const 1488
    i32.const 59
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2457,7 +2457,7 @@
    i32.const 0
    i32.const 1488
    i32.const 61
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2471,7 +2471,7 @@
    i32.const 0
    i32.const 1488
    i32.const 62
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2485,7 +2485,7 @@
    i32.const 0
    i32.const 1488
    i32.const 63
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2499,7 +2499,7 @@
    i32.const 0
    i32.const 1488
    i32.const 64
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2513,7 +2513,7 @@
    i32.const 0
    i32.const 1488
    i32.const 65
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2526,7 +2526,7 @@
    i32.const 0
    i32.const 1488
    i32.const 67
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2539,7 +2539,7 @@
    i32.const 0
    i32.const 1488
    i32.const 68
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2552,7 +2552,7 @@
    i32.const 0
    i32.const 1488
    i32.const 70
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2565,7 +2565,7 @@
    i32.const 0
    i32.const 1488
    i32.const 71
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2578,7 +2578,7 @@
    i32.const 0
    i32.const 1488
    i32.const 72
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2591,7 +2591,7 @@
    i32.const 0
    i32.const 1488
    i32.const 73
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2604,7 +2604,7 @@
    i32.const 0
    i32.const 1488
    i32.const 74
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2617,7 +2617,7 @@
    i32.const 0
    i32.const 1488
    i32.const 75
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2630,7 +2630,7 @@
    i32.const 0
    i32.const 1488
    i32.const 76
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2643,7 +2643,7 @@
    i32.const 0
    i32.const 1488
    i32.const 77
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2659,7 +2659,7 @@
    i32.const 0
    i32.const 1488
    i32.const 79
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2675,7 +2675,7 @@
    i32.const 0
    i32.const 1488
    i32.const 80
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2691,7 +2691,7 @@
    i32.const 0
    i32.const 1488
    i32.const 81
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2707,7 +2707,7 @@
    i32.const 0
    i32.const 1488
    i32.const 82
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2723,7 +2723,7 @@
    i32.const 0
    i32.const 1488
    i32.const 83
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2739,7 +2739,7 @@
    i32.const 0
    i32.const 1488
    i32.const 84
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2755,7 +2755,7 @@
    i32.const 0
    i32.const 1488
    i32.const 85
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2771,7 +2771,7 @@
    i32.const 0
    i32.const 1488
    i32.const 87
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2787,7 +2787,7 @@
    i32.const 0
    i32.const 1488
    i32.const 88
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2803,7 +2803,7 @@
    i32.const 0
    i32.const 1488
    i32.const 89
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2819,7 +2819,7 @@
    i32.const 0
    i32.const 1488
    i32.const 90
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2835,7 +2835,7 @@
    i32.const 0
    i32.const 1488
    i32.const 91
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2851,7 +2851,7 @@
    i32.const 0
    i32.const 1488
    i32.const 92
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2867,7 +2867,7 @@
    i32.const 0
    i32.const 1488
    i32.const 93
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2881,7 +2881,7 @@
    i32.const 0
    i32.const 1488
    i32.const 95
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2895,7 +2895,7 @@
    i32.const 0
    i32.const 1488
    i32.const 96
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2909,7 +2909,7 @@
    i32.const 0
    i32.const 1488
    i32.const 97
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2923,7 +2923,7 @@
    i32.const 0
    i32.const 1488
    i32.const 98
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2937,7 +2937,7 @@
    i32.const 0
    i32.const 1488
    i32.const 99
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2951,7 +2951,7 @@
    i32.const 0
    i32.const 1488
    i32.const 101
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2965,7 +2965,7 @@
    i32.const 0
    i32.const 1488
    i32.const 102
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2979,7 +2979,7 @@
    i32.const 0
    i32.const 1488
    i32.const 103
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2993,7 +2993,7 @@
    i32.const 0
    i32.const 1488
    i32.const 104
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3007,7 +3007,7 @@
    i32.const 0
    i32.const 1488
    i32.const 105
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3020,7 +3020,7 @@
    i32.const 0
    i32.const 1488
    i32.const 107
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3033,7 +3033,7 @@
    i32.const 0
    i32.const 1488
    i32.const 108
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3051,7 +3051,7 @@
    i32.const 0
    i32.const 1488
    i32.const 111
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3069,7 +3069,7 @@
    i32.const 0
    i32.const 1488
    i32.const 114
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3086,7 +3086,7 @@
    i32.const 0
    i32.const 1488
    i32.const 117
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3103,7 +3103,7 @@
    i32.const 0
    i32.const 1488
    i32.const 120
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3115,7 +3115,7 @@
    i32.const 1312
    i32.const 1440
    i32.const 117
-   i32.const 49
+   i32.const 50
    call $~lib/builtins/abort
    unreachable
   end
@@ -3132,7 +3132,7 @@
    i32.const 0
    i32.const 1488
    i32.const 123
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3152,7 +3152,7 @@
    i32.const 0
    i32.const 1488
    i32.const 126
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3172,7 +3172,7 @@
    i32.const 0
    i32.const 1488
    i32.const 129
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3190,7 +3190,7 @@
    i32.const 0
    i32.const 1488
    i32.const 132
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3208,7 +3208,7 @@
    i32.const 0
    i32.const 1488
    i32.const 135
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3225,7 +3225,7 @@
    i32.const 0
    i32.const 1488
    i32.const 138
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3242,7 +3242,7 @@
    i32.const 0
    i32.const 1488
    i32.const 141
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3254,7 +3254,7 @@
    i32.const 1312
    i32.const 1440
    i32.const 136
-   i32.const 49
+   i32.const 50
    call $~lib/builtins/abort
    unreachable
   end
@@ -3271,7 +3271,7 @@
    i32.const 0
    i32.const 1488
    i32.const 144
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3291,7 +3291,7 @@
    i32.const 0
    i32.const 1488
    i32.const 147
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3311,7 +3311,7 @@
    i32.const 0
    i32.const 1488
    i32.const 150
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3329,7 +3329,7 @@
    i32.const 0
    i32.const 1488
    i32.const 153
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3347,7 +3347,7 @@
    i32.const 0
    i32.const 1488
    i32.const 156
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3364,7 +3364,7 @@
    i32.const 0
    i32.const 1488
    i32.const 159
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3381,7 +3381,7 @@
    i32.const 0
    i32.const 1488
    i32.const 162
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3405,7 +3405,7 @@
    i32.const 0
    i32.const 1488
    i32.const 165
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3417,7 +3417,7 @@
    i32.const 0
    i32.const 1488
    i32.const 166
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3448,7 +3448,7 @@
    i32.const 0
    i32.const 1264
    i32.const 122
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -3493,7 +3493,7 @@
     i32.const 0
     i32.const 1264
     i32.const 126
-    i32.const 17
+    i32.const 18
     call $~lib/builtins/abort
     unreachable
    end
@@ -3516,7 +3516,7 @@
     i32.const 0
     i32.const 1264
     i32.const 136
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end

--- a/tests/compiler/std/dataview.untouched.wat
+++ b/tests/compiler/std/dataview.untouched.wat
@@ -64,7 +64,7 @@
    i32.const 0
    i32.const 144
    i32.const 277
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -89,7 +89,7 @@
    i32.const 0
    i32.const 144
    i32.const 279
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -141,7 +141,7 @@
    i32.const 0
    i32.const 144
    i32.const 292
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -271,7 +271,7 @@
    i32.const 0
    i32.const 144
    i32.const 205
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -286,7 +286,7 @@
    i32.const 0
    i32.const 144
    i32.const 207
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -379,7 +379,7 @@
     i32.const 0
     i32.const 144
     i32.const 228
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -442,7 +442,7 @@
    i32.const 0
    i32.const 144
    i32.const 243
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -458,7 +458,7 @@
    i32.const 0
    i32.const 144
    i32.const 244
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -515,7 +515,7 @@
    i32.const 0
    i32.const 144
    i32.const 260
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -634,7 +634,7 @@
    i32.const 0
    i32.const 144
    i32.const 386
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -657,7 +657,7 @@
     i32.const 0
     i32.const 144
     i32.const 396
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -688,7 +688,7 @@
     i32.const 0
     i32.const 144
     i32.const 408
-    i32.const 4
+    i32.const 5
     call $~lib/builtins/abort
     unreachable
    end
@@ -914,7 +914,7 @@
    i32.const 192
    i32.const 144
    i32.const 461
-   i32.const 29
+   i32.const 30
    call $~lib/builtins/abort
    unreachable
   end
@@ -1008,7 +1008,7 @@
    i32.const 0
    i32.const 144
    i32.const 338
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1071,7 +1071,7 @@
      i32.const 0
      i32.const 144
      i32.const 351
-     i32.const 17
+     i32.const 18
      call $~lib/builtins/abort
      unreachable
     end
@@ -1216,7 +1216,7 @@
    i32.const 0
    i32.const 144
    i32.const 365
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1305,7 +1305,7 @@
    i32.const 0
    i32.const 144
    i32.const 501
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1346,7 +1346,7 @@
       i32.const 0
       i32.const 144
       i32.const 513
-      i32.const 19
+      i32.const 20
       call $~lib/builtins/abort
       unreachable
      end
@@ -1365,7 +1365,7 @@
      i32.const 0
      i32.const 144
      i32.const 518
-     i32.const 17
+     i32.const 18
      call $~lib/builtins/abort
      unreachable
     end
@@ -1382,7 +1382,7 @@
    i32.const 0
    i32.const 144
    i32.const 521
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1642,7 +1642,7 @@
    i32.const 0
    i32.const 256
    i32.const 109
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1663,7 +1663,7 @@
    i32.const 0
    i32.const 256
    i32.const 112
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1705,7 +1705,7 @@
    i32.const 32
    i32.const 80
    i32.const 23
-   i32.const 56
+   i32.const 57
    call $~lib/builtins/abort
    unreachable
   end
@@ -1788,7 +1788,7 @@
    i32.const 304
    i32.const 368
    i32.const 163
-   i32.const 44
+   i32.const 45
    call $~lib/builtins/abort
    unreachable
   end
@@ -1829,7 +1829,7 @@
    i32.const 32
    i32.const 432
    i32.const 25
-   i32.const 6
+   i32.const 7
    call $~lib/builtins/abort
    unreachable
   end
@@ -1918,7 +1918,7 @@
    i32.const 304
    i32.const 432
    i32.const 35
-   i32.const 6
+   i32.const 7
    call $~lib/builtins/abort
    unreachable
   end
@@ -1993,7 +1993,7 @@
    i32.const 304
    i32.const 432
    i32.const 48
-   i32.const 6
+   i32.const 7
    call $~lib/builtins/abort
    unreachable
   end
@@ -2023,7 +2023,7 @@
    i32.const 304
    i32.const 432
    i32.const 59
-   i32.const 49
+   i32.const 50
    call $~lib/builtins/abort
    unreachable
   end
@@ -2065,7 +2065,7 @@
    i32.const 304
    i32.const 432
    i32.const 66
-   i32.const 6
+   i32.const 7
    call $~lib/builtins/abort
    unreachable
   end
@@ -2113,7 +2113,7 @@
    i32.const 304
    i32.const 432
    i32.const 74
-   i32.const 6
+   i32.const 7
    call $~lib/builtins/abort
    unreachable
   end
@@ -2186,7 +2186,7 @@
    i32.const 304
    i32.const 432
    i32.const 159
-   i32.const 6
+   i32.const 7
    call $~lib/builtins/abort
    unreachable
   end
@@ -2213,7 +2213,7 @@
    i32.const 304
    i32.const 432
    i32.const 80
-   i32.const 49
+   i32.const 50
    call $~lib/builtins/abort
    unreachable
   end
@@ -2253,7 +2253,7 @@
    i32.const 304
    i32.const 432
    i32.const 87
-   i32.const 6
+   i32.const 7
    call $~lib/builtins/abort
    unreachable
   end
@@ -2287,7 +2287,7 @@
    i32.const 304
    i32.const 432
    i32.const 95
-   i32.const 6
+   i32.const 7
    call $~lib/builtins/abort
    unreachable
   end
@@ -2321,7 +2321,7 @@
    i32.const 304
    i32.const 432
    i32.const 167
-   i32.const 6
+   i32.const 7
    call $~lib/builtins/abort
    unreachable
   end
@@ -2354,7 +2354,7 @@
    i32.const 304
    i32.const 432
    i32.const 103
-   i32.const 6
+   i32.const 7
    call $~lib/builtins/abort
    unreachable
   end
@@ -2392,7 +2392,7 @@
    i32.const 304
    i32.const 432
    i32.const 111
-   i32.const 6
+   i32.const 7
    call $~lib/builtins/abort
    unreachable
   end
@@ -2424,7 +2424,7 @@
    i32.const 304
    i32.const 432
    i32.const 117
-   i32.const 49
+   i32.const 50
    call $~lib/builtins/abort
    unreachable
   end
@@ -2450,7 +2450,7 @@
    i32.const 304
    i32.const 432
    i32.const 124
-   i32.const 6
+   i32.const 7
    call $~lib/builtins/abort
    unreachable
   end
@@ -2482,7 +2482,7 @@
    i32.const 304
    i32.const 432
    i32.const 131
-   i32.const 6
+   i32.const 7
    call $~lib/builtins/abort
    unreachable
   end
@@ -2514,7 +2514,7 @@
    i32.const 304
    i32.const 432
    i32.const 175
-   i32.const 6
+   i32.const 7
    call $~lib/builtins/abort
    unreachable
   end
@@ -2540,7 +2540,7 @@
    i32.const 304
    i32.const 432
    i32.const 136
-   i32.const 49
+   i32.const 50
    call $~lib/builtins/abort
    unreachable
   end
@@ -2566,7 +2566,7 @@
    i32.const 304
    i32.const 432
    i32.const 143
-   i32.const 6
+   i32.const 7
    call $~lib/builtins/abort
    unreachable
   end
@@ -2598,7 +2598,7 @@
    i32.const 304
    i32.const 432
    i32.const 150
-   i32.const 6
+   i32.const 7
    call $~lib/builtins/abort
    unreachable
   end
@@ -2630,7 +2630,7 @@
    i32.const 304
    i32.const 432
    i32.const 182
-   i32.const 6
+   i32.const 7
    call $~lib/builtins/abort
    unreachable
   end
@@ -2743,7 +2743,7 @@
    i32.const 0
    i32.const 480
    i32.const 15
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2758,7 +2758,7 @@
    i32.const 0
    i32.const 480
    i32.const 16
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2773,7 +2773,7 @@
    i32.const 0
    i32.const 480
    i32.const 17
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2788,7 +2788,7 @@
    i32.const 0
    i32.const 480
    i32.const 18
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2803,7 +2803,7 @@
    i32.const 0
    i32.const 480
    i32.const 19
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2818,7 +2818,7 @@
    i32.const 0
    i32.const 480
    i32.const 21
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2833,7 +2833,7 @@
    i32.const 0
    i32.const 480
    i32.const 22
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2848,7 +2848,7 @@
    i32.const 0
    i32.const 480
    i32.const 23
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2863,7 +2863,7 @@
    i32.const 0
    i32.const 480
    i32.const 24
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2878,7 +2878,7 @@
    i32.const 0
    i32.const 480
    i32.const 25
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2893,7 +2893,7 @@
    i32.const 0
    i32.const 480
    i32.const 27
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2908,7 +2908,7 @@
    i32.const 0
    i32.const 480
    i32.const 28
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2922,7 +2922,7 @@
    i32.const 0
    i32.const 480
    i32.const 30
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2936,7 +2936,7 @@
    i32.const 0
    i32.const 480
    i32.const 31
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2950,7 +2950,7 @@
    i32.const 0
    i32.const 480
    i32.const 32
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2964,7 +2964,7 @@
    i32.const 0
    i32.const 480
    i32.const 33
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2978,7 +2978,7 @@
    i32.const 0
    i32.const 480
    i32.const 34
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2992,7 +2992,7 @@
    i32.const 0
    i32.const 480
    i32.const 35
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3006,7 +3006,7 @@
    i32.const 0
    i32.const 480
    i32.const 36
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3020,7 +3020,7 @@
    i32.const 0
    i32.const 480
    i32.const 37
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3039,7 +3039,7 @@
    i32.const 0
    i32.const 480
    i32.const 39
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3058,7 +3058,7 @@
    i32.const 0
    i32.const 480
    i32.const 40
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3077,7 +3077,7 @@
    i32.const 0
    i32.const 480
    i32.const 41
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3096,7 +3096,7 @@
    i32.const 0
    i32.const 480
    i32.const 42
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3115,7 +3115,7 @@
    i32.const 0
    i32.const 480
    i32.const 43
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3134,7 +3134,7 @@
    i32.const 0
    i32.const 480
    i32.const 44
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3153,7 +3153,7 @@
    i32.const 0
    i32.const 480
    i32.const 45
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3172,7 +3172,7 @@
    i32.const 0
    i32.const 480
    i32.const 47
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3191,7 +3191,7 @@
    i32.const 0
    i32.const 480
    i32.const 48
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3210,7 +3210,7 @@
    i32.const 0
    i32.const 480
    i32.const 49
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3229,7 +3229,7 @@
    i32.const 0
    i32.const 480
    i32.const 50
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3248,7 +3248,7 @@
    i32.const 0
    i32.const 480
    i32.const 51
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3267,7 +3267,7 @@
    i32.const 0
    i32.const 480
    i32.const 52
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3286,7 +3286,7 @@
    i32.const 0
    i32.const 480
    i32.const 53
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3301,7 +3301,7 @@
    i32.const 0
    i32.const 480
    i32.const 55
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3316,7 +3316,7 @@
    i32.const 0
    i32.const 480
    i32.const 56
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3331,7 +3331,7 @@
    i32.const 0
    i32.const 480
    i32.const 57
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3346,7 +3346,7 @@
    i32.const 0
    i32.const 480
    i32.const 58
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3361,7 +3361,7 @@
    i32.const 0
    i32.const 480
    i32.const 59
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3376,7 +3376,7 @@
    i32.const 0
    i32.const 480
    i32.const 61
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3391,7 +3391,7 @@
    i32.const 0
    i32.const 480
    i32.const 62
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3406,7 +3406,7 @@
    i32.const 0
    i32.const 480
    i32.const 63
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3421,7 +3421,7 @@
    i32.const 0
    i32.const 480
    i32.const 64
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3436,7 +3436,7 @@
    i32.const 0
    i32.const 480
    i32.const 65
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3451,7 +3451,7 @@
    i32.const 0
    i32.const 480
    i32.const 67
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3466,7 +3466,7 @@
    i32.const 0
    i32.const 480
    i32.const 68
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3480,7 +3480,7 @@
    i32.const 0
    i32.const 480
    i32.const 70
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3494,7 +3494,7 @@
    i32.const 0
    i32.const 480
    i32.const 71
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3508,7 +3508,7 @@
    i32.const 0
    i32.const 480
    i32.const 72
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3522,7 +3522,7 @@
    i32.const 0
    i32.const 480
    i32.const 73
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3536,7 +3536,7 @@
    i32.const 0
    i32.const 480
    i32.const 74
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3550,7 +3550,7 @@
    i32.const 0
    i32.const 480
    i32.const 75
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3564,7 +3564,7 @@
    i32.const 0
    i32.const 480
    i32.const 76
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3578,7 +3578,7 @@
    i32.const 0
    i32.const 480
    i32.const 77
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3595,7 +3595,7 @@
    i32.const 0
    i32.const 480
    i32.const 79
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3612,7 +3612,7 @@
    i32.const 0
    i32.const 480
    i32.const 80
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3629,7 +3629,7 @@
    i32.const 0
    i32.const 480
    i32.const 81
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3646,7 +3646,7 @@
    i32.const 0
    i32.const 480
    i32.const 82
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3663,7 +3663,7 @@
    i32.const 0
    i32.const 480
    i32.const 83
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3680,7 +3680,7 @@
    i32.const 0
    i32.const 480
    i32.const 84
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3697,7 +3697,7 @@
    i32.const 0
    i32.const 480
    i32.const 85
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3714,7 +3714,7 @@
    i32.const 0
    i32.const 480
    i32.const 87
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3731,7 +3731,7 @@
    i32.const 0
    i32.const 480
    i32.const 88
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3748,7 +3748,7 @@
    i32.const 0
    i32.const 480
    i32.const 89
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3765,7 +3765,7 @@
    i32.const 0
    i32.const 480
    i32.const 90
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3782,7 +3782,7 @@
    i32.const 0
    i32.const 480
    i32.const 91
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3799,7 +3799,7 @@
    i32.const 0
    i32.const 480
    i32.const 92
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3816,7 +3816,7 @@
    i32.const 0
    i32.const 480
    i32.const 93
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3831,7 +3831,7 @@
    i32.const 0
    i32.const 480
    i32.const 95
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3846,7 +3846,7 @@
    i32.const 0
    i32.const 480
    i32.const 96
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3861,7 +3861,7 @@
    i32.const 0
    i32.const 480
    i32.const 97
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3876,7 +3876,7 @@
    i32.const 0
    i32.const 480
    i32.const 98
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3891,7 +3891,7 @@
    i32.const 0
    i32.const 480
    i32.const 99
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3906,7 +3906,7 @@
    i32.const 0
    i32.const 480
    i32.const 101
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3921,7 +3921,7 @@
    i32.const 0
    i32.const 480
    i32.const 102
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3936,7 +3936,7 @@
    i32.const 0
    i32.const 480
    i32.const 103
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3951,7 +3951,7 @@
    i32.const 0
    i32.const 480
    i32.const 104
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3966,7 +3966,7 @@
    i32.const 0
    i32.const 480
    i32.const 105
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3981,7 +3981,7 @@
    i32.const 0
    i32.const 480
    i32.const 107
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3996,7 +3996,7 @@
    i32.const 0
    i32.const 480
    i32.const 108
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4016,7 +4016,7 @@
    i32.const 0
    i32.const 480
    i32.const 111
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4036,7 +4036,7 @@
    i32.const 0
    i32.const 480
    i32.const 114
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4056,7 +4056,7 @@
    i32.const 0
    i32.const 480
    i32.const 117
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4076,7 +4076,7 @@
    i32.const 0
    i32.const 480
    i32.const 120
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4094,7 +4094,7 @@
    i32.const 0
    i32.const 480
    i32.const 123
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4118,7 +4118,7 @@
    i32.const 0
    i32.const 480
    i32.const 126
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4142,7 +4142,7 @@
    i32.const 0
    i32.const 480
    i32.const 129
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4162,7 +4162,7 @@
    i32.const 0
    i32.const 480
    i32.const 132
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4182,7 +4182,7 @@
    i32.const 0
    i32.const 480
    i32.const 135
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4202,7 +4202,7 @@
    i32.const 0
    i32.const 480
    i32.const 138
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4222,7 +4222,7 @@
    i32.const 0
    i32.const 480
    i32.const 141
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4240,7 +4240,7 @@
    i32.const 0
    i32.const 480
    i32.const 144
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4262,7 +4262,7 @@
    i32.const 0
    i32.const 480
    i32.const 147
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4284,7 +4284,7 @@
    i32.const 0
    i32.const 480
    i32.const 150
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4304,7 +4304,7 @@
    i32.const 0
    i32.const 480
    i32.const 153
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4324,7 +4324,7 @@
    i32.const 0
    i32.const 480
    i32.const 156
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4344,7 +4344,7 @@
    i32.const 0
    i32.const 480
    i32.const 159
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4364,7 +4364,7 @@
    i32.const 0
    i32.const 480
    i32.const 162
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4390,7 +4390,7 @@
    i32.const 0
    i32.const 480
    i32.const 165
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4403,7 +4403,7 @@
    i32.const 0
    i32.const 480
    i32.const 166
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4456,7 +4456,7 @@
    i32.const 0
    i32.const 256
    i32.const 122
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -4478,7 +4478,7 @@
     i32.const 0
     i32.const 256
     i32.const 126
-    i32.const 17
+    i32.const 18
     call $~lib/builtins/abort
     unreachable
    end
@@ -4494,7 +4494,7 @@
     i32.const 0
     i32.const 256
     i32.const 136
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -4526,7 +4526,7 @@
    i32.const 0
    i32.const 256
    i32.const 69
-   i32.const 15
+   i32.const 16
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/std/date.optimized.wat
+++ b/tests/compiler/std/date.optimized.wat
@@ -33,7 +33,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -52,7 +52,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -73,7 +73,7 @@
    i32.const 0
    i32.const 1040
    i32.const 5
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -85,7 +85,7 @@
    i32.const 0
    i32.const 1040
    i32.const 7
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -159,7 +159,7 @@
    i32.const 0
    i32.const 1040
    i32.const 10
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -178,7 +178,7 @@
    i32.const 0
    i32.const 1040
    i32.const 12
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/std/date.untouched.wat
+++ b/tests/compiler/std/date.untouched.wat
@@ -199,7 +199,7 @@
    i32.const 0
    i32.const 32
    i32.const 1
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -234,7 +234,7 @@
    i32.const 0
    i32.const 32
    i32.const 2
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -271,7 +271,7 @@
    i32.const 0
    i32.const 32
    i32.const 5
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -284,7 +284,7 @@
    i32.const 0
    i32.const 32
    i32.const 7
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -311,7 +311,7 @@
    i32.const 0
    i32.const 32
    i32.const 10
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -332,7 +332,7 @@
    i32.const 0
    i32.const 32
    i32.const 12
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/std/map.optimized.wat
+++ b/tests/compiler/std/map.optimized.wat
@@ -59,7 +59,7 @@
    i32.const 0
    i32.const 1040
    i32.const 277
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -81,7 +81,7 @@
    i32.const 0
    i32.const 1040
    i32.const 279
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -124,7 +124,7 @@
    i32.const 0
    i32.const 1040
    i32.const 292
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -220,7 +220,7 @@
    i32.const 0
    i32.const 1040
    i32.const 205
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -234,7 +234,7 @@
    i32.const 0
    i32.const 1040
    i32.const 207
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -307,7 +307,7 @@
     i32.const 0
     i32.const 1040
     i32.const 228
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -362,7 +362,7 @@
    i32.const 0
    i32.const 1040
    i32.const 243
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -377,7 +377,7 @@
    i32.const 0
    i32.const 1040
    i32.const 244
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -425,7 +425,7 @@
    i32.const 0
    i32.const 1040
    i32.const 260
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -508,7 +508,7 @@
    i32.const 0
    i32.const 1040
    i32.const 386
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -525,7 +525,7 @@
     i32.const 0
     i32.const 1040
     i32.const 396
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -553,7 +553,7 @@
     i32.const 0
     i32.const 1040
     i32.const 408
-    i32.const 4
+    i32.const 5
     call $~lib/builtins/abort
     unreachable
    end
@@ -694,7 +694,7 @@
    i32.const 1088
    i32.const 1040
    i32.const 461
-   i32.const 29
+   i32.const 30
    call $~lib/builtins/abort
    unreachable
   end
@@ -767,7 +767,7 @@
    i32.const 0
    i32.const 1040
    i32.const 338
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -819,7 +819,7 @@
      i32.const 0
      i32.const 1040
      i32.const 351
-     i32.const 17
+     i32.const 18
      call $~lib/builtins/abort
      unreachable
     end
@@ -852,7 +852,7 @@
    i32.const 0
    i32.const 1040
    i32.const 365
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -923,7 +923,7 @@
    i32.const 0
    i32.const 1040
    i32.const 501
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1014,7 +1014,7 @@
      i32.const 0
      i32.const 1040
      i32.const 513
-     i32.const 19
+     i32.const 20
      call $~lib/builtins/abort
      unreachable
     end
@@ -1030,7 +1030,7 @@
    i32.const 0
    i32.const 1040
    i32.const 521
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1087,7 +1087,7 @@
     i32.const 0
     i32.const 1152
     i32.const 109
-    i32.const 2
+    i32.const 3
     call $~lib/builtins/abort
     unreachable
    end
@@ -1106,7 +1106,7 @@
     i32.const 0
     i32.const 1152
     i32.const 112
-    i32.const 13
+    i32.const 14
     call $~lib/builtins/abort
     unreachable
    end
@@ -1280,7 +1280,7 @@
    i32.const 1200
    i32.const 1248
    i32.const 54
-   i32.const 42
+   i32.const 43
    call $~lib/builtins/abort
    unreachable
   end
@@ -1645,7 +1645,7 @@
    i32.const 1360
    i32.const 1424
    i32.const 111
-   i32.const 16
+   i32.const 17
    call $~lib/builtins/abort
    unreachable
   end
@@ -1963,7 +1963,7 @@
     i32.const 1200
     i32.const 1472
     i32.const 14
-    i32.const 47
+    i32.const 48
     call $~lib/builtins/abort
     unreachable
    end
@@ -2010,7 +2010,7 @@
     i32.const 0
     i32.const 1040
     i32.const 581
-    i32.const 2
+    i32.const 3
     call $~lib/builtins/abort
     unreachable
    end
@@ -2056,7 +2056,7 @@
     i32.const 1520
     i32.const 1472
     i32.const 120
-    i32.const 21
+    i32.const 22
     call $~lib/builtins/abort
     unreachable
    end
@@ -2112,7 +2112,7 @@
    i32.const 1200
    i32.const 1472
    i32.const 57
-   i32.const 59
+   i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
@@ -2215,7 +2215,7 @@
    i32.const 1200
    i32.const 1472
    i32.const 57
-   i32.const 59
+   i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
@@ -2286,7 +2286,7 @@
     i32.const 1520
     i32.const 1472
     i32.const 120
-    i32.const 21
+    i32.const 22
     call $~lib/builtins/abort
     unreachable
    end
@@ -2444,7 +2444,7 @@
    i32.const 1520
    i32.const 1472
    i32.const 104
-   i32.const 41
+   i32.const 42
    call $~lib/builtins/abort
    unreachable
   end
@@ -3133,7 +3133,7 @@
      i32.const 0
      i32.const 1312
      i32.const 6
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -3156,7 +3156,7 @@
      i32.const 0
      i32.const 1312
      i32.const 8
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -3175,7 +3175,7 @@
      i32.const 0
      i32.const 1312
      i32.const 9
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -3194,7 +3194,7 @@
    i32.const 0
    i32.const 1312
    i32.const 11
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3217,7 +3217,7 @@
      i32.const 0
      i32.const 1312
      i32.const 15
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -3236,7 +3236,7 @@
      i32.const 0
      i32.const 1312
      i32.const 16
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -3259,7 +3259,7 @@
      i32.const 0
      i32.const 1312
      i32.const 18
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -3278,7 +3278,7 @@
      i32.const 0
      i32.const 1312
      i32.const 19
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -3297,7 +3297,7 @@
    i32.const 0
    i32.const 1312
    i32.const 21
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3347,7 +3347,7 @@
      i32.const 1520
      i32.const 1472
      i32.const 104
-     i32.const 41
+     i32.const 42
      call $~lib/builtins/abort
      unreachable
     end
@@ -3369,7 +3369,7 @@
      i32.const 0
      i32.const 1312
      i32.const 31
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -3383,7 +3383,7 @@
      i32.const 0
      i32.const 1312
      i32.const 32
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -3415,7 +3415,7 @@
    i32.const 0
    i32.const 1312
    i32.const 36
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3427,7 +3427,7 @@
    i32.const 0
    i32.const 1312
    i32.const 37
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3450,7 +3450,7 @@
      i32.const 0
      i32.const 1312
      i32.const 41
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -3469,7 +3469,7 @@
      i32.const 0
      i32.const 1312
      i32.const 42
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -3483,7 +3483,7 @@
      i32.const 0
      i32.const 1312
      i32.const 44
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -3502,7 +3502,7 @@
    i32.const 0
    i32.const 1312
    i32.const 46
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3524,7 +3524,7 @@
      i32.const 0
      i32.const 1312
      i32.const 50
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -3547,7 +3547,7 @@
      i32.const 0
      i32.const 1312
      i32.const 52
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -3561,7 +3561,7 @@
      i32.const 0
      i32.const 1312
      i32.const 54
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -3580,7 +3580,7 @@
    i32.const 0
    i32.const 1312
    i32.const 56
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3592,7 +3592,7 @@
    i32.const 0
    i32.const 1312
    i32.const 60
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3859,7 +3859,7 @@
    i32.const 1360
    i32.const 1424
    i32.const 111
-   i32.const 16
+   i32.const 17
    call $~lib/builtins/abort
    unreachable
   end
@@ -3888,7 +3888,7 @@
    i32.const 1200
    i32.const 1472
    i32.const 57
-   i32.const 59
+   i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
@@ -4352,7 +4352,7 @@
      i32.const 0
      i32.const 1312
      i32.const 6
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -4373,7 +4373,7 @@
      i32.const 0
      i32.const 1312
      i32.const 8
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -4390,7 +4390,7 @@
      i32.const 0
      i32.const 1312
      i32.const 9
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -4409,7 +4409,7 @@
    i32.const 0
    i32.const 1312
    i32.const 11
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4430,7 +4430,7 @@
      i32.const 0
      i32.const 1312
      i32.const 15
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -4447,7 +4447,7 @@
      i32.const 0
      i32.const 1312
      i32.const 16
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -4468,7 +4468,7 @@
      i32.const 0
      i32.const 1312
      i32.const 18
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -4485,7 +4485,7 @@
      i32.const 0
      i32.const 1312
      i32.const 19
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -4504,7 +4504,7 @@
    i32.const 0
    i32.const 1312
    i32.const 21
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4554,7 +4554,7 @@
      i32.const 1520
      i32.const 1472
      i32.const 104
-     i32.const 41
+     i32.const 42
      call $~lib/builtins/abort
      unreachable
     end
@@ -4576,7 +4576,7 @@
      i32.const 0
      i32.const 1312
      i32.const 31
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -4590,7 +4590,7 @@
      i32.const 0
      i32.const 1312
      i32.const 32
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -4622,7 +4622,7 @@
    i32.const 0
    i32.const 1312
    i32.const 36
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4634,7 +4634,7 @@
    i32.const 0
    i32.const 1312
    i32.const 37
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4655,7 +4655,7 @@
      i32.const 0
      i32.const 1312
      i32.const 41
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -4672,7 +4672,7 @@
      i32.const 0
      i32.const 1312
      i32.const 42
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -4686,7 +4686,7 @@
      i32.const 0
      i32.const 1312
      i32.const 44
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -4705,7 +4705,7 @@
    i32.const 0
    i32.const 1312
    i32.const 46
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4725,7 +4725,7 @@
      i32.const 0
      i32.const 1312
      i32.const 50
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -4746,7 +4746,7 @@
      i32.const 0
      i32.const 1312
      i32.const 52
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -4760,7 +4760,7 @@
      i32.const 0
      i32.const 1312
      i32.const 54
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -4779,7 +4779,7 @@
    i32.const 0
    i32.const 1312
    i32.const 56
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4791,7 +4791,7 @@
    i32.const 0
    i32.const 1312
    i32.const 60
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -5122,7 +5122,7 @@
    i32.const 1360
    i32.const 1424
    i32.const 111
-   i32.const 16
+   i32.const 17
    call $~lib/builtins/abort
    unreachable
   end
@@ -5143,7 +5143,7 @@
     i32.const 1520
     i32.const 1472
     i32.const 120
-    i32.const 21
+    i32.const 22
     call $~lib/builtins/abort
     unreachable
    end
@@ -5203,7 +5203,7 @@
    i32.const 1200
    i32.const 1472
    i32.const 57
-   i32.const 59
+   i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
@@ -5676,7 +5676,7 @@
      i32.const 0
      i32.const 1312
      i32.const 6
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -5699,7 +5699,7 @@
      i32.const 0
      i32.const 1312
      i32.const 8
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -5718,7 +5718,7 @@
      i32.const 0
      i32.const 1312
      i32.const 9
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -5737,7 +5737,7 @@
    i32.const 0
    i32.const 1312
    i32.const 11
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -5760,7 +5760,7 @@
      i32.const 0
      i32.const 1312
      i32.const 15
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -5779,7 +5779,7 @@
      i32.const 0
      i32.const 1312
      i32.const 16
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -5802,7 +5802,7 @@
      i32.const 0
      i32.const 1312
      i32.const 18
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -5821,7 +5821,7 @@
      i32.const 0
      i32.const 1312
      i32.const 19
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -5840,7 +5840,7 @@
    i32.const 0
    i32.const 1312
    i32.const 21
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -5890,7 +5890,7 @@
      i32.const 1520
      i32.const 1472
      i32.const 104
-     i32.const 41
+     i32.const 42
      call $~lib/builtins/abort
      unreachable
     end
@@ -5914,7 +5914,7 @@
      i32.const 0
      i32.const 1312
      i32.const 31
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -5928,7 +5928,7 @@
      i32.const 0
      i32.const 1312
      i32.const 32
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -5960,7 +5960,7 @@
    i32.const 0
    i32.const 1312
    i32.const 36
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -5972,7 +5972,7 @@
    i32.const 0
    i32.const 1312
    i32.const 37
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -5995,7 +5995,7 @@
      i32.const 0
      i32.const 1312
      i32.const 41
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -6014,7 +6014,7 @@
      i32.const 0
      i32.const 1312
      i32.const 42
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -6028,7 +6028,7 @@
      i32.const 0
      i32.const 1312
      i32.const 44
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -6047,7 +6047,7 @@
    i32.const 0
    i32.const 1312
    i32.const 46
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -6069,7 +6069,7 @@
      i32.const 0
      i32.const 1312
      i32.const 50
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -6092,7 +6092,7 @@
      i32.const 0
      i32.const 1312
      i32.const 52
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -6106,7 +6106,7 @@
      i32.const 0
      i32.const 1312
      i32.const 54
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -6125,7 +6125,7 @@
    i32.const 0
    i32.const 1312
    i32.const 56
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -6137,7 +6137,7 @@
    i32.const 0
    i32.const 1312
    i32.const 60
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -6404,7 +6404,7 @@
    i32.const 1360
    i32.const 1424
    i32.const 111
-   i32.const 16
+   i32.const 17
    call $~lib/builtins/abort
    unreachable
   end
@@ -6435,7 +6435,7 @@
    i32.const 1200
    i32.const 1472
    i32.const 57
-   i32.const 59
+   i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
@@ -6902,7 +6902,7 @@
      i32.const 0
      i32.const 1312
      i32.const 6
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -6923,7 +6923,7 @@
      i32.const 0
      i32.const 1312
      i32.const 8
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -6940,7 +6940,7 @@
      i32.const 0
      i32.const 1312
      i32.const 9
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -6959,7 +6959,7 @@
    i32.const 0
    i32.const 1312
    i32.const 11
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -6980,7 +6980,7 @@
      i32.const 0
      i32.const 1312
      i32.const 15
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -6997,7 +6997,7 @@
      i32.const 0
      i32.const 1312
      i32.const 16
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -7018,7 +7018,7 @@
      i32.const 0
      i32.const 1312
      i32.const 18
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -7035,7 +7035,7 @@
      i32.const 0
      i32.const 1312
      i32.const 19
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -7054,7 +7054,7 @@
    i32.const 0
    i32.const 1312
    i32.const 21
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -7104,7 +7104,7 @@
      i32.const 1520
      i32.const 1472
      i32.const 104
-     i32.const 41
+     i32.const 42
      call $~lib/builtins/abort
      unreachable
     end
@@ -7128,7 +7128,7 @@
      i32.const 0
      i32.const 1312
      i32.const 31
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -7142,7 +7142,7 @@
      i32.const 0
      i32.const 1312
      i32.const 32
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -7174,7 +7174,7 @@
    i32.const 0
    i32.const 1312
    i32.const 36
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -7186,7 +7186,7 @@
    i32.const 0
    i32.const 1312
    i32.const 37
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -7207,7 +7207,7 @@
      i32.const 0
      i32.const 1312
      i32.const 41
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -7224,7 +7224,7 @@
      i32.const 0
      i32.const 1312
      i32.const 42
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -7238,7 +7238,7 @@
      i32.const 0
      i32.const 1312
      i32.const 44
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -7257,7 +7257,7 @@
    i32.const 0
    i32.const 1312
    i32.const 46
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -7277,7 +7277,7 @@
      i32.const 0
      i32.const 1312
      i32.const 50
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -7298,7 +7298,7 @@
      i32.const 0
      i32.const 1312
      i32.const 52
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -7312,7 +7312,7 @@
      i32.const 0
      i32.const 1312
      i32.const 54
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -7331,7 +7331,7 @@
    i32.const 0
    i32.const 1312
    i32.const 56
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -7343,7 +7343,7 @@
    i32.const 0
    i32.const 1312
    i32.const 60
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -7379,7 +7379,7 @@
    i32.const 1360
    i32.const 1424
    i32.const 111
-   i32.const 16
+   i32.const 17
    call $~lib/builtins/abort
    unreachable
   end
@@ -7468,7 +7468,7 @@
      i32.const 0
      i32.const 1312
      i32.const 6
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -7487,7 +7487,7 @@
      i32.const 0
      i32.const 1312
      i32.const 8
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -7502,7 +7502,7 @@
      i32.const 0
      i32.const 1312
      i32.const 9
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -7521,7 +7521,7 @@
    i32.const 0
    i32.const 1312
    i32.const 11
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -7540,7 +7540,7 @@
      i32.const 0
      i32.const 1312
      i32.const 15
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -7555,7 +7555,7 @@
      i32.const 0
      i32.const 1312
      i32.const 16
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -7574,7 +7574,7 @@
      i32.const 0
      i32.const 1312
      i32.const 18
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -7589,7 +7589,7 @@
      i32.const 0
      i32.const 1312
      i32.const 19
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -7608,7 +7608,7 @@
    i32.const 0
    i32.const 1312
    i32.const 21
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -7685,7 +7685,7 @@
      i32.const 0
      i32.const 1312
      i32.const 31
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -7699,7 +7699,7 @@
      i32.const 0
      i32.const 1312
      i32.const 32
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -7731,7 +7731,7 @@
    i32.const 0
    i32.const 1312
    i32.const 36
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -7743,7 +7743,7 @@
    i32.const 0
    i32.const 1312
    i32.const 37
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -7762,7 +7762,7 @@
      i32.const 0
      i32.const 1312
      i32.const 41
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -7777,7 +7777,7 @@
      i32.const 0
      i32.const 1312
      i32.const 42
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -7791,7 +7791,7 @@
      i32.const 0
      i32.const 1312
      i32.const 44
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -7810,7 +7810,7 @@
    i32.const 0
    i32.const 1312
    i32.const 46
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -7828,7 +7828,7 @@
      i32.const 0
      i32.const 1312
      i32.const 50
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -7847,7 +7847,7 @@
      i32.const 0
      i32.const 1312
      i32.const 52
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -7861,7 +7861,7 @@
      i32.const 0
      i32.const 1312
      i32.const 54
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -7880,7 +7880,7 @@
    i32.const 0
    i32.const 1312
    i32.const 56
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -7892,7 +7892,7 @@
    i32.const 0
    i32.const 1312
    i32.const 60
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -7931,7 +7931,7 @@
    i32.const 1200
    i32.const 1472
    i32.const 57
-   i32.const 59
+   i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
@@ -8069,7 +8069,7 @@
      i32.const 0
      i32.const 1312
      i32.const 6
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -8088,7 +8088,7 @@
      i32.const 0
      i32.const 1312
      i32.const 8
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -8103,7 +8103,7 @@
      i32.const 0
      i32.const 1312
      i32.const 9
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -8122,7 +8122,7 @@
    i32.const 0
    i32.const 1312
    i32.const 11
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -8141,7 +8141,7 @@
      i32.const 0
      i32.const 1312
      i32.const 15
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -8156,7 +8156,7 @@
      i32.const 0
      i32.const 1312
      i32.const 16
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -8175,7 +8175,7 @@
      i32.const 0
      i32.const 1312
      i32.const 18
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -8190,7 +8190,7 @@
      i32.const 0
      i32.const 1312
      i32.const 19
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -8209,7 +8209,7 @@
    i32.const 0
    i32.const 1312
    i32.const 21
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -8267,7 +8267,7 @@
      i32.const 0
      i32.const 1312
      i32.const 31
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -8281,7 +8281,7 @@
      i32.const 0
      i32.const 1312
      i32.const 32
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -8313,7 +8313,7 @@
    i32.const 0
    i32.const 1312
    i32.const 36
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -8325,7 +8325,7 @@
    i32.const 0
    i32.const 1312
    i32.const 37
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -8344,7 +8344,7 @@
      i32.const 0
      i32.const 1312
      i32.const 41
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -8359,7 +8359,7 @@
      i32.const 0
      i32.const 1312
      i32.const 42
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -8373,7 +8373,7 @@
      i32.const 0
      i32.const 1312
      i32.const 44
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -8392,7 +8392,7 @@
    i32.const 0
    i32.const 1312
    i32.const 46
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -8410,7 +8410,7 @@
      i32.const 0
      i32.const 1312
      i32.const 50
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -8429,7 +8429,7 @@
      i32.const 0
      i32.const 1312
      i32.const 52
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -8443,7 +8443,7 @@
      i32.const 0
      i32.const 1312
      i32.const 54
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -8462,7 +8462,7 @@
    i32.const 0
    i32.const 1312
    i32.const 56
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -8474,7 +8474,7 @@
    i32.const 0
    i32.const 1312
    i32.const 60
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -8875,7 +8875,7 @@
    i32.const 1360
    i32.const 1424
    i32.const 111
-   i32.const 16
+   i32.const 17
    call $~lib/builtins/abort
    unreachable
   end
@@ -8896,7 +8896,7 @@
     i32.const 1520
     i32.const 1472
     i32.const 120
-    i32.const 21
+    i32.const 22
     call $~lib/builtins/abort
     unreachable
    end
@@ -8956,7 +8956,7 @@
    i32.const 1200
    i32.const 1472
    i32.const 57
-   i32.const 59
+   i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
@@ -9143,7 +9143,7 @@
    i32.const 1520
    i32.const 1472
    i32.const 104
-   i32.const 41
+   i32.const 42
    call $~lib/builtins/abort
    unreachable
   end
@@ -9521,7 +9521,7 @@
      i32.const 0
      i32.const 1312
      i32.const 6
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -9541,7 +9541,7 @@
      i32.const 0
      i32.const 1312
      i32.const 8
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -9557,7 +9557,7 @@
      i32.const 0
      i32.const 1312
      i32.const 9
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -9576,7 +9576,7 @@
    i32.const 0
    i32.const 1312
    i32.const 11
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -9595,7 +9595,7 @@
      i32.const 0
      i32.const 1312
      i32.const 15
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -9611,7 +9611,7 @@
      i32.const 0
      i32.const 1312
      i32.const 16
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -9631,7 +9631,7 @@
      i32.const 0
      i32.const 1312
      i32.const 18
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -9647,7 +9647,7 @@
      i32.const 0
      i32.const 1312
      i32.const 19
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -9666,7 +9666,7 @@
    i32.const 0
    i32.const 1312
    i32.const 21
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -9724,7 +9724,7 @@
      i32.const 0
      i32.const 1312
      i32.const 31
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -9739,7 +9739,7 @@
      i32.const 0
      i32.const 1312
      i32.const 32
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -9771,7 +9771,7 @@
    i32.const 0
    i32.const 1312
    i32.const 36
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -9783,7 +9783,7 @@
    i32.const 0
    i32.const 1312
    i32.const 37
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -9802,7 +9802,7 @@
      i32.const 0
      i32.const 1312
      i32.const 41
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -9818,7 +9818,7 @@
      i32.const 0
      i32.const 1312
      i32.const 42
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -9832,7 +9832,7 @@
      i32.const 0
      i32.const 1312
      i32.const 44
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -9851,7 +9851,7 @@
    i32.const 0
    i32.const 1312
    i32.const 46
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -9869,7 +9869,7 @@
      i32.const 0
      i32.const 1312
      i32.const 50
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -9889,7 +9889,7 @@
      i32.const 0
      i32.const 1312
      i32.const 52
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -9903,7 +9903,7 @@
      i32.const 0
      i32.const 1312
      i32.const 54
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -9922,7 +9922,7 @@
    i32.const 0
    i32.const 1312
    i32.const 56
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -9934,7 +9934,7 @@
    i32.const 0
    i32.const 1312
    i32.const 60
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -9973,7 +9973,7 @@
    i32.const 1200
    i32.const 1472
    i32.const 57
-   i32.const 59
+   i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
@@ -10111,7 +10111,7 @@
      i32.const 0
      i32.const 1312
      i32.const 6
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -10131,7 +10131,7 @@
      i32.const 0
      i32.const 1312
      i32.const 8
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -10147,7 +10147,7 @@
      i32.const 0
      i32.const 1312
      i32.const 9
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -10166,7 +10166,7 @@
    i32.const 0
    i32.const 1312
    i32.const 11
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10185,7 +10185,7 @@
      i32.const 0
      i32.const 1312
      i32.const 15
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -10201,7 +10201,7 @@
      i32.const 0
      i32.const 1312
      i32.const 16
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -10221,7 +10221,7 @@
      i32.const 0
      i32.const 1312
      i32.const 18
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -10237,7 +10237,7 @@
      i32.const 0
      i32.const 1312
      i32.const 19
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -10256,7 +10256,7 @@
    i32.const 0
    i32.const 1312
    i32.const 21
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10314,7 +10314,7 @@
      i32.const 0
      i32.const 1312
      i32.const 31
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -10329,7 +10329,7 @@
      i32.const 0
      i32.const 1312
      i32.const 32
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -10361,7 +10361,7 @@
    i32.const 0
    i32.const 1312
    i32.const 36
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10373,7 +10373,7 @@
    i32.const 0
    i32.const 1312
    i32.const 37
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10392,7 +10392,7 @@
      i32.const 0
      i32.const 1312
      i32.const 41
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -10408,7 +10408,7 @@
      i32.const 0
      i32.const 1312
      i32.const 42
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -10422,7 +10422,7 @@
      i32.const 0
      i32.const 1312
      i32.const 44
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -10441,7 +10441,7 @@
    i32.const 0
    i32.const 1312
    i32.const 46
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10459,7 +10459,7 @@
      i32.const 0
      i32.const 1312
      i32.const 50
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -10479,7 +10479,7 @@
      i32.const 0
      i32.const 1312
      i32.const 52
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -10493,7 +10493,7 @@
      i32.const 0
      i32.const 1312
      i32.const 54
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -10512,7 +10512,7 @@
    i32.const 0
    i32.const 1312
    i32.const 56
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10524,7 +10524,7 @@
    i32.const 0
    i32.const 1312
    i32.const 60
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10830,7 +10830,7 @@
    i32.const 1360
    i32.const 1424
    i32.const 111
-   i32.const 16
+   i32.const 17
    call $~lib/builtins/abort
    unreachable
   end
@@ -10862,7 +10862,7 @@
    i32.const 1200
    i32.const 1472
    i32.const 57
-   i32.const 59
+   i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
@@ -10948,7 +10948,7 @@
        i32.const 1520
        i32.const 1472
        i32.const 120
-       i32.const 21
+       i32.const 22
        call $~lib/builtins/abort
        unreachable
       end
@@ -11321,7 +11321,7 @@
      i32.const 0
      i32.const 1312
      i32.const 6
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -11341,7 +11341,7 @@
      i32.const 0
      i32.const 1312
      i32.const 8
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -11357,7 +11357,7 @@
      i32.const 0
      i32.const 1312
      i32.const 9
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -11376,7 +11376,7 @@
    i32.const 0
    i32.const 1312
    i32.const 11
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11395,7 +11395,7 @@
      i32.const 0
      i32.const 1312
      i32.const 15
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -11411,7 +11411,7 @@
      i32.const 0
      i32.const 1312
      i32.const 16
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -11431,7 +11431,7 @@
      i32.const 0
      i32.const 1312
      i32.const 18
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -11447,7 +11447,7 @@
      i32.const 0
      i32.const 1312
      i32.const 19
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -11466,7 +11466,7 @@
    i32.const 0
    i32.const 1312
    i32.const 21
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11516,7 +11516,7 @@
      i32.const 1520
      i32.const 1472
      i32.const 104
-     i32.const 41
+     i32.const 42
      call $~lib/builtins/abort
      unreachable
     end
@@ -11540,7 +11540,7 @@
      i32.const 0
      i32.const 1312
      i32.const 31
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -11555,7 +11555,7 @@
      i32.const 0
      i32.const 1312
      i32.const 32
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -11587,7 +11587,7 @@
    i32.const 0
    i32.const 1312
    i32.const 36
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11599,7 +11599,7 @@
    i32.const 0
    i32.const 1312
    i32.const 37
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11618,7 +11618,7 @@
      i32.const 0
      i32.const 1312
      i32.const 41
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -11634,7 +11634,7 @@
      i32.const 0
      i32.const 1312
      i32.const 42
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -11648,7 +11648,7 @@
      i32.const 0
      i32.const 1312
      i32.const 44
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -11667,7 +11667,7 @@
    i32.const 0
    i32.const 1312
    i32.const 46
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11685,7 +11685,7 @@
      i32.const 0
      i32.const 1312
      i32.const 50
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -11705,7 +11705,7 @@
      i32.const 0
      i32.const 1312
      i32.const 52
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -11719,7 +11719,7 @@
      i32.const 0
      i32.const 1312
      i32.const 54
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -11738,7 +11738,7 @@
    i32.const 0
    i32.const 1312
    i32.const 56
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11750,7 +11750,7 @@
    i32.const 0
    i32.const 1312
    i32.const 60
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12056,7 +12056,7 @@
    i32.const 1360
    i32.const 1424
    i32.const 111
-   i32.const 16
+   i32.const 17
    call $~lib/builtins/abort
    unreachable
   end
@@ -12088,7 +12088,7 @@
    i32.const 1200
    i32.const 1472
    i32.const 57
-   i32.const 59
+   i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
@@ -12174,7 +12174,7 @@
        i32.const 1520
        i32.const 1472
        i32.const 120
-       i32.const 21
+       i32.const 22
        call $~lib/builtins/abort
        unreachable
       end
@@ -12583,7 +12583,7 @@
      i32.const 0
      i32.const 1312
      i32.const 6
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -12603,7 +12603,7 @@
      i32.const 0
      i32.const 1312
      i32.const 8
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -12619,7 +12619,7 @@
      i32.const 0
      i32.const 1312
      i32.const 9
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -12638,7 +12638,7 @@
    i32.const 0
    i32.const 1312
    i32.const 11
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12657,7 +12657,7 @@
      i32.const 0
      i32.const 1312
      i32.const 15
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -12673,7 +12673,7 @@
      i32.const 0
      i32.const 1312
      i32.const 16
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -12693,7 +12693,7 @@
      i32.const 0
      i32.const 1312
      i32.const 18
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -12709,7 +12709,7 @@
      i32.const 0
      i32.const 1312
      i32.const 19
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -12728,7 +12728,7 @@
    i32.const 0
    i32.const 1312
    i32.const 21
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12778,7 +12778,7 @@
      i32.const 1520
      i32.const 1472
      i32.const 104
-     i32.const 41
+     i32.const 42
      call $~lib/builtins/abort
      unreachable
     end
@@ -12802,7 +12802,7 @@
      i32.const 0
      i32.const 1312
      i32.const 31
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -12817,7 +12817,7 @@
      i32.const 0
      i32.const 1312
      i32.const 32
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -12849,7 +12849,7 @@
    i32.const 0
    i32.const 1312
    i32.const 36
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12861,7 +12861,7 @@
    i32.const 0
    i32.const 1312
    i32.const 37
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12880,7 +12880,7 @@
      i32.const 0
      i32.const 1312
      i32.const 41
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -12896,7 +12896,7 @@
      i32.const 0
      i32.const 1312
      i32.const 42
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -12910,7 +12910,7 @@
      i32.const 0
      i32.const 1312
      i32.const 44
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -12929,7 +12929,7 @@
    i32.const 0
    i32.const 1312
    i32.const 46
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12947,7 +12947,7 @@
      i32.const 0
      i32.const 1312
      i32.const 50
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -12967,7 +12967,7 @@
      i32.const 0
      i32.const 1312
      i32.const 52
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -12981,7 +12981,7 @@
      i32.const 0
      i32.const 1312
      i32.const 54
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -13000,7 +13000,7 @@
    i32.const 0
    i32.const 1312
    i32.const 56
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13012,7 +13012,7 @@
    i32.const 0
    i32.const 1312
    i32.const 60
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13058,7 +13058,7 @@
    i32.const 0
    i32.const 1152
    i32.const 122
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -13110,7 +13110,7 @@
     i32.const 0
     i32.const 1152
     i32.const 126
-    i32.const 17
+    i32.const 18
     call $~lib/builtins/abort
     unreachable
    end
@@ -13125,7 +13125,7 @@
     i32.const 0
     i32.const 1152
     i32.const 136
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end

--- a/tests/compiler/std/map.untouched.wat
+++ b/tests/compiler/std/map.untouched.wat
@@ -72,7 +72,7 @@
    i32.const 0
    i32.const 32
    i32.const 277
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -97,7 +97,7 @@
    i32.const 0
    i32.const 32
    i32.const 279
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -149,7 +149,7 @@
    i32.const 0
    i32.const 32
    i32.const 292
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -279,7 +279,7 @@
    i32.const 0
    i32.const 32
    i32.const 205
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -294,7 +294,7 @@
    i32.const 0
    i32.const 32
    i32.const 207
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -387,7 +387,7 @@
     i32.const 0
     i32.const 32
     i32.const 228
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -450,7 +450,7 @@
    i32.const 0
    i32.const 32
    i32.const 243
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -466,7 +466,7 @@
    i32.const 0
    i32.const 32
    i32.const 244
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -523,7 +523,7 @@
    i32.const 0
    i32.const 32
    i32.const 260
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -642,7 +642,7 @@
    i32.const 0
    i32.const 32
    i32.const 386
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -665,7 +665,7 @@
     i32.const 0
     i32.const 32
     i32.const 396
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -696,7 +696,7 @@
     i32.const 0
     i32.const 32
     i32.const 408
-    i32.const 4
+    i32.const 5
     call $~lib/builtins/abort
     unreachable
    end
@@ -922,7 +922,7 @@
    i32.const 80
    i32.const 32
    i32.const 461
-   i32.const 29
+   i32.const 30
    call $~lib/builtins/abort
    unreachable
   end
@@ -1016,7 +1016,7 @@
    i32.const 0
    i32.const 32
    i32.const 338
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1079,7 +1079,7 @@
      i32.const 0
      i32.const 32
      i32.const 351
-     i32.const 17
+     i32.const 18
      call $~lib/builtins/abort
      unreachable
     end
@@ -1224,7 +1224,7 @@
    i32.const 0
    i32.const 32
    i32.const 365
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1313,7 +1313,7 @@
    i32.const 0
    i32.const 32
    i32.const 501
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1354,7 +1354,7 @@
       i32.const 0
       i32.const 32
       i32.const 513
-      i32.const 19
+      i32.const 20
       call $~lib/builtins/abort
       unreachable
      end
@@ -1373,7 +1373,7 @@
      i32.const 0
      i32.const 32
      i32.const 518
-     i32.const 17
+     i32.const 18
      call $~lib/builtins/abort
      unreachable
     end
@@ -1390,7 +1390,7 @@
    i32.const 0
    i32.const 32
    i32.const 521
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1441,7 +1441,7 @@
    i32.const 0
    i32.const 144
    i32.const 109
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1462,7 +1462,7 @@
    i32.const 0
    i32.const 144
    i32.const 112
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1697,7 +1697,7 @@
    i32.const 192
    i32.const 240
    i32.const 54
-   i32.const 42
+   i32.const 43
    call $~lib/builtins/abort
    unreachable
   end
@@ -2163,7 +2163,7 @@
    i32.const 352
    i32.const 416
    i32.const 111
-   i32.const 16
+   i32.const 17
    call $~lib/builtins/abort
    unreachable
   end
@@ -2187,7 +2187,7 @@
    i32.const 192
    i32.const 464
    i32.const 57
-   i32.const 59
+   i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
@@ -2292,7 +2292,7 @@
    i32.const 0
    i32.const 32
    i32.const 581
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3709,7 +3709,7 @@
     i32.const 192
     i32.const 464
     i32.const 14
-    i32.const 47
+    i32.const 48
     call $~lib/builtins/abort
     unreachable
    end
@@ -3771,7 +3771,7 @@
     i32.const 512
     i32.const 464
     i32.const 120
-    i32.const 21
+    i32.const 22
     call $~lib/builtins/abort
     unreachable
    end
@@ -3883,7 +3883,7 @@
    i32.const 192
    i32.const 464
    i32.const 57
-   i32.const 59
+   i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
@@ -3971,7 +3971,7 @@
     i32.const 512
     i32.const 464
     i32.const 120
-    i32.const 21
+    i32.const 22
     call $~lib/builtins/abort
     unreachable
    end
@@ -4237,7 +4237,7 @@
    i32.const 512
    i32.const 464
    i32.const 104
-   i32.const 41
+   i32.const 42
    call $~lib/builtins/abort
    unreachable
   end
@@ -4266,7 +4266,7 @@
    i32.const 512
    i32.const 464
    i32.const 104
-   i32.const 41
+   i32.const 42
    call $~lib/builtins/abort
    unreachable
   end
@@ -5067,7 +5067,7 @@
      i32.const 0
      i32.const 304
      i32.const 6
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -5090,7 +5090,7 @@
      i32.const 0
      i32.const 304
      i32.const 8
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -5110,7 +5110,7 @@
      i32.const 0
      i32.const 304
      i32.const 9
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -5130,7 +5130,7 @@
    i32.const 0
    i32.const 304
    i32.const 11
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -5155,7 +5155,7 @@
      i32.const 0
      i32.const 304
      i32.const 15
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -5175,7 +5175,7 @@
      i32.const 0
      i32.const 304
      i32.const 16
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -5198,7 +5198,7 @@
      i32.const 0
      i32.const 304
      i32.const 18
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -5218,7 +5218,7 @@
      i32.const 0
      i32.const 304
      i32.const 19
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -5238,7 +5238,7 @@
    i32.const 0
    i32.const 304
    i32.const 21
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -5280,7 +5280,7 @@
      i32.const 0
      i32.const 304
      i32.const 31
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -5294,7 +5294,7 @@
      i32.const 0
      i32.const 304
      i32.const 32
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -5328,7 +5328,7 @@
    i32.const 0
    i32.const 304
    i32.const 36
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -5341,7 +5341,7 @@
    i32.const 0
    i32.const 304
    i32.const 37
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -5366,7 +5366,7 @@
      i32.const 0
      i32.const 304
      i32.const 41
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -5386,7 +5386,7 @@
      i32.const 0
      i32.const 304
      i32.const 42
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -5403,7 +5403,7 @@
      i32.const 0
      i32.const 304
      i32.const 44
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -5423,7 +5423,7 @@
    i32.const 0
    i32.const 304
    i32.const 46
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -5449,7 +5449,7 @@
      i32.const 0
      i32.const 304
      i32.const 50
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -5472,7 +5472,7 @@
      i32.const 0
      i32.const 304
      i32.const 52
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -5489,7 +5489,7 @@
      i32.const 0
      i32.const 304
      i32.const 54
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -5509,7 +5509,7 @@
    i32.const 0
    i32.const 304
    i32.const 56
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -5524,7 +5524,7 @@
    i32.const 0
    i32.const 304
    i32.const 60
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -5964,7 +5964,7 @@
    i32.const 352
    i32.const 416
    i32.const 111
-   i32.const 16
+   i32.const 17
    call $~lib/builtins/abort
    unreachable
   end
@@ -5988,7 +5988,7 @@
    i32.const 192
    i32.const 464
    i32.const 57
-   i32.const 59
+   i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
@@ -6076,7 +6076,7 @@
     i32.const 512
     i32.const 464
     i32.const 120
-    i32.const 21
+    i32.const 22
     call $~lib/builtins/abort
     unreachable
    end
@@ -6335,7 +6335,7 @@
    i32.const 512
    i32.const 464
    i32.const 104
-   i32.const 41
+   i32.const 42
    call $~lib/builtins/abort
    unreachable
   end
@@ -6772,7 +6772,7 @@
      i32.const 0
      i32.const 304
      i32.const 6
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -6793,7 +6793,7 @@
      i32.const 0
      i32.const 304
      i32.const 8
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -6811,7 +6811,7 @@
      i32.const 0
      i32.const 304
      i32.const 9
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -6831,7 +6831,7 @@
    i32.const 0
    i32.const 304
    i32.const 11
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -6854,7 +6854,7 @@
      i32.const 0
      i32.const 304
      i32.const 15
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -6872,7 +6872,7 @@
      i32.const 0
      i32.const 304
      i32.const 16
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -6893,7 +6893,7 @@
      i32.const 0
      i32.const 304
      i32.const 18
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -6911,7 +6911,7 @@
      i32.const 0
      i32.const 304
      i32.const 19
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -6931,7 +6931,7 @@
    i32.const 0
    i32.const 304
    i32.const 21
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -6973,7 +6973,7 @@
      i32.const 0
      i32.const 304
      i32.const 31
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -6987,7 +6987,7 @@
      i32.const 0
      i32.const 304
      i32.const 32
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -7021,7 +7021,7 @@
    i32.const 0
    i32.const 304
    i32.const 36
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -7034,7 +7034,7 @@
    i32.const 0
    i32.const 304
    i32.const 37
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -7057,7 +7057,7 @@
      i32.const 0
      i32.const 304
      i32.const 41
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -7075,7 +7075,7 @@
      i32.const 0
      i32.const 304
      i32.const 42
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -7092,7 +7092,7 @@
      i32.const 0
      i32.const 304
      i32.const 44
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -7112,7 +7112,7 @@
    i32.const 0
    i32.const 304
    i32.const 46
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -7136,7 +7136,7 @@
      i32.const 0
      i32.const 304
      i32.const 50
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -7157,7 +7157,7 @@
      i32.const 0
      i32.const 304
      i32.const 52
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -7174,7 +7174,7 @@
      i32.const 0
      i32.const 304
      i32.const 54
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -7194,7 +7194,7 @@
    i32.const 0
    i32.const 304
    i32.const 56
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -7209,7 +7209,7 @@
    i32.const 0
    i32.const 304
    i32.const 60
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -7679,7 +7679,7 @@
    i32.const 352
    i32.const 416
    i32.const 111
-   i32.const 16
+   i32.const 17
    call $~lib/builtins/abort
    unreachable
   end
@@ -7703,7 +7703,7 @@
    i32.const 192
    i32.const 464
    i32.const 57
-   i32.const 59
+   i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
@@ -7791,7 +7791,7 @@
     i32.const 512
     i32.const 464
     i32.const 120
-    i32.const 21
+    i32.const 22
     call $~lib/builtins/abort
     unreachable
    end
@@ -8050,7 +8050,7 @@
    i32.const 512
    i32.const 464
    i32.const 104
-   i32.const 41
+   i32.const 42
    call $~lib/builtins/abort
    unreachable
   end
@@ -8495,7 +8495,7 @@
      i32.const 0
      i32.const 304
      i32.const 6
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -8518,7 +8518,7 @@
      i32.const 0
      i32.const 304
      i32.const 8
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -8538,7 +8538,7 @@
      i32.const 0
      i32.const 304
      i32.const 9
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -8558,7 +8558,7 @@
    i32.const 0
    i32.const 304
    i32.const 11
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -8583,7 +8583,7 @@
      i32.const 0
      i32.const 304
      i32.const 15
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -8603,7 +8603,7 @@
      i32.const 0
      i32.const 304
      i32.const 16
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -8626,7 +8626,7 @@
      i32.const 0
      i32.const 304
      i32.const 18
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -8646,7 +8646,7 @@
      i32.const 0
      i32.const 304
      i32.const 19
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -8666,7 +8666,7 @@
    i32.const 0
    i32.const 304
    i32.const 21
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -8708,7 +8708,7 @@
      i32.const 0
      i32.const 304
      i32.const 31
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -8722,7 +8722,7 @@
      i32.const 0
      i32.const 304
      i32.const 32
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -8756,7 +8756,7 @@
    i32.const 0
    i32.const 304
    i32.const 36
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -8769,7 +8769,7 @@
    i32.const 0
    i32.const 304
    i32.const 37
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -8794,7 +8794,7 @@
      i32.const 0
      i32.const 304
      i32.const 41
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -8814,7 +8814,7 @@
      i32.const 0
      i32.const 304
      i32.const 42
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -8831,7 +8831,7 @@
      i32.const 0
      i32.const 304
      i32.const 44
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -8851,7 +8851,7 @@
    i32.const 0
    i32.const 304
    i32.const 46
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -8877,7 +8877,7 @@
      i32.const 0
      i32.const 304
      i32.const 50
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -8900,7 +8900,7 @@
      i32.const 0
      i32.const 304
      i32.const 52
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -8917,7 +8917,7 @@
      i32.const 0
      i32.const 304
      i32.const 54
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -8937,7 +8937,7 @@
    i32.const 0
    i32.const 304
    i32.const 56
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -8952,7 +8952,7 @@
    i32.const 0
    i32.const 304
    i32.const 60
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -9392,7 +9392,7 @@
    i32.const 352
    i32.const 416
    i32.const 111
-   i32.const 16
+   i32.const 17
    call $~lib/builtins/abort
    unreachable
   end
@@ -9416,7 +9416,7 @@
    i32.const 192
    i32.const 464
    i32.const 57
-   i32.const 59
+   i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
@@ -9504,7 +9504,7 @@
     i32.const 512
     i32.const 464
     i32.const 120
-    i32.const 21
+    i32.const 22
     call $~lib/builtins/abort
     unreachable
    end
@@ -9763,7 +9763,7 @@
    i32.const 512
    i32.const 464
    i32.const 104
-   i32.const 41
+   i32.const 42
    call $~lib/builtins/abort
    unreachable
   end
@@ -10200,7 +10200,7 @@
      i32.const 0
      i32.const 304
      i32.const 6
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -10221,7 +10221,7 @@
      i32.const 0
      i32.const 304
      i32.const 8
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -10239,7 +10239,7 @@
      i32.const 0
      i32.const 304
      i32.const 9
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -10259,7 +10259,7 @@
    i32.const 0
    i32.const 304
    i32.const 11
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10282,7 +10282,7 @@
      i32.const 0
      i32.const 304
      i32.const 15
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -10300,7 +10300,7 @@
      i32.const 0
      i32.const 304
      i32.const 16
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -10321,7 +10321,7 @@
      i32.const 0
      i32.const 304
      i32.const 18
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -10339,7 +10339,7 @@
      i32.const 0
      i32.const 304
      i32.const 19
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -10359,7 +10359,7 @@
    i32.const 0
    i32.const 304
    i32.const 21
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10401,7 +10401,7 @@
      i32.const 0
      i32.const 304
      i32.const 31
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -10415,7 +10415,7 @@
      i32.const 0
      i32.const 304
      i32.const 32
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -10449,7 +10449,7 @@
    i32.const 0
    i32.const 304
    i32.const 36
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10462,7 +10462,7 @@
    i32.const 0
    i32.const 304
    i32.const 37
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10485,7 +10485,7 @@
      i32.const 0
      i32.const 304
      i32.const 41
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -10503,7 +10503,7 @@
      i32.const 0
      i32.const 304
      i32.const 42
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -10520,7 +10520,7 @@
      i32.const 0
      i32.const 304
      i32.const 44
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -10540,7 +10540,7 @@
    i32.const 0
    i32.const 304
    i32.const 46
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10564,7 +10564,7 @@
      i32.const 0
      i32.const 304
      i32.const 50
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -10585,7 +10585,7 @@
      i32.const 0
      i32.const 304
      i32.const 52
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -10602,7 +10602,7 @@
      i32.const 0
      i32.const 304
      i32.const 54
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -10622,7 +10622,7 @@
    i32.const 0
    i32.const 304
    i32.const 56
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10637,7 +10637,7 @@
    i32.const 0
    i32.const 304
    i32.const 60
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10687,7 +10687,7 @@
    i32.const 352
    i32.const 416
    i32.const 111
-   i32.const 16
+   i32.const 17
    call $~lib/builtins/abort
    unreachable
   end
@@ -10931,7 +10931,7 @@
      i32.const 0
      i32.const 304
      i32.const 6
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -10950,7 +10950,7 @@
      i32.const 0
      i32.const 304
      i32.const 8
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -10966,7 +10966,7 @@
      i32.const 0
      i32.const 304
      i32.const 9
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -10986,7 +10986,7 @@
    i32.const 0
    i32.const 304
    i32.const 11
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11007,7 +11007,7 @@
      i32.const 0
      i32.const 304
      i32.const 15
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -11023,7 +11023,7 @@
      i32.const 0
      i32.const 304
      i32.const 16
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -11042,7 +11042,7 @@
      i32.const 0
      i32.const 304
      i32.const 18
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -11058,7 +11058,7 @@
      i32.const 0
      i32.const 304
      i32.const 19
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -11078,7 +11078,7 @@
    i32.const 0
    i32.const 304
    i32.const 21
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11120,7 +11120,7 @@
      i32.const 0
      i32.const 304
      i32.const 31
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -11134,7 +11134,7 @@
      i32.const 0
      i32.const 304
      i32.const 32
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -11168,7 +11168,7 @@
    i32.const 0
    i32.const 304
    i32.const 36
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11181,7 +11181,7 @@
    i32.const 0
    i32.const 304
    i32.const 37
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11202,7 +11202,7 @@
      i32.const 0
      i32.const 304
      i32.const 41
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -11218,7 +11218,7 @@
      i32.const 0
      i32.const 304
      i32.const 42
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -11235,7 +11235,7 @@
      i32.const 0
      i32.const 304
      i32.const 44
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -11255,7 +11255,7 @@
    i32.const 0
    i32.const 304
    i32.const 46
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11277,7 +11277,7 @@
      i32.const 0
      i32.const 304
      i32.const 50
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -11296,7 +11296,7 @@
      i32.const 0
      i32.const 304
      i32.const 52
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -11313,7 +11313,7 @@
      i32.const 0
      i32.const 304
      i32.const 54
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -11333,7 +11333,7 @@
    i32.const 0
    i32.const 304
    i32.const 56
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11348,7 +11348,7 @@
    i32.const 0
    i32.const 304
    i32.const 60
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11780,7 +11780,7 @@
    i32.const 352
    i32.const 416
    i32.const 111
-   i32.const 16
+   i32.const 17
    call $~lib/builtins/abort
    unreachable
   end
@@ -11804,7 +11804,7 @@
    i32.const 192
    i32.const 464
    i32.const 57
-   i32.const 59
+   i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
@@ -11892,7 +11892,7 @@
     i32.const 512
     i32.const 464
     i32.const 120
-    i32.const 21
+    i32.const 22
     call $~lib/builtins/abort
     unreachable
    end
@@ -12151,7 +12151,7 @@
    i32.const 512
    i32.const 464
    i32.const 104
-   i32.const 41
+   i32.const 42
    call $~lib/builtins/abort
    unreachable
   end
@@ -12578,7 +12578,7 @@
      i32.const 0
      i32.const 304
      i32.const 6
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -12597,7 +12597,7 @@
      i32.const 0
      i32.const 304
      i32.const 8
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -12613,7 +12613,7 @@
      i32.const 0
      i32.const 304
      i32.const 9
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -12633,7 +12633,7 @@
    i32.const 0
    i32.const 304
    i32.const 11
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12654,7 +12654,7 @@
      i32.const 0
      i32.const 304
      i32.const 15
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -12670,7 +12670,7 @@
      i32.const 0
      i32.const 304
      i32.const 16
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -12689,7 +12689,7 @@
      i32.const 0
      i32.const 304
      i32.const 18
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -12705,7 +12705,7 @@
      i32.const 0
      i32.const 304
      i32.const 19
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -12725,7 +12725,7 @@
    i32.const 0
    i32.const 304
    i32.const 21
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12767,7 +12767,7 @@
      i32.const 0
      i32.const 304
      i32.const 31
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -12781,7 +12781,7 @@
      i32.const 0
      i32.const 304
      i32.const 32
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -12815,7 +12815,7 @@
    i32.const 0
    i32.const 304
    i32.const 36
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12828,7 +12828,7 @@
    i32.const 0
    i32.const 304
    i32.const 37
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12849,7 +12849,7 @@
      i32.const 0
      i32.const 304
      i32.const 41
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -12865,7 +12865,7 @@
      i32.const 0
      i32.const 304
      i32.const 42
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -12882,7 +12882,7 @@
      i32.const 0
      i32.const 304
      i32.const 44
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -12902,7 +12902,7 @@
    i32.const 0
    i32.const 304
    i32.const 46
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12924,7 +12924,7 @@
      i32.const 0
      i32.const 304
      i32.const 50
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -12943,7 +12943,7 @@
      i32.const 0
      i32.const 304
      i32.const 52
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -12960,7 +12960,7 @@
      i32.const 0
      i32.const 304
      i32.const 54
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -12980,7 +12980,7 @@
    i32.const 0
    i32.const 304
    i32.const 56
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12995,7 +12995,7 @@
    i32.const 0
    i32.const 304
    i32.const 60
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13517,7 +13517,7 @@
    i32.const 352
    i32.const 416
    i32.const 111
-   i32.const 16
+   i32.const 17
    call $~lib/builtins/abort
    unreachable
   end
@@ -13541,7 +13541,7 @@
    i32.const 192
    i32.const 464
    i32.const 57
-   i32.const 59
+   i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
@@ -13629,7 +13629,7 @@
     i32.const 512
     i32.const 464
     i32.const 120
-    i32.const 21
+    i32.const 22
     call $~lib/builtins/abort
     unreachable
    end
@@ -13888,7 +13888,7 @@
    i32.const 512
    i32.const 464
    i32.const 104
-   i32.const 41
+   i32.const 42
    call $~lib/builtins/abort
    unreachable
   end
@@ -14318,7 +14318,7 @@
      i32.const 0
      i32.const 304
      i32.const 6
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -14338,7 +14338,7 @@
      i32.const 0
      i32.const 304
      i32.const 8
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -14355,7 +14355,7 @@
      i32.const 0
      i32.const 304
      i32.const 9
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -14375,7 +14375,7 @@
    i32.const 0
    i32.const 304
    i32.const 11
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14396,7 +14396,7 @@
      i32.const 0
      i32.const 304
      i32.const 15
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -14413,7 +14413,7 @@
      i32.const 0
      i32.const 304
      i32.const 16
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -14433,7 +14433,7 @@
      i32.const 0
      i32.const 304
      i32.const 18
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -14450,7 +14450,7 @@
      i32.const 0
      i32.const 304
      i32.const 19
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -14470,7 +14470,7 @@
    i32.const 0
    i32.const 304
    i32.const 21
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14512,7 +14512,7 @@
      i32.const 0
      i32.const 304
      i32.const 31
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -14527,7 +14527,7 @@
      i32.const 0
      i32.const 304
      i32.const 32
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -14561,7 +14561,7 @@
    i32.const 0
    i32.const 304
    i32.const 36
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14574,7 +14574,7 @@
    i32.const 0
    i32.const 304
    i32.const 37
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14595,7 +14595,7 @@
      i32.const 0
      i32.const 304
      i32.const 41
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -14612,7 +14612,7 @@
      i32.const 0
      i32.const 304
      i32.const 42
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -14629,7 +14629,7 @@
      i32.const 0
      i32.const 304
      i32.const 44
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -14649,7 +14649,7 @@
    i32.const 0
    i32.const 304
    i32.const 46
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14671,7 +14671,7 @@
      i32.const 0
      i32.const 304
      i32.const 50
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -14691,7 +14691,7 @@
      i32.const 0
      i32.const 304
      i32.const 52
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -14708,7 +14708,7 @@
      i32.const 0
      i32.const 304
      i32.const 54
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -14728,7 +14728,7 @@
    i32.const 0
    i32.const 304
    i32.const 56
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14743,7 +14743,7 @@
    i32.const 0
    i32.const 304
    i32.const 60
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -15177,7 +15177,7 @@
    i32.const 352
    i32.const 416
    i32.const 111
-   i32.const 16
+   i32.const 17
    call $~lib/builtins/abort
    unreachable
   end
@@ -15201,7 +15201,7 @@
    i32.const 192
    i32.const 464
    i32.const 57
-   i32.const 59
+   i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
@@ -15289,7 +15289,7 @@
     i32.const 512
     i32.const 464
     i32.const 120
-    i32.const 21
+    i32.const 22
     call $~lib/builtins/abort
     unreachable
    end
@@ -15548,7 +15548,7 @@
    i32.const 512
    i32.const 464
    i32.const 104
-   i32.const 41
+   i32.const 42
    call $~lib/builtins/abort
    unreachable
   end
@@ -15978,7 +15978,7 @@
      i32.const 0
      i32.const 304
      i32.const 6
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -15998,7 +15998,7 @@
      i32.const 0
      i32.const 304
      i32.const 8
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -16015,7 +16015,7 @@
      i32.const 0
      i32.const 304
      i32.const 9
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -16035,7 +16035,7 @@
    i32.const 0
    i32.const 304
    i32.const 11
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -16056,7 +16056,7 @@
      i32.const 0
      i32.const 304
      i32.const 15
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -16073,7 +16073,7 @@
      i32.const 0
      i32.const 304
      i32.const 16
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -16093,7 +16093,7 @@
      i32.const 0
      i32.const 304
      i32.const 18
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -16110,7 +16110,7 @@
      i32.const 0
      i32.const 304
      i32.const 19
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -16130,7 +16130,7 @@
    i32.const 0
    i32.const 304
    i32.const 21
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -16172,7 +16172,7 @@
      i32.const 0
      i32.const 304
      i32.const 31
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -16187,7 +16187,7 @@
      i32.const 0
      i32.const 304
      i32.const 32
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -16221,7 +16221,7 @@
    i32.const 0
    i32.const 304
    i32.const 36
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -16234,7 +16234,7 @@
    i32.const 0
    i32.const 304
    i32.const 37
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -16255,7 +16255,7 @@
      i32.const 0
      i32.const 304
      i32.const 41
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -16272,7 +16272,7 @@
      i32.const 0
      i32.const 304
      i32.const 42
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -16289,7 +16289,7 @@
      i32.const 0
      i32.const 304
      i32.const 44
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -16309,7 +16309,7 @@
    i32.const 0
    i32.const 304
    i32.const 46
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -16331,7 +16331,7 @@
      i32.const 0
      i32.const 304
      i32.const 50
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -16351,7 +16351,7 @@
      i32.const 0
      i32.const 304
      i32.const 52
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -16368,7 +16368,7 @@
      i32.const 0
      i32.const 304
      i32.const 54
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -16388,7 +16388,7 @@
    i32.const 0
    i32.const 304
    i32.const 56
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -16403,7 +16403,7 @@
    i32.const 0
    i32.const 304
    i32.const 60
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -16841,7 +16841,7 @@
    i32.const 352
    i32.const 416
    i32.const 111
-   i32.const 16
+   i32.const 17
    call $~lib/builtins/abort
    unreachable
   end
@@ -16865,7 +16865,7 @@
    i32.const 192
    i32.const 464
    i32.const 57
-   i32.const 59
+   i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
@@ -16953,7 +16953,7 @@
     i32.const 512
     i32.const 464
     i32.const 120
-    i32.const 21
+    i32.const 22
     call $~lib/builtins/abort
     unreachable
    end
@@ -17212,7 +17212,7 @@
    i32.const 512
    i32.const 464
    i32.const 104
-   i32.const 41
+   i32.const 42
    call $~lib/builtins/abort
    unreachable
   end
@@ -17645,7 +17645,7 @@
      i32.const 0
      i32.const 304
      i32.const 6
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -17665,7 +17665,7 @@
      i32.const 0
      i32.const 304
      i32.const 8
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -17682,7 +17682,7 @@
      i32.const 0
      i32.const 304
      i32.const 9
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -17702,7 +17702,7 @@
    i32.const 0
    i32.const 304
    i32.const 11
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -17723,7 +17723,7 @@
      i32.const 0
      i32.const 304
      i32.const 15
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -17740,7 +17740,7 @@
      i32.const 0
      i32.const 304
      i32.const 16
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -17760,7 +17760,7 @@
      i32.const 0
      i32.const 304
      i32.const 18
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -17777,7 +17777,7 @@
      i32.const 0
      i32.const 304
      i32.const 19
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -17797,7 +17797,7 @@
    i32.const 0
    i32.const 304
    i32.const 21
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -17839,7 +17839,7 @@
      i32.const 0
      i32.const 304
      i32.const 31
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -17854,7 +17854,7 @@
      i32.const 0
      i32.const 304
      i32.const 32
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -17888,7 +17888,7 @@
    i32.const 0
    i32.const 304
    i32.const 36
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -17901,7 +17901,7 @@
    i32.const 0
    i32.const 304
    i32.const 37
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -17922,7 +17922,7 @@
      i32.const 0
      i32.const 304
      i32.const 41
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -17939,7 +17939,7 @@
      i32.const 0
      i32.const 304
      i32.const 42
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -17956,7 +17956,7 @@
      i32.const 0
      i32.const 304
      i32.const 44
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -17976,7 +17976,7 @@
    i32.const 0
    i32.const 304
    i32.const 46
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -17998,7 +17998,7 @@
      i32.const 0
      i32.const 304
      i32.const 50
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -18018,7 +18018,7 @@
      i32.const 0
      i32.const 304
      i32.const 52
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -18035,7 +18035,7 @@
      i32.const 0
      i32.const 304
      i32.const 54
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -18055,7 +18055,7 @@
    i32.const 0
    i32.const 304
    i32.const 56
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -18070,7 +18070,7 @@
    i32.const 0
    i32.const 304
    i32.const 60
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -18508,7 +18508,7 @@
    i32.const 352
    i32.const 416
    i32.const 111
-   i32.const 16
+   i32.const 17
    call $~lib/builtins/abort
    unreachable
   end
@@ -18532,7 +18532,7 @@
    i32.const 192
    i32.const 464
    i32.const 57
-   i32.const 59
+   i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
@@ -18620,7 +18620,7 @@
     i32.const 512
     i32.const 464
     i32.const 120
-    i32.const 21
+    i32.const 22
     call $~lib/builtins/abort
     unreachable
    end
@@ -18879,7 +18879,7 @@
    i32.const 512
    i32.const 464
    i32.const 104
-   i32.const 41
+   i32.const 42
    call $~lib/builtins/abort
    unreachable
   end
@@ -19312,7 +19312,7 @@
      i32.const 0
      i32.const 304
      i32.const 6
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -19332,7 +19332,7 @@
      i32.const 0
      i32.const 304
      i32.const 8
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -19349,7 +19349,7 @@
      i32.const 0
      i32.const 304
      i32.const 9
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -19369,7 +19369,7 @@
    i32.const 0
    i32.const 304
    i32.const 11
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -19390,7 +19390,7 @@
      i32.const 0
      i32.const 304
      i32.const 15
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -19407,7 +19407,7 @@
      i32.const 0
      i32.const 304
      i32.const 16
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -19427,7 +19427,7 @@
      i32.const 0
      i32.const 304
      i32.const 18
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -19444,7 +19444,7 @@
      i32.const 0
      i32.const 304
      i32.const 19
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -19464,7 +19464,7 @@
    i32.const 0
    i32.const 304
    i32.const 21
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -19506,7 +19506,7 @@
      i32.const 0
      i32.const 304
      i32.const 31
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -19521,7 +19521,7 @@
      i32.const 0
      i32.const 304
      i32.const 32
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -19555,7 +19555,7 @@
    i32.const 0
    i32.const 304
    i32.const 36
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -19568,7 +19568,7 @@
    i32.const 0
    i32.const 304
    i32.const 37
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -19589,7 +19589,7 @@
      i32.const 0
      i32.const 304
      i32.const 41
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -19606,7 +19606,7 @@
      i32.const 0
      i32.const 304
      i32.const 42
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -19623,7 +19623,7 @@
      i32.const 0
      i32.const 304
      i32.const 44
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -19643,7 +19643,7 @@
    i32.const 0
    i32.const 304
    i32.const 46
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -19665,7 +19665,7 @@
      i32.const 0
      i32.const 304
      i32.const 50
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -19685,7 +19685,7 @@
      i32.const 0
      i32.const 304
      i32.const 52
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -19702,7 +19702,7 @@
      i32.const 0
      i32.const 304
      i32.const 54
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -19722,7 +19722,7 @@
    i32.const 0
    i32.const 304
    i32.const 56
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -19737,7 +19737,7 @@
    i32.const 0
    i32.const 304
    i32.const 60
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -19792,7 +19792,7 @@
    i32.const 0
    i32.const 144
    i32.const 122
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -19814,7 +19814,7 @@
     i32.const 0
     i32.const 144
     i32.const 126
-    i32.const 17
+    i32.const 18
     call $~lib/builtins/abort
     unreachable
    end
@@ -19830,7 +19830,7 @@
     i32.const 0
     i32.const 144
     i32.const 136
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -19862,7 +19862,7 @@
    i32.const 0
    i32.const 144
    i32.const 69
-   i32.const 15
+   i32.const 16
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/std/math.optimized.wat
+++ b/tests/compiler/std/math.optimized.wat
@@ -8624,7 +8624,7 @@
    i32.const 0
    i32.const 3952
    i32.const 1406
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -11433,7 +11433,7 @@
    i32.const 0
    i32.const 1040
    i32.const 111
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11446,7 +11446,7 @@
    i32.const 0
    i32.const 1040
    i32.const 112
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11459,7 +11459,7 @@
    i32.const 0
    i32.const 1040
    i32.const 113
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11472,7 +11472,7 @@
    i32.const 0
    i32.const 1040
    i32.const 114
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11485,7 +11485,7 @@
    i32.const 0
    i32.const 1040
    i32.const 115
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11498,7 +11498,7 @@
    i32.const 0
    i32.const 1040
    i32.const 116
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11511,7 +11511,7 @@
    i32.const 0
    i32.const 1040
    i32.const 117
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11525,7 +11525,7 @@
    i32.const 0
    i32.const 1040
    i32.const 119
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11539,7 +11539,7 @@
    i32.const 0
    i32.const 1040
    i32.const 120
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11553,7 +11553,7 @@
    i32.const 0
    i32.const 1040
    i32.const 121
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11567,7 +11567,7 @@
    i32.const 0
    i32.const 1040
    i32.const 122
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11581,7 +11581,7 @@
    i32.const 0
    i32.const 1040
    i32.const 123
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11595,7 +11595,7 @@
    i32.const 0
    i32.const 1040
    i32.const 124
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11609,7 +11609,7 @@
    i32.const 0
    i32.const 1040
    i32.const 125
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11622,7 +11622,7 @@
    i32.const 0
    i32.const 1040
    i32.const 136
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11635,7 +11635,7 @@
    i32.const 0
    i32.const 1040
    i32.const 137
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11648,7 +11648,7 @@
    i32.const 0
    i32.const 1040
    i32.const 138
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11661,7 +11661,7 @@
    i32.const 0
    i32.const 1040
    i32.const 139
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11674,7 +11674,7 @@
    i32.const 0
    i32.const 1040
    i32.const 140
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11687,7 +11687,7 @@
    i32.const 0
    i32.const 1040
    i32.const 141
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11700,7 +11700,7 @@
    i32.const 0
    i32.const 1040
    i32.const 142
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11713,7 +11713,7 @@
    i32.const 0
    i32.const 1040
    i32.const 143
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11726,7 +11726,7 @@
    i32.const 0
    i32.const 1040
    i32.const 144
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11739,7 +11739,7 @@
    i32.const 0
    i32.const 1040
    i32.const 145
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11752,7 +11752,7 @@
    i32.const 0
    i32.const 1040
    i32.const 148
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11765,7 +11765,7 @@
    i32.const 0
    i32.const 1040
    i32.const 149
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11778,7 +11778,7 @@
    i32.const 0
    i32.const 1040
    i32.const 150
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11791,7 +11791,7 @@
    i32.const 0
    i32.const 1040
    i32.const 151
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11804,7 +11804,7 @@
    i32.const 0
    i32.const 1040
    i32.const 152
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11817,7 +11817,7 @@
    i32.const 0
    i32.const 1040
    i32.const 153
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11830,7 +11830,7 @@
    i32.const 0
    i32.const 1040
    i32.const 154
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11843,7 +11843,7 @@
    i32.const 0
    i32.const 1040
    i32.const 155
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11856,7 +11856,7 @@
    i32.const 0
    i32.const 1040
    i32.const 156
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11869,7 +11869,7 @@
    i32.const 0
    i32.const 1040
    i32.const 157
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11882,7 +11882,7 @@
    i32.const 0
    i32.const 1040
    i32.const 158
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11895,7 +11895,7 @@
    i32.const 0
    i32.const 1040
    i32.const 159
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11908,7 +11908,7 @@
    i32.const 0
    i32.const 1040
    i32.const 160
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11921,7 +11921,7 @@
    i32.const 0
    i32.const 1040
    i32.const 161
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11934,7 +11934,7 @@
    i32.const 0
    i32.const 1040
    i32.const 162
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11947,7 +11947,7 @@
    i32.const 0
    i32.const 1040
    i32.const 163
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11960,7 +11960,7 @@
    i32.const 0
    i32.const 1040
    i32.const 164
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11973,7 +11973,7 @@
    i32.const 0
    i32.const 1040
    i32.const 165
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11986,7 +11986,7 @@
    i32.const 0
    i32.const 1040
    i32.const 166
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11999,7 +11999,7 @@
    i32.const 0
    i32.const 1040
    i32.const 175
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12012,7 +12012,7 @@
    i32.const 0
    i32.const 1040
    i32.const 176
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12025,7 +12025,7 @@
    i32.const 0
    i32.const 1040
    i32.const 177
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12038,7 +12038,7 @@
    i32.const 0
    i32.const 1040
    i32.const 178
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12051,7 +12051,7 @@
    i32.const 0
    i32.const 1040
    i32.const 179
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12064,7 +12064,7 @@
    i32.const 0
    i32.const 1040
    i32.const 180
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12077,7 +12077,7 @@
    i32.const 0
    i32.const 1040
    i32.const 181
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12090,7 +12090,7 @@
    i32.const 0
    i32.const 1040
    i32.const 182
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12103,7 +12103,7 @@
    i32.const 0
    i32.const 1040
    i32.const 183
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12116,7 +12116,7 @@
    i32.const 0
    i32.const 1040
    i32.const 184
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12129,7 +12129,7 @@
    i32.const 0
    i32.const 1040
    i32.const 187
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12142,7 +12142,7 @@
    i32.const 0
    i32.const 1040
    i32.const 188
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12155,7 +12155,7 @@
    i32.const 0
    i32.const 1040
    i32.const 189
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12168,7 +12168,7 @@
    i32.const 0
    i32.const 1040
    i32.const 190
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12181,7 +12181,7 @@
    i32.const 0
    i32.const 1040
    i32.const 191
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12194,7 +12194,7 @@
    i32.const 0
    i32.const 1040
    i32.const 192
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12207,7 +12207,7 @@
    i32.const 0
    i32.const 1040
    i32.const 193
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12220,7 +12220,7 @@
    i32.const 0
    i32.const 1040
    i32.const 194
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12233,7 +12233,7 @@
    i32.const 0
    i32.const 1040
    i32.const 195
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12246,7 +12246,7 @@
    i32.const 0
    i32.const 1040
    i32.const 196
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12259,7 +12259,7 @@
    i32.const 0
    i32.const 1040
    i32.const 197
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12272,7 +12272,7 @@
    i32.const 0
    i32.const 1040
    i32.const 198
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12285,7 +12285,7 @@
    i32.const 0
    i32.const 1040
    i32.const 199
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12298,7 +12298,7 @@
    i32.const 0
    i32.const 1040
    i32.const 200
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12311,7 +12311,7 @@
    i32.const 0
    i32.const 1040
    i32.const 201
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12324,7 +12324,7 @@
    i32.const 0
    i32.const 1040
    i32.const 202
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12337,7 +12337,7 @@
    i32.const 0
    i32.const 1040
    i32.const 203
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12350,7 +12350,7 @@
    i32.const 0
    i32.const 1040
    i32.const 204
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12363,7 +12363,7 @@
    i32.const 0
    i32.const 1040
    i32.const 205
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12375,7 +12375,7 @@
    i32.const 0
    i32.const 1040
    i32.const 217
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12387,7 +12387,7 @@
    i32.const 0
    i32.const 1040
    i32.const 218
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12399,7 +12399,7 @@
    i32.const 0
    i32.const 1040
    i32.const 219
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12411,7 +12411,7 @@
    i32.const 0
    i32.const 1040
    i32.const 220
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12423,7 +12423,7 @@
    i32.const 0
    i32.const 1040
    i32.const 221
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12435,7 +12435,7 @@
    i32.const 0
    i32.const 1040
    i32.const 222
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12447,7 +12447,7 @@
    i32.const 0
    i32.const 1040
    i32.const 223
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12459,7 +12459,7 @@
    i32.const 0
    i32.const 1040
    i32.const 224
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12471,7 +12471,7 @@
    i32.const 0
    i32.const 1040
    i32.const 225
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12483,7 +12483,7 @@
    i32.const 0
    i32.const 1040
    i32.const 226
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12495,7 +12495,7 @@
    i32.const 0
    i32.const 1040
    i32.const 229
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12507,7 +12507,7 @@
    i32.const 0
    i32.const 1040
    i32.const 230
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12519,7 +12519,7 @@
    i32.const 0
    i32.const 1040
    i32.const 231
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12531,7 +12531,7 @@
    i32.const 0
    i32.const 1040
    i32.const 232
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12543,7 +12543,7 @@
    i32.const 0
    i32.const 1040
    i32.const 233
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12555,7 +12555,7 @@
    i32.const 0
    i32.const 1040
    i32.const 234
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12567,7 +12567,7 @@
    i32.const 0
    i32.const 1040
    i32.const 235
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12579,7 +12579,7 @@
    i32.const 0
    i32.const 1040
    i32.const 244
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12591,7 +12591,7 @@
    i32.const 0
    i32.const 1040
    i32.const 245
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12603,7 +12603,7 @@
    i32.const 0
    i32.const 1040
    i32.const 246
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12615,7 +12615,7 @@
    i32.const 0
    i32.const 1040
    i32.const 247
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12627,7 +12627,7 @@
    i32.const 0
    i32.const 1040
    i32.const 248
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12639,7 +12639,7 @@
    i32.const 0
    i32.const 1040
    i32.const 249
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12651,7 +12651,7 @@
    i32.const 0
    i32.const 1040
    i32.const 250
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12663,7 +12663,7 @@
    i32.const 0
    i32.const 1040
    i32.const 251
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12675,7 +12675,7 @@
    i32.const 0
    i32.const 1040
    i32.const 252
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12687,7 +12687,7 @@
    i32.const 0
    i32.const 1040
    i32.const 253
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12699,7 +12699,7 @@
    i32.const 0
    i32.const 1040
    i32.const 256
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12711,7 +12711,7 @@
    i32.const 0
    i32.const 1040
    i32.const 257
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12723,7 +12723,7 @@
    i32.const 0
    i32.const 1040
    i32.const 258
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12735,7 +12735,7 @@
    i32.const 0
    i32.const 1040
    i32.const 259
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12747,7 +12747,7 @@
    i32.const 0
    i32.const 1040
    i32.const 260
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12759,7 +12759,7 @@
    i32.const 0
    i32.const 1040
    i32.const 261
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12771,7 +12771,7 @@
    i32.const 0
    i32.const 1040
    i32.const 262
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12784,7 +12784,7 @@
    i32.const 0
    i32.const 1040
    i32.const 274
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12797,7 +12797,7 @@
    i32.const 0
    i32.const 1040
    i32.const 275
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12810,7 +12810,7 @@
    i32.const 0
    i32.const 1040
    i32.const 276
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12823,7 +12823,7 @@
    i32.const 0
    i32.const 1040
    i32.const 277
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12836,7 +12836,7 @@
    i32.const 0
    i32.const 1040
    i32.const 278
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12849,7 +12849,7 @@
    i32.const 0
    i32.const 1040
    i32.const 279
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12862,7 +12862,7 @@
    i32.const 0
    i32.const 1040
    i32.const 280
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12875,7 +12875,7 @@
    i32.const 0
    i32.const 1040
    i32.const 281
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12888,7 +12888,7 @@
    i32.const 0
    i32.const 1040
    i32.const 282
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12901,7 +12901,7 @@
    i32.const 0
    i32.const 1040
    i32.const 283
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12914,7 +12914,7 @@
    i32.const 0
    i32.const 1040
    i32.const 286
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12927,7 +12927,7 @@
    i32.const 0
    i32.const 1040
    i32.const 287
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12940,7 +12940,7 @@
    i32.const 0
    i32.const 1040
    i32.const 288
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12953,7 +12953,7 @@
    i32.const 0
    i32.const 1040
    i32.const 289
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12966,7 +12966,7 @@
    i32.const 0
    i32.const 1040
    i32.const 290
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12979,7 +12979,7 @@
    i32.const 0
    i32.const 1040
    i32.const 291
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12992,7 +12992,7 @@
    i32.const 0
    i32.const 1040
    i32.const 292
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13005,7 +13005,7 @@
    i32.const 0
    i32.const 1040
    i32.const 293
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13018,7 +13018,7 @@
    i32.const 0
    i32.const 1040
    i32.const 294
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13031,7 +13031,7 @@
    i32.const 0
    i32.const 1040
    i32.const 295
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13044,7 +13044,7 @@
    i32.const 0
    i32.const 1040
    i32.const 304
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13057,7 +13057,7 @@
    i32.const 0
    i32.const 1040
    i32.const 305
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13070,7 +13070,7 @@
    i32.const 0
    i32.const 1040
    i32.const 306
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13083,7 +13083,7 @@
    i32.const 0
    i32.const 1040
    i32.const 307
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13096,7 +13096,7 @@
    i32.const 0
    i32.const 1040
    i32.const 308
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13109,7 +13109,7 @@
    i32.const 0
    i32.const 1040
    i32.const 309
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13122,7 +13122,7 @@
    i32.const 0
    i32.const 1040
    i32.const 310
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13135,7 +13135,7 @@
    i32.const 0
    i32.const 1040
    i32.const 311
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13148,7 +13148,7 @@
    i32.const 0
    i32.const 1040
    i32.const 312
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13161,7 +13161,7 @@
    i32.const 0
    i32.const 1040
    i32.const 313
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13174,7 +13174,7 @@
    i32.const 0
    i32.const 1040
    i32.const 316
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13187,7 +13187,7 @@
    i32.const 0
    i32.const 1040
    i32.const 317
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13200,7 +13200,7 @@
    i32.const 0
    i32.const 1040
    i32.const 318
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13213,7 +13213,7 @@
    i32.const 0
    i32.const 1040
    i32.const 319
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13226,7 +13226,7 @@
    i32.const 0
    i32.const 1040
    i32.const 320
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13239,7 +13239,7 @@
    i32.const 0
    i32.const 1040
    i32.const 321
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13252,7 +13252,7 @@
    i32.const 0
    i32.const 1040
    i32.const 322
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13265,7 +13265,7 @@
    i32.const 0
    i32.const 1040
    i32.const 323
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13278,7 +13278,7 @@
    i32.const 0
    i32.const 1040
    i32.const 324
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13291,7 +13291,7 @@
    i32.const 0
    i32.const 1040
    i32.const 325
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13304,7 +13304,7 @@
    i32.const 0
    i32.const 1040
    i32.const 326
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13317,7 +13317,7 @@
    i32.const 0
    i32.const 1040
    i32.const 338
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13330,7 +13330,7 @@
    i32.const 0
    i32.const 1040
    i32.const 339
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13343,7 +13343,7 @@
    i32.const 0
    i32.const 1040
    i32.const 340
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13356,7 +13356,7 @@
    i32.const 0
    i32.const 1040
    i32.const 341
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13369,7 +13369,7 @@
    i32.const 0
    i32.const 1040
    i32.const 342
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13382,7 +13382,7 @@
    i32.const 0
    i32.const 1040
    i32.const 343
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13395,7 +13395,7 @@
    i32.const 0
    i32.const 1040
    i32.const 344
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13408,7 +13408,7 @@
    i32.const 0
    i32.const 1040
    i32.const 345
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13421,7 +13421,7 @@
    i32.const 0
    i32.const 1040
    i32.const 346
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13434,7 +13434,7 @@
    i32.const 0
    i32.const 1040
    i32.const 347
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13447,7 +13447,7 @@
    i32.const 0
    i32.const 1040
    i32.const 350
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13460,7 +13460,7 @@
    i32.const 0
    i32.const 1040
    i32.const 351
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13473,7 +13473,7 @@
    i32.const 0
    i32.const 1040
    i32.const 352
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13486,7 +13486,7 @@
    i32.const 0
    i32.const 1040
    i32.const 353
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13499,7 +13499,7 @@
    i32.const 0
    i32.const 1040
    i32.const 354
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13512,7 +13512,7 @@
    i32.const 0
    i32.const 1040
    i32.const 355
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13525,7 +13525,7 @@
    i32.const 0
    i32.const 1040
    i32.const 356
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13538,7 +13538,7 @@
    i32.const 0
    i32.const 1040
    i32.const 372
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13551,7 +13551,7 @@
    i32.const 0
    i32.const 1040
    i32.const 374
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13564,7 +13564,7 @@
    i32.const 0
    i32.const 1040
    i32.const 375
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13577,7 +13577,7 @@
    i32.const 0
    i32.const 1040
    i32.const 384
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13590,7 +13590,7 @@
    i32.const 0
    i32.const 1040
    i32.const 385
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13603,7 +13603,7 @@
    i32.const 0
    i32.const 1040
    i32.const 386
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13616,7 +13616,7 @@
    i32.const 0
    i32.const 1040
    i32.const 387
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13629,7 +13629,7 @@
    i32.const 0
    i32.const 1040
    i32.const 388
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13642,7 +13642,7 @@
    i32.const 0
    i32.const 1040
    i32.const 389
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13655,7 +13655,7 @@
    i32.const 0
    i32.const 1040
    i32.const 390
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13668,7 +13668,7 @@
    i32.const 0
    i32.const 1040
    i32.const 391
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13681,7 +13681,7 @@
    i32.const 0
    i32.const 1040
    i32.const 392
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13694,7 +13694,7 @@
    i32.const 0
    i32.const 1040
    i32.const 393
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13707,7 +13707,7 @@
    i32.const 0
    i32.const 1040
    i32.const 396
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13720,7 +13720,7 @@
    i32.const 0
    i32.const 1040
    i32.const 397
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13733,7 +13733,7 @@
    i32.const 0
    i32.const 1040
    i32.const 398
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13746,7 +13746,7 @@
    i32.const 0
    i32.const 1040
    i32.const 399
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13759,7 +13759,7 @@
    i32.const 0
    i32.const 1040
    i32.const 400
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13772,7 +13772,7 @@
    i32.const 0
    i32.const 1040
    i32.const 401
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13785,7 +13785,7 @@
    i32.const 0
    i32.const 1040
    i32.const 402
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13798,7 +13798,7 @@
    i32.const 0
    i32.const 1040
    i32.const 403
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13811,7 +13811,7 @@
    i32.const 0
    i32.const 1040
    i32.const 415
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13824,7 +13824,7 @@
    i32.const 0
    i32.const 1040
    i32.const 416
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13837,7 +13837,7 @@
    i32.const 0
    i32.const 1040
    i32.const 417
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13850,7 +13850,7 @@
    i32.const 0
    i32.const 1040
    i32.const 418
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13863,7 +13863,7 @@
    i32.const 0
    i32.const 1040
    i32.const 419
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13876,7 +13876,7 @@
    i32.const 0
    i32.const 1040
    i32.const 420
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13889,7 +13889,7 @@
    i32.const 0
    i32.const 1040
    i32.const 421
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13902,7 +13902,7 @@
    i32.const 0
    i32.const 1040
    i32.const 422
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13915,7 +13915,7 @@
    i32.const 0
    i32.const 1040
    i32.const 423
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13928,7 +13928,7 @@
    i32.const 0
    i32.const 1040
    i32.const 424
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13941,7 +13941,7 @@
    i32.const 0
    i32.const 1040
    i32.const 427
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13954,7 +13954,7 @@
    i32.const 0
    i32.const 1040
    i32.const 428
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13967,7 +13967,7 @@
    i32.const 0
    i32.const 1040
    i32.const 429
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13980,7 +13980,7 @@
    i32.const 0
    i32.const 1040
    i32.const 430
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13993,7 +13993,7 @@
    i32.const 0
    i32.const 1040
    i32.const 431
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14006,7 +14006,7 @@
    i32.const 0
    i32.const 1040
    i32.const 432
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14019,7 +14019,7 @@
    i32.const 0
    i32.const 1040
    i32.const 433
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14032,7 +14032,7 @@
    i32.const 0
    i32.const 1040
    i32.const 434
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14045,7 +14045,7 @@
    i32.const 0
    i32.const 1040
    i32.const 435
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14058,7 +14058,7 @@
    i32.const 0
    i32.const 1040
    i32.const 436
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14071,7 +14071,7 @@
    i32.const 0
    i32.const 1040
    i32.const 445
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14084,7 +14084,7 @@
    i32.const 0
    i32.const 1040
    i32.const 446
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14097,7 +14097,7 @@
    i32.const 0
    i32.const 1040
    i32.const 447
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14110,7 +14110,7 @@
    i32.const 0
    i32.const 1040
    i32.const 448
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14123,7 +14123,7 @@
    i32.const 0
    i32.const 1040
    i32.const 449
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14136,7 +14136,7 @@
    i32.const 0
    i32.const 1040
    i32.const 450
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14149,7 +14149,7 @@
    i32.const 0
    i32.const 1040
    i32.const 451
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14162,7 +14162,7 @@
    i32.const 0
    i32.const 1040
    i32.const 452
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14175,7 +14175,7 @@
    i32.const 0
    i32.const 1040
    i32.const 453
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14188,7 +14188,7 @@
    i32.const 0
    i32.const 1040
    i32.const 454
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14201,7 +14201,7 @@
    i32.const 0
    i32.const 1040
    i32.const 457
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14214,7 +14214,7 @@
    i32.const 0
    i32.const 1040
    i32.const 458
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14227,7 +14227,7 @@
    i32.const 0
    i32.const 1040
    i32.const 459
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14240,7 +14240,7 @@
    i32.const 0
    i32.const 1040
    i32.const 460
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14253,7 +14253,7 @@
    i32.const 0
    i32.const 1040
    i32.const 461
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14266,7 +14266,7 @@
    i32.const 0
    i32.const 1040
    i32.const 462
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14279,7 +14279,7 @@
    i32.const 0
    i32.const 1040
    i32.const 463
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14292,7 +14292,7 @@
    i32.const 0
    i32.const 1040
    i32.const 464
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14305,7 +14305,7 @@
    i32.const 0
    i32.const 1040
    i32.const 465
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14318,7 +14318,7 @@
    i32.const 0
    i32.const 1040
    i32.const 466
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14331,7 +14331,7 @@
    i32.const 0
    i32.const 1040
    i32.const 478
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14344,7 +14344,7 @@
    i32.const 0
    i32.const 1040
    i32.const 479
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14357,7 +14357,7 @@
    i32.const 0
    i32.const 1040
    i32.const 480
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14370,7 +14370,7 @@
    i32.const 0
    i32.const 1040
    i32.const 481
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14383,7 +14383,7 @@
    i32.const 0
    i32.const 1040
    i32.const 482
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14396,7 +14396,7 @@
    i32.const 0
    i32.const 1040
    i32.const 483
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14409,7 +14409,7 @@
    i32.const 0
    i32.const 1040
    i32.const 484
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14422,7 +14422,7 @@
    i32.const 0
    i32.const 1040
    i32.const 485
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14435,7 +14435,7 @@
    i32.const 0
    i32.const 1040
    i32.const 486
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14448,7 +14448,7 @@
    i32.const 0
    i32.const 1040
    i32.const 487
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14461,7 +14461,7 @@
    i32.const 0
    i32.const 1040
    i32.const 490
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14474,7 +14474,7 @@
    i32.const 0
    i32.const 1040
    i32.const 491
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14487,7 +14487,7 @@
    i32.const 0
    i32.const 1040
    i32.const 492
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14500,7 +14500,7 @@
    i32.const 0
    i32.const 1040
    i32.const 493
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14513,7 +14513,7 @@
    i32.const 0
    i32.const 1040
    i32.const 494
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14526,7 +14526,7 @@
    i32.const 0
    i32.const 1040
    i32.const 523
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14539,7 +14539,7 @@
    i32.const 0
    i32.const 1040
    i32.const 524
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14552,7 +14552,7 @@
    i32.const 0
    i32.const 1040
    i32.const 525
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14565,7 +14565,7 @@
    i32.const 0
    i32.const 1040
    i32.const 526
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14578,7 +14578,7 @@
    i32.const 0
    i32.const 1040
    i32.const 527
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14591,7 +14591,7 @@
    i32.const 0
    i32.const 1040
    i32.const 528
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14604,7 +14604,7 @@
    i32.const 0
    i32.const 1040
    i32.const 529
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14617,7 +14617,7 @@
    i32.const 0
    i32.const 1040
    i32.const 530
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14630,7 +14630,7 @@
    i32.const 0
    i32.const 1040
    i32.const 531
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14643,7 +14643,7 @@
    i32.const 0
    i32.const 1040
    i32.const 532
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14656,7 +14656,7 @@
    i32.const 0
    i32.const 1040
    i32.const 535
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14669,7 +14669,7 @@
    i32.const 0
    i32.const 1040
    i32.const 536
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14682,7 +14682,7 @@
    i32.const 0
    i32.const 1040
    i32.const 537
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14695,7 +14695,7 @@
    i32.const 0
    i32.const 1040
    i32.const 538
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14708,7 +14708,7 @@
    i32.const 0
    i32.const 1040
    i32.const 539
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14721,7 +14721,7 @@
    i32.const 0
    i32.const 1040
    i32.const 551
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14734,7 +14734,7 @@
    i32.const 0
    i32.const 1040
    i32.const 552
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14747,7 +14747,7 @@
    i32.const 0
    i32.const 1040
    i32.const 553
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14760,7 +14760,7 @@
    i32.const 0
    i32.const 1040
    i32.const 554
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14773,7 +14773,7 @@
    i32.const 0
    i32.const 1040
    i32.const 555
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14786,7 +14786,7 @@
    i32.const 0
    i32.const 1040
    i32.const 556
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14799,7 +14799,7 @@
    i32.const 0
    i32.const 1040
    i32.const 557
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14812,7 +14812,7 @@
    i32.const 0
    i32.const 1040
    i32.const 558
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14825,7 +14825,7 @@
    i32.const 0
    i32.const 1040
    i32.const 559
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14838,7 +14838,7 @@
    i32.const 0
    i32.const 1040
    i32.const 560
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14851,7 +14851,7 @@
    i32.const 0
    i32.const 1040
    i32.const 563
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14864,7 +14864,7 @@
    i32.const 0
    i32.const 1040
    i32.const 564
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14877,7 +14877,7 @@
    i32.const 0
    i32.const 1040
    i32.const 565
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14890,7 +14890,7 @@
    i32.const 0
    i32.const 1040
    i32.const 566
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14903,7 +14903,7 @@
    i32.const 0
    i32.const 1040
    i32.const 567
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14916,7 +14916,7 @@
    i32.const 0
    i32.const 1040
    i32.const 568
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14929,7 +14929,7 @@
    i32.const 0
    i32.const 1040
    i32.const 569
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14942,7 +14942,7 @@
    i32.const 0
    i32.const 1040
    i32.const 570
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14955,7 +14955,7 @@
    i32.const 0
    i32.const 1040
    i32.const 579
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14968,7 +14968,7 @@
    i32.const 0
    i32.const 1040
    i32.const 580
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14981,7 +14981,7 @@
    i32.const 0
    i32.const 1040
    i32.const 581
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14994,7 +14994,7 @@
    i32.const 0
    i32.const 1040
    i32.const 582
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15007,7 +15007,7 @@
    i32.const 0
    i32.const 1040
    i32.const 583
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15020,7 +15020,7 @@
    i32.const 0
    i32.const 1040
    i32.const 584
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15033,7 +15033,7 @@
    i32.const 0
    i32.const 1040
    i32.const 585
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15046,7 +15046,7 @@
    i32.const 0
    i32.const 1040
    i32.const 586
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15059,7 +15059,7 @@
    i32.const 0
    i32.const 1040
    i32.const 587
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15072,7 +15072,7 @@
    i32.const 0
    i32.const 1040
    i32.const 588
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15085,7 +15085,7 @@
    i32.const 0
    i32.const 1040
    i32.const 591
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15098,7 +15098,7 @@
    i32.const 0
    i32.const 1040
    i32.const 592
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15111,7 +15111,7 @@
    i32.const 0
    i32.const 1040
    i32.const 593
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15124,7 +15124,7 @@
    i32.const 0
    i32.const 1040
    i32.const 594
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15137,7 +15137,7 @@
    i32.const 0
    i32.const 1040
    i32.const 595
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15150,7 +15150,7 @@
    i32.const 0
    i32.const 1040
    i32.const 596
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15163,7 +15163,7 @@
    i32.const 0
    i32.const 1040
    i32.const 597
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15176,7 +15176,7 @@
    i32.const 0
    i32.const 1040
    i32.const 609
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15189,7 +15189,7 @@
    i32.const 0
    i32.const 1040
    i32.const 610
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15202,7 +15202,7 @@
    i32.const 0
    i32.const 1040
    i32.const 611
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15215,7 +15215,7 @@
    i32.const 0
    i32.const 1040
    i32.const 612
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15228,7 +15228,7 @@
    i32.const 0
    i32.const 1040
    i32.const 613
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15241,7 +15241,7 @@
    i32.const 0
    i32.const 1040
    i32.const 614
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15254,7 +15254,7 @@
    i32.const 0
    i32.const 1040
    i32.const 615
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15267,7 +15267,7 @@
    i32.const 0
    i32.const 1040
    i32.const 616
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15280,7 +15280,7 @@
    i32.const 0
    i32.const 1040
    i32.const 617
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15293,7 +15293,7 @@
    i32.const 0
    i32.const 1040
    i32.const 618
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15306,7 +15306,7 @@
    i32.const 0
    i32.const 1040
    i32.const 621
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15319,7 +15319,7 @@
    i32.const 0
    i32.const 1040
    i32.const 622
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15332,7 +15332,7 @@
    i32.const 0
    i32.const 1040
    i32.const 623
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15345,7 +15345,7 @@
    i32.const 0
    i32.const 1040
    i32.const 624
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15358,7 +15358,7 @@
    i32.const 0
    i32.const 1040
    i32.const 625
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15371,7 +15371,7 @@
    i32.const 0
    i32.const 1040
    i32.const 626
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15384,7 +15384,7 @@
    i32.const 0
    i32.const 1040
    i32.const 627
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15397,7 +15397,7 @@
    i32.const 0
    i32.const 1040
    i32.const 628
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15410,7 +15410,7 @@
    i32.const 0
    i32.const 1040
    i32.const 629
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15423,7 +15423,7 @@
    i32.const 0
    i32.const 1040
    i32.const 630
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15436,7 +15436,7 @@
    i32.const 0
    i32.const 1040
    i32.const 631
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15449,7 +15449,7 @@
    i32.const 0
    i32.const 1040
    i32.const 632
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15462,7 +15462,7 @@
    i32.const 0
    i32.const 1040
    i32.const 633
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15475,7 +15475,7 @@
    i32.const 0
    i32.const 1040
    i32.const 634
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15488,7 +15488,7 @@
    i32.const 0
    i32.const 1040
    i32.const 643
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15501,7 +15501,7 @@
    i32.const 0
    i32.const 1040
    i32.const 644
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15514,7 +15514,7 @@
    i32.const 0
    i32.const 1040
    i32.const 645
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15527,7 +15527,7 @@
    i32.const 0
    i32.const 1040
    i32.const 646
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15540,7 +15540,7 @@
    i32.const 0
    i32.const 1040
    i32.const 647
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15553,7 +15553,7 @@
    i32.const 0
    i32.const 1040
    i32.const 648
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15566,7 +15566,7 @@
    i32.const 0
    i32.const 1040
    i32.const 649
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15579,7 +15579,7 @@
    i32.const 0
    i32.const 1040
    i32.const 650
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15592,7 +15592,7 @@
    i32.const 0
    i32.const 1040
    i32.const 651
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15605,7 +15605,7 @@
    i32.const 0
    i32.const 1040
    i32.const 652
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15618,7 +15618,7 @@
    i32.const 0
    i32.const 1040
    i32.const 655
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15631,7 +15631,7 @@
    i32.const 0
    i32.const 1040
    i32.const 656
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15644,7 +15644,7 @@
    i32.const 0
    i32.const 1040
    i32.const 657
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15657,7 +15657,7 @@
    i32.const 0
    i32.const 1040
    i32.const 658
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15670,7 +15670,7 @@
    i32.const 0
    i32.const 1040
    i32.const 659
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15683,7 +15683,7 @@
    i32.const 0
    i32.const 1040
    i32.const 660
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15696,7 +15696,7 @@
    i32.const 0
    i32.const 1040
    i32.const 661
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15709,7 +15709,7 @@
    i32.const 0
    i32.const 1040
    i32.const 662
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15722,7 +15722,7 @@
    i32.const 0
    i32.const 1040
    i32.const 663
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15735,7 +15735,7 @@
    i32.const 0
    i32.const 1040
    i32.const 664
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15748,7 +15748,7 @@
    i32.const 0
    i32.const 1040
    i32.const 665
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15761,7 +15761,7 @@
    i32.const 0
    i32.const 1040
    i32.const 666
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15774,7 +15774,7 @@
    i32.const 0
    i32.const 1040
    i32.const 667
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15787,7 +15787,7 @@
    i32.const 0
    i32.const 1040
    i32.const 668
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15801,7 +15801,7 @@
    i32.const 0
    i32.const 1040
    i32.const 680
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15815,7 +15815,7 @@
    i32.const 0
    i32.const 1040
    i32.const 681
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15829,7 +15829,7 @@
    i32.const 0
    i32.const 1040
    i32.const 682
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15843,7 +15843,7 @@
    i32.const 0
    i32.const 1040
    i32.const 683
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15857,7 +15857,7 @@
    i32.const 0
    i32.const 1040
    i32.const 684
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15871,7 +15871,7 @@
    i32.const 0
    i32.const 1040
    i32.const 685
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15885,7 +15885,7 @@
    i32.const 0
    i32.const 1040
    i32.const 686
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15899,7 +15899,7 @@
    i32.const 0
    i32.const 1040
    i32.const 687
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15913,7 +15913,7 @@
    i32.const 0
    i32.const 1040
    i32.const 688
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15927,7 +15927,7 @@
    i32.const 0
    i32.const 1040
    i32.const 689
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15941,7 +15941,7 @@
    i32.const 0
    i32.const 1040
    i32.const 692
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15955,7 +15955,7 @@
    i32.const 0
    i32.const 1040
    i32.const 693
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15969,7 +15969,7 @@
    i32.const 0
    i32.const 1040
    i32.const 694
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15983,7 +15983,7 @@
    i32.const 0
    i32.const 1040
    i32.const 695
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15997,7 +15997,7 @@
    i32.const 0
    i32.const 1040
    i32.const 696
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16011,7 +16011,7 @@
    i32.const 0
    i32.const 1040
    i32.const 697
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16025,7 +16025,7 @@
    i32.const 0
    i32.const 1040
    i32.const 698
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16039,7 +16039,7 @@
    i32.const 0
    i32.const 1040
    i32.const 699
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16053,7 +16053,7 @@
    i32.const 0
    i32.const 1040
    i32.const 700
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16067,7 +16067,7 @@
    i32.const 0
    i32.const 1040
    i32.const 701
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16081,7 +16081,7 @@
    i32.const 0
    i32.const 1040
    i32.const 702
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16095,7 +16095,7 @@
    i32.const 0
    i32.const 1040
    i32.const 703
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16109,7 +16109,7 @@
    i32.const 0
    i32.const 1040
    i32.const 704
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16123,7 +16123,7 @@
    i32.const 0
    i32.const 1040
    i32.const 705
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16137,7 +16137,7 @@
    i32.const 0
    i32.const 1040
    i32.const 706
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16151,7 +16151,7 @@
    i32.const 0
    i32.const 1040
    i32.const 707
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16165,7 +16165,7 @@
    i32.const 0
    i32.const 1040
    i32.const 708
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16179,7 +16179,7 @@
    i32.const 0
    i32.const 1040
    i32.const 709
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16193,7 +16193,7 @@
    i32.const 0
    i32.const 1040
    i32.const 710
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16207,7 +16207,7 @@
    i32.const 0
    i32.const 1040
    i32.const 711
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16221,7 +16221,7 @@
    i32.const 0
    i32.const 1040
    i32.const 712
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16235,7 +16235,7 @@
    i32.const 0
    i32.const 1040
    i32.const 713
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16249,7 +16249,7 @@
    i32.const 0
    i32.const 1040
    i32.const 714
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16263,7 +16263,7 @@
    i32.const 0
    i32.const 1040
    i32.const 715
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16277,7 +16277,7 @@
    i32.const 0
    i32.const 1040
    i32.const 716
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16291,7 +16291,7 @@
    i32.const 0
    i32.const 1040
    i32.const 717
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16305,7 +16305,7 @@
    i32.const 0
    i32.const 1040
    i32.const 718
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16319,7 +16319,7 @@
    i32.const 0
    i32.const 1040
    i32.const 719
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16333,7 +16333,7 @@
    i32.const 0
    i32.const 1040
    i32.const 720
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16347,7 +16347,7 @@
    i32.const 0
    i32.const 1040
    i32.const 721
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16361,7 +16361,7 @@
    i32.const 0
    i32.const 1040
    i32.const 730
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16375,7 +16375,7 @@
    i32.const 0
    i32.const 1040
    i32.const 731
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16389,7 +16389,7 @@
    i32.const 0
    i32.const 1040
    i32.const 732
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16403,7 +16403,7 @@
    i32.const 0
    i32.const 1040
    i32.const 733
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16417,7 +16417,7 @@
    i32.const 0
    i32.const 1040
    i32.const 734
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16431,7 +16431,7 @@
    i32.const 0
    i32.const 1040
    i32.const 735
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16445,7 +16445,7 @@
    i32.const 0
    i32.const 1040
    i32.const 736
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16459,7 +16459,7 @@
    i32.const 0
    i32.const 1040
    i32.const 737
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16473,7 +16473,7 @@
    i32.const 0
    i32.const 1040
    i32.const 738
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16487,7 +16487,7 @@
    i32.const 0
    i32.const 1040
    i32.const 739
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16501,7 +16501,7 @@
    i32.const 0
    i32.const 1040
    i32.const 742
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16515,7 +16515,7 @@
    i32.const 0
    i32.const 1040
    i32.const 743
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16529,7 +16529,7 @@
    i32.const 0
    i32.const 1040
    i32.const 744
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16543,7 +16543,7 @@
    i32.const 0
    i32.const 1040
    i32.const 745
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16557,7 +16557,7 @@
    i32.const 0
    i32.const 1040
    i32.const 746
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16571,7 +16571,7 @@
    i32.const 0
    i32.const 1040
    i32.const 747
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16585,7 +16585,7 @@
    i32.const 0
    i32.const 1040
    i32.const 748
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16599,7 +16599,7 @@
    i32.const 0
    i32.const 1040
    i32.const 749
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16613,7 +16613,7 @@
    i32.const 0
    i32.const 1040
    i32.const 750
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16627,7 +16627,7 @@
    i32.const 0
    i32.const 1040
    i32.const 751
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16641,7 +16641,7 @@
    i32.const 0
    i32.const 1040
    i32.const 752
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16655,7 +16655,7 @@
    i32.const 0
    i32.const 1040
    i32.const 753
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16669,7 +16669,7 @@
    i32.const 0
    i32.const 1040
    i32.const 754
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16683,7 +16683,7 @@
    i32.const 0
    i32.const 1040
    i32.const 755
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16697,7 +16697,7 @@
    i32.const 0
    i32.const 1040
    i32.const 756
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16711,7 +16711,7 @@
    i32.const 0
    i32.const 1040
    i32.const 757
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16725,7 +16725,7 @@
    i32.const 0
    i32.const 1040
    i32.const 758
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16739,7 +16739,7 @@
    i32.const 0
    i32.const 1040
    i32.const 759
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16753,7 +16753,7 @@
    i32.const 0
    i32.const 1040
    i32.const 760
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16767,7 +16767,7 @@
    i32.const 0
    i32.const 1040
    i32.const 761
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16781,7 +16781,7 @@
    i32.const 0
    i32.const 1040
    i32.const 762
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16795,7 +16795,7 @@
    i32.const 0
    i32.const 1040
    i32.const 763
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16809,7 +16809,7 @@
    i32.const 0
    i32.const 1040
    i32.const 764
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16823,7 +16823,7 @@
    i32.const 0
    i32.const 1040
    i32.const 765
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16837,7 +16837,7 @@
    i32.const 0
    i32.const 1040
    i32.const 766
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16851,7 +16851,7 @@
    i32.const 0
    i32.const 1040
    i32.const 767
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16865,7 +16865,7 @@
    i32.const 0
    i32.const 1040
    i32.const 768
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16879,7 +16879,7 @@
    i32.const 0
    i32.const 1040
    i32.const 769
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16892,7 +16892,7 @@
    i32.const 0
    i32.const 1040
    i32.const 781
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16905,7 +16905,7 @@
    i32.const 0
    i32.const 1040
    i32.const 782
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16918,7 +16918,7 @@
    i32.const 0
    i32.const 1040
    i32.const 783
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16931,7 +16931,7 @@
    i32.const 0
    i32.const 1040
    i32.const 784
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16944,7 +16944,7 @@
    i32.const 0
    i32.const 1040
    i32.const 785
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16957,7 +16957,7 @@
    i32.const 0
    i32.const 1040
    i32.const 786
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16970,7 +16970,7 @@
    i32.const 0
    i32.const 1040
    i32.const 787
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16983,7 +16983,7 @@
    i32.const 0
    i32.const 1040
    i32.const 788
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16996,7 +16996,7 @@
    i32.const 0
    i32.const 1040
    i32.const 789
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17009,7 +17009,7 @@
    i32.const 0
    i32.const 1040
    i32.const 790
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17022,7 +17022,7 @@
    i32.const 0
    i32.const 1040
    i32.const 793
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17035,7 +17035,7 @@
    i32.const 0
    i32.const 1040
    i32.const 794
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17048,7 +17048,7 @@
    i32.const 0
    i32.const 1040
    i32.const 795
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17061,7 +17061,7 @@
    i32.const 0
    i32.const 1040
    i32.const 796
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17074,7 +17074,7 @@
    i32.const 0
    i32.const 1040
    i32.const 797
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17087,7 +17087,7 @@
    i32.const 0
    i32.const 1040
    i32.const 798
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17100,7 +17100,7 @@
    i32.const 0
    i32.const 1040
    i32.const 799
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17113,7 +17113,7 @@
    i32.const 0
    i32.const 1040
    i32.const 800
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17126,7 +17126,7 @@
    i32.const 0
    i32.const 1040
    i32.const 801
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17139,7 +17139,7 @@
    i32.const 0
    i32.const 1040
    i32.const 802
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17152,7 +17152,7 @@
    i32.const 0
    i32.const 1040
    i32.const 811
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17165,7 +17165,7 @@
    i32.const 0
    i32.const 1040
    i32.const 812
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17178,7 +17178,7 @@
    i32.const 0
    i32.const 1040
    i32.const 813
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17191,7 +17191,7 @@
    i32.const 0
    i32.const 1040
    i32.const 814
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17204,7 +17204,7 @@
    i32.const 0
    i32.const 1040
    i32.const 815
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17217,7 +17217,7 @@
    i32.const 0
    i32.const 1040
    i32.const 816
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17230,7 +17230,7 @@
    i32.const 0
    i32.const 1040
    i32.const 817
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17243,7 +17243,7 @@
    i32.const 0
    i32.const 1040
    i32.const 818
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17256,7 +17256,7 @@
    i32.const 0
    i32.const 1040
    i32.const 819
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17269,7 +17269,7 @@
    i32.const 0
    i32.const 1040
    i32.const 820
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17282,7 +17282,7 @@
    i32.const 0
    i32.const 1040
    i32.const 823
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17295,7 +17295,7 @@
    i32.const 0
    i32.const 1040
    i32.const 824
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17308,7 +17308,7 @@
    i32.const 0
    i32.const 1040
    i32.const 825
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17321,7 +17321,7 @@
    i32.const 0
    i32.const 1040
    i32.const 826
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17334,7 +17334,7 @@
    i32.const 0
    i32.const 1040
    i32.const 827
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17347,7 +17347,7 @@
    i32.const 0
    i32.const 1040
    i32.const 828
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17360,7 +17360,7 @@
    i32.const 0
    i32.const 1040
    i32.const 829
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17373,7 +17373,7 @@
    i32.const 0
    i32.const 1040
    i32.const 830
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17386,7 +17386,7 @@
    i32.const 0
    i32.const 1040
    i32.const 831
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17399,7 +17399,7 @@
    i32.const 0
    i32.const 1040
    i32.const 832
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17411,7 +17411,7 @@
    i32.const 0
    i32.const 1040
    i32.const 844
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17423,7 +17423,7 @@
    i32.const 0
    i32.const 1040
    i32.const 845
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17435,7 +17435,7 @@
    i32.const 0
    i32.const 1040
    i32.const 846
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17447,7 +17447,7 @@
    i32.const 0
    i32.const 1040
    i32.const 847
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17459,7 +17459,7 @@
    i32.const 0
    i32.const 1040
    i32.const 848
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17471,7 +17471,7 @@
    i32.const 0
    i32.const 1040
    i32.const 849
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17483,7 +17483,7 @@
    i32.const 0
    i32.const 1040
    i32.const 850
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17495,7 +17495,7 @@
    i32.const 0
    i32.const 1040
    i32.const 851
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17507,7 +17507,7 @@
    i32.const 0
    i32.const 1040
    i32.const 852
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17519,7 +17519,7 @@
    i32.const 0
    i32.const 1040
    i32.const 853
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17531,7 +17531,7 @@
    i32.const 0
    i32.const 1040
    i32.const 856
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17543,7 +17543,7 @@
    i32.const 0
    i32.const 1040
    i32.const 857
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17555,7 +17555,7 @@
    i32.const 0
    i32.const 1040
    i32.const 858
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17567,7 +17567,7 @@
    i32.const 0
    i32.const 1040
    i32.const 859
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17579,7 +17579,7 @@
    i32.const 0
    i32.const 1040
    i32.const 860
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17591,7 +17591,7 @@
    i32.const 0
    i32.const 1040
    i32.const 861
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17603,7 +17603,7 @@
    i32.const 0
    i32.const 1040
    i32.const 862
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17615,7 +17615,7 @@
    i32.const 0
    i32.const 1040
    i32.const 863
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17627,7 +17627,7 @@
    i32.const 0
    i32.const 1040
    i32.const 864
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17639,7 +17639,7 @@
    i32.const 0
    i32.const 1040
    i32.const 865
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17651,7 +17651,7 @@
    i32.const 0
    i32.const 1040
    i32.const 866
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17663,7 +17663,7 @@
    i32.const 0
    i32.const 1040
    i32.const 867
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17675,7 +17675,7 @@
    i32.const 0
    i32.const 1040
    i32.const 868
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17687,7 +17687,7 @@
    i32.const 0
    i32.const 1040
    i32.const 869
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17699,7 +17699,7 @@
    i32.const 0
    i32.const 1040
    i32.const 870
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17711,7 +17711,7 @@
    i32.const 0
    i32.const 1040
    i32.const 871
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17723,7 +17723,7 @@
    i32.const 0
    i32.const 1040
    i32.const 872
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17735,7 +17735,7 @@
    i32.const 0
    i32.const 1040
    i32.const 873
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17747,7 +17747,7 @@
    i32.const 0
    i32.const 1040
    i32.const 874
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17759,7 +17759,7 @@
    i32.const 0
    i32.const 1040
    i32.const 875
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17771,7 +17771,7 @@
    i32.const 0
    i32.const 1040
    i32.const 876
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17783,7 +17783,7 @@
    i32.const 0
    i32.const 1040
    i32.const 877
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17795,7 +17795,7 @@
    i32.const 0
    i32.const 1040
    i32.const 878
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17807,7 +17807,7 @@
    i32.const 0
    i32.const 1040
    i32.const 879
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17819,7 +17819,7 @@
    i32.const 0
    i32.const 1040
    i32.const 880
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17831,7 +17831,7 @@
    i32.const 0
    i32.const 1040
    i32.const 881
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17843,7 +17843,7 @@
    i32.const 0
    i32.const 1040
    i32.const 882
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17855,7 +17855,7 @@
    i32.const 0
    i32.const 1040
    i32.const 883
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17867,7 +17867,7 @@
    i32.const 0
    i32.const 1040
    i32.const 884
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17879,7 +17879,7 @@
    i32.const 0
    i32.const 1040
    i32.const 885
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17891,7 +17891,7 @@
    i32.const 0
    i32.const 1040
    i32.const 886
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17903,7 +17903,7 @@
    i32.const 0
    i32.const 1040
    i32.const 887
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17915,7 +17915,7 @@
    i32.const 0
    i32.const 1040
    i32.const 888
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17927,7 +17927,7 @@
    i32.const 0
    i32.const 1040
    i32.const 889
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17939,7 +17939,7 @@
    i32.const 0
    i32.const 1040
    i32.const 890
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17951,7 +17951,7 @@
    i32.const 0
    i32.const 1040
    i32.const 891
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17963,7 +17963,7 @@
    i32.const 0
    i32.const 1040
    i32.const 892
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17975,7 +17975,7 @@
    i32.const 0
    i32.const 1040
    i32.const 893
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17987,7 +17987,7 @@
    i32.const 0
    i32.const 1040
    i32.const 894
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17999,7 +17999,7 @@
    i32.const 0
    i32.const 1040
    i32.const 895
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18011,7 +18011,7 @@
    i32.const 0
    i32.const 1040
    i32.const 896
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18023,7 +18023,7 @@
    i32.const 0
    i32.const 1040
    i32.const 897
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18035,7 +18035,7 @@
    i32.const 0
    i32.const 1040
    i32.const 898
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18047,7 +18047,7 @@
    i32.const 0
    i32.const 1040
    i32.const 899
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18059,7 +18059,7 @@
    i32.const 0
    i32.const 1040
    i32.const 900
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18071,7 +18071,7 @@
    i32.const 0
    i32.const 1040
    i32.const 909
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18083,7 +18083,7 @@
    i32.const 0
    i32.const 1040
    i32.const 910
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18095,7 +18095,7 @@
    i32.const 0
    i32.const 1040
    i32.const 911
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18107,7 +18107,7 @@
    i32.const 0
    i32.const 1040
    i32.const 912
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18119,7 +18119,7 @@
    i32.const 0
    i32.const 1040
    i32.const 913
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18131,7 +18131,7 @@
    i32.const 0
    i32.const 1040
    i32.const 914
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18143,7 +18143,7 @@
    i32.const 0
    i32.const 1040
    i32.const 915
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18155,7 +18155,7 @@
    i32.const 0
    i32.const 1040
    i32.const 916
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18167,7 +18167,7 @@
    i32.const 0
    i32.const 1040
    i32.const 917
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18179,7 +18179,7 @@
    i32.const 0
    i32.const 1040
    i32.const 918
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18191,7 +18191,7 @@
    i32.const 0
    i32.const 1040
    i32.const 921
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18203,7 +18203,7 @@
    i32.const 0
    i32.const 1040
    i32.const 922
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18215,7 +18215,7 @@
    i32.const 0
    i32.const 1040
    i32.const 923
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18227,7 +18227,7 @@
    i32.const 0
    i32.const 1040
    i32.const 924
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18239,7 +18239,7 @@
    i32.const 0
    i32.const 1040
    i32.const 925
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18251,7 +18251,7 @@
    i32.const 0
    i32.const 1040
    i32.const 926
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18263,7 +18263,7 @@
    i32.const 0
    i32.const 1040
    i32.const 927
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18275,7 +18275,7 @@
    i32.const 0
    i32.const 1040
    i32.const 928
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18287,7 +18287,7 @@
    i32.const 0
    i32.const 1040
    i32.const 929
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18299,7 +18299,7 @@
    i32.const 0
    i32.const 1040
    i32.const 930
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18311,7 +18311,7 @@
    i32.const 0
    i32.const 1040
    i32.const 931
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18323,7 +18323,7 @@
    i32.const 0
    i32.const 1040
    i32.const 932
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18335,7 +18335,7 @@
    i32.const 0
    i32.const 1040
    i32.const 933
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18347,7 +18347,7 @@
    i32.const 0
    i32.const 1040
    i32.const 934
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18359,7 +18359,7 @@
    i32.const 0
    i32.const 1040
    i32.const 935
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18371,7 +18371,7 @@
    i32.const 0
    i32.const 1040
    i32.const 936
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18383,7 +18383,7 @@
    i32.const 0
    i32.const 1040
    i32.const 937
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18395,7 +18395,7 @@
    i32.const 0
    i32.const 1040
    i32.const 938
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18407,7 +18407,7 @@
    i32.const 0
    i32.const 1040
    i32.const 939
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18419,7 +18419,7 @@
    i32.const 0
    i32.const 1040
    i32.const 940
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18431,7 +18431,7 @@
    i32.const 0
    i32.const 1040
    i32.const 941
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18443,7 +18443,7 @@
    i32.const 0
    i32.const 1040
    i32.const 942
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18455,7 +18455,7 @@
    i32.const 0
    i32.const 1040
    i32.const 943
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18467,7 +18467,7 @@
    i32.const 0
    i32.const 1040
    i32.const 944
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18479,7 +18479,7 @@
    i32.const 0
    i32.const 1040
    i32.const 945
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18491,7 +18491,7 @@
    i32.const 0
    i32.const 1040
    i32.const 946
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18503,7 +18503,7 @@
    i32.const 0
    i32.const 1040
    i32.const 947
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18515,7 +18515,7 @@
    i32.const 0
    i32.const 1040
    i32.const 948
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18527,7 +18527,7 @@
    i32.const 0
    i32.const 1040
    i32.const 949
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18539,7 +18539,7 @@
    i32.const 0
    i32.const 1040
    i32.const 950
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18551,7 +18551,7 @@
    i32.const 0
    i32.const 1040
    i32.const 951
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18563,7 +18563,7 @@
    i32.const 0
    i32.const 1040
    i32.const 952
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18575,7 +18575,7 @@
    i32.const 0
    i32.const 1040
    i32.const 953
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18587,7 +18587,7 @@
    i32.const 0
    i32.const 1040
    i32.const 954
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18599,7 +18599,7 @@
    i32.const 0
    i32.const 1040
    i32.const 955
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18611,7 +18611,7 @@
    i32.const 0
    i32.const 1040
    i32.const 956
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18623,7 +18623,7 @@
    i32.const 0
    i32.const 1040
    i32.const 957
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18635,7 +18635,7 @@
    i32.const 0
    i32.const 1040
    i32.const 958
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18647,7 +18647,7 @@
    i32.const 0
    i32.const 1040
    i32.const 959
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18659,7 +18659,7 @@
    i32.const 0
    i32.const 1040
    i32.const 960
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18671,7 +18671,7 @@
    i32.const 0
    i32.const 1040
    i32.const 961
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18683,7 +18683,7 @@
    i32.const 0
    i32.const 1040
    i32.const 962
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18695,7 +18695,7 @@
    i32.const 0
    i32.const 1040
    i32.const 963
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18707,7 +18707,7 @@
    i32.const 0
    i32.const 1040
    i32.const 964
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18719,7 +18719,7 @@
    i32.const 0
    i32.const 1040
    i32.const 965
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18732,7 +18732,7 @@
    i32.const 0
    i32.const 1040
    i32.const 976
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18745,7 +18745,7 @@
    i32.const 0
    i32.const 1040
    i32.const 977
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18758,7 +18758,7 @@
    i32.const 0
    i32.const 1040
    i32.const 978
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18771,7 +18771,7 @@
    i32.const 0
    i32.const 1040
    i32.const 979
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18784,7 +18784,7 @@
    i32.const 0
    i32.const 1040
    i32.const 980
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18797,7 +18797,7 @@
    i32.const 0
    i32.const 1040
    i32.const 981
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18810,7 +18810,7 @@
    i32.const 0
    i32.const 1040
    i32.const 982
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18823,7 +18823,7 @@
    i32.const 0
    i32.const 1040
    i32.const 983
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18836,7 +18836,7 @@
    i32.const 0
    i32.const 1040
    i32.const 984
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18849,7 +18849,7 @@
    i32.const 0
    i32.const 1040
    i32.const 985
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18862,7 +18862,7 @@
    i32.const 0
    i32.const 1040
    i32.const 988
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18875,7 +18875,7 @@
    i32.const 0
    i32.const 1040
    i32.const 989
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18888,7 +18888,7 @@
    i32.const 0
    i32.const 1040
    i32.const 990
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18901,7 +18901,7 @@
    i32.const 0
    i32.const 1040
    i32.const 991
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18914,7 +18914,7 @@
    i32.const 0
    i32.const 1040
    i32.const 992
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18927,7 +18927,7 @@
    i32.const 0
    i32.const 1040
    i32.const 993
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18940,7 +18940,7 @@
    i32.const 0
    i32.const 1040
    i32.const 994
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18953,7 +18953,7 @@
    i32.const 0
    i32.const 1040
    i32.const 995
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18966,7 +18966,7 @@
    i32.const 0
    i32.const 1040
    i32.const 996
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18979,7 +18979,7 @@
    i32.const 0
    i32.const 1040
    i32.const 997
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18992,7 +18992,7 @@
    i32.const 0
    i32.const 1040
    i32.const 998
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19005,7 +19005,7 @@
    i32.const 0
    i32.const 1040
    i32.const 999
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19018,7 +19018,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1000
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19031,7 +19031,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1001
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19044,7 +19044,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1002
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19057,7 +19057,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1003
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19070,7 +19070,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1004
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19083,7 +19083,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1005
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19096,7 +19096,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1006
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19109,7 +19109,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1007
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19122,7 +19122,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1008
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19135,7 +19135,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1009
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19148,7 +19148,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1010
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19161,7 +19161,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1011
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19174,7 +19174,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1012
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19187,7 +19187,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1013
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19200,7 +19200,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1014
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19213,7 +19213,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1015
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19226,7 +19226,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1016
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19239,7 +19239,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1017
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19252,7 +19252,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1018
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19265,7 +19265,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1019
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19278,7 +19278,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1020
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19291,7 +19291,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1021
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19304,7 +19304,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1022
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19317,7 +19317,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1023
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19330,7 +19330,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1024
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19343,7 +19343,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1025
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19356,7 +19356,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1026
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19369,7 +19369,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1027
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19382,7 +19382,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1028
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19395,7 +19395,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1029
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19408,7 +19408,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1030
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19421,7 +19421,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1031
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19434,7 +19434,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1032
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19447,7 +19447,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1033
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19460,7 +19460,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1034
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19473,7 +19473,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1035
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19486,7 +19486,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1036
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19499,7 +19499,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1037
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19512,7 +19512,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1038
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19525,7 +19525,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1039
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19538,7 +19538,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1040
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19551,7 +19551,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1041
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19564,7 +19564,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1042
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19577,7 +19577,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1043
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19590,7 +19590,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1044
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19603,7 +19603,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1045
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19616,7 +19616,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1046
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19629,7 +19629,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1047
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19642,7 +19642,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1048
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19655,7 +19655,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1049
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19668,7 +19668,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1050
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19681,7 +19681,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1051
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19694,7 +19694,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1052
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19707,7 +19707,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1053
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19720,7 +19720,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1054
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19733,7 +19733,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1055
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19746,7 +19746,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1056
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19759,7 +19759,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1057
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19772,7 +19772,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1058
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19785,7 +19785,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1059
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19798,7 +19798,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1060
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19811,7 +19811,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1061
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19824,7 +19824,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1062
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19837,7 +19837,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1063
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19850,7 +19850,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1064
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19863,7 +19863,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1065
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19876,7 +19876,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1068
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19889,7 +19889,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1069
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19902,7 +19902,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1070
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19915,7 +19915,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1071
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19928,7 +19928,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1072
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19941,7 +19941,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1073
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19954,7 +19954,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1074
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19967,7 +19967,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1075
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19980,7 +19980,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1076
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19993,7 +19993,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1077
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20006,7 +20006,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1078
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20019,7 +20019,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1079
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20032,7 +20032,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1080
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20045,7 +20045,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1081
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20058,7 +20058,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1082
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20071,7 +20071,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1083
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20084,7 +20084,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1084
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20097,7 +20097,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1085
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20110,7 +20110,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1086
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20123,7 +20123,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1087
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20136,7 +20136,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1088
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20149,7 +20149,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1089
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20162,7 +20162,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1090
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20175,7 +20175,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1091
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20188,7 +20188,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1092
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20201,7 +20201,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1093
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20214,7 +20214,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1094
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20227,7 +20227,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1095
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20240,7 +20240,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1096
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20253,7 +20253,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1097
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20266,7 +20266,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1098
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20279,7 +20279,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1099
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20292,7 +20292,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1100
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20305,7 +20305,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1101
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20318,7 +20318,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1102
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20331,7 +20331,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1103
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20344,7 +20344,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1104
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20357,7 +20357,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1105
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20370,7 +20370,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1107
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20383,7 +20383,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1108
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20396,7 +20396,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1109
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20408,7 +20408,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1113
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20420,7 +20420,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1114
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20432,7 +20432,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1117
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20444,7 +20444,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1119
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20456,7 +20456,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1120
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20468,7 +20468,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1123
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20480,7 +20480,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1125
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20492,7 +20492,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1128
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20504,7 +20504,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1130
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20516,7 +20516,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1131
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20528,7 +20528,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1132
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20540,7 +20540,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1134
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20552,7 +20552,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1136
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20564,7 +20564,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1137
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20576,7 +20576,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1138
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20588,7 +20588,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1139
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20600,7 +20600,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1140
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20612,7 +20612,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1141
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20625,7 +20625,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1150
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20638,7 +20638,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1151
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20651,7 +20651,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1152
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20664,7 +20664,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1153
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20677,7 +20677,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1154
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20690,7 +20690,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1155
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20703,7 +20703,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1156
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20716,7 +20716,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1157
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20729,7 +20729,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1158
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20742,7 +20742,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1159
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20755,7 +20755,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1162
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20768,7 +20768,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1163
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20781,7 +20781,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1164
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20794,7 +20794,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1165
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20807,7 +20807,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1166
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20820,7 +20820,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1169
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20833,7 +20833,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1170
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20846,7 +20846,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1171
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20859,7 +20859,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1172
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20872,7 +20872,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1173
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20885,7 +20885,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1174
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20898,7 +20898,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1175
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20911,7 +20911,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1176
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20924,7 +20924,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1177
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20937,7 +20937,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1178
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20950,7 +20950,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1179
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20963,7 +20963,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1180
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20976,7 +20976,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1181
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20989,7 +20989,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1182
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21002,7 +21002,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1183
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21015,7 +21015,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1184
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21028,7 +21028,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1185
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21041,7 +21041,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1186
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21054,7 +21054,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1187
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21067,7 +21067,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1188
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21080,7 +21080,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1189
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21093,7 +21093,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1190
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21106,7 +21106,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1191
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21119,7 +21119,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1192
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21132,7 +21132,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1193
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21145,7 +21145,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1194
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21158,7 +21158,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1195
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21171,7 +21171,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1196
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21184,7 +21184,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1197
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21197,7 +21197,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1198
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21210,7 +21210,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1199
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21223,7 +21223,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1200
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21236,7 +21236,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1201
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21249,7 +21249,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1202
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21262,7 +21262,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1203
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21275,7 +21275,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1204
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21288,7 +21288,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1205
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21301,7 +21301,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1206
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21314,7 +21314,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1209
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21327,7 +21327,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1210
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21340,7 +21340,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1211
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21353,7 +21353,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1212
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21366,7 +21366,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1213
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21379,7 +21379,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1214
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21392,7 +21392,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1215
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21405,7 +21405,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1216
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21418,7 +21418,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1217
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21431,7 +21431,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1218
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21444,7 +21444,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1219
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21457,7 +21457,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1220
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21470,7 +21470,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1221
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21483,7 +21483,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1222
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21496,7 +21496,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1233
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21509,7 +21509,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1234
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21522,7 +21522,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1235
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21535,7 +21535,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1236
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21548,7 +21548,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1237
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21561,7 +21561,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1238
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21574,7 +21574,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1239
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21587,7 +21587,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1240
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21600,7 +21600,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1241
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21613,7 +21613,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1242
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21626,7 +21626,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1245
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21639,7 +21639,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1246
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21652,7 +21652,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1247
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21665,7 +21665,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1248
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21678,7 +21678,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1249
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21691,7 +21691,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1258
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21704,7 +21704,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1259
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21717,7 +21717,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1260
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21730,7 +21730,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1261
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21743,7 +21743,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1262
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21756,7 +21756,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1263
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21769,7 +21769,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1264
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21782,7 +21782,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1265
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21795,7 +21795,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1266
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21808,7 +21808,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1267
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21821,7 +21821,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1270
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21834,7 +21834,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1271
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21847,7 +21847,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1272
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21860,7 +21860,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1273
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21873,7 +21873,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1274
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21886,7 +21886,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1286
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21899,7 +21899,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1287
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21912,7 +21912,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1288
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21925,7 +21925,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1289
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21938,7 +21938,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1290
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21951,7 +21951,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1291
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21964,7 +21964,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1292
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21977,7 +21977,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1293
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21990,7 +21990,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1294
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22003,7 +22003,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1295
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22016,7 +22016,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1298
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22029,7 +22029,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1299
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22042,7 +22042,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1300
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22055,7 +22055,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1301
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22068,7 +22068,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1302
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22081,7 +22081,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1303
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22094,7 +22094,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1304
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22107,7 +22107,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1305
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22120,7 +22120,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1306
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22133,7 +22133,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1307
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22146,7 +22146,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1308
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22159,7 +22159,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1311
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22172,7 +22172,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1312
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22185,7 +22185,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1314
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22198,7 +22198,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1321
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22211,7 +22211,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1322
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22224,7 +22224,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1329
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22237,7 +22237,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1336
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22250,7 +22250,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1343
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22263,7 +22263,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1350
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22276,7 +22276,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1357
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22289,7 +22289,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1364
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22302,7 +22302,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1370
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22315,7 +22315,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1376
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22328,7 +22328,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1382
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22341,7 +22341,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1389
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22354,7 +22354,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1396
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22367,7 +22367,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1403
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22380,7 +22380,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1410
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22393,7 +22393,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1417
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22406,7 +22406,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1424
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22419,7 +22419,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1431
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22432,7 +22432,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1438
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22445,7 +22445,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1452
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22458,7 +22458,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1453
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22471,7 +22471,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1454
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22484,7 +22484,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1455
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22497,7 +22497,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1456
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22510,7 +22510,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1457
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22523,7 +22523,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1458
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22536,7 +22536,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1459
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22549,7 +22549,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1460
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22562,7 +22562,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1461
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22575,7 +22575,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1464
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22588,7 +22588,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1465
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22601,7 +22601,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1466
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22614,7 +22614,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1467
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22627,7 +22627,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1468
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22640,7 +22640,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1469
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22653,7 +22653,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1470
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22666,7 +22666,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1471
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22679,7 +22679,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1472
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22692,7 +22692,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1473
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22705,7 +22705,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1474
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22718,7 +22718,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1475
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22731,7 +22731,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1476
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22744,7 +22744,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1477
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22757,7 +22757,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1489
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22770,7 +22770,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1490
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22783,7 +22783,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1491
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22796,7 +22796,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1492
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22809,7 +22809,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1493
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22822,7 +22822,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1494
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22835,7 +22835,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1495
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22848,7 +22848,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1496
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22861,7 +22861,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1497
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22874,7 +22874,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1498
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22887,7 +22887,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1501
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22900,7 +22900,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1502
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22913,7 +22913,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1503
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22926,7 +22926,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1504
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22939,7 +22939,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1505
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22952,7 +22952,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1506
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22965,7 +22965,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1507
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22978,7 +22978,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1508
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22991,7 +22991,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1509
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23004,7 +23004,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1518
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23017,7 +23017,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1519
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23030,7 +23030,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1520
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23043,7 +23043,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1521
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23056,7 +23056,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1522
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23069,7 +23069,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1523
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23082,7 +23082,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1524
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23095,7 +23095,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1525
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23108,7 +23108,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1526
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23121,7 +23121,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1527
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23134,7 +23134,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1530
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23147,7 +23147,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1531
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23160,7 +23160,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1532
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23173,7 +23173,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1533
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23186,7 +23186,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1534
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23199,7 +23199,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1535
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23212,7 +23212,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1536
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23225,7 +23225,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1548
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23238,7 +23238,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1549
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23251,7 +23251,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1550
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23264,7 +23264,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1551
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23277,7 +23277,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1552
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23290,7 +23290,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1553
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23303,7 +23303,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1554
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23316,7 +23316,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1555
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23329,7 +23329,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1556
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23342,7 +23342,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1557
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23355,7 +23355,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1560
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23368,7 +23368,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1561
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23381,7 +23381,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1562
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23394,7 +23394,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1563
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23407,7 +23407,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1564
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23420,7 +23420,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1565
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23433,7 +23433,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1566
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23446,7 +23446,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1567
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23459,7 +23459,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1568
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23472,7 +23472,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1569
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23485,7 +23485,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1570
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23498,7 +23498,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1571
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23511,7 +23511,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1572
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23524,7 +23524,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1573
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23537,7 +23537,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1574
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23550,7 +23550,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1575
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23563,7 +23563,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1576
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23576,7 +23576,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1577
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23589,7 +23589,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1578
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23602,7 +23602,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1579
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23615,7 +23615,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1580
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23628,7 +23628,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1581
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23641,7 +23641,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1582
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23654,7 +23654,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1583
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23667,7 +23667,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1584
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23680,7 +23680,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1595
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23693,7 +23693,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1596
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23706,7 +23706,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1597
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23719,7 +23719,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1598
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23732,7 +23732,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1599
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23745,7 +23745,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1600
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23758,7 +23758,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1601
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23771,7 +23771,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1602
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23784,7 +23784,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1603
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23797,7 +23797,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1604
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23809,7 +23809,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1616
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23821,7 +23821,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1617
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23833,7 +23833,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1618
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23845,7 +23845,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1619
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23857,7 +23857,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1620
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23869,7 +23869,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1621
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23881,7 +23881,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1622
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23893,7 +23893,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1623
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23905,7 +23905,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1624
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23917,7 +23917,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1625
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23929,7 +23929,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1628
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23941,7 +23941,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1629
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23953,7 +23953,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1630
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23965,7 +23965,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1631
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23977,7 +23977,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1632
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23989,7 +23989,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1633
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24001,7 +24001,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1634
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24013,7 +24013,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1635
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24025,7 +24025,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1636
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24037,7 +24037,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1637
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24049,7 +24049,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1638
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24061,7 +24061,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1639
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24073,7 +24073,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1640
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24085,7 +24085,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1641
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24097,7 +24097,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1642
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24109,7 +24109,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1651
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24121,7 +24121,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1652
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24133,7 +24133,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1653
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24145,7 +24145,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1654
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24157,7 +24157,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1655
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24169,7 +24169,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1656
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24181,7 +24181,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1657
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24193,7 +24193,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1658
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24205,7 +24205,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1659
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24217,7 +24217,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1660
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24229,7 +24229,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1663
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24241,7 +24241,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1664
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24253,7 +24253,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1665
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24265,7 +24265,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1666
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24277,7 +24277,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1667
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24289,7 +24289,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1668
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24301,7 +24301,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1669
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24313,7 +24313,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1670
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24325,7 +24325,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1671
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24337,7 +24337,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1672
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24349,7 +24349,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1673
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24361,7 +24361,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1674
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24373,7 +24373,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1675
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24385,7 +24385,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1676
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24397,7 +24397,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1677
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24411,7 +24411,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1691
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24425,7 +24425,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1692
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24439,7 +24439,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1693
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24453,7 +24453,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1694
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24467,7 +24467,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1695
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24481,7 +24481,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1696
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24495,7 +24495,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1697
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24509,7 +24509,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1698
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24523,7 +24523,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1699
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24537,7 +24537,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1700
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24551,7 +24551,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1703
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24565,7 +24565,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1704
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24579,7 +24579,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1705
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24593,7 +24593,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1706
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24607,7 +24607,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1707
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24621,7 +24621,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1708
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24635,7 +24635,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1709
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24649,7 +24649,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1710
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24663,7 +24663,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1711
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24677,7 +24677,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1712
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24691,7 +24691,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1713
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24705,7 +24705,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1714
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24719,7 +24719,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1715
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24733,7 +24733,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1716
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24747,7 +24747,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1717
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24761,7 +24761,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1718
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24775,7 +24775,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1719
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24789,7 +24789,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1720
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24803,7 +24803,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1721
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24817,7 +24817,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1722
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24831,7 +24831,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1723
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24845,7 +24845,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1732
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24859,7 +24859,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1733
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24873,7 +24873,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1734
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24887,7 +24887,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1735
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24901,7 +24901,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1736
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24915,7 +24915,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1737
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24929,7 +24929,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1738
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24943,7 +24943,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1739
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24957,7 +24957,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1740
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24971,7 +24971,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1741
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24985,7 +24985,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1744
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24999,7 +24999,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1745
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25013,7 +25013,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1746
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25027,7 +25027,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1747
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25041,7 +25041,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1748
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25055,7 +25055,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1749
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25069,7 +25069,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1750
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25083,7 +25083,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1751
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25097,7 +25097,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1752
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25111,7 +25111,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1753
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25125,7 +25125,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1754
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25139,7 +25139,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1755
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25153,7 +25153,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1756
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25167,7 +25167,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1757
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25181,7 +25181,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1758
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25195,7 +25195,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1759
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25209,7 +25209,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1760
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25223,7 +25223,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1761
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25237,7 +25237,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1762
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25250,7 +25250,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1774
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25263,7 +25263,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1775
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25276,7 +25276,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1776
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25289,7 +25289,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1777
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25302,7 +25302,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1778
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25315,7 +25315,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1779
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25328,7 +25328,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1780
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25341,7 +25341,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1781
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25354,7 +25354,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1782
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25367,7 +25367,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1783
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25380,7 +25380,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1786
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25393,7 +25393,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1787
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25406,7 +25406,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1788
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25419,7 +25419,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1789
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25432,7 +25432,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1790
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25445,7 +25445,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1791
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25458,7 +25458,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1792
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25471,7 +25471,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1793
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25483,7 +25483,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1802
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25495,7 +25495,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1803
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25507,7 +25507,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1804
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25519,7 +25519,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1805
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25531,7 +25531,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1806
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25543,7 +25543,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1807
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25555,7 +25555,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1808
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25567,7 +25567,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1809
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25579,7 +25579,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1812
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25591,7 +25591,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1813
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25603,7 +25603,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1814
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25615,7 +25615,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1815
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25627,7 +25627,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1816
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25639,7 +25639,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1817
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25651,7 +25651,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1818
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25663,7 +25663,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1819
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25676,7 +25676,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1831
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25689,7 +25689,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1832
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25702,7 +25702,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1833
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25715,7 +25715,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1834
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25728,7 +25728,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1835
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25741,7 +25741,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1836
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25754,7 +25754,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1837
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25767,7 +25767,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1838
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25780,7 +25780,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1839
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25793,7 +25793,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1840
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25806,7 +25806,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1843
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25819,7 +25819,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1844
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25832,7 +25832,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1845
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25845,7 +25845,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1846
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25858,7 +25858,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1847
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25871,7 +25871,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1848
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25884,7 +25884,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1849
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25897,7 +25897,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1850
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25910,7 +25910,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1859
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25923,7 +25923,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1860
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25936,7 +25936,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1861
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25949,7 +25949,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1862
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25962,7 +25962,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1863
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25975,7 +25975,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1864
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25988,7 +25988,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1865
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26001,7 +26001,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1866
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26014,7 +26014,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1867
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26027,7 +26027,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1868
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26040,7 +26040,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1871
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26053,7 +26053,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1872
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26066,7 +26066,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1873
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26079,7 +26079,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1874
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26092,7 +26092,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1875
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26105,7 +26105,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1876
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26118,7 +26118,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1877
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26131,7 +26131,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1878
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26144,7 +26144,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1890
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26157,7 +26157,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1891
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26170,7 +26170,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1892
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26183,7 +26183,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1893
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26196,7 +26196,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1894
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26209,7 +26209,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1895
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26222,7 +26222,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1896
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26235,7 +26235,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1897
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26248,7 +26248,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1898
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26261,7 +26261,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1899
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26274,7 +26274,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1902
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26287,7 +26287,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1903
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26300,7 +26300,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1904
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26313,7 +26313,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1905
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26326,7 +26326,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1906
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26339,7 +26339,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1907
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26352,7 +26352,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1908
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26365,7 +26365,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1909
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26378,7 +26378,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1918
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26391,7 +26391,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1919
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26404,7 +26404,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1920
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26417,7 +26417,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1921
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26430,7 +26430,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1922
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26443,7 +26443,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1923
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26456,7 +26456,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1924
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26469,7 +26469,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1925
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26482,7 +26482,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1926
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26495,7 +26495,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1927
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26508,7 +26508,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1930
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26521,7 +26521,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1931
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26534,7 +26534,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1932
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26547,7 +26547,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1933
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26560,7 +26560,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1934
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26573,7 +26573,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1935
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26586,7 +26586,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1936
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26599,7 +26599,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1937
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26612,7 +26612,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1938
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26625,7 +26625,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1950
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26638,7 +26638,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1951
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26651,7 +26651,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1952
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26664,7 +26664,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1953
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26677,7 +26677,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1954
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26690,7 +26690,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1955
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26703,7 +26703,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1956
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26716,7 +26716,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1957
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26729,7 +26729,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1958
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26742,7 +26742,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1959
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26755,7 +26755,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1962
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26768,7 +26768,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1963
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26781,7 +26781,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1964
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26794,7 +26794,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1965
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26807,7 +26807,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1966
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26820,7 +26820,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1967
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26833,7 +26833,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1968
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26846,7 +26846,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1969
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26859,7 +26859,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1978
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26872,7 +26872,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1979
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26885,7 +26885,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1980
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26898,7 +26898,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1981
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26911,7 +26911,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1982
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26924,7 +26924,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1983
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26937,7 +26937,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1984
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26950,7 +26950,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1985
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26963,7 +26963,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1986
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26976,7 +26976,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1987
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26989,7 +26989,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1990
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27002,7 +27002,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1991
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27015,7 +27015,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1992
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27028,7 +27028,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1993
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27041,7 +27041,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1994
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27054,7 +27054,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1995
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27067,7 +27067,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1996
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27080,7 +27080,7 @@
    i32.const 0
    i32.const 1040
    i32.const 1997
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27093,7 +27093,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2009
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27106,7 +27106,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2010
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27119,7 +27119,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2011
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27132,7 +27132,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2012
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27145,7 +27145,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2013
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27158,7 +27158,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2014
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27171,7 +27171,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2015
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27184,7 +27184,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2016
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27197,7 +27197,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2017
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27210,7 +27210,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2018
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27223,7 +27223,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2021
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27236,7 +27236,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2022
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27249,7 +27249,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2023
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27262,7 +27262,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2024
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27275,7 +27275,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2025
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27288,7 +27288,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2026
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27301,7 +27301,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2027
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27314,7 +27314,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2028
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27327,7 +27327,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2029
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27340,7 +27340,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2030
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27353,7 +27353,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2031
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27366,7 +27366,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2032
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27379,7 +27379,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2033
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27392,7 +27392,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2034
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27405,7 +27405,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2035
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27418,7 +27418,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2036
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27431,7 +27431,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2037
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27444,7 +27444,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2038
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27457,7 +27457,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2039
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27470,7 +27470,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2040
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27483,7 +27483,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2041
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27496,7 +27496,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2042
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27509,7 +27509,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2043
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27522,7 +27522,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2044
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27535,7 +27535,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2045
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27548,7 +27548,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2046
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27561,7 +27561,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2047
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27574,7 +27574,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2048
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27587,7 +27587,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2049
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27600,7 +27600,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2050
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27613,7 +27613,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2051
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27626,7 +27626,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2052
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27639,7 +27639,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2053
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27652,7 +27652,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2054
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27665,7 +27665,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2055
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27678,7 +27678,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2056
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27691,7 +27691,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2057
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27704,7 +27704,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2058
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27717,7 +27717,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2059
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27730,7 +27730,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2060
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27743,7 +27743,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2061
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27756,7 +27756,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2062
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27769,7 +27769,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2063
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27782,7 +27782,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2064
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27795,7 +27795,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2065
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27808,7 +27808,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2066
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27821,7 +27821,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2067
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27834,7 +27834,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2068
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27847,7 +27847,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2069
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27860,7 +27860,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2070
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27873,7 +27873,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2071
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27886,7 +27886,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2072
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27899,7 +27899,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2073
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27912,7 +27912,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2074
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27925,7 +27925,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2075
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27938,7 +27938,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2076
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27951,7 +27951,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2077
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27964,7 +27964,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2078
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27977,7 +27977,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2087
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27990,7 +27990,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2088
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28003,7 +28003,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2089
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28016,7 +28016,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2090
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28029,7 +28029,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2091
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28042,7 +28042,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2092
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28055,7 +28055,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2093
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28068,7 +28068,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2094
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28081,7 +28081,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2095
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28094,7 +28094,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2096
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28107,7 +28107,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2099
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28120,7 +28120,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2100
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28133,7 +28133,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2101
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28146,7 +28146,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2102
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28159,7 +28159,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2103
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28172,7 +28172,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2104
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28185,7 +28185,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2105
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28198,7 +28198,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2106
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28211,7 +28211,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2107
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28224,7 +28224,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2108
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28237,7 +28237,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2109
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28250,7 +28250,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2110
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28263,7 +28263,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2111
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28276,7 +28276,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2112
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28289,7 +28289,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2113
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28302,7 +28302,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2114
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28315,7 +28315,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2115
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28328,7 +28328,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2116
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28341,7 +28341,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2117
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28354,7 +28354,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2118
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28367,7 +28367,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2119
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28380,7 +28380,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2120
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28393,7 +28393,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2121
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28406,7 +28406,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2122
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28419,7 +28419,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2123
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28432,7 +28432,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2124
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28445,7 +28445,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2125
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28458,7 +28458,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2126
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28471,7 +28471,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2127
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28484,7 +28484,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2128
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28497,7 +28497,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2129
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28510,7 +28510,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2130
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28523,7 +28523,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2131
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28536,7 +28536,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2132
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28549,7 +28549,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2133
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28562,7 +28562,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2134
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28575,7 +28575,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2135
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28588,7 +28588,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2136
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28601,7 +28601,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2137
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28614,7 +28614,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2138
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28627,7 +28627,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2139
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28640,7 +28640,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2140
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28653,7 +28653,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2141
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28666,7 +28666,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2142
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28679,7 +28679,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2143
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28692,7 +28692,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2144
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28705,7 +28705,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2145
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28718,7 +28718,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2146
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28731,7 +28731,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2147
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28744,7 +28744,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2148
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28757,7 +28757,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2149
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28770,7 +28770,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2150
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28783,7 +28783,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2151
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28796,7 +28796,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2152
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28809,7 +28809,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2153
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28822,7 +28822,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2154
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28835,7 +28835,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2155
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28848,7 +28848,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2156
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28861,7 +28861,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2168
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28874,7 +28874,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2169
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28887,7 +28887,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2170
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28900,7 +28900,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2171
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28913,7 +28913,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2172
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28926,7 +28926,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2173
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28939,7 +28939,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2174
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28952,7 +28952,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2175
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28965,7 +28965,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2176
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28978,7 +28978,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2177
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28991,7 +28991,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2180
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29004,7 +29004,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2181
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29017,7 +29017,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2182
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29030,7 +29030,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2183
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29043,7 +29043,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2184
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29056,7 +29056,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2185
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29069,7 +29069,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2186
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29082,7 +29082,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2187
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29095,7 +29095,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2188
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29108,7 +29108,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2189
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29121,7 +29121,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2190
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29134,7 +29134,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2191
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29147,7 +29147,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2192
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29160,7 +29160,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2193
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29173,7 +29173,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2194
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29186,7 +29186,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2195
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29199,7 +29199,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2196
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29212,7 +29212,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2197
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29225,7 +29225,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2198
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29238,7 +29238,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2199
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29251,7 +29251,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2200
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29264,7 +29264,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2201
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29277,7 +29277,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2202
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29290,7 +29290,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2203
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29303,7 +29303,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2204
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29316,7 +29316,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2205
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29329,7 +29329,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2206
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29342,7 +29342,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2207
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29355,7 +29355,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2208
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29368,7 +29368,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2209
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29381,7 +29381,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2210
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29394,7 +29394,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2211
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29407,7 +29407,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2212
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29420,7 +29420,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2213
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29433,7 +29433,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2214
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29446,7 +29446,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2215
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29459,7 +29459,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2216
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29472,7 +29472,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2217
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29485,7 +29485,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2218
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29498,7 +29498,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2219
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29511,7 +29511,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2220
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29524,7 +29524,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2221
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29537,7 +29537,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2222
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29550,7 +29550,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2223
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29563,7 +29563,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2224
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29576,7 +29576,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2225
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29589,7 +29589,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2226
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29602,7 +29602,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2227
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29615,7 +29615,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2228
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29628,7 +29628,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2229
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29641,7 +29641,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2230
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29654,7 +29654,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2231
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29667,7 +29667,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2232
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29680,7 +29680,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2233
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29693,7 +29693,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2234
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29706,7 +29706,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2235
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29719,7 +29719,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2236
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29732,7 +29732,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2237
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29745,7 +29745,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2246
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29758,7 +29758,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2247
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29771,7 +29771,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2248
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29784,7 +29784,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2249
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29797,7 +29797,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2250
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29810,7 +29810,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2251
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29823,7 +29823,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2252
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29836,7 +29836,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2253
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29849,7 +29849,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2254
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29862,7 +29862,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2255
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29875,7 +29875,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2258
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29888,7 +29888,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2259
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29901,7 +29901,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2260
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29914,7 +29914,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2261
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29927,7 +29927,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2262
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29940,7 +29940,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2263
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29953,7 +29953,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2264
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29966,7 +29966,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2265
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29979,7 +29979,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2266
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29992,7 +29992,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2267
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30005,7 +30005,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2268
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30018,7 +30018,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2269
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30031,7 +30031,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2270
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30044,7 +30044,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2271
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30057,7 +30057,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2272
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30070,7 +30070,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2273
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30083,7 +30083,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2274
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30096,7 +30096,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2275
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30109,7 +30109,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2276
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30122,7 +30122,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2277
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30135,7 +30135,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2278
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30148,7 +30148,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2279
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30161,7 +30161,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2280
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30174,7 +30174,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2281
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30187,7 +30187,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2282
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30200,7 +30200,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2283
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30213,7 +30213,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2284
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30226,7 +30226,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2285
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30239,7 +30239,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2286
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30252,7 +30252,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2287
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30265,7 +30265,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2288
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30278,7 +30278,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2289
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30291,7 +30291,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2290
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30304,7 +30304,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2291
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30317,7 +30317,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2292
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30330,7 +30330,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2293
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30343,7 +30343,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2294
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30356,7 +30356,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2295
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30369,7 +30369,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2296
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30382,7 +30382,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2297
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30395,7 +30395,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2298
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30408,7 +30408,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2299
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30421,7 +30421,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2300
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30434,7 +30434,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2301
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30447,7 +30447,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2302
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30460,7 +30460,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2303
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30473,7 +30473,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2304
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30486,7 +30486,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2305
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30499,7 +30499,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2306
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30512,7 +30512,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2307
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30525,7 +30525,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2308
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30538,7 +30538,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2309
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30551,7 +30551,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2310
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30564,7 +30564,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2311
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30577,7 +30577,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2312
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30590,7 +30590,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2313
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30603,7 +30603,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2314
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30616,7 +30616,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2315
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30629,7 +30629,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2329
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30642,7 +30642,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2330
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30655,7 +30655,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2331
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30668,7 +30668,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2332
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30681,7 +30681,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2333
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30694,7 +30694,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2334
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30707,7 +30707,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2335
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30720,7 +30720,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2336
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30733,7 +30733,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2337
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30746,7 +30746,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2338
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30759,7 +30759,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2341
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30772,7 +30772,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2342
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30785,7 +30785,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2343
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30798,7 +30798,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2344
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30811,7 +30811,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2345
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30824,7 +30824,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2346
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30837,7 +30837,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2347
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30850,7 +30850,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2348
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30863,7 +30863,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2349
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30876,7 +30876,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2350
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30889,7 +30889,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2351
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30902,7 +30902,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2352
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30915,7 +30915,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2353
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30928,7 +30928,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2354
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30941,7 +30941,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2355
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30954,7 +30954,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2356
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30967,7 +30967,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2357
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30980,7 +30980,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2358
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30993,7 +30993,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2359
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31006,7 +31006,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2360
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31019,7 +31019,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2361
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31032,7 +31032,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2362
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31045,7 +31045,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2363
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31058,7 +31058,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2364
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31071,7 +31071,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2365
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31084,7 +31084,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2366
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31097,7 +31097,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2367
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31110,7 +31110,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2368
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31123,7 +31123,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2369
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31136,7 +31136,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2370
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31149,7 +31149,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2371
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31162,7 +31162,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2372
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31175,7 +31175,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2373
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31188,7 +31188,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2374
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31201,7 +31201,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2375
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31214,7 +31214,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2376
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31227,7 +31227,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2377
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31240,7 +31240,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2378
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31253,7 +31253,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2379
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31266,7 +31266,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2380
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31279,7 +31279,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2381
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31292,7 +31292,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2382
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31305,7 +31305,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2383
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31318,7 +31318,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2384
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31331,7 +31331,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2385
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31344,7 +31344,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2386
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31357,7 +31357,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2387
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31370,7 +31370,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2388
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31383,7 +31383,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2389
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31396,7 +31396,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2390
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31409,7 +31409,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2391
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31422,7 +31422,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2392
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31435,7 +31435,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2393
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31448,7 +31448,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2394
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31461,7 +31461,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2395
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31474,7 +31474,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2396
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31487,7 +31487,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2397
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31500,7 +31500,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2398
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31513,7 +31513,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2399
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31526,7 +31526,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2400
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31539,7 +31539,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2401
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31552,7 +31552,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2402
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31565,7 +31565,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2403
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31578,7 +31578,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2404
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31591,7 +31591,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2405
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31604,7 +31604,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2406
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31617,7 +31617,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2409
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31630,7 +31630,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2410
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31643,7 +31643,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2411
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31656,7 +31656,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2412
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31669,7 +31669,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2413
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31682,7 +31682,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2414
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31695,7 +31695,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2415
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31708,7 +31708,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2416
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31721,7 +31721,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2419
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31734,7 +31734,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2420
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31747,7 +31747,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2421
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31760,7 +31760,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2422
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31773,7 +31773,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2423
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31786,7 +31786,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2424
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31799,7 +31799,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2425
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31812,7 +31812,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2426
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31825,7 +31825,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2429
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31838,7 +31838,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2430
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31851,7 +31851,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2432
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31864,7 +31864,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2433
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31877,7 +31877,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2435
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31890,7 +31890,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2436
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31903,7 +31903,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2438
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31916,7 +31916,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2439
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31929,7 +31929,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2441
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31942,7 +31942,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2442
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31955,7 +31955,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2444
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31968,7 +31968,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2445
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31981,7 +31981,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2447
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31994,7 +31994,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2448
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32007,7 +32007,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2450
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32020,7 +32020,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2451
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32033,7 +32033,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2453
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32046,7 +32046,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2454
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32059,7 +32059,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2456
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32072,7 +32072,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2457
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32085,7 +32085,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2458
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32098,7 +32098,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2459
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32111,7 +32111,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2460
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32124,7 +32124,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2461
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32137,7 +32137,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2462
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32150,7 +32150,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2463
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32163,7 +32163,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2465
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32176,7 +32176,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2466
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32189,7 +32189,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2467
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32202,7 +32202,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2468
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32215,7 +32215,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2469
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32228,7 +32228,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2470
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32241,7 +32241,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2471
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32254,7 +32254,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2472
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32267,7 +32267,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2473
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32280,7 +32280,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2474
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32293,7 +32293,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2475
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32306,7 +32306,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2476
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32319,7 +32319,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2477
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32332,7 +32332,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2478
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32345,7 +32345,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2479
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32358,7 +32358,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2480
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32371,7 +32371,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2481
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32384,7 +32384,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2482
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32397,7 +32397,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2483
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32410,7 +32410,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2484
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32423,7 +32423,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2493
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32436,7 +32436,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2494
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32449,7 +32449,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2495
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32462,7 +32462,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2496
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32475,7 +32475,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2497
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32488,7 +32488,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2498
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32501,7 +32501,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2499
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32514,7 +32514,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2500
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32527,7 +32527,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2501
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32540,7 +32540,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2502
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32553,7 +32553,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2505
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32566,7 +32566,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2506
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32579,7 +32579,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2507
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32592,7 +32592,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2508
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32605,7 +32605,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2509
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32618,7 +32618,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2510
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32631,7 +32631,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2511
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32644,7 +32644,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2512
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32657,7 +32657,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2513
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32670,7 +32670,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2514
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32683,7 +32683,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2515
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32696,7 +32696,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2516
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32709,7 +32709,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2517
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32722,7 +32722,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2518
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32735,7 +32735,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2519
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32748,7 +32748,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2520
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32761,7 +32761,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2521
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32774,7 +32774,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2522
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32787,7 +32787,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2523
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32800,7 +32800,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2524
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32813,7 +32813,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2525
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32826,7 +32826,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2526
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32839,7 +32839,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2527
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32852,7 +32852,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2528
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32865,7 +32865,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2529
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32878,7 +32878,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2530
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32891,7 +32891,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2531
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32904,7 +32904,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2532
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32917,7 +32917,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2533
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32930,7 +32930,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2534
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32943,7 +32943,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2535
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32956,7 +32956,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2536
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32969,7 +32969,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2537
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32982,7 +32982,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2538
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32995,7 +32995,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2539
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33008,7 +33008,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2540
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33021,7 +33021,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2541
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33034,7 +33034,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2542
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33047,7 +33047,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2543
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33060,7 +33060,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2544
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33073,7 +33073,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2545
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33086,7 +33086,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2546
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33099,7 +33099,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2547
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33112,7 +33112,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2548
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33125,7 +33125,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2549
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33138,7 +33138,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2550
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33151,7 +33151,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2551
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33164,7 +33164,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2552
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33177,7 +33177,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2553
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33190,7 +33190,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2554
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33203,7 +33203,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2555
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33216,7 +33216,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2556
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33229,7 +33229,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2557
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33242,7 +33242,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2558
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33255,7 +33255,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2559
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33268,7 +33268,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2560
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33281,7 +33281,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2561
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33294,7 +33294,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2562
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33307,7 +33307,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2563
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33320,7 +33320,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2564
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33333,7 +33333,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2565
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33346,7 +33346,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2566
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33359,7 +33359,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2567
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33372,7 +33372,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2568
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33385,7 +33385,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2569
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33398,7 +33398,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2570
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33412,7 +33412,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2582
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33426,7 +33426,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2583
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33440,7 +33440,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2584
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33454,7 +33454,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2585
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33468,7 +33468,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2586
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33482,7 +33482,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2587
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33496,7 +33496,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2588
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33510,7 +33510,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2589
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33524,7 +33524,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2590
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33538,7 +33538,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2591
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33552,7 +33552,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2594
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33566,7 +33566,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2595
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33580,7 +33580,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2596
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33594,7 +33594,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2597
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33608,7 +33608,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2598
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33622,7 +33622,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2599
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33636,7 +33636,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2600
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33650,7 +33650,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2601
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33664,7 +33664,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2602
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33678,7 +33678,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2603
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33692,7 +33692,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2604
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33706,7 +33706,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2605
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33720,7 +33720,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2606
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33734,7 +33734,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2607
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33748,7 +33748,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2608
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33762,7 +33762,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2609
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33776,7 +33776,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2610
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33790,7 +33790,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2611
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33804,7 +33804,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2612
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33818,7 +33818,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2613
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33832,7 +33832,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2614
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33846,7 +33846,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2615
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33860,7 +33860,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2616
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33874,7 +33874,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2617
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33888,7 +33888,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2618
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33902,7 +33902,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2619
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33916,7 +33916,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2620
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33930,7 +33930,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2621
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33944,7 +33944,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2622
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33958,7 +33958,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2623
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33972,7 +33972,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2624
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33986,7 +33986,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2625
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34000,7 +34000,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2626
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34014,7 +34014,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2627
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34028,7 +34028,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2628
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34042,7 +34042,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2629
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34056,7 +34056,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2630
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34070,7 +34070,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2631
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34084,7 +34084,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2632
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34098,7 +34098,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2633
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34112,7 +34112,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2634
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34126,7 +34126,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2635
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34140,7 +34140,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2636
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34154,7 +34154,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2637
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34168,7 +34168,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2638
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34182,7 +34182,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2639
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34196,7 +34196,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2640
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34210,7 +34210,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2641
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34224,7 +34224,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2642
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34238,7 +34238,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2643
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34252,7 +34252,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2644
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34266,7 +34266,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2645
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34280,7 +34280,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2646
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34294,7 +34294,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2647
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34308,7 +34308,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2648
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34322,7 +34322,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2649
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34336,7 +34336,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2650
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34350,7 +34350,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2651
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34364,7 +34364,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2652
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34378,7 +34378,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2653
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34392,7 +34392,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2654
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34406,7 +34406,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2655
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34420,7 +34420,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2656
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34434,7 +34434,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2657
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34448,7 +34448,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2658
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34462,7 +34462,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2659
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34476,7 +34476,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2660
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34490,7 +34490,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2661
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34504,7 +34504,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2662
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34518,7 +34518,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2663
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34532,7 +34532,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2664
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34546,7 +34546,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2665
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34560,7 +34560,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2666
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34574,7 +34574,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2667
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34588,7 +34588,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2668
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34602,7 +34602,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2669
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34616,7 +34616,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2670
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34630,7 +34630,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2671
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34644,7 +34644,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2672
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34658,7 +34658,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2673
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34672,7 +34672,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2674
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34686,7 +34686,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2675
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34700,7 +34700,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2676
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34714,7 +34714,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2677
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34728,7 +34728,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2678
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34742,7 +34742,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2679
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34756,7 +34756,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2680
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34770,7 +34770,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2681
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34784,7 +34784,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2682
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34798,7 +34798,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2683
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34812,7 +34812,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2684
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34826,7 +34826,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2685
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34839,7 +34839,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2688
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34852,7 +34852,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2689
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34865,7 +34865,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2690
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34878,7 +34878,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2691
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34891,7 +34891,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2692
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34904,7 +34904,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2693
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34917,7 +34917,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2694
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34930,7 +34930,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2695
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34943,7 +34943,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2697
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34956,7 +34956,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2698
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34969,7 +34969,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2699
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34982,7 +34982,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2700
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34995,7 +34995,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2701
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35009,7 +35009,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2702
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35022,7 +35022,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2704
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35035,7 +35035,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2705
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35048,7 +35048,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2706
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35061,7 +35061,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2707
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35074,7 +35074,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2708
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35087,7 +35087,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2709
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35100,7 +35100,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2710
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35114,7 +35114,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2711
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35127,7 +35127,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2713
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35140,7 +35140,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2714
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35153,7 +35153,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2715
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35166,7 +35166,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2716
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35179,7 +35179,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2717
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35192,7 +35192,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2718
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35205,7 +35205,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2719
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35219,7 +35219,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2720
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35232,7 +35232,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2722
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35245,7 +35245,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2723
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35259,7 +35259,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2724
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35272,7 +35272,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2725
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35285,7 +35285,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2726
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35298,7 +35298,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2727
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35311,7 +35311,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2728
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35325,7 +35325,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2729
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35339,7 +35339,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2738
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35353,7 +35353,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2739
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35367,7 +35367,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2740
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35381,7 +35381,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2741
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35395,7 +35395,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2742
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35409,7 +35409,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2743
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35423,7 +35423,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2744
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35437,7 +35437,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2745
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35451,7 +35451,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2746
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35465,7 +35465,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2747
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35479,7 +35479,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2750
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35493,7 +35493,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2751
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35507,7 +35507,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2752
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35521,7 +35521,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2753
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35535,7 +35535,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2754
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35549,7 +35549,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2755
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35563,7 +35563,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2756
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35577,7 +35577,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2757
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35591,7 +35591,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2758
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35605,7 +35605,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2759
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35619,7 +35619,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2760
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35633,7 +35633,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2761
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35647,7 +35647,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2762
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35661,7 +35661,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2763
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35675,7 +35675,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2764
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35689,7 +35689,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2765
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35703,7 +35703,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2766
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35717,7 +35717,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2767
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35731,7 +35731,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2768
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35745,7 +35745,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2769
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35759,7 +35759,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2770
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35773,7 +35773,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2771
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35787,7 +35787,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2772
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35801,7 +35801,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2773
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35815,7 +35815,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2774
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35829,7 +35829,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2775
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35843,7 +35843,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2776
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35857,7 +35857,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2777
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35871,7 +35871,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2778
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35885,7 +35885,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2779
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35899,7 +35899,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2780
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35913,7 +35913,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2781
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35927,7 +35927,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2782
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35941,7 +35941,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2783
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35955,7 +35955,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2784
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35969,7 +35969,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2785
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35983,7 +35983,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2786
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35997,7 +35997,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2787
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36011,7 +36011,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2788
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36025,7 +36025,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2789
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36039,7 +36039,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2790
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36053,7 +36053,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2791
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36067,7 +36067,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2792
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36081,7 +36081,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2793
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36095,7 +36095,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2794
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36109,7 +36109,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2795
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36123,7 +36123,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2796
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36137,7 +36137,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2797
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36151,7 +36151,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2798
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36165,7 +36165,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2799
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36179,7 +36179,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2800
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36193,7 +36193,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2801
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36207,7 +36207,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2802
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36221,7 +36221,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2803
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36235,7 +36235,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2804
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36249,7 +36249,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2805
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36263,7 +36263,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2806
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36277,7 +36277,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2807
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36291,7 +36291,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2808
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36305,7 +36305,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2809
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36319,7 +36319,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2810
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36333,7 +36333,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2811
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36347,7 +36347,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2812
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36361,7 +36361,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2813
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36375,7 +36375,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2814
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36389,7 +36389,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2815
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36403,7 +36403,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2816
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36417,7 +36417,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2817
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36431,7 +36431,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2818
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36445,7 +36445,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2819
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36459,7 +36459,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2820
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36473,7 +36473,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2821
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36487,7 +36487,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2822
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36501,7 +36501,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2823
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36515,7 +36515,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2824
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36529,7 +36529,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2825
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36543,7 +36543,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2826
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36557,7 +36557,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2827
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36571,7 +36571,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2828
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36585,7 +36585,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2829
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36599,7 +36599,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2830
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36613,7 +36613,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2831
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36627,7 +36627,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2832
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36641,7 +36641,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2833
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36655,7 +36655,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2834
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36669,7 +36669,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2835
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36683,7 +36683,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2836
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36697,7 +36697,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2837
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36711,7 +36711,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2838
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36725,7 +36725,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2839
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36739,7 +36739,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2840
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36753,7 +36753,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2841
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36816,7 +36816,7 @@
      i32.const 0
      i32.const 1040
      i32.const 2850
-     i32.const 2
+     i32.const 3
      call $~lib/builtins/abort
      unreachable
     end
@@ -36890,7 +36890,7 @@
      i32.const 0
      i32.const 1040
      i32.const 2858
-     i32.const 2
+     i32.const 3
      call $~lib/builtins/abort
      unreachable
     end
@@ -36909,7 +36909,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2872
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36921,7 +36921,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2873
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36933,7 +36933,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2874
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36945,7 +36945,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2875
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36957,7 +36957,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2876
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36969,7 +36969,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2877
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36981,7 +36981,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2878
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36993,7 +36993,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2879
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37005,7 +37005,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2880
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37017,7 +37017,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2881
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37029,7 +37029,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2884
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37041,7 +37041,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2885
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37053,7 +37053,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2886
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37065,7 +37065,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2887
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37077,7 +37077,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2888
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37089,7 +37089,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2889
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37101,7 +37101,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2890
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37113,7 +37113,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2891
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37125,7 +37125,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2892
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37137,7 +37137,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2893
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37149,7 +37149,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2894
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37161,7 +37161,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2895
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37173,7 +37173,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2896
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37185,7 +37185,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2897
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37197,7 +37197,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2898
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37209,7 +37209,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2899
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37221,7 +37221,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2900
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37233,7 +37233,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2909
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37245,7 +37245,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2910
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37257,7 +37257,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2911
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37269,7 +37269,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2912
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37281,7 +37281,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2913
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37293,7 +37293,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2914
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37305,7 +37305,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2915
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37317,7 +37317,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2916
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37329,7 +37329,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2917
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37341,7 +37341,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2918
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37353,7 +37353,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2921
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37365,7 +37365,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2922
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37377,7 +37377,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2923
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37389,7 +37389,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2924
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37401,7 +37401,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2925
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37413,7 +37413,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2926
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37425,7 +37425,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2927
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37437,7 +37437,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2928
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37449,7 +37449,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2929
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37461,7 +37461,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2930
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37473,7 +37473,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2931
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37485,7 +37485,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2932
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37497,7 +37497,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2933
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37509,7 +37509,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2934
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37521,7 +37521,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2935
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37533,7 +37533,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2936
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37545,7 +37545,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2937
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37557,7 +37557,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2948
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37569,7 +37569,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2949
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37581,7 +37581,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2950
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37593,7 +37593,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2951
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37605,7 +37605,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2952
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37617,7 +37617,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2953
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37629,7 +37629,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2954
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37641,7 +37641,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2955
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37653,7 +37653,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2956
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37665,7 +37665,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2964
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37677,7 +37677,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2965
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37689,7 +37689,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2966
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37701,7 +37701,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2967
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37713,7 +37713,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2968
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37725,7 +37725,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2969
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37737,7 +37737,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2970
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37749,7 +37749,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2971
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37761,7 +37761,7 @@
    i32.const 0
    i32.const 1040
    i32.const 2972
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37774,7 +37774,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3009
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37787,7 +37787,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3010
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37800,7 +37800,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3011
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37813,7 +37813,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3012
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37826,7 +37826,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3013
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37839,7 +37839,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3014
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37852,7 +37852,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3015
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37865,7 +37865,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3016
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37878,7 +37878,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3017
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37891,7 +37891,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3018
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37904,7 +37904,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3021
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37917,7 +37917,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3022
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37930,7 +37930,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3023
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37943,7 +37943,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3024
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37956,7 +37956,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3025
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37969,7 +37969,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3026
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37982,7 +37982,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3027
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37995,7 +37995,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3028
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38008,7 +38008,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3029
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38021,7 +38021,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3030
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38034,7 +38034,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3031
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38047,7 +38047,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3032
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38060,7 +38060,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3033
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38073,7 +38073,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3034
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38086,7 +38086,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3035
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38099,7 +38099,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3036
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38112,7 +38112,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3037
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38125,7 +38125,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3038
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38138,7 +38138,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3039
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38151,7 +38151,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3040
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38164,7 +38164,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3041
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38177,7 +38177,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3042
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38190,7 +38190,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3043
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38203,7 +38203,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3044
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38216,7 +38216,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3045
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38229,7 +38229,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3046
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38242,7 +38242,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3047
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38255,7 +38255,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3048
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38268,7 +38268,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3049
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38281,7 +38281,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3050
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38294,7 +38294,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3051
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38307,7 +38307,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3052
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38320,7 +38320,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3053
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38333,7 +38333,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3054
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38346,7 +38346,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3055
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38359,7 +38359,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3056
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38372,7 +38372,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3057
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38385,7 +38385,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3058
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38398,7 +38398,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3059
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38411,7 +38411,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3060
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38424,7 +38424,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3061
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38437,7 +38437,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3062
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38450,7 +38450,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3063
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38463,7 +38463,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3064
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38476,7 +38476,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3065
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38489,7 +38489,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3066
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38502,7 +38502,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3067
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38515,7 +38515,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3068
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38528,7 +38528,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3069
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38541,7 +38541,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3070
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38554,7 +38554,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3071
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38567,7 +38567,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3072
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38580,7 +38580,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3073
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38593,7 +38593,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3074
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38606,7 +38606,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3075
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38619,7 +38619,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3076
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38632,7 +38632,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3077
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38645,7 +38645,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3078
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38658,7 +38658,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3079
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38671,7 +38671,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3080
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38684,7 +38684,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3081
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38697,7 +38697,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3082
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38710,7 +38710,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3083
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38723,7 +38723,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3084
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38736,7 +38736,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3085
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38749,7 +38749,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3086
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38762,7 +38762,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3087
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38775,7 +38775,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3096
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38788,7 +38788,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3097
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38801,7 +38801,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3098
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38814,7 +38814,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3099
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38827,7 +38827,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3100
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38840,7 +38840,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3101
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38853,7 +38853,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3102
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38866,7 +38866,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3103
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38879,7 +38879,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3104
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38892,7 +38892,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3105
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38905,7 +38905,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3108
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38918,7 +38918,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3109
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38931,7 +38931,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3110
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38944,7 +38944,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3111
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38957,7 +38957,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3112
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38970,7 +38970,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3113
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38983,7 +38983,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3114
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38996,7 +38996,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3115
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39009,7 +39009,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3116
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39022,7 +39022,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3117
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39035,7 +39035,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3118
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39048,7 +39048,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3119
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39061,7 +39061,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3120
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39074,7 +39074,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3121
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39087,7 +39087,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3122
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39100,7 +39100,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3123
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39113,7 +39113,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3124
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39126,7 +39126,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3125
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39139,7 +39139,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3126
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39152,7 +39152,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3127
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39165,7 +39165,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3128
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39178,7 +39178,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3129
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39191,7 +39191,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3130
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39204,7 +39204,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3131
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39217,7 +39217,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3132
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39230,7 +39230,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3133
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39243,7 +39243,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3134
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39256,7 +39256,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3135
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39269,7 +39269,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3136
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39282,7 +39282,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3137
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39295,7 +39295,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3138
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39308,7 +39308,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3139
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39321,7 +39321,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3140
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39334,7 +39334,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3141
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39347,7 +39347,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3142
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39360,7 +39360,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3143
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39373,7 +39373,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3144
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39386,7 +39386,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3145
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39399,7 +39399,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3146
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39412,7 +39412,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3147
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39425,7 +39425,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3148
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39438,7 +39438,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3149
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39451,7 +39451,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3150
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39464,7 +39464,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3151
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39477,7 +39477,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3152
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39490,7 +39490,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3153
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39503,7 +39503,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3154
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39516,7 +39516,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3155
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39529,7 +39529,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3156
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39542,7 +39542,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3157
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39555,7 +39555,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3158
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39568,7 +39568,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3159
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39581,7 +39581,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3160
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39594,7 +39594,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3161
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39607,7 +39607,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3162
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39620,7 +39620,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3163
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39633,7 +39633,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3164
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39646,7 +39646,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3165
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39659,7 +39659,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3166
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39672,7 +39672,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3167
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39685,7 +39685,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3168
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39698,7 +39698,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3169
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39711,7 +39711,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3170
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39724,7 +39724,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3171
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39737,7 +39737,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3172
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39750,7 +39750,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3173
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39763,7 +39763,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3174
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39776,7 +39776,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3186
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39789,7 +39789,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3187
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39802,7 +39802,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3188
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39815,7 +39815,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3189
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39828,7 +39828,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3190
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39841,7 +39841,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3191
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39854,7 +39854,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3192
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39867,7 +39867,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3193
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39880,7 +39880,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3194
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39893,7 +39893,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3195
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39906,7 +39906,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3198
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39919,7 +39919,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3199
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39932,7 +39932,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3200
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39945,7 +39945,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3201
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39958,7 +39958,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3202
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39971,7 +39971,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3203
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39984,7 +39984,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3204
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39997,7 +39997,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3205
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40010,7 +40010,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3206
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40023,7 +40023,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3207
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40036,7 +40036,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3208
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40049,7 +40049,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3209
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40062,7 +40062,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3210
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40075,7 +40075,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3211
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40088,7 +40088,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3212
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40101,7 +40101,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3213
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40114,7 +40114,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3214
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40127,7 +40127,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3215
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40140,7 +40140,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3216
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40153,7 +40153,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3217
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40166,7 +40166,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3218
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40179,7 +40179,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3219
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40192,7 +40192,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3220
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40205,7 +40205,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3221
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40218,7 +40218,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3222
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40231,7 +40231,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3223
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40244,7 +40244,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3224
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40257,7 +40257,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3225
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40270,7 +40270,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3226
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40283,7 +40283,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3227
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40296,7 +40296,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3228
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40309,7 +40309,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3229
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40322,7 +40322,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3230
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40335,7 +40335,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3231
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40348,7 +40348,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3232
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40361,7 +40361,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3233
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40374,7 +40374,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3234
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40387,7 +40387,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3237
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40400,7 +40400,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3238
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40413,7 +40413,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3239
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40426,7 +40426,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3240
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40439,7 +40439,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3241
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40452,7 +40452,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3244
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40465,7 +40465,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3245
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40477,7 +40477,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3248
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40489,7 +40489,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3249
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40501,7 +40501,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3251
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40513,7 +40513,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3252
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40525,7 +40525,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3255
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40537,7 +40537,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3256
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40549,7 +40549,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3257
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40561,7 +40561,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3258
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40573,7 +40573,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3260
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40585,7 +40585,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3261
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40597,7 +40597,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3263
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40609,7 +40609,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3264
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40621,7 +40621,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3265
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40633,7 +40633,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3266
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40645,7 +40645,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3267
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40657,7 +40657,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3270
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40669,7 +40669,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3271
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40682,7 +40682,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3280
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40695,7 +40695,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3281
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40708,7 +40708,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3282
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40721,7 +40721,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3283
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40734,7 +40734,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3284
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40747,7 +40747,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3285
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40760,7 +40760,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3286
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40773,7 +40773,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3287
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40786,7 +40786,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3288
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40799,7 +40799,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3289
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40812,7 +40812,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3292
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40825,7 +40825,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3293
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40838,7 +40838,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3294
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40851,7 +40851,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3295
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40864,7 +40864,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3296
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40877,7 +40877,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3299
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40890,7 +40890,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3300
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40903,7 +40903,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3301
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40916,7 +40916,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3302
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40929,7 +40929,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3303
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40942,7 +40942,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3304
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40955,7 +40955,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3305
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40968,7 +40968,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3306
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40981,7 +40981,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3307
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40994,7 +40994,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3308
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41007,7 +41007,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3309
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41020,7 +41020,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3310
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41033,7 +41033,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3311
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41046,7 +41046,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3312
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41059,7 +41059,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3313
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41072,7 +41072,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3314
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41085,7 +41085,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3315
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41098,7 +41098,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3316
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41111,7 +41111,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3317
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41124,7 +41124,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3318
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41137,7 +41137,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3319
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41150,7 +41150,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3320
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41163,7 +41163,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3321
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41176,7 +41176,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3322
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41189,7 +41189,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3323
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41202,7 +41202,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3324
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41215,7 +41215,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3325
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41228,7 +41228,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3326
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41241,7 +41241,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3327
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41254,7 +41254,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3328
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41267,7 +41267,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3329
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41280,7 +41280,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3330
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41293,7 +41293,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3331
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41306,7 +41306,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3332
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41319,7 +41319,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3333
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41332,7 +41332,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3334
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41345,7 +41345,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3335
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41358,7 +41358,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3336
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41371,7 +41371,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3339
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41384,7 +41384,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3340
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41397,7 +41397,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3341
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41410,7 +41410,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3342
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41423,7 +41423,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3343
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41436,7 +41436,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3344
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41449,7 +41449,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3345
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41462,7 +41462,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3346
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41475,7 +41475,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3347
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41488,7 +41488,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3348
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41501,7 +41501,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3349
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41514,7 +41514,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3350
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41527,7 +41527,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3351
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41540,7 +41540,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3352
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41553,7 +41553,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3364
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41566,7 +41566,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3365
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41579,7 +41579,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3366
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41592,7 +41592,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3367
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41605,7 +41605,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3368
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41618,7 +41618,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3369
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41631,7 +41631,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3370
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41644,7 +41644,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3371
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41657,7 +41657,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3372
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41670,7 +41670,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3373
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41683,7 +41683,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3376
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41696,7 +41696,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3377
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41709,7 +41709,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3378
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41722,7 +41722,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3379
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41735,7 +41735,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3380
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41748,7 +41748,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3389
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41761,7 +41761,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3390
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41774,7 +41774,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3391
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41787,7 +41787,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3392
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41800,7 +41800,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3393
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41813,7 +41813,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3394
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41826,7 +41826,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3395
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41839,7 +41839,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3396
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41852,7 +41852,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3397
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41865,7 +41865,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3398
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41878,7 +41878,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3401
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41891,7 +41891,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3402
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41904,7 +41904,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3403
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41917,7 +41917,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3404
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41930,7 +41930,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3405
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41943,7 +41943,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3417
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41956,7 +41956,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3418
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41969,7 +41969,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3419
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41982,7 +41982,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3420
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41995,7 +41995,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3421
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42008,7 +42008,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3422
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42021,7 +42021,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3423
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42034,7 +42034,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3424
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42047,7 +42047,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3425
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42060,7 +42060,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3426
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42073,7 +42073,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3429
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42086,7 +42086,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3430
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42099,7 +42099,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3431
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42112,7 +42112,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3432
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42125,7 +42125,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3433
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42138,7 +42138,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3434
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42151,7 +42151,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3435
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42164,7 +42164,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3436
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42177,7 +42177,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3437
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42190,7 +42190,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3438
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42203,7 +42203,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3439
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42216,7 +42216,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3440
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42229,7 +42229,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3441
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42242,7 +42242,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3442
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42255,7 +42255,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3443
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42268,7 +42268,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3444
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42281,7 +42281,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3445
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42294,7 +42294,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3446
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42307,7 +42307,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3447
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42320,7 +42320,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3448
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42333,7 +42333,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3449
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42346,7 +42346,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3450
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42359,7 +42359,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3451
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42372,7 +42372,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3452
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42385,7 +42385,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3453
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42398,7 +42398,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3454
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42411,7 +42411,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3455
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42424,7 +42424,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3456
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42437,7 +42437,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3457
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42450,7 +42450,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3458
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42463,7 +42463,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3459
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42476,7 +42476,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3460
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42489,7 +42489,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3461
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42502,7 +42502,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3462
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42515,7 +42515,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3463
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42528,7 +42528,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3464
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42541,7 +42541,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3465
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42554,7 +42554,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3466
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42567,7 +42567,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3467
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42580,7 +42580,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3468
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42593,7 +42593,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3469
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42606,7 +42606,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3470
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42619,7 +42619,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3471
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42632,7 +42632,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3472
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42645,7 +42645,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3473
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42658,7 +42658,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3474
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42671,7 +42671,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3475
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42684,7 +42684,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3476
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42697,7 +42697,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3477
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42710,7 +42710,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3478
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42723,7 +42723,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3479
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42736,7 +42736,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3480
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42749,7 +42749,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3481
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42762,7 +42762,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3482
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42775,7 +42775,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3483
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42788,7 +42788,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3484
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42801,7 +42801,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3485
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42814,7 +42814,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3486
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42827,7 +42827,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3487
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42840,7 +42840,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3488
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42853,7 +42853,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3489
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42866,7 +42866,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3490
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42879,7 +42879,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3491
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42892,7 +42892,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3492
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42905,7 +42905,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3493
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42918,7 +42918,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3494
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42931,7 +42931,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3495
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42944,7 +42944,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3496
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42957,7 +42957,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3497
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42970,7 +42970,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3498
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42983,7 +42983,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3499
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42996,7 +42996,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3500
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43009,7 +43009,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3501
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43022,7 +43022,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3502
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43035,7 +43035,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3511
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43048,7 +43048,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3512
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43061,7 +43061,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3513
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43074,7 +43074,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3514
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43087,7 +43087,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3515
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43100,7 +43100,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3516
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43113,7 +43113,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3517
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43126,7 +43126,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3518
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43139,7 +43139,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3519
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43152,7 +43152,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3520
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43165,7 +43165,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3523
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43178,7 +43178,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3524
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43191,7 +43191,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3525
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43204,7 +43204,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3526
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43217,7 +43217,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3527
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43230,7 +43230,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3528
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43243,7 +43243,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3529
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43256,7 +43256,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3530
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43269,7 +43269,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3531
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43282,7 +43282,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3532
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43295,7 +43295,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3533
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43308,7 +43308,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3534
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43321,7 +43321,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3535
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43334,7 +43334,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3536
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43347,7 +43347,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3537
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43360,7 +43360,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3538
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43373,7 +43373,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3539
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43386,7 +43386,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3540
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43399,7 +43399,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3541
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43412,7 +43412,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3542
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43425,7 +43425,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3543
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43438,7 +43438,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3544
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43451,7 +43451,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3556
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43464,7 +43464,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3557
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43477,7 +43477,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3558
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43490,7 +43490,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3559
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43503,7 +43503,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3560
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43516,7 +43516,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3561
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43529,7 +43529,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3562
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43542,7 +43542,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3563
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43555,7 +43555,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3564
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43568,7 +43568,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3565
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43581,7 +43581,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3568
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43594,7 +43594,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3569
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43607,7 +43607,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3570
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43620,7 +43620,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3571
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43633,7 +43633,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3572
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43646,7 +43646,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3573
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43659,7 +43659,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3574
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43672,7 +43672,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3575
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43685,7 +43685,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3576
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43698,7 +43698,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3577
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43711,7 +43711,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3578
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43724,7 +43724,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3579
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43737,7 +43737,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3580
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43750,7 +43750,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3581
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43763,7 +43763,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3582
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43776,7 +43776,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3583
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43789,7 +43789,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3584
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43802,7 +43802,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3585
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43815,7 +43815,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3586
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43828,7 +43828,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3587
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43841,7 +43841,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3588
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43854,7 +43854,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3589
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43867,7 +43867,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3590
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43880,7 +43880,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3591
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43893,7 +43893,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3592
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43906,7 +43906,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3593
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43919,7 +43919,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3594
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43932,7 +43932,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3595
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43945,7 +43945,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3596
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43958,7 +43958,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3597
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43971,7 +43971,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3598
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43984,7 +43984,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3599
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43997,7 +43997,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3600
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44010,7 +44010,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3601
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44023,7 +44023,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3602
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44036,7 +44036,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3603
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44049,7 +44049,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3604
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44062,7 +44062,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3605
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44075,7 +44075,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3608
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44088,7 +44088,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3609
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44101,7 +44101,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3610
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44114,7 +44114,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3611
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44127,7 +44127,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3612
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44140,7 +44140,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3613
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44153,7 +44153,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3614
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44166,7 +44166,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3615
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44179,7 +44179,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3617
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44192,7 +44192,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3618
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44205,7 +44205,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3619
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44218,7 +44218,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3620
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44231,7 +44231,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3621
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44244,7 +44244,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3622
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44257,7 +44257,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3623
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44270,7 +44270,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3624
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44283,7 +44283,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3627
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44296,7 +44296,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3628
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44309,7 +44309,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3629
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44322,7 +44322,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3630
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44335,7 +44335,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3631
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44348,7 +44348,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3640
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44361,7 +44361,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3641
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44374,7 +44374,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3642
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44387,7 +44387,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3643
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44400,7 +44400,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3644
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44413,7 +44413,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3645
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44426,7 +44426,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3646
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44439,7 +44439,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3647
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44452,7 +44452,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3648
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44465,7 +44465,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3649
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44478,7 +44478,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3652
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44491,7 +44491,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3653
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44504,7 +44504,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3654
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44517,7 +44517,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3655
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44530,7 +44530,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3656
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44543,7 +44543,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3659
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44556,7 +44556,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3660
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44569,7 +44569,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3661
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44582,7 +44582,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3662
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44595,7 +44595,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3663
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44608,7 +44608,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3664
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44621,7 +44621,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3665
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44634,7 +44634,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3666
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44647,7 +44647,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3667
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44660,7 +44660,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3668
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44673,7 +44673,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3669
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44686,7 +44686,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3670
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44699,7 +44699,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3671
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44712,7 +44712,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3672
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44725,7 +44725,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3673
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44738,7 +44738,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3674
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44751,7 +44751,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3675
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44764,7 +44764,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3676
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44777,7 +44777,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3677
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44790,7 +44790,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3678
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44803,7 +44803,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3679
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44816,7 +44816,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3680
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44829,7 +44829,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3681
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44842,7 +44842,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3682
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44855,7 +44855,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3683
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44868,7 +44868,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3684
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44881,7 +44881,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3685
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44894,7 +44894,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3686
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44907,7 +44907,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3687
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44920,7 +44920,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3688
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44933,7 +44933,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3689
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44946,7 +44946,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3690
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44959,7 +44959,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3691
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44972,7 +44972,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3692
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44985,7 +44985,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3693
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44998,7 +44998,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3694
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45011,7 +45011,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3706
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45024,7 +45024,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3707
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45037,7 +45037,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3708
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45050,7 +45050,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3709
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45063,7 +45063,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3710
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45076,7 +45076,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3711
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45089,7 +45089,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3712
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45102,7 +45102,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3713
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45115,7 +45115,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3714
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45128,7 +45128,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3715
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45141,7 +45141,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3718
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45154,7 +45154,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3719
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45167,7 +45167,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3720
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45180,7 +45180,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3721
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45193,7 +45193,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3722
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45206,7 +45206,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3731
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45219,7 +45219,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3732
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45232,7 +45232,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3733
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45245,7 +45245,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3734
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45258,7 +45258,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3735
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45271,7 +45271,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3736
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45284,7 +45284,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3737
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45297,7 +45297,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3738
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45310,7 +45310,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3739
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45323,7 +45323,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3740
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45336,7 +45336,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3743
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45349,7 +45349,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3744
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45362,7 +45362,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3745
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45375,7 +45375,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3746
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45388,7 +45388,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3747
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45400,7 +45400,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3759
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45412,7 +45412,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3760
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45424,7 +45424,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3761
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45436,7 +45436,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3762
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45448,7 +45448,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3763
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45460,7 +45460,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3764
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45472,7 +45472,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3765
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45484,7 +45484,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3766
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45496,7 +45496,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3767
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45508,7 +45508,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3768
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45520,7 +45520,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3771
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45532,7 +45532,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3772
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45544,7 +45544,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3773
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45556,7 +45556,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3774
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45568,7 +45568,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3775
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45580,7 +45580,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3776
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45592,7 +45592,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3777
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45604,7 +45604,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3778
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45616,7 +45616,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3779
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45628,7 +45628,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3780
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45640,7 +45640,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3781
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45652,7 +45652,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3782
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45664,7 +45664,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3783
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45676,7 +45676,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3784
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45688,7 +45688,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3785
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45700,7 +45700,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3794
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45712,7 +45712,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3795
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45724,7 +45724,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3796
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45736,7 +45736,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3797
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45748,7 +45748,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3798
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45760,7 +45760,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3799
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45772,7 +45772,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3800
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45784,7 +45784,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3801
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45796,7 +45796,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3802
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45808,7 +45808,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3803
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45820,7 +45820,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3806
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45832,7 +45832,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3807
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45844,7 +45844,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3808
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45856,7 +45856,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3809
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45868,7 +45868,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3810
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45880,7 +45880,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3811
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45892,7 +45892,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3812
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45904,7 +45904,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3813
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45916,7 +45916,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3814
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45928,7 +45928,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3815
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45940,7 +45940,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3816
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45952,7 +45952,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3817
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45964,7 +45964,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3818
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45976,7 +45976,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3819
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45988,7 +45988,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3820
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46061,7 +46061,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3861
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46074,7 +46074,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3862
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46087,7 +46087,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3863
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46100,7 +46100,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3864
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46113,7 +46113,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3865
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46126,7 +46126,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3866
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46139,7 +46139,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3867
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46152,7 +46152,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3868
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46165,7 +46165,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3869
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46178,7 +46178,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3870
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46191,7 +46191,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3871
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46204,7 +46204,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3872
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46216,7 +46216,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3876
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46228,7 +46228,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3877
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46240,7 +46240,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3878
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46252,7 +46252,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3879
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46264,7 +46264,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3880
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46276,7 +46276,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3881
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46288,7 +46288,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3882
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46300,7 +46300,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3883
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46312,7 +46312,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3884
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46324,7 +46324,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3885
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46336,7 +46336,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3886
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46348,7 +46348,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3887
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46360,7 +46360,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3888
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46372,7 +46372,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3889
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46384,7 +46384,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3890
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46396,7 +46396,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3891
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46409,7 +46409,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3895
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46422,7 +46422,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3896
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46435,7 +46435,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3897
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46448,7 +46448,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3898
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46461,7 +46461,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3900
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46474,7 +46474,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3901
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46487,7 +46487,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3902
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46500,7 +46500,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3903
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46513,7 +46513,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3905
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46526,7 +46526,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3906
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46539,7 +46539,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3907
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46552,7 +46552,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3908
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46565,7 +46565,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3910
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46578,7 +46578,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3911
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46591,7 +46591,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3912
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46604,7 +46604,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3913
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46617,7 +46617,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3915
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46630,7 +46630,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3916
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46643,7 +46643,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3917
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46656,7 +46656,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3918
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46669,7 +46669,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3920
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46682,7 +46682,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3921
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46695,7 +46695,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3922
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46708,7 +46708,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3923
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46721,7 +46721,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3924
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46734,7 +46734,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3925
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46747,7 +46747,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3926
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46764,7 +46764,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3928
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46777,7 +46777,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3932
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46790,7 +46790,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3933
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46804,7 +46804,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3934
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46818,7 +46818,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3935
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46832,7 +46832,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3936
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46845,7 +46845,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3937
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46858,7 +46858,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3938
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46871,7 +46871,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3939
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46884,7 +46884,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3940
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46897,7 +46897,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3941
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46910,7 +46910,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3942
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46923,7 +46923,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3943
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46936,7 +46936,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3944
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46949,7 +46949,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3945
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46962,7 +46962,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3946
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46975,7 +46975,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3947
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46988,7 +46988,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3951
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -47001,7 +47001,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3952
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -47015,7 +47015,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3953
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -47029,7 +47029,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3954
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -47043,7 +47043,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3955
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -47056,7 +47056,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3956
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -47069,7 +47069,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3957
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -47082,7 +47082,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3958
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -47095,7 +47095,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3959
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -47108,7 +47108,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3960
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -47121,7 +47121,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3961
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -47134,7 +47134,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3962
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -47147,7 +47147,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3963
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -47160,7 +47160,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3964
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -47173,7 +47173,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3965
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -47186,7 +47186,7 @@
    i32.const 0
    i32.const 1040
    i32.const 3966
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/std/math.untouched.wat
+++ b/tests/compiler/std/math.untouched.wat
@@ -11231,7 +11231,7 @@
    i32.const 0
    i32.const 13536
    i32.const 1406
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -16068,7 +16068,7 @@
    i32.const 0
    i32.const 32
    i32.const 111
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16082,7 +16082,7 @@
    i32.const 0
    i32.const 32
    i32.const 112
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16096,7 +16096,7 @@
    i32.const 0
    i32.const 32
    i32.const 113
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16110,7 +16110,7 @@
    i32.const 0
    i32.const 32
    i32.const 114
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16124,7 +16124,7 @@
    i32.const 0
    i32.const 32
    i32.const 115
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16138,7 +16138,7 @@
    i32.const 0
    i32.const 32
    i32.const 116
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16152,7 +16152,7 @@
    i32.const 0
    i32.const 32
    i32.const 117
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16167,7 +16167,7 @@
    i32.const 0
    i32.const 32
    i32.const 119
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16182,7 +16182,7 @@
    i32.const 0
    i32.const 32
    i32.const 120
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16197,7 +16197,7 @@
    i32.const 0
    i32.const 32
    i32.const 121
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16212,7 +16212,7 @@
    i32.const 0
    i32.const 32
    i32.const 122
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16227,7 +16227,7 @@
    i32.const 0
    i32.const 32
    i32.const 123
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16242,7 +16242,7 @@
    i32.const 0
    i32.const 32
    i32.const 124
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16257,7 +16257,7 @@
    i32.const 0
    i32.const 32
    i32.const 125
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16272,7 +16272,7 @@
    i32.const 0
    i32.const 32
    i32.const 136
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16287,7 +16287,7 @@
    i32.const 0
    i32.const 32
    i32.const 137
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16302,7 +16302,7 @@
    i32.const 0
    i32.const 32
    i32.const 138
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16317,7 +16317,7 @@
    i32.const 0
    i32.const 32
    i32.const 139
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16332,7 +16332,7 @@
    i32.const 0
    i32.const 32
    i32.const 140
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16347,7 +16347,7 @@
    i32.const 0
    i32.const 32
    i32.const 141
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16362,7 +16362,7 @@
    i32.const 0
    i32.const 32
    i32.const 142
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16377,7 +16377,7 @@
    i32.const 0
    i32.const 32
    i32.const 143
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16392,7 +16392,7 @@
    i32.const 0
    i32.const 32
    i32.const 144
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16407,7 +16407,7 @@
    i32.const 0
    i32.const 32
    i32.const 145
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16422,7 +16422,7 @@
    i32.const 0
    i32.const 32
    i32.const 148
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16437,7 +16437,7 @@
    i32.const 0
    i32.const 32
    i32.const 149
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16452,7 +16452,7 @@
    i32.const 0
    i32.const 32
    i32.const 150
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16467,7 +16467,7 @@
    i32.const 0
    i32.const 32
    i32.const 151
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16482,7 +16482,7 @@
    i32.const 0
    i32.const 32
    i32.const 152
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16497,7 +16497,7 @@
    i32.const 0
    i32.const 32
    i32.const 153
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16512,7 +16512,7 @@
    i32.const 0
    i32.const 32
    i32.const 154
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16527,7 +16527,7 @@
    i32.const 0
    i32.const 32
    i32.const 155
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16542,7 +16542,7 @@
    i32.const 0
    i32.const 32
    i32.const 156
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16557,7 +16557,7 @@
    i32.const 0
    i32.const 32
    i32.const 157
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16572,7 +16572,7 @@
    i32.const 0
    i32.const 32
    i32.const 158
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16587,7 +16587,7 @@
    i32.const 0
    i32.const 32
    i32.const 159
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16602,7 +16602,7 @@
    i32.const 0
    i32.const 32
    i32.const 160
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16617,7 +16617,7 @@
    i32.const 0
    i32.const 32
    i32.const 161
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16632,7 +16632,7 @@
    i32.const 0
    i32.const 32
    i32.const 162
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16647,7 +16647,7 @@
    i32.const 0
    i32.const 32
    i32.const 163
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16662,7 +16662,7 @@
    i32.const 0
    i32.const 32
    i32.const 164
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16677,7 +16677,7 @@
    i32.const 0
    i32.const 32
    i32.const 165
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16692,7 +16692,7 @@
    i32.const 0
    i32.const 32
    i32.const 166
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16707,7 +16707,7 @@
    i32.const 0
    i32.const 32
    i32.const 175
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16722,7 +16722,7 @@
    i32.const 0
    i32.const 32
    i32.const 176
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16737,7 +16737,7 @@
    i32.const 0
    i32.const 32
    i32.const 177
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16752,7 +16752,7 @@
    i32.const 0
    i32.const 32
    i32.const 178
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16767,7 +16767,7 @@
    i32.const 0
    i32.const 32
    i32.const 179
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16782,7 +16782,7 @@
    i32.const 0
    i32.const 32
    i32.const 180
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16797,7 +16797,7 @@
    i32.const 0
    i32.const 32
    i32.const 181
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16812,7 +16812,7 @@
    i32.const 0
    i32.const 32
    i32.const 182
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16827,7 +16827,7 @@
    i32.const 0
    i32.const 32
    i32.const 183
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16842,7 +16842,7 @@
    i32.const 0
    i32.const 32
    i32.const 184
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16857,7 +16857,7 @@
    i32.const 0
    i32.const 32
    i32.const 187
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16872,7 +16872,7 @@
    i32.const 0
    i32.const 32
    i32.const 188
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16887,7 +16887,7 @@
    i32.const 0
    i32.const 32
    i32.const 189
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16902,7 +16902,7 @@
    i32.const 0
    i32.const 32
    i32.const 190
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16917,7 +16917,7 @@
    i32.const 0
    i32.const 32
    i32.const 191
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16932,7 +16932,7 @@
    i32.const 0
    i32.const 32
    i32.const 192
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16947,7 +16947,7 @@
    i32.const 0
    i32.const 32
    i32.const 193
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16962,7 +16962,7 @@
    i32.const 0
    i32.const 32
    i32.const 194
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16977,7 +16977,7 @@
    i32.const 0
    i32.const 32
    i32.const 195
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16992,7 +16992,7 @@
    i32.const 0
    i32.const 32
    i32.const 196
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17007,7 +17007,7 @@
    i32.const 0
    i32.const 32
    i32.const 197
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17022,7 +17022,7 @@
    i32.const 0
    i32.const 32
    i32.const 198
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17037,7 +17037,7 @@
    i32.const 0
    i32.const 32
    i32.const 199
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17052,7 +17052,7 @@
    i32.const 0
    i32.const 32
    i32.const 200
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17067,7 +17067,7 @@
    i32.const 0
    i32.const 32
    i32.const 201
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17082,7 +17082,7 @@
    i32.const 0
    i32.const 32
    i32.const 202
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17097,7 +17097,7 @@
    i32.const 0
    i32.const 32
    i32.const 203
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17112,7 +17112,7 @@
    i32.const 0
    i32.const 32
    i32.const 204
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17127,7 +17127,7 @@
    i32.const 0
    i32.const 32
    i32.const 205
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17141,7 +17141,7 @@
    i32.const 0
    i32.const 32
    i32.const 217
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17155,7 +17155,7 @@
    i32.const 0
    i32.const 32
    i32.const 218
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17169,7 +17169,7 @@
    i32.const 0
    i32.const 32
    i32.const 219
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17183,7 +17183,7 @@
    i32.const 0
    i32.const 32
    i32.const 220
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17197,7 +17197,7 @@
    i32.const 0
    i32.const 32
    i32.const 221
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17211,7 +17211,7 @@
    i32.const 0
    i32.const 32
    i32.const 222
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17225,7 +17225,7 @@
    i32.const 0
    i32.const 32
    i32.const 223
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17239,7 +17239,7 @@
    i32.const 0
    i32.const 32
    i32.const 224
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17253,7 +17253,7 @@
    i32.const 0
    i32.const 32
    i32.const 225
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17267,7 +17267,7 @@
    i32.const 0
    i32.const 32
    i32.const 226
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17281,7 +17281,7 @@
    i32.const 0
    i32.const 32
    i32.const 229
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17295,7 +17295,7 @@
    i32.const 0
    i32.const 32
    i32.const 230
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17309,7 +17309,7 @@
    i32.const 0
    i32.const 32
    i32.const 231
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17323,7 +17323,7 @@
    i32.const 0
    i32.const 32
    i32.const 232
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17337,7 +17337,7 @@
    i32.const 0
    i32.const 32
    i32.const 233
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17351,7 +17351,7 @@
    i32.const 0
    i32.const 32
    i32.const 234
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17365,7 +17365,7 @@
    i32.const 0
    i32.const 32
    i32.const 235
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17379,7 +17379,7 @@
    i32.const 0
    i32.const 32
    i32.const 244
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17393,7 +17393,7 @@
    i32.const 0
    i32.const 32
    i32.const 245
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17407,7 +17407,7 @@
    i32.const 0
    i32.const 32
    i32.const 246
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17421,7 +17421,7 @@
    i32.const 0
    i32.const 32
    i32.const 247
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17435,7 +17435,7 @@
    i32.const 0
    i32.const 32
    i32.const 248
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17449,7 +17449,7 @@
    i32.const 0
    i32.const 32
    i32.const 249
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17463,7 +17463,7 @@
    i32.const 0
    i32.const 32
    i32.const 250
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17477,7 +17477,7 @@
    i32.const 0
    i32.const 32
    i32.const 251
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17491,7 +17491,7 @@
    i32.const 0
    i32.const 32
    i32.const 252
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17505,7 +17505,7 @@
    i32.const 0
    i32.const 32
    i32.const 253
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17519,7 +17519,7 @@
    i32.const 0
    i32.const 32
    i32.const 256
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17533,7 +17533,7 @@
    i32.const 0
    i32.const 32
    i32.const 257
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17547,7 +17547,7 @@
    i32.const 0
    i32.const 32
    i32.const 258
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17561,7 +17561,7 @@
    i32.const 0
    i32.const 32
    i32.const 259
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17575,7 +17575,7 @@
    i32.const 0
    i32.const 32
    i32.const 260
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17589,7 +17589,7 @@
    i32.const 0
    i32.const 32
    i32.const 261
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17603,7 +17603,7 @@
    i32.const 0
    i32.const 32
    i32.const 262
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17617,7 +17617,7 @@
    i32.const 0
    i32.const 32
    i32.const 274
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17631,7 +17631,7 @@
    i32.const 0
    i32.const 32
    i32.const 275
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17645,7 +17645,7 @@
    i32.const 0
    i32.const 32
    i32.const 276
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17659,7 +17659,7 @@
    i32.const 0
    i32.const 32
    i32.const 277
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17673,7 +17673,7 @@
    i32.const 0
    i32.const 32
    i32.const 278
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17687,7 +17687,7 @@
    i32.const 0
    i32.const 32
    i32.const 279
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17701,7 +17701,7 @@
    i32.const 0
    i32.const 32
    i32.const 280
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17715,7 +17715,7 @@
    i32.const 0
    i32.const 32
    i32.const 281
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17729,7 +17729,7 @@
    i32.const 0
    i32.const 32
    i32.const 282
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17743,7 +17743,7 @@
    i32.const 0
    i32.const 32
    i32.const 283
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17757,7 +17757,7 @@
    i32.const 0
    i32.const 32
    i32.const 286
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17771,7 +17771,7 @@
    i32.const 0
    i32.const 32
    i32.const 287
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17785,7 +17785,7 @@
    i32.const 0
    i32.const 32
    i32.const 288
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17799,7 +17799,7 @@
    i32.const 0
    i32.const 32
    i32.const 289
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17813,7 +17813,7 @@
    i32.const 0
    i32.const 32
    i32.const 290
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17827,7 +17827,7 @@
    i32.const 0
    i32.const 32
    i32.const 291
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17841,7 +17841,7 @@
    i32.const 0
    i32.const 32
    i32.const 292
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17855,7 +17855,7 @@
    i32.const 0
    i32.const 32
    i32.const 293
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17869,7 +17869,7 @@
    i32.const 0
    i32.const 32
    i32.const 294
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17883,7 +17883,7 @@
    i32.const 0
    i32.const 32
    i32.const 295
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17897,7 +17897,7 @@
    i32.const 0
    i32.const 32
    i32.const 304
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17911,7 +17911,7 @@
    i32.const 0
    i32.const 32
    i32.const 305
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17925,7 +17925,7 @@
    i32.const 0
    i32.const 32
    i32.const 306
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17939,7 +17939,7 @@
    i32.const 0
    i32.const 32
    i32.const 307
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17953,7 +17953,7 @@
    i32.const 0
    i32.const 32
    i32.const 308
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17967,7 +17967,7 @@
    i32.const 0
    i32.const 32
    i32.const 309
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17981,7 +17981,7 @@
    i32.const 0
    i32.const 32
    i32.const 310
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17995,7 +17995,7 @@
    i32.const 0
    i32.const 32
    i32.const 311
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18009,7 +18009,7 @@
    i32.const 0
    i32.const 32
    i32.const 312
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18023,7 +18023,7 @@
    i32.const 0
    i32.const 32
    i32.const 313
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18037,7 +18037,7 @@
    i32.const 0
    i32.const 32
    i32.const 316
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18051,7 +18051,7 @@
    i32.const 0
    i32.const 32
    i32.const 317
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18065,7 +18065,7 @@
    i32.const 0
    i32.const 32
    i32.const 318
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18079,7 +18079,7 @@
    i32.const 0
    i32.const 32
    i32.const 319
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18093,7 +18093,7 @@
    i32.const 0
    i32.const 32
    i32.const 320
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18107,7 +18107,7 @@
    i32.const 0
    i32.const 32
    i32.const 321
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18121,7 +18121,7 @@
    i32.const 0
    i32.const 32
    i32.const 322
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18135,7 +18135,7 @@
    i32.const 0
    i32.const 32
    i32.const 323
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18149,7 +18149,7 @@
    i32.const 0
    i32.const 32
    i32.const 324
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18163,7 +18163,7 @@
    i32.const 0
    i32.const 32
    i32.const 325
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18177,7 +18177,7 @@
    i32.const 0
    i32.const 32
    i32.const 326
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18191,7 +18191,7 @@
    i32.const 0
    i32.const 32
    i32.const 338
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18205,7 +18205,7 @@
    i32.const 0
    i32.const 32
    i32.const 339
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18219,7 +18219,7 @@
    i32.const 0
    i32.const 32
    i32.const 340
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18233,7 +18233,7 @@
    i32.const 0
    i32.const 32
    i32.const 341
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18247,7 +18247,7 @@
    i32.const 0
    i32.const 32
    i32.const 342
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18261,7 +18261,7 @@
    i32.const 0
    i32.const 32
    i32.const 343
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18275,7 +18275,7 @@
    i32.const 0
    i32.const 32
    i32.const 344
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18289,7 +18289,7 @@
    i32.const 0
    i32.const 32
    i32.const 345
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18303,7 +18303,7 @@
    i32.const 0
    i32.const 32
    i32.const 346
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18317,7 +18317,7 @@
    i32.const 0
    i32.const 32
    i32.const 347
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18331,7 +18331,7 @@
    i32.const 0
    i32.const 32
    i32.const 350
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18345,7 +18345,7 @@
    i32.const 0
    i32.const 32
    i32.const 351
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18359,7 +18359,7 @@
    i32.const 0
    i32.const 32
    i32.const 352
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18373,7 +18373,7 @@
    i32.const 0
    i32.const 32
    i32.const 353
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18387,7 +18387,7 @@
    i32.const 0
    i32.const 32
    i32.const 354
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18401,7 +18401,7 @@
    i32.const 0
    i32.const 32
    i32.const 355
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18415,7 +18415,7 @@
    i32.const 0
    i32.const 32
    i32.const 356
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18429,7 +18429,7 @@
    i32.const 0
    i32.const 32
    i32.const 372
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18443,7 +18443,7 @@
    i32.const 0
    i32.const 32
    i32.const 374
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18457,7 +18457,7 @@
    i32.const 0
    i32.const 32
    i32.const 375
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18471,7 +18471,7 @@
    i32.const 0
    i32.const 32
    i32.const 384
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18485,7 +18485,7 @@
    i32.const 0
    i32.const 32
    i32.const 385
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18499,7 +18499,7 @@
    i32.const 0
    i32.const 32
    i32.const 386
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18513,7 +18513,7 @@
    i32.const 0
    i32.const 32
    i32.const 387
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18527,7 +18527,7 @@
    i32.const 0
    i32.const 32
    i32.const 388
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18541,7 +18541,7 @@
    i32.const 0
    i32.const 32
    i32.const 389
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18555,7 +18555,7 @@
    i32.const 0
    i32.const 32
    i32.const 390
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18569,7 +18569,7 @@
    i32.const 0
    i32.const 32
    i32.const 391
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18583,7 +18583,7 @@
    i32.const 0
    i32.const 32
    i32.const 392
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18597,7 +18597,7 @@
    i32.const 0
    i32.const 32
    i32.const 393
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18611,7 +18611,7 @@
    i32.const 0
    i32.const 32
    i32.const 396
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18625,7 +18625,7 @@
    i32.const 0
    i32.const 32
    i32.const 397
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18639,7 +18639,7 @@
    i32.const 0
    i32.const 32
    i32.const 398
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18653,7 +18653,7 @@
    i32.const 0
    i32.const 32
    i32.const 399
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18667,7 +18667,7 @@
    i32.const 0
    i32.const 32
    i32.const 400
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18681,7 +18681,7 @@
    i32.const 0
    i32.const 32
    i32.const 401
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18695,7 +18695,7 @@
    i32.const 0
    i32.const 32
    i32.const 402
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18709,7 +18709,7 @@
    i32.const 0
    i32.const 32
    i32.const 403
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18723,7 +18723,7 @@
    i32.const 0
    i32.const 32
    i32.const 415
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18737,7 +18737,7 @@
    i32.const 0
    i32.const 32
    i32.const 416
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18751,7 +18751,7 @@
    i32.const 0
    i32.const 32
    i32.const 417
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18765,7 +18765,7 @@
    i32.const 0
    i32.const 32
    i32.const 418
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18779,7 +18779,7 @@
    i32.const 0
    i32.const 32
    i32.const 419
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18793,7 +18793,7 @@
    i32.const 0
    i32.const 32
    i32.const 420
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18807,7 +18807,7 @@
    i32.const 0
    i32.const 32
    i32.const 421
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18821,7 +18821,7 @@
    i32.const 0
    i32.const 32
    i32.const 422
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18835,7 +18835,7 @@
    i32.const 0
    i32.const 32
    i32.const 423
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18849,7 +18849,7 @@
    i32.const 0
    i32.const 32
    i32.const 424
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18863,7 +18863,7 @@
    i32.const 0
    i32.const 32
    i32.const 427
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18877,7 +18877,7 @@
    i32.const 0
    i32.const 32
    i32.const 428
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18891,7 +18891,7 @@
    i32.const 0
    i32.const 32
    i32.const 429
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18905,7 +18905,7 @@
    i32.const 0
    i32.const 32
    i32.const 430
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18919,7 +18919,7 @@
    i32.const 0
    i32.const 32
    i32.const 431
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18933,7 +18933,7 @@
    i32.const 0
    i32.const 32
    i32.const 432
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18947,7 +18947,7 @@
    i32.const 0
    i32.const 32
    i32.const 433
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18961,7 +18961,7 @@
    i32.const 0
    i32.const 32
    i32.const 434
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18975,7 +18975,7 @@
    i32.const 0
    i32.const 32
    i32.const 435
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18989,7 +18989,7 @@
    i32.const 0
    i32.const 32
    i32.const 436
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19003,7 +19003,7 @@
    i32.const 0
    i32.const 32
    i32.const 445
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19017,7 +19017,7 @@
    i32.const 0
    i32.const 32
    i32.const 446
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19031,7 +19031,7 @@
    i32.const 0
    i32.const 32
    i32.const 447
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19045,7 +19045,7 @@
    i32.const 0
    i32.const 32
    i32.const 448
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19059,7 +19059,7 @@
    i32.const 0
    i32.const 32
    i32.const 449
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19073,7 +19073,7 @@
    i32.const 0
    i32.const 32
    i32.const 450
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19087,7 +19087,7 @@
    i32.const 0
    i32.const 32
    i32.const 451
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19101,7 +19101,7 @@
    i32.const 0
    i32.const 32
    i32.const 452
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19115,7 +19115,7 @@
    i32.const 0
    i32.const 32
    i32.const 453
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19129,7 +19129,7 @@
    i32.const 0
    i32.const 32
    i32.const 454
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19143,7 +19143,7 @@
    i32.const 0
    i32.const 32
    i32.const 457
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19157,7 +19157,7 @@
    i32.const 0
    i32.const 32
    i32.const 458
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19171,7 +19171,7 @@
    i32.const 0
    i32.const 32
    i32.const 459
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19185,7 +19185,7 @@
    i32.const 0
    i32.const 32
    i32.const 460
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19199,7 +19199,7 @@
    i32.const 0
    i32.const 32
    i32.const 461
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19213,7 +19213,7 @@
    i32.const 0
    i32.const 32
    i32.const 462
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19227,7 +19227,7 @@
    i32.const 0
    i32.const 32
    i32.const 463
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19241,7 +19241,7 @@
    i32.const 0
    i32.const 32
    i32.const 464
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19255,7 +19255,7 @@
    i32.const 0
    i32.const 32
    i32.const 465
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19269,7 +19269,7 @@
    i32.const 0
    i32.const 32
    i32.const 466
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19283,7 +19283,7 @@
    i32.const 0
    i32.const 32
    i32.const 478
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19297,7 +19297,7 @@
    i32.const 0
    i32.const 32
    i32.const 479
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19311,7 +19311,7 @@
    i32.const 0
    i32.const 32
    i32.const 480
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19325,7 +19325,7 @@
    i32.const 0
    i32.const 32
    i32.const 481
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19339,7 +19339,7 @@
    i32.const 0
    i32.const 32
    i32.const 482
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19353,7 +19353,7 @@
    i32.const 0
    i32.const 32
    i32.const 483
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19367,7 +19367,7 @@
    i32.const 0
    i32.const 32
    i32.const 484
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19381,7 +19381,7 @@
    i32.const 0
    i32.const 32
    i32.const 485
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19395,7 +19395,7 @@
    i32.const 0
    i32.const 32
    i32.const 486
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19409,7 +19409,7 @@
    i32.const 0
    i32.const 32
    i32.const 487
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19423,7 +19423,7 @@
    i32.const 0
    i32.const 32
    i32.const 490
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19437,7 +19437,7 @@
    i32.const 0
    i32.const 32
    i32.const 491
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19451,7 +19451,7 @@
    i32.const 0
    i32.const 32
    i32.const 492
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19465,7 +19465,7 @@
    i32.const 0
    i32.const 32
    i32.const 493
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19479,7 +19479,7 @@
    i32.const 0
    i32.const 32
    i32.const 494
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19493,7 +19493,7 @@
    i32.const 0
    i32.const 32
    i32.const 523
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19507,7 +19507,7 @@
    i32.const 0
    i32.const 32
    i32.const 524
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19521,7 +19521,7 @@
    i32.const 0
    i32.const 32
    i32.const 525
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19535,7 +19535,7 @@
    i32.const 0
    i32.const 32
    i32.const 526
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19549,7 +19549,7 @@
    i32.const 0
    i32.const 32
    i32.const 527
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19563,7 +19563,7 @@
    i32.const 0
    i32.const 32
    i32.const 528
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19577,7 +19577,7 @@
    i32.const 0
    i32.const 32
    i32.const 529
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19591,7 +19591,7 @@
    i32.const 0
    i32.const 32
    i32.const 530
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19605,7 +19605,7 @@
    i32.const 0
    i32.const 32
    i32.const 531
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19619,7 +19619,7 @@
    i32.const 0
    i32.const 32
    i32.const 532
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19633,7 +19633,7 @@
    i32.const 0
    i32.const 32
    i32.const 535
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19647,7 +19647,7 @@
    i32.const 0
    i32.const 32
    i32.const 536
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19661,7 +19661,7 @@
    i32.const 0
    i32.const 32
    i32.const 537
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19675,7 +19675,7 @@
    i32.const 0
    i32.const 32
    i32.const 538
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19689,7 +19689,7 @@
    i32.const 0
    i32.const 32
    i32.const 539
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19703,7 +19703,7 @@
    i32.const 0
    i32.const 32
    i32.const 551
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19717,7 +19717,7 @@
    i32.const 0
    i32.const 32
    i32.const 552
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19731,7 +19731,7 @@
    i32.const 0
    i32.const 32
    i32.const 553
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19745,7 +19745,7 @@
    i32.const 0
    i32.const 32
    i32.const 554
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19759,7 +19759,7 @@
    i32.const 0
    i32.const 32
    i32.const 555
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19773,7 +19773,7 @@
    i32.const 0
    i32.const 32
    i32.const 556
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19787,7 +19787,7 @@
    i32.const 0
    i32.const 32
    i32.const 557
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19801,7 +19801,7 @@
    i32.const 0
    i32.const 32
    i32.const 558
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19815,7 +19815,7 @@
    i32.const 0
    i32.const 32
    i32.const 559
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19829,7 +19829,7 @@
    i32.const 0
    i32.const 32
    i32.const 560
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19843,7 +19843,7 @@
    i32.const 0
    i32.const 32
    i32.const 563
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19857,7 +19857,7 @@
    i32.const 0
    i32.const 32
    i32.const 564
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19871,7 +19871,7 @@
    i32.const 0
    i32.const 32
    i32.const 565
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19885,7 +19885,7 @@
    i32.const 0
    i32.const 32
    i32.const 566
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19899,7 +19899,7 @@
    i32.const 0
    i32.const 32
    i32.const 567
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19913,7 +19913,7 @@
    i32.const 0
    i32.const 32
    i32.const 568
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19927,7 +19927,7 @@
    i32.const 0
    i32.const 32
    i32.const 569
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19941,7 +19941,7 @@
    i32.const 0
    i32.const 32
    i32.const 570
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19955,7 +19955,7 @@
    i32.const 0
    i32.const 32
    i32.const 579
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19969,7 +19969,7 @@
    i32.const 0
    i32.const 32
    i32.const 580
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19983,7 +19983,7 @@
    i32.const 0
    i32.const 32
    i32.const 581
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -19997,7 +19997,7 @@
    i32.const 0
    i32.const 32
    i32.const 582
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20011,7 +20011,7 @@
    i32.const 0
    i32.const 32
    i32.const 583
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20025,7 +20025,7 @@
    i32.const 0
    i32.const 32
    i32.const 584
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20039,7 +20039,7 @@
    i32.const 0
    i32.const 32
    i32.const 585
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20053,7 +20053,7 @@
    i32.const 0
    i32.const 32
    i32.const 586
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20067,7 +20067,7 @@
    i32.const 0
    i32.const 32
    i32.const 587
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20081,7 +20081,7 @@
    i32.const 0
    i32.const 32
    i32.const 588
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20095,7 +20095,7 @@
    i32.const 0
    i32.const 32
    i32.const 591
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20109,7 +20109,7 @@
    i32.const 0
    i32.const 32
    i32.const 592
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20123,7 +20123,7 @@
    i32.const 0
    i32.const 32
    i32.const 593
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20137,7 +20137,7 @@
    i32.const 0
    i32.const 32
    i32.const 594
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20151,7 +20151,7 @@
    i32.const 0
    i32.const 32
    i32.const 595
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20165,7 +20165,7 @@
    i32.const 0
    i32.const 32
    i32.const 596
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20179,7 +20179,7 @@
    i32.const 0
    i32.const 32
    i32.const 597
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20193,7 +20193,7 @@
    i32.const 0
    i32.const 32
    i32.const 609
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20207,7 +20207,7 @@
    i32.const 0
    i32.const 32
    i32.const 610
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20221,7 +20221,7 @@
    i32.const 0
    i32.const 32
    i32.const 611
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20235,7 +20235,7 @@
    i32.const 0
    i32.const 32
    i32.const 612
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20249,7 +20249,7 @@
    i32.const 0
    i32.const 32
    i32.const 613
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20263,7 +20263,7 @@
    i32.const 0
    i32.const 32
    i32.const 614
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20277,7 +20277,7 @@
    i32.const 0
    i32.const 32
    i32.const 615
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20291,7 +20291,7 @@
    i32.const 0
    i32.const 32
    i32.const 616
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20305,7 +20305,7 @@
    i32.const 0
    i32.const 32
    i32.const 617
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20319,7 +20319,7 @@
    i32.const 0
    i32.const 32
    i32.const 618
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20333,7 +20333,7 @@
    i32.const 0
    i32.const 32
    i32.const 621
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20347,7 +20347,7 @@
    i32.const 0
    i32.const 32
    i32.const 622
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20361,7 +20361,7 @@
    i32.const 0
    i32.const 32
    i32.const 623
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20375,7 +20375,7 @@
    i32.const 0
    i32.const 32
    i32.const 624
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20389,7 +20389,7 @@
    i32.const 0
    i32.const 32
    i32.const 625
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20403,7 +20403,7 @@
    i32.const 0
    i32.const 32
    i32.const 626
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20417,7 +20417,7 @@
    i32.const 0
    i32.const 32
    i32.const 627
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20431,7 +20431,7 @@
    i32.const 0
    i32.const 32
    i32.const 628
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20445,7 +20445,7 @@
    i32.const 0
    i32.const 32
    i32.const 629
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20459,7 +20459,7 @@
    i32.const 0
    i32.const 32
    i32.const 630
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20473,7 +20473,7 @@
    i32.const 0
    i32.const 32
    i32.const 631
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20487,7 +20487,7 @@
    i32.const 0
    i32.const 32
    i32.const 632
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20501,7 +20501,7 @@
    i32.const 0
    i32.const 32
    i32.const 633
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20515,7 +20515,7 @@
    i32.const 0
    i32.const 32
    i32.const 634
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20529,7 +20529,7 @@
    i32.const 0
    i32.const 32
    i32.const 643
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20543,7 +20543,7 @@
    i32.const 0
    i32.const 32
    i32.const 644
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20557,7 +20557,7 @@
    i32.const 0
    i32.const 32
    i32.const 645
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20571,7 +20571,7 @@
    i32.const 0
    i32.const 32
    i32.const 646
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20585,7 +20585,7 @@
    i32.const 0
    i32.const 32
    i32.const 647
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20599,7 +20599,7 @@
    i32.const 0
    i32.const 32
    i32.const 648
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20613,7 +20613,7 @@
    i32.const 0
    i32.const 32
    i32.const 649
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20627,7 +20627,7 @@
    i32.const 0
    i32.const 32
    i32.const 650
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20641,7 +20641,7 @@
    i32.const 0
    i32.const 32
    i32.const 651
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20655,7 +20655,7 @@
    i32.const 0
    i32.const 32
    i32.const 652
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20669,7 +20669,7 @@
    i32.const 0
    i32.const 32
    i32.const 655
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20683,7 +20683,7 @@
    i32.const 0
    i32.const 32
    i32.const 656
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20697,7 +20697,7 @@
    i32.const 0
    i32.const 32
    i32.const 657
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20711,7 +20711,7 @@
    i32.const 0
    i32.const 32
    i32.const 658
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20725,7 +20725,7 @@
    i32.const 0
    i32.const 32
    i32.const 659
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20739,7 +20739,7 @@
    i32.const 0
    i32.const 32
    i32.const 660
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20753,7 +20753,7 @@
    i32.const 0
    i32.const 32
    i32.const 661
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20767,7 +20767,7 @@
    i32.const 0
    i32.const 32
    i32.const 662
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20781,7 +20781,7 @@
    i32.const 0
    i32.const 32
    i32.const 663
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20795,7 +20795,7 @@
    i32.const 0
    i32.const 32
    i32.const 664
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20809,7 +20809,7 @@
    i32.const 0
    i32.const 32
    i32.const 665
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20823,7 +20823,7 @@
    i32.const 0
    i32.const 32
    i32.const 666
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20837,7 +20837,7 @@
    i32.const 0
    i32.const 32
    i32.const 667
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20851,7 +20851,7 @@
    i32.const 0
    i32.const 32
    i32.const 668
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20866,7 +20866,7 @@
    i32.const 0
    i32.const 32
    i32.const 680
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20881,7 +20881,7 @@
    i32.const 0
    i32.const 32
    i32.const 681
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20896,7 +20896,7 @@
    i32.const 0
    i32.const 32
    i32.const 682
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20911,7 +20911,7 @@
    i32.const 0
    i32.const 32
    i32.const 683
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20926,7 +20926,7 @@
    i32.const 0
    i32.const 32
    i32.const 684
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20941,7 +20941,7 @@
    i32.const 0
    i32.const 32
    i32.const 685
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20956,7 +20956,7 @@
    i32.const 0
    i32.const 32
    i32.const 686
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20971,7 +20971,7 @@
    i32.const 0
    i32.const 32
    i32.const 687
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -20986,7 +20986,7 @@
    i32.const 0
    i32.const 32
    i32.const 688
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21001,7 +21001,7 @@
    i32.const 0
    i32.const 32
    i32.const 689
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21016,7 +21016,7 @@
    i32.const 0
    i32.const 32
    i32.const 692
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21031,7 +21031,7 @@
    i32.const 0
    i32.const 32
    i32.const 693
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21046,7 +21046,7 @@
    i32.const 0
    i32.const 32
    i32.const 694
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21061,7 +21061,7 @@
    i32.const 0
    i32.const 32
    i32.const 695
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21076,7 +21076,7 @@
    i32.const 0
    i32.const 32
    i32.const 696
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21091,7 +21091,7 @@
    i32.const 0
    i32.const 32
    i32.const 697
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21106,7 +21106,7 @@
    i32.const 0
    i32.const 32
    i32.const 698
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21121,7 +21121,7 @@
    i32.const 0
    i32.const 32
    i32.const 699
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21136,7 +21136,7 @@
    i32.const 0
    i32.const 32
    i32.const 700
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21151,7 +21151,7 @@
    i32.const 0
    i32.const 32
    i32.const 701
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21166,7 +21166,7 @@
    i32.const 0
    i32.const 32
    i32.const 702
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21181,7 +21181,7 @@
    i32.const 0
    i32.const 32
    i32.const 703
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21196,7 +21196,7 @@
    i32.const 0
    i32.const 32
    i32.const 704
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21211,7 +21211,7 @@
    i32.const 0
    i32.const 32
    i32.const 705
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21226,7 +21226,7 @@
    i32.const 0
    i32.const 32
    i32.const 706
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21241,7 +21241,7 @@
    i32.const 0
    i32.const 32
    i32.const 707
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21256,7 +21256,7 @@
    i32.const 0
    i32.const 32
    i32.const 708
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21271,7 +21271,7 @@
    i32.const 0
    i32.const 32
    i32.const 709
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21286,7 +21286,7 @@
    i32.const 0
    i32.const 32
    i32.const 710
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21301,7 +21301,7 @@
    i32.const 0
    i32.const 32
    i32.const 711
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21316,7 +21316,7 @@
    i32.const 0
    i32.const 32
    i32.const 712
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21331,7 +21331,7 @@
    i32.const 0
    i32.const 32
    i32.const 713
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21346,7 +21346,7 @@
    i32.const 0
    i32.const 32
    i32.const 714
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21361,7 +21361,7 @@
    i32.const 0
    i32.const 32
    i32.const 715
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21376,7 +21376,7 @@
    i32.const 0
    i32.const 32
    i32.const 716
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21391,7 +21391,7 @@
    i32.const 0
    i32.const 32
    i32.const 717
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21406,7 +21406,7 @@
    i32.const 0
    i32.const 32
    i32.const 718
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21421,7 +21421,7 @@
    i32.const 0
    i32.const 32
    i32.const 719
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21436,7 +21436,7 @@
    i32.const 0
    i32.const 32
    i32.const 720
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21451,7 +21451,7 @@
    i32.const 0
    i32.const 32
    i32.const 721
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21466,7 +21466,7 @@
    i32.const 0
    i32.const 32
    i32.const 730
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21481,7 +21481,7 @@
    i32.const 0
    i32.const 32
    i32.const 731
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21496,7 +21496,7 @@
    i32.const 0
    i32.const 32
    i32.const 732
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21511,7 +21511,7 @@
    i32.const 0
    i32.const 32
    i32.const 733
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21526,7 +21526,7 @@
    i32.const 0
    i32.const 32
    i32.const 734
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21541,7 +21541,7 @@
    i32.const 0
    i32.const 32
    i32.const 735
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21556,7 +21556,7 @@
    i32.const 0
    i32.const 32
    i32.const 736
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21571,7 +21571,7 @@
    i32.const 0
    i32.const 32
    i32.const 737
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21586,7 +21586,7 @@
    i32.const 0
    i32.const 32
    i32.const 738
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21601,7 +21601,7 @@
    i32.const 0
    i32.const 32
    i32.const 739
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21616,7 +21616,7 @@
    i32.const 0
    i32.const 32
    i32.const 742
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21631,7 +21631,7 @@
    i32.const 0
    i32.const 32
    i32.const 743
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21646,7 +21646,7 @@
    i32.const 0
    i32.const 32
    i32.const 744
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21661,7 +21661,7 @@
    i32.const 0
    i32.const 32
    i32.const 745
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21676,7 +21676,7 @@
    i32.const 0
    i32.const 32
    i32.const 746
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21691,7 +21691,7 @@
    i32.const 0
    i32.const 32
    i32.const 747
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21706,7 +21706,7 @@
    i32.const 0
    i32.const 32
    i32.const 748
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21721,7 +21721,7 @@
    i32.const 0
    i32.const 32
    i32.const 749
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21736,7 +21736,7 @@
    i32.const 0
    i32.const 32
    i32.const 750
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21751,7 +21751,7 @@
    i32.const 0
    i32.const 32
    i32.const 751
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21766,7 +21766,7 @@
    i32.const 0
    i32.const 32
    i32.const 752
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21781,7 +21781,7 @@
    i32.const 0
    i32.const 32
    i32.const 753
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21796,7 +21796,7 @@
    i32.const 0
    i32.const 32
    i32.const 754
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21811,7 +21811,7 @@
    i32.const 0
    i32.const 32
    i32.const 755
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21826,7 +21826,7 @@
    i32.const 0
    i32.const 32
    i32.const 756
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21841,7 +21841,7 @@
    i32.const 0
    i32.const 32
    i32.const 757
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21856,7 +21856,7 @@
    i32.const 0
    i32.const 32
    i32.const 758
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21871,7 +21871,7 @@
    i32.const 0
    i32.const 32
    i32.const 759
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21886,7 +21886,7 @@
    i32.const 0
    i32.const 32
    i32.const 760
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21901,7 +21901,7 @@
    i32.const 0
    i32.const 32
    i32.const 761
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21916,7 +21916,7 @@
    i32.const 0
    i32.const 32
    i32.const 762
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21931,7 +21931,7 @@
    i32.const 0
    i32.const 32
    i32.const 763
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21946,7 +21946,7 @@
    i32.const 0
    i32.const 32
    i32.const 764
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21961,7 +21961,7 @@
    i32.const 0
    i32.const 32
    i32.const 765
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21976,7 +21976,7 @@
    i32.const 0
    i32.const 32
    i32.const 766
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -21991,7 +21991,7 @@
    i32.const 0
    i32.const 32
    i32.const 767
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22006,7 +22006,7 @@
    i32.const 0
    i32.const 32
    i32.const 768
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22021,7 +22021,7 @@
    i32.const 0
    i32.const 32
    i32.const 769
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22035,7 +22035,7 @@
    i32.const 0
    i32.const 32
    i32.const 781
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22049,7 +22049,7 @@
    i32.const 0
    i32.const 32
    i32.const 782
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22063,7 +22063,7 @@
    i32.const 0
    i32.const 32
    i32.const 783
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22077,7 +22077,7 @@
    i32.const 0
    i32.const 32
    i32.const 784
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22091,7 +22091,7 @@
    i32.const 0
    i32.const 32
    i32.const 785
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22105,7 +22105,7 @@
    i32.const 0
    i32.const 32
    i32.const 786
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22119,7 +22119,7 @@
    i32.const 0
    i32.const 32
    i32.const 787
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22133,7 +22133,7 @@
    i32.const 0
    i32.const 32
    i32.const 788
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22147,7 +22147,7 @@
    i32.const 0
    i32.const 32
    i32.const 789
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22161,7 +22161,7 @@
    i32.const 0
    i32.const 32
    i32.const 790
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22175,7 +22175,7 @@
    i32.const 0
    i32.const 32
    i32.const 793
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22189,7 +22189,7 @@
    i32.const 0
    i32.const 32
    i32.const 794
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22203,7 +22203,7 @@
    i32.const 0
    i32.const 32
    i32.const 795
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22217,7 +22217,7 @@
    i32.const 0
    i32.const 32
    i32.const 796
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22231,7 +22231,7 @@
    i32.const 0
    i32.const 32
    i32.const 797
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22245,7 +22245,7 @@
    i32.const 0
    i32.const 32
    i32.const 798
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22259,7 +22259,7 @@
    i32.const 0
    i32.const 32
    i32.const 799
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22273,7 +22273,7 @@
    i32.const 0
    i32.const 32
    i32.const 800
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22287,7 +22287,7 @@
    i32.const 0
    i32.const 32
    i32.const 801
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22301,7 +22301,7 @@
    i32.const 0
    i32.const 32
    i32.const 802
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22315,7 +22315,7 @@
    i32.const 0
    i32.const 32
    i32.const 811
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22329,7 +22329,7 @@
    i32.const 0
    i32.const 32
    i32.const 812
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22343,7 +22343,7 @@
    i32.const 0
    i32.const 32
    i32.const 813
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22357,7 +22357,7 @@
    i32.const 0
    i32.const 32
    i32.const 814
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22371,7 +22371,7 @@
    i32.const 0
    i32.const 32
    i32.const 815
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22385,7 +22385,7 @@
    i32.const 0
    i32.const 32
    i32.const 816
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22399,7 +22399,7 @@
    i32.const 0
    i32.const 32
    i32.const 817
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22413,7 +22413,7 @@
    i32.const 0
    i32.const 32
    i32.const 818
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22427,7 +22427,7 @@
    i32.const 0
    i32.const 32
    i32.const 819
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22441,7 +22441,7 @@
    i32.const 0
    i32.const 32
    i32.const 820
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22455,7 +22455,7 @@
    i32.const 0
    i32.const 32
    i32.const 823
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22469,7 +22469,7 @@
    i32.const 0
    i32.const 32
    i32.const 824
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22483,7 +22483,7 @@
    i32.const 0
    i32.const 32
    i32.const 825
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22497,7 +22497,7 @@
    i32.const 0
    i32.const 32
    i32.const 826
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22511,7 +22511,7 @@
    i32.const 0
    i32.const 32
    i32.const 827
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22525,7 +22525,7 @@
    i32.const 0
    i32.const 32
    i32.const 828
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22539,7 +22539,7 @@
    i32.const 0
    i32.const 32
    i32.const 829
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22553,7 +22553,7 @@
    i32.const 0
    i32.const 32
    i32.const 830
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22567,7 +22567,7 @@
    i32.const 0
    i32.const 32
    i32.const 831
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22581,7 +22581,7 @@
    i32.const 0
    i32.const 32
    i32.const 832
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22595,7 +22595,7 @@
    i32.const 0
    i32.const 32
    i32.const 844
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22609,7 +22609,7 @@
    i32.const 0
    i32.const 32
    i32.const 845
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22623,7 +22623,7 @@
    i32.const 0
    i32.const 32
    i32.const 846
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22637,7 +22637,7 @@
    i32.const 0
    i32.const 32
    i32.const 847
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22651,7 +22651,7 @@
    i32.const 0
    i32.const 32
    i32.const 848
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22665,7 +22665,7 @@
    i32.const 0
    i32.const 32
    i32.const 849
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22679,7 +22679,7 @@
    i32.const 0
    i32.const 32
    i32.const 850
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22693,7 +22693,7 @@
    i32.const 0
    i32.const 32
    i32.const 851
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22707,7 +22707,7 @@
    i32.const 0
    i32.const 32
    i32.const 852
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22721,7 +22721,7 @@
    i32.const 0
    i32.const 32
    i32.const 853
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22735,7 +22735,7 @@
    i32.const 0
    i32.const 32
    i32.const 856
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22749,7 +22749,7 @@
    i32.const 0
    i32.const 32
    i32.const 857
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22763,7 +22763,7 @@
    i32.const 0
    i32.const 32
    i32.const 858
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22777,7 +22777,7 @@
    i32.const 0
    i32.const 32
    i32.const 859
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22791,7 +22791,7 @@
    i32.const 0
    i32.const 32
    i32.const 860
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22805,7 +22805,7 @@
    i32.const 0
    i32.const 32
    i32.const 861
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22819,7 +22819,7 @@
    i32.const 0
    i32.const 32
    i32.const 862
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22833,7 +22833,7 @@
    i32.const 0
    i32.const 32
    i32.const 863
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22847,7 +22847,7 @@
    i32.const 0
    i32.const 32
    i32.const 864
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22861,7 +22861,7 @@
    i32.const 0
    i32.const 32
    i32.const 865
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22875,7 +22875,7 @@
    i32.const 0
    i32.const 32
    i32.const 866
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22889,7 +22889,7 @@
    i32.const 0
    i32.const 32
    i32.const 867
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22903,7 +22903,7 @@
    i32.const 0
    i32.const 32
    i32.const 868
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22917,7 +22917,7 @@
    i32.const 0
    i32.const 32
    i32.const 869
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22931,7 +22931,7 @@
    i32.const 0
    i32.const 32
    i32.const 870
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22945,7 +22945,7 @@
    i32.const 0
    i32.const 32
    i32.const 871
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22959,7 +22959,7 @@
    i32.const 0
    i32.const 32
    i32.const 872
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22973,7 +22973,7 @@
    i32.const 0
    i32.const 32
    i32.const 873
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -22987,7 +22987,7 @@
    i32.const 0
    i32.const 32
    i32.const 874
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23001,7 +23001,7 @@
    i32.const 0
    i32.const 32
    i32.const 875
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23015,7 +23015,7 @@
    i32.const 0
    i32.const 32
    i32.const 876
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23029,7 +23029,7 @@
    i32.const 0
    i32.const 32
    i32.const 877
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23043,7 +23043,7 @@
    i32.const 0
    i32.const 32
    i32.const 878
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23057,7 +23057,7 @@
    i32.const 0
    i32.const 32
    i32.const 879
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23071,7 +23071,7 @@
    i32.const 0
    i32.const 32
    i32.const 880
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23085,7 +23085,7 @@
    i32.const 0
    i32.const 32
    i32.const 881
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23099,7 +23099,7 @@
    i32.const 0
    i32.const 32
    i32.const 882
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23113,7 +23113,7 @@
    i32.const 0
    i32.const 32
    i32.const 883
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23127,7 +23127,7 @@
    i32.const 0
    i32.const 32
    i32.const 884
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23141,7 +23141,7 @@
    i32.const 0
    i32.const 32
    i32.const 885
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23155,7 +23155,7 @@
    i32.const 0
    i32.const 32
    i32.const 886
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23169,7 +23169,7 @@
    i32.const 0
    i32.const 32
    i32.const 887
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23183,7 +23183,7 @@
    i32.const 0
    i32.const 32
    i32.const 888
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23197,7 +23197,7 @@
    i32.const 0
    i32.const 32
    i32.const 889
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23211,7 +23211,7 @@
    i32.const 0
    i32.const 32
    i32.const 890
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23225,7 +23225,7 @@
    i32.const 0
    i32.const 32
    i32.const 891
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23239,7 +23239,7 @@
    i32.const 0
    i32.const 32
    i32.const 892
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23253,7 +23253,7 @@
    i32.const 0
    i32.const 32
    i32.const 893
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23267,7 +23267,7 @@
    i32.const 0
    i32.const 32
    i32.const 894
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23281,7 +23281,7 @@
    i32.const 0
    i32.const 32
    i32.const 895
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23295,7 +23295,7 @@
    i32.const 0
    i32.const 32
    i32.const 896
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23309,7 +23309,7 @@
    i32.const 0
    i32.const 32
    i32.const 897
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23323,7 +23323,7 @@
    i32.const 0
    i32.const 32
    i32.const 898
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23337,7 +23337,7 @@
    i32.const 0
    i32.const 32
    i32.const 899
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23351,7 +23351,7 @@
    i32.const 0
    i32.const 32
    i32.const 900
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23365,7 +23365,7 @@
    i32.const 0
    i32.const 32
    i32.const 909
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23379,7 +23379,7 @@
    i32.const 0
    i32.const 32
    i32.const 910
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23393,7 +23393,7 @@
    i32.const 0
    i32.const 32
    i32.const 911
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23407,7 +23407,7 @@
    i32.const 0
    i32.const 32
    i32.const 912
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23421,7 +23421,7 @@
    i32.const 0
    i32.const 32
    i32.const 913
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23435,7 +23435,7 @@
    i32.const 0
    i32.const 32
    i32.const 914
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23449,7 +23449,7 @@
    i32.const 0
    i32.const 32
    i32.const 915
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23463,7 +23463,7 @@
    i32.const 0
    i32.const 32
    i32.const 916
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23477,7 +23477,7 @@
    i32.const 0
    i32.const 32
    i32.const 917
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23491,7 +23491,7 @@
    i32.const 0
    i32.const 32
    i32.const 918
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23505,7 +23505,7 @@
    i32.const 0
    i32.const 32
    i32.const 921
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23519,7 +23519,7 @@
    i32.const 0
    i32.const 32
    i32.const 922
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23533,7 +23533,7 @@
    i32.const 0
    i32.const 32
    i32.const 923
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23547,7 +23547,7 @@
    i32.const 0
    i32.const 32
    i32.const 924
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23561,7 +23561,7 @@
    i32.const 0
    i32.const 32
    i32.const 925
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23575,7 +23575,7 @@
    i32.const 0
    i32.const 32
    i32.const 926
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23589,7 +23589,7 @@
    i32.const 0
    i32.const 32
    i32.const 927
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23603,7 +23603,7 @@
    i32.const 0
    i32.const 32
    i32.const 928
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23617,7 +23617,7 @@
    i32.const 0
    i32.const 32
    i32.const 929
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23631,7 +23631,7 @@
    i32.const 0
    i32.const 32
    i32.const 930
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23645,7 +23645,7 @@
    i32.const 0
    i32.const 32
    i32.const 931
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23659,7 +23659,7 @@
    i32.const 0
    i32.const 32
    i32.const 932
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23673,7 +23673,7 @@
    i32.const 0
    i32.const 32
    i32.const 933
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23687,7 +23687,7 @@
    i32.const 0
    i32.const 32
    i32.const 934
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23701,7 +23701,7 @@
    i32.const 0
    i32.const 32
    i32.const 935
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23715,7 +23715,7 @@
    i32.const 0
    i32.const 32
    i32.const 936
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23729,7 +23729,7 @@
    i32.const 0
    i32.const 32
    i32.const 937
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23743,7 +23743,7 @@
    i32.const 0
    i32.const 32
    i32.const 938
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23757,7 +23757,7 @@
    i32.const 0
    i32.const 32
    i32.const 939
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23771,7 +23771,7 @@
    i32.const 0
    i32.const 32
    i32.const 940
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23785,7 +23785,7 @@
    i32.const 0
    i32.const 32
    i32.const 941
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23799,7 +23799,7 @@
    i32.const 0
    i32.const 32
    i32.const 942
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23813,7 +23813,7 @@
    i32.const 0
    i32.const 32
    i32.const 943
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23827,7 +23827,7 @@
    i32.const 0
    i32.const 32
    i32.const 944
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23841,7 +23841,7 @@
    i32.const 0
    i32.const 32
    i32.const 945
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23855,7 +23855,7 @@
    i32.const 0
    i32.const 32
    i32.const 946
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23869,7 +23869,7 @@
    i32.const 0
    i32.const 32
    i32.const 947
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23883,7 +23883,7 @@
    i32.const 0
    i32.const 32
    i32.const 948
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23897,7 +23897,7 @@
    i32.const 0
    i32.const 32
    i32.const 949
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23911,7 +23911,7 @@
    i32.const 0
    i32.const 32
    i32.const 950
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23925,7 +23925,7 @@
    i32.const 0
    i32.const 32
    i32.const 951
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23939,7 +23939,7 @@
    i32.const 0
    i32.const 32
    i32.const 952
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23953,7 +23953,7 @@
    i32.const 0
    i32.const 32
    i32.const 953
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23967,7 +23967,7 @@
    i32.const 0
    i32.const 32
    i32.const 954
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23981,7 +23981,7 @@
    i32.const 0
    i32.const 32
    i32.const 955
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -23995,7 +23995,7 @@
    i32.const 0
    i32.const 32
    i32.const 956
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24009,7 +24009,7 @@
    i32.const 0
    i32.const 32
    i32.const 957
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24023,7 +24023,7 @@
    i32.const 0
    i32.const 32
    i32.const 958
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24037,7 +24037,7 @@
    i32.const 0
    i32.const 32
    i32.const 959
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24051,7 +24051,7 @@
    i32.const 0
    i32.const 32
    i32.const 960
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24065,7 +24065,7 @@
    i32.const 0
    i32.const 32
    i32.const 961
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24079,7 +24079,7 @@
    i32.const 0
    i32.const 32
    i32.const 962
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24093,7 +24093,7 @@
    i32.const 0
    i32.const 32
    i32.const 963
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24107,7 +24107,7 @@
    i32.const 0
    i32.const 32
    i32.const 964
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24121,7 +24121,7 @@
    i32.const 0
    i32.const 32
    i32.const 965
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24135,7 +24135,7 @@
    i32.const 0
    i32.const 32
    i32.const 976
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24149,7 +24149,7 @@
    i32.const 0
    i32.const 32
    i32.const 977
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24163,7 +24163,7 @@
    i32.const 0
    i32.const 32
    i32.const 978
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24177,7 +24177,7 @@
    i32.const 0
    i32.const 32
    i32.const 979
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24191,7 +24191,7 @@
    i32.const 0
    i32.const 32
    i32.const 980
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24205,7 +24205,7 @@
    i32.const 0
    i32.const 32
    i32.const 981
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24219,7 +24219,7 @@
    i32.const 0
    i32.const 32
    i32.const 982
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24233,7 +24233,7 @@
    i32.const 0
    i32.const 32
    i32.const 983
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24247,7 +24247,7 @@
    i32.const 0
    i32.const 32
    i32.const 984
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24261,7 +24261,7 @@
    i32.const 0
    i32.const 32
    i32.const 985
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24275,7 +24275,7 @@
    i32.const 0
    i32.const 32
    i32.const 988
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24289,7 +24289,7 @@
    i32.const 0
    i32.const 32
    i32.const 989
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24303,7 +24303,7 @@
    i32.const 0
    i32.const 32
    i32.const 990
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24317,7 +24317,7 @@
    i32.const 0
    i32.const 32
    i32.const 991
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24331,7 +24331,7 @@
    i32.const 0
    i32.const 32
    i32.const 992
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24345,7 +24345,7 @@
    i32.const 0
    i32.const 32
    i32.const 993
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24359,7 +24359,7 @@
    i32.const 0
    i32.const 32
    i32.const 994
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24373,7 +24373,7 @@
    i32.const 0
    i32.const 32
    i32.const 995
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24387,7 +24387,7 @@
    i32.const 0
    i32.const 32
    i32.const 996
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24401,7 +24401,7 @@
    i32.const 0
    i32.const 32
    i32.const 997
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24415,7 +24415,7 @@
    i32.const 0
    i32.const 32
    i32.const 998
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24429,7 +24429,7 @@
    i32.const 0
    i32.const 32
    i32.const 999
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24443,7 +24443,7 @@
    i32.const 0
    i32.const 32
    i32.const 1000
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24457,7 +24457,7 @@
    i32.const 0
    i32.const 32
    i32.const 1001
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24471,7 +24471,7 @@
    i32.const 0
    i32.const 32
    i32.const 1002
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24485,7 +24485,7 @@
    i32.const 0
    i32.const 32
    i32.const 1003
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24499,7 +24499,7 @@
    i32.const 0
    i32.const 32
    i32.const 1004
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24513,7 +24513,7 @@
    i32.const 0
    i32.const 32
    i32.const 1005
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24527,7 +24527,7 @@
    i32.const 0
    i32.const 32
    i32.const 1006
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24541,7 +24541,7 @@
    i32.const 0
    i32.const 32
    i32.const 1007
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24555,7 +24555,7 @@
    i32.const 0
    i32.const 32
    i32.const 1008
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24569,7 +24569,7 @@
    i32.const 0
    i32.const 32
    i32.const 1009
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24583,7 +24583,7 @@
    i32.const 0
    i32.const 32
    i32.const 1010
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24597,7 +24597,7 @@
    i32.const 0
    i32.const 32
    i32.const 1011
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24611,7 +24611,7 @@
    i32.const 0
    i32.const 32
    i32.const 1012
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24625,7 +24625,7 @@
    i32.const 0
    i32.const 32
    i32.const 1013
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24639,7 +24639,7 @@
    i32.const 0
    i32.const 32
    i32.const 1014
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24653,7 +24653,7 @@
    i32.const 0
    i32.const 32
    i32.const 1015
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24667,7 +24667,7 @@
    i32.const 0
    i32.const 32
    i32.const 1016
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24681,7 +24681,7 @@
    i32.const 0
    i32.const 32
    i32.const 1017
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24695,7 +24695,7 @@
    i32.const 0
    i32.const 32
    i32.const 1018
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24709,7 +24709,7 @@
    i32.const 0
    i32.const 32
    i32.const 1019
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24723,7 +24723,7 @@
    i32.const 0
    i32.const 32
    i32.const 1020
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24737,7 +24737,7 @@
    i32.const 0
    i32.const 32
    i32.const 1021
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24751,7 +24751,7 @@
    i32.const 0
    i32.const 32
    i32.const 1022
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24765,7 +24765,7 @@
    i32.const 0
    i32.const 32
    i32.const 1023
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24779,7 +24779,7 @@
    i32.const 0
    i32.const 32
    i32.const 1024
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24793,7 +24793,7 @@
    i32.const 0
    i32.const 32
    i32.const 1025
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24807,7 +24807,7 @@
    i32.const 0
    i32.const 32
    i32.const 1026
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24821,7 +24821,7 @@
    i32.const 0
    i32.const 32
    i32.const 1027
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24835,7 +24835,7 @@
    i32.const 0
    i32.const 32
    i32.const 1028
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24849,7 +24849,7 @@
    i32.const 0
    i32.const 32
    i32.const 1029
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24863,7 +24863,7 @@
    i32.const 0
    i32.const 32
    i32.const 1030
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24877,7 +24877,7 @@
    i32.const 0
    i32.const 32
    i32.const 1031
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24891,7 +24891,7 @@
    i32.const 0
    i32.const 32
    i32.const 1032
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24905,7 +24905,7 @@
    i32.const 0
    i32.const 32
    i32.const 1033
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24919,7 +24919,7 @@
    i32.const 0
    i32.const 32
    i32.const 1034
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24933,7 +24933,7 @@
    i32.const 0
    i32.const 32
    i32.const 1035
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24947,7 +24947,7 @@
    i32.const 0
    i32.const 32
    i32.const 1036
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24961,7 +24961,7 @@
    i32.const 0
    i32.const 32
    i32.const 1037
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24975,7 +24975,7 @@
    i32.const 0
    i32.const 32
    i32.const 1038
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -24989,7 +24989,7 @@
    i32.const 0
    i32.const 32
    i32.const 1039
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25003,7 +25003,7 @@
    i32.const 0
    i32.const 32
    i32.const 1040
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25017,7 +25017,7 @@
    i32.const 0
    i32.const 32
    i32.const 1041
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25031,7 +25031,7 @@
    i32.const 0
    i32.const 32
    i32.const 1042
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25045,7 +25045,7 @@
    i32.const 0
    i32.const 32
    i32.const 1043
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25059,7 +25059,7 @@
    i32.const 0
    i32.const 32
    i32.const 1044
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25073,7 +25073,7 @@
    i32.const 0
    i32.const 32
    i32.const 1045
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25087,7 +25087,7 @@
    i32.const 0
    i32.const 32
    i32.const 1046
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25101,7 +25101,7 @@
    i32.const 0
    i32.const 32
    i32.const 1047
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25115,7 +25115,7 @@
    i32.const 0
    i32.const 32
    i32.const 1048
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25129,7 +25129,7 @@
    i32.const 0
    i32.const 32
    i32.const 1049
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25143,7 +25143,7 @@
    i32.const 0
    i32.const 32
    i32.const 1050
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25157,7 +25157,7 @@
    i32.const 0
    i32.const 32
    i32.const 1051
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25171,7 +25171,7 @@
    i32.const 0
    i32.const 32
    i32.const 1052
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25185,7 +25185,7 @@
    i32.const 0
    i32.const 32
    i32.const 1053
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25199,7 +25199,7 @@
    i32.const 0
    i32.const 32
    i32.const 1054
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25213,7 +25213,7 @@
    i32.const 0
    i32.const 32
    i32.const 1055
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25227,7 +25227,7 @@
    i32.const 0
    i32.const 32
    i32.const 1056
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25241,7 +25241,7 @@
    i32.const 0
    i32.const 32
    i32.const 1057
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25255,7 +25255,7 @@
    i32.const 0
    i32.const 32
    i32.const 1058
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25269,7 +25269,7 @@
    i32.const 0
    i32.const 32
    i32.const 1059
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25283,7 +25283,7 @@
    i32.const 0
    i32.const 32
    i32.const 1060
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25297,7 +25297,7 @@
    i32.const 0
    i32.const 32
    i32.const 1061
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25311,7 +25311,7 @@
    i32.const 0
    i32.const 32
    i32.const 1062
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25325,7 +25325,7 @@
    i32.const 0
    i32.const 32
    i32.const 1063
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25339,7 +25339,7 @@
    i32.const 0
    i32.const 32
    i32.const 1064
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25353,7 +25353,7 @@
    i32.const 0
    i32.const 32
    i32.const 1065
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25367,7 +25367,7 @@
    i32.const 0
    i32.const 32
    i32.const 1068
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25381,7 +25381,7 @@
    i32.const 0
    i32.const 32
    i32.const 1069
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25395,7 +25395,7 @@
    i32.const 0
    i32.const 32
    i32.const 1070
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25409,7 +25409,7 @@
    i32.const 0
    i32.const 32
    i32.const 1071
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25423,7 +25423,7 @@
    i32.const 0
    i32.const 32
    i32.const 1072
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25437,7 +25437,7 @@
    i32.const 0
    i32.const 32
    i32.const 1073
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25451,7 +25451,7 @@
    i32.const 0
    i32.const 32
    i32.const 1074
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25465,7 +25465,7 @@
    i32.const 0
    i32.const 32
    i32.const 1075
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25479,7 +25479,7 @@
    i32.const 0
    i32.const 32
    i32.const 1076
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25493,7 +25493,7 @@
    i32.const 0
    i32.const 32
    i32.const 1077
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25507,7 +25507,7 @@
    i32.const 0
    i32.const 32
    i32.const 1078
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25521,7 +25521,7 @@
    i32.const 0
    i32.const 32
    i32.const 1079
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25535,7 +25535,7 @@
    i32.const 0
    i32.const 32
    i32.const 1080
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25549,7 +25549,7 @@
    i32.const 0
    i32.const 32
    i32.const 1081
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25563,7 +25563,7 @@
    i32.const 0
    i32.const 32
    i32.const 1082
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25577,7 +25577,7 @@
    i32.const 0
    i32.const 32
    i32.const 1083
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25591,7 +25591,7 @@
    i32.const 0
    i32.const 32
    i32.const 1084
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25605,7 +25605,7 @@
    i32.const 0
    i32.const 32
    i32.const 1085
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25619,7 +25619,7 @@
    i32.const 0
    i32.const 32
    i32.const 1086
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25633,7 +25633,7 @@
    i32.const 0
    i32.const 32
    i32.const 1087
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25647,7 +25647,7 @@
    i32.const 0
    i32.const 32
    i32.const 1088
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25661,7 +25661,7 @@
    i32.const 0
    i32.const 32
    i32.const 1089
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25675,7 +25675,7 @@
    i32.const 0
    i32.const 32
    i32.const 1090
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25689,7 +25689,7 @@
    i32.const 0
    i32.const 32
    i32.const 1091
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25703,7 +25703,7 @@
    i32.const 0
    i32.const 32
    i32.const 1092
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25717,7 +25717,7 @@
    i32.const 0
    i32.const 32
    i32.const 1093
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25731,7 +25731,7 @@
    i32.const 0
    i32.const 32
    i32.const 1094
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25745,7 +25745,7 @@
    i32.const 0
    i32.const 32
    i32.const 1095
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25759,7 +25759,7 @@
    i32.const 0
    i32.const 32
    i32.const 1096
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25773,7 +25773,7 @@
    i32.const 0
    i32.const 32
    i32.const 1097
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25787,7 +25787,7 @@
    i32.const 0
    i32.const 32
    i32.const 1098
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25801,7 +25801,7 @@
    i32.const 0
    i32.const 32
    i32.const 1099
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25815,7 +25815,7 @@
    i32.const 0
    i32.const 32
    i32.const 1100
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25829,7 +25829,7 @@
    i32.const 0
    i32.const 32
    i32.const 1101
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25843,7 +25843,7 @@
    i32.const 0
    i32.const 32
    i32.const 1102
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25857,7 +25857,7 @@
    i32.const 0
    i32.const 32
    i32.const 1103
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25871,7 +25871,7 @@
    i32.const 0
    i32.const 32
    i32.const 1104
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25885,7 +25885,7 @@
    i32.const 0
    i32.const 32
    i32.const 1105
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25899,7 +25899,7 @@
    i32.const 0
    i32.const 32
    i32.const 1107
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25913,7 +25913,7 @@
    i32.const 0
    i32.const 32
    i32.const 1108
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25927,7 +25927,7 @@
    i32.const 0
    i32.const 32
    i32.const 1109
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25940,7 +25940,7 @@
    i32.const 0
    i32.const 32
    i32.const 1113
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25953,7 +25953,7 @@
    i32.const 0
    i32.const 32
    i32.const 1114
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25966,7 +25966,7 @@
    i32.const 0
    i32.const 32
    i32.const 1117
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25979,7 +25979,7 @@
    i32.const 0
    i32.const 32
    i32.const 1119
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -25992,7 +25992,7 @@
    i32.const 0
    i32.const 32
    i32.const 1120
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26005,7 +26005,7 @@
    i32.const 0
    i32.const 32
    i32.const 1123
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26018,7 +26018,7 @@
    i32.const 0
    i32.const 32
    i32.const 1125
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26031,7 +26031,7 @@
    i32.const 0
    i32.const 32
    i32.const 1128
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26044,7 +26044,7 @@
    i32.const 0
    i32.const 32
    i32.const 1130
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26057,7 +26057,7 @@
    i32.const 0
    i32.const 32
    i32.const 1131
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26070,7 +26070,7 @@
    i32.const 0
    i32.const 32
    i32.const 1132
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26083,7 +26083,7 @@
    i32.const 0
    i32.const 32
    i32.const 1134
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26096,7 +26096,7 @@
    i32.const 0
    i32.const 32
    i32.const 1136
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26109,7 +26109,7 @@
    i32.const 0
    i32.const 32
    i32.const 1137
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26122,7 +26122,7 @@
    i32.const 0
    i32.const 32
    i32.const 1138
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26135,7 +26135,7 @@
    i32.const 0
    i32.const 32
    i32.const 1139
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26148,7 +26148,7 @@
    i32.const 0
    i32.const 32
    i32.const 1140
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26161,7 +26161,7 @@
    i32.const 0
    i32.const 32
    i32.const 1141
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26175,7 +26175,7 @@
    i32.const 0
    i32.const 32
    i32.const 1150
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26189,7 +26189,7 @@
    i32.const 0
    i32.const 32
    i32.const 1151
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26203,7 +26203,7 @@
    i32.const 0
    i32.const 32
    i32.const 1152
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26217,7 +26217,7 @@
    i32.const 0
    i32.const 32
    i32.const 1153
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26231,7 +26231,7 @@
    i32.const 0
    i32.const 32
    i32.const 1154
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26245,7 +26245,7 @@
    i32.const 0
    i32.const 32
    i32.const 1155
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26259,7 +26259,7 @@
    i32.const 0
    i32.const 32
    i32.const 1156
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26273,7 +26273,7 @@
    i32.const 0
    i32.const 32
    i32.const 1157
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26287,7 +26287,7 @@
    i32.const 0
    i32.const 32
    i32.const 1158
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26301,7 +26301,7 @@
    i32.const 0
    i32.const 32
    i32.const 1159
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26315,7 +26315,7 @@
    i32.const 0
    i32.const 32
    i32.const 1162
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26329,7 +26329,7 @@
    i32.const 0
    i32.const 32
    i32.const 1163
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26343,7 +26343,7 @@
    i32.const 0
    i32.const 32
    i32.const 1164
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26357,7 +26357,7 @@
    i32.const 0
    i32.const 32
    i32.const 1165
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26371,7 +26371,7 @@
    i32.const 0
    i32.const 32
    i32.const 1166
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26385,7 +26385,7 @@
    i32.const 0
    i32.const 32
    i32.const 1169
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26399,7 +26399,7 @@
    i32.const 0
    i32.const 32
    i32.const 1170
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26413,7 +26413,7 @@
    i32.const 0
    i32.const 32
    i32.const 1171
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26427,7 +26427,7 @@
    i32.const 0
    i32.const 32
    i32.const 1172
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26441,7 +26441,7 @@
    i32.const 0
    i32.const 32
    i32.const 1173
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26455,7 +26455,7 @@
    i32.const 0
    i32.const 32
    i32.const 1174
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26469,7 +26469,7 @@
    i32.const 0
    i32.const 32
    i32.const 1175
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26483,7 +26483,7 @@
    i32.const 0
    i32.const 32
    i32.const 1176
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26497,7 +26497,7 @@
    i32.const 0
    i32.const 32
    i32.const 1177
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26511,7 +26511,7 @@
    i32.const 0
    i32.const 32
    i32.const 1178
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26525,7 +26525,7 @@
    i32.const 0
    i32.const 32
    i32.const 1179
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26539,7 +26539,7 @@
    i32.const 0
    i32.const 32
    i32.const 1180
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26553,7 +26553,7 @@
    i32.const 0
    i32.const 32
    i32.const 1181
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26567,7 +26567,7 @@
    i32.const 0
    i32.const 32
    i32.const 1182
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26581,7 +26581,7 @@
    i32.const 0
    i32.const 32
    i32.const 1183
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26595,7 +26595,7 @@
    i32.const 0
    i32.const 32
    i32.const 1184
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26609,7 +26609,7 @@
    i32.const 0
    i32.const 32
    i32.const 1185
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26623,7 +26623,7 @@
    i32.const 0
    i32.const 32
    i32.const 1186
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26637,7 +26637,7 @@
    i32.const 0
    i32.const 32
    i32.const 1187
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26651,7 +26651,7 @@
    i32.const 0
    i32.const 32
    i32.const 1188
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26665,7 +26665,7 @@
    i32.const 0
    i32.const 32
    i32.const 1189
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26679,7 +26679,7 @@
    i32.const 0
    i32.const 32
    i32.const 1190
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26693,7 +26693,7 @@
    i32.const 0
    i32.const 32
    i32.const 1191
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26707,7 +26707,7 @@
    i32.const 0
    i32.const 32
    i32.const 1192
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26721,7 +26721,7 @@
    i32.const 0
    i32.const 32
    i32.const 1193
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26735,7 +26735,7 @@
    i32.const 0
    i32.const 32
    i32.const 1194
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26749,7 +26749,7 @@
    i32.const 0
    i32.const 32
    i32.const 1195
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26763,7 +26763,7 @@
    i32.const 0
    i32.const 32
    i32.const 1196
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26777,7 +26777,7 @@
    i32.const 0
    i32.const 32
    i32.const 1197
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26791,7 +26791,7 @@
    i32.const 0
    i32.const 32
    i32.const 1198
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26805,7 +26805,7 @@
    i32.const 0
    i32.const 32
    i32.const 1199
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26819,7 +26819,7 @@
    i32.const 0
    i32.const 32
    i32.const 1200
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26833,7 +26833,7 @@
    i32.const 0
    i32.const 32
    i32.const 1201
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26847,7 +26847,7 @@
    i32.const 0
    i32.const 32
    i32.const 1202
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26861,7 +26861,7 @@
    i32.const 0
    i32.const 32
    i32.const 1203
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26875,7 +26875,7 @@
    i32.const 0
    i32.const 32
    i32.const 1204
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26889,7 +26889,7 @@
    i32.const 0
    i32.const 32
    i32.const 1205
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26903,7 +26903,7 @@
    i32.const 0
    i32.const 32
    i32.const 1206
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26917,7 +26917,7 @@
    i32.const 0
    i32.const 32
    i32.const 1209
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26931,7 +26931,7 @@
    i32.const 0
    i32.const 32
    i32.const 1210
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26945,7 +26945,7 @@
    i32.const 0
    i32.const 32
    i32.const 1211
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26959,7 +26959,7 @@
    i32.const 0
    i32.const 32
    i32.const 1212
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26973,7 +26973,7 @@
    i32.const 0
    i32.const 32
    i32.const 1213
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -26987,7 +26987,7 @@
    i32.const 0
    i32.const 32
    i32.const 1214
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27001,7 +27001,7 @@
    i32.const 0
    i32.const 32
    i32.const 1215
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27015,7 +27015,7 @@
    i32.const 0
    i32.const 32
    i32.const 1216
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27029,7 +27029,7 @@
    i32.const 0
    i32.const 32
    i32.const 1217
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27043,7 +27043,7 @@
    i32.const 0
    i32.const 32
    i32.const 1218
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27057,7 +27057,7 @@
    i32.const 0
    i32.const 32
    i32.const 1219
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27071,7 +27071,7 @@
    i32.const 0
    i32.const 32
    i32.const 1220
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27085,7 +27085,7 @@
    i32.const 0
    i32.const 32
    i32.const 1221
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27099,7 +27099,7 @@
    i32.const 0
    i32.const 32
    i32.const 1222
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27113,7 +27113,7 @@
    i32.const 0
    i32.const 32
    i32.const 1233
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27127,7 +27127,7 @@
    i32.const 0
    i32.const 32
    i32.const 1234
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27141,7 +27141,7 @@
    i32.const 0
    i32.const 32
    i32.const 1235
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27155,7 +27155,7 @@
    i32.const 0
    i32.const 32
    i32.const 1236
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27169,7 +27169,7 @@
    i32.const 0
    i32.const 32
    i32.const 1237
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27183,7 +27183,7 @@
    i32.const 0
    i32.const 32
    i32.const 1238
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27197,7 +27197,7 @@
    i32.const 0
    i32.const 32
    i32.const 1239
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27211,7 +27211,7 @@
    i32.const 0
    i32.const 32
    i32.const 1240
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27225,7 +27225,7 @@
    i32.const 0
    i32.const 32
    i32.const 1241
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27239,7 +27239,7 @@
    i32.const 0
    i32.const 32
    i32.const 1242
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27253,7 +27253,7 @@
    i32.const 0
    i32.const 32
    i32.const 1245
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27267,7 +27267,7 @@
    i32.const 0
    i32.const 32
    i32.const 1246
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27281,7 +27281,7 @@
    i32.const 0
    i32.const 32
    i32.const 1247
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27295,7 +27295,7 @@
    i32.const 0
    i32.const 32
    i32.const 1248
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27309,7 +27309,7 @@
    i32.const 0
    i32.const 32
    i32.const 1249
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27323,7 +27323,7 @@
    i32.const 0
    i32.const 32
    i32.const 1258
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27337,7 +27337,7 @@
    i32.const 0
    i32.const 32
    i32.const 1259
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27351,7 +27351,7 @@
    i32.const 0
    i32.const 32
    i32.const 1260
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27365,7 +27365,7 @@
    i32.const 0
    i32.const 32
    i32.const 1261
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27379,7 +27379,7 @@
    i32.const 0
    i32.const 32
    i32.const 1262
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27393,7 +27393,7 @@
    i32.const 0
    i32.const 32
    i32.const 1263
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27407,7 +27407,7 @@
    i32.const 0
    i32.const 32
    i32.const 1264
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27421,7 +27421,7 @@
    i32.const 0
    i32.const 32
    i32.const 1265
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27435,7 +27435,7 @@
    i32.const 0
    i32.const 32
    i32.const 1266
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27449,7 +27449,7 @@
    i32.const 0
    i32.const 32
    i32.const 1267
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27463,7 +27463,7 @@
    i32.const 0
    i32.const 32
    i32.const 1270
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27477,7 +27477,7 @@
    i32.const 0
    i32.const 32
    i32.const 1271
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27491,7 +27491,7 @@
    i32.const 0
    i32.const 32
    i32.const 1272
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27505,7 +27505,7 @@
    i32.const 0
    i32.const 32
    i32.const 1273
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27519,7 +27519,7 @@
    i32.const 0
    i32.const 32
    i32.const 1274
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27533,7 +27533,7 @@
    i32.const 0
    i32.const 32
    i32.const 1286
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27547,7 +27547,7 @@
    i32.const 0
    i32.const 32
    i32.const 1287
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27561,7 +27561,7 @@
    i32.const 0
    i32.const 32
    i32.const 1288
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27575,7 +27575,7 @@
    i32.const 0
    i32.const 32
    i32.const 1289
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27589,7 +27589,7 @@
    i32.const 0
    i32.const 32
    i32.const 1290
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27603,7 +27603,7 @@
    i32.const 0
    i32.const 32
    i32.const 1291
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27617,7 +27617,7 @@
    i32.const 0
    i32.const 32
    i32.const 1292
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27631,7 +27631,7 @@
    i32.const 0
    i32.const 32
    i32.const 1293
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27645,7 +27645,7 @@
    i32.const 0
    i32.const 32
    i32.const 1294
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27659,7 +27659,7 @@
    i32.const 0
    i32.const 32
    i32.const 1295
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27673,7 +27673,7 @@
    i32.const 0
    i32.const 32
    i32.const 1298
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27687,7 +27687,7 @@
    i32.const 0
    i32.const 32
    i32.const 1299
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27701,7 +27701,7 @@
    i32.const 0
    i32.const 32
    i32.const 1300
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27715,7 +27715,7 @@
    i32.const 0
    i32.const 32
    i32.const 1301
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27729,7 +27729,7 @@
    i32.const 0
    i32.const 32
    i32.const 1302
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27743,7 +27743,7 @@
    i32.const 0
    i32.const 32
    i32.const 1303
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27757,7 +27757,7 @@
    i32.const 0
    i32.const 32
    i32.const 1304
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27771,7 +27771,7 @@
    i32.const 0
    i32.const 32
    i32.const 1305
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27785,7 +27785,7 @@
    i32.const 0
    i32.const 32
    i32.const 1306
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27799,7 +27799,7 @@
    i32.const 0
    i32.const 32
    i32.const 1307
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27813,7 +27813,7 @@
    i32.const 0
    i32.const 32
    i32.const 1308
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27827,7 +27827,7 @@
    i32.const 0
    i32.const 32
    i32.const 1311
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27841,7 +27841,7 @@
    i32.const 0
    i32.const 32
    i32.const 1312
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27855,7 +27855,7 @@
    i32.const 0
    i32.const 32
    i32.const 1314
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27869,7 +27869,7 @@
    i32.const 0
    i32.const 32
    i32.const 1321
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27883,7 +27883,7 @@
    i32.const 0
    i32.const 32
    i32.const 1322
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27897,7 +27897,7 @@
    i32.const 0
    i32.const 32
    i32.const 1329
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27911,7 +27911,7 @@
    i32.const 0
    i32.const 32
    i32.const 1336
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27925,7 +27925,7 @@
    i32.const 0
    i32.const 32
    i32.const 1343
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27939,7 +27939,7 @@
    i32.const 0
    i32.const 32
    i32.const 1350
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27953,7 +27953,7 @@
    i32.const 0
    i32.const 32
    i32.const 1357
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27967,7 +27967,7 @@
    i32.const 0
    i32.const 32
    i32.const 1364
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27981,7 +27981,7 @@
    i32.const 0
    i32.const 32
    i32.const 1370
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -27995,7 +27995,7 @@
    i32.const 0
    i32.const 32
    i32.const 1376
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28009,7 +28009,7 @@
    i32.const 0
    i32.const 32
    i32.const 1382
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28023,7 +28023,7 @@
    i32.const 0
    i32.const 32
    i32.const 1389
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28037,7 +28037,7 @@
    i32.const 0
    i32.const 32
    i32.const 1396
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28051,7 +28051,7 @@
    i32.const 0
    i32.const 32
    i32.const 1403
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28065,7 +28065,7 @@
    i32.const 0
    i32.const 32
    i32.const 1410
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28079,7 +28079,7 @@
    i32.const 0
    i32.const 32
    i32.const 1417
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28093,7 +28093,7 @@
    i32.const 0
    i32.const 32
    i32.const 1424
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28107,7 +28107,7 @@
    i32.const 0
    i32.const 32
    i32.const 1431
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28121,7 +28121,7 @@
    i32.const 0
    i32.const 32
    i32.const 1438
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28135,7 +28135,7 @@
    i32.const 0
    i32.const 32
    i32.const 1452
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28149,7 +28149,7 @@
    i32.const 0
    i32.const 32
    i32.const 1453
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28163,7 +28163,7 @@
    i32.const 0
    i32.const 32
    i32.const 1454
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28177,7 +28177,7 @@
    i32.const 0
    i32.const 32
    i32.const 1455
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28191,7 +28191,7 @@
    i32.const 0
    i32.const 32
    i32.const 1456
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28205,7 +28205,7 @@
    i32.const 0
    i32.const 32
    i32.const 1457
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28219,7 +28219,7 @@
    i32.const 0
    i32.const 32
    i32.const 1458
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28233,7 +28233,7 @@
    i32.const 0
    i32.const 32
    i32.const 1459
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28247,7 +28247,7 @@
    i32.const 0
    i32.const 32
    i32.const 1460
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28261,7 +28261,7 @@
    i32.const 0
    i32.const 32
    i32.const 1461
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28275,7 +28275,7 @@
    i32.const 0
    i32.const 32
    i32.const 1464
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28289,7 +28289,7 @@
    i32.const 0
    i32.const 32
    i32.const 1465
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28303,7 +28303,7 @@
    i32.const 0
    i32.const 32
    i32.const 1466
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28317,7 +28317,7 @@
    i32.const 0
    i32.const 32
    i32.const 1467
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28331,7 +28331,7 @@
    i32.const 0
    i32.const 32
    i32.const 1468
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28345,7 +28345,7 @@
    i32.const 0
    i32.const 32
    i32.const 1469
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28359,7 +28359,7 @@
    i32.const 0
    i32.const 32
    i32.const 1470
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28373,7 +28373,7 @@
    i32.const 0
    i32.const 32
    i32.const 1471
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28387,7 +28387,7 @@
    i32.const 0
    i32.const 32
    i32.const 1472
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28401,7 +28401,7 @@
    i32.const 0
    i32.const 32
    i32.const 1473
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28415,7 +28415,7 @@
    i32.const 0
    i32.const 32
    i32.const 1474
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28429,7 +28429,7 @@
    i32.const 0
    i32.const 32
    i32.const 1475
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28443,7 +28443,7 @@
    i32.const 0
    i32.const 32
    i32.const 1476
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28457,7 +28457,7 @@
    i32.const 0
    i32.const 32
    i32.const 1477
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28471,7 +28471,7 @@
    i32.const 0
    i32.const 32
    i32.const 1489
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28485,7 +28485,7 @@
    i32.const 0
    i32.const 32
    i32.const 1490
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28499,7 +28499,7 @@
    i32.const 0
    i32.const 32
    i32.const 1491
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28513,7 +28513,7 @@
    i32.const 0
    i32.const 32
    i32.const 1492
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28527,7 +28527,7 @@
    i32.const 0
    i32.const 32
    i32.const 1493
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28541,7 +28541,7 @@
    i32.const 0
    i32.const 32
    i32.const 1494
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28555,7 +28555,7 @@
    i32.const 0
    i32.const 32
    i32.const 1495
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28569,7 +28569,7 @@
    i32.const 0
    i32.const 32
    i32.const 1496
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28583,7 +28583,7 @@
    i32.const 0
    i32.const 32
    i32.const 1497
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28597,7 +28597,7 @@
    i32.const 0
    i32.const 32
    i32.const 1498
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28611,7 +28611,7 @@
    i32.const 0
    i32.const 32
    i32.const 1501
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28625,7 +28625,7 @@
    i32.const 0
    i32.const 32
    i32.const 1502
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28639,7 +28639,7 @@
    i32.const 0
    i32.const 32
    i32.const 1503
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28653,7 +28653,7 @@
    i32.const 0
    i32.const 32
    i32.const 1504
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28667,7 +28667,7 @@
    i32.const 0
    i32.const 32
    i32.const 1505
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28681,7 +28681,7 @@
    i32.const 0
    i32.const 32
    i32.const 1506
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28695,7 +28695,7 @@
    i32.const 0
    i32.const 32
    i32.const 1507
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28709,7 +28709,7 @@
    i32.const 0
    i32.const 32
    i32.const 1508
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28723,7 +28723,7 @@
    i32.const 0
    i32.const 32
    i32.const 1509
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28737,7 +28737,7 @@
    i32.const 0
    i32.const 32
    i32.const 1518
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28751,7 +28751,7 @@
    i32.const 0
    i32.const 32
    i32.const 1519
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28765,7 +28765,7 @@
    i32.const 0
    i32.const 32
    i32.const 1520
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28779,7 +28779,7 @@
    i32.const 0
    i32.const 32
    i32.const 1521
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28793,7 +28793,7 @@
    i32.const 0
    i32.const 32
    i32.const 1522
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28807,7 +28807,7 @@
    i32.const 0
    i32.const 32
    i32.const 1523
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28821,7 +28821,7 @@
    i32.const 0
    i32.const 32
    i32.const 1524
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28835,7 +28835,7 @@
    i32.const 0
    i32.const 32
    i32.const 1525
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28849,7 +28849,7 @@
    i32.const 0
    i32.const 32
    i32.const 1526
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28863,7 +28863,7 @@
    i32.const 0
    i32.const 32
    i32.const 1527
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28877,7 +28877,7 @@
    i32.const 0
    i32.const 32
    i32.const 1530
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28891,7 +28891,7 @@
    i32.const 0
    i32.const 32
    i32.const 1531
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28905,7 +28905,7 @@
    i32.const 0
    i32.const 32
    i32.const 1532
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28919,7 +28919,7 @@
    i32.const 0
    i32.const 32
    i32.const 1533
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28933,7 +28933,7 @@
    i32.const 0
    i32.const 32
    i32.const 1534
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28947,7 +28947,7 @@
    i32.const 0
    i32.const 32
    i32.const 1535
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28961,7 +28961,7 @@
    i32.const 0
    i32.const 32
    i32.const 1536
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28975,7 +28975,7 @@
    i32.const 0
    i32.const 32
    i32.const 1548
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -28989,7 +28989,7 @@
    i32.const 0
    i32.const 32
    i32.const 1549
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29003,7 +29003,7 @@
    i32.const 0
    i32.const 32
    i32.const 1550
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29017,7 +29017,7 @@
    i32.const 0
    i32.const 32
    i32.const 1551
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29031,7 +29031,7 @@
    i32.const 0
    i32.const 32
    i32.const 1552
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29045,7 +29045,7 @@
    i32.const 0
    i32.const 32
    i32.const 1553
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29059,7 +29059,7 @@
    i32.const 0
    i32.const 32
    i32.const 1554
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29073,7 +29073,7 @@
    i32.const 0
    i32.const 32
    i32.const 1555
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29087,7 +29087,7 @@
    i32.const 0
    i32.const 32
    i32.const 1556
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29101,7 +29101,7 @@
    i32.const 0
    i32.const 32
    i32.const 1557
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29115,7 +29115,7 @@
    i32.const 0
    i32.const 32
    i32.const 1560
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29129,7 +29129,7 @@
    i32.const 0
    i32.const 32
    i32.const 1561
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29143,7 +29143,7 @@
    i32.const 0
    i32.const 32
    i32.const 1562
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29157,7 +29157,7 @@
    i32.const 0
    i32.const 32
    i32.const 1563
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29171,7 +29171,7 @@
    i32.const 0
    i32.const 32
    i32.const 1564
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29185,7 +29185,7 @@
    i32.const 0
    i32.const 32
    i32.const 1565
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29199,7 +29199,7 @@
    i32.const 0
    i32.const 32
    i32.const 1566
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29213,7 +29213,7 @@
    i32.const 0
    i32.const 32
    i32.const 1567
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29227,7 +29227,7 @@
    i32.const 0
    i32.const 32
    i32.const 1568
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29241,7 +29241,7 @@
    i32.const 0
    i32.const 32
    i32.const 1569
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29255,7 +29255,7 @@
    i32.const 0
    i32.const 32
    i32.const 1570
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29269,7 +29269,7 @@
    i32.const 0
    i32.const 32
    i32.const 1571
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29283,7 +29283,7 @@
    i32.const 0
    i32.const 32
    i32.const 1572
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29297,7 +29297,7 @@
    i32.const 0
    i32.const 32
    i32.const 1573
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29311,7 +29311,7 @@
    i32.const 0
    i32.const 32
    i32.const 1574
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29325,7 +29325,7 @@
    i32.const 0
    i32.const 32
    i32.const 1575
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29339,7 +29339,7 @@
    i32.const 0
    i32.const 32
    i32.const 1576
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29353,7 +29353,7 @@
    i32.const 0
    i32.const 32
    i32.const 1577
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29367,7 +29367,7 @@
    i32.const 0
    i32.const 32
    i32.const 1578
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29381,7 +29381,7 @@
    i32.const 0
    i32.const 32
    i32.const 1579
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29395,7 +29395,7 @@
    i32.const 0
    i32.const 32
    i32.const 1580
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29409,7 +29409,7 @@
    i32.const 0
    i32.const 32
    i32.const 1581
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29423,7 +29423,7 @@
    i32.const 0
    i32.const 32
    i32.const 1582
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29437,7 +29437,7 @@
    i32.const 0
    i32.const 32
    i32.const 1583
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29451,7 +29451,7 @@
    i32.const 0
    i32.const 32
    i32.const 1584
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29465,7 +29465,7 @@
    i32.const 0
    i32.const 32
    i32.const 1595
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29479,7 +29479,7 @@
    i32.const 0
    i32.const 32
    i32.const 1596
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29493,7 +29493,7 @@
    i32.const 0
    i32.const 32
    i32.const 1597
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29507,7 +29507,7 @@
    i32.const 0
    i32.const 32
    i32.const 1598
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29521,7 +29521,7 @@
    i32.const 0
    i32.const 32
    i32.const 1599
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29535,7 +29535,7 @@
    i32.const 0
    i32.const 32
    i32.const 1600
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29549,7 +29549,7 @@
    i32.const 0
    i32.const 32
    i32.const 1601
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29563,7 +29563,7 @@
    i32.const 0
    i32.const 32
    i32.const 1602
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29577,7 +29577,7 @@
    i32.const 0
    i32.const 32
    i32.const 1603
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29591,7 +29591,7 @@
    i32.const 0
    i32.const 32
    i32.const 1604
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29605,7 +29605,7 @@
    i32.const 0
    i32.const 32
    i32.const 1616
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29619,7 +29619,7 @@
    i32.const 0
    i32.const 32
    i32.const 1617
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29633,7 +29633,7 @@
    i32.const 0
    i32.const 32
    i32.const 1618
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29647,7 +29647,7 @@
    i32.const 0
    i32.const 32
    i32.const 1619
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29661,7 +29661,7 @@
    i32.const 0
    i32.const 32
    i32.const 1620
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29675,7 +29675,7 @@
    i32.const 0
    i32.const 32
    i32.const 1621
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29689,7 +29689,7 @@
    i32.const 0
    i32.const 32
    i32.const 1622
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29703,7 +29703,7 @@
    i32.const 0
    i32.const 32
    i32.const 1623
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29717,7 +29717,7 @@
    i32.const 0
    i32.const 32
    i32.const 1624
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29731,7 +29731,7 @@
    i32.const 0
    i32.const 32
    i32.const 1625
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29745,7 +29745,7 @@
    i32.const 0
    i32.const 32
    i32.const 1628
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29759,7 +29759,7 @@
    i32.const 0
    i32.const 32
    i32.const 1629
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29773,7 +29773,7 @@
    i32.const 0
    i32.const 32
    i32.const 1630
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29787,7 +29787,7 @@
    i32.const 0
    i32.const 32
    i32.const 1631
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29801,7 +29801,7 @@
    i32.const 0
    i32.const 32
    i32.const 1632
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29815,7 +29815,7 @@
    i32.const 0
    i32.const 32
    i32.const 1633
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29829,7 +29829,7 @@
    i32.const 0
    i32.const 32
    i32.const 1634
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29843,7 +29843,7 @@
    i32.const 0
    i32.const 32
    i32.const 1635
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29857,7 +29857,7 @@
    i32.const 0
    i32.const 32
    i32.const 1636
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29871,7 +29871,7 @@
    i32.const 0
    i32.const 32
    i32.const 1637
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29885,7 +29885,7 @@
    i32.const 0
    i32.const 32
    i32.const 1638
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29899,7 +29899,7 @@
    i32.const 0
    i32.const 32
    i32.const 1639
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29913,7 +29913,7 @@
    i32.const 0
    i32.const 32
    i32.const 1640
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29927,7 +29927,7 @@
    i32.const 0
    i32.const 32
    i32.const 1641
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29941,7 +29941,7 @@
    i32.const 0
    i32.const 32
    i32.const 1642
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29955,7 +29955,7 @@
    i32.const 0
    i32.const 32
    i32.const 1651
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29969,7 +29969,7 @@
    i32.const 0
    i32.const 32
    i32.const 1652
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29983,7 +29983,7 @@
    i32.const 0
    i32.const 32
    i32.const 1653
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -29997,7 +29997,7 @@
    i32.const 0
    i32.const 32
    i32.const 1654
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30011,7 +30011,7 @@
    i32.const 0
    i32.const 32
    i32.const 1655
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30025,7 +30025,7 @@
    i32.const 0
    i32.const 32
    i32.const 1656
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30039,7 +30039,7 @@
    i32.const 0
    i32.const 32
    i32.const 1657
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30053,7 +30053,7 @@
    i32.const 0
    i32.const 32
    i32.const 1658
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30067,7 +30067,7 @@
    i32.const 0
    i32.const 32
    i32.const 1659
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30081,7 +30081,7 @@
    i32.const 0
    i32.const 32
    i32.const 1660
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30095,7 +30095,7 @@
    i32.const 0
    i32.const 32
    i32.const 1663
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30109,7 +30109,7 @@
    i32.const 0
    i32.const 32
    i32.const 1664
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30123,7 +30123,7 @@
    i32.const 0
    i32.const 32
    i32.const 1665
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30137,7 +30137,7 @@
    i32.const 0
    i32.const 32
    i32.const 1666
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30151,7 +30151,7 @@
    i32.const 0
    i32.const 32
    i32.const 1667
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30165,7 +30165,7 @@
    i32.const 0
    i32.const 32
    i32.const 1668
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30179,7 +30179,7 @@
    i32.const 0
    i32.const 32
    i32.const 1669
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30193,7 +30193,7 @@
    i32.const 0
    i32.const 32
    i32.const 1670
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30207,7 +30207,7 @@
    i32.const 0
    i32.const 32
    i32.const 1671
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30221,7 +30221,7 @@
    i32.const 0
    i32.const 32
    i32.const 1672
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30235,7 +30235,7 @@
    i32.const 0
    i32.const 32
    i32.const 1673
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30249,7 +30249,7 @@
    i32.const 0
    i32.const 32
    i32.const 1674
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30263,7 +30263,7 @@
    i32.const 0
    i32.const 32
    i32.const 1675
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30277,7 +30277,7 @@
    i32.const 0
    i32.const 32
    i32.const 1676
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30291,7 +30291,7 @@
    i32.const 0
    i32.const 32
    i32.const 1677
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30306,7 +30306,7 @@
    i32.const 0
    i32.const 32
    i32.const 1691
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30321,7 +30321,7 @@
    i32.const 0
    i32.const 32
    i32.const 1692
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30336,7 +30336,7 @@
    i32.const 0
    i32.const 32
    i32.const 1693
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30351,7 +30351,7 @@
    i32.const 0
    i32.const 32
    i32.const 1694
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30366,7 +30366,7 @@
    i32.const 0
    i32.const 32
    i32.const 1695
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30381,7 +30381,7 @@
    i32.const 0
    i32.const 32
    i32.const 1696
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30396,7 +30396,7 @@
    i32.const 0
    i32.const 32
    i32.const 1697
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30411,7 +30411,7 @@
    i32.const 0
    i32.const 32
    i32.const 1698
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30426,7 +30426,7 @@
    i32.const 0
    i32.const 32
    i32.const 1699
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30441,7 +30441,7 @@
    i32.const 0
    i32.const 32
    i32.const 1700
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30456,7 +30456,7 @@
    i32.const 0
    i32.const 32
    i32.const 1703
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30471,7 +30471,7 @@
    i32.const 0
    i32.const 32
    i32.const 1704
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30486,7 +30486,7 @@
    i32.const 0
    i32.const 32
    i32.const 1705
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30501,7 +30501,7 @@
    i32.const 0
    i32.const 32
    i32.const 1706
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30516,7 +30516,7 @@
    i32.const 0
    i32.const 32
    i32.const 1707
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30531,7 +30531,7 @@
    i32.const 0
    i32.const 32
    i32.const 1708
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30546,7 +30546,7 @@
    i32.const 0
    i32.const 32
    i32.const 1709
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30561,7 +30561,7 @@
    i32.const 0
    i32.const 32
    i32.const 1710
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30576,7 +30576,7 @@
    i32.const 0
    i32.const 32
    i32.const 1711
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30591,7 +30591,7 @@
    i32.const 0
    i32.const 32
    i32.const 1712
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30606,7 +30606,7 @@
    i32.const 0
    i32.const 32
    i32.const 1713
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30621,7 +30621,7 @@
    i32.const 0
    i32.const 32
    i32.const 1714
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30636,7 +30636,7 @@
    i32.const 0
    i32.const 32
    i32.const 1715
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30651,7 +30651,7 @@
    i32.const 0
    i32.const 32
    i32.const 1716
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30666,7 +30666,7 @@
    i32.const 0
    i32.const 32
    i32.const 1717
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30681,7 +30681,7 @@
    i32.const 0
    i32.const 32
    i32.const 1718
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30696,7 +30696,7 @@
    i32.const 0
    i32.const 32
    i32.const 1719
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30711,7 +30711,7 @@
    i32.const 0
    i32.const 32
    i32.const 1720
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30726,7 +30726,7 @@
    i32.const 0
    i32.const 32
    i32.const 1721
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30741,7 +30741,7 @@
    i32.const 0
    i32.const 32
    i32.const 1722
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30756,7 +30756,7 @@
    i32.const 0
    i32.const 32
    i32.const 1723
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30771,7 +30771,7 @@
    i32.const 0
    i32.const 32
    i32.const 1732
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30786,7 +30786,7 @@
    i32.const 0
    i32.const 32
    i32.const 1733
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30801,7 +30801,7 @@
    i32.const 0
    i32.const 32
    i32.const 1734
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30816,7 +30816,7 @@
    i32.const 0
    i32.const 32
    i32.const 1735
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30831,7 +30831,7 @@
    i32.const 0
    i32.const 32
    i32.const 1736
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30846,7 +30846,7 @@
    i32.const 0
    i32.const 32
    i32.const 1737
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30861,7 +30861,7 @@
    i32.const 0
    i32.const 32
    i32.const 1738
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30876,7 +30876,7 @@
    i32.const 0
    i32.const 32
    i32.const 1739
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30891,7 +30891,7 @@
    i32.const 0
    i32.const 32
    i32.const 1740
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30906,7 +30906,7 @@
    i32.const 0
    i32.const 32
    i32.const 1741
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30921,7 +30921,7 @@
    i32.const 0
    i32.const 32
    i32.const 1744
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30936,7 +30936,7 @@
    i32.const 0
    i32.const 32
    i32.const 1745
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30951,7 +30951,7 @@
    i32.const 0
    i32.const 32
    i32.const 1746
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30966,7 +30966,7 @@
    i32.const 0
    i32.const 32
    i32.const 1747
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30981,7 +30981,7 @@
    i32.const 0
    i32.const 32
    i32.const 1748
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -30996,7 +30996,7 @@
    i32.const 0
    i32.const 32
    i32.const 1749
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31011,7 +31011,7 @@
    i32.const 0
    i32.const 32
    i32.const 1750
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31026,7 +31026,7 @@
    i32.const 0
    i32.const 32
    i32.const 1751
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31041,7 +31041,7 @@
    i32.const 0
    i32.const 32
    i32.const 1752
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31056,7 +31056,7 @@
    i32.const 0
    i32.const 32
    i32.const 1753
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31071,7 +31071,7 @@
    i32.const 0
    i32.const 32
    i32.const 1754
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31086,7 +31086,7 @@
    i32.const 0
    i32.const 32
    i32.const 1755
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31101,7 +31101,7 @@
    i32.const 0
    i32.const 32
    i32.const 1756
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31116,7 +31116,7 @@
    i32.const 0
    i32.const 32
    i32.const 1757
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31131,7 +31131,7 @@
    i32.const 0
    i32.const 32
    i32.const 1758
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31146,7 +31146,7 @@
    i32.const 0
    i32.const 32
    i32.const 1759
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31161,7 +31161,7 @@
    i32.const 0
    i32.const 32
    i32.const 1760
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31176,7 +31176,7 @@
    i32.const 0
    i32.const 32
    i32.const 1761
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31191,7 +31191,7 @@
    i32.const 0
    i32.const 32
    i32.const 1762
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31205,7 +31205,7 @@
    i32.const 0
    i32.const 32
    i32.const 1774
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31219,7 +31219,7 @@
    i32.const 0
    i32.const 32
    i32.const 1775
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31233,7 +31233,7 @@
    i32.const 0
    i32.const 32
    i32.const 1776
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31247,7 +31247,7 @@
    i32.const 0
    i32.const 32
    i32.const 1777
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31261,7 +31261,7 @@
    i32.const 0
    i32.const 32
    i32.const 1778
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31275,7 +31275,7 @@
    i32.const 0
    i32.const 32
    i32.const 1779
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31289,7 +31289,7 @@
    i32.const 0
    i32.const 32
    i32.const 1780
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31303,7 +31303,7 @@
    i32.const 0
    i32.const 32
    i32.const 1781
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31317,7 +31317,7 @@
    i32.const 0
    i32.const 32
    i32.const 1782
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31331,7 +31331,7 @@
    i32.const 0
    i32.const 32
    i32.const 1783
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31345,7 +31345,7 @@
    i32.const 0
    i32.const 32
    i32.const 1786
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31359,7 +31359,7 @@
    i32.const 0
    i32.const 32
    i32.const 1787
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31373,7 +31373,7 @@
    i32.const 0
    i32.const 32
    i32.const 1788
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31387,7 +31387,7 @@
    i32.const 0
    i32.const 32
    i32.const 1789
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31401,7 +31401,7 @@
    i32.const 0
    i32.const 32
    i32.const 1790
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31415,7 +31415,7 @@
    i32.const 0
    i32.const 32
    i32.const 1791
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31429,7 +31429,7 @@
    i32.const 0
    i32.const 32
    i32.const 1792
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31443,7 +31443,7 @@
    i32.const 0
    i32.const 32
    i32.const 1793
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31457,7 +31457,7 @@
    i32.const 0
    i32.const 32
    i32.const 1802
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31471,7 +31471,7 @@
    i32.const 0
    i32.const 32
    i32.const 1803
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31485,7 +31485,7 @@
    i32.const 0
    i32.const 32
    i32.const 1804
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31499,7 +31499,7 @@
    i32.const 0
    i32.const 32
    i32.const 1805
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31513,7 +31513,7 @@
    i32.const 0
    i32.const 32
    i32.const 1806
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31527,7 +31527,7 @@
    i32.const 0
    i32.const 32
    i32.const 1807
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31541,7 +31541,7 @@
    i32.const 0
    i32.const 32
    i32.const 1808
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31555,7 +31555,7 @@
    i32.const 0
    i32.const 32
    i32.const 1809
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31569,7 +31569,7 @@
    i32.const 0
    i32.const 32
    i32.const 1812
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31583,7 +31583,7 @@
    i32.const 0
    i32.const 32
    i32.const 1813
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31597,7 +31597,7 @@
    i32.const 0
    i32.const 32
    i32.const 1814
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31611,7 +31611,7 @@
    i32.const 0
    i32.const 32
    i32.const 1815
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31625,7 +31625,7 @@
    i32.const 0
    i32.const 32
    i32.const 1816
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31639,7 +31639,7 @@
    i32.const 0
    i32.const 32
    i32.const 1817
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31653,7 +31653,7 @@
    i32.const 0
    i32.const 32
    i32.const 1818
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31667,7 +31667,7 @@
    i32.const 0
    i32.const 32
    i32.const 1819
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31681,7 +31681,7 @@
    i32.const 0
    i32.const 32
    i32.const 1831
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31695,7 +31695,7 @@
    i32.const 0
    i32.const 32
    i32.const 1832
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31709,7 +31709,7 @@
    i32.const 0
    i32.const 32
    i32.const 1833
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31723,7 +31723,7 @@
    i32.const 0
    i32.const 32
    i32.const 1834
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31737,7 +31737,7 @@
    i32.const 0
    i32.const 32
    i32.const 1835
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31751,7 +31751,7 @@
    i32.const 0
    i32.const 32
    i32.const 1836
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31765,7 +31765,7 @@
    i32.const 0
    i32.const 32
    i32.const 1837
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31779,7 +31779,7 @@
    i32.const 0
    i32.const 32
    i32.const 1838
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31793,7 +31793,7 @@
    i32.const 0
    i32.const 32
    i32.const 1839
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31807,7 +31807,7 @@
    i32.const 0
    i32.const 32
    i32.const 1840
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31821,7 +31821,7 @@
    i32.const 0
    i32.const 32
    i32.const 1843
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31835,7 +31835,7 @@
    i32.const 0
    i32.const 32
    i32.const 1844
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31849,7 +31849,7 @@
    i32.const 0
    i32.const 32
    i32.const 1845
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31863,7 +31863,7 @@
    i32.const 0
    i32.const 32
    i32.const 1846
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31877,7 +31877,7 @@
    i32.const 0
    i32.const 32
    i32.const 1847
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31891,7 +31891,7 @@
    i32.const 0
    i32.const 32
    i32.const 1848
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31905,7 +31905,7 @@
    i32.const 0
    i32.const 32
    i32.const 1849
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31919,7 +31919,7 @@
    i32.const 0
    i32.const 32
    i32.const 1850
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31933,7 +31933,7 @@
    i32.const 0
    i32.const 32
    i32.const 1859
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31947,7 +31947,7 @@
    i32.const 0
    i32.const 32
    i32.const 1860
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31961,7 +31961,7 @@
    i32.const 0
    i32.const 32
    i32.const 1861
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31975,7 +31975,7 @@
    i32.const 0
    i32.const 32
    i32.const 1862
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -31989,7 +31989,7 @@
    i32.const 0
    i32.const 32
    i32.const 1863
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32003,7 +32003,7 @@
    i32.const 0
    i32.const 32
    i32.const 1864
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32017,7 +32017,7 @@
    i32.const 0
    i32.const 32
    i32.const 1865
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32031,7 +32031,7 @@
    i32.const 0
    i32.const 32
    i32.const 1866
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32045,7 +32045,7 @@
    i32.const 0
    i32.const 32
    i32.const 1867
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32059,7 +32059,7 @@
    i32.const 0
    i32.const 32
    i32.const 1868
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32073,7 +32073,7 @@
    i32.const 0
    i32.const 32
    i32.const 1871
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32087,7 +32087,7 @@
    i32.const 0
    i32.const 32
    i32.const 1872
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32101,7 +32101,7 @@
    i32.const 0
    i32.const 32
    i32.const 1873
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32115,7 +32115,7 @@
    i32.const 0
    i32.const 32
    i32.const 1874
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32129,7 +32129,7 @@
    i32.const 0
    i32.const 32
    i32.const 1875
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32143,7 +32143,7 @@
    i32.const 0
    i32.const 32
    i32.const 1876
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32157,7 +32157,7 @@
    i32.const 0
    i32.const 32
    i32.const 1877
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32171,7 +32171,7 @@
    i32.const 0
    i32.const 32
    i32.const 1878
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32185,7 +32185,7 @@
    i32.const 0
    i32.const 32
    i32.const 1890
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32199,7 +32199,7 @@
    i32.const 0
    i32.const 32
    i32.const 1891
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32213,7 +32213,7 @@
    i32.const 0
    i32.const 32
    i32.const 1892
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32227,7 +32227,7 @@
    i32.const 0
    i32.const 32
    i32.const 1893
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32241,7 +32241,7 @@
    i32.const 0
    i32.const 32
    i32.const 1894
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32255,7 +32255,7 @@
    i32.const 0
    i32.const 32
    i32.const 1895
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32269,7 +32269,7 @@
    i32.const 0
    i32.const 32
    i32.const 1896
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32283,7 +32283,7 @@
    i32.const 0
    i32.const 32
    i32.const 1897
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32297,7 +32297,7 @@
    i32.const 0
    i32.const 32
    i32.const 1898
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32311,7 +32311,7 @@
    i32.const 0
    i32.const 32
    i32.const 1899
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32325,7 +32325,7 @@
    i32.const 0
    i32.const 32
    i32.const 1902
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32339,7 +32339,7 @@
    i32.const 0
    i32.const 32
    i32.const 1903
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32353,7 +32353,7 @@
    i32.const 0
    i32.const 32
    i32.const 1904
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32367,7 +32367,7 @@
    i32.const 0
    i32.const 32
    i32.const 1905
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32381,7 +32381,7 @@
    i32.const 0
    i32.const 32
    i32.const 1906
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32395,7 +32395,7 @@
    i32.const 0
    i32.const 32
    i32.const 1907
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32409,7 +32409,7 @@
    i32.const 0
    i32.const 32
    i32.const 1908
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32423,7 +32423,7 @@
    i32.const 0
    i32.const 32
    i32.const 1909
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32437,7 +32437,7 @@
    i32.const 0
    i32.const 32
    i32.const 1918
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32451,7 +32451,7 @@
    i32.const 0
    i32.const 32
    i32.const 1919
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32465,7 +32465,7 @@
    i32.const 0
    i32.const 32
    i32.const 1920
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32479,7 +32479,7 @@
    i32.const 0
    i32.const 32
    i32.const 1921
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32493,7 +32493,7 @@
    i32.const 0
    i32.const 32
    i32.const 1922
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32507,7 +32507,7 @@
    i32.const 0
    i32.const 32
    i32.const 1923
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32521,7 +32521,7 @@
    i32.const 0
    i32.const 32
    i32.const 1924
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32535,7 +32535,7 @@
    i32.const 0
    i32.const 32
    i32.const 1925
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32549,7 +32549,7 @@
    i32.const 0
    i32.const 32
    i32.const 1926
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32563,7 +32563,7 @@
    i32.const 0
    i32.const 32
    i32.const 1927
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32577,7 +32577,7 @@
    i32.const 0
    i32.const 32
    i32.const 1930
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32591,7 +32591,7 @@
    i32.const 0
    i32.const 32
    i32.const 1931
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32605,7 +32605,7 @@
    i32.const 0
    i32.const 32
    i32.const 1932
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32619,7 +32619,7 @@
    i32.const 0
    i32.const 32
    i32.const 1933
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32633,7 +32633,7 @@
    i32.const 0
    i32.const 32
    i32.const 1934
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32647,7 +32647,7 @@
    i32.const 0
    i32.const 32
    i32.const 1935
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32661,7 +32661,7 @@
    i32.const 0
    i32.const 32
    i32.const 1936
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32675,7 +32675,7 @@
    i32.const 0
    i32.const 32
    i32.const 1937
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32689,7 +32689,7 @@
    i32.const 0
    i32.const 32
    i32.const 1938
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32703,7 +32703,7 @@
    i32.const 0
    i32.const 32
    i32.const 1950
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32717,7 +32717,7 @@
    i32.const 0
    i32.const 32
    i32.const 1951
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32731,7 +32731,7 @@
    i32.const 0
    i32.const 32
    i32.const 1952
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32745,7 +32745,7 @@
    i32.const 0
    i32.const 32
    i32.const 1953
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32759,7 +32759,7 @@
    i32.const 0
    i32.const 32
    i32.const 1954
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32773,7 +32773,7 @@
    i32.const 0
    i32.const 32
    i32.const 1955
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32787,7 +32787,7 @@
    i32.const 0
    i32.const 32
    i32.const 1956
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32801,7 +32801,7 @@
    i32.const 0
    i32.const 32
    i32.const 1957
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32815,7 +32815,7 @@
    i32.const 0
    i32.const 32
    i32.const 1958
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32829,7 +32829,7 @@
    i32.const 0
    i32.const 32
    i32.const 1959
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32843,7 +32843,7 @@
    i32.const 0
    i32.const 32
    i32.const 1962
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32857,7 +32857,7 @@
    i32.const 0
    i32.const 32
    i32.const 1963
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32871,7 +32871,7 @@
    i32.const 0
    i32.const 32
    i32.const 1964
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32885,7 +32885,7 @@
    i32.const 0
    i32.const 32
    i32.const 1965
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32899,7 +32899,7 @@
    i32.const 0
    i32.const 32
    i32.const 1966
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32913,7 +32913,7 @@
    i32.const 0
    i32.const 32
    i32.const 1967
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32927,7 +32927,7 @@
    i32.const 0
    i32.const 32
    i32.const 1968
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32941,7 +32941,7 @@
    i32.const 0
    i32.const 32
    i32.const 1969
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32955,7 +32955,7 @@
    i32.const 0
    i32.const 32
    i32.const 1978
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32969,7 +32969,7 @@
    i32.const 0
    i32.const 32
    i32.const 1979
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32983,7 +32983,7 @@
    i32.const 0
    i32.const 32
    i32.const 1980
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -32997,7 +32997,7 @@
    i32.const 0
    i32.const 32
    i32.const 1981
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33011,7 +33011,7 @@
    i32.const 0
    i32.const 32
    i32.const 1982
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33025,7 +33025,7 @@
    i32.const 0
    i32.const 32
    i32.const 1983
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33039,7 +33039,7 @@
    i32.const 0
    i32.const 32
    i32.const 1984
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33053,7 +33053,7 @@
    i32.const 0
    i32.const 32
    i32.const 1985
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33067,7 +33067,7 @@
    i32.const 0
    i32.const 32
    i32.const 1986
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33081,7 +33081,7 @@
    i32.const 0
    i32.const 32
    i32.const 1987
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33095,7 +33095,7 @@
    i32.const 0
    i32.const 32
    i32.const 1990
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33109,7 +33109,7 @@
    i32.const 0
    i32.const 32
    i32.const 1991
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33123,7 +33123,7 @@
    i32.const 0
    i32.const 32
    i32.const 1992
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33137,7 +33137,7 @@
    i32.const 0
    i32.const 32
    i32.const 1993
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33151,7 +33151,7 @@
    i32.const 0
    i32.const 32
    i32.const 1994
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33165,7 +33165,7 @@
    i32.const 0
    i32.const 32
    i32.const 1995
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33179,7 +33179,7 @@
    i32.const 0
    i32.const 32
    i32.const 1996
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33193,7 +33193,7 @@
    i32.const 0
    i32.const 32
    i32.const 1997
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33208,7 +33208,7 @@
    i32.const 0
    i32.const 32
    i32.const 2009
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33223,7 +33223,7 @@
    i32.const 0
    i32.const 32
    i32.const 2010
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33238,7 +33238,7 @@
    i32.const 0
    i32.const 32
    i32.const 2011
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33253,7 +33253,7 @@
    i32.const 0
    i32.const 32
    i32.const 2012
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33268,7 +33268,7 @@
    i32.const 0
    i32.const 32
    i32.const 2013
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33283,7 +33283,7 @@
    i32.const 0
    i32.const 32
    i32.const 2014
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33298,7 +33298,7 @@
    i32.const 0
    i32.const 32
    i32.const 2015
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33313,7 +33313,7 @@
    i32.const 0
    i32.const 32
    i32.const 2016
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33328,7 +33328,7 @@
    i32.const 0
    i32.const 32
    i32.const 2017
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33343,7 +33343,7 @@
    i32.const 0
    i32.const 32
    i32.const 2018
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33358,7 +33358,7 @@
    i32.const 0
    i32.const 32
    i32.const 2021
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33373,7 +33373,7 @@
    i32.const 0
    i32.const 32
    i32.const 2022
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33388,7 +33388,7 @@
    i32.const 0
    i32.const 32
    i32.const 2023
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33403,7 +33403,7 @@
    i32.const 0
    i32.const 32
    i32.const 2024
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33418,7 +33418,7 @@
    i32.const 0
    i32.const 32
    i32.const 2025
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33433,7 +33433,7 @@
    i32.const 0
    i32.const 32
    i32.const 2026
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33448,7 +33448,7 @@
    i32.const 0
    i32.const 32
    i32.const 2027
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33463,7 +33463,7 @@
    i32.const 0
    i32.const 32
    i32.const 2028
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33478,7 +33478,7 @@
    i32.const 0
    i32.const 32
    i32.const 2029
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33493,7 +33493,7 @@
    i32.const 0
    i32.const 32
    i32.const 2030
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33508,7 +33508,7 @@
    i32.const 0
    i32.const 32
    i32.const 2031
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33523,7 +33523,7 @@
    i32.const 0
    i32.const 32
    i32.const 2032
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33538,7 +33538,7 @@
    i32.const 0
    i32.const 32
    i32.const 2033
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33553,7 +33553,7 @@
    i32.const 0
    i32.const 32
    i32.const 2034
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33568,7 +33568,7 @@
    i32.const 0
    i32.const 32
    i32.const 2035
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33583,7 +33583,7 @@
    i32.const 0
    i32.const 32
    i32.const 2036
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33598,7 +33598,7 @@
    i32.const 0
    i32.const 32
    i32.const 2037
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33613,7 +33613,7 @@
    i32.const 0
    i32.const 32
    i32.const 2038
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33628,7 +33628,7 @@
    i32.const 0
    i32.const 32
    i32.const 2039
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33643,7 +33643,7 @@
    i32.const 0
    i32.const 32
    i32.const 2040
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33658,7 +33658,7 @@
    i32.const 0
    i32.const 32
    i32.const 2041
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33673,7 +33673,7 @@
    i32.const 0
    i32.const 32
    i32.const 2042
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33688,7 +33688,7 @@
    i32.const 0
    i32.const 32
    i32.const 2043
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33703,7 +33703,7 @@
    i32.const 0
    i32.const 32
    i32.const 2044
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33718,7 +33718,7 @@
    i32.const 0
    i32.const 32
    i32.const 2045
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33733,7 +33733,7 @@
    i32.const 0
    i32.const 32
    i32.const 2046
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33748,7 +33748,7 @@
    i32.const 0
    i32.const 32
    i32.const 2047
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33763,7 +33763,7 @@
    i32.const 0
    i32.const 32
    i32.const 2048
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33778,7 +33778,7 @@
    i32.const 0
    i32.const 32
    i32.const 2049
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33793,7 +33793,7 @@
    i32.const 0
    i32.const 32
    i32.const 2050
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33808,7 +33808,7 @@
    i32.const 0
    i32.const 32
    i32.const 2051
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33823,7 +33823,7 @@
    i32.const 0
    i32.const 32
    i32.const 2052
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33838,7 +33838,7 @@
    i32.const 0
    i32.const 32
    i32.const 2053
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33853,7 +33853,7 @@
    i32.const 0
    i32.const 32
    i32.const 2054
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33868,7 +33868,7 @@
    i32.const 0
    i32.const 32
    i32.const 2055
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33883,7 +33883,7 @@
    i32.const 0
    i32.const 32
    i32.const 2056
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33898,7 +33898,7 @@
    i32.const 0
    i32.const 32
    i32.const 2057
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33913,7 +33913,7 @@
    i32.const 0
    i32.const 32
    i32.const 2058
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33928,7 +33928,7 @@
    i32.const 0
    i32.const 32
    i32.const 2059
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33943,7 +33943,7 @@
    i32.const 0
    i32.const 32
    i32.const 2060
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33958,7 +33958,7 @@
    i32.const 0
    i32.const 32
    i32.const 2061
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33973,7 +33973,7 @@
    i32.const 0
    i32.const 32
    i32.const 2062
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -33988,7 +33988,7 @@
    i32.const 0
    i32.const 32
    i32.const 2063
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34003,7 +34003,7 @@
    i32.const 0
    i32.const 32
    i32.const 2064
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34018,7 +34018,7 @@
    i32.const 0
    i32.const 32
    i32.const 2065
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34033,7 +34033,7 @@
    i32.const 0
    i32.const 32
    i32.const 2066
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34048,7 +34048,7 @@
    i32.const 0
    i32.const 32
    i32.const 2067
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34063,7 +34063,7 @@
    i32.const 0
    i32.const 32
    i32.const 2068
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34078,7 +34078,7 @@
    i32.const 0
    i32.const 32
    i32.const 2069
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34093,7 +34093,7 @@
    i32.const 0
    i32.const 32
    i32.const 2070
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34108,7 +34108,7 @@
    i32.const 0
    i32.const 32
    i32.const 2071
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34123,7 +34123,7 @@
    i32.const 0
    i32.const 32
    i32.const 2072
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34138,7 +34138,7 @@
    i32.const 0
    i32.const 32
    i32.const 2073
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34153,7 +34153,7 @@
    i32.const 0
    i32.const 32
    i32.const 2074
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34168,7 +34168,7 @@
    i32.const 0
    i32.const 32
    i32.const 2075
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34183,7 +34183,7 @@
    i32.const 0
    i32.const 32
    i32.const 2076
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34198,7 +34198,7 @@
    i32.const 0
    i32.const 32
    i32.const 2077
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34213,7 +34213,7 @@
    i32.const 0
    i32.const 32
    i32.const 2078
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34228,7 +34228,7 @@
    i32.const 0
    i32.const 32
    i32.const 2087
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34243,7 +34243,7 @@
    i32.const 0
    i32.const 32
    i32.const 2088
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34258,7 +34258,7 @@
    i32.const 0
    i32.const 32
    i32.const 2089
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34273,7 +34273,7 @@
    i32.const 0
    i32.const 32
    i32.const 2090
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34288,7 +34288,7 @@
    i32.const 0
    i32.const 32
    i32.const 2091
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34303,7 +34303,7 @@
    i32.const 0
    i32.const 32
    i32.const 2092
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34318,7 +34318,7 @@
    i32.const 0
    i32.const 32
    i32.const 2093
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34333,7 +34333,7 @@
    i32.const 0
    i32.const 32
    i32.const 2094
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34348,7 +34348,7 @@
    i32.const 0
    i32.const 32
    i32.const 2095
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34363,7 +34363,7 @@
    i32.const 0
    i32.const 32
    i32.const 2096
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34378,7 +34378,7 @@
    i32.const 0
    i32.const 32
    i32.const 2099
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34393,7 +34393,7 @@
    i32.const 0
    i32.const 32
    i32.const 2100
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34408,7 +34408,7 @@
    i32.const 0
    i32.const 32
    i32.const 2101
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34423,7 +34423,7 @@
    i32.const 0
    i32.const 32
    i32.const 2102
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34438,7 +34438,7 @@
    i32.const 0
    i32.const 32
    i32.const 2103
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34453,7 +34453,7 @@
    i32.const 0
    i32.const 32
    i32.const 2104
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34468,7 +34468,7 @@
    i32.const 0
    i32.const 32
    i32.const 2105
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34483,7 +34483,7 @@
    i32.const 0
    i32.const 32
    i32.const 2106
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34498,7 +34498,7 @@
    i32.const 0
    i32.const 32
    i32.const 2107
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34513,7 +34513,7 @@
    i32.const 0
    i32.const 32
    i32.const 2108
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34528,7 +34528,7 @@
    i32.const 0
    i32.const 32
    i32.const 2109
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34543,7 +34543,7 @@
    i32.const 0
    i32.const 32
    i32.const 2110
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34558,7 +34558,7 @@
    i32.const 0
    i32.const 32
    i32.const 2111
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34573,7 +34573,7 @@
    i32.const 0
    i32.const 32
    i32.const 2112
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34588,7 +34588,7 @@
    i32.const 0
    i32.const 32
    i32.const 2113
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34603,7 +34603,7 @@
    i32.const 0
    i32.const 32
    i32.const 2114
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34618,7 +34618,7 @@
    i32.const 0
    i32.const 32
    i32.const 2115
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34633,7 +34633,7 @@
    i32.const 0
    i32.const 32
    i32.const 2116
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34648,7 +34648,7 @@
    i32.const 0
    i32.const 32
    i32.const 2117
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34663,7 +34663,7 @@
    i32.const 0
    i32.const 32
    i32.const 2118
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34678,7 +34678,7 @@
    i32.const 0
    i32.const 32
    i32.const 2119
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34693,7 +34693,7 @@
    i32.const 0
    i32.const 32
    i32.const 2120
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34708,7 +34708,7 @@
    i32.const 0
    i32.const 32
    i32.const 2121
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34723,7 +34723,7 @@
    i32.const 0
    i32.const 32
    i32.const 2122
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34738,7 +34738,7 @@
    i32.const 0
    i32.const 32
    i32.const 2123
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34753,7 +34753,7 @@
    i32.const 0
    i32.const 32
    i32.const 2124
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34768,7 +34768,7 @@
    i32.const 0
    i32.const 32
    i32.const 2125
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34783,7 +34783,7 @@
    i32.const 0
    i32.const 32
    i32.const 2126
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34798,7 +34798,7 @@
    i32.const 0
    i32.const 32
    i32.const 2127
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34813,7 +34813,7 @@
    i32.const 0
    i32.const 32
    i32.const 2128
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34828,7 +34828,7 @@
    i32.const 0
    i32.const 32
    i32.const 2129
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34843,7 +34843,7 @@
    i32.const 0
    i32.const 32
    i32.const 2130
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34858,7 +34858,7 @@
    i32.const 0
    i32.const 32
    i32.const 2131
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34873,7 +34873,7 @@
    i32.const 0
    i32.const 32
    i32.const 2132
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34888,7 +34888,7 @@
    i32.const 0
    i32.const 32
    i32.const 2133
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34903,7 +34903,7 @@
    i32.const 0
    i32.const 32
    i32.const 2134
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34918,7 +34918,7 @@
    i32.const 0
    i32.const 32
    i32.const 2135
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34933,7 +34933,7 @@
    i32.const 0
    i32.const 32
    i32.const 2136
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34948,7 +34948,7 @@
    i32.const 0
    i32.const 32
    i32.const 2137
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34963,7 +34963,7 @@
    i32.const 0
    i32.const 32
    i32.const 2138
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34978,7 +34978,7 @@
    i32.const 0
    i32.const 32
    i32.const 2139
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -34993,7 +34993,7 @@
    i32.const 0
    i32.const 32
    i32.const 2140
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35008,7 +35008,7 @@
    i32.const 0
    i32.const 32
    i32.const 2141
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35023,7 +35023,7 @@
    i32.const 0
    i32.const 32
    i32.const 2142
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35038,7 +35038,7 @@
    i32.const 0
    i32.const 32
    i32.const 2143
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35053,7 +35053,7 @@
    i32.const 0
    i32.const 32
    i32.const 2144
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35068,7 +35068,7 @@
    i32.const 0
    i32.const 32
    i32.const 2145
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35083,7 +35083,7 @@
    i32.const 0
    i32.const 32
    i32.const 2146
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35098,7 +35098,7 @@
    i32.const 0
    i32.const 32
    i32.const 2147
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35113,7 +35113,7 @@
    i32.const 0
    i32.const 32
    i32.const 2148
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35128,7 +35128,7 @@
    i32.const 0
    i32.const 32
    i32.const 2149
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35143,7 +35143,7 @@
    i32.const 0
    i32.const 32
    i32.const 2150
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35158,7 +35158,7 @@
    i32.const 0
    i32.const 32
    i32.const 2151
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35173,7 +35173,7 @@
    i32.const 0
    i32.const 32
    i32.const 2152
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35188,7 +35188,7 @@
    i32.const 0
    i32.const 32
    i32.const 2153
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35203,7 +35203,7 @@
    i32.const 0
    i32.const 32
    i32.const 2154
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35218,7 +35218,7 @@
    i32.const 0
    i32.const 32
    i32.const 2155
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35233,7 +35233,7 @@
    i32.const 0
    i32.const 32
    i32.const 2156
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35248,7 +35248,7 @@
    i32.const 0
    i32.const 32
    i32.const 2168
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35263,7 +35263,7 @@
    i32.const 0
    i32.const 32
    i32.const 2169
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35278,7 +35278,7 @@
    i32.const 0
    i32.const 32
    i32.const 2170
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35293,7 +35293,7 @@
    i32.const 0
    i32.const 32
    i32.const 2171
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35308,7 +35308,7 @@
    i32.const 0
    i32.const 32
    i32.const 2172
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35323,7 +35323,7 @@
    i32.const 0
    i32.const 32
    i32.const 2173
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35338,7 +35338,7 @@
    i32.const 0
    i32.const 32
    i32.const 2174
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35353,7 +35353,7 @@
    i32.const 0
    i32.const 32
    i32.const 2175
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35368,7 +35368,7 @@
    i32.const 0
    i32.const 32
    i32.const 2176
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35383,7 +35383,7 @@
    i32.const 0
    i32.const 32
    i32.const 2177
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35398,7 +35398,7 @@
    i32.const 0
    i32.const 32
    i32.const 2180
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35413,7 +35413,7 @@
    i32.const 0
    i32.const 32
    i32.const 2181
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35428,7 +35428,7 @@
    i32.const 0
    i32.const 32
    i32.const 2182
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35443,7 +35443,7 @@
    i32.const 0
    i32.const 32
    i32.const 2183
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35458,7 +35458,7 @@
    i32.const 0
    i32.const 32
    i32.const 2184
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35473,7 +35473,7 @@
    i32.const 0
    i32.const 32
    i32.const 2185
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35488,7 +35488,7 @@
    i32.const 0
    i32.const 32
    i32.const 2186
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35503,7 +35503,7 @@
    i32.const 0
    i32.const 32
    i32.const 2187
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35518,7 +35518,7 @@
    i32.const 0
    i32.const 32
    i32.const 2188
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35533,7 +35533,7 @@
    i32.const 0
    i32.const 32
    i32.const 2189
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35548,7 +35548,7 @@
    i32.const 0
    i32.const 32
    i32.const 2190
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35563,7 +35563,7 @@
    i32.const 0
    i32.const 32
    i32.const 2191
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35578,7 +35578,7 @@
    i32.const 0
    i32.const 32
    i32.const 2192
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35593,7 +35593,7 @@
    i32.const 0
    i32.const 32
    i32.const 2193
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35608,7 +35608,7 @@
    i32.const 0
    i32.const 32
    i32.const 2194
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35623,7 +35623,7 @@
    i32.const 0
    i32.const 32
    i32.const 2195
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35638,7 +35638,7 @@
    i32.const 0
    i32.const 32
    i32.const 2196
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35653,7 +35653,7 @@
    i32.const 0
    i32.const 32
    i32.const 2197
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35668,7 +35668,7 @@
    i32.const 0
    i32.const 32
    i32.const 2198
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35683,7 +35683,7 @@
    i32.const 0
    i32.const 32
    i32.const 2199
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35698,7 +35698,7 @@
    i32.const 0
    i32.const 32
    i32.const 2200
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35713,7 +35713,7 @@
    i32.const 0
    i32.const 32
    i32.const 2201
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35728,7 +35728,7 @@
    i32.const 0
    i32.const 32
    i32.const 2202
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35743,7 +35743,7 @@
    i32.const 0
    i32.const 32
    i32.const 2203
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35758,7 +35758,7 @@
    i32.const 0
    i32.const 32
    i32.const 2204
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35773,7 +35773,7 @@
    i32.const 0
    i32.const 32
    i32.const 2205
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35788,7 +35788,7 @@
    i32.const 0
    i32.const 32
    i32.const 2206
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35803,7 +35803,7 @@
    i32.const 0
    i32.const 32
    i32.const 2207
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35818,7 +35818,7 @@
    i32.const 0
    i32.const 32
    i32.const 2208
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35833,7 +35833,7 @@
    i32.const 0
    i32.const 32
    i32.const 2209
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35848,7 +35848,7 @@
    i32.const 0
    i32.const 32
    i32.const 2210
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35863,7 +35863,7 @@
    i32.const 0
    i32.const 32
    i32.const 2211
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35878,7 +35878,7 @@
    i32.const 0
    i32.const 32
    i32.const 2212
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35893,7 +35893,7 @@
    i32.const 0
    i32.const 32
    i32.const 2213
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35908,7 +35908,7 @@
    i32.const 0
    i32.const 32
    i32.const 2214
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35923,7 +35923,7 @@
    i32.const 0
    i32.const 32
    i32.const 2215
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35938,7 +35938,7 @@
    i32.const 0
    i32.const 32
    i32.const 2216
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35953,7 +35953,7 @@
    i32.const 0
    i32.const 32
    i32.const 2217
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35968,7 +35968,7 @@
    i32.const 0
    i32.const 32
    i32.const 2218
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35983,7 +35983,7 @@
    i32.const 0
    i32.const 32
    i32.const 2219
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -35998,7 +35998,7 @@
    i32.const 0
    i32.const 32
    i32.const 2220
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36013,7 +36013,7 @@
    i32.const 0
    i32.const 32
    i32.const 2221
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36028,7 +36028,7 @@
    i32.const 0
    i32.const 32
    i32.const 2222
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36043,7 +36043,7 @@
    i32.const 0
    i32.const 32
    i32.const 2223
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36058,7 +36058,7 @@
    i32.const 0
    i32.const 32
    i32.const 2224
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36073,7 +36073,7 @@
    i32.const 0
    i32.const 32
    i32.const 2225
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36088,7 +36088,7 @@
    i32.const 0
    i32.const 32
    i32.const 2226
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36103,7 +36103,7 @@
    i32.const 0
    i32.const 32
    i32.const 2227
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36118,7 +36118,7 @@
    i32.const 0
    i32.const 32
    i32.const 2228
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36133,7 +36133,7 @@
    i32.const 0
    i32.const 32
    i32.const 2229
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36148,7 +36148,7 @@
    i32.const 0
    i32.const 32
    i32.const 2230
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36163,7 +36163,7 @@
    i32.const 0
    i32.const 32
    i32.const 2231
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36178,7 +36178,7 @@
    i32.const 0
    i32.const 32
    i32.const 2232
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36193,7 +36193,7 @@
    i32.const 0
    i32.const 32
    i32.const 2233
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36208,7 +36208,7 @@
    i32.const 0
    i32.const 32
    i32.const 2234
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36223,7 +36223,7 @@
    i32.const 0
    i32.const 32
    i32.const 2235
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36238,7 +36238,7 @@
    i32.const 0
    i32.const 32
    i32.const 2236
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36253,7 +36253,7 @@
    i32.const 0
    i32.const 32
    i32.const 2237
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36268,7 +36268,7 @@
    i32.const 0
    i32.const 32
    i32.const 2246
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36283,7 +36283,7 @@
    i32.const 0
    i32.const 32
    i32.const 2247
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36298,7 +36298,7 @@
    i32.const 0
    i32.const 32
    i32.const 2248
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36313,7 +36313,7 @@
    i32.const 0
    i32.const 32
    i32.const 2249
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36328,7 +36328,7 @@
    i32.const 0
    i32.const 32
    i32.const 2250
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36343,7 +36343,7 @@
    i32.const 0
    i32.const 32
    i32.const 2251
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36358,7 +36358,7 @@
    i32.const 0
    i32.const 32
    i32.const 2252
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36373,7 +36373,7 @@
    i32.const 0
    i32.const 32
    i32.const 2253
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36388,7 +36388,7 @@
    i32.const 0
    i32.const 32
    i32.const 2254
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36403,7 +36403,7 @@
    i32.const 0
    i32.const 32
    i32.const 2255
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36418,7 +36418,7 @@
    i32.const 0
    i32.const 32
    i32.const 2258
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36433,7 +36433,7 @@
    i32.const 0
    i32.const 32
    i32.const 2259
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36448,7 +36448,7 @@
    i32.const 0
    i32.const 32
    i32.const 2260
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36463,7 +36463,7 @@
    i32.const 0
    i32.const 32
    i32.const 2261
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36478,7 +36478,7 @@
    i32.const 0
    i32.const 32
    i32.const 2262
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36493,7 +36493,7 @@
    i32.const 0
    i32.const 32
    i32.const 2263
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36508,7 +36508,7 @@
    i32.const 0
    i32.const 32
    i32.const 2264
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36523,7 +36523,7 @@
    i32.const 0
    i32.const 32
    i32.const 2265
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36538,7 +36538,7 @@
    i32.const 0
    i32.const 32
    i32.const 2266
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36553,7 +36553,7 @@
    i32.const 0
    i32.const 32
    i32.const 2267
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36568,7 +36568,7 @@
    i32.const 0
    i32.const 32
    i32.const 2268
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36583,7 +36583,7 @@
    i32.const 0
    i32.const 32
    i32.const 2269
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36598,7 +36598,7 @@
    i32.const 0
    i32.const 32
    i32.const 2270
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36613,7 +36613,7 @@
    i32.const 0
    i32.const 32
    i32.const 2271
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36628,7 +36628,7 @@
    i32.const 0
    i32.const 32
    i32.const 2272
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36643,7 +36643,7 @@
    i32.const 0
    i32.const 32
    i32.const 2273
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36658,7 +36658,7 @@
    i32.const 0
    i32.const 32
    i32.const 2274
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36673,7 +36673,7 @@
    i32.const 0
    i32.const 32
    i32.const 2275
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36688,7 +36688,7 @@
    i32.const 0
    i32.const 32
    i32.const 2276
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36703,7 +36703,7 @@
    i32.const 0
    i32.const 32
    i32.const 2277
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36718,7 +36718,7 @@
    i32.const 0
    i32.const 32
    i32.const 2278
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36733,7 +36733,7 @@
    i32.const 0
    i32.const 32
    i32.const 2279
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36748,7 +36748,7 @@
    i32.const 0
    i32.const 32
    i32.const 2280
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36763,7 +36763,7 @@
    i32.const 0
    i32.const 32
    i32.const 2281
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36778,7 +36778,7 @@
    i32.const 0
    i32.const 32
    i32.const 2282
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36793,7 +36793,7 @@
    i32.const 0
    i32.const 32
    i32.const 2283
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36808,7 +36808,7 @@
    i32.const 0
    i32.const 32
    i32.const 2284
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36823,7 +36823,7 @@
    i32.const 0
    i32.const 32
    i32.const 2285
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36838,7 +36838,7 @@
    i32.const 0
    i32.const 32
    i32.const 2286
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36853,7 +36853,7 @@
    i32.const 0
    i32.const 32
    i32.const 2287
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36868,7 +36868,7 @@
    i32.const 0
    i32.const 32
    i32.const 2288
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36883,7 +36883,7 @@
    i32.const 0
    i32.const 32
    i32.const 2289
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36898,7 +36898,7 @@
    i32.const 0
    i32.const 32
    i32.const 2290
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36913,7 +36913,7 @@
    i32.const 0
    i32.const 32
    i32.const 2291
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36928,7 +36928,7 @@
    i32.const 0
    i32.const 32
    i32.const 2292
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36943,7 +36943,7 @@
    i32.const 0
    i32.const 32
    i32.const 2293
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36958,7 +36958,7 @@
    i32.const 0
    i32.const 32
    i32.const 2294
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36973,7 +36973,7 @@
    i32.const 0
    i32.const 32
    i32.const 2295
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -36988,7 +36988,7 @@
    i32.const 0
    i32.const 32
    i32.const 2296
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37003,7 +37003,7 @@
    i32.const 0
    i32.const 32
    i32.const 2297
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37018,7 +37018,7 @@
    i32.const 0
    i32.const 32
    i32.const 2298
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37033,7 +37033,7 @@
    i32.const 0
    i32.const 32
    i32.const 2299
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37048,7 +37048,7 @@
    i32.const 0
    i32.const 32
    i32.const 2300
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37063,7 +37063,7 @@
    i32.const 0
    i32.const 32
    i32.const 2301
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37078,7 +37078,7 @@
    i32.const 0
    i32.const 32
    i32.const 2302
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37093,7 +37093,7 @@
    i32.const 0
    i32.const 32
    i32.const 2303
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37108,7 +37108,7 @@
    i32.const 0
    i32.const 32
    i32.const 2304
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37123,7 +37123,7 @@
    i32.const 0
    i32.const 32
    i32.const 2305
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37138,7 +37138,7 @@
    i32.const 0
    i32.const 32
    i32.const 2306
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37153,7 +37153,7 @@
    i32.const 0
    i32.const 32
    i32.const 2307
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37168,7 +37168,7 @@
    i32.const 0
    i32.const 32
    i32.const 2308
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37183,7 +37183,7 @@
    i32.const 0
    i32.const 32
    i32.const 2309
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37198,7 +37198,7 @@
    i32.const 0
    i32.const 32
    i32.const 2310
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37213,7 +37213,7 @@
    i32.const 0
    i32.const 32
    i32.const 2311
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37228,7 +37228,7 @@
    i32.const 0
    i32.const 32
    i32.const 2312
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37243,7 +37243,7 @@
    i32.const 0
    i32.const 32
    i32.const 2313
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37258,7 +37258,7 @@
    i32.const 0
    i32.const 32
    i32.const 2314
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37273,7 +37273,7 @@
    i32.const 0
    i32.const 32
    i32.const 2315
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37288,7 +37288,7 @@
    i32.const 0
    i32.const 32
    i32.const 2329
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37303,7 +37303,7 @@
    i32.const 0
    i32.const 32
    i32.const 2330
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37318,7 +37318,7 @@
    i32.const 0
    i32.const 32
    i32.const 2331
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37333,7 +37333,7 @@
    i32.const 0
    i32.const 32
    i32.const 2332
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37348,7 +37348,7 @@
    i32.const 0
    i32.const 32
    i32.const 2333
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37363,7 +37363,7 @@
    i32.const 0
    i32.const 32
    i32.const 2334
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37378,7 +37378,7 @@
    i32.const 0
    i32.const 32
    i32.const 2335
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37393,7 +37393,7 @@
    i32.const 0
    i32.const 32
    i32.const 2336
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37408,7 +37408,7 @@
    i32.const 0
    i32.const 32
    i32.const 2337
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37423,7 +37423,7 @@
    i32.const 0
    i32.const 32
    i32.const 2338
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37438,7 +37438,7 @@
    i32.const 0
    i32.const 32
    i32.const 2341
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37453,7 +37453,7 @@
    i32.const 0
    i32.const 32
    i32.const 2342
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37468,7 +37468,7 @@
    i32.const 0
    i32.const 32
    i32.const 2343
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37483,7 +37483,7 @@
    i32.const 0
    i32.const 32
    i32.const 2344
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37498,7 +37498,7 @@
    i32.const 0
    i32.const 32
    i32.const 2345
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37513,7 +37513,7 @@
    i32.const 0
    i32.const 32
    i32.const 2346
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37528,7 +37528,7 @@
    i32.const 0
    i32.const 32
    i32.const 2347
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37543,7 +37543,7 @@
    i32.const 0
    i32.const 32
    i32.const 2348
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37558,7 +37558,7 @@
    i32.const 0
    i32.const 32
    i32.const 2349
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37573,7 +37573,7 @@
    i32.const 0
    i32.const 32
    i32.const 2350
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37588,7 +37588,7 @@
    i32.const 0
    i32.const 32
    i32.const 2351
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37603,7 +37603,7 @@
    i32.const 0
    i32.const 32
    i32.const 2352
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37618,7 +37618,7 @@
    i32.const 0
    i32.const 32
    i32.const 2353
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37633,7 +37633,7 @@
    i32.const 0
    i32.const 32
    i32.const 2354
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37648,7 +37648,7 @@
    i32.const 0
    i32.const 32
    i32.const 2355
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37663,7 +37663,7 @@
    i32.const 0
    i32.const 32
    i32.const 2356
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37678,7 +37678,7 @@
    i32.const 0
    i32.const 32
    i32.const 2357
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37693,7 +37693,7 @@
    i32.const 0
    i32.const 32
    i32.const 2358
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37708,7 +37708,7 @@
    i32.const 0
    i32.const 32
    i32.const 2359
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37723,7 +37723,7 @@
    i32.const 0
    i32.const 32
    i32.const 2360
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37738,7 +37738,7 @@
    i32.const 0
    i32.const 32
    i32.const 2361
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37753,7 +37753,7 @@
    i32.const 0
    i32.const 32
    i32.const 2362
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37768,7 +37768,7 @@
    i32.const 0
    i32.const 32
    i32.const 2363
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37783,7 +37783,7 @@
    i32.const 0
    i32.const 32
    i32.const 2364
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37798,7 +37798,7 @@
    i32.const 0
    i32.const 32
    i32.const 2365
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37813,7 +37813,7 @@
    i32.const 0
    i32.const 32
    i32.const 2366
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37828,7 +37828,7 @@
    i32.const 0
    i32.const 32
    i32.const 2367
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37843,7 +37843,7 @@
    i32.const 0
    i32.const 32
    i32.const 2368
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37858,7 +37858,7 @@
    i32.const 0
    i32.const 32
    i32.const 2369
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37873,7 +37873,7 @@
    i32.const 0
    i32.const 32
    i32.const 2370
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37888,7 +37888,7 @@
    i32.const 0
    i32.const 32
    i32.const 2371
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37903,7 +37903,7 @@
    i32.const 0
    i32.const 32
    i32.const 2372
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37918,7 +37918,7 @@
    i32.const 0
    i32.const 32
    i32.const 2373
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37933,7 +37933,7 @@
    i32.const 0
    i32.const 32
    i32.const 2374
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37948,7 +37948,7 @@
    i32.const 0
    i32.const 32
    i32.const 2375
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37963,7 +37963,7 @@
    i32.const 0
    i32.const 32
    i32.const 2376
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37978,7 +37978,7 @@
    i32.const 0
    i32.const 32
    i32.const 2377
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -37993,7 +37993,7 @@
    i32.const 0
    i32.const 32
    i32.const 2378
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38008,7 +38008,7 @@
    i32.const 0
    i32.const 32
    i32.const 2379
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38023,7 +38023,7 @@
    i32.const 0
    i32.const 32
    i32.const 2380
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38038,7 +38038,7 @@
    i32.const 0
    i32.const 32
    i32.const 2381
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38053,7 +38053,7 @@
    i32.const 0
    i32.const 32
    i32.const 2382
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38068,7 +38068,7 @@
    i32.const 0
    i32.const 32
    i32.const 2383
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38083,7 +38083,7 @@
    i32.const 0
    i32.const 32
    i32.const 2384
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38098,7 +38098,7 @@
    i32.const 0
    i32.const 32
    i32.const 2385
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38113,7 +38113,7 @@
    i32.const 0
    i32.const 32
    i32.const 2386
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38128,7 +38128,7 @@
    i32.const 0
    i32.const 32
    i32.const 2387
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38143,7 +38143,7 @@
    i32.const 0
    i32.const 32
    i32.const 2388
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38158,7 +38158,7 @@
    i32.const 0
    i32.const 32
    i32.const 2389
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38173,7 +38173,7 @@
    i32.const 0
    i32.const 32
    i32.const 2390
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38188,7 +38188,7 @@
    i32.const 0
    i32.const 32
    i32.const 2391
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38203,7 +38203,7 @@
    i32.const 0
    i32.const 32
    i32.const 2392
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38218,7 +38218,7 @@
    i32.const 0
    i32.const 32
    i32.const 2393
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38233,7 +38233,7 @@
    i32.const 0
    i32.const 32
    i32.const 2394
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38248,7 +38248,7 @@
    i32.const 0
    i32.const 32
    i32.const 2395
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38263,7 +38263,7 @@
    i32.const 0
    i32.const 32
    i32.const 2396
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38278,7 +38278,7 @@
    i32.const 0
    i32.const 32
    i32.const 2397
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38293,7 +38293,7 @@
    i32.const 0
    i32.const 32
    i32.const 2398
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38308,7 +38308,7 @@
    i32.const 0
    i32.const 32
    i32.const 2399
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38323,7 +38323,7 @@
    i32.const 0
    i32.const 32
    i32.const 2400
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38338,7 +38338,7 @@
    i32.const 0
    i32.const 32
    i32.const 2401
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38353,7 +38353,7 @@
    i32.const 0
    i32.const 32
    i32.const 2402
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38368,7 +38368,7 @@
    i32.const 0
    i32.const 32
    i32.const 2403
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38383,7 +38383,7 @@
    i32.const 0
    i32.const 32
    i32.const 2404
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38398,7 +38398,7 @@
    i32.const 0
    i32.const 32
    i32.const 2405
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38413,7 +38413,7 @@
    i32.const 0
    i32.const 32
    i32.const 2406
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38428,7 +38428,7 @@
    i32.const 0
    i32.const 32
    i32.const 2409
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38443,7 +38443,7 @@
    i32.const 0
    i32.const 32
    i32.const 2410
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38458,7 +38458,7 @@
    i32.const 0
    i32.const 32
    i32.const 2411
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38473,7 +38473,7 @@
    i32.const 0
    i32.const 32
    i32.const 2412
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38488,7 +38488,7 @@
    i32.const 0
    i32.const 32
    i32.const 2413
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38503,7 +38503,7 @@
    i32.const 0
    i32.const 32
    i32.const 2414
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38518,7 +38518,7 @@
    i32.const 0
    i32.const 32
    i32.const 2415
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38533,7 +38533,7 @@
    i32.const 0
    i32.const 32
    i32.const 2416
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38548,7 +38548,7 @@
    i32.const 0
    i32.const 32
    i32.const 2419
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38563,7 +38563,7 @@
    i32.const 0
    i32.const 32
    i32.const 2420
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38578,7 +38578,7 @@
    i32.const 0
    i32.const 32
    i32.const 2421
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38593,7 +38593,7 @@
    i32.const 0
    i32.const 32
    i32.const 2422
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38608,7 +38608,7 @@
    i32.const 0
    i32.const 32
    i32.const 2423
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38623,7 +38623,7 @@
    i32.const 0
    i32.const 32
    i32.const 2424
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38638,7 +38638,7 @@
    i32.const 0
    i32.const 32
    i32.const 2425
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38653,7 +38653,7 @@
    i32.const 0
    i32.const 32
    i32.const 2426
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38668,7 +38668,7 @@
    i32.const 0
    i32.const 32
    i32.const 2429
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38683,7 +38683,7 @@
    i32.const 0
    i32.const 32
    i32.const 2430
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38698,7 +38698,7 @@
    i32.const 0
    i32.const 32
    i32.const 2432
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38713,7 +38713,7 @@
    i32.const 0
    i32.const 32
    i32.const 2433
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38728,7 +38728,7 @@
    i32.const 0
    i32.const 32
    i32.const 2435
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38743,7 +38743,7 @@
    i32.const 0
    i32.const 32
    i32.const 2436
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38758,7 +38758,7 @@
    i32.const 0
    i32.const 32
    i32.const 2438
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38773,7 +38773,7 @@
    i32.const 0
    i32.const 32
    i32.const 2439
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38788,7 +38788,7 @@
    i32.const 0
    i32.const 32
    i32.const 2441
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38803,7 +38803,7 @@
    i32.const 0
    i32.const 32
    i32.const 2442
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38818,7 +38818,7 @@
    i32.const 0
    i32.const 32
    i32.const 2444
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38833,7 +38833,7 @@
    i32.const 0
    i32.const 32
    i32.const 2445
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38848,7 +38848,7 @@
    i32.const 0
    i32.const 32
    i32.const 2447
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38863,7 +38863,7 @@
    i32.const 0
    i32.const 32
    i32.const 2448
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38878,7 +38878,7 @@
    i32.const 0
    i32.const 32
    i32.const 2450
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38893,7 +38893,7 @@
    i32.const 0
    i32.const 32
    i32.const 2451
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38908,7 +38908,7 @@
    i32.const 0
    i32.const 32
    i32.const 2453
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38923,7 +38923,7 @@
    i32.const 0
    i32.const 32
    i32.const 2454
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38938,7 +38938,7 @@
    i32.const 0
    i32.const 32
    i32.const 2456
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38953,7 +38953,7 @@
    i32.const 0
    i32.const 32
    i32.const 2457
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38968,7 +38968,7 @@
    i32.const 0
    i32.const 32
    i32.const 2458
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38983,7 +38983,7 @@
    i32.const 0
    i32.const 32
    i32.const 2459
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -38998,7 +38998,7 @@
    i32.const 0
    i32.const 32
    i32.const 2460
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39013,7 +39013,7 @@
    i32.const 0
    i32.const 32
    i32.const 2461
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39028,7 +39028,7 @@
    i32.const 0
    i32.const 32
    i32.const 2462
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39043,7 +39043,7 @@
    i32.const 0
    i32.const 32
    i32.const 2463
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39058,7 +39058,7 @@
    i32.const 0
    i32.const 32
    i32.const 2465
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39073,7 +39073,7 @@
    i32.const 0
    i32.const 32
    i32.const 2466
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39088,7 +39088,7 @@
    i32.const 0
    i32.const 32
    i32.const 2467
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39103,7 +39103,7 @@
    i32.const 0
    i32.const 32
    i32.const 2468
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39118,7 +39118,7 @@
    i32.const 0
    i32.const 32
    i32.const 2469
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39133,7 +39133,7 @@
    i32.const 0
    i32.const 32
    i32.const 2470
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39148,7 +39148,7 @@
    i32.const 0
    i32.const 32
    i32.const 2471
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39163,7 +39163,7 @@
    i32.const 0
    i32.const 32
    i32.const 2472
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39178,7 +39178,7 @@
    i32.const 0
    i32.const 32
    i32.const 2473
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39193,7 +39193,7 @@
    i32.const 0
    i32.const 32
    i32.const 2474
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39208,7 +39208,7 @@
    i32.const 0
    i32.const 32
    i32.const 2475
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39223,7 +39223,7 @@
    i32.const 0
    i32.const 32
    i32.const 2476
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39238,7 +39238,7 @@
    i32.const 0
    i32.const 32
    i32.const 2477
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39253,7 +39253,7 @@
    i32.const 0
    i32.const 32
    i32.const 2478
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39268,7 +39268,7 @@
    i32.const 0
    i32.const 32
    i32.const 2479
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39283,7 +39283,7 @@
    i32.const 0
    i32.const 32
    i32.const 2480
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39298,7 +39298,7 @@
    i32.const 0
    i32.const 32
    i32.const 2481
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39313,7 +39313,7 @@
    i32.const 0
    i32.const 32
    i32.const 2482
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39328,7 +39328,7 @@
    i32.const 0
    i32.const 32
    i32.const 2483
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39343,7 +39343,7 @@
    i32.const 0
    i32.const 32
    i32.const 2484
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39358,7 +39358,7 @@
    i32.const 0
    i32.const 32
    i32.const 2493
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39373,7 +39373,7 @@
    i32.const 0
    i32.const 32
    i32.const 2494
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39388,7 +39388,7 @@
    i32.const 0
    i32.const 32
    i32.const 2495
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39403,7 +39403,7 @@
    i32.const 0
    i32.const 32
    i32.const 2496
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39418,7 +39418,7 @@
    i32.const 0
    i32.const 32
    i32.const 2497
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39433,7 +39433,7 @@
    i32.const 0
    i32.const 32
    i32.const 2498
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39448,7 +39448,7 @@
    i32.const 0
    i32.const 32
    i32.const 2499
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39463,7 +39463,7 @@
    i32.const 0
    i32.const 32
    i32.const 2500
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39478,7 +39478,7 @@
    i32.const 0
    i32.const 32
    i32.const 2501
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39493,7 +39493,7 @@
    i32.const 0
    i32.const 32
    i32.const 2502
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39508,7 +39508,7 @@
    i32.const 0
    i32.const 32
    i32.const 2505
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39523,7 +39523,7 @@
    i32.const 0
    i32.const 32
    i32.const 2506
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39538,7 +39538,7 @@
    i32.const 0
    i32.const 32
    i32.const 2507
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39553,7 +39553,7 @@
    i32.const 0
    i32.const 32
    i32.const 2508
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39568,7 +39568,7 @@
    i32.const 0
    i32.const 32
    i32.const 2509
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39583,7 +39583,7 @@
    i32.const 0
    i32.const 32
    i32.const 2510
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39598,7 +39598,7 @@
    i32.const 0
    i32.const 32
    i32.const 2511
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39613,7 +39613,7 @@
    i32.const 0
    i32.const 32
    i32.const 2512
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39628,7 +39628,7 @@
    i32.const 0
    i32.const 32
    i32.const 2513
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39643,7 +39643,7 @@
    i32.const 0
    i32.const 32
    i32.const 2514
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39658,7 +39658,7 @@
    i32.const 0
    i32.const 32
    i32.const 2515
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39673,7 +39673,7 @@
    i32.const 0
    i32.const 32
    i32.const 2516
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39688,7 +39688,7 @@
    i32.const 0
    i32.const 32
    i32.const 2517
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39703,7 +39703,7 @@
    i32.const 0
    i32.const 32
    i32.const 2518
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39718,7 +39718,7 @@
    i32.const 0
    i32.const 32
    i32.const 2519
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39733,7 +39733,7 @@
    i32.const 0
    i32.const 32
    i32.const 2520
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39748,7 +39748,7 @@
    i32.const 0
    i32.const 32
    i32.const 2521
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39763,7 +39763,7 @@
    i32.const 0
    i32.const 32
    i32.const 2522
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39778,7 +39778,7 @@
    i32.const 0
    i32.const 32
    i32.const 2523
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39793,7 +39793,7 @@
    i32.const 0
    i32.const 32
    i32.const 2524
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39808,7 +39808,7 @@
    i32.const 0
    i32.const 32
    i32.const 2525
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39823,7 +39823,7 @@
    i32.const 0
    i32.const 32
    i32.const 2526
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39838,7 +39838,7 @@
    i32.const 0
    i32.const 32
    i32.const 2527
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39853,7 +39853,7 @@
    i32.const 0
    i32.const 32
    i32.const 2528
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39868,7 +39868,7 @@
    i32.const 0
    i32.const 32
    i32.const 2529
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39883,7 +39883,7 @@
    i32.const 0
    i32.const 32
    i32.const 2530
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39898,7 +39898,7 @@
    i32.const 0
    i32.const 32
    i32.const 2531
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39913,7 +39913,7 @@
    i32.const 0
    i32.const 32
    i32.const 2532
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39928,7 +39928,7 @@
    i32.const 0
    i32.const 32
    i32.const 2533
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39943,7 +39943,7 @@
    i32.const 0
    i32.const 32
    i32.const 2534
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39958,7 +39958,7 @@
    i32.const 0
    i32.const 32
    i32.const 2535
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39973,7 +39973,7 @@
    i32.const 0
    i32.const 32
    i32.const 2536
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -39988,7 +39988,7 @@
    i32.const 0
    i32.const 32
    i32.const 2537
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40003,7 +40003,7 @@
    i32.const 0
    i32.const 32
    i32.const 2538
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40018,7 +40018,7 @@
    i32.const 0
    i32.const 32
    i32.const 2539
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40033,7 +40033,7 @@
    i32.const 0
    i32.const 32
    i32.const 2540
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40048,7 +40048,7 @@
    i32.const 0
    i32.const 32
    i32.const 2541
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40063,7 +40063,7 @@
    i32.const 0
    i32.const 32
    i32.const 2542
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40078,7 +40078,7 @@
    i32.const 0
    i32.const 32
    i32.const 2543
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40093,7 +40093,7 @@
    i32.const 0
    i32.const 32
    i32.const 2544
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40108,7 +40108,7 @@
    i32.const 0
    i32.const 32
    i32.const 2545
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40123,7 +40123,7 @@
    i32.const 0
    i32.const 32
    i32.const 2546
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40138,7 +40138,7 @@
    i32.const 0
    i32.const 32
    i32.const 2547
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40153,7 +40153,7 @@
    i32.const 0
    i32.const 32
    i32.const 2548
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40168,7 +40168,7 @@
    i32.const 0
    i32.const 32
    i32.const 2549
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40183,7 +40183,7 @@
    i32.const 0
    i32.const 32
    i32.const 2550
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40198,7 +40198,7 @@
    i32.const 0
    i32.const 32
    i32.const 2551
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40213,7 +40213,7 @@
    i32.const 0
    i32.const 32
    i32.const 2552
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40228,7 +40228,7 @@
    i32.const 0
    i32.const 32
    i32.const 2553
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40243,7 +40243,7 @@
    i32.const 0
    i32.const 32
    i32.const 2554
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40258,7 +40258,7 @@
    i32.const 0
    i32.const 32
    i32.const 2555
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40273,7 +40273,7 @@
    i32.const 0
    i32.const 32
    i32.const 2556
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40288,7 +40288,7 @@
    i32.const 0
    i32.const 32
    i32.const 2557
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40303,7 +40303,7 @@
    i32.const 0
    i32.const 32
    i32.const 2558
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40318,7 +40318,7 @@
    i32.const 0
    i32.const 32
    i32.const 2559
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40333,7 +40333,7 @@
    i32.const 0
    i32.const 32
    i32.const 2560
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40348,7 +40348,7 @@
    i32.const 0
    i32.const 32
    i32.const 2561
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40363,7 +40363,7 @@
    i32.const 0
    i32.const 32
    i32.const 2562
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40378,7 +40378,7 @@
    i32.const 0
    i32.const 32
    i32.const 2563
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40393,7 +40393,7 @@
    i32.const 0
    i32.const 32
    i32.const 2564
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40408,7 +40408,7 @@
    i32.const 0
    i32.const 32
    i32.const 2565
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40423,7 +40423,7 @@
    i32.const 0
    i32.const 32
    i32.const 2566
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40438,7 +40438,7 @@
    i32.const 0
    i32.const 32
    i32.const 2567
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40453,7 +40453,7 @@
    i32.const 0
    i32.const 32
    i32.const 2568
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40468,7 +40468,7 @@
    i32.const 0
    i32.const 32
    i32.const 2569
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40483,7 +40483,7 @@
    i32.const 0
    i32.const 32
    i32.const 2570
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40498,7 +40498,7 @@
    i32.const 0
    i32.const 32
    i32.const 2582
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40513,7 +40513,7 @@
    i32.const 0
    i32.const 32
    i32.const 2583
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40528,7 +40528,7 @@
    i32.const 0
    i32.const 32
    i32.const 2584
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40543,7 +40543,7 @@
    i32.const 0
    i32.const 32
    i32.const 2585
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40558,7 +40558,7 @@
    i32.const 0
    i32.const 32
    i32.const 2586
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40573,7 +40573,7 @@
    i32.const 0
    i32.const 32
    i32.const 2587
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40588,7 +40588,7 @@
    i32.const 0
    i32.const 32
    i32.const 2588
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40603,7 +40603,7 @@
    i32.const 0
    i32.const 32
    i32.const 2589
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40618,7 +40618,7 @@
    i32.const 0
    i32.const 32
    i32.const 2590
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40633,7 +40633,7 @@
    i32.const 0
    i32.const 32
    i32.const 2591
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40648,7 +40648,7 @@
    i32.const 0
    i32.const 32
    i32.const 2594
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40663,7 +40663,7 @@
    i32.const 0
    i32.const 32
    i32.const 2595
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40678,7 +40678,7 @@
    i32.const 0
    i32.const 32
    i32.const 2596
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40693,7 +40693,7 @@
    i32.const 0
    i32.const 32
    i32.const 2597
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40708,7 +40708,7 @@
    i32.const 0
    i32.const 32
    i32.const 2598
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40723,7 +40723,7 @@
    i32.const 0
    i32.const 32
    i32.const 2599
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40738,7 +40738,7 @@
    i32.const 0
    i32.const 32
    i32.const 2600
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40753,7 +40753,7 @@
    i32.const 0
    i32.const 32
    i32.const 2601
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40768,7 +40768,7 @@
    i32.const 0
    i32.const 32
    i32.const 2602
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40783,7 +40783,7 @@
    i32.const 0
    i32.const 32
    i32.const 2603
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40798,7 +40798,7 @@
    i32.const 0
    i32.const 32
    i32.const 2604
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40813,7 +40813,7 @@
    i32.const 0
    i32.const 32
    i32.const 2605
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40828,7 +40828,7 @@
    i32.const 0
    i32.const 32
    i32.const 2606
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40843,7 +40843,7 @@
    i32.const 0
    i32.const 32
    i32.const 2607
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40858,7 +40858,7 @@
    i32.const 0
    i32.const 32
    i32.const 2608
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40873,7 +40873,7 @@
    i32.const 0
    i32.const 32
    i32.const 2609
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40888,7 +40888,7 @@
    i32.const 0
    i32.const 32
    i32.const 2610
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40903,7 +40903,7 @@
    i32.const 0
    i32.const 32
    i32.const 2611
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40918,7 +40918,7 @@
    i32.const 0
    i32.const 32
    i32.const 2612
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40933,7 +40933,7 @@
    i32.const 0
    i32.const 32
    i32.const 2613
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40948,7 +40948,7 @@
    i32.const 0
    i32.const 32
    i32.const 2614
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40963,7 +40963,7 @@
    i32.const 0
    i32.const 32
    i32.const 2615
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40978,7 +40978,7 @@
    i32.const 0
    i32.const 32
    i32.const 2616
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -40993,7 +40993,7 @@
    i32.const 0
    i32.const 32
    i32.const 2617
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41008,7 +41008,7 @@
    i32.const 0
    i32.const 32
    i32.const 2618
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41023,7 +41023,7 @@
    i32.const 0
    i32.const 32
    i32.const 2619
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41038,7 +41038,7 @@
    i32.const 0
    i32.const 32
    i32.const 2620
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41053,7 +41053,7 @@
    i32.const 0
    i32.const 32
    i32.const 2621
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41068,7 +41068,7 @@
    i32.const 0
    i32.const 32
    i32.const 2622
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41083,7 +41083,7 @@
    i32.const 0
    i32.const 32
    i32.const 2623
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41098,7 +41098,7 @@
    i32.const 0
    i32.const 32
    i32.const 2624
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41113,7 +41113,7 @@
    i32.const 0
    i32.const 32
    i32.const 2625
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41128,7 +41128,7 @@
    i32.const 0
    i32.const 32
    i32.const 2626
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41143,7 +41143,7 @@
    i32.const 0
    i32.const 32
    i32.const 2627
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41158,7 +41158,7 @@
    i32.const 0
    i32.const 32
    i32.const 2628
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41173,7 +41173,7 @@
    i32.const 0
    i32.const 32
    i32.const 2629
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41188,7 +41188,7 @@
    i32.const 0
    i32.const 32
    i32.const 2630
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41203,7 +41203,7 @@
    i32.const 0
    i32.const 32
    i32.const 2631
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41218,7 +41218,7 @@
    i32.const 0
    i32.const 32
    i32.const 2632
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41233,7 +41233,7 @@
    i32.const 0
    i32.const 32
    i32.const 2633
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41248,7 +41248,7 @@
    i32.const 0
    i32.const 32
    i32.const 2634
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41263,7 +41263,7 @@
    i32.const 0
    i32.const 32
    i32.const 2635
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41278,7 +41278,7 @@
    i32.const 0
    i32.const 32
    i32.const 2636
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41293,7 +41293,7 @@
    i32.const 0
    i32.const 32
    i32.const 2637
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41308,7 +41308,7 @@
    i32.const 0
    i32.const 32
    i32.const 2638
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41323,7 +41323,7 @@
    i32.const 0
    i32.const 32
    i32.const 2639
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41338,7 +41338,7 @@
    i32.const 0
    i32.const 32
    i32.const 2640
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41353,7 +41353,7 @@
    i32.const 0
    i32.const 32
    i32.const 2641
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41368,7 +41368,7 @@
    i32.const 0
    i32.const 32
    i32.const 2642
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41383,7 +41383,7 @@
    i32.const 0
    i32.const 32
    i32.const 2643
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41398,7 +41398,7 @@
    i32.const 0
    i32.const 32
    i32.const 2644
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41413,7 +41413,7 @@
    i32.const 0
    i32.const 32
    i32.const 2645
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41428,7 +41428,7 @@
    i32.const 0
    i32.const 32
    i32.const 2646
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41443,7 +41443,7 @@
    i32.const 0
    i32.const 32
    i32.const 2647
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41458,7 +41458,7 @@
    i32.const 0
    i32.const 32
    i32.const 2648
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41473,7 +41473,7 @@
    i32.const 0
    i32.const 32
    i32.const 2649
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41488,7 +41488,7 @@
    i32.const 0
    i32.const 32
    i32.const 2650
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41503,7 +41503,7 @@
    i32.const 0
    i32.const 32
    i32.const 2651
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41518,7 +41518,7 @@
    i32.const 0
    i32.const 32
    i32.const 2652
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41533,7 +41533,7 @@
    i32.const 0
    i32.const 32
    i32.const 2653
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41548,7 +41548,7 @@
    i32.const 0
    i32.const 32
    i32.const 2654
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41563,7 +41563,7 @@
    i32.const 0
    i32.const 32
    i32.const 2655
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41578,7 +41578,7 @@
    i32.const 0
    i32.const 32
    i32.const 2656
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41593,7 +41593,7 @@
    i32.const 0
    i32.const 32
    i32.const 2657
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41608,7 +41608,7 @@
    i32.const 0
    i32.const 32
    i32.const 2658
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41623,7 +41623,7 @@
    i32.const 0
    i32.const 32
    i32.const 2659
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41638,7 +41638,7 @@
    i32.const 0
    i32.const 32
    i32.const 2660
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41653,7 +41653,7 @@
    i32.const 0
    i32.const 32
    i32.const 2661
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41668,7 +41668,7 @@
    i32.const 0
    i32.const 32
    i32.const 2662
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41683,7 +41683,7 @@
    i32.const 0
    i32.const 32
    i32.const 2663
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41698,7 +41698,7 @@
    i32.const 0
    i32.const 32
    i32.const 2664
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41713,7 +41713,7 @@
    i32.const 0
    i32.const 32
    i32.const 2665
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41728,7 +41728,7 @@
    i32.const 0
    i32.const 32
    i32.const 2666
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41743,7 +41743,7 @@
    i32.const 0
    i32.const 32
    i32.const 2667
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41758,7 +41758,7 @@
    i32.const 0
    i32.const 32
    i32.const 2668
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41773,7 +41773,7 @@
    i32.const 0
    i32.const 32
    i32.const 2669
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41788,7 +41788,7 @@
    i32.const 0
    i32.const 32
    i32.const 2670
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41803,7 +41803,7 @@
    i32.const 0
    i32.const 32
    i32.const 2671
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41818,7 +41818,7 @@
    i32.const 0
    i32.const 32
    i32.const 2672
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41833,7 +41833,7 @@
    i32.const 0
    i32.const 32
    i32.const 2673
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41848,7 +41848,7 @@
    i32.const 0
    i32.const 32
    i32.const 2674
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41863,7 +41863,7 @@
    i32.const 0
    i32.const 32
    i32.const 2675
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41878,7 +41878,7 @@
    i32.const 0
    i32.const 32
    i32.const 2676
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41893,7 +41893,7 @@
    i32.const 0
    i32.const 32
    i32.const 2677
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41908,7 +41908,7 @@
    i32.const 0
    i32.const 32
    i32.const 2678
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41923,7 +41923,7 @@
    i32.const 0
    i32.const 32
    i32.const 2679
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41938,7 +41938,7 @@
    i32.const 0
    i32.const 32
    i32.const 2680
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41953,7 +41953,7 @@
    i32.const 0
    i32.const 32
    i32.const 2681
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41968,7 +41968,7 @@
    i32.const 0
    i32.const 32
    i32.const 2682
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41983,7 +41983,7 @@
    i32.const 0
    i32.const 32
    i32.const 2683
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -41998,7 +41998,7 @@
    i32.const 0
    i32.const 32
    i32.const 2684
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42013,7 +42013,7 @@
    i32.const 0
    i32.const 32
    i32.const 2685
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42027,7 +42027,7 @@
    i32.const 0
    i32.const 32
    i32.const 2688
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42041,7 +42041,7 @@
    i32.const 0
    i32.const 32
    i32.const 2689
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42055,7 +42055,7 @@
    i32.const 0
    i32.const 32
    i32.const 2690
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42069,7 +42069,7 @@
    i32.const 0
    i32.const 32
    i32.const 2691
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42083,7 +42083,7 @@
    i32.const 0
    i32.const 32
    i32.const 2692
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42097,7 +42097,7 @@
    i32.const 0
    i32.const 32
    i32.const 2693
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42111,7 +42111,7 @@
    i32.const 0
    i32.const 32
    i32.const 2694
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42125,7 +42125,7 @@
    i32.const 0
    i32.const 32
    i32.const 2695
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42139,7 +42139,7 @@
    i32.const 0
    i32.const 32
    i32.const 2697
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42153,7 +42153,7 @@
    i32.const 0
    i32.const 32
    i32.const 2698
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42167,7 +42167,7 @@
    i32.const 0
    i32.const 32
    i32.const 2699
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42181,7 +42181,7 @@
    i32.const 0
    i32.const 32
    i32.const 2700
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42195,7 +42195,7 @@
    i32.const 0
    i32.const 32
    i32.const 2701
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42210,7 +42210,7 @@
    i32.const 0
    i32.const 32
    i32.const 2702
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42224,7 +42224,7 @@
    i32.const 0
    i32.const 32
    i32.const 2704
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42238,7 +42238,7 @@
    i32.const 0
    i32.const 32
    i32.const 2705
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42252,7 +42252,7 @@
    i32.const 0
    i32.const 32
    i32.const 2706
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42266,7 +42266,7 @@
    i32.const 0
    i32.const 32
    i32.const 2707
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42280,7 +42280,7 @@
    i32.const 0
    i32.const 32
    i32.const 2708
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42294,7 +42294,7 @@
    i32.const 0
    i32.const 32
    i32.const 2709
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42308,7 +42308,7 @@
    i32.const 0
    i32.const 32
    i32.const 2710
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42323,7 +42323,7 @@
    i32.const 0
    i32.const 32
    i32.const 2711
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42337,7 +42337,7 @@
    i32.const 0
    i32.const 32
    i32.const 2713
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42351,7 +42351,7 @@
    i32.const 0
    i32.const 32
    i32.const 2714
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42365,7 +42365,7 @@
    i32.const 0
    i32.const 32
    i32.const 2715
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42379,7 +42379,7 @@
    i32.const 0
    i32.const 32
    i32.const 2716
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42393,7 +42393,7 @@
    i32.const 0
    i32.const 32
    i32.const 2717
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42407,7 +42407,7 @@
    i32.const 0
    i32.const 32
    i32.const 2718
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42421,7 +42421,7 @@
    i32.const 0
    i32.const 32
    i32.const 2719
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42436,7 +42436,7 @@
    i32.const 0
    i32.const 32
    i32.const 2720
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42450,7 +42450,7 @@
    i32.const 0
    i32.const 32
    i32.const 2722
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42464,7 +42464,7 @@
    i32.const 0
    i32.const 32
    i32.const 2723
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42479,7 +42479,7 @@
    i32.const 0
    i32.const 32
    i32.const 2724
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42493,7 +42493,7 @@
    i32.const 0
    i32.const 32
    i32.const 2725
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42507,7 +42507,7 @@
    i32.const 0
    i32.const 32
    i32.const 2726
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42521,7 +42521,7 @@
    i32.const 0
    i32.const 32
    i32.const 2727
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42535,7 +42535,7 @@
    i32.const 0
    i32.const 32
    i32.const 2728
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42550,7 +42550,7 @@
    i32.const 0
    i32.const 32
    i32.const 2729
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42565,7 +42565,7 @@
    i32.const 0
    i32.const 32
    i32.const 2738
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42580,7 +42580,7 @@
    i32.const 0
    i32.const 32
    i32.const 2739
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42595,7 +42595,7 @@
    i32.const 0
    i32.const 32
    i32.const 2740
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42610,7 +42610,7 @@
    i32.const 0
    i32.const 32
    i32.const 2741
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42625,7 +42625,7 @@
    i32.const 0
    i32.const 32
    i32.const 2742
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42640,7 +42640,7 @@
    i32.const 0
    i32.const 32
    i32.const 2743
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42655,7 +42655,7 @@
    i32.const 0
    i32.const 32
    i32.const 2744
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42670,7 +42670,7 @@
    i32.const 0
    i32.const 32
    i32.const 2745
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42685,7 +42685,7 @@
    i32.const 0
    i32.const 32
    i32.const 2746
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42700,7 +42700,7 @@
    i32.const 0
    i32.const 32
    i32.const 2747
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42715,7 +42715,7 @@
    i32.const 0
    i32.const 32
    i32.const 2750
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42730,7 +42730,7 @@
    i32.const 0
    i32.const 32
    i32.const 2751
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42745,7 +42745,7 @@
    i32.const 0
    i32.const 32
    i32.const 2752
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42760,7 +42760,7 @@
    i32.const 0
    i32.const 32
    i32.const 2753
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42775,7 +42775,7 @@
    i32.const 0
    i32.const 32
    i32.const 2754
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42790,7 +42790,7 @@
    i32.const 0
    i32.const 32
    i32.const 2755
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42805,7 +42805,7 @@
    i32.const 0
    i32.const 32
    i32.const 2756
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42820,7 +42820,7 @@
    i32.const 0
    i32.const 32
    i32.const 2757
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42835,7 +42835,7 @@
    i32.const 0
    i32.const 32
    i32.const 2758
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42850,7 +42850,7 @@
    i32.const 0
    i32.const 32
    i32.const 2759
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42865,7 +42865,7 @@
    i32.const 0
    i32.const 32
    i32.const 2760
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42880,7 +42880,7 @@
    i32.const 0
    i32.const 32
    i32.const 2761
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42895,7 +42895,7 @@
    i32.const 0
    i32.const 32
    i32.const 2762
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42910,7 +42910,7 @@
    i32.const 0
    i32.const 32
    i32.const 2763
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42925,7 +42925,7 @@
    i32.const 0
    i32.const 32
    i32.const 2764
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42940,7 +42940,7 @@
    i32.const 0
    i32.const 32
    i32.const 2765
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42955,7 +42955,7 @@
    i32.const 0
    i32.const 32
    i32.const 2766
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42970,7 +42970,7 @@
    i32.const 0
    i32.const 32
    i32.const 2767
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -42985,7 +42985,7 @@
    i32.const 0
    i32.const 32
    i32.const 2768
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43000,7 +43000,7 @@
    i32.const 0
    i32.const 32
    i32.const 2769
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43015,7 +43015,7 @@
    i32.const 0
    i32.const 32
    i32.const 2770
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43030,7 +43030,7 @@
    i32.const 0
    i32.const 32
    i32.const 2771
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43045,7 +43045,7 @@
    i32.const 0
    i32.const 32
    i32.const 2772
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43060,7 +43060,7 @@
    i32.const 0
    i32.const 32
    i32.const 2773
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43075,7 +43075,7 @@
    i32.const 0
    i32.const 32
    i32.const 2774
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43090,7 +43090,7 @@
    i32.const 0
    i32.const 32
    i32.const 2775
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43105,7 +43105,7 @@
    i32.const 0
    i32.const 32
    i32.const 2776
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43120,7 +43120,7 @@
    i32.const 0
    i32.const 32
    i32.const 2777
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43135,7 +43135,7 @@
    i32.const 0
    i32.const 32
    i32.const 2778
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43150,7 +43150,7 @@
    i32.const 0
    i32.const 32
    i32.const 2779
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43165,7 +43165,7 @@
    i32.const 0
    i32.const 32
    i32.const 2780
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43180,7 +43180,7 @@
    i32.const 0
    i32.const 32
    i32.const 2781
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43195,7 +43195,7 @@
    i32.const 0
    i32.const 32
    i32.const 2782
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43210,7 +43210,7 @@
    i32.const 0
    i32.const 32
    i32.const 2783
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43225,7 +43225,7 @@
    i32.const 0
    i32.const 32
    i32.const 2784
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43240,7 +43240,7 @@
    i32.const 0
    i32.const 32
    i32.const 2785
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43255,7 +43255,7 @@
    i32.const 0
    i32.const 32
    i32.const 2786
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43270,7 +43270,7 @@
    i32.const 0
    i32.const 32
    i32.const 2787
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43285,7 +43285,7 @@
    i32.const 0
    i32.const 32
    i32.const 2788
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43300,7 +43300,7 @@
    i32.const 0
    i32.const 32
    i32.const 2789
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43315,7 +43315,7 @@
    i32.const 0
    i32.const 32
    i32.const 2790
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43330,7 +43330,7 @@
    i32.const 0
    i32.const 32
    i32.const 2791
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43345,7 +43345,7 @@
    i32.const 0
    i32.const 32
    i32.const 2792
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43360,7 +43360,7 @@
    i32.const 0
    i32.const 32
    i32.const 2793
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43375,7 +43375,7 @@
    i32.const 0
    i32.const 32
    i32.const 2794
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43390,7 +43390,7 @@
    i32.const 0
    i32.const 32
    i32.const 2795
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43405,7 +43405,7 @@
    i32.const 0
    i32.const 32
    i32.const 2796
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43420,7 +43420,7 @@
    i32.const 0
    i32.const 32
    i32.const 2797
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43435,7 +43435,7 @@
    i32.const 0
    i32.const 32
    i32.const 2798
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43450,7 +43450,7 @@
    i32.const 0
    i32.const 32
    i32.const 2799
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43465,7 +43465,7 @@
    i32.const 0
    i32.const 32
    i32.const 2800
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43480,7 +43480,7 @@
    i32.const 0
    i32.const 32
    i32.const 2801
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43495,7 +43495,7 @@
    i32.const 0
    i32.const 32
    i32.const 2802
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43510,7 +43510,7 @@
    i32.const 0
    i32.const 32
    i32.const 2803
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43525,7 +43525,7 @@
    i32.const 0
    i32.const 32
    i32.const 2804
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43540,7 +43540,7 @@
    i32.const 0
    i32.const 32
    i32.const 2805
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43555,7 +43555,7 @@
    i32.const 0
    i32.const 32
    i32.const 2806
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43570,7 +43570,7 @@
    i32.const 0
    i32.const 32
    i32.const 2807
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43585,7 +43585,7 @@
    i32.const 0
    i32.const 32
    i32.const 2808
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43600,7 +43600,7 @@
    i32.const 0
    i32.const 32
    i32.const 2809
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43615,7 +43615,7 @@
    i32.const 0
    i32.const 32
    i32.const 2810
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43630,7 +43630,7 @@
    i32.const 0
    i32.const 32
    i32.const 2811
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43645,7 +43645,7 @@
    i32.const 0
    i32.const 32
    i32.const 2812
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43660,7 +43660,7 @@
    i32.const 0
    i32.const 32
    i32.const 2813
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43675,7 +43675,7 @@
    i32.const 0
    i32.const 32
    i32.const 2814
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43690,7 +43690,7 @@
    i32.const 0
    i32.const 32
    i32.const 2815
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43705,7 +43705,7 @@
    i32.const 0
    i32.const 32
    i32.const 2816
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43720,7 +43720,7 @@
    i32.const 0
    i32.const 32
    i32.const 2817
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43735,7 +43735,7 @@
    i32.const 0
    i32.const 32
    i32.const 2818
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43750,7 +43750,7 @@
    i32.const 0
    i32.const 32
    i32.const 2819
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43765,7 +43765,7 @@
    i32.const 0
    i32.const 32
    i32.const 2820
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43780,7 +43780,7 @@
    i32.const 0
    i32.const 32
    i32.const 2821
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43795,7 +43795,7 @@
    i32.const 0
    i32.const 32
    i32.const 2822
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43810,7 +43810,7 @@
    i32.const 0
    i32.const 32
    i32.const 2823
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43825,7 +43825,7 @@
    i32.const 0
    i32.const 32
    i32.const 2824
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43840,7 +43840,7 @@
    i32.const 0
    i32.const 32
    i32.const 2825
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43855,7 +43855,7 @@
    i32.const 0
    i32.const 32
    i32.const 2826
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43870,7 +43870,7 @@
    i32.const 0
    i32.const 32
    i32.const 2827
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43885,7 +43885,7 @@
    i32.const 0
    i32.const 32
    i32.const 2828
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43900,7 +43900,7 @@
    i32.const 0
    i32.const 32
    i32.const 2829
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43915,7 +43915,7 @@
    i32.const 0
    i32.const 32
    i32.const 2830
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43930,7 +43930,7 @@
    i32.const 0
    i32.const 32
    i32.const 2831
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43945,7 +43945,7 @@
    i32.const 0
    i32.const 32
    i32.const 2832
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43960,7 +43960,7 @@
    i32.const 0
    i32.const 32
    i32.const 2833
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43975,7 +43975,7 @@
    i32.const 0
    i32.const 32
    i32.const 2834
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -43990,7 +43990,7 @@
    i32.const 0
    i32.const 32
    i32.const 2835
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44005,7 +44005,7 @@
    i32.const 0
    i32.const 32
    i32.const 2836
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44020,7 +44020,7 @@
    i32.const 0
    i32.const 32
    i32.const 2837
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44035,7 +44035,7 @@
    i32.const 0
    i32.const 32
    i32.const 2838
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44050,7 +44050,7 @@
    i32.const 0
    i32.const 32
    i32.const 2839
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44065,7 +44065,7 @@
    i32.const 0
    i32.const 32
    i32.const 2840
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44080,7 +44080,7 @@
    i32.const 0
    i32.const 32
    i32.const 2841
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44114,7 +44114,7 @@
      i32.const 0
      i32.const 32
      i32.const 2850
-     i32.const 2
+     i32.const 3
      call $~lib/builtins/abort
      unreachable
     end
@@ -44157,7 +44157,7 @@
      i32.const 0
      i32.const 32
      i32.const 2858
-     i32.const 2
+     i32.const 3
      call $~lib/builtins/abort
      unreachable
     end
@@ -44178,7 +44178,7 @@
    i32.const 0
    i32.const 32
    i32.const 2872
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44192,7 +44192,7 @@
    i32.const 0
    i32.const 32
    i32.const 2873
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44206,7 +44206,7 @@
    i32.const 0
    i32.const 32
    i32.const 2874
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44220,7 +44220,7 @@
    i32.const 0
    i32.const 32
    i32.const 2875
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44234,7 +44234,7 @@
    i32.const 0
    i32.const 32
    i32.const 2876
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44248,7 +44248,7 @@
    i32.const 0
    i32.const 32
    i32.const 2877
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44262,7 +44262,7 @@
    i32.const 0
    i32.const 32
    i32.const 2878
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44276,7 +44276,7 @@
    i32.const 0
    i32.const 32
    i32.const 2879
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44290,7 +44290,7 @@
    i32.const 0
    i32.const 32
    i32.const 2880
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44304,7 +44304,7 @@
    i32.const 0
    i32.const 32
    i32.const 2881
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44318,7 +44318,7 @@
    i32.const 0
    i32.const 32
    i32.const 2884
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44332,7 +44332,7 @@
    i32.const 0
    i32.const 32
    i32.const 2885
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44346,7 +44346,7 @@
    i32.const 0
    i32.const 32
    i32.const 2886
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44360,7 +44360,7 @@
    i32.const 0
    i32.const 32
    i32.const 2887
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44374,7 +44374,7 @@
    i32.const 0
    i32.const 32
    i32.const 2888
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44388,7 +44388,7 @@
    i32.const 0
    i32.const 32
    i32.const 2889
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44402,7 +44402,7 @@
    i32.const 0
    i32.const 32
    i32.const 2890
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44416,7 +44416,7 @@
    i32.const 0
    i32.const 32
    i32.const 2891
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44430,7 +44430,7 @@
    i32.const 0
    i32.const 32
    i32.const 2892
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44444,7 +44444,7 @@
    i32.const 0
    i32.const 32
    i32.const 2893
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44458,7 +44458,7 @@
    i32.const 0
    i32.const 32
    i32.const 2894
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44472,7 +44472,7 @@
    i32.const 0
    i32.const 32
    i32.const 2895
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44486,7 +44486,7 @@
    i32.const 0
    i32.const 32
    i32.const 2896
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44500,7 +44500,7 @@
    i32.const 0
    i32.const 32
    i32.const 2897
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44514,7 +44514,7 @@
    i32.const 0
    i32.const 32
    i32.const 2898
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44528,7 +44528,7 @@
    i32.const 0
    i32.const 32
    i32.const 2899
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44542,7 +44542,7 @@
    i32.const 0
    i32.const 32
    i32.const 2900
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44556,7 +44556,7 @@
    i32.const 0
    i32.const 32
    i32.const 2909
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44570,7 +44570,7 @@
    i32.const 0
    i32.const 32
    i32.const 2910
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44584,7 +44584,7 @@
    i32.const 0
    i32.const 32
    i32.const 2911
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44598,7 +44598,7 @@
    i32.const 0
    i32.const 32
    i32.const 2912
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44612,7 +44612,7 @@
    i32.const 0
    i32.const 32
    i32.const 2913
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44626,7 +44626,7 @@
    i32.const 0
    i32.const 32
    i32.const 2914
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44640,7 +44640,7 @@
    i32.const 0
    i32.const 32
    i32.const 2915
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44654,7 +44654,7 @@
    i32.const 0
    i32.const 32
    i32.const 2916
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44668,7 +44668,7 @@
    i32.const 0
    i32.const 32
    i32.const 2917
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44682,7 +44682,7 @@
    i32.const 0
    i32.const 32
    i32.const 2918
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44696,7 +44696,7 @@
    i32.const 0
    i32.const 32
    i32.const 2921
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44710,7 +44710,7 @@
    i32.const 0
    i32.const 32
    i32.const 2922
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44724,7 +44724,7 @@
    i32.const 0
    i32.const 32
    i32.const 2923
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44738,7 +44738,7 @@
    i32.const 0
    i32.const 32
    i32.const 2924
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44752,7 +44752,7 @@
    i32.const 0
    i32.const 32
    i32.const 2925
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44766,7 +44766,7 @@
    i32.const 0
    i32.const 32
    i32.const 2926
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44780,7 +44780,7 @@
    i32.const 0
    i32.const 32
    i32.const 2927
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44794,7 +44794,7 @@
    i32.const 0
    i32.const 32
    i32.const 2928
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44808,7 +44808,7 @@
    i32.const 0
    i32.const 32
    i32.const 2929
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44822,7 +44822,7 @@
    i32.const 0
    i32.const 32
    i32.const 2930
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44836,7 +44836,7 @@
    i32.const 0
    i32.const 32
    i32.const 2931
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44850,7 +44850,7 @@
    i32.const 0
    i32.const 32
    i32.const 2932
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44864,7 +44864,7 @@
    i32.const 0
    i32.const 32
    i32.const 2933
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44878,7 +44878,7 @@
    i32.const 0
    i32.const 32
    i32.const 2934
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44892,7 +44892,7 @@
    i32.const 0
    i32.const 32
    i32.const 2935
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44906,7 +44906,7 @@
    i32.const 0
    i32.const 32
    i32.const 2936
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44920,7 +44920,7 @@
    i32.const 0
    i32.const 32
    i32.const 2937
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44934,7 +44934,7 @@
    i32.const 0
    i32.const 32
    i32.const 2948
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44948,7 +44948,7 @@
    i32.const 0
    i32.const 32
    i32.const 2949
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44962,7 +44962,7 @@
    i32.const 0
    i32.const 32
    i32.const 2950
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44976,7 +44976,7 @@
    i32.const 0
    i32.const 32
    i32.const 2951
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -44990,7 +44990,7 @@
    i32.const 0
    i32.const 32
    i32.const 2952
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45004,7 +45004,7 @@
    i32.const 0
    i32.const 32
    i32.const 2953
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45018,7 +45018,7 @@
    i32.const 0
    i32.const 32
    i32.const 2954
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45032,7 +45032,7 @@
    i32.const 0
    i32.const 32
    i32.const 2955
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45046,7 +45046,7 @@
    i32.const 0
    i32.const 32
    i32.const 2956
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45060,7 +45060,7 @@
    i32.const 0
    i32.const 32
    i32.const 2964
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45074,7 +45074,7 @@
    i32.const 0
    i32.const 32
    i32.const 2965
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45088,7 +45088,7 @@
    i32.const 0
    i32.const 32
    i32.const 2966
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45102,7 +45102,7 @@
    i32.const 0
    i32.const 32
    i32.const 2967
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45116,7 +45116,7 @@
    i32.const 0
    i32.const 32
    i32.const 2968
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45130,7 +45130,7 @@
    i32.const 0
    i32.const 32
    i32.const 2969
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45144,7 +45144,7 @@
    i32.const 0
    i32.const 32
    i32.const 2970
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45158,7 +45158,7 @@
    i32.const 0
    i32.const 32
    i32.const 2971
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45172,7 +45172,7 @@
    i32.const 0
    i32.const 32
    i32.const 2972
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45196,7 +45196,7 @@
    i32.const 0
    i32.const 32
    i32.const 2978
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45220,7 +45220,7 @@
    i32.const 0
    i32.const 32
    i32.const 2979
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45244,7 +45244,7 @@
    i32.const 0
    i32.const 32
    i32.const 2980
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45268,7 +45268,7 @@
    i32.const 0
    i32.const 32
    i32.const 2981
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45292,7 +45292,7 @@
    i32.const 0
    i32.const 32
    i32.const 2982
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45316,7 +45316,7 @@
    i32.const 0
    i32.const 32
    i32.const 2983
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45340,7 +45340,7 @@
    i32.const 0
    i32.const 32
    i32.const 2984
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45364,7 +45364,7 @@
    i32.const 0
    i32.const 32
    i32.const 2985
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45387,7 +45387,7 @@
    i32.const 0
    i32.const 32
    i32.const 2991
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45410,7 +45410,7 @@
    i32.const 0
    i32.const 32
    i32.const 2992
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45433,7 +45433,7 @@
    i32.const 0
    i32.const 32
    i32.const 2993
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45456,7 +45456,7 @@
    i32.const 0
    i32.const 32
    i32.const 2994
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45479,7 +45479,7 @@
    i32.const 0
    i32.const 32
    i32.const 2995
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45502,7 +45502,7 @@
    i32.const 0
    i32.const 32
    i32.const 2996
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45525,7 +45525,7 @@
    i32.const 0
    i32.const 32
    i32.const 2997
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45548,7 +45548,7 @@
    i32.const 0
    i32.const 32
    i32.const 2998
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45563,7 +45563,7 @@
    i32.const 0
    i32.const 32
    i32.const 3009
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45578,7 +45578,7 @@
    i32.const 0
    i32.const 32
    i32.const 3010
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45593,7 +45593,7 @@
    i32.const 0
    i32.const 32
    i32.const 3011
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45608,7 +45608,7 @@
    i32.const 0
    i32.const 32
    i32.const 3012
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45623,7 +45623,7 @@
    i32.const 0
    i32.const 32
    i32.const 3013
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45638,7 +45638,7 @@
    i32.const 0
    i32.const 32
    i32.const 3014
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45653,7 +45653,7 @@
    i32.const 0
    i32.const 32
    i32.const 3015
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45668,7 +45668,7 @@
    i32.const 0
    i32.const 32
    i32.const 3016
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45683,7 +45683,7 @@
    i32.const 0
    i32.const 32
    i32.const 3017
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45698,7 +45698,7 @@
    i32.const 0
    i32.const 32
    i32.const 3018
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45713,7 +45713,7 @@
    i32.const 0
    i32.const 32
    i32.const 3021
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45728,7 +45728,7 @@
    i32.const 0
    i32.const 32
    i32.const 3022
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45743,7 +45743,7 @@
    i32.const 0
    i32.const 32
    i32.const 3023
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45758,7 +45758,7 @@
    i32.const 0
    i32.const 32
    i32.const 3024
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45773,7 +45773,7 @@
    i32.const 0
    i32.const 32
    i32.const 3025
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45788,7 +45788,7 @@
    i32.const 0
    i32.const 32
    i32.const 3026
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45803,7 +45803,7 @@
    i32.const 0
    i32.const 32
    i32.const 3027
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45818,7 +45818,7 @@
    i32.const 0
    i32.const 32
    i32.const 3028
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45833,7 +45833,7 @@
    i32.const 0
    i32.const 32
    i32.const 3029
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45848,7 +45848,7 @@
    i32.const 0
    i32.const 32
    i32.const 3030
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45863,7 +45863,7 @@
    i32.const 0
    i32.const 32
    i32.const 3031
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45878,7 +45878,7 @@
    i32.const 0
    i32.const 32
    i32.const 3032
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45893,7 +45893,7 @@
    i32.const 0
    i32.const 32
    i32.const 3033
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45908,7 +45908,7 @@
    i32.const 0
    i32.const 32
    i32.const 3034
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45923,7 +45923,7 @@
    i32.const 0
    i32.const 32
    i32.const 3035
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45938,7 +45938,7 @@
    i32.const 0
    i32.const 32
    i32.const 3036
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45953,7 +45953,7 @@
    i32.const 0
    i32.const 32
    i32.const 3037
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45968,7 +45968,7 @@
    i32.const 0
    i32.const 32
    i32.const 3038
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45983,7 +45983,7 @@
    i32.const 0
    i32.const 32
    i32.const 3039
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -45998,7 +45998,7 @@
    i32.const 0
    i32.const 32
    i32.const 3040
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46013,7 +46013,7 @@
    i32.const 0
    i32.const 32
    i32.const 3041
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46028,7 +46028,7 @@
    i32.const 0
    i32.const 32
    i32.const 3042
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46043,7 +46043,7 @@
    i32.const 0
    i32.const 32
    i32.const 3043
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46058,7 +46058,7 @@
    i32.const 0
    i32.const 32
    i32.const 3044
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46073,7 +46073,7 @@
    i32.const 0
    i32.const 32
    i32.const 3045
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46088,7 +46088,7 @@
    i32.const 0
    i32.const 32
    i32.const 3046
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46103,7 +46103,7 @@
    i32.const 0
    i32.const 32
    i32.const 3047
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46118,7 +46118,7 @@
    i32.const 0
    i32.const 32
    i32.const 3048
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46133,7 +46133,7 @@
    i32.const 0
    i32.const 32
    i32.const 3049
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46148,7 +46148,7 @@
    i32.const 0
    i32.const 32
    i32.const 3050
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46163,7 +46163,7 @@
    i32.const 0
    i32.const 32
    i32.const 3051
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46178,7 +46178,7 @@
    i32.const 0
    i32.const 32
    i32.const 3052
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46193,7 +46193,7 @@
    i32.const 0
    i32.const 32
    i32.const 3053
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46208,7 +46208,7 @@
    i32.const 0
    i32.const 32
    i32.const 3054
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46223,7 +46223,7 @@
    i32.const 0
    i32.const 32
    i32.const 3055
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46238,7 +46238,7 @@
    i32.const 0
    i32.const 32
    i32.const 3056
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46253,7 +46253,7 @@
    i32.const 0
    i32.const 32
    i32.const 3057
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46268,7 +46268,7 @@
    i32.const 0
    i32.const 32
    i32.const 3058
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46283,7 +46283,7 @@
    i32.const 0
    i32.const 32
    i32.const 3059
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46298,7 +46298,7 @@
    i32.const 0
    i32.const 32
    i32.const 3060
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46313,7 +46313,7 @@
    i32.const 0
    i32.const 32
    i32.const 3061
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46328,7 +46328,7 @@
    i32.const 0
    i32.const 32
    i32.const 3062
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46343,7 +46343,7 @@
    i32.const 0
    i32.const 32
    i32.const 3063
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46358,7 +46358,7 @@
    i32.const 0
    i32.const 32
    i32.const 3064
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46373,7 +46373,7 @@
    i32.const 0
    i32.const 32
    i32.const 3065
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46388,7 +46388,7 @@
    i32.const 0
    i32.const 32
    i32.const 3066
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46403,7 +46403,7 @@
    i32.const 0
    i32.const 32
    i32.const 3067
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46418,7 +46418,7 @@
    i32.const 0
    i32.const 32
    i32.const 3068
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46433,7 +46433,7 @@
    i32.const 0
    i32.const 32
    i32.const 3069
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46448,7 +46448,7 @@
    i32.const 0
    i32.const 32
    i32.const 3070
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46463,7 +46463,7 @@
    i32.const 0
    i32.const 32
    i32.const 3071
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46478,7 +46478,7 @@
    i32.const 0
    i32.const 32
    i32.const 3072
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46493,7 +46493,7 @@
    i32.const 0
    i32.const 32
    i32.const 3073
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46508,7 +46508,7 @@
    i32.const 0
    i32.const 32
    i32.const 3074
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46523,7 +46523,7 @@
    i32.const 0
    i32.const 32
    i32.const 3075
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46538,7 +46538,7 @@
    i32.const 0
    i32.const 32
    i32.const 3076
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46553,7 +46553,7 @@
    i32.const 0
    i32.const 32
    i32.const 3077
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46568,7 +46568,7 @@
    i32.const 0
    i32.const 32
    i32.const 3078
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46583,7 +46583,7 @@
    i32.const 0
    i32.const 32
    i32.const 3079
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46598,7 +46598,7 @@
    i32.const 0
    i32.const 32
    i32.const 3080
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46613,7 +46613,7 @@
    i32.const 0
    i32.const 32
    i32.const 3081
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46628,7 +46628,7 @@
    i32.const 0
    i32.const 32
    i32.const 3082
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46643,7 +46643,7 @@
    i32.const 0
    i32.const 32
    i32.const 3083
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46658,7 +46658,7 @@
    i32.const 0
    i32.const 32
    i32.const 3084
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46673,7 +46673,7 @@
    i32.const 0
    i32.const 32
    i32.const 3085
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46688,7 +46688,7 @@
    i32.const 0
    i32.const 32
    i32.const 3086
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46703,7 +46703,7 @@
    i32.const 0
    i32.const 32
    i32.const 3087
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46718,7 +46718,7 @@
    i32.const 0
    i32.const 32
    i32.const 3096
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46733,7 +46733,7 @@
    i32.const 0
    i32.const 32
    i32.const 3097
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46748,7 +46748,7 @@
    i32.const 0
    i32.const 32
    i32.const 3098
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46763,7 +46763,7 @@
    i32.const 0
    i32.const 32
    i32.const 3099
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46778,7 +46778,7 @@
    i32.const 0
    i32.const 32
    i32.const 3100
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46793,7 +46793,7 @@
    i32.const 0
    i32.const 32
    i32.const 3101
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46808,7 +46808,7 @@
    i32.const 0
    i32.const 32
    i32.const 3102
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46823,7 +46823,7 @@
    i32.const 0
    i32.const 32
    i32.const 3103
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46838,7 +46838,7 @@
    i32.const 0
    i32.const 32
    i32.const 3104
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46853,7 +46853,7 @@
    i32.const 0
    i32.const 32
    i32.const 3105
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46868,7 +46868,7 @@
    i32.const 0
    i32.const 32
    i32.const 3108
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46883,7 +46883,7 @@
    i32.const 0
    i32.const 32
    i32.const 3109
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46898,7 +46898,7 @@
    i32.const 0
    i32.const 32
    i32.const 3110
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46913,7 +46913,7 @@
    i32.const 0
    i32.const 32
    i32.const 3111
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46928,7 +46928,7 @@
    i32.const 0
    i32.const 32
    i32.const 3112
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46943,7 +46943,7 @@
    i32.const 0
    i32.const 32
    i32.const 3113
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46958,7 +46958,7 @@
    i32.const 0
    i32.const 32
    i32.const 3114
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46973,7 +46973,7 @@
    i32.const 0
    i32.const 32
    i32.const 3115
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -46988,7 +46988,7 @@
    i32.const 0
    i32.const 32
    i32.const 3116
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -47003,7 +47003,7 @@
    i32.const 0
    i32.const 32
    i32.const 3117
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -47018,7 +47018,7 @@
    i32.const 0
    i32.const 32
    i32.const 3118
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -47033,7 +47033,7 @@
    i32.const 0
    i32.const 32
    i32.const 3119
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -47048,7 +47048,7 @@
    i32.const 0
    i32.const 32
    i32.const 3120
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -47063,7 +47063,7 @@
    i32.const 0
    i32.const 32
    i32.const 3121
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -47078,7 +47078,7 @@
    i32.const 0
    i32.const 32
    i32.const 3122
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -47093,7 +47093,7 @@
    i32.const 0
    i32.const 32
    i32.const 3123
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -47108,7 +47108,7 @@
    i32.const 0
    i32.const 32
    i32.const 3124
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -47123,7 +47123,7 @@
    i32.const 0
    i32.const 32
    i32.const 3125
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -47138,7 +47138,7 @@
    i32.const 0
    i32.const 32
    i32.const 3126
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -47153,7 +47153,7 @@
    i32.const 0
    i32.const 32
    i32.const 3127
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -47168,7 +47168,7 @@
    i32.const 0
    i32.const 32
    i32.const 3128
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -47183,7 +47183,7 @@
    i32.const 0
    i32.const 32
    i32.const 3129
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -47198,7 +47198,7 @@
    i32.const 0
    i32.const 32
    i32.const 3130
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -47213,7 +47213,7 @@
    i32.const 0
    i32.const 32
    i32.const 3131
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -47228,7 +47228,7 @@
    i32.const 0
    i32.const 32
    i32.const 3132
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -47243,7 +47243,7 @@
    i32.const 0
    i32.const 32
    i32.const 3133
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -47258,7 +47258,7 @@
    i32.const 0
    i32.const 32
    i32.const 3134
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -47273,7 +47273,7 @@
    i32.const 0
    i32.const 32
    i32.const 3135
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -47288,7 +47288,7 @@
    i32.const 0
    i32.const 32
    i32.const 3136
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -47303,7 +47303,7 @@
    i32.const 0
    i32.const 32
    i32.const 3137
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -47318,7 +47318,7 @@
    i32.const 0
    i32.const 32
    i32.const 3138
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -47333,7 +47333,7 @@
    i32.const 0
    i32.const 32
    i32.const 3139
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -47348,7 +47348,7 @@
    i32.const 0
    i32.const 32
    i32.const 3140
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -47363,7 +47363,7 @@
    i32.const 0
    i32.const 32
    i32.const 3141
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -47378,7 +47378,7 @@
    i32.const 0
    i32.const 32
    i32.const 3142
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -47393,7 +47393,7 @@
    i32.const 0
    i32.const 32
    i32.const 3143
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -47408,7 +47408,7 @@
    i32.const 0
    i32.const 32
    i32.const 3144
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -47423,7 +47423,7 @@
    i32.const 0
    i32.const 32
    i32.const 3145
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -47438,7 +47438,7 @@
    i32.const 0
    i32.const 32
    i32.const 3146
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -47453,7 +47453,7 @@
    i32.const 0
    i32.const 32
    i32.const 3147
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -47468,7 +47468,7 @@
    i32.const 0
    i32.const 32
    i32.const 3148
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -47483,7 +47483,7 @@
    i32.const 0
    i32.const 32
    i32.const 3149
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -47498,7 +47498,7 @@
    i32.const 0
    i32.const 32
    i32.const 3150
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -47513,7 +47513,7 @@
    i32.const 0
    i32.const 32
    i32.const 3151
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -47528,7 +47528,7 @@
    i32.const 0
    i32.const 32
    i32.const 3152
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -47543,7 +47543,7 @@
    i32.const 0
    i32.const 32
    i32.const 3153
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -47558,7 +47558,7 @@
    i32.const 0
    i32.const 32
    i32.const 3154
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -47573,7 +47573,7 @@
    i32.const 0
    i32.const 32
    i32.const 3155
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -47588,7 +47588,7 @@
    i32.const 0
    i32.const 32
    i32.const 3156
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -47603,7 +47603,7 @@
    i32.const 0
    i32.const 32
    i32.const 3157
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -47618,7 +47618,7 @@
    i32.const 0
    i32.const 32
    i32.const 3158
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -47633,7 +47633,7 @@
    i32.const 0
    i32.const 32
    i32.const 3159
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -47648,7 +47648,7 @@
    i32.const 0
    i32.const 32
    i32.const 3160
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -47663,7 +47663,7 @@
    i32.const 0
    i32.const 32
    i32.const 3161
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -47678,7 +47678,7 @@
    i32.const 0
    i32.const 32
    i32.const 3162
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -47693,7 +47693,7 @@
    i32.const 0
    i32.const 32
    i32.const 3163
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -47708,7 +47708,7 @@
    i32.const 0
    i32.const 32
    i32.const 3164
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -47723,7 +47723,7 @@
    i32.const 0
    i32.const 32
    i32.const 3165
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -47738,7 +47738,7 @@
    i32.const 0
    i32.const 32
    i32.const 3166
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -47753,7 +47753,7 @@
    i32.const 0
    i32.const 32
    i32.const 3167
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -47768,7 +47768,7 @@
    i32.const 0
    i32.const 32
    i32.const 3168
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -47783,7 +47783,7 @@
    i32.const 0
    i32.const 32
    i32.const 3169
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -47798,7 +47798,7 @@
    i32.const 0
    i32.const 32
    i32.const 3170
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -47813,7 +47813,7 @@
    i32.const 0
    i32.const 32
    i32.const 3171
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -47828,7 +47828,7 @@
    i32.const 0
    i32.const 32
    i32.const 3172
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -47843,7 +47843,7 @@
    i32.const 0
    i32.const 32
    i32.const 3173
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -47858,7 +47858,7 @@
    i32.const 0
    i32.const 32
    i32.const 3174
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -47872,7 +47872,7 @@
    i32.const 0
    i32.const 32
    i32.const 3186
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -47886,7 +47886,7 @@
    i32.const 0
    i32.const 32
    i32.const 3187
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -47900,7 +47900,7 @@
    i32.const 0
    i32.const 32
    i32.const 3188
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -47914,7 +47914,7 @@
    i32.const 0
    i32.const 32
    i32.const 3189
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -47928,7 +47928,7 @@
    i32.const 0
    i32.const 32
    i32.const 3190
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -47942,7 +47942,7 @@
    i32.const 0
    i32.const 32
    i32.const 3191
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -47956,7 +47956,7 @@
    i32.const 0
    i32.const 32
    i32.const 3192
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -47970,7 +47970,7 @@
    i32.const 0
    i32.const 32
    i32.const 3193
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -47984,7 +47984,7 @@
    i32.const 0
    i32.const 32
    i32.const 3194
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -47998,7 +47998,7 @@
    i32.const 0
    i32.const 32
    i32.const 3195
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -48012,7 +48012,7 @@
    i32.const 0
    i32.const 32
    i32.const 3198
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -48026,7 +48026,7 @@
    i32.const 0
    i32.const 32
    i32.const 3199
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -48040,7 +48040,7 @@
    i32.const 0
    i32.const 32
    i32.const 3200
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -48054,7 +48054,7 @@
    i32.const 0
    i32.const 32
    i32.const 3201
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -48068,7 +48068,7 @@
    i32.const 0
    i32.const 32
    i32.const 3202
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -48082,7 +48082,7 @@
    i32.const 0
    i32.const 32
    i32.const 3203
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -48096,7 +48096,7 @@
    i32.const 0
    i32.const 32
    i32.const 3204
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -48110,7 +48110,7 @@
    i32.const 0
    i32.const 32
    i32.const 3205
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -48124,7 +48124,7 @@
    i32.const 0
    i32.const 32
    i32.const 3206
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -48138,7 +48138,7 @@
    i32.const 0
    i32.const 32
    i32.const 3207
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -48152,7 +48152,7 @@
    i32.const 0
    i32.const 32
    i32.const 3208
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -48166,7 +48166,7 @@
    i32.const 0
    i32.const 32
    i32.const 3209
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -48180,7 +48180,7 @@
    i32.const 0
    i32.const 32
    i32.const 3210
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -48194,7 +48194,7 @@
    i32.const 0
    i32.const 32
    i32.const 3211
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -48208,7 +48208,7 @@
    i32.const 0
    i32.const 32
    i32.const 3212
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -48222,7 +48222,7 @@
    i32.const 0
    i32.const 32
    i32.const 3213
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -48236,7 +48236,7 @@
    i32.const 0
    i32.const 32
    i32.const 3214
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -48250,7 +48250,7 @@
    i32.const 0
    i32.const 32
    i32.const 3215
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -48264,7 +48264,7 @@
    i32.const 0
    i32.const 32
    i32.const 3216
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -48278,7 +48278,7 @@
    i32.const 0
    i32.const 32
    i32.const 3217
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -48292,7 +48292,7 @@
    i32.const 0
    i32.const 32
    i32.const 3218
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -48306,7 +48306,7 @@
    i32.const 0
    i32.const 32
    i32.const 3219
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -48320,7 +48320,7 @@
    i32.const 0
    i32.const 32
    i32.const 3220
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -48334,7 +48334,7 @@
    i32.const 0
    i32.const 32
    i32.const 3221
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -48348,7 +48348,7 @@
    i32.const 0
    i32.const 32
    i32.const 3222
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -48362,7 +48362,7 @@
    i32.const 0
    i32.const 32
    i32.const 3223
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -48376,7 +48376,7 @@
    i32.const 0
    i32.const 32
    i32.const 3224
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -48390,7 +48390,7 @@
    i32.const 0
    i32.const 32
    i32.const 3225
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -48404,7 +48404,7 @@
    i32.const 0
    i32.const 32
    i32.const 3226
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -48418,7 +48418,7 @@
    i32.const 0
    i32.const 32
    i32.const 3227
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -48432,7 +48432,7 @@
    i32.const 0
    i32.const 32
    i32.const 3228
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -48446,7 +48446,7 @@
    i32.const 0
    i32.const 32
    i32.const 3229
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -48460,7 +48460,7 @@
    i32.const 0
    i32.const 32
    i32.const 3230
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -48474,7 +48474,7 @@
    i32.const 0
    i32.const 32
    i32.const 3231
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -48488,7 +48488,7 @@
    i32.const 0
    i32.const 32
    i32.const 3232
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -48502,7 +48502,7 @@
    i32.const 0
    i32.const 32
    i32.const 3233
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -48516,7 +48516,7 @@
    i32.const 0
    i32.const 32
    i32.const 3234
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -48530,7 +48530,7 @@
    i32.const 0
    i32.const 32
    i32.const 3237
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -48544,7 +48544,7 @@
    i32.const 0
    i32.const 32
    i32.const 3238
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -48558,7 +48558,7 @@
    i32.const 0
    i32.const 32
    i32.const 3239
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -48572,7 +48572,7 @@
    i32.const 0
    i32.const 32
    i32.const 3240
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -48586,7 +48586,7 @@
    i32.const 0
    i32.const 32
    i32.const 3241
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -48600,7 +48600,7 @@
    i32.const 0
    i32.const 32
    i32.const 3244
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -48614,7 +48614,7 @@
    i32.const 0
    i32.const 32
    i32.const 3245
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -48627,7 +48627,7 @@
    i32.const 0
    i32.const 32
    i32.const 3248
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -48640,7 +48640,7 @@
    i32.const 0
    i32.const 32
    i32.const 3249
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -48653,7 +48653,7 @@
    i32.const 0
    i32.const 32
    i32.const 3251
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -48666,7 +48666,7 @@
    i32.const 0
    i32.const 32
    i32.const 3252
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -48679,7 +48679,7 @@
    i32.const 0
    i32.const 32
    i32.const 3255
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -48692,7 +48692,7 @@
    i32.const 0
    i32.const 32
    i32.const 3256
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -48705,7 +48705,7 @@
    i32.const 0
    i32.const 32
    i32.const 3257
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -48718,7 +48718,7 @@
    i32.const 0
    i32.const 32
    i32.const 3258
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -48731,7 +48731,7 @@
    i32.const 0
    i32.const 32
    i32.const 3260
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -48744,7 +48744,7 @@
    i32.const 0
    i32.const 32
    i32.const 3261
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -48757,7 +48757,7 @@
    i32.const 0
    i32.const 32
    i32.const 3263
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -48770,7 +48770,7 @@
    i32.const 0
    i32.const 32
    i32.const 3264
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -48783,7 +48783,7 @@
    i32.const 0
    i32.const 32
    i32.const 3265
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -48796,7 +48796,7 @@
    i32.const 0
    i32.const 32
    i32.const 3266
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -48809,7 +48809,7 @@
    i32.const 0
    i32.const 32
    i32.const 3267
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -48822,7 +48822,7 @@
    i32.const 0
    i32.const 32
    i32.const 3270
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -48835,7 +48835,7 @@
    i32.const 0
    i32.const 32
    i32.const 3271
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -48849,7 +48849,7 @@
    i32.const 0
    i32.const 32
    i32.const 3280
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -48863,7 +48863,7 @@
    i32.const 0
    i32.const 32
    i32.const 3281
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -48877,7 +48877,7 @@
    i32.const 0
    i32.const 32
    i32.const 3282
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -48891,7 +48891,7 @@
    i32.const 0
    i32.const 32
    i32.const 3283
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -48905,7 +48905,7 @@
    i32.const 0
    i32.const 32
    i32.const 3284
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -48919,7 +48919,7 @@
    i32.const 0
    i32.const 32
    i32.const 3285
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -48933,7 +48933,7 @@
    i32.const 0
    i32.const 32
    i32.const 3286
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -48947,7 +48947,7 @@
    i32.const 0
    i32.const 32
    i32.const 3287
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -48961,7 +48961,7 @@
    i32.const 0
    i32.const 32
    i32.const 3288
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -48975,7 +48975,7 @@
    i32.const 0
    i32.const 32
    i32.const 3289
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -48989,7 +48989,7 @@
    i32.const 0
    i32.const 32
    i32.const 3292
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -49003,7 +49003,7 @@
    i32.const 0
    i32.const 32
    i32.const 3293
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -49017,7 +49017,7 @@
    i32.const 0
    i32.const 32
    i32.const 3294
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -49031,7 +49031,7 @@
    i32.const 0
    i32.const 32
    i32.const 3295
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -49045,7 +49045,7 @@
    i32.const 0
    i32.const 32
    i32.const 3296
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -49059,7 +49059,7 @@
    i32.const 0
    i32.const 32
    i32.const 3299
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -49073,7 +49073,7 @@
    i32.const 0
    i32.const 32
    i32.const 3300
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -49087,7 +49087,7 @@
    i32.const 0
    i32.const 32
    i32.const 3301
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -49101,7 +49101,7 @@
    i32.const 0
    i32.const 32
    i32.const 3302
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -49115,7 +49115,7 @@
    i32.const 0
    i32.const 32
    i32.const 3303
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -49129,7 +49129,7 @@
    i32.const 0
    i32.const 32
    i32.const 3304
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -49143,7 +49143,7 @@
    i32.const 0
    i32.const 32
    i32.const 3305
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -49157,7 +49157,7 @@
    i32.const 0
    i32.const 32
    i32.const 3306
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -49171,7 +49171,7 @@
    i32.const 0
    i32.const 32
    i32.const 3307
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -49185,7 +49185,7 @@
    i32.const 0
    i32.const 32
    i32.const 3308
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -49199,7 +49199,7 @@
    i32.const 0
    i32.const 32
    i32.const 3309
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -49213,7 +49213,7 @@
    i32.const 0
    i32.const 32
    i32.const 3310
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -49227,7 +49227,7 @@
    i32.const 0
    i32.const 32
    i32.const 3311
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -49241,7 +49241,7 @@
    i32.const 0
    i32.const 32
    i32.const 3312
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -49255,7 +49255,7 @@
    i32.const 0
    i32.const 32
    i32.const 3313
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -49269,7 +49269,7 @@
    i32.const 0
    i32.const 32
    i32.const 3314
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -49283,7 +49283,7 @@
    i32.const 0
    i32.const 32
    i32.const 3315
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -49297,7 +49297,7 @@
    i32.const 0
    i32.const 32
    i32.const 3316
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -49311,7 +49311,7 @@
    i32.const 0
    i32.const 32
    i32.const 3317
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -49325,7 +49325,7 @@
    i32.const 0
    i32.const 32
    i32.const 3318
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -49339,7 +49339,7 @@
    i32.const 0
    i32.const 32
    i32.const 3319
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -49353,7 +49353,7 @@
    i32.const 0
    i32.const 32
    i32.const 3320
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -49367,7 +49367,7 @@
    i32.const 0
    i32.const 32
    i32.const 3321
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -49381,7 +49381,7 @@
    i32.const 0
    i32.const 32
    i32.const 3322
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -49395,7 +49395,7 @@
    i32.const 0
    i32.const 32
    i32.const 3323
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -49409,7 +49409,7 @@
    i32.const 0
    i32.const 32
    i32.const 3324
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -49423,7 +49423,7 @@
    i32.const 0
    i32.const 32
    i32.const 3325
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -49437,7 +49437,7 @@
    i32.const 0
    i32.const 32
    i32.const 3326
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -49451,7 +49451,7 @@
    i32.const 0
    i32.const 32
    i32.const 3327
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -49465,7 +49465,7 @@
    i32.const 0
    i32.const 32
    i32.const 3328
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -49479,7 +49479,7 @@
    i32.const 0
    i32.const 32
    i32.const 3329
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -49493,7 +49493,7 @@
    i32.const 0
    i32.const 32
    i32.const 3330
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -49507,7 +49507,7 @@
    i32.const 0
    i32.const 32
    i32.const 3331
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -49521,7 +49521,7 @@
    i32.const 0
    i32.const 32
    i32.const 3332
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -49535,7 +49535,7 @@
    i32.const 0
    i32.const 32
    i32.const 3333
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -49549,7 +49549,7 @@
    i32.const 0
    i32.const 32
    i32.const 3334
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -49563,7 +49563,7 @@
    i32.const 0
    i32.const 32
    i32.const 3335
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -49577,7 +49577,7 @@
    i32.const 0
    i32.const 32
    i32.const 3336
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -49591,7 +49591,7 @@
    i32.const 0
    i32.const 32
    i32.const 3339
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -49605,7 +49605,7 @@
    i32.const 0
    i32.const 32
    i32.const 3340
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -49619,7 +49619,7 @@
    i32.const 0
    i32.const 32
    i32.const 3341
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -49633,7 +49633,7 @@
    i32.const 0
    i32.const 32
    i32.const 3342
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -49647,7 +49647,7 @@
    i32.const 0
    i32.const 32
    i32.const 3343
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -49661,7 +49661,7 @@
    i32.const 0
    i32.const 32
    i32.const 3344
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -49675,7 +49675,7 @@
    i32.const 0
    i32.const 32
    i32.const 3345
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -49689,7 +49689,7 @@
    i32.const 0
    i32.const 32
    i32.const 3346
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -49703,7 +49703,7 @@
    i32.const 0
    i32.const 32
    i32.const 3347
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -49717,7 +49717,7 @@
    i32.const 0
    i32.const 32
    i32.const 3348
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -49731,7 +49731,7 @@
    i32.const 0
    i32.const 32
    i32.const 3349
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -49745,7 +49745,7 @@
    i32.const 0
    i32.const 32
    i32.const 3350
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -49759,7 +49759,7 @@
    i32.const 0
    i32.const 32
    i32.const 3351
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -49773,7 +49773,7 @@
    i32.const 0
    i32.const 32
    i32.const 3352
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -49787,7 +49787,7 @@
    i32.const 0
    i32.const 32
    i32.const 3364
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -49801,7 +49801,7 @@
    i32.const 0
    i32.const 32
    i32.const 3365
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -49815,7 +49815,7 @@
    i32.const 0
    i32.const 32
    i32.const 3366
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -49829,7 +49829,7 @@
    i32.const 0
    i32.const 32
    i32.const 3367
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -49843,7 +49843,7 @@
    i32.const 0
    i32.const 32
    i32.const 3368
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -49857,7 +49857,7 @@
    i32.const 0
    i32.const 32
    i32.const 3369
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -49871,7 +49871,7 @@
    i32.const 0
    i32.const 32
    i32.const 3370
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -49885,7 +49885,7 @@
    i32.const 0
    i32.const 32
    i32.const 3371
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -49899,7 +49899,7 @@
    i32.const 0
    i32.const 32
    i32.const 3372
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -49913,7 +49913,7 @@
    i32.const 0
    i32.const 32
    i32.const 3373
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -49927,7 +49927,7 @@
    i32.const 0
    i32.const 32
    i32.const 3376
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -49941,7 +49941,7 @@
    i32.const 0
    i32.const 32
    i32.const 3377
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -49955,7 +49955,7 @@
    i32.const 0
    i32.const 32
    i32.const 3378
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -49969,7 +49969,7 @@
    i32.const 0
    i32.const 32
    i32.const 3379
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -49983,7 +49983,7 @@
    i32.const 0
    i32.const 32
    i32.const 3380
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -49997,7 +49997,7 @@
    i32.const 0
    i32.const 32
    i32.const 3389
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -50011,7 +50011,7 @@
    i32.const 0
    i32.const 32
    i32.const 3390
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -50025,7 +50025,7 @@
    i32.const 0
    i32.const 32
    i32.const 3391
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -50039,7 +50039,7 @@
    i32.const 0
    i32.const 32
    i32.const 3392
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -50053,7 +50053,7 @@
    i32.const 0
    i32.const 32
    i32.const 3393
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -50067,7 +50067,7 @@
    i32.const 0
    i32.const 32
    i32.const 3394
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -50081,7 +50081,7 @@
    i32.const 0
    i32.const 32
    i32.const 3395
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -50095,7 +50095,7 @@
    i32.const 0
    i32.const 32
    i32.const 3396
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -50109,7 +50109,7 @@
    i32.const 0
    i32.const 32
    i32.const 3397
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -50123,7 +50123,7 @@
    i32.const 0
    i32.const 32
    i32.const 3398
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -50137,7 +50137,7 @@
    i32.const 0
    i32.const 32
    i32.const 3401
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -50151,7 +50151,7 @@
    i32.const 0
    i32.const 32
    i32.const 3402
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -50165,7 +50165,7 @@
    i32.const 0
    i32.const 32
    i32.const 3403
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -50179,7 +50179,7 @@
    i32.const 0
    i32.const 32
    i32.const 3404
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -50193,7 +50193,7 @@
    i32.const 0
    i32.const 32
    i32.const 3405
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -50207,7 +50207,7 @@
    i32.const 0
    i32.const 32
    i32.const 3417
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -50221,7 +50221,7 @@
    i32.const 0
    i32.const 32
    i32.const 3418
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -50235,7 +50235,7 @@
    i32.const 0
    i32.const 32
    i32.const 3419
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -50249,7 +50249,7 @@
    i32.const 0
    i32.const 32
    i32.const 3420
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -50263,7 +50263,7 @@
    i32.const 0
    i32.const 32
    i32.const 3421
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -50277,7 +50277,7 @@
    i32.const 0
    i32.const 32
    i32.const 3422
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -50291,7 +50291,7 @@
    i32.const 0
    i32.const 32
    i32.const 3423
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -50305,7 +50305,7 @@
    i32.const 0
    i32.const 32
    i32.const 3424
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -50319,7 +50319,7 @@
    i32.const 0
    i32.const 32
    i32.const 3425
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -50333,7 +50333,7 @@
    i32.const 0
    i32.const 32
    i32.const 3426
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -50347,7 +50347,7 @@
    i32.const 0
    i32.const 32
    i32.const 3429
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -50361,7 +50361,7 @@
    i32.const 0
    i32.const 32
    i32.const 3430
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -50375,7 +50375,7 @@
    i32.const 0
    i32.const 32
    i32.const 3431
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -50389,7 +50389,7 @@
    i32.const 0
    i32.const 32
    i32.const 3432
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -50403,7 +50403,7 @@
    i32.const 0
    i32.const 32
    i32.const 3433
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -50417,7 +50417,7 @@
    i32.const 0
    i32.const 32
    i32.const 3434
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -50431,7 +50431,7 @@
    i32.const 0
    i32.const 32
    i32.const 3435
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -50445,7 +50445,7 @@
    i32.const 0
    i32.const 32
    i32.const 3436
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -50459,7 +50459,7 @@
    i32.const 0
    i32.const 32
    i32.const 3437
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -50473,7 +50473,7 @@
    i32.const 0
    i32.const 32
    i32.const 3438
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -50487,7 +50487,7 @@
    i32.const 0
    i32.const 32
    i32.const 3439
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -50501,7 +50501,7 @@
    i32.const 0
    i32.const 32
    i32.const 3440
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -50515,7 +50515,7 @@
    i32.const 0
    i32.const 32
    i32.const 3441
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -50529,7 +50529,7 @@
    i32.const 0
    i32.const 32
    i32.const 3442
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -50543,7 +50543,7 @@
    i32.const 0
    i32.const 32
    i32.const 3443
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -50557,7 +50557,7 @@
    i32.const 0
    i32.const 32
    i32.const 3444
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -50571,7 +50571,7 @@
    i32.const 0
    i32.const 32
    i32.const 3445
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -50585,7 +50585,7 @@
    i32.const 0
    i32.const 32
    i32.const 3446
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -50599,7 +50599,7 @@
    i32.const 0
    i32.const 32
    i32.const 3447
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -50613,7 +50613,7 @@
    i32.const 0
    i32.const 32
    i32.const 3448
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -50627,7 +50627,7 @@
    i32.const 0
    i32.const 32
    i32.const 3449
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -50641,7 +50641,7 @@
    i32.const 0
    i32.const 32
    i32.const 3450
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -50655,7 +50655,7 @@
    i32.const 0
    i32.const 32
    i32.const 3451
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -50669,7 +50669,7 @@
    i32.const 0
    i32.const 32
    i32.const 3452
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -50683,7 +50683,7 @@
    i32.const 0
    i32.const 32
    i32.const 3453
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -50697,7 +50697,7 @@
    i32.const 0
    i32.const 32
    i32.const 3454
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -50711,7 +50711,7 @@
    i32.const 0
    i32.const 32
    i32.const 3455
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -50725,7 +50725,7 @@
    i32.const 0
    i32.const 32
    i32.const 3456
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -50739,7 +50739,7 @@
    i32.const 0
    i32.const 32
    i32.const 3457
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -50753,7 +50753,7 @@
    i32.const 0
    i32.const 32
    i32.const 3458
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -50767,7 +50767,7 @@
    i32.const 0
    i32.const 32
    i32.const 3459
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -50781,7 +50781,7 @@
    i32.const 0
    i32.const 32
    i32.const 3460
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -50795,7 +50795,7 @@
    i32.const 0
    i32.const 32
    i32.const 3461
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -50809,7 +50809,7 @@
    i32.const 0
    i32.const 32
    i32.const 3462
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -50823,7 +50823,7 @@
    i32.const 0
    i32.const 32
    i32.const 3463
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -50837,7 +50837,7 @@
    i32.const 0
    i32.const 32
    i32.const 3464
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -50851,7 +50851,7 @@
    i32.const 0
    i32.const 32
    i32.const 3465
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -50865,7 +50865,7 @@
    i32.const 0
    i32.const 32
    i32.const 3466
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -50879,7 +50879,7 @@
    i32.const 0
    i32.const 32
    i32.const 3467
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -50893,7 +50893,7 @@
    i32.const 0
    i32.const 32
    i32.const 3468
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -50907,7 +50907,7 @@
    i32.const 0
    i32.const 32
    i32.const 3469
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -50921,7 +50921,7 @@
    i32.const 0
    i32.const 32
    i32.const 3470
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -50935,7 +50935,7 @@
    i32.const 0
    i32.const 32
    i32.const 3471
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -50949,7 +50949,7 @@
    i32.const 0
    i32.const 32
    i32.const 3472
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -50963,7 +50963,7 @@
    i32.const 0
    i32.const 32
    i32.const 3473
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -50977,7 +50977,7 @@
    i32.const 0
    i32.const 32
    i32.const 3474
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -50991,7 +50991,7 @@
    i32.const 0
    i32.const 32
    i32.const 3475
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -51005,7 +51005,7 @@
    i32.const 0
    i32.const 32
    i32.const 3476
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -51019,7 +51019,7 @@
    i32.const 0
    i32.const 32
    i32.const 3477
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -51033,7 +51033,7 @@
    i32.const 0
    i32.const 32
    i32.const 3478
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -51047,7 +51047,7 @@
    i32.const 0
    i32.const 32
    i32.const 3479
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -51061,7 +51061,7 @@
    i32.const 0
    i32.const 32
    i32.const 3480
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -51075,7 +51075,7 @@
    i32.const 0
    i32.const 32
    i32.const 3481
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -51089,7 +51089,7 @@
    i32.const 0
    i32.const 32
    i32.const 3482
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -51103,7 +51103,7 @@
    i32.const 0
    i32.const 32
    i32.const 3483
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -51117,7 +51117,7 @@
    i32.const 0
    i32.const 32
    i32.const 3484
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -51131,7 +51131,7 @@
    i32.const 0
    i32.const 32
    i32.const 3485
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -51145,7 +51145,7 @@
    i32.const 0
    i32.const 32
    i32.const 3486
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -51159,7 +51159,7 @@
    i32.const 0
    i32.const 32
    i32.const 3487
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -51173,7 +51173,7 @@
    i32.const 0
    i32.const 32
    i32.const 3488
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -51187,7 +51187,7 @@
    i32.const 0
    i32.const 32
    i32.const 3489
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -51201,7 +51201,7 @@
    i32.const 0
    i32.const 32
    i32.const 3490
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -51215,7 +51215,7 @@
    i32.const 0
    i32.const 32
    i32.const 3491
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -51229,7 +51229,7 @@
    i32.const 0
    i32.const 32
    i32.const 3492
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -51243,7 +51243,7 @@
    i32.const 0
    i32.const 32
    i32.const 3493
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -51257,7 +51257,7 @@
    i32.const 0
    i32.const 32
    i32.const 3494
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -51271,7 +51271,7 @@
    i32.const 0
    i32.const 32
    i32.const 3495
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -51285,7 +51285,7 @@
    i32.const 0
    i32.const 32
    i32.const 3496
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -51299,7 +51299,7 @@
    i32.const 0
    i32.const 32
    i32.const 3497
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -51313,7 +51313,7 @@
    i32.const 0
    i32.const 32
    i32.const 3498
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -51327,7 +51327,7 @@
    i32.const 0
    i32.const 32
    i32.const 3499
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -51341,7 +51341,7 @@
    i32.const 0
    i32.const 32
    i32.const 3500
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -51355,7 +51355,7 @@
    i32.const 0
    i32.const 32
    i32.const 3501
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -51369,7 +51369,7 @@
    i32.const 0
    i32.const 32
    i32.const 3502
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -51383,7 +51383,7 @@
    i32.const 0
    i32.const 32
    i32.const 3511
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -51397,7 +51397,7 @@
    i32.const 0
    i32.const 32
    i32.const 3512
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -51411,7 +51411,7 @@
    i32.const 0
    i32.const 32
    i32.const 3513
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -51425,7 +51425,7 @@
    i32.const 0
    i32.const 32
    i32.const 3514
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -51439,7 +51439,7 @@
    i32.const 0
    i32.const 32
    i32.const 3515
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -51453,7 +51453,7 @@
    i32.const 0
    i32.const 32
    i32.const 3516
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -51467,7 +51467,7 @@
    i32.const 0
    i32.const 32
    i32.const 3517
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -51481,7 +51481,7 @@
    i32.const 0
    i32.const 32
    i32.const 3518
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -51495,7 +51495,7 @@
    i32.const 0
    i32.const 32
    i32.const 3519
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -51509,7 +51509,7 @@
    i32.const 0
    i32.const 32
    i32.const 3520
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -51523,7 +51523,7 @@
    i32.const 0
    i32.const 32
    i32.const 3523
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -51537,7 +51537,7 @@
    i32.const 0
    i32.const 32
    i32.const 3524
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -51551,7 +51551,7 @@
    i32.const 0
    i32.const 32
    i32.const 3525
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -51565,7 +51565,7 @@
    i32.const 0
    i32.const 32
    i32.const 3526
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -51579,7 +51579,7 @@
    i32.const 0
    i32.const 32
    i32.const 3527
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -51593,7 +51593,7 @@
    i32.const 0
    i32.const 32
    i32.const 3528
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -51607,7 +51607,7 @@
    i32.const 0
    i32.const 32
    i32.const 3529
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -51621,7 +51621,7 @@
    i32.const 0
    i32.const 32
    i32.const 3530
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -51635,7 +51635,7 @@
    i32.const 0
    i32.const 32
    i32.const 3531
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -51649,7 +51649,7 @@
    i32.const 0
    i32.const 32
    i32.const 3532
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -51663,7 +51663,7 @@
    i32.const 0
    i32.const 32
    i32.const 3533
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -51677,7 +51677,7 @@
    i32.const 0
    i32.const 32
    i32.const 3534
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -51691,7 +51691,7 @@
    i32.const 0
    i32.const 32
    i32.const 3535
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -51705,7 +51705,7 @@
    i32.const 0
    i32.const 32
    i32.const 3536
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -51719,7 +51719,7 @@
    i32.const 0
    i32.const 32
    i32.const 3537
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -51733,7 +51733,7 @@
    i32.const 0
    i32.const 32
    i32.const 3538
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -51747,7 +51747,7 @@
    i32.const 0
    i32.const 32
    i32.const 3539
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -51761,7 +51761,7 @@
    i32.const 0
    i32.const 32
    i32.const 3540
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -51775,7 +51775,7 @@
    i32.const 0
    i32.const 32
    i32.const 3541
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -51789,7 +51789,7 @@
    i32.const 0
    i32.const 32
    i32.const 3542
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -51803,7 +51803,7 @@
    i32.const 0
    i32.const 32
    i32.const 3543
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -51817,7 +51817,7 @@
    i32.const 0
    i32.const 32
    i32.const 3544
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -51831,7 +51831,7 @@
    i32.const 0
    i32.const 32
    i32.const 3556
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -51845,7 +51845,7 @@
    i32.const 0
    i32.const 32
    i32.const 3557
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -51859,7 +51859,7 @@
    i32.const 0
    i32.const 32
    i32.const 3558
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -51873,7 +51873,7 @@
    i32.const 0
    i32.const 32
    i32.const 3559
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -51887,7 +51887,7 @@
    i32.const 0
    i32.const 32
    i32.const 3560
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -51901,7 +51901,7 @@
    i32.const 0
    i32.const 32
    i32.const 3561
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -51915,7 +51915,7 @@
    i32.const 0
    i32.const 32
    i32.const 3562
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -51929,7 +51929,7 @@
    i32.const 0
    i32.const 32
    i32.const 3563
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -51943,7 +51943,7 @@
    i32.const 0
    i32.const 32
    i32.const 3564
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -51957,7 +51957,7 @@
    i32.const 0
    i32.const 32
    i32.const 3565
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -51971,7 +51971,7 @@
    i32.const 0
    i32.const 32
    i32.const 3568
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -51985,7 +51985,7 @@
    i32.const 0
    i32.const 32
    i32.const 3569
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -51999,7 +51999,7 @@
    i32.const 0
    i32.const 32
    i32.const 3570
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -52013,7 +52013,7 @@
    i32.const 0
    i32.const 32
    i32.const 3571
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -52027,7 +52027,7 @@
    i32.const 0
    i32.const 32
    i32.const 3572
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -52041,7 +52041,7 @@
    i32.const 0
    i32.const 32
    i32.const 3573
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -52055,7 +52055,7 @@
    i32.const 0
    i32.const 32
    i32.const 3574
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -52069,7 +52069,7 @@
    i32.const 0
    i32.const 32
    i32.const 3575
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -52083,7 +52083,7 @@
    i32.const 0
    i32.const 32
    i32.const 3576
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -52097,7 +52097,7 @@
    i32.const 0
    i32.const 32
    i32.const 3577
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -52111,7 +52111,7 @@
    i32.const 0
    i32.const 32
    i32.const 3578
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -52125,7 +52125,7 @@
    i32.const 0
    i32.const 32
    i32.const 3579
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -52139,7 +52139,7 @@
    i32.const 0
    i32.const 32
    i32.const 3580
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -52153,7 +52153,7 @@
    i32.const 0
    i32.const 32
    i32.const 3581
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -52167,7 +52167,7 @@
    i32.const 0
    i32.const 32
    i32.const 3582
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -52181,7 +52181,7 @@
    i32.const 0
    i32.const 32
    i32.const 3583
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -52195,7 +52195,7 @@
    i32.const 0
    i32.const 32
    i32.const 3584
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -52209,7 +52209,7 @@
    i32.const 0
    i32.const 32
    i32.const 3585
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -52223,7 +52223,7 @@
    i32.const 0
    i32.const 32
    i32.const 3586
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -52237,7 +52237,7 @@
    i32.const 0
    i32.const 32
    i32.const 3587
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -52251,7 +52251,7 @@
    i32.const 0
    i32.const 32
    i32.const 3588
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -52265,7 +52265,7 @@
    i32.const 0
    i32.const 32
    i32.const 3589
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -52279,7 +52279,7 @@
    i32.const 0
    i32.const 32
    i32.const 3590
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -52293,7 +52293,7 @@
    i32.const 0
    i32.const 32
    i32.const 3591
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -52307,7 +52307,7 @@
    i32.const 0
    i32.const 32
    i32.const 3592
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -52321,7 +52321,7 @@
    i32.const 0
    i32.const 32
    i32.const 3593
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -52335,7 +52335,7 @@
    i32.const 0
    i32.const 32
    i32.const 3594
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -52349,7 +52349,7 @@
    i32.const 0
    i32.const 32
    i32.const 3595
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -52363,7 +52363,7 @@
    i32.const 0
    i32.const 32
    i32.const 3596
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -52377,7 +52377,7 @@
    i32.const 0
    i32.const 32
    i32.const 3597
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -52391,7 +52391,7 @@
    i32.const 0
    i32.const 32
    i32.const 3598
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -52405,7 +52405,7 @@
    i32.const 0
    i32.const 32
    i32.const 3599
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -52419,7 +52419,7 @@
    i32.const 0
    i32.const 32
    i32.const 3600
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -52433,7 +52433,7 @@
    i32.const 0
    i32.const 32
    i32.const 3601
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -52447,7 +52447,7 @@
    i32.const 0
    i32.const 32
    i32.const 3602
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -52461,7 +52461,7 @@
    i32.const 0
    i32.const 32
    i32.const 3603
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -52475,7 +52475,7 @@
    i32.const 0
    i32.const 32
    i32.const 3604
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -52489,7 +52489,7 @@
    i32.const 0
    i32.const 32
    i32.const 3605
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -52503,7 +52503,7 @@
    i32.const 0
    i32.const 32
    i32.const 3608
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -52517,7 +52517,7 @@
    i32.const 0
    i32.const 32
    i32.const 3609
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -52531,7 +52531,7 @@
    i32.const 0
    i32.const 32
    i32.const 3610
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -52545,7 +52545,7 @@
    i32.const 0
    i32.const 32
    i32.const 3611
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -52559,7 +52559,7 @@
    i32.const 0
    i32.const 32
    i32.const 3612
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -52573,7 +52573,7 @@
    i32.const 0
    i32.const 32
    i32.const 3613
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -52587,7 +52587,7 @@
    i32.const 0
    i32.const 32
    i32.const 3614
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -52601,7 +52601,7 @@
    i32.const 0
    i32.const 32
    i32.const 3615
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -52615,7 +52615,7 @@
    i32.const 0
    i32.const 32
    i32.const 3617
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -52629,7 +52629,7 @@
    i32.const 0
    i32.const 32
    i32.const 3618
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -52643,7 +52643,7 @@
    i32.const 0
    i32.const 32
    i32.const 3619
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -52657,7 +52657,7 @@
    i32.const 0
    i32.const 32
    i32.const 3620
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -52671,7 +52671,7 @@
    i32.const 0
    i32.const 32
    i32.const 3621
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -52685,7 +52685,7 @@
    i32.const 0
    i32.const 32
    i32.const 3622
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -52699,7 +52699,7 @@
    i32.const 0
    i32.const 32
    i32.const 3623
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -52713,7 +52713,7 @@
    i32.const 0
    i32.const 32
    i32.const 3624
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -52727,7 +52727,7 @@
    i32.const 0
    i32.const 32
    i32.const 3627
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -52741,7 +52741,7 @@
    i32.const 0
    i32.const 32
    i32.const 3628
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -52755,7 +52755,7 @@
    i32.const 0
    i32.const 32
    i32.const 3629
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -52769,7 +52769,7 @@
    i32.const 0
    i32.const 32
    i32.const 3630
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -52783,7 +52783,7 @@
    i32.const 0
    i32.const 32
    i32.const 3631
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -52797,7 +52797,7 @@
    i32.const 0
    i32.const 32
    i32.const 3640
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -52811,7 +52811,7 @@
    i32.const 0
    i32.const 32
    i32.const 3641
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -52825,7 +52825,7 @@
    i32.const 0
    i32.const 32
    i32.const 3642
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -52839,7 +52839,7 @@
    i32.const 0
    i32.const 32
    i32.const 3643
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -52853,7 +52853,7 @@
    i32.const 0
    i32.const 32
    i32.const 3644
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -52867,7 +52867,7 @@
    i32.const 0
    i32.const 32
    i32.const 3645
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -52881,7 +52881,7 @@
    i32.const 0
    i32.const 32
    i32.const 3646
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -52895,7 +52895,7 @@
    i32.const 0
    i32.const 32
    i32.const 3647
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -52909,7 +52909,7 @@
    i32.const 0
    i32.const 32
    i32.const 3648
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -52923,7 +52923,7 @@
    i32.const 0
    i32.const 32
    i32.const 3649
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -52937,7 +52937,7 @@
    i32.const 0
    i32.const 32
    i32.const 3652
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -52951,7 +52951,7 @@
    i32.const 0
    i32.const 32
    i32.const 3653
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -52965,7 +52965,7 @@
    i32.const 0
    i32.const 32
    i32.const 3654
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -52979,7 +52979,7 @@
    i32.const 0
    i32.const 32
    i32.const 3655
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -52993,7 +52993,7 @@
    i32.const 0
    i32.const 32
    i32.const 3656
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -53007,7 +53007,7 @@
    i32.const 0
    i32.const 32
    i32.const 3659
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -53021,7 +53021,7 @@
    i32.const 0
    i32.const 32
    i32.const 3660
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -53035,7 +53035,7 @@
    i32.const 0
    i32.const 32
    i32.const 3661
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -53049,7 +53049,7 @@
    i32.const 0
    i32.const 32
    i32.const 3662
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -53063,7 +53063,7 @@
    i32.const 0
    i32.const 32
    i32.const 3663
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -53077,7 +53077,7 @@
    i32.const 0
    i32.const 32
    i32.const 3664
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -53091,7 +53091,7 @@
    i32.const 0
    i32.const 32
    i32.const 3665
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -53105,7 +53105,7 @@
    i32.const 0
    i32.const 32
    i32.const 3666
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -53119,7 +53119,7 @@
    i32.const 0
    i32.const 32
    i32.const 3667
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -53133,7 +53133,7 @@
    i32.const 0
    i32.const 32
    i32.const 3668
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -53147,7 +53147,7 @@
    i32.const 0
    i32.const 32
    i32.const 3669
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -53161,7 +53161,7 @@
    i32.const 0
    i32.const 32
    i32.const 3670
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -53175,7 +53175,7 @@
    i32.const 0
    i32.const 32
    i32.const 3671
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -53189,7 +53189,7 @@
    i32.const 0
    i32.const 32
    i32.const 3672
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -53203,7 +53203,7 @@
    i32.const 0
    i32.const 32
    i32.const 3673
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -53217,7 +53217,7 @@
    i32.const 0
    i32.const 32
    i32.const 3674
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -53231,7 +53231,7 @@
    i32.const 0
    i32.const 32
    i32.const 3675
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -53245,7 +53245,7 @@
    i32.const 0
    i32.const 32
    i32.const 3676
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -53259,7 +53259,7 @@
    i32.const 0
    i32.const 32
    i32.const 3677
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -53273,7 +53273,7 @@
    i32.const 0
    i32.const 32
    i32.const 3678
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -53287,7 +53287,7 @@
    i32.const 0
    i32.const 32
    i32.const 3679
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -53301,7 +53301,7 @@
    i32.const 0
    i32.const 32
    i32.const 3680
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -53315,7 +53315,7 @@
    i32.const 0
    i32.const 32
    i32.const 3681
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -53329,7 +53329,7 @@
    i32.const 0
    i32.const 32
    i32.const 3682
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -53343,7 +53343,7 @@
    i32.const 0
    i32.const 32
    i32.const 3683
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -53357,7 +53357,7 @@
    i32.const 0
    i32.const 32
    i32.const 3684
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -53371,7 +53371,7 @@
    i32.const 0
    i32.const 32
    i32.const 3685
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -53385,7 +53385,7 @@
    i32.const 0
    i32.const 32
    i32.const 3686
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -53399,7 +53399,7 @@
    i32.const 0
    i32.const 32
    i32.const 3687
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -53413,7 +53413,7 @@
    i32.const 0
    i32.const 32
    i32.const 3688
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -53427,7 +53427,7 @@
    i32.const 0
    i32.const 32
    i32.const 3689
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -53441,7 +53441,7 @@
    i32.const 0
    i32.const 32
    i32.const 3690
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -53455,7 +53455,7 @@
    i32.const 0
    i32.const 32
    i32.const 3691
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -53469,7 +53469,7 @@
    i32.const 0
    i32.const 32
    i32.const 3692
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -53483,7 +53483,7 @@
    i32.const 0
    i32.const 32
    i32.const 3693
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -53497,7 +53497,7 @@
    i32.const 0
    i32.const 32
    i32.const 3694
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -53511,7 +53511,7 @@
    i32.const 0
    i32.const 32
    i32.const 3706
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -53525,7 +53525,7 @@
    i32.const 0
    i32.const 32
    i32.const 3707
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -53539,7 +53539,7 @@
    i32.const 0
    i32.const 32
    i32.const 3708
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -53553,7 +53553,7 @@
    i32.const 0
    i32.const 32
    i32.const 3709
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -53567,7 +53567,7 @@
    i32.const 0
    i32.const 32
    i32.const 3710
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -53581,7 +53581,7 @@
    i32.const 0
    i32.const 32
    i32.const 3711
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -53595,7 +53595,7 @@
    i32.const 0
    i32.const 32
    i32.const 3712
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -53609,7 +53609,7 @@
    i32.const 0
    i32.const 32
    i32.const 3713
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -53623,7 +53623,7 @@
    i32.const 0
    i32.const 32
    i32.const 3714
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -53637,7 +53637,7 @@
    i32.const 0
    i32.const 32
    i32.const 3715
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -53651,7 +53651,7 @@
    i32.const 0
    i32.const 32
    i32.const 3718
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -53665,7 +53665,7 @@
    i32.const 0
    i32.const 32
    i32.const 3719
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -53679,7 +53679,7 @@
    i32.const 0
    i32.const 32
    i32.const 3720
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -53693,7 +53693,7 @@
    i32.const 0
    i32.const 32
    i32.const 3721
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -53707,7 +53707,7 @@
    i32.const 0
    i32.const 32
    i32.const 3722
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -53721,7 +53721,7 @@
    i32.const 0
    i32.const 32
    i32.const 3731
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -53735,7 +53735,7 @@
    i32.const 0
    i32.const 32
    i32.const 3732
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -53749,7 +53749,7 @@
    i32.const 0
    i32.const 32
    i32.const 3733
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -53763,7 +53763,7 @@
    i32.const 0
    i32.const 32
    i32.const 3734
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -53777,7 +53777,7 @@
    i32.const 0
    i32.const 32
    i32.const 3735
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -53791,7 +53791,7 @@
    i32.const 0
    i32.const 32
    i32.const 3736
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -53805,7 +53805,7 @@
    i32.const 0
    i32.const 32
    i32.const 3737
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -53819,7 +53819,7 @@
    i32.const 0
    i32.const 32
    i32.const 3738
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -53833,7 +53833,7 @@
    i32.const 0
    i32.const 32
    i32.const 3739
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -53847,7 +53847,7 @@
    i32.const 0
    i32.const 32
    i32.const 3740
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -53861,7 +53861,7 @@
    i32.const 0
    i32.const 32
    i32.const 3743
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -53875,7 +53875,7 @@
    i32.const 0
    i32.const 32
    i32.const 3744
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -53889,7 +53889,7 @@
    i32.const 0
    i32.const 32
    i32.const 3745
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -53903,7 +53903,7 @@
    i32.const 0
    i32.const 32
    i32.const 3746
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -53917,7 +53917,7 @@
    i32.const 0
    i32.const 32
    i32.const 3747
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -53931,7 +53931,7 @@
    i32.const 0
    i32.const 32
    i32.const 3759
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -53945,7 +53945,7 @@
    i32.const 0
    i32.const 32
    i32.const 3760
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -53959,7 +53959,7 @@
    i32.const 0
    i32.const 32
    i32.const 3761
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -53973,7 +53973,7 @@
    i32.const 0
    i32.const 32
    i32.const 3762
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -53987,7 +53987,7 @@
    i32.const 0
    i32.const 32
    i32.const 3763
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -54001,7 +54001,7 @@
    i32.const 0
    i32.const 32
    i32.const 3764
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -54015,7 +54015,7 @@
    i32.const 0
    i32.const 32
    i32.const 3765
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -54029,7 +54029,7 @@
    i32.const 0
    i32.const 32
    i32.const 3766
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -54043,7 +54043,7 @@
    i32.const 0
    i32.const 32
    i32.const 3767
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -54057,7 +54057,7 @@
    i32.const 0
    i32.const 32
    i32.const 3768
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -54071,7 +54071,7 @@
    i32.const 0
    i32.const 32
    i32.const 3771
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -54085,7 +54085,7 @@
    i32.const 0
    i32.const 32
    i32.const 3772
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -54099,7 +54099,7 @@
    i32.const 0
    i32.const 32
    i32.const 3773
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -54113,7 +54113,7 @@
    i32.const 0
    i32.const 32
    i32.const 3774
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -54127,7 +54127,7 @@
    i32.const 0
    i32.const 32
    i32.const 3775
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -54141,7 +54141,7 @@
    i32.const 0
    i32.const 32
    i32.const 3776
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -54155,7 +54155,7 @@
    i32.const 0
    i32.const 32
    i32.const 3777
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -54169,7 +54169,7 @@
    i32.const 0
    i32.const 32
    i32.const 3778
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -54183,7 +54183,7 @@
    i32.const 0
    i32.const 32
    i32.const 3779
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -54197,7 +54197,7 @@
    i32.const 0
    i32.const 32
    i32.const 3780
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -54211,7 +54211,7 @@
    i32.const 0
    i32.const 32
    i32.const 3781
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -54225,7 +54225,7 @@
    i32.const 0
    i32.const 32
    i32.const 3782
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -54239,7 +54239,7 @@
    i32.const 0
    i32.const 32
    i32.const 3783
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -54253,7 +54253,7 @@
    i32.const 0
    i32.const 32
    i32.const 3784
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -54267,7 +54267,7 @@
    i32.const 0
    i32.const 32
    i32.const 3785
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -54281,7 +54281,7 @@
    i32.const 0
    i32.const 32
    i32.const 3794
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -54295,7 +54295,7 @@
    i32.const 0
    i32.const 32
    i32.const 3795
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -54309,7 +54309,7 @@
    i32.const 0
    i32.const 32
    i32.const 3796
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -54323,7 +54323,7 @@
    i32.const 0
    i32.const 32
    i32.const 3797
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -54337,7 +54337,7 @@
    i32.const 0
    i32.const 32
    i32.const 3798
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -54351,7 +54351,7 @@
    i32.const 0
    i32.const 32
    i32.const 3799
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -54365,7 +54365,7 @@
    i32.const 0
    i32.const 32
    i32.const 3800
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -54379,7 +54379,7 @@
    i32.const 0
    i32.const 32
    i32.const 3801
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -54393,7 +54393,7 @@
    i32.const 0
    i32.const 32
    i32.const 3802
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -54407,7 +54407,7 @@
    i32.const 0
    i32.const 32
    i32.const 3803
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -54421,7 +54421,7 @@
    i32.const 0
    i32.const 32
    i32.const 3806
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -54435,7 +54435,7 @@
    i32.const 0
    i32.const 32
    i32.const 3807
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -54449,7 +54449,7 @@
    i32.const 0
    i32.const 32
    i32.const 3808
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -54463,7 +54463,7 @@
    i32.const 0
    i32.const 32
    i32.const 3809
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -54477,7 +54477,7 @@
    i32.const 0
    i32.const 32
    i32.const 3810
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -54491,7 +54491,7 @@
    i32.const 0
    i32.const 32
    i32.const 3811
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -54505,7 +54505,7 @@
    i32.const 0
    i32.const 32
    i32.const 3812
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -54519,7 +54519,7 @@
    i32.const 0
    i32.const 32
    i32.const 3813
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -54533,7 +54533,7 @@
    i32.const 0
    i32.const 32
    i32.const 3814
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -54547,7 +54547,7 @@
    i32.const 0
    i32.const 32
    i32.const 3815
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -54561,7 +54561,7 @@
    i32.const 0
    i32.const 32
    i32.const 3816
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -54575,7 +54575,7 @@
    i32.const 0
    i32.const 32
    i32.const 3817
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -54589,7 +54589,7 @@
    i32.const 0
    i32.const 32
    i32.const 3818
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -54603,7 +54603,7 @@
    i32.const 0
    i32.const 32
    i32.const 3819
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -54617,7 +54617,7 @@
    i32.const 0
    i32.const 32
    i32.const 3820
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -54711,7 +54711,7 @@
    i32.const 0
    i32.const 32
    i32.const 3861
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -54725,7 +54725,7 @@
    i32.const 0
    i32.const 32
    i32.const 3862
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -54739,7 +54739,7 @@
    i32.const 0
    i32.const 32
    i32.const 3863
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -54753,7 +54753,7 @@
    i32.const 0
    i32.const 32
    i32.const 3864
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -54767,7 +54767,7 @@
    i32.const 0
    i32.const 32
    i32.const 3865
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -54781,7 +54781,7 @@
    i32.const 0
    i32.const 32
    i32.const 3866
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -54795,7 +54795,7 @@
    i32.const 0
    i32.const 32
    i32.const 3867
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -54809,7 +54809,7 @@
    i32.const 0
    i32.const 32
    i32.const 3868
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -54823,7 +54823,7 @@
    i32.const 0
    i32.const 32
    i32.const 3869
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -54837,7 +54837,7 @@
    i32.const 0
    i32.const 32
    i32.const 3870
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -54851,7 +54851,7 @@
    i32.const 0
    i32.const 32
    i32.const 3871
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -54865,7 +54865,7 @@
    i32.const 0
    i32.const 32
    i32.const 3872
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -54878,7 +54878,7 @@
    i32.const 0
    i32.const 32
    i32.const 3876
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -54891,7 +54891,7 @@
    i32.const 0
    i32.const 32
    i32.const 3877
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -54904,7 +54904,7 @@
    i32.const 0
    i32.const 32
    i32.const 3878
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -54917,7 +54917,7 @@
    i32.const 0
    i32.const 32
    i32.const 3879
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -54930,7 +54930,7 @@
    i32.const 0
    i32.const 32
    i32.const 3880
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -54943,7 +54943,7 @@
    i32.const 0
    i32.const 32
    i32.const 3881
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -54956,7 +54956,7 @@
    i32.const 0
    i32.const 32
    i32.const 3882
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -54969,7 +54969,7 @@
    i32.const 0
    i32.const 32
    i32.const 3883
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -54982,7 +54982,7 @@
    i32.const 0
    i32.const 32
    i32.const 3884
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -54995,7 +54995,7 @@
    i32.const 0
    i32.const 32
    i32.const 3885
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -55008,7 +55008,7 @@
    i32.const 0
    i32.const 32
    i32.const 3886
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -55021,7 +55021,7 @@
    i32.const 0
    i32.const 32
    i32.const 3887
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -55034,7 +55034,7 @@
    i32.const 0
    i32.const 32
    i32.const 3888
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -55047,7 +55047,7 @@
    i32.const 0
    i32.const 32
    i32.const 3889
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -55060,7 +55060,7 @@
    i32.const 0
    i32.const 32
    i32.const 3890
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -55073,7 +55073,7 @@
    i32.const 0
    i32.const 32
    i32.const 3891
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -55087,7 +55087,7 @@
    i32.const 0
    i32.const 32
    i32.const 3895
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -55101,7 +55101,7 @@
    i32.const 0
    i32.const 32
    i32.const 3896
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -55115,7 +55115,7 @@
    i32.const 0
    i32.const 32
    i32.const 3897
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -55129,7 +55129,7 @@
    i32.const 0
    i32.const 32
    i32.const 3898
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -55143,7 +55143,7 @@
    i32.const 0
    i32.const 32
    i32.const 3900
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -55157,7 +55157,7 @@
    i32.const 0
    i32.const 32
    i32.const 3901
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -55171,7 +55171,7 @@
    i32.const 0
    i32.const 32
    i32.const 3902
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -55185,7 +55185,7 @@
    i32.const 0
    i32.const 32
    i32.const 3903
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -55199,7 +55199,7 @@
    i32.const 0
    i32.const 32
    i32.const 3905
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -55213,7 +55213,7 @@
    i32.const 0
    i32.const 32
    i32.const 3906
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -55227,7 +55227,7 @@
    i32.const 0
    i32.const 32
    i32.const 3907
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -55241,7 +55241,7 @@
    i32.const 0
    i32.const 32
    i32.const 3908
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -55255,7 +55255,7 @@
    i32.const 0
    i32.const 32
    i32.const 3910
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -55269,7 +55269,7 @@
    i32.const 0
    i32.const 32
    i32.const 3911
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -55283,7 +55283,7 @@
    i32.const 0
    i32.const 32
    i32.const 3912
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -55297,7 +55297,7 @@
    i32.const 0
    i32.const 32
    i32.const 3913
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -55311,7 +55311,7 @@
    i32.const 0
    i32.const 32
    i32.const 3915
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -55325,7 +55325,7 @@
    i32.const 0
    i32.const 32
    i32.const 3916
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -55339,7 +55339,7 @@
    i32.const 0
    i32.const 32
    i32.const 3917
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -55353,7 +55353,7 @@
    i32.const 0
    i32.const 32
    i32.const 3918
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -55367,7 +55367,7 @@
    i32.const 0
    i32.const 32
    i32.const 3920
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -55381,7 +55381,7 @@
    i32.const 0
    i32.const 32
    i32.const 3921
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -55395,7 +55395,7 @@
    i32.const 0
    i32.const 32
    i32.const 3922
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -55409,7 +55409,7 @@
    i32.const 0
    i32.const 32
    i32.const 3923
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -55423,7 +55423,7 @@
    i32.const 0
    i32.const 32
    i32.const 3924
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -55437,7 +55437,7 @@
    i32.const 0
    i32.const 32
    i32.const 3925
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -55451,7 +55451,7 @@
    i32.const 0
    i32.const 32
    i32.const 3926
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -55469,7 +55469,7 @@
    i32.const 0
    i32.const 32
    i32.const 3928
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -55483,7 +55483,7 @@
    i32.const 0
    i32.const 32
    i32.const 3932
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -55497,7 +55497,7 @@
    i32.const 0
    i32.const 32
    i32.const 3933
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -55512,7 +55512,7 @@
    i32.const 0
    i32.const 32
    i32.const 3934
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -55527,7 +55527,7 @@
    i32.const 0
    i32.const 32
    i32.const 3935
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -55542,7 +55542,7 @@
    i32.const 0
    i32.const 32
    i32.const 3936
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -55556,7 +55556,7 @@
    i32.const 0
    i32.const 32
    i32.const 3937
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -55570,7 +55570,7 @@
    i32.const 0
    i32.const 32
    i32.const 3938
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -55584,7 +55584,7 @@
    i32.const 0
    i32.const 32
    i32.const 3939
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -55598,7 +55598,7 @@
    i32.const 0
    i32.const 32
    i32.const 3940
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -55612,7 +55612,7 @@
    i32.const 0
    i32.const 32
    i32.const 3941
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -55626,7 +55626,7 @@
    i32.const 0
    i32.const 32
    i32.const 3942
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -55640,7 +55640,7 @@
    i32.const 0
    i32.const 32
    i32.const 3943
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -55654,7 +55654,7 @@
    i32.const 0
    i32.const 32
    i32.const 3944
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -55668,7 +55668,7 @@
    i32.const 0
    i32.const 32
    i32.const 3945
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -55682,7 +55682,7 @@
    i32.const 0
    i32.const 32
    i32.const 3946
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -55696,7 +55696,7 @@
    i32.const 0
    i32.const 32
    i32.const 3947
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -55710,7 +55710,7 @@
    i32.const 0
    i32.const 32
    i32.const 3951
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -55724,7 +55724,7 @@
    i32.const 0
    i32.const 32
    i32.const 3952
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -55739,7 +55739,7 @@
    i32.const 0
    i32.const 32
    i32.const 3953
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -55754,7 +55754,7 @@
    i32.const 0
    i32.const 32
    i32.const 3954
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -55769,7 +55769,7 @@
    i32.const 0
    i32.const 32
    i32.const 3955
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -55783,7 +55783,7 @@
    i32.const 0
    i32.const 32
    i32.const 3956
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -55797,7 +55797,7 @@
    i32.const 0
    i32.const 32
    i32.const 3957
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -55811,7 +55811,7 @@
    i32.const 0
    i32.const 32
    i32.const 3958
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -55825,7 +55825,7 @@
    i32.const 0
    i32.const 32
    i32.const 3959
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -55839,7 +55839,7 @@
    i32.const 0
    i32.const 32
    i32.const 3960
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -55853,7 +55853,7 @@
    i32.const 0
    i32.const 32
    i32.const 3961
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -55867,7 +55867,7 @@
    i32.const 0
    i32.const 32
    i32.const 3962
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -55881,7 +55881,7 @@
    i32.const 0
    i32.const 32
    i32.const 3963
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -55895,7 +55895,7 @@
    i32.const 0
    i32.const 32
    i32.const 3964
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -55909,7 +55909,7 @@
    i32.const 0
    i32.const 32
    i32.const 3965
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -55923,7 +55923,7 @@
    i32.const 0
    i32.const 32
    i32.const 3966
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/std/mod.optimized.wat
+++ b/tests/compiler/std/mod.optimized.wat
@@ -491,7 +491,7 @@
    i32.const 0
    i32.const 1040
    i32.const 19
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -504,7 +504,7 @@
    i32.const 0
    i32.const 1040
    i32.const 20
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -517,7 +517,7 @@
    i32.const 0
    i32.const 1040
    i32.const 21
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -530,7 +530,7 @@
    i32.const 0
    i32.const 1040
    i32.const 22
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -543,7 +543,7 @@
    i32.const 0
    i32.const 1040
    i32.const 23
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -556,7 +556,7 @@
    i32.const 0
    i32.const 1040
    i32.const 24
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -569,7 +569,7 @@
    i32.const 0
    i32.const 1040
    i32.const 25
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -582,7 +582,7 @@
    i32.const 0
    i32.const 1040
    i32.const 26
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -595,7 +595,7 @@
    i32.const 0
    i32.const 1040
    i32.const 27
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -608,7 +608,7 @@
    i32.const 0
    i32.const 1040
    i32.const 28
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -621,7 +621,7 @@
    i32.const 0
    i32.const 1040
    i32.const 29
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -634,7 +634,7 @@
    i32.const 0
    i32.const 1040
    i32.const 30
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -647,7 +647,7 @@
    i32.const 0
    i32.const 1040
    i32.const 31
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -660,7 +660,7 @@
    i32.const 0
    i32.const 1040
    i32.const 32
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -673,7 +673,7 @@
    i32.const 0
    i32.const 1040
    i32.const 33
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -686,7 +686,7 @@
    i32.const 0
    i32.const 1040
    i32.const 34
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -699,7 +699,7 @@
    i32.const 0
    i32.const 1040
    i32.const 35
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -712,7 +712,7 @@
    i32.const 0
    i32.const 1040
    i32.const 36
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -725,7 +725,7 @@
    i32.const 0
    i32.const 1040
    i32.const 37
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -738,7 +738,7 @@
    i32.const 0
    i32.const 1040
    i32.const 38
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -751,7 +751,7 @@
    i32.const 0
    i32.const 1040
    i32.const 39
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -764,7 +764,7 @@
    i32.const 0
    i32.const 1040
    i32.const 40
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -777,7 +777,7 @@
    i32.const 0
    i32.const 1040
    i32.const 41
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -790,7 +790,7 @@
    i32.const 0
    i32.const 1040
    i32.const 42
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -803,7 +803,7 @@
    i32.const 0
    i32.const 1040
    i32.const 43
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -816,7 +816,7 @@
    i32.const 0
    i32.const 1040
    i32.const 44
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -829,7 +829,7 @@
    i32.const 0
    i32.const 1040
    i32.const 45
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -842,7 +842,7 @@
    i32.const 0
    i32.const 1040
    i32.const 46
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -855,7 +855,7 @@
    i32.const 0
    i32.const 1040
    i32.const 47
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -868,7 +868,7 @@
    i32.const 0
    i32.const 1040
    i32.const 50
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -881,7 +881,7 @@
    i32.const 0
    i32.const 1040
    i32.const 51
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -894,7 +894,7 @@
    i32.const 0
    i32.const 1040
    i32.const 52
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -907,7 +907,7 @@
    i32.const 0
    i32.const 1040
    i32.const 53
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -920,7 +920,7 @@
    i32.const 0
    i32.const 1040
    i32.const 54
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -933,7 +933,7 @@
    i32.const 0
    i32.const 1040
    i32.const 55
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -946,7 +946,7 @@
    i32.const 0
    i32.const 1040
    i32.const 56
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -959,7 +959,7 @@
    i32.const 0
    i32.const 1040
    i32.const 57
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -972,7 +972,7 @@
    i32.const 0
    i32.const 1040
    i32.const 58
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -985,7 +985,7 @@
    i32.const 0
    i32.const 1040
    i32.const 59
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -998,7 +998,7 @@
    i32.const 0
    i32.const 1040
    i32.const 60
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1011,7 +1011,7 @@
    i32.const 0
    i32.const 1040
    i32.const 61
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1024,7 +1024,7 @@
    i32.const 0
    i32.const 1040
    i32.const 62
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1037,7 +1037,7 @@
    i32.const 0
    i32.const 1040
    i32.const 63
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1050,7 +1050,7 @@
    i32.const 0
    i32.const 1040
    i32.const 64
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1063,7 +1063,7 @@
    i32.const 0
    i32.const 1040
    i32.const 65
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1076,7 +1076,7 @@
    i32.const 0
    i32.const 1040
    i32.const 66
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1089,7 +1089,7 @@
    i32.const 0
    i32.const 1040
    i32.const 67
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1102,7 +1102,7 @@
    i32.const 0
    i32.const 1040
    i32.const 68
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1115,7 +1115,7 @@
    i32.const 0
    i32.const 1040
    i32.const 69
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1128,7 +1128,7 @@
    i32.const 0
    i32.const 1040
    i32.const 70
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1141,7 +1141,7 @@
    i32.const 0
    i32.const 1040
    i32.const 71
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1154,7 +1154,7 @@
    i32.const 0
    i32.const 1040
    i32.const 72
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1167,7 +1167,7 @@
    i32.const 0
    i32.const 1040
    i32.const 73
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1180,7 +1180,7 @@
    i32.const 0
    i32.const 1040
    i32.const 74
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1193,7 +1193,7 @@
    i32.const 0
    i32.const 1040
    i32.const 75
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1206,7 +1206,7 @@
    i32.const 0
    i32.const 1040
    i32.const 76
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1219,7 +1219,7 @@
    i32.const 0
    i32.const 1040
    i32.const 77
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1232,7 +1232,7 @@
    i32.const 0
    i32.const 1040
    i32.const 78
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1245,7 +1245,7 @@
    i32.const 0
    i32.const 1040
    i32.const 79
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1258,7 +1258,7 @@
    i32.const 0
    i32.const 1040
    i32.const 80
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1271,7 +1271,7 @@
    i32.const 0
    i32.const 1040
    i32.const 81
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1284,7 +1284,7 @@
    i32.const 0
    i32.const 1040
    i32.const 82
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1297,7 +1297,7 @@
    i32.const 0
    i32.const 1040
    i32.const 83
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1310,7 +1310,7 @@
    i32.const 0
    i32.const 1040
    i32.const 84
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1323,7 +1323,7 @@
    i32.const 0
    i32.const 1040
    i32.const 85
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1336,7 +1336,7 @@
    i32.const 0
    i32.const 1040
    i32.const 86
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1349,7 +1349,7 @@
    i32.const 0
    i32.const 1040
    i32.const 87
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1362,7 +1362,7 @@
    i32.const 0
    i32.const 1040
    i32.const 88
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1375,7 +1375,7 @@
    i32.const 0
    i32.const 1040
    i32.const 89
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1388,7 +1388,7 @@
    i32.const 0
    i32.const 1040
    i32.const 90
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1401,7 +1401,7 @@
    i32.const 0
    i32.const 1040
    i32.const 91
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1414,7 +1414,7 @@
    i32.const 0
    i32.const 1040
    i32.const 92
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1427,7 +1427,7 @@
    i32.const 0
    i32.const 1040
    i32.const 93
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1440,7 +1440,7 @@
    i32.const 0
    i32.const 1040
    i32.const 94
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1453,7 +1453,7 @@
    i32.const 0
    i32.const 1040
    i32.const 103
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1466,7 +1466,7 @@
    i32.const 0
    i32.const 1040
    i32.const 104
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1479,7 +1479,7 @@
    i32.const 0
    i32.const 1040
    i32.const 105
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1492,7 +1492,7 @@
    i32.const 0
    i32.const 1040
    i32.const 106
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1505,7 +1505,7 @@
    i32.const 0
    i32.const 1040
    i32.const 107
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1518,7 +1518,7 @@
    i32.const 0
    i32.const 1040
    i32.const 108
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1531,7 +1531,7 @@
    i32.const 0
    i32.const 1040
    i32.const 109
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1544,7 +1544,7 @@
    i32.const 0
    i32.const 1040
    i32.const 110
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1557,7 +1557,7 @@
    i32.const 0
    i32.const 1040
    i32.const 111
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1570,7 +1570,7 @@
    i32.const 0
    i32.const 1040
    i32.const 112
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1583,7 +1583,7 @@
    i32.const 0
    i32.const 1040
    i32.const 113
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1596,7 +1596,7 @@
    i32.const 0
    i32.const 1040
    i32.const 114
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1609,7 +1609,7 @@
    i32.const 0
    i32.const 1040
    i32.const 115
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1622,7 +1622,7 @@
    i32.const 0
    i32.const 1040
    i32.const 116
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1635,7 +1635,7 @@
    i32.const 0
    i32.const 1040
    i32.const 117
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1648,7 +1648,7 @@
    i32.const 0
    i32.const 1040
    i32.const 118
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1661,7 +1661,7 @@
    i32.const 0
    i32.const 1040
    i32.const 119
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1674,7 +1674,7 @@
    i32.const 0
    i32.const 1040
    i32.const 120
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1687,7 +1687,7 @@
    i32.const 0
    i32.const 1040
    i32.const 121
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1700,7 +1700,7 @@
    i32.const 0
    i32.const 1040
    i32.const 122
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1713,7 +1713,7 @@
    i32.const 0
    i32.const 1040
    i32.const 125
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1726,7 +1726,7 @@
    i32.const 0
    i32.const 1040
    i32.const 126
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1739,7 +1739,7 @@
    i32.const 0
    i32.const 1040
    i32.const 127
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1752,7 +1752,7 @@
    i32.const 0
    i32.const 1040
    i32.const 128
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1765,7 +1765,7 @@
    i32.const 0
    i32.const 1040
    i32.const 129
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1778,7 +1778,7 @@
    i32.const 0
    i32.const 1040
    i32.const 130
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1791,7 +1791,7 @@
    i32.const 0
    i32.const 1040
    i32.const 131
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1804,7 +1804,7 @@
    i32.const 0
    i32.const 1040
    i32.const 132
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1817,7 +1817,7 @@
    i32.const 0
    i32.const 1040
    i32.const 133
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1830,7 +1830,7 @@
    i32.const 0
    i32.const 1040
    i32.const 134
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1843,7 +1843,7 @@
    i32.const 0
    i32.const 1040
    i32.const 135
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1856,7 +1856,7 @@
    i32.const 0
    i32.const 1040
    i32.const 136
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1869,7 +1869,7 @@
    i32.const 0
    i32.const 1040
    i32.const 137
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1882,7 +1882,7 @@
    i32.const 0
    i32.const 1040
    i32.const 138
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1895,7 +1895,7 @@
    i32.const 0
    i32.const 1040
    i32.const 139
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1908,7 +1908,7 @@
    i32.const 0
    i32.const 1040
    i32.const 140
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1921,7 +1921,7 @@
    i32.const 0
    i32.const 1040
    i32.const 141
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1934,7 +1934,7 @@
    i32.const 0
    i32.const 1040
    i32.const 142
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1947,7 +1947,7 @@
    i32.const 0
    i32.const 1040
    i32.const 143
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1960,7 +1960,7 @@
    i32.const 0
    i32.const 1040
    i32.const 144
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1973,7 +1973,7 @@
    i32.const 0
    i32.const 1040
    i32.const 145
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1986,7 +1986,7 @@
    i32.const 0
    i32.const 1040
    i32.const 146
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1999,7 +1999,7 @@
    i32.const 0
    i32.const 1040
    i32.const 147
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2012,7 +2012,7 @@
    i32.const 0
    i32.const 1040
    i32.const 148
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2025,7 +2025,7 @@
    i32.const 0
    i32.const 1040
    i32.const 149
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2038,7 +2038,7 @@
    i32.const 0
    i32.const 1040
    i32.const 150
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2051,7 +2051,7 @@
    i32.const 0
    i32.const 1040
    i32.const 151
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2064,7 +2064,7 @@
    i32.const 0
    i32.const 1040
    i32.const 152
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2077,7 +2077,7 @@
    i32.const 0
    i32.const 1040
    i32.const 153
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2090,7 +2090,7 @@
    i32.const 0
    i32.const 1040
    i32.const 154
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2103,7 +2103,7 @@
    i32.const 0
    i32.const 1040
    i32.const 155
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2116,7 +2116,7 @@
    i32.const 0
    i32.const 1040
    i32.const 156
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2129,7 +2129,7 @@
    i32.const 0
    i32.const 1040
    i32.const 157
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2142,7 +2142,7 @@
    i32.const 0
    i32.const 1040
    i32.const 158
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2155,7 +2155,7 @@
    i32.const 0
    i32.const 1040
    i32.const 159
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2168,7 +2168,7 @@
    i32.const 0
    i32.const 1040
    i32.const 160
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2181,7 +2181,7 @@
    i32.const 0
    i32.const 1040
    i32.const 161
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2194,7 +2194,7 @@
    i32.const 0
    i32.const 1040
    i32.const 162
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2207,7 +2207,7 @@
    i32.const 0
    i32.const 1040
    i32.const 163
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2220,7 +2220,7 @@
    i32.const 0
    i32.const 1040
    i32.const 164
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2233,7 +2233,7 @@
    i32.const 0
    i32.const 1040
    i32.const 165
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/std/mod.untouched.wat
+++ b/tests/compiler/std/mod.untouched.wat
@@ -613,7 +613,7 @@
    i32.const 0
    i32.const 32
    i32.const 19
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -626,7 +626,7 @@
    i32.const 0
    i32.const 32
    i32.const 20
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -639,7 +639,7 @@
    i32.const 0
    i32.const 32
    i32.const 21
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -652,7 +652,7 @@
    i32.const 0
    i32.const 32
    i32.const 22
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -665,7 +665,7 @@
    i32.const 0
    i32.const 32
    i32.const 23
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -678,7 +678,7 @@
    i32.const 0
    i32.const 32
    i32.const 24
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -691,7 +691,7 @@
    i32.const 0
    i32.const 32
    i32.const 25
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -704,7 +704,7 @@
    i32.const 0
    i32.const 32
    i32.const 26
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -717,7 +717,7 @@
    i32.const 0
    i32.const 32
    i32.const 27
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -730,7 +730,7 @@
    i32.const 0
    i32.const 32
    i32.const 28
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -743,7 +743,7 @@
    i32.const 0
    i32.const 32
    i32.const 29
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -756,7 +756,7 @@
    i32.const 0
    i32.const 32
    i32.const 30
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -769,7 +769,7 @@
    i32.const 0
    i32.const 32
    i32.const 31
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -782,7 +782,7 @@
    i32.const 0
    i32.const 32
    i32.const 32
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -795,7 +795,7 @@
    i32.const 0
    i32.const 32
    i32.const 33
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -808,7 +808,7 @@
    i32.const 0
    i32.const 32
    i32.const 34
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -821,7 +821,7 @@
    i32.const 0
    i32.const 32
    i32.const 35
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -834,7 +834,7 @@
    i32.const 0
    i32.const 32
    i32.const 36
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -847,7 +847,7 @@
    i32.const 0
    i32.const 32
    i32.const 37
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -860,7 +860,7 @@
    i32.const 0
    i32.const 32
    i32.const 38
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -873,7 +873,7 @@
    i32.const 0
    i32.const 32
    i32.const 39
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -886,7 +886,7 @@
    i32.const 0
    i32.const 32
    i32.const 40
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -899,7 +899,7 @@
    i32.const 0
    i32.const 32
    i32.const 41
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -912,7 +912,7 @@
    i32.const 0
    i32.const 32
    i32.const 42
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -925,7 +925,7 @@
    i32.const 0
    i32.const 32
    i32.const 43
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -938,7 +938,7 @@
    i32.const 0
    i32.const 32
    i32.const 44
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -951,7 +951,7 @@
    i32.const 0
    i32.const 32
    i32.const 45
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -964,7 +964,7 @@
    i32.const 0
    i32.const 32
    i32.const 46
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -977,7 +977,7 @@
    i32.const 0
    i32.const 32
    i32.const 47
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -990,7 +990,7 @@
    i32.const 0
    i32.const 32
    i32.const 50
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1003,7 +1003,7 @@
    i32.const 0
    i32.const 32
    i32.const 51
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1016,7 +1016,7 @@
    i32.const 0
    i32.const 32
    i32.const 52
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1029,7 +1029,7 @@
    i32.const 0
    i32.const 32
    i32.const 53
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1042,7 +1042,7 @@
    i32.const 0
    i32.const 32
    i32.const 54
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1055,7 +1055,7 @@
    i32.const 0
    i32.const 32
    i32.const 55
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1068,7 +1068,7 @@
    i32.const 0
    i32.const 32
    i32.const 56
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1081,7 +1081,7 @@
    i32.const 0
    i32.const 32
    i32.const 57
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1094,7 +1094,7 @@
    i32.const 0
    i32.const 32
    i32.const 58
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1107,7 +1107,7 @@
    i32.const 0
    i32.const 32
    i32.const 59
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1120,7 +1120,7 @@
    i32.const 0
    i32.const 32
    i32.const 60
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1133,7 +1133,7 @@
    i32.const 0
    i32.const 32
    i32.const 61
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1146,7 +1146,7 @@
    i32.const 0
    i32.const 32
    i32.const 62
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1159,7 +1159,7 @@
    i32.const 0
    i32.const 32
    i32.const 63
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1172,7 +1172,7 @@
    i32.const 0
    i32.const 32
    i32.const 64
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1185,7 +1185,7 @@
    i32.const 0
    i32.const 32
    i32.const 65
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1198,7 +1198,7 @@
    i32.const 0
    i32.const 32
    i32.const 66
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1211,7 +1211,7 @@
    i32.const 0
    i32.const 32
    i32.const 67
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1224,7 +1224,7 @@
    i32.const 0
    i32.const 32
    i32.const 68
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1237,7 +1237,7 @@
    i32.const 0
    i32.const 32
    i32.const 69
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1250,7 +1250,7 @@
    i32.const 0
    i32.const 32
    i32.const 70
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1263,7 +1263,7 @@
    i32.const 0
    i32.const 32
    i32.const 71
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1276,7 +1276,7 @@
    i32.const 0
    i32.const 32
    i32.const 72
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1289,7 +1289,7 @@
    i32.const 0
    i32.const 32
    i32.const 73
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1302,7 +1302,7 @@
    i32.const 0
    i32.const 32
    i32.const 74
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1315,7 +1315,7 @@
    i32.const 0
    i32.const 32
    i32.const 75
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1328,7 +1328,7 @@
    i32.const 0
    i32.const 32
    i32.const 76
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1341,7 +1341,7 @@
    i32.const 0
    i32.const 32
    i32.const 77
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1354,7 +1354,7 @@
    i32.const 0
    i32.const 32
    i32.const 78
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1367,7 +1367,7 @@
    i32.const 0
    i32.const 32
    i32.const 79
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1380,7 +1380,7 @@
    i32.const 0
    i32.const 32
    i32.const 80
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1393,7 +1393,7 @@
    i32.const 0
    i32.const 32
    i32.const 81
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1406,7 +1406,7 @@
    i32.const 0
    i32.const 32
    i32.const 82
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1419,7 +1419,7 @@
    i32.const 0
    i32.const 32
    i32.const 83
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1432,7 +1432,7 @@
    i32.const 0
    i32.const 32
    i32.const 84
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1445,7 +1445,7 @@
    i32.const 0
    i32.const 32
    i32.const 85
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1458,7 +1458,7 @@
    i32.const 0
    i32.const 32
    i32.const 86
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1471,7 +1471,7 @@
    i32.const 0
    i32.const 32
    i32.const 87
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1484,7 +1484,7 @@
    i32.const 0
    i32.const 32
    i32.const 88
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1497,7 +1497,7 @@
    i32.const 0
    i32.const 32
    i32.const 89
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1510,7 +1510,7 @@
    i32.const 0
    i32.const 32
    i32.const 90
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1523,7 +1523,7 @@
    i32.const 0
    i32.const 32
    i32.const 91
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1536,7 +1536,7 @@
    i32.const 0
    i32.const 32
    i32.const 92
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1549,7 +1549,7 @@
    i32.const 0
    i32.const 32
    i32.const 93
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1562,7 +1562,7 @@
    i32.const 0
    i32.const 32
    i32.const 94
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1575,7 +1575,7 @@
    i32.const 0
    i32.const 32
    i32.const 103
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1588,7 +1588,7 @@
    i32.const 0
    i32.const 32
    i32.const 104
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1601,7 +1601,7 @@
    i32.const 0
    i32.const 32
    i32.const 105
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1614,7 +1614,7 @@
    i32.const 0
    i32.const 32
    i32.const 106
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1627,7 +1627,7 @@
    i32.const 0
    i32.const 32
    i32.const 107
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1640,7 +1640,7 @@
    i32.const 0
    i32.const 32
    i32.const 108
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1653,7 +1653,7 @@
    i32.const 0
    i32.const 32
    i32.const 109
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1666,7 +1666,7 @@
    i32.const 0
    i32.const 32
    i32.const 110
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1679,7 +1679,7 @@
    i32.const 0
    i32.const 32
    i32.const 111
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1692,7 +1692,7 @@
    i32.const 0
    i32.const 32
    i32.const 112
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1705,7 +1705,7 @@
    i32.const 0
    i32.const 32
    i32.const 113
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1718,7 +1718,7 @@
    i32.const 0
    i32.const 32
    i32.const 114
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1731,7 +1731,7 @@
    i32.const 0
    i32.const 32
    i32.const 115
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1744,7 +1744,7 @@
    i32.const 0
    i32.const 32
    i32.const 116
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1757,7 +1757,7 @@
    i32.const 0
    i32.const 32
    i32.const 117
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1770,7 +1770,7 @@
    i32.const 0
    i32.const 32
    i32.const 118
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1783,7 +1783,7 @@
    i32.const 0
    i32.const 32
    i32.const 119
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1796,7 +1796,7 @@
    i32.const 0
    i32.const 32
    i32.const 120
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1809,7 +1809,7 @@
    i32.const 0
    i32.const 32
    i32.const 121
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1822,7 +1822,7 @@
    i32.const 0
    i32.const 32
    i32.const 122
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1835,7 +1835,7 @@
    i32.const 0
    i32.const 32
    i32.const 125
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1848,7 +1848,7 @@
    i32.const 0
    i32.const 32
    i32.const 126
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1861,7 +1861,7 @@
    i32.const 0
    i32.const 32
    i32.const 127
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1874,7 +1874,7 @@
    i32.const 0
    i32.const 32
    i32.const 128
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1887,7 +1887,7 @@
    i32.const 0
    i32.const 32
    i32.const 129
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1900,7 +1900,7 @@
    i32.const 0
    i32.const 32
    i32.const 130
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1913,7 +1913,7 @@
    i32.const 0
    i32.const 32
    i32.const 131
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1926,7 +1926,7 @@
    i32.const 0
    i32.const 32
    i32.const 132
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1939,7 +1939,7 @@
    i32.const 0
    i32.const 32
    i32.const 133
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1952,7 +1952,7 @@
    i32.const 0
    i32.const 32
    i32.const 134
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1965,7 +1965,7 @@
    i32.const 0
    i32.const 32
    i32.const 135
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1978,7 +1978,7 @@
    i32.const 0
    i32.const 32
    i32.const 136
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1991,7 +1991,7 @@
    i32.const 0
    i32.const 32
    i32.const 137
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2004,7 +2004,7 @@
    i32.const 0
    i32.const 32
    i32.const 138
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2017,7 +2017,7 @@
    i32.const 0
    i32.const 32
    i32.const 139
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2030,7 +2030,7 @@
    i32.const 0
    i32.const 32
    i32.const 140
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2043,7 +2043,7 @@
    i32.const 0
    i32.const 32
    i32.const 141
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2056,7 +2056,7 @@
    i32.const 0
    i32.const 32
    i32.const 142
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2069,7 +2069,7 @@
    i32.const 0
    i32.const 32
    i32.const 143
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2082,7 +2082,7 @@
    i32.const 0
    i32.const 32
    i32.const 144
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2095,7 +2095,7 @@
    i32.const 0
    i32.const 32
    i32.const 145
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2108,7 +2108,7 @@
    i32.const 0
    i32.const 32
    i32.const 146
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2121,7 +2121,7 @@
    i32.const 0
    i32.const 32
    i32.const 147
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2134,7 +2134,7 @@
    i32.const 0
    i32.const 32
    i32.const 148
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2147,7 +2147,7 @@
    i32.const 0
    i32.const 32
    i32.const 149
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2160,7 +2160,7 @@
    i32.const 0
    i32.const 32
    i32.const 150
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2173,7 +2173,7 @@
    i32.const 0
    i32.const 32
    i32.const 151
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2186,7 +2186,7 @@
    i32.const 0
    i32.const 32
    i32.const 152
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2199,7 +2199,7 @@
    i32.const 0
    i32.const 32
    i32.const 153
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2212,7 +2212,7 @@
    i32.const 0
    i32.const 32
    i32.const 154
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2225,7 +2225,7 @@
    i32.const 0
    i32.const 32
    i32.const 155
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2238,7 +2238,7 @@
    i32.const 0
    i32.const 32
    i32.const 156
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2251,7 +2251,7 @@
    i32.const 0
    i32.const 32
    i32.const 157
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2264,7 +2264,7 @@
    i32.const 0
    i32.const 32
    i32.const 158
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2277,7 +2277,7 @@
    i32.const 0
    i32.const 32
    i32.const 159
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2290,7 +2290,7 @@
    i32.const 0
    i32.const 32
    i32.const 160
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2303,7 +2303,7 @@
    i32.const 0
    i32.const 32
    i32.const 161
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2316,7 +2316,7 @@
    i32.const 0
    i32.const 32
    i32.const 162
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2329,7 +2329,7 @@
    i32.const 0
    i32.const 32
    i32.const 163
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2342,7 +2342,7 @@
    i32.const 0
    i32.const 32
    i32.const 164
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2355,7 +2355,7 @@
    i32.const 0
    i32.const 32
    i32.const 165
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/std/object-literal.optimized.wat
+++ b/tests/compiler/std/object-literal.optimized.wat
@@ -202,7 +202,7 @@
    i32.const 0
    i32.const 1088
    i32.const 7
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -241,7 +241,7 @@
    i32.const 0
    i32.const 1088
    i32.const 8
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -259,7 +259,7 @@
    i32.const 0
    i32.const 1088
    i32.const 24
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -277,7 +277,7 @@
    i32.const 0
    i32.const 1088
    i32.const 19
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/std/object-literal.untouched.wat
+++ b/tests/compiler/std/object-literal.untouched.wat
@@ -345,7 +345,7 @@
    i32.const 0
    i32.const 80
    i32.const 7
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -358,7 +358,7 @@
    i32.const 0
    i32.const 80
    i32.const 8
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -378,7 +378,7 @@
    i32.const 0
    i32.const 80
    i32.const 24
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -395,7 +395,7 @@
    i32.const 0
    i32.const 80
    i32.const 19
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/std/object.optimized.wat
+++ b/tests/compiler/std/object.optimized.wat
@@ -191,7 +191,7 @@
    i32.const 0
    i32.const 1040
    i32.const 4
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -202,7 +202,7 @@
    i32.const 0
    i32.const 1040
    i32.const 5
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -213,7 +213,7 @@
    i32.const 0
    i32.const 1040
    i32.const 6
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -224,7 +224,7 @@
    i32.const 0
    i32.const 1040
    i32.const 7
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -235,7 +235,7 @@
    i32.const 0
    i32.const 1040
    i32.const 8
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -248,7 +248,7 @@
    i32.const 0
    i32.const 1040
    i32.const 9
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -261,7 +261,7 @@
    i32.const 0
    i32.const 1040
    i32.const 11
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -274,7 +274,7 @@
    i32.const 0
    i32.const 1040
    i32.const 12
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -285,7 +285,7 @@
    i32.const 0
    i32.const 1040
    i32.const 13
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -296,7 +296,7 @@
    i32.const 0
    i32.const 1040
    i32.const 14
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -307,7 +307,7 @@
    i32.const 0
    i32.const 1040
    i32.const 15
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -318,7 +318,7 @@
    i32.const 0
    i32.const 1040
    i32.const 16
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -331,7 +331,7 @@
    i32.const 0
    i32.const 1040
    i32.const 17
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -344,7 +344,7 @@
    i32.const 0
    i32.const 1040
    i32.const 19
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -355,7 +355,7 @@
    i32.const 0
    i32.const 1040
    i32.const 20
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -366,7 +366,7 @@
    i32.const 0
    i32.const 1040
    i32.const 21
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -377,7 +377,7 @@
    i32.const 0
    i32.const 1040
    i32.const 22
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -388,7 +388,7 @@
    i32.const 0
    i32.const 1040
    i32.const 23
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -401,7 +401,7 @@
    i32.const 0
    i32.const 1040
    i32.const 24
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -414,7 +414,7 @@
    i32.const 0
    i32.const 1040
    i32.const 26
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -427,7 +427,7 @@
    i32.const 0
    i32.const 1040
    i32.const 27
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -438,7 +438,7 @@
    i32.const 0
    i32.const 1040
    i32.const 28
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -449,7 +449,7 @@
    i32.const 0
    i32.const 1040
    i32.const 29
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -460,7 +460,7 @@
    i32.const 0
    i32.const 1040
    i32.const 30
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -471,7 +471,7 @@
    i32.const 0
    i32.const 1040
    i32.const 31
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -484,7 +484,7 @@
    i32.const 0
    i32.const 1040
    i32.const 32
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -495,7 +495,7 @@
    i32.const 0
    i32.const 1040
    i32.const 34
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -506,7 +506,7 @@
    i32.const 0
    i32.const 1040
    i32.const 35
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -519,7 +519,7 @@
    i32.const 0
    i32.const 1040
    i32.const 36
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -532,7 +532,7 @@
    i32.const 0
    i32.const 1040
    i32.const 41
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -543,7 +543,7 @@
    i32.const 0
    i32.const 1040
    i32.const 42
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -556,7 +556,7 @@
    i32.const 0
    i32.const 1040
    i32.const 43
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -569,7 +569,7 @@
    i32.const 0
    i32.const 1040
    i32.const 45
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -580,7 +580,7 @@
    i32.const 0
    i32.const 1040
    i32.const 46
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -591,7 +591,7 @@
    i32.const 0
    i32.const 1040
    i32.const 47
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -604,7 +604,7 @@
    i32.const 0
    i32.const 1040
    i32.const 49
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -615,7 +615,7 @@
    i32.const 0
    i32.const 1040
    i32.const 50
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -626,7 +626,7 @@
    i32.const 0
    i32.const 1040
    i32.const 51
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/std/object.untouched.wat
+++ b/tests/compiler/std/object.untouched.wat
@@ -330,7 +330,7 @@
    i32.const 0
    i32.const 32
    i32.const 4
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -344,7 +344,7 @@
    i32.const 0
    i32.const 32
    i32.const 5
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -358,7 +358,7 @@
    i32.const 0
    i32.const 32
    i32.const 6
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -372,7 +372,7 @@
    i32.const 0
    i32.const 32
    i32.const 7
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -386,7 +386,7 @@
    i32.const 0
    i32.const 32
    i32.const 8
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -400,7 +400,7 @@
    i32.const 0
    i32.const 32
    i32.const 9
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -414,7 +414,7 @@
    i32.const 0
    i32.const 32
    i32.const 11
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -428,7 +428,7 @@
    i32.const 0
    i32.const 32
    i32.const 12
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -442,7 +442,7 @@
    i32.const 0
    i32.const 32
    i32.const 13
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -456,7 +456,7 @@
    i32.const 0
    i32.const 32
    i32.const 14
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -470,7 +470,7 @@
    i32.const 0
    i32.const 32
    i32.const 15
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -484,7 +484,7 @@
    i32.const 0
    i32.const 32
    i32.const 16
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -498,7 +498,7 @@
    i32.const 0
    i32.const 32
    i32.const 17
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -512,7 +512,7 @@
    i32.const 0
    i32.const 32
    i32.const 19
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -526,7 +526,7 @@
    i32.const 0
    i32.const 32
    i32.const 20
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -540,7 +540,7 @@
    i32.const 0
    i32.const 32
    i32.const 21
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -554,7 +554,7 @@
    i32.const 0
    i32.const 32
    i32.const 22
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -568,7 +568,7 @@
    i32.const 0
    i32.const 32
    i32.const 23
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -582,7 +582,7 @@
    i32.const 0
    i32.const 32
    i32.const 24
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -596,7 +596,7 @@
    i32.const 0
    i32.const 32
    i32.const 26
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -610,7 +610,7 @@
    i32.const 0
    i32.const 32
    i32.const 27
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -624,7 +624,7 @@
    i32.const 0
    i32.const 32
    i32.const 28
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -638,7 +638,7 @@
    i32.const 0
    i32.const 32
    i32.const 29
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -652,7 +652,7 @@
    i32.const 0
    i32.const 32
    i32.const 30
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -666,7 +666,7 @@
    i32.const 0
    i32.const 32
    i32.const 31
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -680,7 +680,7 @@
    i32.const 0
    i32.const 32
    i32.const 32
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -694,7 +694,7 @@
    i32.const 0
    i32.const 32
    i32.const 34
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -708,7 +708,7 @@
    i32.const 0
    i32.const 32
    i32.const 35
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -722,7 +722,7 @@
    i32.const 0
    i32.const 32
    i32.const 36
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -736,7 +736,7 @@
    i32.const 0
    i32.const 32
    i32.const 38
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -750,7 +750,7 @@
    i32.const 0
    i32.const 32
    i32.const 39
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -764,7 +764,7 @@
    i32.const 0
    i32.const 32
    i32.const 41
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -778,7 +778,7 @@
    i32.const 0
    i32.const 32
    i32.const 42
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -792,7 +792,7 @@
    i32.const 0
    i32.const 32
    i32.const 43
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -806,7 +806,7 @@
    i32.const 0
    i32.const 32
    i32.const 45
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -820,7 +820,7 @@
    i32.const 0
    i32.const 32
    i32.const 46
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -834,7 +834,7 @@
    i32.const 0
    i32.const 32
    i32.const 47
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -848,7 +848,7 @@
    i32.const 0
    i32.const 32
    i32.const 49
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -862,7 +862,7 @@
    i32.const 0
    i32.const 32
    i32.const 50
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -876,7 +876,7 @@
    i32.const 0
    i32.const 32
    i32.const 51
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/std/operator-overloading.optimized.wat
+++ b/tests/compiler/std/operator-overloading.optimized.wat
@@ -1280,7 +1280,7 @@
    i32.const 0
    i32.const 1040
    i32.const 145
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1321,7 +1321,7 @@
    i32.const 0
    i32.const 1040
    i32.const 151
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1364,7 +1364,7 @@
    i32.const 0
    i32.const 1040
    i32.const 157
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1407,7 +1407,7 @@
    i32.const 0
    i32.const 1040
    i32.const 163
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1449,7 +1449,7 @@
    i32.const 0
    i32.const 1040
    i32.const 169
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1498,7 +1498,7 @@
    i32.const 0
    i32.const 1040
    i32.const 175
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1541,7 +1541,7 @@
    i32.const 0
    i32.const 1040
    i32.const 181
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1584,7 +1584,7 @@
    i32.const 0
    i32.const 1040
    i32.const 187
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1627,7 +1627,7 @@
    i32.const 0
    i32.const 1040
    i32.const 193
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1650,7 +1650,7 @@
    i32.const 0
    i32.const 1040
    i32.const 199
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1671,7 +1671,7 @@
    i32.const 0
    i32.const 1040
    i32.const 205
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1684,7 +1684,7 @@
    i32.const 0
    i32.const 1040
    i32.const 209
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1699,7 +1699,7 @@
    i32.const 0
    i32.const 1040
    i32.const 213
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1735,7 +1735,7 @@
    i32.const 0
    i32.const 1040
    i32.const 219
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1771,7 +1771,7 @@
    i32.const 0
    i32.const 1040
    i32.const 225
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1807,7 +1807,7 @@
    i32.const 0
    i32.const 1040
    i32.const 231
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1843,7 +1843,7 @@
    i32.const 0
    i32.const 1040
    i32.const 237
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1879,7 +1879,7 @@
    i32.const 0
    i32.const 1040
    i32.const 242
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1915,7 +1915,7 @@
    i32.const 0
    i32.const 1040
    i32.const 247
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1951,7 +1951,7 @@
    i32.const 0
    i32.const 1040
    i32.const 252
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1985,7 +1985,7 @@
    i32.const 0
    i32.const 1040
    i32.const 257
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2027,7 +2027,7 @@
    i32.const 0
    i32.const 1040
    i32.const 262
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2069,7 +2069,7 @@
    i32.const 0
    i32.const 1040
    i32.const 267
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2103,7 +2103,7 @@
    i32.const 0
    i32.const 1040
    i32.const 272
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2114,7 +2114,7 @@
    i32.const 0
    i32.const 1040
    i32.const 273
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2154,7 +2154,7 @@
    i32.const 0
    i32.const 1040
    i32.const 279
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2188,7 +2188,7 @@
    i32.const 0
    i32.const 1040
    i32.const 282
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2224,7 +2224,7 @@
    i32.const 0
    i32.const 1040
    i32.const 287
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2245,7 +2245,7 @@
    i32.const 0
    i32.const 1040
    i32.const 288
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2279,7 +2279,7 @@
    i32.const 0
    i32.const 1040
    i32.const 291
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2298,7 +2298,7 @@
    i32.const 0
    i32.const 1040
    i32.const 292
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2352,7 +2352,7 @@
    i32.const 0
    i32.const 1040
    i32.const 312
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2406,7 +2406,7 @@
    i32.const 0
    i32.const 1040
    i32.const 332
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/std/operator-overloading.untouched.wat
+++ b/tests/compiler/std/operator-overloading.untouched.wat
@@ -1897,7 +1897,7 @@
    i32.const 0
    i32.const 32
    i32.const 145
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1934,7 +1934,7 @@
    i32.const 0
    i32.const 32
    i32.const 151
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1971,7 +1971,7 @@
    i32.const 0
    i32.const 32
    i32.const 157
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2008,7 +2008,7 @@
    i32.const 0
    i32.const 32
    i32.const 163
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2045,7 +2045,7 @@
    i32.const 0
    i32.const 32
    i32.const 169
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2082,7 +2082,7 @@
    i32.const 0
    i32.const 32
    i32.const 175
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2119,7 +2119,7 @@
    i32.const 0
    i32.const 32
    i32.const 181
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2156,7 +2156,7 @@
    i32.const 0
    i32.const 32
    i32.const 187
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2193,7 +2193,7 @@
    i32.const 0
    i32.const 32
    i32.const 193
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2219,7 +2219,7 @@
    i32.const 0
    i32.const 32
    i32.const 199
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2245,7 +2245,7 @@
    i32.const 0
    i32.const 32
    i32.const 205
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2261,7 +2261,7 @@
    i32.const 0
    i32.const 32
    i32.const 209
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2277,7 +2277,7 @@
    i32.const 0
    i32.const 32
    i32.const 213
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2303,7 +2303,7 @@
    i32.const 0
    i32.const 32
    i32.const 219
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2329,7 +2329,7 @@
    i32.const 0
    i32.const 32
    i32.const 225
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2355,7 +2355,7 @@
    i32.const 0
    i32.const 32
    i32.const 231
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2381,7 +2381,7 @@
    i32.const 0
    i32.const 32
    i32.const 237
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2413,7 +2413,7 @@
    i32.const 0
    i32.const 32
    i32.const 242
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2445,7 +2445,7 @@
    i32.const 0
    i32.const 32
    i32.const 247
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2488,7 +2488,7 @@
    i32.const 0
    i32.const 32
    i32.const 252
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2521,7 +2521,7 @@
    i32.const 0
    i32.const 32
    i32.const 257
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2558,7 +2558,7 @@
    i32.const 0
    i32.const 32
    i32.const 262
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2595,7 +2595,7 @@
    i32.const 0
    i32.const 32
    i32.const 267
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2624,7 +2624,7 @@
    i32.const 0
    i32.const 32
    i32.const 272
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2636,7 +2636,7 @@
    i32.const 0
    i32.const 32
    i32.const 273
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2678,7 +2678,7 @@
    i32.const 0
    i32.const 32
    i32.const 279
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2715,7 +2715,7 @@
    i32.const 0
    i32.const 32
    i32.const 282
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2765,7 +2765,7 @@
    i32.const 0
    i32.const 32
    i32.const 287
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2786,7 +2786,7 @@
    i32.const 0
    i32.const 32
    i32.const 288
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2838,7 +2838,7 @@
    i32.const 0
    i32.const 32
    i32.const 291
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2859,7 +2859,7 @@
    i32.const 0
    i32.const 32
    i32.const 292
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2948,7 +2948,7 @@
    i32.const 0
    i32.const 32
    i32.const 312
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3029,7 +3029,7 @@
    i32.const 0
    i32.const 32
    i32.const 332
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/std/pointer.optimized.wat
+++ b/tests/compiler/std/pointer.optimized.wat
@@ -208,7 +208,7 @@
    i32.const 0
    i32.const 1040
    i32.const 83
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -220,7 +220,7 @@
    i32.const 0
    i32.const 1040
    i32.const 84
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -235,7 +235,7 @@
    i32.const 0
    i32.const 1040
    i32.const 87
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -250,7 +250,7 @@
    i32.const 0
    i32.const 1040
    i32.const 90
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -261,7 +261,7 @@
    i32.const 0
    i32.const 1040
    i32.const 92
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -278,7 +278,7 @@
    i32.const 0
    i32.const 1040
    i32.const 94
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -289,7 +289,7 @@
    i32.const 0
    i32.const 1040
    i32.const 95
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -300,7 +300,7 @@
    i32.const 0
    i32.const 1040
    i32.const 97
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -319,7 +319,7 @@
    i32.const 0
    i32.const 1040
    i32.const 100
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -331,7 +331,7 @@
    i32.const 0
    i32.const 1040
    i32.const 101
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -343,7 +343,7 @@
    i32.const 0
    i32.const 1040
    i32.const 102
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -391,7 +391,7 @@
    i32.const 0
    i32.const 1040
    i32.const 105
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -403,7 +403,7 @@
    i32.const 0
    i32.const 1040
    i32.const 106
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -415,7 +415,7 @@
    i32.const 0
    i32.const 1040
    i32.const 107
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -435,7 +435,7 @@
    i32.const 0
    i32.const 1040
    i32.const 113
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -447,7 +447,7 @@
    i32.const 0
    i32.const 1040
    i32.const 114
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -459,7 +459,7 @@
    i32.const 0
    i32.const 1040
    i32.const 116
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -471,7 +471,7 @@
    i32.const 0
    i32.const 1040
    i32.const 117
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -483,7 +483,7 @@
    i32.const 0
    i32.const 1040
    i32.const 119
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -495,7 +495,7 @@
    i32.const 0
    i32.const 1040
    i32.const 120
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -510,7 +510,7 @@
    i32.const 0
    i32.const 1040
    i32.const 123
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -522,7 +522,7 @@
    i32.const 0
    i32.const 1040
    i32.const 124
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -534,7 +534,7 @@
    i32.const 0
    i32.const 1040
    i32.const 125
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -549,7 +549,7 @@
    i32.const 0
    i32.const 1040
    i32.const 128
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -561,7 +561,7 @@
    i32.const 0
    i32.const 1040
    i32.const 129
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/std/pointer.untouched.wat
+++ b/tests/compiler/std/pointer.untouched.wat
@@ -1510,7 +1510,7 @@
    i32.const 0
    i32.const 32
    i32.const 78
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1524,7 +1524,7 @@
    i32.const 0
    i32.const 32
    i32.const 79
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1558,7 +1558,7 @@
    i32.const 0
    i32.const 32
    i32.const 83
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1576,7 +1576,7 @@
    i32.const 0
    i32.const 32
    i32.const 84
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1606,7 +1606,7 @@
    i32.const 0
    i32.const 32
    i32.const 87
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1636,7 +1636,7 @@
    i32.const 0
    i32.const 32
    i32.const 90
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1650,7 +1650,7 @@
    i32.const 0
    i32.const 32
    i32.const 92
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1685,7 +1685,7 @@
    i32.const 0
    i32.const 32
    i32.const 94
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1699,7 +1699,7 @@
    i32.const 0
    i32.const 32
    i32.const 95
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1713,7 +1713,7 @@
    i32.const 0
    i32.const 32
    i32.const 97
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1767,7 +1767,7 @@
    i32.const 0
    i32.const 32
    i32.const 100
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1785,7 +1785,7 @@
    i32.const 0
    i32.const 32
    i32.const 101
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1803,7 +1803,7 @@
    i32.const 0
    i32.const 32
    i32.const 102
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1842,7 +1842,7 @@
    i32.const 0
    i32.const 32
    i32.const 105
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1860,7 +1860,7 @@
    i32.const 0
    i32.const 32
    i32.const 106
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1878,7 +1878,7 @@
    i32.const 0
    i32.const 32
    i32.const 107
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1932,7 +1932,7 @@
    i32.const 0
    i32.const 32
    i32.const 113
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1953,7 +1953,7 @@
    i32.const 0
    i32.const 32
    i32.const 114
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1974,7 +1974,7 @@
    i32.const 0
    i32.const 32
    i32.const 116
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1995,7 +1995,7 @@
    i32.const 0
    i32.const 32
    i32.const 117
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2008,7 +2008,7 @@
    i32.const 0
    i32.const 32
    i32.const 119
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2021,7 +2021,7 @@
    i32.const 0
    i32.const 32
    i32.const 120
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2055,7 +2055,7 @@
    i32.const 0
    i32.const 32
    i32.const 123
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2076,7 +2076,7 @@
    i32.const 0
    i32.const 32
    i32.const 124
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2089,7 +2089,7 @@
    i32.const 0
    i32.const 32
    i32.const 125
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2114,7 +2114,7 @@
    i32.const 0
    i32.const 32
    i32.const 128
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2127,7 +2127,7 @@
    i32.const 0
    i32.const 32
    i32.const 129
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/std/polyfills.untouched.wat
+++ b/tests/compiler/std/polyfills.untouched.wat
@@ -267,7 +267,7 @@
    i32.const 0
    i32.const 32
    i32.const 4
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -284,7 +284,7 @@
    i32.const 0
    i32.const 32
    i32.const 5
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -299,7 +299,7 @@
    i32.const 0
    i32.const 32
    i32.const 8
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -316,7 +316,7 @@
    i32.const 0
    i32.const 32
    i32.const 9
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -329,7 +329,7 @@
    i32.const 0
    i32.const 32
    i32.const 12
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -342,7 +342,7 @@
    i32.const 0
    i32.const 32
    i32.const 13
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -355,7 +355,7 @@
    i32.const 0
    i32.const 32
    i32.const 16
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -368,7 +368,7 @@
    i32.const 0
    i32.const 32
    i32.const 17
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -381,7 +381,7 @@
    i32.const 0
    i32.const 32
    i32.const 20
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -394,7 +394,7 @@
    i32.const 0
    i32.const 32
    i32.const 21
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -409,7 +409,7 @@
    i32.const 0
    i32.const 32
    i32.const 24
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -426,7 +426,7 @@
    i32.const 0
    i32.const 32
    i32.const 25
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -441,7 +441,7 @@
    i32.const 0
    i32.const 32
    i32.const 28
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -458,7 +458,7 @@
    i32.const 0
    i32.const 32
    i32.const 29
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -471,7 +471,7 @@
    i32.const 0
    i32.const 32
    i32.const 32
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -484,7 +484,7 @@
    i32.const 0
    i32.const 32
    i32.const 33
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/std/set.optimized.wat
+++ b/tests/compiler/std/set.optimized.wat
@@ -56,7 +56,7 @@
    i32.const 0
    i32.const 1040
    i32.const 277
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -78,7 +78,7 @@
    i32.const 0
    i32.const 1040
    i32.const 279
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -121,7 +121,7 @@
    i32.const 0
    i32.const 1040
    i32.const 292
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -217,7 +217,7 @@
    i32.const 0
    i32.const 1040
    i32.const 205
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -231,7 +231,7 @@
    i32.const 0
    i32.const 1040
    i32.const 207
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -304,7 +304,7 @@
     i32.const 0
     i32.const 1040
     i32.const 228
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -359,7 +359,7 @@
    i32.const 0
    i32.const 1040
    i32.const 243
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -374,7 +374,7 @@
    i32.const 0
    i32.const 1040
    i32.const 244
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -422,7 +422,7 @@
    i32.const 0
    i32.const 1040
    i32.const 260
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -505,7 +505,7 @@
    i32.const 0
    i32.const 1040
    i32.const 386
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -522,7 +522,7 @@
     i32.const 0
     i32.const 1040
     i32.const 396
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -550,7 +550,7 @@
     i32.const 0
     i32.const 1040
     i32.const 408
-    i32.const 4
+    i32.const 5
     call $~lib/builtins/abort
     unreachable
    end
@@ -691,7 +691,7 @@
    i32.const 1088
    i32.const 1040
    i32.const 461
-   i32.const 29
+   i32.const 30
    call $~lib/builtins/abort
    unreachable
   end
@@ -764,7 +764,7 @@
    i32.const 0
    i32.const 1040
    i32.const 338
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -816,7 +816,7 @@
      i32.const 0
      i32.const 1040
      i32.const 351
-     i32.const 17
+     i32.const 18
      call $~lib/builtins/abort
      unreachable
     end
@@ -849,7 +849,7 @@
    i32.const 0
    i32.const 1040
    i32.const 365
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -920,7 +920,7 @@
    i32.const 0
    i32.const 1040
    i32.const 501
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1011,7 +1011,7 @@
      i32.const 0
      i32.const 1040
      i32.const 513
-     i32.const 19
+     i32.const 20
      call $~lib/builtins/abort
      unreachable
     end
@@ -1027,7 +1027,7 @@
    i32.const 0
    i32.const 1040
    i32.const 521
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1084,7 +1084,7 @@
     i32.const 0
     i32.const 1152
     i32.const 109
-    i32.const 2
+    i32.const 3
     call $~lib/builtins/abort
     unreachable
    end
@@ -1103,7 +1103,7 @@
     i32.const 0
     i32.const 1152
     i32.const 112
-    i32.const 13
+    i32.const 14
     call $~lib/builtins/abort
     unreachable
    end
@@ -1277,7 +1277,7 @@
    i32.const 1200
    i32.const 1248
    i32.const 54
-   i32.const 42
+   i32.const 43
    call $~lib/builtins/abort
    unreachable
   end
@@ -1954,7 +1954,7 @@
     i32.const 1200
     i32.const 1360
     i32.const 14
-    i32.const 47
+    i32.const 48
     call $~lib/builtins/abort
     unreachable
    end
@@ -2001,7 +2001,7 @@
     i32.const 0
     i32.const 1040
     i32.const 581
-    i32.const 2
+    i32.const 3
     call $~lib/builtins/abort
     unreachable
    end
@@ -2047,7 +2047,7 @@
     i32.const 1408
     i32.const 1360
     i32.const 120
-    i32.const 21
+    i32.const 22
     call $~lib/builtins/abort
     unreachable
    end
@@ -2091,7 +2091,7 @@
    i32.const 1200
    i32.const 1360
    i32.const 57
-   i32.const 59
+   i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
@@ -2188,7 +2188,7 @@
    i32.const 1408
    i32.const 1360
    i32.const 104
-   i32.const 41
+   i32.const 42
    call $~lib/builtins/abort
    unreachable
   end
@@ -2284,7 +2284,7 @@
      i32.const 0
      i32.const 1312
      i32.const 6
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -2300,7 +2300,7 @@
      i32.const 0
      i32.const 1312
      i32.const 8
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -2319,7 +2319,7 @@
    i32.const 0
    i32.const 1312
    i32.const 10
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2342,7 +2342,7 @@
      i32.const 0
      i32.const 1312
      i32.const 14
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -2358,7 +2358,7 @@
      i32.const 0
      i32.const 1312
      i32.const 16
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -2377,7 +2377,7 @@
    i32.const 0
    i32.const 1312
    i32.const 18
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2402,7 +2402,7 @@
      i32.const 0
      i32.const 1312
      i32.const 24
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -2428,7 +2428,7 @@
    i32.const 0
    i32.const 1312
    i32.const 27
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2451,7 +2451,7 @@
      i32.const 0
      i32.const 1312
      i32.const 31
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -2465,7 +2465,7 @@
      i32.const 0
      i32.const 1312
      i32.const 33
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -2484,7 +2484,7 @@
    i32.const 0
    i32.const 1312
    i32.const 35
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2506,7 +2506,7 @@
      i32.const 0
      i32.const 1312
      i32.const 39
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -2522,7 +2522,7 @@
      i32.const 0
      i32.const 1312
      i32.const 41
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -2536,7 +2536,7 @@
      i32.const 0
      i32.const 1312
      i32.const 43
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -2555,7 +2555,7 @@
    i32.const 0
    i32.const 1312
    i32.const 45
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2567,7 +2567,7 @@
    i32.const 0
    i32.const 1312
    i32.const 49
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2855,7 +2855,7 @@
    i32.const 1200
    i32.const 1360
    i32.const 57
-   i32.const 59
+   i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
@@ -2952,7 +2952,7 @@
    i32.const 1408
    i32.const 1360
    i32.const 104
-   i32.const 41
+   i32.const 42
    call $~lib/builtins/abort
    unreachable
   end
@@ -3044,7 +3044,7 @@
      i32.const 0
      i32.const 1312
      i32.const 6
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -3060,7 +3060,7 @@
      i32.const 0
      i32.const 1312
      i32.const 8
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -3079,7 +3079,7 @@
    i32.const 0
    i32.const 1312
    i32.const 10
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3100,7 +3100,7 @@
      i32.const 0
      i32.const 1312
      i32.const 14
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -3116,7 +3116,7 @@
      i32.const 0
      i32.const 1312
      i32.const 16
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -3135,7 +3135,7 @@
    i32.const 0
    i32.const 1312
    i32.const 18
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3160,7 +3160,7 @@
      i32.const 0
      i32.const 1312
      i32.const 24
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -3186,7 +3186,7 @@
    i32.const 0
    i32.const 1312
    i32.const 27
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3207,7 +3207,7 @@
      i32.const 0
      i32.const 1312
      i32.const 31
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -3221,7 +3221,7 @@
      i32.const 0
      i32.const 1312
      i32.const 33
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -3240,7 +3240,7 @@
    i32.const 0
    i32.const 1312
    i32.const 35
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3260,7 +3260,7 @@
      i32.const 0
      i32.const 1312
      i32.const 39
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -3276,7 +3276,7 @@
      i32.const 0
      i32.const 1312
      i32.const 41
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -3290,7 +3290,7 @@
      i32.const 0
      i32.const 1312
      i32.const 43
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -3309,7 +3309,7 @@
    i32.const 0
    i32.const 1312
    i32.const 45
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3321,7 +3321,7 @@
    i32.const 0
    i32.const 1312
    i32.const 49
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3663,7 +3663,7 @@
     i32.const 1408
     i32.const 1360
     i32.const 120
-    i32.const 21
+    i32.const 22
     call $~lib/builtins/abort
     unreachable
    end
@@ -3711,7 +3711,7 @@
    i32.const 1200
    i32.const 1360
    i32.const 57
-   i32.const 59
+   i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
@@ -3811,7 +3811,7 @@
    i32.const 1408
    i32.const 1360
    i32.const 104
-   i32.const 41
+   i32.const 42
    call $~lib/builtins/abort
    unreachable
   end
@@ -3909,7 +3909,7 @@
      i32.const 0
      i32.const 1312
      i32.const 6
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -3925,7 +3925,7 @@
      i32.const 0
      i32.const 1312
      i32.const 8
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -3944,7 +3944,7 @@
    i32.const 0
    i32.const 1312
    i32.const 10
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3967,7 +3967,7 @@
      i32.const 0
      i32.const 1312
      i32.const 14
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -3983,7 +3983,7 @@
      i32.const 0
      i32.const 1312
      i32.const 16
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -4002,7 +4002,7 @@
    i32.const 0
    i32.const 1312
    i32.const 18
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4027,7 +4027,7 @@
      i32.const 0
      i32.const 1312
      i32.const 24
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -4053,7 +4053,7 @@
    i32.const 0
    i32.const 1312
    i32.const 27
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4076,7 +4076,7 @@
      i32.const 0
      i32.const 1312
      i32.const 31
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -4090,7 +4090,7 @@
      i32.const 0
      i32.const 1312
      i32.const 33
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -4109,7 +4109,7 @@
    i32.const 0
    i32.const 1312
    i32.const 35
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4131,7 +4131,7 @@
      i32.const 0
      i32.const 1312
      i32.const 39
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -4147,7 +4147,7 @@
      i32.const 0
      i32.const 1312
      i32.const 41
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -4161,7 +4161,7 @@
      i32.const 0
      i32.const 1312
      i32.const 43
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -4180,7 +4180,7 @@
    i32.const 0
    i32.const 1312
    i32.const 45
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4192,7 +4192,7 @@
    i32.const 0
    i32.const 1312
    i32.const 49
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4482,7 +4482,7 @@
    i32.const 1200
    i32.const 1360
    i32.const 57
-   i32.const 59
+   i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
@@ -4582,7 +4582,7 @@
    i32.const 1408
    i32.const 1360
    i32.const 104
-   i32.const 41
+   i32.const 42
    call $~lib/builtins/abort
    unreachable
   end
@@ -4676,7 +4676,7 @@
      i32.const 0
      i32.const 1312
      i32.const 6
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -4692,7 +4692,7 @@
      i32.const 0
      i32.const 1312
      i32.const 8
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -4711,7 +4711,7 @@
    i32.const 0
    i32.const 1312
    i32.const 10
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4732,7 +4732,7 @@
      i32.const 0
      i32.const 1312
      i32.const 14
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -4748,7 +4748,7 @@
      i32.const 0
      i32.const 1312
      i32.const 16
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -4767,7 +4767,7 @@
    i32.const 0
    i32.const 1312
    i32.const 18
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4792,7 +4792,7 @@
      i32.const 0
      i32.const 1312
      i32.const 24
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -4818,7 +4818,7 @@
    i32.const 0
    i32.const 1312
    i32.const 27
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4839,7 +4839,7 @@
      i32.const 0
      i32.const 1312
      i32.const 31
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -4853,7 +4853,7 @@
      i32.const 0
      i32.const 1312
      i32.const 33
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -4872,7 +4872,7 @@
    i32.const 0
    i32.const 1312
    i32.const 35
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4892,7 +4892,7 @@
      i32.const 0
      i32.const 1312
      i32.const 39
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -4908,7 +4908,7 @@
      i32.const 0
      i32.const 1312
      i32.const 41
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -4922,7 +4922,7 @@
      i32.const 0
      i32.const 1312
      i32.const 43
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -4941,7 +4941,7 @@
    i32.const 0
    i32.const 1312
    i32.const 45
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4953,7 +4953,7 @@
    i32.const 0
    i32.const 1312
    i32.const 49
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -5301,7 +5301,7 @@
     i32.const 1408
     i32.const 1360
     i32.const 120
-    i32.const 21
+    i32.const 22
     call $~lib/builtins/abort
     unreachable
    end
@@ -5349,7 +5349,7 @@
    i32.const 1200
    i32.const 1360
    i32.const 57
-   i32.const 59
+   i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
@@ -5449,7 +5449,7 @@
    i32.const 1408
    i32.const 1360
    i32.const 104
-   i32.const 41
+   i32.const 42
    call $~lib/builtins/abort
    unreachable
   end
@@ -5539,7 +5539,7 @@
      i32.const 0
      i32.const 1312
      i32.const 6
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -5555,7 +5555,7 @@
      i32.const 0
      i32.const 1312
      i32.const 8
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -5574,7 +5574,7 @@
    i32.const 0
    i32.const 1312
    i32.const 10
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -5593,7 +5593,7 @@
      i32.const 0
      i32.const 1312
      i32.const 14
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -5609,7 +5609,7 @@
      i32.const 0
      i32.const 1312
      i32.const 16
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -5628,7 +5628,7 @@
    i32.const 0
    i32.const 1312
    i32.const 18
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -5653,7 +5653,7 @@
      i32.const 0
      i32.const 1312
      i32.const 24
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -5679,7 +5679,7 @@
    i32.const 0
    i32.const 1312
    i32.const 27
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -5698,7 +5698,7 @@
      i32.const 0
      i32.const 1312
      i32.const 31
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -5712,7 +5712,7 @@
      i32.const 0
      i32.const 1312
      i32.const 33
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -5731,7 +5731,7 @@
    i32.const 0
    i32.const 1312
    i32.const 35
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -5749,7 +5749,7 @@
      i32.const 0
      i32.const 1312
      i32.const 39
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -5765,7 +5765,7 @@
      i32.const 0
      i32.const 1312
      i32.const 41
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -5779,7 +5779,7 @@
      i32.const 0
      i32.const 1312
      i32.const 43
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -5798,7 +5798,7 @@
    i32.const 0
    i32.const 1312
    i32.const 45
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -5810,7 +5810,7 @@
    i32.const 0
    i32.const 1312
    i32.const 49
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -5873,7 +5873,7 @@
    i32.const 1200
    i32.const 1360
    i32.const 57
-   i32.const 59
+   i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
@@ -5983,7 +5983,7 @@
      i32.const 0
      i32.const 1312
      i32.const 6
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -5999,7 +5999,7 @@
      i32.const 0
      i32.const 1312
      i32.const 8
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -6018,7 +6018,7 @@
    i32.const 0
    i32.const 1312
    i32.const 10
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -6037,7 +6037,7 @@
      i32.const 0
      i32.const 1312
      i32.const 14
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -6053,7 +6053,7 @@
      i32.const 0
      i32.const 1312
      i32.const 16
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -6072,7 +6072,7 @@
    i32.const 0
    i32.const 1312
    i32.const 18
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -6097,7 +6097,7 @@
      i32.const 0
      i32.const 1312
      i32.const 24
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -6123,7 +6123,7 @@
    i32.const 0
    i32.const 1312
    i32.const 27
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -6142,7 +6142,7 @@
      i32.const 0
      i32.const 1312
      i32.const 31
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -6156,7 +6156,7 @@
      i32.const 0
      i32.const 1312
      i32.const 33
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -6175,7 +6175,7 @@
    i32.const 0
    i32.const 1312
    i32.const 35
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -6193,7 +6193,7 @@
      i32.const 0
      i32.const 1312
      i32.const 39
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -6209,7 +6209,7 @@
      i32.const 0
      i32.const 1312
      i32.const 41
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -6223,7 +6223,7 @@
      i32.const 0
      i32.const 1312
      i32.const 43
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -6242,7 +6242,7 @@
    i32.const 0
    i32.const 1312
    i32.const 45
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -6254,7 +6254,7 @@
    i32.const 0
    i32.const 1312
    i32.const 49
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -6670,7 +6670,7 @@
     i32.const 1408
     i32.const 1360
     i32.const 120
-    i32.const 21
+    i32.const 22
     call $~lib/builtins/abort
     unreachable
    end
@@ -6718,7 +6718,7 @@
    i32.const 1200
    i32.const 1360
    i32.const 57
-   i32.const 59
+   i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
@@ -6818,7 +6818,7 @@
    i32.const 1408
    i32.const 1360
    i32.const 104
-   i32.const 41
+   i32.const 42
    call $~lib/builtins/abort
    unreachable
   end
@@ -6910,7 +6910,7 @@
      i32.const 0
      i32.const 1312
      i32.const 6
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -6926,7 +6926,7 @@
      i32.const 0
      i32.const 1312
      i32.const 8
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -6945,7 +6945,7 @@
    i32.const 0
    i32.const 1312
    i32.const 10
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -6964,7 +6964,7 @@
      i32.const 0
      i32.const 1312
      i32.const 14
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -6980,7 +6980,7 @@
      i32.const 0
      i32.const 1312
      i32.const 16
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -6999,7 +6999,7 @@
    i32.const 0
    i32.const 1312
    i32.const 18
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -7024,7 +7024,7 @@
      i32.const 0
      i32.const 1312
      i32.const 24
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -7050,7 +7050,7 @@
    i32.const 0
    i32.const 1312
    i32.const 27
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -7069,7 +7069,7 @@
      i32.const 0
      i32.const 1312
      i32.const 31
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -7083,7 +7083,7 @@
      i32.const 0
      i32.const 1312
      i32.const 33
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -7102,7 +7102,7 @@
    i32.const 0
    i32.const 1312
    i32.const 35
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -7120,7 +7120,7 @@
      i32.const 0
      i32.const 1312
      i32.const 39
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -7136,7 +7136,7 @@
      i32.const 0
      i32.const 1312
      i32.const 41
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -7150,7 +7150,7 @@
      i32.const 0
      i32.const 1312
      i32.const 43
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -7169,7 +7169,7 @@
    i32.const 0
    i32.const 1312
    i32.const 45
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -7181,7 +7181,7 @@
    i32.const 0
    i32.const 1312
    i32.const 49
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -7244,7 +7244,7 @@
    i32.const 1200
    i32.const 1360
    i32.const 57
-   i32.const 59
+   i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
@@ -7355,7 +7355,7 @@
      i32.const 0
      i32.const 1312
      i32.const 6
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -7371,7 +7371,7 @@
      i32.const 0
      i32.const 1312
      i32.const 8
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -7390,7 +7390,7 @@
    i32.const 0
    i32.const 1312
    i32.const 10
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -7409,7 +7409,7 @@
      i32.const 0
      i32.const 1312
      i32.const 14
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -7425,7 +7425,7 @@
      i32.const 0
      i32.const 1312
      i32.const 16
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -7444,7 +7444,7 @@
    i32.const 0
    i32.const 1312
    i32.const 18
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -7469,7 +7469,7 @@
      i32.const 0
      i32.const 1312
      i32.const 24
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -7495,7 +7495,7 @@
    i32.const 0
    i32.const 1312
    i32.const 27
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -7514,7 +7514,7 @@
      i32.const 0
      i32.const 1312
      i32.const 31
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -7528,7 +7528,7 @@
      i32.const 0
      i32.const 1312
      i32.const 33
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -7547,7 +7547,7 @@
    i32.const 0
    i32.const 1312
    i32.const 35
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -7565,7 +7565,7 @@
      i32.const 0
      i32.const 1312
      i32.const 39
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -7581,7 +7581,7 @@
      i32.const 0
      i32.const 1312
      i32.const 41
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -7595,7 +7595,7 @@
      i32.const 0
      i32.const 1312
      i32.const 43
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -7614,7 +7614,7 @@
    i32.const 0
    i32.const 1312
    i32.const 45
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -7626,7 +7626,7 @@
    i32.const 0
    i32.const 1312
    i32.const 49
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -7957,7 +7957,7 @@
    i32.const 1200
    i32.const 1360
    i32.const 57
-   i32.const 59
+   i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
@@ -8048,7 +8048,7 @@
        i32.const 1408
        i32.const 1360
        i32.const 120
-       i32.const 21
+       i32.const 22
        call $~lib/builtins/abort
        unreachable
       end
@@ -8090,7 +8090,7 @@
    i32.const 1408
    i32.const 1360
    i32.const 104
-   i32.const 41
+   i32.const 42
    call $~lib/builtins/abort
    unreachable
   end
@@ -8183,7 +8183,7 @@
      i32.const 0
      i32.const 1312
      i32.const 6
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -8199,7 +8199,7 @@
      i32.const 0
      i32.const 1312
      i32.const 8
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -8218,7 +8218,7 @@
    i32.const 0
    i32.const 1312
    i32.const 10
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -8237,7 +8237,7 @@
      i32.const 0
      i32.const 1312
      i32.const 14
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -8253,7 +8253,7 @@
      i32.const 0
      i32.const 1312
      i32.const 16
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -8272,7 +8272,7 @@
    i32.const 0
    i32.const 1312
    i32.const 18
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -8297,7 +8297,7 @@
      i32.const 0
      i32.const 1312
      i32.const 24
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -8323,7 +8323,7 @@
    i32.const 0
    i32.const 1312
    i32.const 27
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -8342,7 +8342,7 @@
      i32.const 0
      i32.const 1312
      i32.const 31
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -8356,7 +8356,7 @@
      i32.const 0
      i32.const 1312
      i32.const 33
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -8375,7 +8375,7 @@
    i32.const 0
    i32.const 1312
    i32.const 35
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -8393,7 +8393,7 @@
      i32.const 0
      i32.const 1312
      i32.const 39
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -8409,7 +8409,7 @@
      i32.const 0
      i32.const 1312
      i32.const 41
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -8423,7 +8423,7 @@
      i32.const 0
      i32.const 1312
      i32.const 43
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -8442,7 +8442,7 @@
    i32.const 0
    i32.const 1312
    i32.const 45
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -8454,7 +8454,7 @@
    i32.const 0
    i32.const 1312
    i32.const 49
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -8785,7 +8785,7 @@
    i32.const 1200
    i32.const 1360
    i32.const 57
-   i32.const 59
+   i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
@@ -8876,7 +8876,7 @@
        i32.const 1408
        i32.const 1360
        i32.const 120
-       i32.const 21
+       i32.const 22
        call $~lib/builtins/abort
        unreachable
       end
@@ -8918,7 +8918,7 @@
    i32.const 1408
    i32.const 1360
    i32.const 104
-   i32.const 41
+   i32.const 42
    call $~lib/builtins/abort
    unreachable
   end
@@ -9011,7 +9011,7 @@
      i32.const 0
      i32.const 1312
      i32.const 6
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -9027,7 +9027,7 @@
      i32.const 0
      i32.const 1312
      i32.const 8
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -9046,7 +9046,7 @@
    i32.const 0
    i32.const 1312
    i32.const 10
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -9065,7 +9065,7 @@
      i32.const 0
      i32.const 1312
      i32.const 14
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -9081,7 +9081,7 @@
      i32.const 0
      i32.const 1312
      i32.const 16
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -9100,7 +9100,7 @@
    i32.const 0
    i32.const 1312
    i32.const 18
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -9125,7 +9125,7 @@
      i32.const 0
      i32.const 1312
      i32.const 24
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -9151,7 +9151,7 @@
    i32.const 0
    i32.const 1312
    i32.const 27
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -9170,7 +9170,7 @@
      i32.const 0
      i32.const 1312
      i32.const 31
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -9184,7 +9184,7 @@
      i32.const 0
      i32.const 1312
      i32.const 33
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -9203,7 +9203,7 @@
    i32.const 0
    i32.const 1312
    i32.const 35
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -9221,7 +9221,7 @@
      i32.const 0
      i32.const 1312
      i32.const 39
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -9237,7 +9237,7 @@
      i32.const 0
      i32.const 1312
      i32.const 41
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -9251,7 +9251,7 @@
      i32.const 0
      i32.const 1312
      i32.const 43
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -9270,7 +9270,7 @@
    i32.const 0
    i32.const 1312
    i32.const 45
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -9282,7 +9282,7 @@
    i32.const 0
    i32.const 1312
    i32.const 49
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -9324,7 +9324,7 @@
    i32.const 0
    i32.const 1152
    i32.const 122
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -9376,7 +9376,7 @@
     i32.const 0
     i32.const 1152
     i32.const 126
-    i32.const 17
+    i32.const 18
     call $~lib/builtins/abort
     unreachable
    end
@@ -9391,7 +9391,7 @@
     i32.const 0
     i32.const 1152
     i32.const 136
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end

--- a/tests/compiler/std/set.untouched.wat
+++ b/tests/compiler/std/set.untouched.wat
@@ -67,7 +67,7 @@
    i32.const 0
    i32.const 32
    i32.const 277
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -92,7 +92,7 @@
    i32.const 0
    i32.const 32
    i32.const 279
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -144,7 +144,7 @@
    i32.const 0
    i32.const 32
    i32.const 292
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -274,7 +274,7 @@
    i32.const 0
    i32.const 32
    i32.const 205
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -289,7 +289,7 @@
    i32.const 0
    i32.const 32
    i32.const 207
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -382,7 +382,7 @@
     i32.const 0
     i32.const 32
     i32.const 228
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -445,7 +445,7 @@
    i32.const 0
    i32.const 32
    i32.const 243
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -461,7 +461,7 @@
    i32.const 0
    i32.const 32
    i32.const 244
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -518,7 +518,7 @@
    i32.const 0
    i32.const 32
    i32.const 260
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -637,7 +637,7 @@
    i32.const 0
    i32.const 32
    i32.const 386
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -660,7 +660,7 @@
     i32.const 0
     i32.const 32
     i32.const 396
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -691,7 +691,7 @@
     i32.const 0
     i32.const 32
     i32.const 408
-    i32.const 4
+    i32.const 5
     call $~lib/builtins/abort
     unreachable
    end
@@ -917,7 +917,7 @@
    i32.const 80
    i32.const 32
    i32.const 461
-   i32.const 29
+   i32.const 30
    call $~lib/builtins/abort
    unreachable
   end
@@ -1011,7 +1011,7 @@
    i32.const 0
    i32.const 32
    i32.const 338
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1074,7 +1074,7 @@
      i32.const 0
      i32.const 32
      i32.const 351
-     i32.const 17
+     i32.const 18
      call $~lib/builtins/abort
      unreachable
     end
@@ -1219,7 +1219,7 @@
    i32.const 0
    i32.const 32
    i32.const 365
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1308,7 +1308,7 @@
    i32.const 0
    i32.const 32
    i32.const 501
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1349,7 +1349,7 @@
       i32.const 0
       i32.const 32
       i32.const 513
-      i32.const 19
+      i32.const 20
       call $~lib/builtins/abort
       unreachable
      end
@@ -1368,7 +1368,7 @@
      i32.const 0
      i32.const 32
      i32.const 518
-     i32.const 17
+     i32.const 18
      call $~lib/builtins/abort
      unreachable
     end
@@ -1385,7 +1385,7 @@
    i32.const 0
    i32.const 32
    i32.const 521
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1436,7 +1436,7 @@
    i32.const 0
    i32.const 144
    i32.const 109
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1457,7 +1457,7 @@
    i32.const 0
    i32.const 144
    i32.const 112
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1692,7 +1692,7 @@
    i32.const 192
    i32.const 240
    i32.const 54
-   i32.const 42
+   i32.const 43
    call $~lib/builtins/abort
    unreachable
   end
@@ -2135,7 +2135,7 @@
    i32.const 192
    i32.const 352
    i32.const 57
-   i32.const 59
+   i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
@@ -2240,7 +2240,7 @@
    i32.const 0
    i32.const 32
    i32.const 581
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3657,7 +3657,7 @@
     i32.const 192
     i32.const 352
     i32.const 14
-    i32.const 47
+    i32.const 48
     call $~lib/builtins/abort
     unreachable
    end
@@ -3719,7 +3719,7 @@
     i32.const 400
     i32.const 352
     i32.const 120
-    i32.const 21
+    i32.const 22
     call $~lib/builtins/abort
     unreachable
    end
@@ -3825,7 +3825,7 @@
    i32.const 400
    i32.const 352
    i32.const 104
-   i32.const 41
+   i32.const 42
    call $~lib/builtins/abort
    unreachable
   end
@@ -3946,7 +3946,7 @@
      i32.const 0
      i32.const 304
      i32.const 6
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -3962,7 +3962,7 @@
      i32.const 0
      i32.const 304
      i32.const 8
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -3982,7 +3982,7 @@
    i32.const 0
    i32.const 304
    i32.const 10
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4007,7 +4007,7 @@
      i32.const 0
      i32.const 304
      i32.const 14
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -4023,7 +4023,7 @@
      i32.const 0
      i32.const 304
      i32.const 16
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -4043,7 +4043,7 @@
    i32.const 0
    i32.const 304
    i32.const 18
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4073,7 +4073,7 @@
      i32.const 0
      i32.const 304
      i32.const 24
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -4100,7 +4100,7 @@
    i32.const 0
    i32.const 304
    i32.const 27
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4125,7 +4125,7 @@
      i32.const 0
      i32.const 304
      i32.const 31
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -4142,7 +4142,7 @@
      i32.const 0
      i32.const 304
      i32.const 33
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -4162,7 +4162,7 @@
    i32.const 0
    i32.const 304
    i32.const 35
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4188,7 +4188,7 @@
      i32.const 0
      i32.const 304
      i32.const 39
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -4204,7 +4204,7 @@
      i32.const 0
      i32.const 304
      i32.const 41
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -4221,7 +4221,7 @@
      i32.const 0
      i32.const 304
      i32.const 43
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -4241,7 +4241,7 @@
    i32.const 0
    i32.const 304
    i32.const 45
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4256,7 +4256,7 @@
    i32.const 0
    i32.const 304
    i32.const 49
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4671,7 +4671,7 @@
    i32.const 192
    i32.const 352
    i32.const 57
-   i32.const 59
+   i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
@@ -4759,7 +4759,7 @@
     i32.const 400
     i32.const 352
     i32.const 120
-    i32.const 21
+    i32.const 22
     call $~lib/builtins/abort
     unreachable
    end
@@ -4865,7 +4865,7 @@
    i32.const 400
    i32.const 352
    i32.const 104
-   i32.const 41
+   i32.const 42
    call $~lib/builtins/abort
    unreachable
   end
@@ -4982,7 +4982,7 @@
      i32.const 0
      i32.const 304
      i32.const 6
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -4998,7 +4998,7 @@
      i32.const 0
      i32.const 304
      i32.const 8
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -5018,7 +5018,7 @@
    i32.const 0
    i32.const 304
    i32.const 10
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -5041,7 +5041,7 @@
      i32.const 0
      i32.const 304
      i32.const 14
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -5057,7 +5057,7 @@
      i32.const 0
      i32.const 304
      i32.const 16
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -5077,7 +5077,7 @@
    i32.const 0
    i32.const 304
    i32.const 18
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -5107,7 +5107,7 @@
      i32.const 0
      i32.const 304
      i32.const 24
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -5134,7 +5134,7 @@
    i32.const 0
    i32.const 304
    i32.const 27
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -5157,7 +5157,7 @@
      i32.const 0
      i32.const 304
      i32.const 31
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -5174,7 +5174,7 @@
      i32.const 0
      i32.const 304
      i32.const 33
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -5194,7 +5194,7 @@
    i32.const 0
    i32.const 304
    i32.const 35
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -5218,7 +5218,7 @@
      i32.const 0
      i32.const 304
      i32.const 39
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -5234,7 +5234,7 @@
      i32.const 0
      i32.const 304
      i32.const 41
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -5251,7 +5251,7 @@
      i32.const 0
      i32.const 304
      i32.const 43
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -5271,7 +5271,7 @@
    i32.const 0
    i32.const 304
    i32.const 45
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -5286,7 +5286,7 @@
    i32.const 0
    i32.const 304
    i32.const 49
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -5729,7 +5729,7 @@
    i32.const 192
    i32.const 352
    i32.const 57
-   i32.const 59
+   i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
@@ -5817,7 +5817,7 @@
     i32.const 400
     i32.const 352
     i32.const 120
-    i32.const 21
+    i32.const 22
     call $~lib/builtins/abort
     unreachable
    end
@@ -5923,7 +5923,7 @@
    i32.const 400
    i32.const 352
    i32.const 104
-   i32.const 41
+   i32.const 42
    call $~lib/builtins/abort
    unreachable
   end
@@ -6044,7 +6044,7 @@
      i32.const 0
      i32.const 304
      i32.const 6
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -6060,7 +6060,7 @@
      i32.const 0
      i32.const 304
      i32.const 8
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -6080,7 +6080,7 @@
    i32.const 0
    i32.const 304
    i32.const 10
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -6105,7 +6105,7 @@
      i32.const 0
      i32.const 304
      i32.const 14
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -6121,7 +6121,7 @@
      i32.const 0
      i32.const 304
      i32.const 16
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -6141,7 +6141,7 @@
    i32.const 0
    i32.const 304
    i32.const 18
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -6171,7 +6171,7 @@
      i32.const 0
      i32.const 304
      i32.const 24
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -6198,7 +6198,7 @@
    i32.const 0
    i32.const 304
    i32.const 27
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -6223,7 +6223,7 @@
      i32.const 0
      i32.const 304
      i32.const 31
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -6240,7 +6240,7 @@
      i32.const 0
      i32.const 304
      i32.const 33
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -6260,7 +6260,7 @@
    i32.const 0
    i32.const 304
    i32.const 35
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -6286,7 +6286,7 @@
      i32.const 0
      i32.const 304
      i32.const 39
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -6302,7 +6302,7 @@
      i32.const 0
      i32.const 304
      i32.const 41
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -6319,7 +6319,7 @@
      i32.const 0
      i32.const 304
      i32.const 43
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -6339,7 +6339,7 @@
    i32.const 0
    i32.const 304
    i32.const 45
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -6354,7 +6354,7 @@
    i32.const 0
    i32.const 304
    i32.const 49
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -6769,7 +6769,7 @@
    i32.const 192
    i32.const 352
    i32.const 57
-   i32.const 59
+   i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
@@ -6857,7 +6857,7 @@
     i32.const 400
     i32.const 352
     i32.const 120
-    i32.const 21
+    i32.const 22
     call $~lib/builtins/abort
     unreachable
    end
@@ -6963,7 +6963,7 @@
    i32.const 400
    i32.const 352
    i32.const 104
-   i32.const 41
+   i32.const 42
    call $~lib/builtins/abort
    unreachable
   end
@@ -7080,7 +7080,7 @@
      i32.const 0
      i32.const 304
      i32.const 6
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -7096,7 +7096,7 @@
      i32.const 0
      i32.const 304
      i32.const 8
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -7116,7 +7116,7 @@
    i32.const 0
    i32.const 304
    i32.const 10
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -7139,7 +7139,7 @@
      i32.const 0
      i32.const 304
      i32.const 14
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -7155,7 +7155,7 @@
      i32.const 0
      i32.const 304
      i32.const 16
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -7175,7 +7175,7 @@
    i32.const 0
    i32.const 304
    i32.const 18
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -7205,7 +7205,7 @@
      i32.const 0
      i32.const 304
      i32.const 24
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -7232,7 +7232,7 @@
    i32.const 0
    i32.const 304
    i32.const 27
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -7255,7 +7255,7 @@
      i32.const 0
      i32.const 304
      i32.const 31
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -7272,7 +7272,7 @@
      i32.const 0
      i32.const 304
      i32.const 33
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -7292,7 +7292,7 @@
    i32.const 0
    i32.const 304
    i32.const 35
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -7316,7 +7316,7 @@
      i32.const 0
      i32.const 304
      i32.const 39
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -7332,7 +7332,7 @@
      i32.const 0
      i32.const 304
      i32.const 41
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -7349,7 +7349,7 @@
      i32.const 0
      i32.const 304
      i32.const 43
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -7369,7 +7369,7 @@
    i32.const 0
    i32.const 304
    i32.const 45
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -7384,7 +7384,7 @@
    i32.const 0
    i32.const 304
    i32.const 49
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -7835,7 +7835,7 @@
    i32.const 192
    i32.const 352
    i32.const 57
-   i32.const 59
+   i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
@@ -7923,7 +7923,7 @@
     i32.const 400
     i32.const 352
     i32.const 120
-    i32.const 21
+    i32.const 22
     call $~lib/builtins/abort
     unreachable
    end
@@ -8029,7 +8029,7 @@
    i32.const 400
    i32.const 352
    i32.const 104
-   i32.const 41
+   i32.const 42
    call $~lib/builtins/abort
    unreachable
   end
@@ -8138,7 +8138,7 @@
      i32.const 0
      i32.const 304
      i32.const 6
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -8154,7 +8154,7 @@
      i32.const 0
      i32.const 304
      i32.const 8
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -8174,7 +8174,7 @@
    i32.const 0
    i32.const 304
    i32.const 10
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -8195,7 +8195,7 @@
      i32.const 0
      i32.const 304
      i32.const 14
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -8211,7 +8211,7 @@
      i32.const 0
      i32.const 304
      i32.const 16
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -8231,7 +8231,7 @@
    i32.const 0
    i32.const 304
    i32.const 18
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -8261,7 +8261,7 @@
      i32.const 0
      i32.const 304
      i32.const 24
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -8288,7 +8288,7 @@
    i32.const 0
    i32.const 304
    i32.const 27
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -8309,7 +8309,7 @@
      i32.const 0
      i32.const 304
      i32.const 31
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -8326,7 +8326,7 @@
      i32.const 0
      i32.const 304
      i32.const 33
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -8346,7 +8346,7 @@
    i32.const 0
    i32.const 304
    i32.const 35
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -8368,7 +8368,7 @@
      i32.const 0
      i32.const 304
      i32.const 39
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -8384,7 +8384,7 @@
      i32.const 0
      i32.const 304
      i32.const 41
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -8401,7 +8401,7 @@
      i32.const 0
      i32.const 304
      i32.const 43
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -8421,7 +8421,7 @@
    i32.const 0
    i32.const 304
    i32.const 45
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -8436,7 +8436,7 @@
    i32.const 0
    i32.const 304
    i32.const 49
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -8845,7 +8845,7 @@
    i32.const 192
    i32.const 352
    i32.const 57
-   i32.const 59
+   i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
@@ -8933,7 +8933,7 @@
     i32.const 400
     i32.const 352
     i32.const 120
-    i32.const 21
+    i32.const 22
     call $~lib/builtins/abort
     unreachable
    end
@@ -9039,7 +9039,7 @@
    i32.const 400
    i32.const 352
    i32.const 104
-   i32.const 41
+   i32.const 42
    call $~lib/builtins/abort
    unreachable
   end
@@ -9148,7 +9148,7 @@
      i32.const 0
      i32.const 304
      i32.const 6
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -9164,7 +9164,7 @@
      i32.const 0
      i32.const 304
      i32.const 8
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -9184,7 +9184,7 @@
    i32.const 0
    i32.const 304
    i32.const 10
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -9205,7 +9205,7 @@
      i32.const 0
      i32.const 304
      i32.const 14
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -9221,7 +9221,7 @@
      i32.const 0
      i32.const 304
      i32.const 16
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -9241,7 +9241,7 @@
    i32.const 0
    i32.const 304
    i32.const 18
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -9271,7 +9271,7 @@
      i32.const 0
      i32.const 304
      i32.const 24
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -9298,7 +9298,7 @@
    i32.const 0
    i32.const 304
    i32.const 27
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -9319,7 +9319,7 @@
      i32.const 0
      i32.const 304
      i32.const 31
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -9336,7 +9336,7 @@
      i32.const 0
      i32.const 304
      i32.const 33
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -9356,7 +9356,7 @@
    i32.const 0
    i32.const 304
    i32.const 35
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -9378,7 +9378,7 @@
      i32.const 0
      i32.const 304
      i32.const 39
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -9394,7 +9394,7 @@
      i32.const 0
      i32.const 304
      i32.const 41
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -9411,7 +9411,7 @@
      i32.const 0
      i32.const 304
      i32.const 43
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -9431,7 +9431,7 @@
    i32.const 0
    i32.const 304
    i32.const 45
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -9446,7 +9446,7 @@
    i32.const 0
    i32.const 304
    i32.const 49
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -9945,7 +9945,7 @@
    i32.const 192
    i32.const 352
    i32.const 57
-   i32.const 59
+   i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
@@ -10033,7 +10033,7 @@
     i32.const 400
     i32.const 352
     i32.const 120
-    i32.const 21
+    i32.const 22
     call $~lib/builtins/abort
     unreachable
    end
@@ -10139,7 +10139,7 @@
    i32.const 400
    i32.const 352
    i32.const 104
-   i32.const 41
+   i32.const 42
    call $~lib/builtins/abort
    unreachable
   end
@@ -10250,7 +10250,7 @@
      i32.const 0
      i32.const 304
      i32.const 6
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -10266,7 +10266,7 @@
      i32.const 0
      i32.const 304
      i32.const 8
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -10286,7 +10286,7 @@
    i32.const 0
    i32.const 304
    i32.const 10
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10307,7 +10307,7 @@
      i32.const 0
      i32.const 304
      i32.const 14
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -10323,7 +10323,7 @@
      i32.const 0
      i32.const 304
      i32.const 16
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -10343,7 +10343,7 @@
    i32.const 0
    i32.const 304
    i32.const 18
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10373,7 +10373,7 @@
      i32.const 0
      i32.const 304
      i32.const 24
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -10400,7 +10400,7 @@
    i32.const 0
    i32.const 304
    i32.const 27
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10421,7 +10421,7 @@
      i32.const 0
      i32.const 304
      i32.const 31
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -10438,7 +10438,7 @@
      i32.const 0
      i32.const 304
      i32.const 33
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -10458,7 +10458,7 @@
    i32.const 0
    i32.const 304
    i32.const 35
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10480,7 +10480,7 @@
      i32.const 0
      i32.const 304
      i32.const 39
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -10496,7 +10496,7 @@
      i32.const 0
      i32.const 304
      i32.const 41
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -10513,7 +10513,7 @@
      i32.const 0
      i32.const 304
      i32.const 43
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -10533,7 +10533,7 @@
    i32.const 0
    i32.const 304
    i32.const 45
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10548,7 +10548,7 @@
    i32.const 0
    i32.const 304
    i32.const 49
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10959,7 +10959,7 @@
    i32.const 192
    i32.const 352
    i32.const 57
-   i32.const 59
+   i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
@@ -11047,7 +11047,7 @@
     i32.const 400
     i32.const 352
     i32.const 120
-    i32.const 21
+    i32.const 22
     call $~lib/builtins/abort
     unreachable
    end
@@ -11153,7 +11153,7 @@
    i32.const 400
    i32.const 352
    i32.const 104
-   i32.const 41
+   i32.const 42
    call $~lib/builtins/abort
    unreachable
   end
@@ -11264,7 +11264,7 @@
      i32.const 0
      i32.const 304
      i32.const 6
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -11280,7 +11280,7 @@
      i32.const 0
      i32.const 304
      i32.const 8
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -11300,7 +11300,7 @@
    i32.const 0
    i32.const 304
    i32.const 10
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11321,7 +11321,7 @@
      i32.const 0
      i32.const 304
      i32.const 14
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -11337,7 +11337,7 @@
      i32.const 0
      i32.const 304
      i32.const 16
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -11357,7 +11357,7 @@
    i32.const 0
    i32.const 304
    i32.const 18
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11387,7 +11387,7 @@
      i32.const 0
      i32.const 304
      i32.const 24
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -11414,7 +11414,7 @@
    i32.const 0
    i32.const 304
    i32.const 27
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11435,7 +11435,7 @@
      i32.const 0
      i32.const 304
      i32.const 31
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -11452,7 +11452,7 @@
      i32.const 0
      i32.const 304
      i32.const 33
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -11472,7 +11472,7 @@
    i32.const 0
    i32.const 304
    i32.const 35
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11494,7 +11494,7 @@
      i32.const 0
      i32.const 304
      i32.const 39
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -11510,7 +11510,7 @@
      i32.const 0
      i32.const 304
      i32.const 41
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -11527,7 +11527,7 @@
      i32.const 0
      i32.const 304
      i32.const 43
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -11547,7 +11547,7 @@
    i32.const 0
    i32.const 304
    i32.const 45
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11562,7 +11562,7 @@
    i32.const 0
    i32.const 304
    i32.const 49
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11976,7 +11976,7 @@
    i32.const 192
    i32.const 352
    i32.const 57
-   i32.const 59
+   i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
@@ -12064,7 +12064,7 @@
     i32.const 400
     i32.const 352
     i32.const 120
-    i32.const 21
+    i32.const 22
     call $~lib/builtins/abort
     unreachable
    end
@@ -12170,7 +12170,7 @@
    i32.const 400
    i32.const 352
    i32.const 104
-   i32.const 41
+   i32.const 42
    call $~lib/builtins/abort
    unreachable
   end
@@ -12282,7 +12282,7 @@
      i32.const 0
      i32.const 304
      i32.const 6
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -12298,7 +12298,7 @@
      i32.const 0
      i32.const 304
      i32.const 8
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -12318,7 +12318,7 @@
    i32.const 0
    i32.const 304
    i32.const 10
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12339,7 +12339,7 @@
      i32.const 0
      i32.const 304
      i32.const 14
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -12355,7 +12355,7 @@
      i32.const 0
      i32.const 304
      i32.const 16
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -12375,7 +12375,7 @@
    i32.const 0
    i32.const 304
    i32.const 18
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12405,7 +12405,7 @@
      i32.const 0
      i32.const 304
      i32.const 24
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -12432,7 +12432,7 @@
    i32.const 0
    i32.const 304
    i32.const 27
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12453,7 +12453,7 @@
      i32.const 0
      i32.const 304
      i32.const 31
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -12470,7 +12470,7 @@
      i32.const 0
      i32.const 304
      i32.const 33
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -12490,7 +12490,7 @@
    i32.const 0
    i32.const 304
    i32.const 35
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12512,7 +12512,7 @@
      i32.const 0
      i32.const 304
      i32.const 39
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -12528,7 +12528,7 @@
      i32.const 0
      i32.const 304
      i32.const 41
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -12545,7 +12545,7 @@
      i32.const 0
      i32.const 304
      i32.const 43
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -12565,7 +12565,7 @@
    i32.const 0
    i32.const 304
    i32.const 45
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12580,7 +12580,7 @@
    i32.const 0
    i32.const 304
    i32.const 49
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12994,7 +12994,7 @@
    i32.const 192
    i32.const 352
    i32.const 57
-   i32.const 59
+   i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
@@ -13082,7 +13082,7 @@
     i32.const 400
     i32.const 352
     i32.const 120
-    i32.const 21
+    i32.const 22
     call $~lib/builtins/abort
     unreachable
    end
@@ -13188,7 +13188,7 @@
    i32.const 400
    i32.const 352
    i32.const 104
-   i32.const 41
+   i32.const 42
    call $~lib/builtins/abort
    unreachable
   end
@@ -13300,7 +13300,7 @@
      i32.const 0
      i32.const 304
      i32.const 6
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -13316,7 +13316,7 @@
      i32.const 0
      i32.const 304
      i32.const 8
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -13336,7 +13336,7 @@
    i32.const 0
    i32.const 304
    i32.const 10
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13357,7 +13357,7 @@
      i32.const 0
      i32.const 304
      i32.const 14
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -13373,7 +13373,7 @@
      i32.const 0
      i32.const 304
      i32.const 16
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -13393,7 +13393,7 @@
    i32.const 0
    i32.const 304
    i32.const 18
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13423,7 +13423,7 @@
      i32.const 0
      i32.const 304
      i32.const 24
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -13450,7 +13450,7 @@
    i32.const 0
    i32.const 304
    i32.const 27
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13471,7 +13471,7 @@
      i32.const 0
      i32.const 304
      i32.const 31
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -13488,7 +13488,7 @@
      i32.const 0
      i32.const 304
      i32.const 33
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -13508,7 +13508,7 @@
    i32.const 0
    i32.const 304
    i32.const 35
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13530,7 +13530,7 @@
      i32.const 0
      i32.const 304
      i32.const 39
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -13546,7 +13546,7 @@
      i32.const 0
      i32.const 304
      i32.const 41
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -13563,7 +13563,7 @@
      i32.const 0
      i32.const 304
      i32.const 43
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -13583,7 +13583,7 @@
    i32.const 0
    i32.const 304
    i32.const 45
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13598,7 +13598,7 @@
    i32.const 0
    i32.const 304
    i32.const 49
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13649,7 +13649,7 @@
    i32.const 0
    i32.const 144
    i32.const 122
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -13671,7 +13671,7 @@
     i32.const 0
     i32.const 144
     i32.const 126
-    i32.const 17
+    i32.const 18
     call $~lib/builtins/abort
     unreachable
    end
@@ -13687,7 +13687,7 @@
     i32.const 0
     i32.const 144
     i32.const 136
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -13719,7 +13719,7 @@
    i32.const 0
    i32.const 144
    i32.const 69
-   i32.const 15
+   i32.const 16
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/std/static-array.optimized.wat
+++ b/tests/compiler/std/static-array.optimized.wat
@@ -38,7 +38,7 @@
    i32.const 1360
    i32.const 1424
    i32.const 104
-   i32.const 41
+   i32.const 42
    call $~lib/builtins/abort
    unreachable
   end
@@ -284,7 +284,7 @@
    i32.const 0
    i32.const 1520
    i32.const 43
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -302,7 +302,7 @@
    i32.const 0
    i32.const 1520
    i32.const 46
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -596,7 +596,7 @@
     i32.const 1472
     i32.const 1424
     i32.const 14
-    i32.const 47
+    i32.const 48
     call $~lib/builtins/abort
     unreachable
    end
@@ -640,7 +640,7 @@
    i32.const 1360
    i32.const 1424
    i32.const 104
-   i32.const 41
+   i32.const 42
    call $~lib/builtins/abort
    unreachable
   end
@@ -661,7 +661,7 @@
    i32.const 1360
    i32.const 1424
    i32.const 104
-   i32.const 41
+   i32.const 42
    call $~lib/builtins/abort
    unreachable
   end
@@ -682,7 +682,7 @@
    i32.const 1360
    i32.const 1424
    i32.const 104
-   i32.const 41
+   i32.const 42
    call $~lib/builtins/abort
    unreachable
   end
@@ -703,7 +703,7 @@
    i32.const 0
    i32.const 1296
    i32.const 6
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -715,7 +715,7 @@
    i32.const 0
    i32.const 1296
    i32.const 7
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -727,7 +727,7 @@
    i32.const 0
    i32.const 1296
    i32.const 8
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -759,7 +759,7 @@
    i32.const 0
    i32.const 1296
    i32.const 10
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -771,7 +771,7 @@
    i32.const 0
    i32.const 1296
    i32.const 12
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -783,7 +783,7 @@
    i32.const 0
    i32.const 1296
    i32.const 13
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -795,7 +795,7 @@
    i32.const 0
    i32.const 1296
    i32.const 14
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -823,7 +823,7 @@
    i32.const 0
    i32.const 1296
    i32.const 16
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -835,7 +835,7 @@
    i32.const 0
    i32.const 1296
    i32.const 18
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -847,7 +847,7 @@
    i32.const 0
    i32.const 1296
    i32.const 19
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -859,7 +859,7 @@
    i32.const 0
    i32.const 1296
    i32.const 20
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -887,7 +887,7 @@
    i32.const 0
    i32.const 1296
    i32.const 22
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -899,7 +899,7 @@
    i32.const 0
    i32.const 1296
    i32.const 24
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -911,7 +911,7 @@
    i32.const 0
    i32.const 1296
    i32.const 25
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -923,7 +923,7 @@
    i32.const 0
    i32.const 1296
    i32.const 26
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -951,7 +951,7 @@
    i32.const 0
    i32.const 1296
    i32.const 28
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/std/static-array.untouched.wat
+++ b/tests/compiler/std/static-array.untouched.wat
@@ -60,7 +60,7 @@
    i32.const 352
    i32.const 416
    i32.const 104
-   i32.const 41
+   i32.const 42
    call $~lib/builtins/abort
    unreachable
   end
@@ -1444,7 +1444,7 @@
    i32.const 0
    i32.const 512
    i32.const 43
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1464,7 +1464,7 @@
    i32.const 0
    i32.const 512
    i32.const 46
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1776,7 +1776,7 @@
     i32.const 464
     i32.const 416
     i32.const 14
-    i32.const 47
+    i32.const 48
     call $~lib/builtins/abort
     unreachable
    end
@@ -1838,7 +1838,7 @@
     i32.const 352
     i32.const 416
     i32.const 120
-    i32.const 21
+    i32.const 22
     call $~lib/builtins/abort
     unreachable
    end
@@ -1882,7 +1882,7 @@
    i32.const 352
    i32.const 416
    i32.const 104
-   i32.const 41
+   i32.const 42
    call $~lib/builtins/abort
    unreachable
   end
@@ -1915,7 +1915,7 @@
     i32.const 352
     i32.const 416
     i32.const 120
-    i32.const 21
+    i32.const 22
     call $~lib/builtins/abort
     unreachable
    end
@@ -1959,7 +1959,7 @@
    i32.const 352
    i32.const 416
    i32.const 104
-   i32.const 41
+   i32.const 42
    call $~lib/builtins/abort
    unreachable
   end
@@ -1992,7 +1992,7 @@
     i32.const 352
     i32.const 416
     i32.const 120
-    i32.const 21
+    i32.const 22
     call $~lib/builtins/abort
     unreachable
    end
@@ -2036,7 +2036,7 @@
    i32.const 352
    i32.const 416
    i32.const 104
-   i32.const 41
+   i32.const 42
    call $~lib/builtins/abort
    unreachable
   end
@@ -2069,7 +2069,7 @@
     i32.const 352
     i32.const 416
     i32.const 120
-    i32.const 21
+    i32.const 22
     call $~lib/builtins/abort
     unreachable
    end
@@ -2102,7 +2102,7 @@
    i32.const 0
    i32.const 288
    i32.const 6
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2116,7 +2116,7 @@
    i32.const 0
    i32.const 288
    i32.const 7
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2130,7 +2130,7 @@
    i32.const 0
    i32.const 288
    i32.const 8
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2158,7 +2158,7 @@
    i32.const 0
    i32.const 288
    i32.const 10
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2171,7 +2171,7 @@
    i32.const 0
    i32.const 288
    i32.const 12
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2185,7 +2185,7 @@
    i32.const 0
    i32.const 288
    i32.const 13
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2199,7 +2199,7 @@
    i32.const 0
    i32.const 288
    i32.const 14
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2217,7 +2217,7 @@
    i32.const 0
    i32.const 288
    i32.const 16
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2230,7 +2230,7 @@
    i32.const 0
    i32.const 288
    i32.const 18
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2244,7 +2244,7 @@
    i32.const 0
    i32.const 288
    i32.const 19
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2258,7 +2258,7 @@
    i32.const 0
    i32.const 288
    i32.const 20
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2276,7 +2276,7 @@
    i32.const 0
    i32.const 288
    i32.const 22
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2289,7 +2289,7 @@
    i32.const 0
    i32.const 288
    i32.const 24
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2303,7 +2303,7 @@
    i32.const 0
    i32.const 288
    i32.const 25
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2317,7 +2317,7 @@
    i32.const 0
    i32.const 288
    i32.const 26
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2335,7 +2335,7 @@
    i32.const 0
    i32.const 288
    i32.const 28
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/std/staticarray.optimized.wat
+++ b/tests/compiler/std/staticarray.optimized.wat
@@ -47,7 +47,7 @@
    i32.const 1072
    i32.const 1136
    i32.const 95
-   i32.const 40
+   i32.const 41
    call $~lib/builtins/abort
    unreachable
   end
@@ -67,7 +67,7 @@
    i32.const 1072
    i32.const 1136
    i32.const 110
-   i32.const 40
+   i32.const 41
    call $~lib/builtins/abort
    unreachable
   end
@@ -90,7 +90,7 @@
    i32.const 0
    i32.const 1328
    i32.const 277
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -112,7 +112,7 @@
    i32.const 0
    i32.const 1328
    i32.const 279
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -155,7 +155,7 @@
    i32.const 0
    i32.const 1328
    i32.const 292
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -251,7 +251,7 @@
    i32.const 0
    i32.const 1328
    i32.const 205
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -265,7 +265,7 @@
    i32.const 0
    i32.const 1328
    i32.const 207
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -338,7 +338,7 @@
     i32.const 0
     i32.const 1328
     i32.const 228
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -393,7 +393,7 @@
    i32.const 0
    i32.const 1328
    i32.const 243
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -408,7 +408,7 @@
    i32.const 0
    i32.const 1328
    i32.const 244
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -456,7 +456,7 @@
    i32.const 0
    i32.const 1328
    i32.const 260
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -539,7 +539,7 @@
    i32.const 0
    i32.const 1328
    i32.const 386
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -556,7 +556,7 @@
     i32.const 0
     i32.const 1328
     i32.const 396
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -584,7 +584,7 @@
     i32.const 0
     i32.const 1328
     i32.const 408
-    i32.const 4
+    i32.const 5
     call $~lib/builtins/abort
     unreachable
    end
@@ -774,7 +774,7 @@
    i32.const 0
    i32.const 1328
    i32.const 338
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -826,7 +826,7 @@
      i32.const 0
      i32.const 1328
      i32.const 351
-     i32.const 17
+     i32.const 18
      call $~lib/builtins/abort
      unreachable
     end
@@ -859,7 +859,7 @@
    i32.const 0
    i32.const 1328
    i32.const 365
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -930,7 +930,7 @@
    i32.const 0
    i32.const 1328
    i32.const 501
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -941,7 +941,7 @@
    i32.const 1376
    i32.const 1328
    i32.const 461
-   i32.const 29
+   i32.const 30
    call $~lib/builtins/abort
    unreachable
   end
@@ -1041,7 +1041,7 @@
      i32.const 0
      i32.const 1328
      i32.const 513
-     i32.const 19
+     i32.const 20
      call $~lib/builtins/abort
      unreachable
     end
@@ -1057,7 +1057,7 @@
    i32.const 0
    i32.const 1328
    i32.const 521
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1301,7 +1301,7 @@
     i32.const 0
     i32.const 1440
     i32.const 109
-    i32.const 2
+    i32.const 3
     call $~lib/builtins/abort
     unreachable
    end
@@ -1320,7 +1320,7 @@
     i32.const 0
     i32.const 1440
     i32.const 112
-    i32.const 13
+    i32.const 14
     call $~lib/builtins/abort
     unreachable
    end
@@ -1356,7 +1356,7 @@
    i32.const 0
    i32.const 1200
    i32.const 3
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1368,7 +1368,7 @@
    i32.const 0
    i32.const 1200
    i32.const 4
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1384,7 +1384,7 @@
    i32.const 0
    i32.const 1200
    i32.const 6
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1397,7 +1397,7 @@
    i32.const 0
    i32.const 1200
    i32.const 10
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1409,7 +1409,7 @@
    i32.const 0
    i32.const 1200
    i32.const 11
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1425,7 +1425,7 @@
    i32.const 0
    i32.const 1200
    i32.const 13
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1440,7 +1440,7 @@
    i32.const 0
    i32.const 1200
    i32.const 20
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1453,7 +1453,7 @@
    i32.const 0
    i32.const 1200
    i32.const 21
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1466,7 +1466,7 @@
    i32.const 0
    i32.const 1200
    i32.const 22
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1478,7 +1478,7 @@
    i32.const 0
    i32.const 1200
    i32.const 23
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1494,7 +1494,7 @@
    i32.const 0
    i32.const 1200
    i32.const 25
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1511,7 +1511,7 @@
    i32.const 0
    i32.const 1200
    i32.const 27
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1582,7 +1582,7 @@
    i32.const 0
    i32.const 1440
    i32.const 122
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1649,7 +1649,7 @@
     i32.const 0
     i32.const 1440
     i32.const 126
-    i32.const 17
+    i32.const 18
     call $~lib/builtins/abort
     unreachable
    end
@@ -1672,7 +1672,7 @@
     i32.const 0
     i32.const 1440
     i32.const 136
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end

--- a/tests/compiler/std/staticarray.untouched.wat
+++ b/tests/compiler/std/staticarray.untouched.wat
@@ -63,7 +63,7 @@
    i32.const 64
    i32.const 128
    i32.const 95
-   i32.const 40
+   i32.const 41
    call $~lib/builtins/abort
    unreachable
   end
@@ -91,7 +91,7 @@
    i32.const 64
    i32.const 128
    i32.const 110
-   i32.const 40
+   i32.const 41
    call $~lib/builtins/abort
    unreachable
   end
@@ -122,7 +122,7 @@
    i32.const 0
    i32.const 320
    i32.const 277
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -147,7 +147,7 @@
    i32.const 0
    i32.const 320
    i32.const 279
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -199,7 +199,7 @@
    i32.const 0
    i32.const 320
    i32.const 292
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -329,7 +329,7 @@
    i32.const 0
    i32.const 320
    i32.const 205
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -344,7 +344,7 @@
    i32.const 0
    i32.const 320
    i32.const 207
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -437,7 +437,7 @@
     i32.const 0
     i32.const 320
     i32.const 228
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -500,7 +500,7 @@
    i32.const 0
    i32.const 320
    i32.const 243
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -516,7 +516,7 @@
    i32.const 0
    i32.const 320
    i32.const 244
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -573,7 +573,7 @@
    i32.const 0
    i32.const 320
    i32.const 260
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -692,7 +692,7 @@
    i32.const 0
    i32.const 320
    i32.const 386
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -715,7 +715,7 @@
     i32.const 0
     i32.const 320
     i32.const 396
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -746,7 +746,7 @@
     i32.const 0
     i32.const 320
     i32.const 408
-    i32.const 4
+    i32.const 5
     call $~lib/builtins/abort
     unreachable
    end
@@ -972,7 +972,7 @@
    i32.const 368
    i32.const 320
    i32.const 461
-   i32.const 29
+   i32.const 30
    call $~lib/builtins/abort
    unreachable
   end
@@ -1066,7 +1066,7 @@
    i32.const 0
    i32.const 320
    i32.const 338
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1129,7 +1129,7 @@
      i32.const 0
      i32.const 320
      i32.const 351
-     i32.const 17
+     i32.const 18
      call $~lib/builtins/abort
      unreachable
     end
@@ -1274,7 +1274,7 @@
    i32.const 0
    i32.const 320
    i32.const 365
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1363,7 +1363,7 @@
    i32.const 0
    i32.const 320
    i32.const 501
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1404,7 +1404,7 @@
       i32.const 0
       i32.const 320
       i32.const 513
-      i32.const 19
+      i32.const 20
       call $~lib/builtins/abort
       unreachable
      end
@@ -1423,7 +1423,7 @@
      i32.const 0
      i32.const 320
      i32.const 518
-     i32.const 17
+     i32.const 18
      call $~lib/builtins/abort
      unreachable
     end
@@ -1440,7 +1440,7 @@
    i32.const 0
    i32.const 320
    i32.const 521
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -2750,7 +2750,7 @@
    i32.const 0
    i32.const 432
    i32.const 109
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2771,7 +2771,7 @@
    i32.const 0
    i32.const 432
    i32.const 112
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -2832,7 +2832,7 @@
    i32.const 0
    i32.const 192
    i32.const 3
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2845,7 +2845,7 @@
    i32.const 0
    i32.const 192
    i32.const 4
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2863,7 +2863,7 @@
    i32.const 0
    i32.const 192
    i32.const 6
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2877,7 +2877,7 @@
    i32.const 0
    i32.const 192
    i32.const 10
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2890,7 +2890,7 @@
    i32.const 0
    i32.const 192
    i32.const 11
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2908,7 +2908,7 @@
    i32.const 0
    i32.const 192
    i32.const 13
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2924,7 +2924,7 @@
    i32.const 0
    i32.const 192
    i32.const 20
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2938,7 +2938,7 @@
    i32.const 0
    i32.const 192
    i32.const 21
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2952,7 +2952,7 @@
    i32.const 0
    i32.const 192
    i32.const 22
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2965,7 +2965,7 @@
    i32.const 0
    i32.const 192
    i32.const 23
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2983,7 +2983,7 @@
    i32.const 0
    i32.const 192
    i32.const 25
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3003,7 +3003,7 @@
    i32.const 0
    i32.const 192
    i32.const 27
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3103,7 +3103,7 @@
    i32.const 0
    i32.const 432
    i32.const 122
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -3125,7 +3125,7 @@
     i32.const 0
     i32.const 432
     i32.const 126
-    i32.const 17
+    i32.const 18
     call $~lib/builtins/abort
     unreachable
    end
@@ -3141,7 +3141,7 @@
     i32.const 0
     i32.const 432
     i32.const 136
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -3173,7 +3173,7 @@
    i32.const 0
    i32.const 432
    i32.const 69
-   i32.const 15
+   i32.const 16
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/std/string-casemapping.optimized.wat
+++ b/tests/compiler/std/string-casemapping.optimized.wat
@@ -330,7 +330,7 @@
     i32.const 0
     i32.const 1056
     i32.const 109
-    i32.const 2
+    i32.const 3
     call $~lib/builtins/abort
     unreachable
    end
@@ -349,7 +349,7 @@
     i32.const 0
     i32.const 1056
     i32.const 112
-    i32.const 13
+    i32.const 14
     call $~lib/builtins/abort
     unreachable
    end
@@ -371,7 +371,7 @@
    i32.const 0
    i32.const 1104
    i32.const 277
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -393,7 +393,7 @@
    i32.const 0
    i32.const 1104
    i32.const 279
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -436,7 +436,7 @@
    i32.const 0
    i32.const 1104
    i32.const 292
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -532,7 +532,7 @@
    i32.const 0
    i32.const 1104
    i32.const 205
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -546,7 +546,7 @@
    i32.const 0
    i32.const 1104
    i32.const 207
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -619,7 +619,7 @@
     i32.const 0
     i32.const 1104
     i32.const 228
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -674,7 +674,7 @@
    i32.const 0
    i32.const 1104
    i32.const 243
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -689,7 +689,7 @@
    i32.const 0
    i32.const 1104
    i32.const 244
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -737,7 +737,7 @@
    i32.const 0
    i32.const 1104
    i32.const 260
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -820,7 +820,7 @@
    i32.const 0
    i32.const 1104
    i32.const 386
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -837,7 +837,7 @@
     i32.const 0
     i32.const 1104
     i32.const 396
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -865,7 +865,7 @@
     i32.const 0
     i32.const 1104
     i32.const 408
-    i32.const 4
+    i32.const 5
     call $~lib/builtins/abort
     unreachable
    end
@@ -1006,7 +1006,7 @@
    i32.const 1152
    i32.const 1104
    i32.const 461
-   i32.const 29
+   i32.const 30
    call $~lib/builtins/abort
    unreachable
   end
@@ -1079,7 +1079,7 @@
    i32.const 0
    i32.const 1104
    i32.const 338
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1131,7 +1131,7 @@
      i32.const 0
      i32.const 1104
      i32.const 351
-     i32.const 17
+     i32.const 18
      call $~lib/builtins/abort
      unreachable
     end
@@ -1164,7 +1164,7 @@
    i32.const 0
    i32.const 1104
    i32.const 365
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1235,7 +1235,7 @@
    i32.const 0
    i32.const 1104
    i32.const 501
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1326,7 +1326,7 @@
      i32.const 0
      i32.const 1104
      i32.const 513
-     i32.const 19
+     i32.const 20
      call $~lib/builtins/abort
      unreachable
     end
@@ -1342,7 +1342,7 @@
    i32.const 0
    i32.const 1104
    i32.const 521
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1852,7 +1852,7 @@
    i32.const 0
    i32.const 1104
    i32.const 581
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2801,7 +2801,7 @@
    i32.const 0
    i32.const 14992
    i32.const 33
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -3006,7 +3006,7 @@
    i32.const 0
    i32.const 6688
    i32.const 8
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3020,7 +3020,7 @@
    i32.const 0
    i32.const 6688
    i32.const 9
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3034,7 +3034,7 @@
    i32.const 0
    i32.const 6688
    i32.const 10
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3048,7 +3048,7 @@
    i32.const 0
    i32.const 6688
    i32.const 11
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3062,7 +3062,7 @@
    i32.const 0
    i32.const 6688
    i32.const 12
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3076,7 +3076,7 @@
    i32.const 0
    i32.const 6688
    i32.const 13
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3090,7 +3090,7 @@
    i32.const 0
    i32.const 6688
    i32.const 14
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3104,7 +3104,7 @@
    i32.const 0
    i32.const 6688
    i32.const 15
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3118,7 +3118,7 @@
    i32.const 0
    i32.const 6688
    i32.const 16
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3132,7 +3132,7 @@
    i32.const 0
    i32.const 6688
    i32.const 17
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3146,7 +3146,7 @@
    i32.const 0
    i32.const 6688
    i32.const 18
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3160,7 +3160,7 @@
    i32.const 0
    i32.const 6688
    i32.const 19
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3174,7 +3174,7 @@
    i32.const 0
    i32.const 6688
    i32.const 20
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3188,7 +3188,7 @@
    i32.const 0
    i32.const 6688
    i32.const 21
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3202,7 +3202,7 @@
    i32.const 0
    i32.const 6688
    i32.const 22
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3216,7 +3216,7 @@
    i32.const 0
    i32.const 6688
    i32.const 23
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3230,7 +3230,7 @@
    i32.const 0
    i32.const 6688
    i32.const 24
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3244,7 +3244,7 @@
    i32.const 0
    i32.const 6688
    i32.const 25
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3258,7 +3258,7 @@
    i32.const 0
    i32.const 6688
    i32.const 26
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3272,7 +3272,7 @@
    i32.const 0
    i32.const 6688
    i32.const 27
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3286,7 +3286,7 @@
    i32.const 0
    i32.const 6688
    i32.const 28
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3300,7 +3300,7 @@
    i32.const 0
    i32.const 6688
    i32.const 32
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3314,7 +3314,7 @@
    i32.const 0
    i32.const 6688
    i32.const 36
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3328,7 +3328,7 @@
    i32.const 0
    i32.const 6688
    i32.const 37
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3342,7 +3342,7 @@
    i32.const 0
    i32.const 6688
    i32.const 38
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3358,7 +3358,7 @@
    i32.const 0
    i32.const 6688
    i32.const 42
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3374,7 +3374,7 @@
    i32.const 0
    i32.const 6688
    i32.const 43
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3390,7 +3390,7 @@
    i32.const 0
    i32.const 6688
    i32.const 44
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3406,7 +3406,7 @@
    i32.const 0
    i32.const 6688
    i32.const 50
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3422,7 +3422,7 @@
    i32.const 0
    i32.const 6688
    i32.const 51
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3436,7 +3436,7 @@
    i32.const 0
    i32.const 6688
    i32.const 54
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3450,7 +3450,7 @@
    i32.const 0
    i32.const 6688
    i32.const 55
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3464,7 +3464,7 @@
    i32.const 0
    i32.const 6688
    i32.const 56
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3478,7 +3478,7 @@
    i32.const 0
    i32.const 6688
    i32.const 59
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3492,7 +3492,7 @@
    i32.const 0
    i32.const 6688
    i32.const 60
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3506,7 +3506,7 @@
    i32.const 0
    i32.const 6688
    i32.const 61
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3520,7 +3520,7 @@
    i32.const 0
    i32.const 6688
    i32.const 62
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3534,7 +3534,7 @@
    i32.const 0
    i32.const 6688
    i32.const 63
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3548,7 +3548,7 @@
    i32.const 0
    i32.const 6688
    i32.const 64
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3562,7 +3562,7 @@
    i32.const 0
    i32.const 6688
    i32.const 65
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3576,7 +3576,7 @@
    i32.const 0
    i32.const 6688
    i32.const 66
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3590,7 +3590,7 @@
    i32.const 0
    i32.const 6688
    i32.const 67
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3604,7 +3604,7 @@
    i32.const 0
    i32.const 6688
    i32.const 68
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3618,7 +3618,7 @@
    i32.const 0
    i32.const 6688
    i32.const 69
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3632,7 +3632,7 @@
    i32.const 0
    i32.const 6688
    i32.const 70
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3646,7 +3646,7 @@
    i32.const 0
    i32.const 6688
    i32.const 72
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3660,7 +3660,7 @@
    i32.const 0
    i32.const 6688
    i32.const 73
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3674,7 +3674,7 @@
    i32.const 0
    i32.const 6688
    i32.const 74
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3688,7 +3688,7 @@
    i32.const 0
    i32.const 6688
    i32.const 75
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3702,7 +3702,7 @@
    i32.const 0
    i32.const 6688
    i32.const 78
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3716,7 +3716,7 @@
    i32.const 0
    i32.const 6688
    i32.const 79
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3730,7 +3730,7 @@
    i32.const 0
    i32.const 6688
    i32.const 80
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3744,7 +3744,7 @@
    i32.const 0
    i32.const 6688
    i32.const 81
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3758,7 +3758,7 @@
    i32.const 0
    i32.const 6688
    i32.const 82
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3772,7 +3772,7 @@
    i32.const 0
    i32.const 6688
    i32.const 83
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3786,7 +3786,7 @@
    i32.const 0
    i32.const 6688
    i32.const 84
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3800,7 +3800,7 @@
    i32.const 0
    i32.const 6688
    i32.const 85
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3814,7 +3814,7 @@
    i32.const 0
    i32.const 6688
    i32.const 86
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3828,7 +3828,7 @@
    i32.const 0
    i32.const 6688
    i32.const 87
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3842,7 +3842,7 @@
    i32.const 0
    i32.const 6688
    i32.const 88
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3856,7 +3856,7 @@
    i32.const 0
    i32.const 6688
    i32.const 89
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3870,7 +3870,7 @@
    i32.const 0
    i32.const 6688
    i32.const 90
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3884,7 +3884,7 @@
    i32.const 0
    i32.const 6688
    i32.const 91
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3898,7 +3898,7 @@
    i32.const 0
    i32.const 6688
    i32.const 92
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3912,7 +3912,7 @@
    i32.const 0
    i32.const 6688
    i32.const 93
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3926,7 +3926,7 @@
    i32.const 0
    i32.const 6688
    i32.const 94
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3940,7 +3940,7 @@
    i32.const 0
    i32.const 6688
    i32.const 95
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3954,7 +3954,7 @@
    i32.const 0
    i32.const 6688
    i32.const 96
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3968,7 +3968,7 @@
    i32.const 0
    i32.const 6688
    i32.const 99
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3982,7 +3982,7 @@
    i32.const 0
    i32.const 6688
    i32.const 100
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3996,7 +3996,7 @@
    i32.const 0
    i32.const 6688
    i32.const 101
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -4010,7 +4010,7 @@
    i32.const 0
    i32.const 6688
    i32.const 102
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -4024,7 +4024,7 @@
    i32.const 0
    i32.const 6688
    i32.const 103
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -4038,7 +4038,7 @@
    i32.const 0
    i32.const 6688
    i32.const 104
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -4052,7 +4052,7 @@
    i32.const 0
    i32.const 6688
    i32.const 105
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -4066,7 +4066,7 @@
    i32.const 0
    i32.const 6688
    i32.const 106
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -4080,7 +4080,7 @@
    i32.const 0
    i32.const 6688
    i32.const 107
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -4094,7 +4094,7 @@
    i32.const 0
    i32.const 6688
    i32.const 108
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -4108,7 +4108,7 @@
    i32.const 0
    i32.const 6688
    i32.const 109
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -4122,7 +4122,7 @@
    i32.const 0
    i32.const 6688
    i32.const 110
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -4136,7 +4136,7 @@
    i32.const 0
    i32.const 6688
    i32.const 111
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -4332,7 +4332,7 @@
      i32.const 0
      i32.const 6688
      i32.const 148
-     i32.const 2
+     i32.const 3
      call $~lib/builtins/abort
      unreachable
     end
@@ -4343,7 +4343,7 @@
      i32.const 0
      i32.const 6688
      i32.const 149
-     i32.const 2
+     i32.const 3
      call $~lib/builtins/abort
      unreachable
     end
@@ -4562,7 +4562,7 @@
    i32.const 0
    i32.const 1056
    i32.const 122
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -4607,7 +4607,7 @@
     i32.const 0
     i32.const 1056
     i32.const 126
-    i32.const 17
+    i32.const 18
     call $~lib/builtins/abort
     unreachable
    end
@@ -4622,7 +4622,7 @@
     i32.const 0
     i32.const 1056
     i32.const 136
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end

--- a/tests/compiler/std/string-casemapping.untouched.wat
+++ b/tests/compiler/std/string-casemapping.untouched.wat
@@ -221,7 +221,7 @@
    i32.const 0
    i32.const 48
    i32.const 109
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -242,7 +242,7 @@
    i32.const 0
    i32.const 48
    i32.const 112
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -281,7 +281,7 @@
    i32.const 0
    i32.const 96
    i32.const 277
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -306,7 +306,7 @@
    i32.const 0
    i32.const 96
    i32.const 279
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -358,7 +358,7 @@
    i32.const 0
    i32.const 96
    i32.const 292
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -488,7 +488,7 @@
    i32.const 0
    i32.const 96
    i32.const 205
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -503,7 +503,7 @@
    i32.const 0
    i32.const 96
    i32.const 207
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -596,7 +596,7 @@
     i32.const 0
     i32.const 96
     i32.const 228
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -659,7 +659,7 @@
    i32.const 0
    i32.const 96
    i32.const 243
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -675,7 +675,7 @@
    i32.const 0
    i32.const 96
    i32.const 244
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -732,7 +732,7 @@
    i32.const 0
    i32.const 96
    i32.const 260
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -851,7 +851,7 @@
    i32.const 0
    i32.const 96
    i32.const 386
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -874,7 +874,7 @@
     i32.const 0
     i32.const 96
     i32.const 396
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -905,7 +905,7 @@
     i32.const 0
     i32.const 96
     i32.const 408
-    i32.const 4
+    i32.const 5
     call $~lib/builtins/abort
     unreachable
    end
@@ -1131,7 +1131,7 @@
    i32.const 144
    i32.const 96
    i32.const 461
-   i32.const 29
+   i32.const 30
    call $~lib/builtins/abort
    unreachable
   end
@@ -1225,7 +1225,7 @@
    i32.const 0
    i32.const 96
    i32.const 338
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1288,7 +1288,7 @@
      i32.const 0
      i32.const 96
      i32.const 351
-     i32.const 17
+     i32.const 18
      call $~lib/builtins/abort
      unreachable
     end
@@ -1433,7 +1433,7 @@
    i32.const 0
    i32.const 96
    i32.const 365
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1522,7 +1522,7 @@
    i32.const 0
    i32.const 96
    i32.const 501
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1563,7 +1563,7 @@
       i32.const 0
       i32.const 96
       i32.const 513
-      i32.const 19
+      i32.const 20
       call $~lib/builtins/abort
       unreachable
      end
@@ -1582,7 +1582,7 @@
      i32.const 0
      i32.const 96
      i32.const 518
-     i32.const 17
+     i32.const 18
      call $~lib/builtins/abort
      unreachable
     end
@@ -1599,7 +1599,7 @@
    i32.const 0
    i32.const 96
    i32.const 521
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1869,7 +1869,7 @@
    i32.const 0
    i32.const 96
    i32.const 581
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4407,7 +4407,7 @@
    i32.const 0
    i32.const 14272
    i32.const 33
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -4630,7 +4630,7 @@
    i32.const 0
    i32.const 5824
    i32.const 8
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -4644,7 +4644,7 @@
    i32.const 0
    i32.const 5824
    i32.const 9
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -4658,7 +4658,7 @@
    i32.const 0
    i32.const 5824
    i32.const 10
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -4672,7 +4672,7 @@
    i32.const 0
    i32.const 5824
    i32.const 11
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -4686,7 +4686,7 @@
    i32.const 0
    i32.const 5824
    i32.const 12
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -4700,7 +4700,7 @@
    i32.const 0
    i32.const 5824
    i32.const 13
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -4714,7 +4714,7 @@
    i32.const 0
    i32.const 5824
    i32.const 14
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -4728,7 +4728,7 @@
    i32.const 0
    i32.const 5824
    i32.const 15
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -4742,7 +4742,7 @@
    i32.const 0
    i32.const 5824
    i32.const 16
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -4756,7 +4756,7 @@
    i32.const 0
    i32.const 5824
    i32.const 17
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -4770,7 +4770,7 @@
    i32.const 0
    i32.const 5824
    i32.const 18
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -4784,7 +4784,7 @@
    i32.const 0
    i32.const 5824
    i32.const 19
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -4798,7 +4798,7 @@
    i32.const 0
    i32.const 5824
    i32.const 20
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -4812,7 +4812,7 @@
    i32.const 0
    i32.const 5824
    i32.const 21
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -4826,7 +4826,7 @@
    i32.const 0
    i32.const 5824
    i32.const 22
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -4840,7 +4840,7 @@
    i32.const 0
    i32.const 5824
    i32.const 23
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -4854,7 +4854,7 @@
    i32.const 0
    i32.const 5824
    i32.const 24
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -4868,7 +4868,7 @@
    i32.const 0
    i32.const 5824
    i32.const 25
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -4882,7 +4882,7 @@
    i32.const 0
    i32.const 5824
    i32.const 26
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -4896,7 +4896,7 @@
    i32.const 0
    i32.const 5824
    i32.const 27
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -4910,7 +4910,7 @@
    i32.const 0
    i32.const 5824
    i32.const 28
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -4924,7 +4924,7 @@
    i32.const 0
    i32.const 5824
    i32.const 32
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -4938,7 +4938,7 @@
    i32.const 0
    i32.const 5824
    i32.const 36
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -4952,7 +4952,7 @@
    i32.const 0
    i32.const 5824
    i32.const 37
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -4966,7 +4966,7 @@
    i32.const 0
    i32.const 5824
    i32.const 38
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -4982,7 +4982,7 @@
    i32.const 0
    i32.const 5824
    i32.const 42
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -4998,7 +4998,7 @@
    i32.const 0
    i32.const 5824
    i32.const 43
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -5014,7 +5014,7 @@
    i32.const 0
    i32.const 5824
    i32.const 44
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -5030,7 +5030,7 @@
    i32.const 0
    i32.const 5824
    i32.const 50
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -5046,7 +5046,7 @@
    i32.const 0
    i32.const 5824
    i32.const 51
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -5060,7 +5060,7 @@
    i32.const 0
    i32.const 5824
    i32.const 54
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -5074,7 +5074,7 @@
    i32.const 0
    i32.const 5824
    i32.const 55
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -5088,7 +5088,7 @@
    i32.const 0
    i32.const 5824
    i32.const 56
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -5102,7 +5102,7 @@
    i32.const 0
    i32.const 5824
    i32.const 59
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -5116,7 +5116,7 @@
    i32.const 0
    i32.const 5824
    i32.const 60
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -5130,7 +5130,7 @@
    i32.const 0
    i32.const 5824
    i32.const 61
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -5144,7 +5144,7 @@
    i32.const 0
    i32.const 5824
    i32.const 62
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -5158,7 +5158,7 @@
    i32.const 0
    i32.const 5824
    i32.const 63
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -5172,7 +5172,7 @@
    i32.const 0
    i32.const 5824
    i32.const 64
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -5186,7 +5186,7 @@
    i32.const 0
    i32.const 5824
    i32.const 65
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -5200,7 +5200,7 @@
    i32.const 0
    i32.const 5824
    i32.const 66
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -5214,7 +5214,7 @@
    i32.const 0
    i32.const 5824
    i32.const 67
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -5228,7 +5228,7 @@
    i32.const 0
    i32.const 5824
    i32.const 68
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -5242,7 +5242,7 @@
    i32.const 0
    i32.const 5824
    i32.const 69
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -5256,7 +5256,7 @@
    i32.const 0
    i32.const 5824
    i32.const 70
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -5270,7 +5270,7 @@
    i32.const 0
    i32.const 5824
    i32.const 72
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -5284,7 +5284,7 @@
    i32.const 0
    i32.const 5824
    i32.const 73
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -5298,7 +5298,7 @@
    i32.const 0
    i32.const 5824
    i32.const 74
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -5312,7 +5312,7 @@
    i32.const 0
    i32.const 5824
    i32.const 75
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -5326,7 +5326,7 @@
    i32.const 0
    i32.const 5824
    i32.const 78
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -5340,7 +5340,7 @@
    i32.const 0
    i32.const 5824
    i32.const 79
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -5354,7 +5354,7 @@
    i32.const 0
    i32.const 5824
    i32.const 80
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -5368,7 +5368,7 @@
    i32.const 0
    i32.const 5824
    i32.const 81
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -5382,7 +5382,7 @@
    i32.const 0
    i32.const 5824
    i32.const 82
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -5396,7 +5396,7 @@
    i32.const 0
    i32.const 5824
    i32.const 83
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -5410,7 +5410,7 @@
    i32.const 0
    i32.const 5824
    i32.const 84
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -5424,7 +5424,7 @@
    i32.const 0
    i32.const 5824
    i32.const 85
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -5438,7 +5438,7 @@
    i32.const 0
    i32.const 5824
    i32.const 86
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -5452,7 +5452,7 @@
    i32.const 0
    i32.const 5824
    i32.const 87
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -5466,7 +5466,7 @@
    i32.const 0
    i32.const 5824
    i32.const 88
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -5480,7 +5480,7 @@
    i32.const 0
    i32.const 5824
    i32.const 89
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -5494,7 +5494,7 @@
    i32.const 0
    i32.const 5824
    i32.const 90
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -5508,7 +5508,7 @@
    i32.const 0
    i32.const 5824
    i32.const 91
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -5522,7 +5522,7 @@
    i32.const 0
    i32.const 5824
    i32.const 92
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -5536,7 +5536,7 @@
    i32.const 0
    i32.const 5824
    i32.const 93
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -5550,7 +5550,7 @@
    i32.const 0
    i32.const 5824
    i32.const 94
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -5564,7 +5564,7 @@
    i32.const 0
    i32.const 5824
    i32.const 95
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -5578,7 +5578,7 @@
    i32.const 0
    i32.const 5824
    i32.const 96
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -5592,7 +5592,7 @@
    i32.const 0
    i32.const 5824
    i32.const 99
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -5606,7 +5606,7 @@
    i32.const 0
    i32.const 5824
    i32.const 100
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -5620,7 +5620,7 @@
    i32.const 0
    i32.const 5824
    i32.const 101
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -5634,7 +5634,7 @@
    i32.const 0
    i32.const 5824
    i32.const 102
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -5648,7 +5648,7 @@
    i32.const 0
    i32.const 5824
    i32.const 103
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -5662,7 +5662,7 @@
    i32.const 0
    i32.const 5824
    i32.const 104
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -5676,7 +5676,7 @@
    i32.const 0
    i32.const 5824
    i32.const 105
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -5690,7 +5690,7 @@
    i32.const 0
    i32.const 5824
    i32.const 106
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -5704,7 +5704,7 @@
    i32.const 0
    i32.const 5824
    i32.const 107
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -5718,7 +5718,7 @@
    i32.const 0
    i32.const 5824
    i32.const 108
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -5732,7 +5732,7 @@
    i32.const 0
    i32.const 5824
    i32.const 109
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -5746,7 +5746,7 @@
    i32.const 0
    i32.const 5824
    i32.const 110
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -5760,7 +5760,7 @@
    i32.const 0
    i32.const 5824
    i32.const 111
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -5962,7 +5962,7 @@
      i32.const 0
      i32.const 5824
      i32.const 148
-     i32.const 2
+     i32.const 3
      call $~lib/builtins/abort
      unreachable
     end
@@ -5974,7 +5974,7 @@
      i32.const 0
      i32.const 5824
      i32.const 149
-     i32.const 2
+     i32.const 3
      call $~lib/builtins/abort
      unreachable
     end
@@ -6199,7 +6199,7 @@
    i32.const 0
    i32.const 48
    i32.const 122
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -6221,7 +6221,7 @@
     i32.const 0
     i32.const 48
     i32.const 126
-    i32.const 17
+    i32.const 18
     call $~lib/builtins/abort
     unreachable
    end
@@ -6237,7 +6237,7 @@
     i32.const 0
     i32.const 48
     i32.const 136
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -6269,7 +6269,7 @@
    i32.const 0
    i32.const 48
    i32.const 69
-   i32.const 15
+   i32.const 16
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/std/string-encoding.optimized.wat
+++ b/tests/compiler/std/string-encoding.optimized.wat
@@ -60,7 +60,7 @@
     i32.const 0
     i32.const 1072
     i32.const 109
-    i32.const 2
+    i32.const 3
     call $~lib/builtins/abort
     unreachable
    end
@@ -79,7 +79,7 @@
     i32.const 0
     i32.const 1072
     i32.const 112
-    i32.const 13
+    i32.const 14
     call $~lib/builtins/abort
     unreachable
    end
@@ -112,7 +112,7 @@
    i32.const 0
    i32.const 1184
    i32.const 277
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -134,7 +134,7 @@
    i32.const 0
    i32.const 1184
    i32.const 279
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -177,7 +177,7 @@
    i32.const 0
    i32.const 1184
    i32.const 292
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -273,7 +273,7 @@
    i32.const 0
    i32.const 1184
    i32.const 205
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -287,7 +287,7 @@
    i32.const 0
    i32.const 1184
    i32.const 207
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -360,7 +360,7 @@
     i32.const 0
     i32.const 1184
     i32.const 228
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -415,7 +415,7 @@
    i32.const 0
    i32.const 1184
    i32.const 243
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -430,7 +430,7 @@
    i32.const 0
    i32.const 1184
    i32.const 244
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -478,7 +478,7 @@
    i32.const 0
    i32.const 1184
    i32.const 260
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -561,7 +561,7 @@
    i32.const 0
    i32.const 1184
    i32.const 386
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -578,7 +578,7 @@
     i32.const 0
     i32.const 1184
     i32.const 396
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -606,7 +606,7 @@
     i32.const 0
     i32.const 1184
     i32.const 408
-    i32.const 4
+    i32.const 5
     call $~lib/builtins/abort
     unreachable
    end
@@ -747,7 +747,7 @@
    i32.const 1232
    i32.const 1184
    i32.const 461
-   i32.const 29
+   i32.const 30
    call $~lib/builtins/abort
    unreachable
   end
@@ -820,7 +820,7 @@
    i32.const 0
    i32.const 1184
    i32.const 338
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -872,7 +872,7 @@
      i32.const 0
      i32.const 1184
      i32.const 351
-     i32.const 17
+     i32.const 18
      call $~lib/builtins/abort
      unreachable
     end
@@ -905,7 +905,7 @@
    i32.const 0
    i32.const 1184
    i32.const 365
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -976,7 +976,7 @@
    i32.const 0
    i32.const 1184
    i32.const 501
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1067,7 +1067,7 @@
      i32.const 0
      i32.const 1184
      i32.const 513
-     i32.const 19
+     i32.const 20
      call $~lib/builtins/abort
      unreachable
     end
@@ -1083,7 +1083,7 @@
    i32.const 0
    i32.const 1184
    i32.const 521
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1330,7 +1330,7 @@
    i32.const 0
    i32.const 1120
    i32.const 15
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1342,7 +1342,7 @@
    i32.const 0
    i32.const 1120
    i32.const 16
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1354,7 +1354,7 @@
    i32.const 0
    i32.const 1120
    i32.const 17
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1366,7 +1366,7 @@
    i32.const 0
    i32.const 1120
    i32.const 18
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1378,7 +1378,7 @@
    i32.const 0
    i32.const 1120
    i32.const 19
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1390,7 +1390,7 @@
    i32.const 0
    i32.const 1120
    i32.const 20
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1400,7 +1400,7 @@
    i32.const 0
    i32.const 1120
    i32.const 21
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1412,7 +1412,7 @@
    i32.const 0
    i32.const 1120
    i32.const 22
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1422,7 +1422,7 @@
    i32.const 0
    i32.const 1120
    i32.const 23
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1434,7 +1434,7 @@
    i32.const 0
    i32.const 1120
    i32.const 24
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1446,7 +1446,7 @@
    i32.const 0
    i32.const 1120
    i32.const 25
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1458,7 +1458,7 @@
    i32.const 0
    i32.const 1120
    i32.const 26
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1470,7 +1470,7 @@
    i32.const 0
    i32.const 1120
    i32.const 27
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1636,7 +1636,7 @@
    i32.const 0
    i32.const 1120
    i32.const 42
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1651,7 +1651,7 @@
    i32.const 0
    i32.const 1120
    i32.const 43
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1666,7 +1666,7 @@
    i32.const 0
    i32.const 1120
    i32.const 44
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1683,7 +1683,7 @@
    i32.const 0
    i32.const 1120
    i32.const 45
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1700,7 +1700,7 @@
    i32.const 0
    i32.const 1120
    i32.const 46
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1717,7 +1717,7 @@
    i32.const 0
    i32.const 1120
    i32.const 47
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1734,7 +1734,7 @@
    i32.const 0
    i32.const 1120
    i32.const 48
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2054,7 +2054,7 @@
    i32.const 0
    i32.const 1120
    i32.const 63
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2066,7 +2066,7 @@
    i32.const 0
    i32.const 1120
    i32.const 64
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2078,7 +2078,7 @@
    i32.const 0
    i32.const 1120
    i32.const 65
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2090,7 +2090,7 @@
    i32.const 0
    i32.const 1120
    i32.const 66
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2102,7 +2102,7 @@
    i32.const 0
    i32.const 1120
    i32.const 67
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2114,7 +2114,7 @@
    i32.const 0
    i32.const 1120
    i32.const 68
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2126,7 +2126,7 @@
    i32.const 0
    i32.const 1120
    i32.const 69
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2138,7 +2138,7 @@
    i32.const 0
    i32.const 1120
    i32.const 70
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2150,7 +2150,7 @@
    i32.const 0
    i32.const 1120
    i32.const 71
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2162,7 +2162,7 @@
    i32.const 0
    i32.const 1120
    i32.const 72
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2174,7 +2174,7 @@
    i32.const 0
    i32.const 1120
    i32.const 73
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2198,7 +2198,7 @@
    i32.const 0
    i32.const 1120
    i32.const 80
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2210,7 +2210,7 @@
    i32.const 0
    i32.const 1120
    i32.const 81
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2222,7 +2222,7 @@
    i32.const 0
    i32.const 1120
    i32.const 82
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2234,7 +2234,7 @@
    i32.const 0
    i32.const 1120
    i32.const 83
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2246,7 +2246,7 @@
    i32.const 0
    i32.const 1120
    i32.const 84
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2258,7 +2258,7 @@
    i32.const 0
    i32.const 1120
    i32.const 85
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2270,7 +2270,7 @@
    i32.const 0
    i32.const 1120
    i32.const 86
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2282,7 +2282,7 @@
    i32.const 0
    i32.const 1120
    i32.const 87
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2294,7 +2294,7 @@
    i32.const 0
    i32.const 1120
    i32.const 88
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2306,7 +2306,7 @@
    i32.const 0
    i32.const 1120
    i32.const 89
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2318,7 +2318,7 @@
    i32.const 0
    i32.const 1120
    i32.const 90
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2328,7 +2328,7 @@
    i32.const 0
    i32.const 1120
    i32.const 91
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2467,7 +2467,7 @@
    i32.const 0
    i32.const 1440
    i32.const 738
-   i32.const 6
+   i32.const 7
    call $~lib/builtins/abort
    unreachable
   end
@@ -2673,7 +2673,7 @@
    i32.const 0
    i32.const 1184
    i32.const 581
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2714,7 +2714,7 @@
    i32.const 0
    i32.const 1120
    i32.const 103
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2727,7 +2727,7 @@
    i32.const 0
    i32.const 1120
    i32.const 105
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2744,7 +2744,7 @@
    i32.const 0
    i32.const 1120
    i32.const 107
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2757,7 +2757,7 @@
    i32.const 0
    i32.const 1120
    i32.const 109
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2772,7 +2772,7 @@
    i32.const 0
    i32.const 1120
    i32.const 110
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2790,7 +2790,7 @@
    i32.const 0
    i32.const 1120
    i32.const 112
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2839,7 +2839,7 @@
    i32.const 0
    i32.const 1120
    i32.const 121
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2855,7 +2855,7 @@
    i32.const 0
    i32.const 1120
    i32.const 122
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2871,7 +2871,7 @@
    i32.const 0
    i32.const 1120
    i32.const 123
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2889,7 +2889,7 @@
    i32.const 0
    i32.const 1120
    i32.const 124
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2907,7 +2907,7 @@
    i32.const 0
    i32.const 1120
    i32.const 125
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2925,7 +2925,7 @@
    i32.const 0
    i32.const 1120
    i32.const 126
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2943,7 +2943,7 @@
    i32.const 0
    i32.const 1120
    i32.const 128
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2961,7 +2961,7 @@
    i32.const 0
    i32.const 1120
    i32.const 129
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2979,7 +2979,7 @@
    i32.const 0
    i32.const 1120
    i32.const 130
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3023,7 +3023,7 @@
    i32.const 0
    i32.const 1120
    i32.const 136
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3039,7 +3039,7 @@
    i32.const 0
    i32.const 1120
    i32.const 138
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3063,7 +3063,7 @@
    i32.const 0
    i32.const 1120
    i32.const 8
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3080,7 +3080,7 @@
    i32.const 0
    i32.const 1120
    i32.const 33
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3098,7 +3098,7 @@
    i32.const 0
    i32.const 1120
    i32.const 55
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3111,7 +3111,7 @@
    i32.const 0
    i32.const 1120
    i32.const 56
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3131,7 +3131,7 @@
    i32.const 0
    i32.const 1120
    i32.const 97
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3168,7 +3168,7 @@
    i32.const 0
    i32.const 1072
    i32.const 122
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -3213,7 +3213,7 @@
     i32.const 0
     i32.const 1072
     i32.const 126
-    i32.const 17
+    i32.const 18
     call $~lib/builtins/abort
     unreachable
    end
@@ -3228,7 +3228,7 @@
     i32.const 0
     i32.const 1072
     i32.const 136
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end

--- a/tests/compiler/std/string-encoding.untouched.wat
+++ b/tests/compiler/std/string-encoding.untouched.wat
@@ -62,7 +62,7 @@
    i32.const 0
    i32.const 64
    i32.const 109
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -83,7 +83,7 @@
    i32.const 0
    i32.const 64
    i32.const 112
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -135,7 +135,7 @@
    i32.const 0
    i32.const 112
    i32.const 8
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -162,7 +162,7 @@
    i32.const 0
    i32.const 176
    i32.const 277
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -187,7 +187,7 @@
    i32.const 0
    i32.const 176
    i32.const 279
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -239,7 +239,7 @@
    i32.const 0
    i32.const 176
    i32.const 292
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -369,7 +369,7 @@
    i32.const 0
    i32.const 176
    i32.const 205
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -384,7 +384,7 @@
    i32.const 0
    i32.const 176
    i32.const 207
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -477,7 +477,7 @@
     i32.const 0
     i32.const 176
     i32.const 228
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -540,7 +540,7 @@
    i32.const 0
    i32.const 176
    i32.const 243
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -556,7 +556,7 @@
    i32.const 0
    i32.const 176
    i32.const 244
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -613,7 +613,7 @@
    i32.const 0
    i32.const 176
    i32.const 260
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -732,7 +732,7 @@
    i32.const 0
    i32.const 176
    i32.const 386
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -755,7 +755,7 @@
     i32.const 0
     i32.const 176
     i32.const 396
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -786,7 +786,7 @@
     i32.const 0
     i32.const 176
     i32.const 408
-    i32.const 4
+    i32.const 5
     call $~lib/builtins/abort
     unreachable
    end
@@ -1012,7 +1012,7 @@
    i32.const 224
    i32.const 176
    i32.const 461
-   i32.const 29
+   i32.const 30
    call $~lib/builtins/abort
    unreachable
   end
@@ -1106,7 +1106,7 @@
    i32.const 0
    i32.const 176
    i32.const 338
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1169,7 +1169,7 @@
      i32.const 0
      i32.const 176
      i32.const 351
-     i32.const 17
+     i32.const 18
      call $~lib/builtins/abort
      unreachable
     end
@@ -1314,7 +1314,7 @@
    i32.const 0
    i32.const 176
    i32.const 365
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1403,7 +1403,7 @@
    i32.const 0
    i32.const 176
    i32.const 501
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1444,7 +1444,7 @@
       i32.const 0
       i32.const 176
       i32.const 513
-      i32.const 19
+      i32.const 20
       call $~lib/builtins/abort
       unreachable
      end
@@ -1463,7 +1463,7 @@
      i32.const 0
      i32.const 176
      i32.const 518
-     i32.const 17
+     i32.const 18
      call $~lib/builtins/abort
      unreachable
     end
@@ -1480,7 +1480,7 @@
    i32.const 0
    i32.const 176
    i32.const 521
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -2823,7 +2823,7 @@
    i32.const 0
    i32.const 112
    i32.const 15
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2836,7 +2836,7 @@
    i32.const 0
    i32.const 112
    i32.const 16
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2849,7 +2849,7 @@
    i32.const 0
    i32.const 112
    i32.const 17
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2862,7 +2862,7 @@
    i32.const 0
    i32.const 112
    i32.const 18
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2875,7 +2875,7 @@
    i32.const 0
    i32.const 112
    i32.const 19
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2888,7 +2888,7 @@
    i32.const 0
    i32.const 112
    i32.const 20
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2901,7 +2901,7 @@
    i32.const 0
    i32.const 112
    i32.const 21
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2914,7 +2914,7 @@
    i32.const 0
    i32.const 112
    i32.const 22
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2927,7 +2927,7 @@
    i32.const 0
    i32.const 112
    i32.const 23
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2940,7 +2940,7 @@
    i32.const 0
    i32.const 112
    i32.const 24
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2953,7 +2953,7 @@
    i32.const 0
    i32.const 112
    i32.const 25
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2966,7 +2966,7 @@
    i32.const 0
    i32.const 112
    i32.const 26
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2979,7 +2979,7 @@
    i32.const 0
    i32.const 112
    i32.const 27
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3229,7 +3229,7 @@
    i32.const 0
    i32.const 112
    i32.const 33
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3268,7 +3268,7 @@
    i32.const 0
    i32.const 112
    i32.const 42
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3283,7 +3283,7 @@
    i32.const 0
    i32.const 112
    i32.const 43
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3298,7 +3298,7 @@
    i32.const 0
    i32.const 112
    i32.const 44
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3315,7 +3315,7 @@
    i32.const 0
    i32.const 112
    i32.const 45
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3332,7 +3332,7 @@
    i32.const 0
    i32.const 112
    i32.const 46
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3349,7 +3349,7 @@
    i32.const 0
    i32.const 112
    i32.const 47
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3366,7 +3366,7 @@
    i32.const 0
    i32.const 112
    i32.const 48
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3509,7 +3509,7 @@
    i32.const 0
    i32.const 112
    i32.const 55
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3523,7 +3523,7 @@
    i32.const 0
    i32.const 112
    i32.const 56
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3788,7 +3788,7 @@
    i32.const 0
    i32.const 112
    i32.const 63
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3801,7 +3801,7 @@
    i32.const 0
    i32.const 112
    i32.const 64
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3814,7 +3814,7 @@
    i32.const 0
    i32.const 112
    i32.const 65
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3827,7 +3827,7 @@
    i32.const 0
    i32.const 112
    i32.const 66
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3840,7 +3840,7 @@
    i32.const 0
    i32.const 112
    i32.const 67
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3853,7 +3853,7 @@
    i32.const 0
    i32.const 112
    i32.const 68
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3866,7 +3866,7 @@
    i32.const 0
    i32.const 112
    i32.const 69
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3879,7 +3879,7 @@
    i32.const 0
    i32.const 112
    i32.const 70
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3892,7 +3892,7 @@
    i32.const 0
    i32.const 112
    i32.const 71
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3905,7 +3905,7 @@
    i32.const 0
    i32.const 112
    i32.const 72
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3918,7 +3918,7 @@
    i32.const 0
    i32.const 112
    i32.const 73
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3943,7 +3943,7 @@
    i32.const 0
    i32.const 112
    i32.const 80
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3956,7 +3956,7 @@
    i32.const 0
    i32.const 112
    i32.const 81
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3969,7 +3969,7 @@
    i32.const 0
    i32.const 112
    i32.const 82
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3982,7 +3982,7 @@
    i32.const 0
    i32.const 112
    i32.const 83
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3995,7 +3995,7 @@
    i32.const 0
    i32.const 112
    i32.const 84
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4008,7 +4008,7 @@
    i32.const 0
    i32.const 112
    i32.const 85
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4021,7 +4021,7 @@
    i32.const 0
    i32.const 112
    i32.const 86
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4034,7 +4034,7 @@
    i32.const 0
    i32.const 112
    i32.const 87
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4047,7 +4047,7 @@
    i32.const 0
    i32.const 112
    i32.const 88
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4060,7 +4060,7 @@
    i32.const 0
    i32.const 112
    i32.const 89
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4073,7 +4073,7 @@
    i32.const 0
    i32.const 112
    i32.const 90
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4086,7 +4086,7 @@
    i32.const 0
    i32.const 112
    i32.const 91
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4133,7 +4133,7 @@
    i32.const 0
    i32.const 176
    i32.const 581
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4308,7 +4308,7 @@
    i32.const 0
    i32.const 432
    i32.const 738
-   i32.const 6
+   i32.const 7
    call $~lib/builtins/abort
    unreachable
   end
@@ -4532,7 +4532,7 @@
    i32.const 0
    i32.const 112
    i32.const 97
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4565,7 +4565,7 @@
    i32.const 0
    i32.const 112
    i32.const 103
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4581,7 +4581,7 @@
    i32.const 0
    i32.const 112
    i32.const 105
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4598,7 +4598,7 @@
    i32.const 0
    i32.const 112
    i32.const 107
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4614,7 +4614,7 @@
    i32.const 0
    i32.const 112
    i32.const 109
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4629,7 +4629,7 @@
    i32.const 0
    i32.const 112
    i32.const 110
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4648,7 +4648,7 @@
    i32.const 0
    i32.const 112
    i32.const 112
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4704,7 +4704,7 @@
    i32.const 0
    i32.const 112
    i32.const 121
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4720,7 +4720,7 @@
    i32.const 0
    i32.const 112
    i32.const 122
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4736,7 +4736,7 @@
    i32.const 0
    i32.const 112
    i32.const 123
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4754,7 +4754,7 @@
    i32.const 0
    i32.const 112
    i32.const 124
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4772,7 +4772,7 @@
    i32.const 0
    i32.const 112
    i32.const 125
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4790,7 +4790,7 @@
    i32.const 0
    i32.const 112
    i32.const 126
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4808,7 +4808,7 @@
    i32.const 0
    i32.const 112
    i32.const 128
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4826,7 +4826,7 @@
    i32.const 0
    i32.const 112
    i32.const 129
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4844,7 +4844,7 @@
    i32.const 0
    i32.const 112
    i32.const 130
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4892,7 +4892,7 @@
    i32.const 0
    i32.const 112
    i32.const 136
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4909,7 +4909,7 @@
    i32.const 0
    i32.const 112
    i32.const 138
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4965,7 +4965,7 @@
    i32.const 0
    i32.const 64
    i32.const 122
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -4987,7 +4987,7 @@
     i32.const 0
     i32.const 64
     i32.const 126
-    i32.const 17
+    i32.const 18
     call $~lib/builtins/abort
     unreachable
    end
@@ -5003,7 +5003,7 @@
     i32.const 0
     i32.const 64
     i32.const 136
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -5038,7 +5038,7 @@
    i32.const 0
    i32.const 64
    i32.const 69
-   i32.const 15
+   i32.const 16
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/std/string.optimized.wat
+++ b/tests/compiler/std/string.optimized.wat
@@ -411,7 +411,7 @@
     i32.const 0
     i32.const 1168
     i32.const 109
-    i32.const 2
+    i32.const 3
     call $~lib/builtins/abort
     unreachable
    end
@@ -430,7 +430,7 @@
     i32.const 0
     i32.const 1168
     i32.const 112
-    i32.const 13
+    i32.const 14
     call $~lib/builtins/abort
     unreachable
    end
@@ -596,7 +596,7 @@
    i32.const 0
    i32.const 1360
    i32.const 277
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -618,7 +618,7 @@
    i32.const 0
    i32.const 1360
    i32.const 279
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -661,7 +661,7 @@
    i32.const 0
    i32.const 1360
    i32.const 292
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -757,7 +757,7 @@
    i32.const 0
    i32.const 1360
    i32.const 205
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -771,7 +771,7 @@
    i32.const 0
    i32.const 1360
    i32.const 207
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -844,7 +844,7 @@
     i32.const 0
     i32.const 1360
     i32.const 228
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -899,7 +899,7 @@
    i32.const 0
    i32.const 1360
    i32.const 243
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -914,7 +914,7 @@
    i32.const 0
    i32.const 1360
    i32.const 244
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -962,7 +962,7 @@
    i32.const 0
    i32.const 1360
    i32.const 260
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1045,7 +1045,7 @@
    i32.const 0
    i32.const 1360
    i32.const 386
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -1062,7 +1062,7 @@
     i32.const 0
     i32.const 1360
     i32.const 396
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -1090,7 +1090,7 @@
     i32.const 0
     i32.const 1360
     i32.const 408
-    i32.const 4
+    i32.const 5
     call $~lib/builtins/abort
     unreachable
    end
@@ -1231,7 +1231,7 @@
    i32.const 1408
    i32.const 1360
    i32.const 461
-   i32.const 29
+   i32.const 30
    call $~lib/builtins/abort
    unreachable
   end
@@ -1304,7 +1304,7 @@
    i32.const 0
    i32.const 1360
    i32.const 338
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1356,7 +1356,7 @@
      i32.const 0
      i32.const 1360
      i32.const 351
-     i32.const 17
+     i32.const 18
      call $~lib/builtins/abort
      unreachable
     end
@@ -1389,7 +1389,7 @@
    i32.const 0
    i32.const 1360
    i32.const 365
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1460,7 +1460,7 @@
    i32.const 0
    i32.const 1360
    i32.const 501
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1551,7 +1551,7 @@
      i32.const 0
      i32.const 1360
      i32.const 513
-     i32.const 19
+     i32.const 20
      call $~lib/builtins/abort
      unreachable
     end
@@ -1567,7 +1567,7 @@
    i32.const 0
    i32.const 1360
    i32.const 521
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1655,7 +1655,7 @@
    i32.const 0
    i32.const 1536
    i32.const 33
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -4157,7 +4157,7 @@
    i32.const 11904
    i32.const 1536
    i32.const 322
-   i32.const 6
+   i32.const 7
    call $~lib/builtins/abort
    unreachable
   end
@@ -4328,7 +4328,7 @@
    i32.const 0
    i32.const 1360
    i32.const 581
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -5175,7 +5175,7 @@
     i32.const 11904
     i32.const 13168
     i32.const 14
-    i32.const 47
+    i32.const 48
     call $~lib/builtins/abort
     unreachable
    end
@@ -5441,7 +5441,7 @@
    i32.const 13216
    i32.const 13168
    i32.const 104
-   i32.const 41
+   i32.const 42
    call $~lib/builtins/abort
    unreachable
   end
@@ -5461,7 +5461,7 @@
    i32.const 13280
    i32.const 13168
    i32.const 108
-   i32.const 39
+   i32.const 40
    call $~lib/builtins/abort
    unreachable
   end
@@ -6988,7 +6988,7 @@
    i32.const 0
    i32.const 1088
    i32.const 8
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -7000,7 +7000,7 @@
    i32.const 0
    i32.const 1088
    i32.const 10
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -7012,7 +7012,7 @@
    i32.const 0
    i32.const 1088
    i32.const 11
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -7024,7 +7024,7 @@
    i32.const 0
    i32.const 1088
    i32.const 12
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -7036,7 +7036,7 @@
    i32.const 0
    i32.const 1088
    i32.const 14
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -7058,7 +7058,7 @@
    i32.const 0
    i32.const 1088
    i32.const 15
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -7069,7 +7069,7 @@
    i32.const 0
    i32.const 1088
    i32.const 17
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -7082,7 +7082,7 @@
    i32.const 0
    i32.const 1088
    i32.const 18
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -7095,7 +7095,7 @@
    i32.const 0
    i32.const 1088
    i32.const 19
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -7111,7 +7111,7 @@
    i32.const 0
    i32.const 1088
    i32.const 21
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -7127,7 +7127,7 @@
    i32.const 0
    i32.const 1088
    i32.const 22
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -7143,7 +7143,7 @@
    i32.const 0
    i32.const 1088
    i32.const 23
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -7158,7 +7158,7 @@
    i32.const 0
    i32.const 1088
    i32.const 24
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -7172,7 +7172,7 @@
    i32.const 0
    i32.const 1088
    i32.const 26
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -7186,7 +7186,7 @@
    i32.const 0
    i32.const 1088
    i32.const 27
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -7200,7 +7200,7 @@
    i32.const 0
    i32.const 1088
    i32.const 28
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -7254,7 +7254,7 @@
    i32.const 0
    i32.const 1088
    i32.const 30
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -7290,7 +7290,7 @@
    i32.const 0
    i32.const 1088
    i32.const 31
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -7304,7 +7304,7 @@
    i32.const 0
    i32.const 1088
    i32.const 32
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -7320,7 +7320,7 @@
    i32.const 0
    i32.const 1088
    i32.const 34
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -7336,7 +7336,7 @@
    i32.const 0
    i32.const 1088
    i32.const 35
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -7352,7 +7352,7 @@
    i32.const 0
    i32.const 1088
    i32.const 36
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -7368,7 +7368,7 @@
    i32.const 0
    i32.const 1088
    i32.const 37
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -7384,7 +7384,7 @@
    i32.const 0
    i32.const 1088
    i32.const 38
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -7400,7 +7400,7 @@
    i32.const 0
    i32.const 1088
    i32.const 39
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -7416,7 +7416,7 @@
    i32.const 0
    i32.const 1088
    i32.const 40
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -7432,7 +7432,7 @@
    i32.const 0
    i32.const 1088
    i32.const 41
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -7448,7 +7448,7 @@
    i32.const 0
    i32.const 1088
    i32.const 43
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -7464,7 +7464,7 @@
    i32.const 0
    i32.const 1088
    i32.const 44
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -7480,7 +7480,7 @@
    i32.const 0
    i32.const 1088
    i32.const 45
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -7496,7 +7496,7 @@
    i32.const 0
    i32.const 1088
    i32.const 46
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -7512,7 +7512,7 @@
    i32.const 0
    i32.const 1088
    i32.const 47
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -7528,7 +7528,7 @@
    i32.const 0
    i32.const 1088
    i32.const 48
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -7544,7 +7544,7 @@
    i32.const 0
    i32.const 1088
    i32.const 49
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -7560,7 +7560,7 @@
    i32.const 0
    i32.const 1088
    i32.const 50
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -7572,7 +7572,7 @@
    i32.const 0
    i32.const 1088
    i32.const 52
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -7586,7 +7586,7 @@
    i32.const 0
    i32.const 1088
    i32.const 53
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -7598,7 +7598,7 @@
    i32.const 0
    i32.const 1088
    i32.const 54
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -7610,7 +7610,7 @@
    i32.const 0
    i32.const 1088
    i32.const 55
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -7622,7 +7622,7 @@
    i32.const 0
    i32.const 1088
    i32.const 56
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -7636,7 +7636,7 @@
    i32.const 0
    i32.const 1088
    i32.const 57
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -7650,7 +7650,7 @@
    i32.const 0
    i32.const 1088
    i32.const 58
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -7664,7 +7664,7 @@
    i32.const 0
    i32.const 1088
    i32.const 59
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -7678,7 +7678,7 @@
    i32.const 0
    i32.const 1088
    i32.const 60
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -7692,7 +7692,7 @@
    i32.const 0
    i32.const 1088
    i32.const 61
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -7704,7 +7704,7 @@
    i32.const 0
    i32.const 1088
    i32.const 63
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -7718,7 +7718,7 @@
    i32.const 0
    i32.const 1088
    i32.const 64
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -7733,7 +7733,7 @@
    i32.const 0
    i32.const 1088
    i32.const 65
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -7747,7 +7747,7 @@
    i32.const 0
    i32.const 1088
    i32.const 66
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -7761,7 +7761,7 @@
    i32.const 0
    i32.const 1088
    i32.const 67
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -7775,7 +7775,7 @@
    i32.const 0
    i32.const 1088
    i32.const 68
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -7789,7 +7789,7 @@
    i32.const 0
    i32.const 1088
    i32.const 69
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -7803,7 +7803,7 @@
    i32.const 0
    i32.const 1088
    i32.const 70
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -7817,7 +7817,7 @@
    i32.const 0
    i32.const 1088
    i32.const 71
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -7831,7 +7831,7 @@
    i32.const 0
    i32.const 1088
    i32.const 72
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -7843,7 +7843,7 @@
    i32.const 0
    i32.const 1088
    i32.const 73
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -7854,7 +7854,7 @@
    i32.const 0
    i32.const 1088
    i32.const 75
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -7867,7 +7867,7 @@
    i32.const 0
    i32.const 1088
    i32.const 76
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -7880,7 +7880,7 @@
    i32.const 0
    i32.const 1088
    i32.const 77
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -7891,7 +7891,7 @@
    i32.const 0
    i32.const 1088
    i32.const 78
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -7904,7 +7904,7 @@
    i32.const 0
    i32.const 1088
    i32.const 79
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -7917,7 +7917,7 @@
    i32.const 0
    i32.const 1088
    i32.const 80
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -7930,7 +7930,7 @@
    i32.const 0
    i32.const 1088
    i32.const 81
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -7943,7 +7943,7 @@
    i32.const 0
    i32.const 1088
    i32.const 82
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -7956,7 +7956,7 @@
    i32.const 0
    i32.const 1088
    i32.const 83
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -7969,7 +7969,7 @@
    i32.const 0
    i32.const 1088
    i32.const 84
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -7983,7 +7983,7 @@
    i32.const 0
    i32.const 1088
    i32.const 86
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -7997,7 +7997,7 @@
    i32.const 0
    i32.const 1088
    i32.const 87
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -8011,7 +8011,7 @@
    i32.const 0
    i32.const 1088
    i32.const 88
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -8025,7 +8025,7 @@
    i32.const 0
    i32.const 1088
    i32.const 90
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -8039,7 +8039,7 @@
    i32.const 0
    i32.const 1088
    i32.const 91
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -8053,7 +8053,7 @@
    i32.const 0
    i32.const 1088
    i32.const 92
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -8067,7 +8067,7 @@
    i32.const 0
    i32.const 1088
    i32.const 94
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -8081,7 +8081,7 @@
    i32.const 0
    i32.const 1088
    i32.const 95
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -8095,7 +8095,7 @@
    i32.const 0
    i32.const 1088
    i32.const 96
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -8107,7 +8107,7 @@
    i32.const 0
    i32.const 1088
    i32.const 98
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -8119,7 +8119,7 @@
    i32.const 0
    i32.const 1088
    i32.const 99
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -8131,7 +8131,7 @@
    i32.const 0
    i32.const 1088
    i32.const 100
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -8143,7 +8143,7 @@
    i32.const 0
    i32.const 1088
    i32.const 101
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -8155,7 +8155,7 @@
    i32.const 0
    i32.const 1088
    i32.const 102
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -8167,7 +8167,7 @@
    i32.const 0
    i32.const 1088
    i32.const 103
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -8179,7 +8179,7 @@
    i32.const 0
    i32.const 1088
    i32.const 104
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -8191,7 +8191,7 @@
    i32.const 0
    i32.const 1088
    i32.const 105
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -8203,7 +8203,7 @@
    i32.const 0
    i32.const 1088
    i32.const 106
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -8215,7 +8215,7 @@
    i32.const 0
    i32.const 1088
    i32.const 107
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -8227,7 +8227,7 @@
    i32.const 0
    i32.const 1088
    i32.const 108
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -8239,7 +8239,7 @@
    i32.const 0
    i32.const 1088
    i32.const 109
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -8251,7 +8251,7 @@
    i32.const 0
    i32.const 1088
    i32.const 110
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -8263,7 +8263,7 @@
    i32.const 0
    i32.const 1088
    i32.const 112
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -8275,7 +8275,7 @@
    i32.const 0
    i32.const 1088
    i32.const 113
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -8286,7 +8286,7 @@
    i32.const 0
    i32.const 1088
    i32.const 115
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -8297,7 +8297,7 @@
    i32.const 0
    i32.const 1088
    i32.const 116
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -8309,7 +8309,7 @@
    i32.const 0
    i32.const 1088
    i32.const 119
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -8321,7 +8321,7 @@
    i32.const 0
    i32.const 1088
    i32.const 120
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -8333,7 +8333,7 @@
    i32.const 0
    i32.const 1088
    i32.const 121
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -8345,7 +8345,7 @@
    i32.const 0
    i32.const 1088
    i32.const 122
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -8357,7 +8357,7 @@
    i32.const 0
    i32.const 1088
    i32.const 123
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -8369,7 +8369,7 @@
    i32.const 0
    i32.const 1088
    i32.const 124
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -8381,7 +8381,7 @@
    i32.const 0
    i32.const 1088
    i32.const 125
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -8393,7 +8393,7 @@
    i32.const 0
    i32.const 1088
    i32.const 126
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -8405,7 +8405,7 @@
    i32.const 0
    i32.const 1088
    i32.const 127
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -8417,7 +8417,7 @@
    i32.const 0
    i32.const 1088
    i32.const 128
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -8429,7 +8429,7 @@
    i32.const 0
    i32.const 1088
    i32.const 129
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -8441,7 +8441,7 @@
    i32.const 0
    i32.const 1088
    i32.const 130
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -8453,7 +8453,7 @@
    i32.const 0
    i32.const 1088
    i32.const 131
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -8465,7 +8465,7 @@
    i32.const 0
    i32.const 1088
    i32.const 132
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -8477,7 +8477,7 @@
    i32.const 0
    i32.const 1088
    i32.const 133
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -8489,7 +8489,7 @@
    i32.const 0
    i32.const 1088
    i32.const 134
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -8501,7 +8501,7 @@
    i32.const 0
    i32.const 1088
    i32.const 135
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -8513,7 +8513,7 @@
    i32.const 0
    i32.const 1088
    i32.const 136
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -8525,7 +8525,7 @@
    i32.const 0
    i32.const 1088
    i32.const 137
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -8538,7 +8538,7 @@
    i32.const 0
    i32.const 1088
    i32.const 138
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -8550,7 +8550,7 @@
    i32.const 0
    i32.const 1088
    i32.const 141
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -8562,7 +8562,7 @@
    i32.const 0
    i32.const 1088
    i32.const 142
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -8574,7 +8574,7 @@
    i32.const 0
    i32.const 1088
    i32.const 143
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -8586,7 +8586,7 @@
    i32.const 0
    i32.const 1088
    i32.const 144
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -8598,7 +8598,7 @@
    i32.const 0
    i32.const 1088
    i32.const 145
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -8610,7 +8610,7 @@
    i32.const 0
    i32.const 1088
    i32.const 146
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -8622,7 +8622,7 @@
    i32.const 0
    i32.const 1088
    i32.const 147
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -8634,7 +8634,7 @@
    i32.const 0
    i32.const 1088
    i32.const 148
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -8646,7 +8646,7 @@
    i32.const 0
    i32.const 1088
    i32.const 150
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -8658,7 +8658,7 @@
    i32.const 0
    i32.const 1088
    i32.const 151
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -8670,7 +8670,7 @@
    i32.const 0
    i32.const 1088
    i32.const 154
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -8682,7 +8682,7 @@
    i32.const 0
    i32.const 1088
    i32.const 155
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -8694,7 +8694,7 @@
    i32.const 0
    i32.const 1088
    i32.const 156
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -8706,7 +8706,7 @@
    i32.const 0
    i32.const 1088
    i32.const 157
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -8718,7 +8718,7 @@
    i32.const 0
    i32.const 1088
    i32.const 158
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -8730,7 +8730,7 @@
    i32.const 0
    i32.const 1088
    i32.const 159
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -8742,7 +8742,7 @@
    i32.const 0
    i32.const 1088
    i32.const 160
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -8754,7 +8754,7 @@
    i32.const 0
    i32.const 1088
    i32.const 161
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -8766,7 +8766,7 @@
    i32.const 0
    i32.const 1088
    i32.const 162
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -8778,7 +8778,7 @@
    i32.const 0
    i32.const 1088
    i32.const 163
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -8790,7 +8790,7 @@
    i32.const 0
    i32.const 1088
    i32.const 164
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -8802,7 +8802,7 @@
    i32.const 0
    i32.const 1088
    i32.const 165
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -8814,7 +8814,7 @@
    i32.const 0
    i32.const 1088
    i32.const 166
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -8826,7 +8826,7 @@
    i32.const 0
    i32.const 1088
    i32.const 167
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -8838,7 +8838,7 @@
    i32.const 0
    i32.const 1088
    i32.const 168
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -8850,7 +8850,7 @@
    i32.const 0
    i32.const 1088
    i32.const 169
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -8862,7 +8862,7 @@
    i32.const 0
    i32.const 1088
    i32.const 170
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -8874,7 +8874,7 @@
    i32.const 0
    i32.const 1088
    i32.const 171
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -8886,7 +8886,7 @@
    i32.const 0
    i32.const 1088
    i32.const 172
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -8898,7 +8898,7 @@
    i32.const 0
    i32.const 1088
    i32.const 173
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -8910,7 +8910,7 @@
    i32.const 0
    i32.const 1088
    i32.const 174
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -8922,7 +8922,7 @@
    i32.const 0
    i32.const 1088
    i32.const 175
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -8934,7 +8934,7 @@
    i32.const 0
    i32.const 1088
    i32.const 176
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -8946,7 +8946,7 @@
    i32.const 0
    i32.const 1088
    i32.const 177
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -8958,7 +8958,7 @@
    i32.const 0
    i32.const 1088
    i32.const 178
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -8970,7 +8970,7 @@
    i32.const 0
    i32.const 1088
    i32.const 179
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -8982,7 +8982,7 @@
    i32.const 0
    i32.const 1088
    i32.const 180
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -8994,7 +8994,7 @@
    i32.const 0
    i32.const 1088
    i32.const 181
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -9006,7 +9006,7 @@
    i32.const 0
    i32.const 1088
    i32.const 182
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -9018,7 +9018,7 @@
    i32.const 0
    i32.const 1088
    i32.const 183
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -9030,7 +9030,7 @@
    i32.const 0
    i32.const 1088
    i32.const 184
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -9042,7 +9042,7 @@
    i32.const 0
    i32.const 1088
    i32.const 185
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -9054,7 +9054,7 @@
    i32.const 0
    i32.const 1088
    i32.const 186
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -9066,7 +9066,7 @@
    i32.const 0
    i32.const 1088
    i32.const 187
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -9078,7 +9078,7 @@
    i32.const 0
    i32.const 1088
    i32.const 188
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -9090,7 +9090,7 @@
    i32.const 0
    i32.const 1088
    i32.const 189
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -9102,7 +9102,7 @@
    i32.const 0
    i32.const 1088
    i32.const 190
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -9114,7 +9114,7 @@
    i32.const 0
    i32.const 1088
    i32.const 191
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -9126,7 +9126,7 @@
    i32.const 0
    i32.const 1088
    i32.const 192
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -9138,7 +9138,7 @@
    i32.const 0
    i32.const 1088
    i32.const 193
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -9150,7 +9150,7 @@
    i32.const 0
    i32.const 1088
    i32.const 194
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -9162,7 +9162,7 @@
    i32.const 0
    i32.const 1088
    i32.const 195
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -9174,7 +9174,7 @@
    i32.const 0
    i32.const 1088
    i32.const 196
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -9187,7 +9187,7 @@
    i32.const 0
    i32.const 1088
    i32.const 197
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -9200,7 +9200,7 @@
    i32.const 0
    i32.const 1088
    i32.const 198
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -9213,7 +9213,7 @@
    i32.const 0
    i32.const 1088
    i32.const 199
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -9226,7 +9226,7 @@
    i32.const 0
    i32.const 1088
    i32.const 200
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -9239,7 +9239,7 @@
    i32.const 0
    i32.const 1088
    i32.const 201
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -9252,7 +9252,7 @@
    i32.const 0
    i32.const 1088
    i32.const 202
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -9265,7 +9265,7 @@
    i32.const 0
    i32.const 1088
    i32.const 203
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -9278,7 +9278,7 @@
    i32.const 0
    i32.const 1088
    i32.const 204
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -9291,7 +9291,7 @@
    i32.const 0
    i32.const 1088
    i32.const 205
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -9304,7 +9304,7 @@
    i32.const 0
    i32.const 1088
    i32.const 206
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -9317,7 +9317,7 @@
    i32.const 0
    i32.const 1088
    i32.const 207
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -9330,7 +9330,7 @@
    i32.const 0
    i32.const 1088
    i32.const 208
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -9343,7 +9343,7 @@
    i32.const 0
    i32.const 1088
    i32.const 209
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -9356,7 +9356,7 @@
    i32.const 0
    i32.const 1088
    i32.const 210
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -9369,7 +9369,7 @@
    i32.const 0
    i32.const 1088
    i32.const 211
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -9382,7 +9382,7 @@
    i32.const 0
    i32.const 1088
    i32.const 212
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -9394,7 +9394,7 @@
    i32.const 0
    i32.const 1088
    i32.const 213
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -9406,7 +9406,7 @@
    i32.const 0
    i32.const 1088
    i32.const 214
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -9418,7 +9418,7 @@
    i32.const 0
    i32.const 1088
    i32.const 215
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -9430,7 +9430,7 @@
    i32.const 0
    i32.const 1088
    i32.const 216
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -9442,7 +9442,7 @@
    i32.const 0
    i32.const 1088
    i32.const 217
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -9454,7 +9454,7 @@
    i32.const 0
    i32.const 1088
    i32.const 218
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -9466,7 +9466,7 @@
    i32.const 0
    i32.const 1088
    i32.const 219
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -9478,7 +9478,7 @@
    i32.const 0
    i32.const 1088
    i32.const 220
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -9490,7 +9490,7 @@
    i32.const 0
    i32.const 1088
    i32.const 221
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -9502,7 +9502,7 @@
    i32.const 0
    i32.const 1088
    i32.const 222
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -9514,7 +9514,7 @@
    i32.const 0
    i32.const 1088
    i32.const 223
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -9526,7 +9526,7 @@
    i32.const 0
    i32.const 1088
    i32.const 224
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -9538,7 +9538,7 @@
    i32.const 0
    i32.const 1088
    i32.const 225
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -9550,7 +9550,7 @@
    i32.const 0
    i32.const 1088
    i32.const 226
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -9562,7 +9562,7 @@
    i32.const 0
    i32.const 1088
    i32.const 227
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -9574,7 +9574,7 @@
    i32.const 0
    i32.const 1088
    i32.const 228
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -9586,7 +9586,7 @@
    i32.const 0
    i32.const 1088
    i32.const 229
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -9598,7 +9598,7 @@
    i32.const 0
    i32.const 1088
    i32.const 230
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -9610,7 +9610,7 @@
    i32.const 0
    i32.const 1088
    i32.const 231
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -9622,7 +9622,7 @@
    i32.const 0
    i32.const 1088
    i32.const 232
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -9634,7 +9634,7 @@
    i32.const 0
    i32.const 1088
    i32.const 233
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -9646,7 +9646,7 @@
    i32.const 0
    i32.const 1088
    i32.const 234
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -9658,7 +9658,7 @@
    i32.const 0
    i32.const 1088
    i32.const 235
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -9670,7 +9670,7 @@
    i32.const 0
    i32.const 1088
    i32.const 236
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -9682,7 +9682,7 @@
    i32.const 0
    i32.const 1088
    i32.const 237
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -9695,7 +9695,7 @@
    i32.const 0
    i32.const 1088
    i32.const 238
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -9708,7 +9708,7 @@
    i32.const 0
    i32.const 1088
    i32.const 239
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -9721,7 +9721,7 @@
    i32.const 0
    i32.const 1088
    i32.const 240
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -9733,7 +9733,7 @@
    i32.const 0
    i32.const 1088
    i32.const 244
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -9745,7 +9745,7 @@
    i32.const 0
    i32.const 1088
    i32.const 257
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -9757,7 +9757,7 @@
    i32.const 0
    i32.const 1088
    i32.const 261
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -9781,7 +9781,7 @@
    i32.const 0
    i32.const 1088
    i32.const 264
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -9793,7 +9793,7 @@
    i32.const 0
    i32.const 1088
    i32.const 282
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -9805,7 +9805,7 @@
    i32.const 0
    i32.const 1088
    i32.const 283
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -9817,7 +9817,7 @@
    i32.const 0
    i32.const 1088
    i32.const 284
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -9829,7 +9829,7 @@
    i32.const 0
    i32.const 1088
    i32.const 285
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -9841,7 +9841,7 @@
    i32.const 0
    i32.const 1088
    i32.const 286
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -9853,7 +9853,7 @@
    i32.const 0
    i32.const 1088
    i32.const 287
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -9865,7 +9865,7 @@
    i32.const 0
    i32.const 1088
    i32.const 288
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -9877,7 +9877,7 @@
    i32.const 0
    i32.const 1088
    i32.const 289
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -9889,7 +9889,7 @@
    i32.const 0
    i32.const 1088
    i32.const 290
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -9901,7 +9901,7 @@
    i32.const 0
    i32.const 1088
    i32.const 291
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -9913,7 +9913,7 @@
    i32.const 0
    i32.const 1088
    i32.const 292
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -9925,7 +9925,7 @@
    i32.const 0
    i32.const 1088
    i32.const 293
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -9937,7 +9937,7 @@
    i32.const 0
    i32.const 1088
    i32.const 294
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -9949,7 +9949,7 @@
    i32.const 0
    i32.const 1088
    i32.const 295
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -9961,7 +9961,7 @@
    i32.const 0
    i32.const 1088
    i32.const 296
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -9973,7 +9973,7 @@
    i32.const 0
    i32.const 1088
    i32.const 297
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -9985,7 +9985,7 @@
    i32.const 0
    i32.const 1088
    i32.const 298
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -9997,7 +9997,7 @@
    i32.const 0
    i32.const 1088
    i32.const 299
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -10009,7 +10009,7 @@
    i32.const 0
    i32.const 1088
    i32.const 300
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -10021,7 +10021,7 @@
    i32.const 0
    i32.const 1088
    i32.const 301
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -10033,7 +10033,7 @@
    i32.const 0
    i32.const 1088
    i32.const 302
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -10045,7 +10045,7 @@
    i32.const 0
    i32.const 1088
    i32.const 303
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -10057,7 +10057,7 @@
    i32.const 0
    i32.const 1088
    i32.const 304
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -10069,7 +10069,7 @@
    i32.const 0
    i32.const 1088
    i32.const 305
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -10082,7 +10082,7 @@
    i32.const 0
    i32.const 1088
    i32.const 308
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -10094,7 +10094,7 @@
    i32.const 0
    i32.const 1088
    i32.const 309
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -10110,7 +10110,7 @@
    i32.const 0
    i32.const 1088
    i32.const 313
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10120,7 +10120,7 @@
    i32.const 0
    i32.const 1088
    i32.const 314
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10134,7 +10134,7 @@
    i32.const 0
    i32.const 1088
    i32.const 316
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -10145,7 +10145,7 @@
    i32.const 0
    i32.const 1088
    i32.const 317
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -10156,7 +10156,7 @@
    i32.const 0
    i32.const 1088
    i32.const 318
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -10167,7 +10167,7 @@
    i32.const 0
    i32.const 1088
    i32.const 319
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -10179,7 +10179,7 @@
    i32.const 0
    i32.const 1088
    i32.const 320
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -10190,7 +10190,7 @@
    i32.const 0
    i32.const 1088
    i32.const 321
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -10202,7 +10202,7 @@
    i32.const 0
    i32.const 1088
    i32.const 322
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -10213,7 +10213,7 @@
    i32.const 0
    i32.const 1088
    i32.const 323
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -10224,7 +10224,7 @@
    i32.const 0
    i32.const 1088
    i32.const 324
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -10236,7 +10236,7 @@
    i32.const 0
    i32.const 1088
    i32.const 325
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -10247,7 +10247,7 @@
    i32.const 0
    i32.const 1088
    i32.const 326
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -10258,7 +10258,7 @@
    i32.const 0
    i32.const 1088
    i32.const 327
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -10270,7 +10270,7 @@
    i32.const 0
    i32.const 1088
    i32.const 329
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -10282,7 +10282,7 @@
    i32.const 0
    i32.const 1088
    i32.const 330
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -10293,7 +10293,7 @@
    i32.const 0
    i32.const 1088
    i32.const 331
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -10305,7 +10305,7 @@
    i32.const 0
    i32.const 1088
    i32.const 332
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -10316,7 +10316,7 @@
    i32.const 0
    i32.const 1088
    i32.const 333
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -10327,7 +10327,7 @@
    i32.const 0
    i32.const 1088
    i32.const 335
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -10338,7 +10338,7 @@
    i32.const 0
    i32.const 1088
    i32.const 336
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -10350,7 +10350,7 @@
    i32.const 0
    i32.const 1088
    i32.const 338
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -10362,7 +10362,7 @@
    i32.const 0
    i32.const 1088
    i32.const 339
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -10373,7 +10373,7 @@
    i32.const 0
    i32.const 1088
    i32.const 340
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -10384,7 +10384,7 @@
    i32.const 0
    i32.const 1088
    i32.const 341
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -10395,7 +10395,7 @@
    i32.const 0
    i32.const 1088
    i32.const 342
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -10406,7 +10406,7 @@
    i32.const 0
    i32.const 1088
    i32.const 343
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -10417,7 +10417,7 @@
    i32.const 0
    i32.const 1088
    i32.const 344
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -10428,7 +10428,7 @@
    i32.const 0
    i32.const 1088
    i32.const 345
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -10439,7 +10439,7 @@
    i32.const 0
    i32.const 1088
    i32.const 346
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -10450,7 +10450,7 @@
    i32.const 0
    i32.const 1088
    i32.const 347
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -10471,7 +10471,7 @@
    i32.const 0
    i32.const 1088
    i32.const 352
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10491,7 +10491,7 @@
    i32.const 0
    i32.const 1088
    i32.const 355
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -10506,7 +10506,7 @@
    i32.const 0
    i32.const 1088
    i32.const 357
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -10521,7 +10521,7 @@
    i32.const 0
    i32.const 1088
    i32.const 358
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -10536,7 +10536,7 @@
    i32.const 0
    i32.const 1088
    i32.const 359
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -10551,7 +10551,7 @@
    i32.const 0
    i32.const 1088
    i32.const 360
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -10566,7 +10566,7 @@
    i32.const 0
    i32.const 1088
    i32.const 361
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -10581,7 +10581,7 @@
    i32.const 0
    i32.const 1088
    i32.const 362
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -10596,7 +10596,7 @@
    i32.const 0
    i32.const 1088
    i32.const 363
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -10611,7 +10611,7 @@
    i32.const 0
    i32.const 1088
    i32.const 364
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -10626,7 +10626,7 @@
    i32.const 0
    i32.const 1088
    i32.const 365
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -10642,7 +10642,7 @@
    i32.const 0
    i32.const 1088
    i32.const 367
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -10658,7 +10658,7 @@
    i32.const 0
    i32.const 1088
    i32.const 368
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -10674,7 +10674,7 @@
    i32.const 0
    i32.const 1088
    i32.const 369
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -10690,7 +10690,7 @@
    i32.const 0
    i32.const 1088
    i32.const 370
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -10706,7 +10706,7 @@
    i32.const 0
    i32.const 1088
    i32.const 371
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -10722,7 +10722,7 @@
    i32.const 0
    i32.const 1088
    i32.const 372
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -10738,7 +10738,7 @@
    i32.const 0
    i32.const 1088
    i32.const 373
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -10754,7 +10754,7 @@
    i32.const 0
    i32.const 1088
    i32.const 374
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -10770,7 +10770,7 @@
    i32.const 0
    i32.const 1088
    i32.const 375
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -10786,7 +10786,7 @@
    i32.const 0
    i32.const 1088
    i32.const 376
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -10802,7 +10802,7 @@
    i32.const 0
    i32.const 1088
    i32.const 377
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -10818,7 +10818,7 @@
    i32.const 0
    i32.const 1088
    i32.const 378
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -10834,7 +10834,7 @@
    i32.const 0
    i32.const 1088
    i32.const 379
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -10850,7 +10850,7 @@
    i32.const 0
    i32.const 1088
    i32.const 381
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -10866,7 +10866,7 @@
    i32.const 0
    i32.const 1088
    i32.const 382
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -10882,7 +10882,7 @@
    i32.const 0
    i32.const 1088
    i32.const 384
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -10898,7 +10898,7 @@
    i32.const 0
    i32.const 1088
    i32.const 385
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -10914,7 +10914,7 @@
    i32.const 0
    i32.const 1088
    i32.const 386
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -10930,7 +10930,7 @@
    i32.const 0
    i32.const 1088
    i32.const 387
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -10946,7 +10946,7 @@
    i32.const 0
    i32.const 1088
    i32.const 388
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -10962,7 +10962,7 @@
    i32.const 0
    i32.const 1088
    i32.const 389
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -10978,7 +10978,7 @@
    i32.const 0
    i32.const 1088
    i32.const 390
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -10994,7 +10994,7 @@
    i32.const 0
    i32.const 1088
    i32.const 391
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11010,7 +11010,7 @@
    i32.const 0
    i32.const 1088
    i32.const 392
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11026,7 +11026,7 @@
    i32.const 0
    i32.const 1088
    i32.const 393
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11042,7 +11042,7 @@
    i32.const 0
    i32.const 1088
    i32.const 394
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11058,7 +11058,7 @@
    i32.const 0
    i32.const 1088
    i32.const 396
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11074,7 +11074,7 @@
    i32.const 0
    i32.const 1088
    i32.const 397
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11090,7 +11090,7 @@
    i32.const 0
    i32.const 1088
    i32.const 398
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11106,7 +11106,7 @@
    i32.const 0
    i32.const 1088
    i32.const 399
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11122,7 +11122,7 @@
    i32.const 0
    i32.const 1088
    i32.const 400
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11138,7 +11138,7 @@
    i32.const 0
    i32.const 1088
    i32.const 401
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11154,7 +11154,7 @@
    i32.const 0
    i32.const 1088
    i32.const 402
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11170,7 +11170,7 @@
    i32.const 0
    i32.const 1088
    i32.const 403
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11190,7 +11190,7 @@
    i32.const 0
    i32.const 1088
    i32.const 407
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11206,7 +11206,7 @@
    i32.const 0
    i32.const 1088
    i32.const 408
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11222,7 +11222,7 @@
    i32.const 0
    i32.const 1088
    i32.const 409
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11238,7 +11238,7 @@
    i32.const 0
    i32.const 1088
    i32.const 410
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11254,7 +11254,7 @@
    i32.const 0
    i32.const 1088
    i32.const 411
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11270,7 +11270,7 @@
    i32.const 0
    i32.const 1088
    i32.const 412
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11286,7 +11286,7 @@
    i32.const 0
    i32.const 1088
    i32.const 413
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11302,7 +11302,7 @@
    i32.const 0
    i32.const 1088
    i32.const 415
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11318,7 +11318,7 @@
    i32.const 0
    i32.const 1088
    i32.const 416
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11334,7 +11334,7 @@
    i32.const 0
    i32.const 1088
    i32.const 417
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11350,7 +11350,7 @@
    i32.const 0
    i32.const 1088
    i32.const 418
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11366,7 +11366,7 @@
    i32.const 0
    i32.const 1088
    i32.const 419
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11382,7 +11382,7 @@
    i32.const 0
    i32.const 1088
    i32.const 420
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11398,7 +11398,7 @@
    i32.const 0
    i32.const 1088
    i32.const 421
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11414,7 +11414,7 @@
    i32.const 0
    i32.const 1088
    i32.const 422
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11430,7 +11430,7 @@
    i32.const 0
    i32.const 1088
    i32.const 423
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11446,7 +11446,7 @@
    i32.const 0
    i32.const 1088
    i32.const 424
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11462,7 +11462,7 @@
    i32.const 0
    i32.const 1088
    i32.const 426
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11478,7 +11478,7 @@
    i32.const 0
    i32.const 1088
    i32.const 427
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11494,7 +11494,7 @@
    i32.const 0
    i32.const 1088
    i32.const 428
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11510,7 +11510,7 @@
    i32.const 0
    i32.const 1088
    i32.const 429
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11526,7 +11526,7 @@
    i32.const 0
    i32.const 1088
    i32.const 430
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11542,7 +11542,7 @@
    i32.const 0
    i32.const 1088
    i32.const 431
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11558,7 +11558,7 @@
    i32.const 0
    i32.const 1088
    i32.const 432
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11574,7 +11574,7 @@
    i32.const 0
    i32.const 1088
    i32.const 433
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11590,7 +11590,7 @@
    i32.const 0
    i32.const 1088
    i32.const 434
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11606,7 +11606,7 @@
    i32.const 0
    i32.const 1088
    i32.const 435
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11635,7 +11635,7 @@
    i32.const 0
    i32.const 1088
    i32.const 441
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11652,7 +11652,7 @@
    i32.const 0
    i32.const 1088
    i32.const 443
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11684,7 +11684,7 @@
    i32.const 0
    i32.const 1088
    i32.const 445
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11716,7 +11716,7 @@
    i32.const 0
    i32.const 1088
    i32.const 447
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11772,7 +11772,7 @@
    i32.const 0
    i32.const 1088
    i32.const 449
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11828,7 +11828,7 @@
    i32.const 0
    i32.const 1088
    i32.const 451
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11896,7 +11896,7 @@
    i32.const 0
    i32.const 1088
    i32.const 453
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11964,7 +11964,7 @@
    i32.const 0
    i32.const 1088
    i32.const 455
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12032,7 +12032,7 @@
    i32.const 0
    i32.const 1088
    i32.const 457
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12088,7 +12088,7 @@
    i32.const 0
    i32.const 1088
    i32.const 459
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12105,7 +12105,7 @@
    i32.const 0
    i32.const 1088
    i32.const 461
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12137,7 +12137,7 @@
    i32.const 0
    i32.const 1088
    i32.const 463
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12169,7 +12169,7 @@
    i32.const 0
    i32.const 1088
    i32.const 465
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12225,7 +12225,7 @@
    i32.const 0
    i32.const 1088
    i32.const 467
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12281,7 +12281,7 @@
    i32.const 0
    i32.const 1088
    i32.const 469
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12337,7 +12337,7 @@
    i32.const 0
    i32.const 1088
    i32.const 471
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12353,7 +12353,7 @@
    i32.const 0
    i32.const 1088
    i32.const 474
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12367,7 +12367,7 @@
    i32.const 0
    i32.const 1088
    i32.const 475
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12381,7 +12381,7 @@
    i32.const 0
    i32.const 1088
    i32.const 476
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12395,7 +12395,7 @@
    i32.const 0
    i32.const 1088
    i32.const 477
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12409,7 +12409,7 @@
    i32.const 0
    i32.const 1088
    i32.const 478
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12423,7 +12423,7 @@
    i32.const 0
    i32.const 1088
    i32.const 479
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12437,7 +12437,7 @@
    i32.const 0
    i32.const 1088
    i32.const 480
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12451,7 +12451,7 @@
    i32.const 0
    i32.const 1088
    i32.const 481
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12465,7 +12465,7 @@
    i32.const 0
    i32.const 1088
    i32.const 482
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12479,7 +12479,7 @@
    i32.const 0
    i32.const 1088
    i32.const 483
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12493,7 +12493,7 @@
    i32.const 0
    i32.const 1088
    i32.const 484
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12507,7 +12507,7 @@
    i32.const 0
    i32.const 1088
    i32.const 485
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12521,7 +12521,7 @@
    i32.const 0
    i32.const 1088
    i32.const 486
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12535,7 +12535,7 @@
    i32.const 0
    i32.const 1088
    i32.const 487
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12549,7 +12549,7 @@
    i32.const 0
    i32.const 1088
    i32.const 488
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12563,7 +12563,7 @@
    i32.const 0
    i32.const 1088
    i32.const 489
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12577,7 +12577,7 @@
    i32.const 0
    i32.const 1088
    i32.const 490
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12591,7 +12591,7 @@
    i32.const 0
    i32.const 1088
    i32.const 492
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12605,7 +12605,7 @@
    i32.const 0
    i32.const 1088
    i32.const 493
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12619,7 +12619,7 @@
    i32.const 0
    i32.const 1088
    i32.const 494
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12633,7 +12633,7 @@
    i32.const 0
    i32.const 1088
    i32.const 495
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12647,7 +12647,7 @@
    i32.const 0
    i32.const 1088
    i32.const 496
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12661,7 +12661,7 @@
    i32.const 0
    i32.const 1088
    i32.const 498
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12675,7 +12675,7 @@
    i32.const 0
    i32.const 1088
    i32.const 499
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12689,7 +12689,7 @@
    i32.const 0
    i32.const 1088
    i32.const 500
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12703,7 +12703,7 @@
    i32.const 0
    i32.const 1088
    i32.const 501
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12717,7 +12717,7 @@
    i32.const 0
    i32.const 1088
    i32.const 502
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12731,7 +12731,7 @@
    i32.const 0
    i32.const 1088
    i32.const 503
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12745,7 +12745,7 @@
    i32.const 0
    i32.const 1088
    i32.const 504
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12759,7 +12759,7 @@
    i32.const 0
    i32.const 1088
    i32.const 505
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12773,7 +12773,7 @@
    i32.const 0
    i32.const 1088
    i32.const 506
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12787,7 +12787,7 @@
    i32.const 0
    i32.const 1088
    i32.const 507
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12801,7 +12801,7 @@
    i32.const 0
    i32.const 1088
    i32.const 508
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12815,7 +12815,7 @@
    i32.const 0
    i32.const 1088
    i32.const 509
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12829,7 +12829,7 @@
    i32.const 0
    i32.const 1088
    i32.const 510
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12843,7 +12843,7 @@
    i32.const 0
    i32.const 1088
    i32.const 511
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12857,7 +12857,7 @@
    i32.const 0
    i32.const 1088
    i32.const 512
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12871,7 +12871,7 @@
    i32.const 0
    i32.const 1088
    i32.const 513
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12885,7 +12885,7 @@
    i32.const 0
    i32.const 1088
    i32.const 514
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12899,7 +12899,7 @@
    i32.const 0
    i32.const 1088
    i32.const 515
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12913,7 +12913,7 @@
    i32.const 0
    i32.const 1088
    i32.const 516
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12927,7 +12927,7 @@
    i32.const 0
    i32.const 1088
    i32.const 517
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12941,7 +12941,7 @@
    i32.const 0
    i32.const 1088
    i32.const 518
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12955,7 +12955,7 @@
    i32.const 0
    i32.const 1088
    i32.const 520
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12969,7 +12969,7 @@
    i32.const 0
    i32.const 1088
    i32.const 521
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12983,7 +12983,7 @@
    i32.const 0
    i32.const 1088
    i32.const 522
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12997,7 +12997,7 @@
    i32.const 0
    i32.const 1088
    i32.const 523
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13011,7 +13011,7 @@
    i32.const 0
    i32.const 1088
    i32.const 524
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13025,7 +13025,7 @@
    i32.const 0
    i32.const 1088
    i32.const 525
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13039,7 +13039,7 @@
    i32.const 0
    i32.const 1088
    i32.const 526
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13053,7 +13053,7 @@
    i32.const 0
    i32.const 1088
    i32.const 527
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13067,7 +13067,7 @@
    i32.const 0
    i32.const 1088
    i32.const 528
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13081,7 +13081,7 @@
    i32.const 0
    i32.const 1088
    i32.const 529
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13095,7 +13095,7 @@
    i32.const 0
    i32.const 1088
    i32.const 530
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13109,7 +13109,7 @@
    i32.const 0
    i32.const 1088
    i32.const 531
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13123,7 +13123,7 @@
    i32.const 0
    i32.const 1088
    i32.const 534
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13137,7 +13137,7 @@
    i32.const 0
    i32.const 1088
    i32.const 535
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13151,7 +13151,7 @@
    i32.const 0
    i32.const 1088
    i32.const 536
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13165,7 +13165,7 @@
    i32.const 0
    i32.const 1088
    i32.const 537
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13179,7 +13179,7 @@
    i32.const 0
    i32.const 1088
    i32.const 538
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13193,7 +13193,7 @@
    i32.const 0
    i32.const 1088
    i32.const 539
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13207,7 +13207,7 @@
    i32.const 0
    i32.const 1088
    i32.const 540
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13221,7 +13221,7 @@
    i32.const 0
    i32.const 1088
    i32.const 541
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13235,7 +13235,7 @@
    i32.const 0
    i32.const 1088
    i32.const 542
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13249,7 +13249,7 @@
    i32.const 0
    i32.const 1088
    i32.const 543
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13263,7 +13263,7 @@
    i32.const 0
    i32.const 1088
    i32.const 544
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13277,7 +13277,7 @@
    i32.const 0
    i32.const 1088
    i32.const 547
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13291,7 +13291,7 @@
    i32.const 0
    i32.const 1088
    i32.const 548
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13305,7 +13305,7 @@
    i32.const 0
    i32.const 1088
    i32.const 549
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13319,7 +13319,7 @@
    i32.const 0
    i32.const 1088
    i32.const 550
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13333,7 +13333,7 @@
    i32.const 0
    i32.const 1088
    i32.const 551
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13347,7 +13347,7 @@
    i32.const 0
    i32.const 1088
    i32.const 557
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13361,7 +13361,7 @@
    i32.const 0
    i32.const 1088
    i32.const 558
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13375,7 +13375,7 @@
    i32.const 0
    i32.const 1088
    i32.const 559
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13389,7 +13389,7 @@
    i32.const 0
    i32.const 1088
    i32.const 560
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13403,7 +13403,7 @@
    i32.const 0
    i32.const 1088
    i32.const 562
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13417,7 +13417,7 @@
    i32.const 0
    i32.const 1088
    i32.const 563
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13431,7 +13431,7 @@
    i32.const 0
    i32.const 1088
    i32.const 564
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13445,7 +13445,7 @@
    i32.const 0
    i32.const 1088
    i32.const 565
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13459,7 +13459,7 @@
    i32.const 0
    i32.const 1088
    i32.const 566
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13473,7 +13473,7 @@
    i32.const 0
    i32.const 1088
    i32.const 567
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13487,7 +13487,7 @@
    i32.const 0
    i32.const 1088
    i32.const 569
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13501,7 +13501,7 @@
    i32.const 0
    i32.const 1088
    i32.const 570
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13515,7 +13515,7 @@
    i32.const 0
    i32.const 1088
    i32.const 571
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13529,7 +13529,7 @@
    i32.const 0
    i32.const 1088
    i32.const 572
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13543,7 +13543,7 @@
    i32.const 0
    i32.const 1088
    i32.const 573
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13557,7 +13557,7 @@
    i32.const 0
    i32.const 1088
    i32.const 574
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13571,7 +13571,7 @@
    i32.const 0
    i32.const 1088
    i32.const 575
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13585,7 +13585,7 @@
    i32.const 0
    i32.const 1088
    i32.const 576
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13599,7 +13599,7 @@
    i32.const 0
    i32.const 1088
    i32.const 577
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13613,7 +13613,7 @@
    i32.const 0
    i32.const 1088
    i32.const 579
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13627,7 +13627,7 @@
    i32.const 0
    i32.const 1088
    i32.const 580
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13641,7 +13641,7 @@
    i32.const 0
    i32.const 1088
    i32.const 582
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13655,7 +13655,7 @@
    i32.const 0
    i32.const 1088
    i32.const 583
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13669,7 +13669,7 @@
    i32.const 0
    i32.const 1088
    i32.const 584
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13683,7 +13683,7 @@
    i32.const 0
    i32.const 1088
    i32.const 585
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13697,7 +13697,7 @@
    i32.const 0
    i32.const 1088
    i32.const 587
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13711,7 +13711,7 @@
    i32.const 0
    i32.const 1088
    i32.const 588
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13725,7 +13725,7 @@
    i32.const 0
    i32.const 1088
    i32.const 589
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13739,7 +13739,7 @@
    i32.const 0
    i32.const 1088
    i32.const 590
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13753,7 +13753,7 @@
    i32.const 0
    i32.const 1088
    i32.const 591
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13767,7 +13767,7 @@
    i32.const 0
    i32.const 1088
    i32.const 592
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13781,7 +13781,7 @@
    i32.const 0
    i32.const 1088
    i32.const 593
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13795,7 +13795,7 @@
    i32.const 0
    i32.const 1088
    i32.const 594
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13809,7 +13809,7 @@
    i32.const 0
    i32.const 1088
    i32.const 595
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14274,7 +14274,7 @@
    i32.const 0
    i32.const 1168
    i32.const 122
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -14352,7 +14352,7 @@
     i32.const 0
     i32.const 1168
     i32.const 126
-    i32.const 17
+    i32.const 18
     call $~lib/builtins/abort
     unreachable
    end
@@ -14367,7 +14367,7 @@
     i32.const 0
     i32.const 1168
     i32.const 136
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end

--- a/tests/compiler/std/string.untouched.wat
+++ b/tests/compiler/std/string.untouched.wat
@@ -426,7 +426,7 @@
    i32.const 0
    i32.const 160
    i32.const 109
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -447,7 +447,7 @@
    i32.const 0
    i32.const 160
    i32.const 112
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -736,7 +736,7 @@
    i32.const 0
    i32.const 352
    i32.const 277
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -761,7 +761,7 @@
    i32.const 0
    i32.const 352
    i32.const 279
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -813,7 +813,7 @@
    i32.const 0
    i32.const 352
    i32.const 292
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -943,7 +943,7 @@
    i32.const 0
    i32.const 352
    i32.const 205
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -958,7 +958,7 @@
    i32.const 0
    i32.const 352
    i32.const 207
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1051,7 +1051,7 @@
     i32.const 0
     i32.const 352
     i32.const 228
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -1114,7 +1114,7 @@
    i32.const 0
    i32.const 352
    i32.const 243
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1130,7 +1130,7 @@
    i32.const 0
    i32.const 352
    i32.const 244
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1187,7 +1187,7 @@
    i32.const 0
    i32.const 352
    i32.const 260
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1306,7 +1306,7 @@
    i32.const 0
    i32.const 352
    i32.const 386
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -1329,7 +1329,7 @@
     i32.const 0
     i32.const 352
     i32.const 396
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -1360,7 +1360,7 @@
     i32.const 0
     i32.const 352
     i32.const 408
-    i32.const 4
+    i32.const 5
     call $~lib/builtins/abort
     unreachable
    end
@@ -1586,7 +1586,7 @@
    i32.const 400
    i32.const 352
    i32.const 461
-   i32.const 29
+   i32.const 30
    call $~lib/builtins/abort
    unreachable
   end
@@ -1680,7 +1680,7 @@
    i32.const 0
    i32.const 352
    i32.const 338
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1743,7 +1743,7 @@
      i32.const 0
      i32.const 352
      i32.const 351
-     i32.const 17
+     i32.const 18
      call $~lib/builtins/abort
      unreachable
     end
@@ -1888,7 +1888,7 @@
    i32.const 0
    i32.const 352
    i32.const 365
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1977,7 +1977,7 @@
    i32.const 0
    i32.const 352
    i32.const 501
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -2018,7 +2018,7 @@
       i32.const 0
       i32.const 352
       i32.const 513
-      i32.const 19
+      i32.const 20
       call $~lib/builtins/abort
       unreachable
      end
@@ -2037,7 +2037,7 @@
      i32.const 0
      i32.const 352
      i32.const 518
-     i32.const 17
+     i32.const 18
      call $~lib/builtins/abort
      unreachable
     end
@@ -2054,7 +2054,7 @@
    i32.const 0
    i32.const 352
    i32.const 521
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -2146,7 +2146,7 @@
    i32.const 0
    i32.const 528
    i32.const 33
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -6913,7 +6913,7 @@
    i32.const 10896
    i32.const 528
    i32.const 322
-   i32.const 6
+   i32.const 7
    call $~lib/builtins/abort
    unreachable
   end
@@ -7128,7 +7128,7 @@
    i32.const 0
    i32.const 352
    i32.const 581
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -8195,7 +8195,7 @@
     i32.const 10896
     i32.const 12160
     i32.const 14
-    i32.const 47
+    i32.const 48
     call $~lib/builtins/abort
     unreachable
    end
@@ -8600,7 +8600,7 @@
    i32.const 12208
    i32.const 12160
    i32.const 104
-   i32.const 41
+   i32.const 42
    call $~lib/builtins/abort
    unreachable
   end
@@ -8616,7 +8616,7 @@
    i32.const 12272
    i32.const 12160
    i32.const 108
-   i32.const 39
+   i32.const 40
    call $~lib/builtins/abort
    unreachable
   end
@@ -10776,7 +10776,7 @@
    i32.const 0
    i32.const 80
    i32.const 8
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -10788,7 +10788,7 @@
    i32.const 0
    i32.const 80
    i32.const 10
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -10800,7 +10800,7 @@
    i32.const 0
    i32.const 80
    i32.const 11
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -10812,7 +10812,7 @@
    i32.const 0
    i32.const 80
    i32.const 12
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -10825,7 +10825,7 @@
    i32.const 0
    i32.const 80
    i32.const 14
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -10839,7 +10839,7 @@
    i32.const 0
    i32.const 80
    i32.const 15
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -10853,7 +10853,7 @@
    i32.const 0
    i32.const 80
    i32.const 17
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -10867,7 +10867,7 @@
    i32.const 0
    i32.const 80
    i32.const 18
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -10881,7 +10881,7 @@
    i32.const 0
    i32.const 80
    i32.const 19
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -10898,7 +10898,7 @@
    i32.const 0
    i32.const 80
    i32.const 21
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -10915,7 +10915,7 @@
    i32.const 0
    i32.const 80
    i32.const 22
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -10932,7 +10932,7 @@
    i32.const 0
    i32.const 80
    i32.const 23
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -10947,7 +10947,7 @@
    i32.const 0
    i32.const 80
    i32.const 24
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -10961,7 +10961,7 @@
    i32.const 0
    i32.const 80
    i32.const 26
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -10975,7 +10975,7 @@
    i32.const 0
    i32.const 80
    i32.const 27
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -10989,7 +10989,7 @@
    i32.const 0
    i32.const 80
    i32.const 28
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11002,7 +11002,7 @@
    i32.const 0
    i32.const 80
    i32.const 30
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11015,7 +11015,7 @@
    i32.const 0
    i32.const 80
    i32.const 31
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11028,7 +11028,7 @@
    i32.const 0
    i32.const 80
    i32.const 32
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11044,7 +11044,7 @@
    i32.const 0
    i32.const 80
    i32.const 34
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11060,7 +11060,7 @@
    i32.const 0
    i32.const 80
    i32.const 35
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11076,7 +11076,7 @@
    i32.const 0
    i32.const 80
    i32.const 36
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11092,7 +11092,7 @@
    i32.const 0
    i32.const 80
    i32.const 37
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11108,7 +11108,7 @@
    i32.const 0
    i32.const 80
    i32.const 38
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11124,7 +11124,7 @@
    i32.const 0
    i32.const 80
    i32.const 39
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11140,7 +11140,7 @@
    i32.const 0
    i32.const 80
    i32.const 40
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11156,7 +11156,7 @@
    i32.const 0
    i32.const 80
    i32.const 41
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11172,7 +11172,7 @@
    i32.const 0
    i32.const 80
    i32.const 43
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11188,7 +11188,7 @@
    i32.const 0
    i32.const 80
    i32.const 44
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11204,7 +11204,7 @@
    i32.const 0
    i32.const 80
    i32.const 45
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11220,7 +11220,7 @@
    i32.const 0
    i32.const 80
    i32.const 46
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11236,7 +11236,7 @@
    i32.const 0
    i32.const 80
    i32.const 47
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11252,7 +11252,7 @@
    i32.const 0
    i32.const 80
    i32.const 48
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11268,7 +11268,7 @@
    i32.const 0
    i32.const 80
    i32.const 49
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11284,7 +11284,7 @@
    i32.const 0
    i32.const 80
    i32.const 50
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11299,7 +11299,7 @@
    i32.const 0
    i32.const 80
    i32.const 52
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11314,7 +11314,7 @@
    i32.const 0
    i32.const 80
    i32.const 53
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11329,7 +11329,7 @@
    i32.const 0
    i32.const 80
    i32.const 54
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11344,7 +11344,7 @@
    i32.const 0
    i32.const 80
    i32.const 55
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11359,7 +11359,7 @@
    i32.const 0
    i32.const 80
    i32.const 56
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11374,7 +11374,7 @@
    i32.const 0
    i32.const 80
    i32.const 57
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11389,7 +11389,7 @@
    i32.const 0
    i32.const 80
    i32.const 58
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11404,7 +11404,7 @@
    i32.const 0
    i32.const 80
    i32.const 59
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11419,7 +11419,7 @@
    i32.const 0
    i32.const 80
    i32.const 60
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11434,7 +11434,7 @@
    i32.const 0
    i32.const 80
    i32.const 61
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11449,7 +11449,7 @@
    i32.const 0
    i32.const 80
    i32.const 63
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11464,7 +11464,7 @@
    i32.const 0
    i32.const 80
    i32.const 64
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11480,7 +11480,7 @@
    i32.const 0
    i32.const 80
    i32.const 65
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11495,7 +11495,7 @@
    i32.const 0
    i32.const 80
    i32.const 66
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11510,7 +11510,7 @@
    i32.const 0
    i32.const 80
    i32.const 67
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11525,7 +11525,7 @@
    i32.const 0
    i32.const 80
    i32.const 68
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11540,7 +11540,7 @@
    i32.const 0
    i32.const 80
    i32.const 69
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11555,7 +11555,7 @@
    i32.const 0
    i32.const 80
    i32.const 70
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11570,7 +11570,7 @@
    i32.const 0
    i32.const 80
    i32.const 71
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11585,7 +11585,7 @@
    i32.const 0
    i32.const 80
    i32.const 72
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11600,7 +11600,7 @@
    i32.const 0
    i32.const 80
    i32.const 73
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11614,7 +11614,7 @@
    i32.const 0
    i32.const 80
    i32.const 75
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11628,7 +11628,7 @@
    i32.const 0
    i32.const 80
    i32.const 76
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11642,7 +11642,7 @@
    i32.const 0
    i32.const 80
    i32.const 77
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11656,7 +11656,7 @@
    i32.const 0
    i32.const 80
    i32.const 78
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11670,7 +11670,7 @@
    i32.const 0
    i32.const 80
    i32.const 79
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11684,7 +11684,7 @@
    i32.const 0
    i32.const 80
    i32.const 80
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11698,7 +11698,7 @@
    i32.const 0
    i32.const 80
    i32.const 81
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11712,7 +11712,7 @@
    i32.const 0
    i32.const 80
    i32.const 82
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11726,7 +11726,7 @@
    i32.const 0
    i32.const 80
    i32.const 83
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11740,7 +11740,7 @@
    i32.const 0
    i32.const 80
    i32.const 84
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11754,7 +11754,7 @@
    i32.const 0
    i32.const 80
    i32.const 86
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11768,7 +11768,7 @@
    i32.const 0
    i32.const 80
    i32.const 87
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11782,7 +11782,7 @@
    i32.const 0
    i32.const 80
    i32.const 88
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11796,7 +11796,7 @@
    i32.const 0
    i32.const 80
    i32.const 90
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11810,7 +11810,7 @@
    i32.const 0
    i32.const 80
    i32.const 91
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11824,7 +11824,7 @@
    i32.const 0
    i32.const 80
    i32.const 92
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11838,7 +11838,7 @@
    i32.const 0
    i32.const 80
    i32.const 94
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11852,7 +11852,7 @@
    i32.const 0
    i32.const 80
    i32.const 95
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11866,7 +11866,7 @@
    i32.const 0
    i32.const 80
    i32.const 96
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11880,7 +11880,7 @@
    i32.const 0
    i32.const 80
    i32.const 98
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11894,7 +11894,7 @@
    i32.const 0
    i32.const 80
    i32.const 99
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11908,7 +11908,7 @@
    i32.const 0
    i32.const 80
    i32.const 100
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11922,7 +11922,7 @@
    i32.const 0
    i32.const 80
    i32.const 101
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11936,7 +11936,7 @@
    i32.const 0
    i32.const 80
    i32.const 102
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11950,7 +11950,7 @@
    i32.const 0
    i32.const 80
    i32.const 103
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11964,7 +11964,7 @@
    i32.const 0
    i32.const 80
    i32.const 104
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11978,7 +11978,7 @@
    i32.const 0
    i32.const 80
    i32.const 105
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -11992,7 +11992,7 @@
    i32.const 0
    i32.const 80
    i32.const 106
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12006,7 +12006,7 @@
    i32.const 0
    i32.const 80
    i32.const 107
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12020,7 +12020,7 @@
    i32.const 0
    i32.const 80
    i32.const 108
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12034,7 +12034,7 @@
    i32.const 0
    i32.const 80
    i32.const 109
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12048,7 +12048,7 @@
    i32.const 0
    i32.const 80
    i32.const 110
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12062,7 +12062,7 @@
    i32.const 0
    i32.const 80
    i32.const 112
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12076,7 +12076,7 @@
    i32.const 0
    i32.const 80
    i32.const 113
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12090,7 +12090,7 @@
    i32.const 0
    i32.const 80
    i32.const 115
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12104,7 +12104,7 @@
    i32.const 0
    i32.const 80
    i32.const 116
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12117,7 +12117,7 @@
    i32.const 0
    i32.const 80
    i32.const 119
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12130,7 +12130,7 @@
    i32.const 0
    i32.const 80
    i32.const 120
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12143,7 +12143,7 @@
    i32.const 0
    i32.const 80
    i32.const 121
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12156,7 +12156,7 @@
    i32.const 0
    i32.const 80
    i32.const 122
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12169,7 +12169,7 @@
    i32.const 0
    i32.const 80
    i32.const 123
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12182,7 +12182,7 @@
    i32.const 0
    i32.const 80
    i32.const 124
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12195,7 +12195,7 @@
    i32.const 0
    i32.const 80
    i32.const 125
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12208,7 +12208,7 @@
    i32.const 0
    i32.const 80
    i32.const 126
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12221,7 +12221,7 @@
    i32.const 0
    i32.const 80
    i32.const 127
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12234,7 +12234,7 @@
    i32.const 0
    i32.const 80
    i32.const 128
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12247,7 +12247,7 @@
    i32.const 0
    i32.const 80
    i32.const 129
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12260,7 +12260,7 @@
    i32.const 0
    i32.const 80
    i32.const 130
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12273,7 +12273,7 @@
    i32.const 0
    i32.const 80
    i32.const 131
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12286,7 +12286,7 @@
    i32.const 0
    i32.const 80
    i32.const 132
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12299,7 +12299,7 @@
    i32.const 0
    i32.const 80
    i32.const 133
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12312,7 +12312,7 @@
    i32.const 0
    i32.const 80
    i32.const 134
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12325,7 +12325,7 @@
    i32.const 0
    i32.const 80
    i32.const 135
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12338,7 +12338,7 @@
    i32.const 0
    i32.const 80
    i32.const 136
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12351,7 +12351,7 @@
    i32.const 0
    i32.const 80
    i32.const 137
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12365,7 +12365,7 @@
    i32.const 0
    i32.const 80
    i32.const 138
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12378,7 +12378,7 @@
    i32.const 0
    i32.const 80
    i32.const 141
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12391,7 +12391,7 @@
    i32.const 0
    i32.const 80
    i32.const 142
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12404,7 +12404,7 @@
    i32.const 0
    i32.const 80
    i32.const 143
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12417,7 +12417,7 @@
    i32.const 0
    i32.const 80
    i32.const 144
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12430,7 +12430,7 @@
    i32.const 0
    i32.const 80
    i32.const 145
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12443,7 +12443,7 @@
    i32.const 0
    i32.const 80
    i32.const 146
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12456,7 +12456,7 @@
    i32.const 0
    i32.const 80
    i32.const 147
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12469,7 +12469,7 @@
    i32.const 0
    i32.const 80
    i32.const 148
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12482,7 +12482,7 @@
    i32.const 0
    i32.const 80
    i32.const 150
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12495,7 +12495,7 @@
    i32.const 0
    i32.const 80
    i32.const 151
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12508,7 +12508,7 @@
    i32.const 0
    i32.const 80
    i32.const 154
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12521,7 +12521,7 @@
    i32.const 0
    i32.const 80
    i32.const 155
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12534,7 +12534,7 @@
    i32.const 0
    i32.const 80
    i32.const 156
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12547,7 +12547,7 @@
    i32.const 0
    i32.const 80
    i32.const 157
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12560,7 +12560,7 @@
    i32.const 0
    i32.const 80
    i32.const 158
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12573,7 +12573,7 @@
    i32.const 0
    i32.const 80
    i32.const 159
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12586,7 +12586,7 @@
    i32.const 0
    i32.const 80
    i32.const 160
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12599,7 +12599,7 @@
    i32.const 0
    i32.const 80
    i32.const 161
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12612,7 +12612,7 @@
    i32.const 0
    i32.const 80
    i32.const 162
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12625,7 +12625,7 @@
    i32.const 0
    i32.const 80
    i32.const 163
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12638,7 +12638,7 @@
    i32.const 0
    i32.const 80
    i32.const 164
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12651,7 +12651,7 @@
    i32.const 0
    i32.const 80
    i32.const 165
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12664,7 +12664,7 @@
    i32.const 0
    i32.const 80
    i32.const 166
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12677,7 +12677,7 @@
    i32.const 0
    i32.const 80
    i32.const 167
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12690,7 +12690,7 @@
    i32.const 0
    i32.const 80
    i32.const 168
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12703,7 +12703,7 @@
    i32.const 0
    i32.const 80
    i32.const 169
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12716,7 +12716,7 @@
    i32.const 0
    i32.const 80
    i32.const 170
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12729,7 +12729,7 @@
    i32.const 0
    i32.const 80
    i32.const 171
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12742,7 +12742,7 @@
    i32.const 0
    i32.const 80
    i32.const 172
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12755,7 +12755,7 @@
    i32.const 0
    i32.const 80
    i32.const 173
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12768,7 +12768,7 @@
    i32.const 0
    i32.const 80
    i32.const 174
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12781,7 +12781,7 @@
    i32.const 0
    i32.const 80
    i32.const 175
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12794,7 +12794,7 @@
    i32.const 0
    i32.const 80
    i32.const 176
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12807,7 +12807,7 @@
    i32.const 0
    i32.const 80
    i32.const 177
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12820,7 +12820,7 @@
    i32.const 0
    i32.const 80
    i32.const 178
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12833,7 +12833,7 @@
    i32.const 0
    i32.const 80
    i32.const 179
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12846,7 +12846,7 @@
    i32.const 0
    i32.const 80
    i32.const 180
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12859,7 +12859,7 @@
    i32.const 0
    i32.const 80
    i32.const 181
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12872,7 +12872,7 @@
    i32.const 0
    i32.const 80
    i32.const 182
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12885,7 +12885,7 @@
    i32.const 0
    i32.const 80
    i32.const 183
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12898,7 +12898,7 @@
    i32.const 0
    i32.const 80
    i32.const 184
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12911,7 +12911,7 @@
    i32.const 0
    i32.const 80
    i32.const 185
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12924,7 +12924,7 @@
    i32.const 0
    i32.const 80
    i32.const 186
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12937,7 +12937,7 @@
    i32.const 0
    i32.const 80
    i32.const 187
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12950,7 +12950,7 @@
    i32.const 0
    i32.const 80
    i32.const 188
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12963,7 +12963,7 @@
    i32.const 0
    i32.const 80
    i32.const 189
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12976,7 +12976,7 @@
    i32.const 0
    i32.const 80
    i32.const 190
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -12989,7 +12989,7 @@
    i32.const 0
    i32.const 80
    i32.const 191
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13002,7 +13002,7 @@
    i32.const 0
    i32.const 80
    i32.const 192
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13015,7 +13015,7 @@
    i32.const 0
    i32.const 80
    i32.const 193
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13028,7 +13028,7 @@
    i32.const 0
    i32.const 80
    i32.const 194
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13041,7 +13041,7 @@
    i32.const 0
    i32.const 80
    i32.const 195
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13054,7 +13054,7 @@
    i32.const 0
    i32.const 80
    i32.const 196
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13068,7 +13068,7 @@
    i32.const 0
    i32.const 80
    i32.const 197
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13082,7 +13082,7 @@
    i32.const 0
    i32.const 80
    i32.const 198
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13096,7 +13096,7 @@
    i32.const 0
    i32.const 80
    i32.const 199
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13110,7 +13110,7 @@
    i32.const 0
    i32.const 80
    i32.const 200
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13124,7 +13124,7 @@
    i32.const 0
    i32.const 80
    i32.const 201
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13138,7 +13138,7 @@
    i32.const 0
    i32.const 80
    i32.const 202
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13152,7 +13152,7 @@
    i32.const 0
    i32.const 80
    i32.const 203
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13166,7 +13166,7 @@
    i32.const 0
    i32.const 80
    i32.const 204
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13180,7 +13180,7 @@
    i32.const 0
    i32.const 80
    i32.const 205
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13194,7 +13194,7 @@
    i32.const 0
    i32.const 80
    i32.const 206
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13208,7 +13208,7 @@
    i32.const 0
    i32.const 80
    i32.const 207
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13222,7 +13222,7 @@
    i32.const 0
    i32.const 80
    i32.const 208
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13236,7 +13236,7 @@
    i32.const 0
    i32.const 80
    i32.const 209
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13250,7 +13250,7 @@
    i32.const 0
    i32.const 80
    i32.const 210
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13264,7 +13264,7 @@
    i32.const 0
    i32.const 80
    i32.const 211
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13278,7 +13278,7 @@
    i32.const 0
    i32.const 80
    i32.const 212
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13291,7 +13291,7 @@
    i32.const 0
    i32.const 80
    i32.const 213
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13304,7 +13304,7 @@
    i32.const 0
    i32.const 80
    i32.const 214
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13317,7 +13317,7 @@
    i32.const 0
    i32.const 80
    i32.const 215
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13330,7 +13330,7 @@
    i32.const 0
    i32.const 80
    i32.const 216
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13343,7 +13343,7 @@
    i32.const 0
    i32.const 80
    i32.const 217
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13356,7 +13356,7 @@
    i32.const 0
    i32.const 80
    i32.const 218
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13369,7 +13369,7 @@
    i32.const 0
    i32.const 80
    i32.const 219
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13382,7 +13382,7 @@
    i32.const 0
    i32.const 80
    i32.const 220
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13395,7 +13395,7 @@
    i32.const 0
    i32.const 80
    i32.const 221
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13408,7 +13408,7 @@
    i32.const 0
    i32.const 80
    i32.const 222
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13421,7 +13421,7 @@
    i32.const 0
    i32.const 80
    i32.const 223
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13434,7 +13434,7 @@
    i32.const 0
    i32.const 80
    i32.const 224
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13447,7 +13447,7 @@
    i32.const 0
    i32.const 80
    i32.const 225
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13460,7 +13460,7 @@
    i32.const 0
    i32.const 80
    i32.const 226
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13473,7 +13473,7 @@
    i32.const 0
    i32.const 80
    i32.const 227
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13486,7 +13486,7 @@
    i32.const 0
    i32.const 80
    i32.const 228
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13499,7 +13499,7 @@
    i32.const 0
    i32.const 80
    i32.const 229
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13512,7 +13512,7 @@
    i32.const 0
    i32.const 80
    i32.const 230
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13525,7 +13525,7 @@
    i32.const 0
    i32.const 80
    i32.const 231
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13538,7 +13538,7 @@
    i32.const 0
    i32.const 80
    i32.const 232
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13551,7 +13551,7 @@
    i32.const 0
    i32.const 80
    i32.const 233
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13564,7 +13564,7 @@
    i32.const 0
    i32.const 80
    i32.const 234
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13577,7 +13577,7 @@
    i32.const 0
    i32.const 80
    i32.const 235
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13590,7 +13590,7 @@
    i32.const 0
    i32.const 80
    i32.const 236
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13603,7 +13603,7 @@
    i32.const 0
    i32.const 80
    i32.const 237
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13617,7 +13617,7 @@
    i32.const 0
    i32.const 80
    i32.const 238
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13631,7 +13631,7 @@
    i32.const 0
    i32.const 80
    i32.const 239
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13645,7 +13645,7 @@
    i32.const 0
    i32.const 80
    i32.const 240
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13658,7 +13658,7 @@
    i32.const 0
    i32.const 80
    i32.const 244
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13671,7 +13671,7 @@
    i32.const 0
    i32.const 80
    i32.const 257
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13684,7 +13684,7 @@
    i32.const 0
    i32.const 80
    i32.const 261
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13709,7 +13709,7 @@
    i32.const 0
    i32.const 80
    i32.const 264
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13722,7 +13722,7 @@
    i32.const 0
    i32.const 80
    i32.const 282
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13735,7 +13735,7 @@
    i32.const 0
    i32.const 80
    i32.const 283
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13748,7 +13748,7 @@
    i32.const 0
    i32.const 80
    i32.const 284
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13761,7 +13761,7 @@
    i32.const 0
    i32.const 80
    i32.const 285
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13774,7 +13774,7 @@
    i32.const 0
    i32.const 80
    i32.const 286
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13787,7 +13787,7 @@
    i32.const 0
    i32.const 80
    i32.const 287
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13800,7 +13800,7 @@
    i32.const 0
    i32.const 80
    i32.const 288
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13813,7 +13813,7 @@
    i32.const 0
    i32.const 80
    i32.const 289
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13826,7 +13826,7 @@
    i32.const 0
    i32.const 80
    i32.const 290
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13839,7 +13839,7 @@
    i32.const 0
    i32.const 80
    i32.const 291
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13852,7 +13852,7 @@
    i32.const 0
    i32.const 80
    i32.const 292
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13865,7 +13865,7 @@
    i32.const 0
    i32.const 80
    i32.const 293
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13878,7 +13878,7 @@
    i32.const 0
    i32.const 80
    i32.const 294
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13891,7 +13891,7 @@
    i32.const 0
    i32.const 80
    i32.const 295
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13904,7 +13904,7 @@
    i32.const 0
    i32.const 80
    i32.const 296
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13917,7 +13917,7 @@
    i32.const 0
    i32.const 80
    i32.const 297
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13930,7 +13930,7 @@
    i32.const 0
    i32.const 80
    i32.const 298
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13943,7 +13943,7 @@
    i32.const 0
    i32.const 80
    i32.const 299
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13956,7 +13956,7 @@
    i32.const 0
    i32.const 80
    i32.const 300
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13969,7 +13969,7 @@
    i32.const 0
    i32.const 80
    i32.const 301
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13982,7 +13982,7 @@
    i32.const 0
    i32.const 80
    i32.const 302
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -13995,7 +13995,7 @@
    i32.const 0
    i32.const 80
    i32.const 303
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14008,7 +14008,7 @@
    i32.const 0
    i32.const 80
    i32.const 304
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14021,7 +14021,7 @@
    i32.const 0
    i32.const 80
    i32.const 305
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14035,7 +14035,7 @@
    i32.const 0
    i32.const 80
    i32.const 308
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14048,7 +14048,7 @@
    i32.const 0
    i32.const 80
    i32.const 309
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14066,7 +14066,7 @@
    i32.const 0
    i32.const 80
    i32.const 313
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14078,7 +14078,7 @@
    i32.const 0
    i32.const 80
    i32.const 314
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14094,7 +14094,7 @@
    i32.const 0
    i32.const 80
    i32.const 316
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14106,7 +14106,7 @@
    i32.const 0
    i32.const 80
    i32.const 317
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14118,7 +14118,7 @@
    i32.const 0
    i32.const 80
    i32.const 318
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14130,7 +14130,7 @@
    i32.const 0
    i32.const 80
    i32.const 319
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14142,7 +14142,7 @@
    i32.const 0
    i32.const 80
    i32.const 320
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14154,7 +14154,7 @@
    i32.const 0
    i32.const 80
    i32.const 321
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14166,7 +14166,7 @@
    i32.const 0
    i32.const 80
    i32.const 322
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14178,7 +14178,7 @@
    i32.const 0
    i32.const 80
    i32.const 323
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14190,7 +14190,7 @@
    i32.const 0
    i32.const 80
    i32.const 324
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14202,7 +14202,7 @@
    i32.const 0
    i32.const 80
    i32.const 325
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14214,7 +14214,7 @@
    i32.const 0
    i32.const 80
    i32.const 326
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14226,7 +14226,7 @@
    i32.const 0
    i32.const 80
    i32.const 327
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14238,7 +14238,7 @@
    i32.const 0
    i32.const 80
    i32.const 329
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14250,7 +14250,7 @@
    i32.const 0
    i32.const 80
    i32.const 330
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14262,7 +14262,7 @@
    i32.const 0
    i32.const 80
    i32.const 331
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14274,7 +14274,7 @@
    i32.const 0
    i32.const 80
    i32.const 332
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14287,7 +14287,7 @@
    i32.const 0
    i32.const 80
    i32.const 333
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14300,7 +14300,7 @@
    i32.const 0
    i32.const 80
    i32.const 335
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14313,7 +14313,7 @@
    i32.const 0
    i32.const 80
    i32.const 336
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14325,7 +14325,7 @@
    i32.const 0
    i32.const 80
    i32.const 338
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14337,7 +14337,7 @@
    i32.const 0
    i32.const 80
    i32.const 339
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14349,7 +14349,7 @@
    i32.const 0
    i32.const 80
    i32.const 340
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14361,7 +14361,7 @@
    i32.const 0
    i32.const 80
    i32.const 341
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14374,7 +14374,7 @@
    i32.const 0
    i32.const 80
    i32.const 342
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14387,7 +14387,7 @@
    i32.const 0
    i32.const 80
    i32.const 343
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14400,7 +14400,7 @@
    i32.const 0
    i32.const 80
    i32.const 344
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14413,7 +14413,7 @@
    i32.const 0
    i32.const 80
    i32.const 345
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14425,7 +14425,7 @@
    i32.const 0
    i32.const 80
    i32.const 346
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14437,7 +14437,7 @@
    i32.const 0
    i32.const 80
    i32.const 347
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14462,7 +14462,7 @@
    i32.const 0
    i32.const 80
    i32.const 352
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14485,7 +14485,7 @@
    i32.const 0
    i32.const 80
    i32.const 355
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14500,7 +14500,7 @@
    i32.const 0
    i32.const 80
    i32.const 357
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14515,7 +14515,7 @@
    i32.const 0
    i32.const 80
    i32.const 358
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14530,7 +14530,7 @@
    i32.const 0
    i32.const 80
    i32.const 359
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14545,7 +14545,7 @@
    i32.const 0
    i32.const 80
    i32.const 360
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14560,7 +14560,7 @@
    i32.const 0
    i32.const 80
    i32.const 361
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14575,7 +14575,7 @@
    i32.const 0
    i32.const 80
    i32.const 362
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14590,7 +14590,7 @@
    i32.const 0
    i32.const 80
    i32.const 363
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14605,7 +14605,7 @@
    i32.const 0
    i32.const 80
    i32.const 364
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14620,7 +14620,7 @@
    i32.const 0
    i32.const 80
    i32.const 365
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14636,7 +14636,7 @@
    i32.const 0
    i32.const 80
    i32.const 367
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14652,7 +14652,7 @@
    i32.const 0
    i32.const 80
    i32.const 368
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14668,7 +14668,7 @@
    i32.const 0
    i32.const 80
    i32.const 369
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14684,7 +14684,7 @@
    i32.const 0
    i32.const 80
    i32.const 370
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14700,7 +14700,7 @@
    i32.const 0
    i32.const 80
    i32.const 371
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14716,7 +14716,7 @@
    i32.const 0
    i32.const 80
    i32.const 372
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14732,7 +14732,7 @@
    i32.const 0
    i32.const 80
    i32.const 373
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14748,7 +14748,7 @@
    i32.const 0
    i32.const 80
    i32.const 374
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14764,7 +14764,7 @@
    i32.const 0
    i32.const 80
    i32.const 375
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14780,7 +14780,7 @@
    i32.const 0
    i32.const 80
    i32.const 376
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14796,7 +14796,7 @@
    i32.const 0
    i32.const 80
    i32.const 377
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14812,7 +14812,7 @@
    i32.const 0
    i32.const 80
    i32.const 378
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14828,7 +14828,7 @@
    i32.const 0
    i32.const 80
    i32.const 379
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14844,7 +14844,7 @@
    i32.const 0
    i32.const 80
    i32.const 381
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14860,7 +14860,7 @@
    i32.const 0
    i32.const 80
    i32.const 382
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14876,7 +14876,7 @@
    i32.const 0
    i32.const 80
    i32.const 384
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14892,7 +14892,7 @@
    i32.const 0
    i32.const 80
    i32.const 385
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14908,7 +14908,7 @@
    i32.const 0
    i32.const 80
    i32.const 386
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14924,7 +14924,7 @@
    i32.const 0
    i32.const 80
    i32.const 387
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14940,7 +14940,7 @@
    i32.const 0
    i32.const 80
    i32.const 388
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14956,7 +14956,7 @@
    i32.const 0
    i32.const 80
    i32.const 389
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14972,7 +14972,7 @@
    i32.const 0
    i32.const 80
    i32.const 390
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -14988,7 +14988,7 @@
    i32.const 0
    i32.const 80
    i32.const 391
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15004,7 +15004,7 @@
    i32.const 0
    i32.const 80
    i32.const 392
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15020,7 +15020,7 @@
    i32.const 0
    i32.const 80
    i32.const 393
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15036,7 +15036,7 @@
    i32.const 0
    i32.const 80
    i32.const 394
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15052,7 +15052,7 @@
    i32.const 0
    i32.const 80
    i32.const 396
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15068,7 +15068,7 @@
    i32.const 0
    i32.const 80
    i32.const 397
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15084,7 +15084,7 @@
    i32.const 0
    i32.const 80
    i32.const 398
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15100,7 +15100,7 @@
    i32.const 0
    i32.const 80
    i32.const 399
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15116,7 +15116,7 @@
    i32.const 0
    i32.const 80
    i32.const 400
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15132,7 +15132,7 @@
    i32.const 0
    i32.const 80
    i32.const 401
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15148,7 +15148,7 @@
    i32.const 0
    i32.const 80
    i32.const 402
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15164,7 +15164,7 @@
    i32.const 0
    i32.const 80
    i32.const 403
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15186,7 +15186,7 @@
    i32.const 0
    i32.const 80
    i32.const 407
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15202,7 +15202,7 @@
    i32.const 0
    i32.const 80
    i32.const 408
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15218,7 +15218,7 @@
    i32.const 0
    i32.const 80
    i32.const 409
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15234,7 +15234,7 @@
    i32.const 0
    i32.const 80
    i32.const 410
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15250,7 +15250,7 @@
    i32.const 0
    i32.const 80
    i32.const 411
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15266,7 +15266,7 @@
    i32.const 0
    i32.const 80
    i32.const 412
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15282,7 +15282,7 @@
    i32.const 0
    i32.const 80
    i32.const 413
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15298,7 +15298,7 @@
    i32.const 0
    i32.const 80
    i32.const 415
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15314,7 +15314,7 @@
    i32.const 0
    i32.const 80
    i32.const 416
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15330,7 +15330,7 @@
    i32.const 0
    i32.const 80
    i32.const 417
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15346,7 +15346,7 @@
    i32.const 0
    i32.const 80
    i32.const 418
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15362,7 +15362,7 @@
    i32.const 0
    i32.const 80
    i32.const 419
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15378,7 +15378,7 @@
    i32.const 0
    i32.const 80
    i32.const 420
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15394,7 +15394,7 @@
    i32.const 0
    i32.const 80
    i32.const 421
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15410,7 +15410,7 @@
    i32.const 0
    i32.const 80
    i32.const 422
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15426,7 +15426,7 @@
    i32.const 0
    i32.const 80
    i32.const 423
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15442,7 +15442,7 @@
    i32.const 0
    i32.const 80
    i32.const 424
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15458,7 +15458,7 @@
    i32.const 0
    i32.const 80
    i32.const 426
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15474,7 +15474,7 @@
    i32.const 0
    i32.const 80
    i32.const 427
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15490,7 +15490,7 @@
    i32.const 0
    i32.const 80
    i32.const 428
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15506,7 +15506,7 @@
    i32.const 0
    i32.const 80
    i32.const 429
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15522,7 +15522,7 @@
    i32.const 0
    i32.const 80
    i32.const 430
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15538,7 +15538,7 @@
    i32.const 0
    i32.const 80
    i32.const 431
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15554,7 +15554,7 @@
    i32.const 0
    i32.const 80
    i32.const 432
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15570,7 +15570,7 @@
    i32.const 0
    i32.const 80
    i32.const 433
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15586,7 +15586,7 @@
    i32.const 0
    i32.const 80
    i32.const 434
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15602,7 +15602,7 @@
    i32.const 0
    i32.const 80
    i32.const 435
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -15642,7 +15642,7 @@
    i32.const 0
    i32.const 80
    i32.const 441
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -15664,7 +15664,7 @@
    i32.const 0
    i32.const 80
    i32.const 443
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -15702,7 +15702,7 @@
    i32.const 0
    i32.const 80
    i32.const 445
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -15740,7 +15740,7 @@
    i32.const 0
    i32.const 80
    i32.const 447
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -15810,7 +15810,7 @@
    i32.const 0
    i32.const 80
    i32.const 449
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -15880,7 +15880,7 @@
    i32.const 0
    i32.const 80
    i32.const 451
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -15966,7 +15966,7 @@
    i32.const 0
    i32.const 80
    i32.const 453
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -16052,7 +16052,7 @@
    i32.const 0
    i32.const 80
    i32.const 455
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -16138,7 +16138,7 @@
    i32.const 0
    i32.const 80
    i32.const 457
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -16208,7 +16208,7 @@
    i32.const 0
    i32.const 80
    i32.const 459
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -16230,7 +16230,7 @@
    i32.const 0
    i32.const 80
    i32.const 461
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -16268,7 +16268,7 @@
    i32.const 0
    i32.const 80
    i32.const 463
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -16306,7 +16306,7 @@
    i32.const 0
    i32.const 80
    i32.const 465
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -16376,7 +16376,7 @@
    i32.const 0
    i32.const 80
    i32.const 467
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -16446,7 +16446,7 @@
    i32.const 0
    i32.const 80
    i32.const 469
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -16516,7 +16516,7 @@
    i32.const 0
    i32.const 80
    i32.const 471
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -16532,7 +16532,7 @@
    i32.const 0
    i32.const 80
    i32.const 474
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16546,7 +16546,7 @@
    i32.const 0
    i32.const 80
    i32.const 475
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16560,7 +16560,7 @@
    i32.const 0
    i32.const 80
    i32.const 476
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16574,7 +16574,7 @@
    i32.const 0
    i32.const 80
    i32.const 477
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16588,7 +16588,7 @@
    i32.const 0
    i32.const 80
    i32.const 478
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16602,7 +16602,7 @@
    i32.const 0
    i32.const 80
    i32.const 479
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16616,7 +16616,7 @@
    i32.const 0
    i32.const 80
    i32.const 480
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16630,7 +16630,7 @@
    i32.const 0
    i32.const 80
    i32.const 481
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16644,7 +16644,7 @@
    i32.const 0
    i32.const 80
    i32.const 482
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16658,7 +16658,7 @@
    i32.const 0
    i32.const 80
    i32.const 483
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16672,7 +16672,7 @@
    i32.const 0
    i32.const 80
    i32.const 484
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16686,7 +16686,7 @@
    i32.const 0
    i32.const 80
    i32.const 485
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16700,7 +16700,7 @@
    i32.const 0
    i32.const 80
    i32.const 486
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16714,7 +16714,7 @@
    i32.const 0
    i32.const 80
    i32.const 487
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16728,7 +16728,7 @@
    i32.const 0
    i32.const 80
    i32.const 488
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16742,7 +16742,7 @@
    i32.const 0
    i32.const 80
    i32.const 489
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16756,7 +16756,7 @@
    i32.const 0
    i32.const 80
    i32.const 490
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16770,7 +16770,7 @@
    i32.const 0
    i32.const 80
    i32.const 492
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16784,7 +16784,7 @@
    i32.const 0
    i32.const 80
    i32.const 493
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16798,7 +16798,7 @@
    i32.const 0
    i32.const 80
    i32.const 494
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16812,7 +16812,7 @@
    i32.const 0
    i32.const 80
    i32.const 495
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16826,7 +16826,7 @@
    i32.const 0
    i32.const 80
    i32.const 496
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16840,7 +16840,7 @@
    i32.const 0
    i32.const 80
    i32.const 498
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16854,7 +16854,7 @@
    i32.const 0
    i32.const 80
    i32.const 499
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16868,7 +16868,7 @@
    i32.const 0
    i32.const 80
    i32.const 500
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16882,7 +16882,7 @@
    i32.const 0
    i32.const 80
    i32.const 501
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16896,7 +16896,7 @@
    i32.const 0
    i32.const 80
    i32.const 502
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16910,7 +16910,7 @@
    i32.const 0
    i32.const 80
    i32.const 503
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16924,7 +16924,7 @@
    i32.const 0
    i32.const 80
    i32.const 504
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16938,7 +16938,7 @@
    i32.const 0
    i32.const 80
    i32.const 505
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16952,7 +16952,7 @@
    i32.const 0
    i32.const 80
    i32.const 506
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16966,7 +16966,7 @@
    i32.const 0
    i32.const 80
    i32.const 507
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16980,7 +16980,7 @@
    i32.const 0
    i32.const 80
    i32.const 508
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -16994,7 +16994,7 @@
    i32.const 0
    i32.const 80
    i32.const 509
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17008,7 +17008,7 @@
    i32.const 0
    i32.const 80
    i32.const 510
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17022,7 +17022,7 @@
    i32.const 0
    i32.const 80
    i32.const 511
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17036,7 +17036,7 @@
    i32.const 0
    i32.const 80
    i32.const 512
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17050,7 +17050,7 @@
    i32.const 0
    i32.const 80
    i32.const 513
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17064,7 +17064,7 @@
    i32.const 0
    i32.const 80
    i32.const 514
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17078,7 +17078,7 @@
    i32.const 0
    i32.const 80
    i32.const 515
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17092,7 +17092,7 @@
    i32.const 0
    i32.const 80
    i32.const 516
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17106,7 +17106,7 @@
    i32.const 0
    i32.const 80
    i32.const 517
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17120,7 +17120,7 @@
    i32.const 0
    i32.const 80
    i32.const 518
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17134,7 +17134,7 @@
    i32.const 0
    i32.const 80
    i32.const 520
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17148,7 +17148,7 @@
    i32.const 0
    i32.const 80
    i32.const 521
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17162,7 +17162,7 @@
    i32.const 0
    i32.const 80
    i32.const 522
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17176,7 +17176,7 @@
    i32.const 0
    i32.const 80
    i32.const 523
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17190,7 +17190,7 @@
    i32.const 0
    i32.const 80
    i32.const 524
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17204,7 +17204,7 @@
    i32.const 0
    i32.const 80
    i32.const 525
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17218,7 +17218,7 @@
    i32.const 0
    i32.const 80
    i32.const 526
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17232,7 +17232,7 @@
    i32.const 0
    i32.const 80
    i32.const 527
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17246,7 +17246,7 @@
    i32.const 0
    i32.const 80
    i32.const 528
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17260,7 +17260,7 @@
    i32.const 0
    i32.const 80
    i32.const 529
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17274,7 +17274,7 @@
    i32.const 0
    i32.const 80
    i32.const 530
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17288,7 +17288,7 @@
    i32.const 0
    i32.const 80
    i32.const 531
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17302,7 +17302,7 @@
    i32.const 0
    i32.const 80
    i32.const 534
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17316,7 +17316,7 @@
    i32.const 0
    i32.const 80
    i32.const 535
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17330,7 +17330,7 @@
    i32.const 0
    i32.const 80
    i32.const 536
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17344,7 +17344,7 @@
    i32.const 0
    i32.const 80
    i32.const 537
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17358,7 +17358,7 @@
    i32.const 0
    i32.const 80
    i32.const 538
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17372,7 +17372,7 @@
    i32.const 0
    i32.const 80
    i32.const 539
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17386,7 +17386,7 @@
    i32.const 0
    i32.const 80
    i32.const 540
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17400,7 +17400,7 @@
    i32.const 0
    i32.const 80
    i32.const 541
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17414,7 +17414,7 @@
    i32.const 0
    i32.const 80
    i32.const 542
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17428,7 +17428,7 @@
    i32.const 0
    i32.const 80
    i32.const 543
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17442,7 +17442,7 @@
    i32.const 0
    i32.const 80
    i32.const 544
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17456,7 +17456,7 @@
    i32.const 0
    i32.const 80
    i32.const 547
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17470,7 +17470,7 @@
    i32.const 0
    i32.const 80
    i32.const 548
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17484,7 +17484,7 @@
    i32.const 0
    i32.const 80
    i32.const 549
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17498,7 +17498,7 @@
    i32.const 0
    i32.const 80
    i32.const 550
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17512,7 +17512,7 @@
    i32.const 0
    i32.const 80
    i32.const 551
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17526,7 +17526,7 @@
    i32.const 0
    i32.const 80
    i32.const 557
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17540,7 +17540,7 @@
    i32.const 0
    i32.const 80
    i32.const 558
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17554,7 +17554,7 @@
    i32.const 0
    i32.const 80
    i32.const 559
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17568,7 +17568,7 @@
    i32.const 0
    i32.const 80
    i32.const 560
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17582,7 +17582,7 @@
    i32.const 0
    i32.const 80
    i32.const 562
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17596,7 +17596,7 @@
    i32.const 0
    i32.const 80
    i32.const 563
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17610,7 +17610,7 @@
    i32.const 0
    i32.const 80
    i32.const 564
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17624,7 +17624,7 @@
    i32.const 0
    i32.const 80
    i32.const 565
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17638,7 +17638,7 @@
    i32.const 0
    i32.const 80
    i32.const 566
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17652,7 +17652,7 @@
    i32.const 0
    i32.const 80
    i32.const 567
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17666,7 +17666,7 @@
    i32.const 0
    i32.const 80
    i32.const 569
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17680,7 +17680,7 @@
    i32.const 0
    i32.const 80
    i32.const 570
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17694,7 +17694,7 @@
    i32.const 0
    i32.const 80
    i32.const 571
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17708,7 +17708,7 @@
    i32.const 0
    i32.const 80
    i32.const 572
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17722,7 +17722,7 @@
    i32.const 0
    i32.const 80
    i32.const 573
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17736,7 +17736,7 @@
    i32.const 0
    i32.const 80
    i32.const 574
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17750,7 +17750,7 @@
    i32.const 0
    i32.const 80
    i32.const 575
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17764,7 +17764,7 @@
    i32.const 0
    i32.const 80
    i32.const 576
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17778,7 +17778,7 @@
    i32.const 0
    i32.const 80
    i32.const 577
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17792,7 +17792,7 @@
    i32.const 0
    i32.const 80
    i32.const 579
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17806,7 +17806,7 @@
    i32.const 0
    i32.const 80
    i32.const 580
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17820,7 +17820,7 @@
    i32.const 0
    i32.const 80
    i32.const 582
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17834,7 +17834,7 @@
    i32.const 0
    i32.const 80
    i32.const 583
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17848,7 +17848,7 @@
    i32.const 0
    i32.const 80
    i32.const 584
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17862,7 +17862,7 @@
    i32.const 0
    i32.const 80
    i32.const 585
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17876,7 +17876,7 @@
    i32.const 0
    i32.const 80
    i32.const 587
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17890,7 +17890,7 @@
    i32.const 0
    i32.const 80
    i32.const 588
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17904,7 +17904,7 @@
    i32.const 0
    i32.const 80
    i32.const 589
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17918,7 +17918,7 @@
    i32.const 0
    i32.const 80
    i32.const 590
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17932,7 +17932,7 @@
    i32.const 0
    i32.const 80
    i32.const 591
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17946,7 +17946,7 @@
    i32.const 0
    i32.const 80
    i32.const 592
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17960,7 +17960,7 @@
    i32.const 0
    i32.const 80
    i32.const 593
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17974,7 +17974,7 @@
    i32.const 0
    i32.const 80
    i32.const 594
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -17988,7 +17988,7 @@
    i32.const 0
    i32.const 80
    i32.const 595
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -18453,7 +18453,7 @@
    i32.const 0
    i32.const 160
    i32.const 122
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -18475,7 +18475,7 @@
     i32.const 0
     i32.const 160
     i32.const 126
-    i32.const 17
+    i32.const 18
     call $~lib/builtins/abort
     unreachable
    end
@@ -18491,7 +18491,7 @@
     i32.const 0
     i32.const 160
     i32.const 136
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -18526,7 +18526,7 @@
    i32.const 0
    i32.const 160
    i32.const 69
-   i32.const 15
+   i32.const 16
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/std/symbol.optimized.wat
+++ b/tests/compiler/std/symbol.optimized.wat
@@ -317,7 +317,7 @@
    i32.const 1120
    i32.const 1168
    i32.const 54
-   i32.const 42
+   i32.const 43
    call $~lib/builtins/abort
    unreachable
   end
@@ -1048,7 +1048,7 @@
      i32.const 1232
      i32.const 1296
      i32.const 111
-     i32.const 16
+     i32.const 17
      call $~lib/builtins/abort
      unreachable
     end
@@ -1147,7 +1147,7 @@
    i32.const 1232
    i32.const 1296
    i32.const 111
-   i32.const 16
+   i32.const 17
    call $~lib/builtins/abort
    unreachable
   end
@@ -1480,7 +1480,7 @@
    i32.const 0
    i32.const 1072
    i32.const 4
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1499,7 +1499,7 @@
    i32.const 0
    i32.const 1072
    i32.const 9
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1514,7 +1514,7 @@
    i32.const 0
    i32.const 1072
    i32.const 14
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1523,7 +1523,7 @@
    i32.const 0
    i32.const 1072
    i32.const 15
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1535,7 +1535,7 @@
    i32.const 0
    i32.const 1072
    i32.const 17
-   i32.const 11
+   i32.const 12
    call $~lib/builtins/abort
    unreachable
   end
@@ -1549,7 +1549,7 @@
    i32.const 0
    i32.const 1072
    i32.const 18
-   i32.const 11
+   i32.const 12
    call $~lib/builtins/abort
    unreachable
   end
@@ -1563,7 +1563,7 @@
    i32.const 0
    i32.const 1072
    i32.const 20
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1575,7 +1575,7 @@
    i32.const 0
    i32.const 1072
    i32.const 21
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1588,7 +1588,7 @@
    i32.const 0
    i32.const 1072
    i32.const 23
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1601,7 +1601,7 @@
    i32.const 0
    i32.const 1072
    i32.const 24
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1618,7 +1618,7 @@
    i32.const 0
    i32.const 1072
    i32.const 28
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1631,7 +1631,7 @@
    i32.const 0
    i32.const 1072
    i32.const 29
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/std/symbol.untouched.wat
+++ b/tests/compiler/std/symbol.untouched.wat
@@ -412,7 +412,7 @@
    i32.const 112
    i32.const 160
    i32.const 54
-   i32.const 42
+   i32.const 43
    call $~lib/builtins/abort
    unreachable
   end
@@ -944,7 +944,7 @@
    i32.const 224
    i32.const 288
    i32.const 111
-   i32.const 16
+   i32.const 17
    call $~lib/builtins/abort
    unreachable
   end
@@ -1707,7 +1707,7 @@
    i32.const 224
    i32.const 288
    i32.const 111
-   i32.const 16
+   i32.const 17
    call $~lib/builtins/abort
    unreachable
   end
@@ -3292,7 +3292,7 @@
    i32.const 0
    i32.const 64
    i32.const 4
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3320,7 +3320,7 @@
    i32.const 0
    i32.const 64
    i32.const 9
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3338,7 +3338,7 @@
    i32.const 0
    i32.const 64
    i32.const 14
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3350,7 +3350,7 @@
    i32.const 0
    i32.const 64
    i32.const 15
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3363,7 +3363,7 @@
    i32.const 0
    i32.const 64
    i32.const 17
-   i32.const 11
+   i32.const 12
    call $~lib/builtins/abort
    unreachable
   end
@@ -3378,7 +3378,7 @@
    i32.const 0
    i32.const 64
    i32.const 18
-   i32.const 11
+   i32.const 12
    call $~lib/builtins/abort
    unreachable
   end
@@ -3392,7 +3392,7 @@
    i32.const 0
    i32.const 64
    i32.const 20
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3404,7 +3404,7 @@
    i32.const 0
    i32.const 64
    i32.const 21
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3419,7 +3419,7 @@
    i32.const 0
    i32.const 64
    i32.const 23
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3433,7 +3433,7 @@
    i32.const 0
    i32.const 64
    i32.const 24
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3451,7 +3451,7 @@
    i32.const 0
    i32.const 64
    i32.const 28
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -3465,7 +3465,7 @@
    i32.const 0
    i32.const 64
    i32.const 29
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/std/typedarray.optimized.wat
+++ b/tests/compiler/std/typedarray.optimized.wat
@@ -222,7 +222,7 @@
    i32.const 0
    i32.const 1152
    i32.const 277
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -244,7 +244,7 @@
    i32.const 0
    i32.const 1152
    i32.const 279
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -287,7 +287,7 @@
    i32.const 0
    i32.const 1152
    i32.const 292
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -383,7 +383,7 @@
    i32.const 0
    i32.const 1152
    i32.const 205
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -397,7 +397,7 @@
    i32.const 0
    i32.const 1152
    i32.const 207
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -470,7 +470,7 @@
     i32.const 0
     i32.const 1152
     i32.const 228
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -525,7 +525,7 @@
    i32.const 0
    i32.const 1152
    i32.const 243
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -540,7 +540,7 @@
    i32.const 0
    i32.const 1152
    i32.const 244
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -588,7 +588,7 @@
    i32.const 0
    i32.const 1152
    i32.const 260
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -671,7 +671,7 @@
    i32.const 0
    i32.const 1152
    i32.const 386
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -688,7 +688,7 @@
     i32.const 0
     i32.const 1152
     i32.const 396
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -716,7 +716,7 @@
     i32.const 0
     i32.const 1152
     i32.const 408
-    i32.const 4
+    i32.const 5
     call $~lib/builtins/abort
     unreachable
    end
@@ -857,7 +857,7 @@
    i32.const 1200
    i32.const 1152
    i32.const 461
-   i32.const 29
+   i32.const 30
    call $~lib/builtins/abort
    unreachable
   end
@@ -930,7 +930,7 @@
    i32.const 0
    i32.const 1152
    i32.const 338
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -982,7 +982,7 @@
      i32.const 0
      i32.const 1152
      i32.const 351
-     i32.const 17
+     i32.const 18
      call $~lib/builtins/abort
      unreachable
     end
@@ -1015,7 +1015,7 @@
    i32.const 0
    i32.const 1152
    i32.const 365
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1086,7 +1086,7 @@
    i32.const 0
    i32.const 1152
    i32.const 501
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1177,7 +1177,7 @@
      i32.const 0
      i32.const 1152
      i32.const 513
-     i32.const 19
+     i32.const 20
      call $~lib/builtins/abort
      unreachable
     end
@@ -1193,7 +1193,7 @@
    i32.const 0
    i32.const 1152
    i32.const 521
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1423,7 +1423,7 @@
     i32.const 0
     i32.const 1264
     i32.const 109
-    i32.const 2
+    i32.const 3
     call $~lib/builtins/abort
     unreachable
    end
@@ -1442,7 +1442,7 @@
     i32.const 0
     i32.const 1264
     i32.const 112
-    i32.const 13
+    i32.const 14
     call $~lib/builtins/abort
     unreachable
    end
@@ -1472,7 +1472,7 @@
    i32.const 1040
    i32.const 1088
    i32.const 23
-   i32.const 56
+   i32.const 57
    call $~lib/builtins/abort
    unreachable
   end
@@ -1654,7 +1654,7 @@
    i32.const 0
    i32.const 1312
    i32.const 32
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1666,7 +1666,7 @@
    i32.const 0
    i32.const 1312
    i32.const 33
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1678,7 +1678,7 @@
    i32.const 0
    i32.const 1312
    i32.const 34
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1690,7 +1690,7 @@
    i32.const 0
    i32.const 1312
    i32.const 37
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1702,7 +1702,7 @@
    i32.const 0
    i32.const 1312
    i32.const 38
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1714,7 +1714,7 @@
    i32.const 0
    i32.const 1312
    i32.const 39
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1726,7 +1726,7 @@
    i32.const 0
    i32.const 1312
    i32.const 42
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1738,7 +1738,7 @@
    i32.const 0
    i32.const 1312
    i32.const 43
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1750,7 +1750,7 @@
    i32.const 0
    i32.const 1312
    i32.const 44
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1762,7 +1762,7 @@
    i32.const 0
    i32.const 1312
    i32.const 47
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1776,7 +1776,7 @@
    i32.const 0
    i32.const 1312
    i32.const 48
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1790,7 +1790,7 @@
    i32.const 0
    i32.const 1312
    i32.const 49
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1802,7 +1802,7 @@
    i32.const 0
    i32.const 1312
    i32.const 52
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1816,7 +1816,7 @@
    i32.const 0
    i32.const 1312
    i32.const 53
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1830,7 +1830,7 @@
    i32.const 0
    i32.const 1312
    i32.const 54
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1842,7 +1842,7 @@
    i32.const 0
    i32.const 1312
    i32.const 57
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1856,7 +1856,7 @@
    i32.const 0
    i32.const 1312
    i32.const 58
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1870,7 +1870,7 @@
    i32.const 0
    i32.const 1312
    i32.const 59
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1882,7 +1882,7 @@
    i32.const 0
    i32.const 1312
    i32.const 62
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1896,7 +1896,7 @@
    i32.const 0
    i32.const 1312
    i32.const 63
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1910,7 +1910,7 @@
    i32.const 0
    i32.const 1312
    i32.const 64
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1922,7 +1922,7 @@
    i32.const 0
    i32.const 1312
    i32.const 67
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1936,7 +1936,7 @@
    i32.const 0
    i32.const 1312
    i32.const 68
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1950,7 +1950,7 @@
    i32.const 0
    i32.const 1312
    i32.const 69
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1962,7 +1962,7 @@
    i32.const 0
    i32.const 1312
    i32.const 72
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1976,7 +1976,7 @@
    i32.const 0
    i32.const 1312
    i32.const 73
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1990,7 +1990,7 @@
    i32.const 0
    i32.const 1312
    i32.const 74
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2002,7 +2002,7 @@
    i32.const 0
    i32.const 1312
    i32.const 77
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2016,7 +2016,7 @@
    i32.const 0
    i32.const 1312
    i32.const 78
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2030,7 +2030,7 @@
    i32.const 0
    i32.const 1312
    i32.const 79
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2042,7 +2042,7 @@
    i32.const 0
    i32.const 1312
    i32.const 82
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2056,7 +2056,7 @@
    i32.const 0
    i32.const 1312
    i32.const 83
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2070,7 +2070,7 @@
    i32.const 0
    i32.const 1312
    i32.const 84
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2108,7 +2108,7 @@
    i32.const 1376
    i32.const 1440
    i32.const 675
-   i32.const 63
+   i32.const 64
    call $~lib/builtins/abort
    unreachable
   end
@@ -2132,7 +2132,7 @@
    i32.const 1376
    i32.const 1440
    i32.const 664
-   i32.const 63
+   i32.const 64
    call $~lib/builtins/abort
    unreachable
   end
@@ -2236,7 +2236,7 @@
    i32.const 1376
    i32.const 1440
    i32.const 1315
-   i32.const 63
+   i32.const 64
    call $~lib/builtins/abort
    unreachable
   end
@@ -2448,7 +2448,7 @@
    i32.const 0
    i32.const 1152
    i32.const 581
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2766,7 +2766,7 @@
    i32.const 1376
    i32.const 1440
    i32.const 1304
-   i32.const 63
+   i32.const 64
    call $~lib/builtins/abort
    unreachable
   end
@@ -2787,7 +2787,7 @@
    i32.const 1376
    i32.const 1440
    i32.const 291
-   i32.const 44
+   i32.const 45
    call $~lib/builtins/abort
    unreachable
   end
@@ -2819,7 +2819,7 @@
    i32.const 1376
    i32.const 1440
    i32.const 280
-   i32.const 44
+   i32.const 45
    call $~lib/builtins/abort
    unreachable
   end
@@ -2838,7 +2838,7 @@
    i32.const 1376
    i32.const 1440
    i32.const 35
-   i32.const 44
+   i32.const 45
    call $~lib/builtins/abort
    unreachable
   end
@@ -3138,7 +3138,7 @@
    i32.const 1376
    i32.const 1440
    i32.const 24
-   i32.const 44
+   i32.const 45
    call $~lib/builtins/abort
    unreachable
   end
@@ -3188,7 +3188,7 @@
      i32.const 1376
      i32.const 1536
      i32.const 104
-     i32.const 41
+     i32.const 42
      call $~lib/builtins/abort
      unreachable
     end
@@ -3386,7 +3386,7 @@
    i32.const 1376
    i32.const 1536
    i32.const 104
-   i32.const 41
+   i32.const 42
    call $~lib/builtins/abort
    unreachable
   end
@@ -3639,7 +3639,7 @@
    i32.const 1376
    i32.const 1440
    i32.const 163
-   i32.const 44
+   i32.const 45
    call $~lib/builtins/abort
    unreachable
   end
@@ -3698,7 +3698,7 @@
    i32.const 1376
    i32.const 1440
    i32.const 419
-   i32.const 63
+   i32.const 64
    call $~lib/builtins/abort
    unreachable
   end
@@ -3722,7 +3722,7 @@
    i32.const 1376
    i32.const 1440
    i32.const 547
-   i32.const 63
+   i32.const 64
    call $~lib/builtins/abort
    unreachable
   end
@@ -3787,7 +3787,7 @@
    i32.const 1376
    i32.const 1440
    i32.const 803
-   i32.const 63
+   i32.const 64
    call $~lib/builtins/abort
    unreachable
   end
@@ -3811,7 +3811,7 @@
    i32.const 1376
    i32.const 1440
    i32.const 931
-   i32.const 63
+   i32.const 64
    call $~lib/builtins/abort
    unreachable
   end
@@ -3881,7 +3881,7 @@
    i32.const 1376
    i32.const 1440
    i32.const 1059
-   i32.const 63
+   i32.const 64
    call $~lib/builtins/abort
    unreachable
   end
@@ -3905,7 +3905,7 @@
    i32.const 1376
    i32.const 1440
    i32.const 1187
-   i32.const 63
+   i32.const 64
    call $~lib/builtins/abort
    unreachable
   end
@@ -4064,7 +4064,7 @@
    i32.const 1376
    i32.const 1440
    i32.const 152
-   i32.const 44
+   i32.const 45
    call $~lib/builtins/abort
    unreachable
   end
@@ -4085,7 +4085,7 @@
    i32.const 1376
    i32.const 1440
    i32.const 408
-   i32.const 63
+   i32.const 64
    call $~lib/builtins/abort
    unreachable
   end
@@ -4108,7 +4108,7 @@
    i32.const 1376
    i32.const 1440
    i32.const 536
-   i32.const 63
+   i32.const 64
    call $~lib/builtins/abort
    unreachable
   end
@@ -4131,7 +4131,7 @@
    i32.const 1376
    i32.const 1440
    i32.const 792
-   i32.const 63
+   i32.const 64
    call $~lib/builtins/abort
    unreachable
   end
@@ -4159,7 +4159,7 @@
    i32.const 1376
    i32.const 1440
    i32.const 920
-   i32.const 63
+   i32.const 64
    call $~lib/builtins/abort
    unreachable
   end
@@ -4182,7 +4182,7 @@
    i32.const 1376
    i32.const 1440
    i32.const 1048
-   i32.const 63
+   i32.const 64
    call $~lib/builtins/abort
    unreachable
   end
@@ -4210,7 +4210,7 @@
    i32.const 1376
    i32.const 1440
    i32.const 1176
-   i32.const 63
+   i32.const 64
    call $~lib/builtins/abort
    unreachable
   end
@@ -4448,7 +4448,7 @@
    i32.const 0
    i32.const 1312
    i32.const 390
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4460,7 +4460,7 @@
    i32.const 0
    i32.const 1312
    i32.const 391
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4473,7 +4473,7 @@
    i32.const 0
    i32.const 1312
    i32.const 392
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4486,7 +4486,7 @@
    i32.const 0
    i32.const 1312
    i32.const 393
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4499,7 +4499,7 @@
    i32.const 0
    i32.const 1312
    i32.const 394
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4615,7 +4615,7 @@
    i32.const 0
    i32.const 1312
    i32.const 390
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4627,7 +4627,7 @@
    i32.const 0
    i32.const 1312
    i32.const 391
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4640,7 +4640,7 @@
    i32.const 0
    i32.const 1312
    i32.const 392
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4653,7 +4653,7 @@
    i32.const 0
    i32.const 1312
    i32.const 393
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4666,7 +4666,7 @@
    i32.const 0
    i32.const 1312
    i32.const 394
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4775,7 +4775,7 @@
    i32.const 0
    i32.const 1312
    i32.const 390
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4787,7 +4787,7 @@
    i32.const 0
    i32.const 1312
    i32.const 391
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4800,7 +4800,7 @@
    i32.const 0
    i32.const 1312
    i32.const 392
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4813,7 +4813,7 @@
    i32.const 0
    i32.const 1312
    i32.const 393
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4826,7 +4826,7 @@
    i32.const 0
    i32.const 1312
    i32.const 394
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4960,7 +4960,7 @@
    i32.const 0
    i32.const 1312
    i32.const 390
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4974,7 +4974,7 @@
    i32.const 0
    i32.const 1312
    i32.const 391
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -4987,7 +4987,7 @@
    i32.const 0
    i32.const 1312
    i32.const 392
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -5000,7 +5000,7 @@
    i32.const 0
    i32.const 1312
    i32.const 393
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -5013,7 +5013,7 @@
    i32.const 0
    i32.const 1312
    i32.const 394
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -5145,7 +5145,7 @@
    i32.const 0
    i32.const 1312
    i32.const 390
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -5159,7 +5159,7 @@
    i32.const 0
    i32.const 1312
    i32.const 391
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -5172,7 +5172,7 @@
    i32.const 0
    i32.const 1312
    i32.const 392
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -5185,7 +5185,7 @@
    i32.const 0
    i32.const 1312
    i32.const 393
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -5198,7 +5198,7 @@
    i32.const 0
    i32.const 1312
    i32.const 394
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -5326,7 +5326,7 @@
    i32.const 0
    i32.const 1312
    i32.const 390
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -5340,7 +5340,7 @@
    i32.const 0
    i32.const 1312
    i32.const 391
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -5353,7 +5353,7 @@
    i32.const 0
    i32.const 1312
    i32.const 392
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -5366,7 +5366,7 @@
    i32.const 0
    i32.const 1312
    i32.const 393
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -5379,7 +5379,7 @@
    i32.const 0
    i32.const 1312
    i32.const 394
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -5507,7 +5507,7 @@
    i32.const 0
    i32.const 1312
    i32.const 390
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -5521,7 +5521,7 @@
    i32.const 0
    i32.const 1312
    i32.const 391
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -5534,7 +5534,7 @@
    i32.const 0
    i32.const 1312
    i32.const 392
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -5547,7 +5547,7 @@
    i32.const 0
    i32.const 1312
    i32.const 393
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -5560,7 +5560,7 @@
    i32.const 0
    i32.const 1312
    i32.const 394
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -5688,7 +5688,7 @@
    i32.const 0
    i32.const 1312
    i32.const 390
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -5702,7 +5702,7 @@
    i32.const 0
    i32.const 1312
    i32.const 391
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -5715,7 +5715,7 @@
    i32.const 0
    i32.const 1312
    i32.const 392
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -5728,7 +5728,7 @@
    i32.const 0
    i32.const 1312
    i32.const 393
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -5741,7 +5741,7 @@
    i32.const 0
    i32.const 1312
    i32.const 394
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -5869,7 +5869,7 @@
    i32.const 0
    i32.const 1312
    i32.const 390
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -5883,7 +5883,7 @@
    i32.const 0
    i32.const 1312
    i32.const 391
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -5896,7 +5896,7 @@
    i32.const 0
    i32.const 1312
    i32.const 392
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -5909,7 +5909,7 @@
    i32.const 0
    i32.const 1312
    i32.const 393
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -5922,7 +5922,7 @@
    i32.const 0
    i32.const 1312
    i32.const 394
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -6050,7 +6050,7 @@
    i32.const 0
    i32.const 1312
    i32.const 390
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -6064,7 +6064,7 @@
    i32.const 0
    i32.const 1312
    i32.const 391
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -6077,7 +6077,7 @@
    i32.const 0
    i32.const 1312
    i32.const 392
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -6090,7 +6090,7 @@
    i32.const 0
    i32.const 1312
    i32.const 393
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -6103,7 +6103,7 @@
    i32.const 0
    i32.const 1312
    i32.const 394
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -6231,7 +6231,7 @@
    i32.const 0
    i32.const 1312
    i32.const 390
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -6245,7 +6245,7 @@
    i32.const 0
    i32.const 1312
    i32.const 391
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -6258,7 +6258,7 @@
    i32.const 0
    i32.const 1312
    i32.const 392
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -6271,7 +6271,7 @@
    i32.const 0
    i32.const 1312
    i32.const 393
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -6284,7 +6284,7 @@
    i32.const 0
    i32.const 1312
    i32.const 394
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -7810,7 +7810,7 @@
    i32.const 0
    i32.const 1312
    i32.const 490
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -7821,7 +7821,7 @@
    i32.const 0
    i32.const 1312
    i32.const 491
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -7832,7 +7832,7 @@
    i32.const 0
    i32.const 1312
    i32.const 492
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -7888,7 +7888,7 @@
    i32.const 0
    i32.const 1312
    i32.const 490
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -7899,7 +7899,7 @@
    i32.const 0
    i32.const 1312
    i32.const 491
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -7910,7 +7910,7 @@
    i32.const 0
    i32.const 1312
    i32.const 492
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -7929,7 +7929,7 @@
    i32.const 0
    i32.const 1312
    i32.const 490
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -7940,7 +7940,7 @@
    i32.const 0
    i32.const 1312
    i32.const 491
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -7951,7 +7951,7 @@
    i32.const 0
    i32.const 1312
    i32.const 492
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -8008,7 +8008,7 @@
    i32.const 0
    i32.const 1312
    i32.const 490
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -8019,7 +8019,7 @@
    i32.const 0
    i32.const 1312
    i32.const 491
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -8030,7 +8030,7 @@
    i32.const 0
    i32.const 1312
    i32.const 492
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -8087,7 +8087,7 @@
    i32.const 0
    i32.const 1312
    i32.const 490
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -8098,7 +8098,7 @@
    i32.const 0
    i32.const 1312
    i32.const 491
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -8109,7 +8109,7 @@
    i32.const 0
    i32.const 1312
    i32.const 492
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -8129,7 +8129,7 @@
    i32.const 0
    i32.const 1312
    i32.const 490
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -8140,7 +8140,7 @@
    i32.const 0
    i32.const 1312
    i32.const 491
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -8151,7 +8151,7 @@
    i32.const 0
    i32.const 1312
    i32.const 492
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -8288,7 +8288,7 @@
      i32.const 0
      i32.const 1312
      i32.const 524
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -8314,7 +8314,7 @@
    i32.const 0
    i32.const 1312
    i32.const 529
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -8327,7 +8327,7 @@
    i32.const 0
    i32.const 1312
    i32.const 530
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -8340,7 +8340,7 @@
    i32.const 0
    i32.const 1312
    i32.const 531
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -8353,7 +8353,7 @@
    i32.const 0
    i32.const 1312
    i32.const 532
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -8549,7 +8549,7 @@
      i32.const 0
      i32.const 1312
      i32.const 524
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -8574,7 +8574,7 @@
    i32.const 0
    i32.const 1312
    i32.const 529
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -8587,7 +8587,7 @@
    i32.const 0
    i32.const 1312
    i32.const 530
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -8600,7 +8600,7 @@
    i32.const 0
    i32.const 1312
    i32.const 531
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -8613,7 +8613,7 @@
    i32.const 0
    i32.const 1312
    i32.const 532
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -8759,7 +8759,7 @@
      i32.const 0
      i32.const 1312
      i32.const 524
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -8784,7 +8784,7 @@
    i32.const 0
    i32.const 1312
    i32.const 529
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -8797,7 +8797,7 @@
    i32.const 0
    i32.const 1312
    i32.const 530
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -8810,7 +8810,7 @@
    i32.const 0
    i32.const 1312
    i32.const 531
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -8823,7 +8823,7 @@
    i32.const 0
    i32.const 1312
    i32.const 532
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -9038,7 +9038,7 @@
      i32.const 0
      i32.const 1312
      i32.const 524
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -9063,7 +9063,7 @@
    i32.const 0
    i32.const 1312
    i32.const 529
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -9076,7 +9076,7 @@
    i32.const 0
    i32.const 1312
    i32.const 530
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -9089,7 +9089,7 @@
    i32.const 0
    i32.const 1312
    i32.const 531
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -9102,7 +9102,7 @@
    i32.const 0
    i32.const 1312
    i32.const 532
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -9311,7 +9311,7 @@
      i32.const 0
      i32.const 1312
      i32.const 524
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -9336,7 +9336,7 @@
    i32.const 0
    i32.const 1312
    i32.const 529
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -9349,7 +9349,7 @@
    i32.const 0
    i32.const 1312
    i32.const 530
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -9362,7 +9362,7 @@
    i32.const 0
    i32.const 1312
    i32.const 531
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -9375,7 +9375,7 @@
    i32.const 0
    i32.const 1312
    i32.const 532
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -9510,7 +9510,7 @@
      i32.const 0
      i32.const 1312
      i32.const 524
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -9536,7 +9536,7 @@
    i32.const 0
    i32.const 1312
    i32.const 529
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -9549,7 +9549,7 @@
    i32.const 0
    i32.const 1312
    i32.const 530
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -9562,7 +9562,7 @@
    i32.const 0
    i32.const 1312
    i32.const 531
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -9575,7 +9575,7 @@
    i32.const 0
    i32.const 1312
    i32.const 532
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -9722,7 +9722,7 @@
      i32.const 0
      i32.const 1312
      i32.const 524
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -9747,7 +9747,7 @@
    i32.const 0
    i32.const 1312
    i32.const 529
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -9760,7 +9760,7 @@
    i32.const 0
    i32.const 1312
    i32.const 530
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -9773,7 +9773,7 @@
    i32.const 0
    i32.const 1312
    i32.const 531
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -9786,7 +9786,7 @@
    i32.const 0
    i32.const 1312
    i32.const 532
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -9992,7 +9992,7 @@
      i32.const 0
      i32.const 1312
      i32.const 524
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -10017,7 +10017,7 @@
    i32.const 0
    i32.const 1312
    i32.const 529
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10030,7 +10030,7 @@
    i32.const 0
    i32.const 1312
    i32.const 530
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10043,7 +10043,7 @@
    i32.const 0
    i32.const 1312
    i32.const 531
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10056,7 +10056,7 @@
    i32.const 0
    i32.const 1312
    i32.const 532
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10206,7 +10206,7 @@
      i32.const 0
      i32.const 1312
      i32.const 524
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -10231,7 +10231,7 @@
    i32.const 0
    i32.const 1312
    i32.const 529
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10244,7 +10244,7 @@
    i32.const 0
    i32.const 1312
    i32.const 530
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10257,7 +10257,7 @@
    i32.const 0
    i32.const 1312
    i32.const 531
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10270,7 +10270,7 @@
    i32.const 0
    i32.const 1312
    i32.const 532
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10476,7 +10476,7 @@
      i32.const 0
      i32.const 1312
      i32.const 524
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -10501,7 +10501,7 @@
    i32.const 0
    i32.const 1312
    i32.const 529
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10514,7 +10514,7 @@
    i32.const 0
    i32.const 1312
    i32.const 530
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10527,7 +10527,7 @@
    i32.const 0
    i32.const 1312
    i32.const 531
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10540,7 +10540,7 @@
    i32.const 0
    i32.const 1312
    i32.const 532
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10678,7 +10678,7 @@
      i32.const 0
      i32.const 1312
      i32.const 524
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -10704,7 +10704,7 @@
    i32.const 0
    i32.const 1312
    i32.const 529
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10717,7 +10717,7 @@
    i32.const 0
    i32.const 1312
    i32.const 530
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10730,7 +10730,7 @@
    i32.const 0
    i32.const 1312
    i32.const 531
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10743,7 +10743,7 @@
    i32.const 0
    i32.const 1312
    i32.const 532
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10939,7 +10939,7 @@
    i32.const 0
    i32.const 1312
    i32.const 557
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10953,7 +10953,7 @@
    i32.const 0
    i32.const 1312
    i32.const 558
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10967,7 +10967,7 @@
    i32.const 0
    i32.const 1312
    i32.const 559
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10981,7 +10981,7 @@
    i32.const 0
    i32.const 1312
    i32.const 560
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10995,7 +10995,7 @@
    i32.const 0
    i32.const 1312
    i32.const 561
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11009,7 +11009,7 @@
    i32.const 0
    i32.const 1312
    i32.const 562
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11023,7 +11023,7 @@
    i32.const 0
    i32.const 1312
    i32.const 563
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11037,7 +11037,7 @@
    i32.const 0
    i32.const 1312
    i32.const 564
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11051,7 +11051,7 @@
    i32.const 0
    i32.const 1312
    i32.const 565
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11064,7 +11064,7 @@
    i32.const 0
    i32.const 1312
    i32.const 567
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11079,7 +11079,7 @@
    i32.const 0
    i32.const 1312
    i32.const 568
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11094,7 +11094,7 @@
    i32.const 0
    i32.const 1312
    i32.const 569
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11109,7 +11109,7 @@
    i32.const 0
    i32.const 1312
    i32.const 570
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11123,7 +11123,7 @@
    i32.const 0
    i32.const 1312
    i32.const 571
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11137,7 +11137,7 @@
    i32.const 0
    i32.const 1312
    i32.const 572
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11151,7 +11151,7 @@
    i32.const 0
    i32.const 1312
    i32.const 573
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11165,7 +11165,7 @@
    i32.const 0
    i32.const 1312
    i32.const 574
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11179,7 +11179,7 @@
    i32.const 0
    i32.const 1312
    i32.const 575
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11193,7 +11193,7 @@
    i32.const 0
    i32.const 1312
    i32.const 576
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11211,7 +11211,7 @@
    i32.const 0
    i32.const 1312
    i32.const 580
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11223,7 +11223,7 @@
    i32.const 0
    i32.const 1312
    i32.const 581
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11237,7 +11237,7 @@
    i32.const 0
    i32.const 1312
    i32.const 582
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11251,7 +11251,7 @@
    i32.const 0
    i32.const 1312
    i32.const 583
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11265,7 +11265,7 @@
    i32.const 0
    i32.const 1312
    i32.const 584
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11279,7 +11279,7 @@
    i32.const 0
    i32.const 1312
    i32.const 585
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11293,7 +11293,7 @@
    i32.const 0
    i32.const 1312
    i32.const 586
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11307,7 +11307,7 @@
    i32.const 0
    i32.const 1312
    i32.const 587
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11357,7 +11357,7 @@
    i32.const 0
    i32.const 1312
    i32.const 557
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11371,7 +11371,7 @@
    i32.const 0
    i32.const 1312
    i32.const 558
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11385,7 +11385,7 @@
    i32.const 0
    i32.const 1312
    i32.const 559
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11399,7 +11399,7 @@
    i32.const 0
    i32.const 1312
    i32.const 560
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11413,7 +11413,7 @@
    i32.const 0
    i32.const 1312
    i32.const 561
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11427,7 +11427,7 @@
    i32.const 0
    i32.const 1312
    i32.const 562
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11441,7 +11441,7 @@
    i32.const 0
    i32.const 1312
    i32.const 563
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11455,7 +11455,7 @@
    i32.const 0
    i32.const 1312
    i32.const 564
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11469,7 +11469,7 @@
    i32.const 0
    i32.const 1312
    i32.const 565
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11482,7 +11482,7 @@
    i32.const 0
    i32.const 1312
    i32.const 567
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11497,7 +11497,7 @@
    i32.const 0
    i32.const 1312
    i32.const 568
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11512,7 +11512,7 @@
    i32.const 0
    i32.const 1312
    i32.const 569
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11527,7 +11527,7 @@
    i32.const 0
    i32.const 1312
    i32.const 570
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11541,7 +11541,7 @@
    i32.const 0
    i32.const 1312
    i32.const 571
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11555,7 +11555,7 @@
    i32.const 0
    i32.const 1312
    i32.const 572
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11569,7 +11569,7 @@
    i32.const 0
    i32.const 1312
    i32.const 573
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11583,7 +11583,7 @@
    i32.const 0
    i32.const 1312
    i32.const 574
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11597,7 +11597,7 @@
    i32.const 0
    i32.const 1312
    i32.const 575
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11611,7 +11611,7 @@
    i32.const 0
    i32.const 1312
    i32.const 576
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11628,7 +11628,7 @@
    i32.const 0
    i32.const 1312
    i32.const 580
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11640,7 +11640,7 @@
    i32.const 0
    i32.const 1312
    i32.const 581
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11654,7 +11654,7 @@
    i32.const 0
    i32.const 1312
    i32.const 582
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11668,7 +11668,7 @@
    i32.const 0
    i32.const 1312
    i32.const 583
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11682,7 +11682,7 @@
    i32.const 0
    i32.const 1312
    i32.const 584
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11696,7 +11696,7 @@
    i32.const 0
    i32.const 1312
    i32.const 585
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11710,7 +11710,7 @@
    i32.const 0
    i32.const 1312
    i32.const 586
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11724,7 +11724,7 @@
    i32.const 0
    i32.const 1312
    i32.const 587
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11774,7 +11774,7 @@
    i32.const 0
    i32.const 1312
    i32.const 557
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11788,7 +11788,7 @@
    i32.const 0
    i32.const 1312
    i32.const 558
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11802,7 +11802,7 @@
    i32.const 0
    i32.const 1312
    i32.const 559
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11816,7 +11816,7 @@
    i32.const 0
    i32.const 1312
    i32.const 560
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11830,7 +11830,7 @@
    i32.const 0
    i32.const 1312
    i32.const 561
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11844,7 +11844,7 @@
    i32.const 0
    i32.const 1312
    i32.const 562
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11858,7 +11858,7 @@
    i32.const 0
    i32.const 1312
    i32.const 563
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11872,7 +11872,7 @@
    i32.const 0
    i32.const 1312
    i32.const 564
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11886,7 +11886,7 @@
    i32.const 0
    i32.const 1312
    i32.const 565
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11899,7 +11899,7 @@
    i32.const 0
    i32.const 1312
    i32.const 567
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11914,7 +11914,7 @@
    i32.const 0
    i32.const 1312
    i32.const 568
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11929,7 +11929,7 @@
    i32.const 0
    i32.const 1312
    i32.const 569
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11944,7 +11944,7 @@
    i32.const 0
    i32.const 1312
    i32.const 570
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11958,7 +11958,7 @@
    i32.const 0
    i32.const 1312
    i32.const 571
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11972,7 +11972,7 @@
    i32.const 0
    i32.const 1312
    i32.const 572
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11986,7 +11986,7 @@
    i32.const 0
    i32.const 1312
    i32.const 573
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12000,7 +12000,7 @@
    i32.const 0
    i32.const 1312
    i32.const 574
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12014,7 +12014,7 @@
    i32.const 0
    i32.const 1312
    i32.const 575
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12028,7 +12028,7 @@
    i32.const 0
    i32.const 1312
    i32.const 576
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12045,7 +12045,7 @@
    i32.const 0
    i32.const 1312
    i32.const 580
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12057,7 +12057,7 @@
    i32.const 0
    i32.const 1312
    i32.const 581
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12071,7 +12071,7 @@
    i32.const 0
    i32.const 1312
    i32.const 582
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12085,7 +12085,7 @@
    i32.const 0
    i32.const 1312
    i32.const 583
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12099,7 +12099,7 @@
    i32.const 0
    i32.const 1312
    i32.const 584
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12113,7 +12113,7 @@
    i32.const 0
    i32.const 1312
    i32.const 585
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12127,7 +12127,7 @@
    i32.const 0
    i32.const 1312
    i32.const 586
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12141,7 +12141,7 @@
    i32.const 0
    i32.const 1312
    i32.const 587
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12343,7 +12343,7 @@
    i32.const 0
    i32.const 1312
    i32.const 557
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12357,7 +12357,7 @@
    i32.const 0
    i32.const 1312
    i32.const 558
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12371,7 +12371,7 @@
    i32.const 0
    i32.const 1312
    i32.const 559
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12385,7 +12385,7 @@
    i32.const 0
    i32.const 1312
    i32.const 560
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12399,7 +12399,7 @@
    i32.const 0
    i32.const 1312
    i32.const 561
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12413,7 +12413,7 @@
    i32.const 0
    i32.const 1312
    i32.const 562
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12427,7 +12427,7 @@
    i32.const 0
    i32.const 1312
    i32.const 563
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12441,7 +12441,7 @@
    i32.const 0
    i32.const 1312
    i32.const 564
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12455,7 +12455,7 @@
    i32.const 0
    i32.const 1312
    i32.const 565
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12468,7 +12468,7 @@
    i32.const 0
    i32.const 1312
    i32.const 567
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12483,7 +12483,7 @@
    i32.const 0
    i32.const 1312
    i32.const 568
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12498,7 +12498,7 @@
    i32.const 0
    i32.const 1312
    i32.const 569
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12513,7 +12513,7 @@
    i32.const 0
    i32.const 1312
    i32.const 570
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12527,7 +12527,7 @@
    i32.const 0
    i32.const 1312
    i32.const 571
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12541,7 +12541,7 @@
    i32.const 0
    i32.const 1312
    i32.const 572
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12555,7 +12555,7 @@
    i32.const 0
    i32.const 1312
    i32.const 573
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12569,7 +12569,7 @@
    i32.const 0
    i32.const 1312
    i32.const 574
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12583,7 +12583,7 @@
    i32.const 0
    i32.const 1312
    i32.const 575
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12597,7 +12597,7 @@
    i32.const 0
    i32.const 1312
    i32.const 576
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12614,7 +12614,7 @@
    i32.const 0
    i32.const 1312
    i32.const 580
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12626,7 +12626,7 @@
    i32.const 0
    i32.const 1312
    i32.const 581
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12640,7 +12640,7 @@
    i32.const 0
    i32.const 1312
    i32.const 582
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12654,7 +12654,7 @@
    i32.const 0
    i32.const 1312
    i32.const 583
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12668,7 +12668,7 @@
    i32.const 0
    i32.const 1312
    i32.const 584
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12682,7 +12682,7 @@
    i32.const 0
    i32.const 1312
    i32.const 585
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12696,7 +12696,7 @@
    i32.const 0
    i32.const 1312
    i32.const 586
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12710,7 +12710,7 @@
    i32.const 0
    i32.const 1312
    i32.const 587
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12760,7 +12760,7 @@
    i32.const 0
    i32.const 1312
    i32.const 557
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12774,7 +12774,7 @@
    i32.const 0
    i32.const 1312
    i32.const 558
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12788,7 +12788,7 @@
    i32.const 0
    i32.const 1312
    i32.const 559
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12802,7 +12802,7 @@
    i32.const 0
    i32.const 1312
    i32.const 560
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12816,7 +12816,7 @@
    i32.const 0
    i32.const 1312
    i32.const 561
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12830,7 +12830,7 @@
    i32.const 0
    i32.const 1312
    i32.const 562
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12844,7 +12844,7 @@
    i32.const 0
    i32.const 1312
    i32.const 563
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12858,7 +12858,7 @@
    i32.const 0
    i32.const 1312
    i32.const 564
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12872,7 +12872,7 @@
    i32.const 0
    i32.const 1312
    i32.const 565
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12885,7 +12885,7 @@
    i32.const 0
    i32.const 1312
    i32.const 567
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12900,7 +12900,7 @@
    i32.const 0
    i32.const 1312
    i32.const 568
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12915,7 +12915,7 @@
    i32.const 0
    i32.const 1312
    i32.const 569
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12930,7 +12930,7 @@
    i32.const 0
    i32.const 1312
    i32.const 570
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12944,7 +12944,7 @@
    i32.const 0
    i32.const 1312
    i32.const 571
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12958,7 +12958,7 @@
    i32.const 0
    i32.const 1312
    i32.const 572
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12972,7 +12972,7 @@
    i32.const 0
    i32.const 1312
    i32.const 573
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12986,7 +12986,7 @@
    i32.const 0
    i32.const 1312
    i32.const 574
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13000,7 +13000,7 @@
    i32.const 0
    i32.const 1312
    i32.const 575
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13014,7 +13014,7 @@
    i32.const 0
    i32.const 1312
    i32.const 576
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13031,7 +13031,7 @@
    i32.const 0
    i32.const 1312
    i32.const 580
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13043,7 +13043,7 @@
    i32.const 0
    i32.const 1312
    i32.const 581
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13057,7 +13057,7 @@
    i32.const 0
    i32.const 1312
    i32.const 582
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13071,7 +13071,7 @@
    i32.const 0
    i32.const 1312
    i32.const 583
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13085,7 +13085,7 @@
    i32.const 0
    i32.const 1312
    i32.const 584
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13099,7 +13099,7 @@
    i32.const 0
    i32.const 1312
    i32.const 585
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13113,7 +13113,7 @@
    i32.const 0
    i32.const 1312
    i32.const 586
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13127,7 +13127,7 @@
    i32.const 0
    i32.const 1312
    i32.const 587
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13321,7 +13321,7 @@
    i32.const 0
    i32.const 1312
    i32.const 557
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13335,7 +13335,7 @@
    i32.const 0
    i32.const 1312
    i32.const 558
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13349,7 +13349,7 @@
    i32.const 0
    i32.const 1312
    i32.const 559
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13363,7 +13363,7 @@
    i32.const 0
    i32.const 1312
    i32.const 560
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13377,7 +13377,7 @@
    i32.const 0
    i32.const 1312
    i32.const 561
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13391,7 +13391,7 @@
    i32.const 0
    i32.const 1312
    i32.const 562
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13405,7 +13405,7 @@
    i32.const 0
    i32.const 1312
    i32.const 563
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13419,7 +13419,7 @@
    i32.const 0
    i32.const 1312
    i32.const 564
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13433,7 +13433,7 @@
    i32.const 0
    i32.const 1312
    i32.const 565
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13446,7 +13446,7 @@
    i32.const 0
    i32.const 1312
    i32.const 567
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13461,7 +13461,7 @@
    i32.const 0
    i32.const 1312
    i32.const 568
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13476,7 +13476,7 @@
    i32.const 0
    i32.const 1312
    i32.const 569
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13491,7 +13491,7 @@
    i32.const 0
    i32.const 1312
    i32.const 570
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13505,7 +13505,7 @@
    i32.const 0
    i32.const 1312
    i32.const 571
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13519,7 +13519,7 @@
    i32.const 0
    i32.const 1312
    i32.const 572
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13533,7 +13533,7 @@
    i32.const 0
    i32.const 1312
    i32.const 573
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13547,7 +13547,7 @@
    i32.const 0
    i32.const 1312
    i32.const 574
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13561,7 +13561,7 @@
    i32.const 0
    i32.const 1312
    i32.const 575
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13575,7 +13575,7 @@
    i32.const 0
    i32.const 1312
    i32.const 576
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13593,7 +13593,7 @@
    i32.const 0
    i32.const 1312
    i32.const 580
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13605,7 +13605,7 @@
    i32.const 0
    i32.const 1312
    i32.const 581
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13619,7 +13619,7 @@
    i32.const 0
    i32.const 1312
    i32.const 582
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13633,7 +13633,7 @@
    i32.const 0
    i32.const 1312
    i32.const 583
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13647,7 +13647,7 @@
    i32.const 0
    i32.const 1312
    i32.const 584
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13661,7 +13661,7 @@
    i32.const 0
    i32.const 1312
    i32.const 585
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13675,7 +13675,7 @@
    i32.const 0
    i32.const 1312
    i32.const 586
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13689,7 +13689,7 @@
    i32.const 0
    i32.const 1312
    i32.const 587
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13737,7 +13737,7 @@
    i32.const 0
    i32.const 1312
    i32.const 557
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13751,7 +13751,7 @@
    i32.const 0
    i32.const 1312
    i32.const 558
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13765,7 +13765,7 @@
    i32.const 0
    i32.const 1312
    i32.const 559
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13779,7 +13779,7 @@
    i32.const 0
    i32.const 1312
    i32.const 560
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13793,7 +13793,7 @@
    i32.const 0
    i32.const 1312
    i32.const 561
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13807,7 +13807,7 @@
    i32.const 0
    i32.const 1312
    i32.const 562
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13821,7 +13821,7 @@
    i32.const 0
    i32.const 1312
    i32.const 563
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13835,7 +13835,7 @@
    i32.const 0
    i32.const 1312
    i32.const 564
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13849,7 +13849,7 @@
    i32.const 0
    i32.const 1312
    i32.const 565
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13862,7 +13862,7 @@
    i32.const 0
    i32.const 1312
    i32.const 567
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13877,7 +13877,7 @@
    i32.const 0
    i32.const 1312
    i32.const 568
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13892,7 +13892,7 @@
    i32.const 0
    i32.const 1312
    i32.const 569
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13907,7 +13907,7 @@
    i32.const 0
    i32.const 1312
    i32.const 570
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13921,7 +13921,7 @@
    i32.const 0
    i32.const 1312
    i32.const 571
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13935,7 +13935,7 @@
    i32.const 0
    i32.const 1312
    i32.const 572
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13949,7 +13949,7 @@
    i32.const 0
    i32.const 1312
    i32.const 573
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13963,7 +13963,7 @@
    i32.const 0
    i32.const 1312
    i32.const 574
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13977,7 +13977,7 @@
    i32.const 0
    i32.const 1312
    i32.const 575
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13991,7 +13991,7 @@
    i32.const 0
    i32.const 1312
    i32.const 576
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14008,7 +14008,7 @@
    i32.const 0
    i32.const 1312
    i32.const 580
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14020,7 +14020,7 @@
    i32.const 0
    i32.const 1312
    i32.const 581
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14034,7 +14034,7 @@
    i32.const 0
    i32.const 1312
    i32.const 582
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14048,7 +14048,7 @@
    i32.const 0
    i32.const 1312
    i32.const 583
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14062,7 +14062,7 @@
    i32.const 0
    i32.const 1312
    i32.const 584
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14076,7 +14076,7 @@
    i32.const 0
    i32.const 1312
    i32.const 585
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14090,7 +14090,7 @@
    i32.const 0
    i32.const 1312
    i32.const 586
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14104,7 +14104,7 @@
    i32.const 0
    i32.const 1312
    i32.const 587
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14299,7 +14299,7 @@
    i32.const 0
    i32.const 1312
    i32.const 557
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14313,7 +14313,7 @@
    i32.const 0
    i32.const 1312
    i32.const 558
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14327,7 +14327,7 @@
    i32.const 0
    i32.const 1312
    i32.const 559
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14341,7 +14341,7 @@
    i32.const 0
    i32.const 1312
    i32.const 560
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14355,7 +14355,7 @@
    i32.const 0
    i32.const 1312
    i32.const 561
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14369,7 +14369,7 @@
    i32.const 0
    i32.const 1312
    i32.const 562
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14383,7 +14383,7 @@
    i32.const 0
    i32.const 1312
    i32.const 563
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14397,7 +14397,7 @@
    i32.const 0
    i32.const 1312
    i32.const 564
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14411,7 +14411,7 @@
    i32.const 0
    i32.const 1312
    i32.const 565
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14424,7 +14424,7 @@
    i32.const 0
    i32.const 1312
    i32.const 567
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14439,7 +14439,7 @@
    i32.const 0
    i32.const 1312
    i32.const 568
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14454,7 +14454,7 @@
    i32.const 0
    i32.const 1312
    i32.const 569
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14469,7 +14469,7 @@
    i32.const 0
    i32.const 1312
    i32.const 570
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14483,7 +14483,7 @@
    i32.const 0
    i32.const 1312
    i32.const 571
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14497,7 +14497,7 @@
    i32.const 0
    i32.const 1312
    i32.const 572
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14511,7 +14511,7 @@
    i32.const 0
    i32.const 1312
    i32.const 573
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14525,7 +14525,7 @@
    i32.const 0
    i32.const 1312
    i32.const 574
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14539,7 +14539,7 @@
    i32.const 0
    i32.const 1312
    i32.const 575
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14553,7 +14553,7 @@
    i32.const 0
    i32.const 1312
    i32.const 576
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14570,7 +14570,7 @@
    i32.const 0
    i32.const 1312
    i32.const 580
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14582,7 +14582,7 @@
    i32.const 0
    i32.const 1312
    i32.const 581
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14596,7 +14596,7 @@
    i32.const 0
    i32.const 1312
    i32.const 582
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14610,7 +14610,7 @@
    i32.const 0
    i32.const 1312
    i32.const 583
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14624,7 +14624,7 @@
    i32.const 0
    i32.const 1312
    i32.const 584
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14638,7 +14638,7 @@
    i32.const 0
    i32.const 1312
    i32.const 585
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14652,7 +14652,7 @@
    i32.const 0
    i32.const 1312
    i32.const 586
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14666,7 +14666,7 @@
    i32.const 0
    i32.const 1312
    i32.const 587
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14715,7 +14715,7 @@
    i32.const 0
    i32.const 1312
    i32.const 557
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14729,7 +14729,7 @@
    i32.const 0
    i32.const 1312
    i32.const 558
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14743,7 +14743,7 @@
    i32.const 0
    i32.const 1312
    i32.const 559
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14757,7 +14757,7 @@
    i32.const 0
    i32.const 1312
    i32.const 560
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14771,7 +14771,7 @@
    i32.const 0
    i32.const 1312
    i32.const 561
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14785,7 +14785,7 @@
    i32.const 0
    i32.const 1312
    i32.const 562
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14799,7 +14799,7 @@
    i32.const 0
    i32.const 1312
    i32.const 563
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14813,7 +14813,7 @@
    i32.const 0
    i32.const 1312
    i32.const 564
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14827,7 +14827,7 @@
    i32.const 0
    i32.const 1312
    i32.const 565
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14840,7 +14840,7 @@
    i32.const 0
    i32.const 1312
    i32.const 567
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14855,7 +14855,7 @@
    i32.const 0
    i32.const 1312
    i32.const 568
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14870,7 +14870,7 @@
    i32.const 0
    i32.const 1312
    i32.const 569
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14885,7 +14885,7 @@
    i32.const 0
    i32.const 1312
    i32.const 570
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14899,7 +14899,7 @@
    i32.const 0
    i32.const 1312
    i32.const 571
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14913,7 +14913,7 @@
    i32.const 0
    i32.const 1312
    i32.const 572
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14927,7 +14927,7 @@
    i32.const 0
    i32.const 1312
    i32.const 573
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14941,7 +14941,7 @@
    i32.const 0
    i32.const 1312
    i32.const 574
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14955,7 +14955,7 @@
    i32.const 0
    i32.const 1312
    i32.const 575
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14969,7 +14969,7 @@
    i32.const 0
    i32.const 1312
    i32.const 576
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14986,7 +14986,7 @@
    i32.const 0
    i32.const 1312
    i32.const 580
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14998,7 +14998,7 @@
    i32.const 0
    i32.const 1312
    i32.const 581
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -15012,7 +15012,7 @@
    i32.const 0
    i32.const 1312
    i32.const 582
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -15026,7 +15026,7 @@
    i32.const 0
    i32.const 1312
    i32.const 583
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -15040,7 +15040,7 @@
    i32.const 0
    i32.const 1312
    i32.const 584
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -15054,7 +15054,7 @@
    i32.const 0
    i32.const 1312
    i32.const 585
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -15068,7 +15068,7 @@
    i32.const 0
    i32.const 1312
    i32.const 586
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -15082,7 +15082,7 @@
    i32.const 0
    i32.const 1312
    i32.const 587
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -15277,7 +15277,7 @@
    i32.const 0
    i32.const 1312
    i32.const 557
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -15291,7 +15291,7 @@
    i32.const 0
    i32.const 1312
    i32.const 558
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -15305,7 +15305,7 @@
    i32.const 0
    i32.const 1312
    i32.const 559
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -15319,7 +15319,7 @@
    i32.const 0
    i32.const 1312
    i32.const 560
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -15333,7 +15333,7 @@
    i32.const 0
    i32.const 1312
    i32.const 561
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -15347,7 +15347,7 @@
    i32.const 0
    i32.const 1312
    i32.const 562
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -15361,7 +15361,7 @@
    i32.const 0
    i32.const 1312
    i32.const 563
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -15375,7 +15375,7 @@
    i32.const 0
    i32.const 1312
    i32.const 564
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -15389,7 +15389,7 @@
    i32.const 0
    i32.const 1312
    i32.const 565
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -15402,7 +15402,7 @@
    i32.const 0
    i32.const 1312
    i32.const 567
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -15417,7 +15417,7 @@
    i32.const 0
    i32.const 1312
    i32.const 568
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -15432,7 +15432,7 @@
    i32.const 0
    i32.const 1312
    i32.const 569
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -15447,7 +15447,7 @@
    i32.const 0
    i32.const 1312
    i32.const 570
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -15461,7 +15461,7 @@
    i32.const 0
    i32.const 1312
    i32.const 571
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -15475,7 +15475,7 @@
    i32.const 0
    i32.const 1312
    i32.const 572
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -15489,7 +15489,7 @@
    i32.const 0
    i32.const 1312
    i32.const 573
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -15503,7 +15503,7 @@
    i32.const 0
    i32.const 1312
    i32.const 574
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -15517,7 +15517,7 @@
    i32.const 0
    i32.const 1312
    i32.const 575
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -15531,7 +15531,7 @@
    i32.const 0
    i32.const 1312
    i32.const 576
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -15548,7 +15548,7 @@
    i32.const 0
    i32.const 1312
    i32.const 580
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -15560,7 +15560,7 @@
    i32.const 0
    i32.const 1312
    i32.const 581
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -15574,7 +15574,7 @@
    i32.const 0
    i32.const 1312
    i32.const 582
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -15588,7 +15588,7 @@
    i32.const 0
    i32.const 1312
    i32.const 583
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -15602,7 +15602,7 @@
    i32.const 0
    i32.const 1312
    i32.const 584
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -15616,7 +15616,7 @@
    i32.const 0
    i32.const 1312
    i32.const 585
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -15630,7 +15630,7 @@
    i32.const 0
    i32.const 1312
    i32.const 586
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -15644,7 +15644,7 @@
    i32.const 0
    i32.const 1312
    i32.const 587
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -15839,7 +15839,7 @@
    i32.const 0
    i32.const 1312
    i32.const 557
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -15853,7 +15853,7 @@
    i32.const 0
    i32.const 1312
    i32.const 558
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -15867,7 +15867,7 @@
    i32.const 0
    i32.const 1312
    i32.const 559
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -15881,7 +15881,7 @@
    i32.const 0
    i32.const 1312
    i32.const 560
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -15895,7 +15895,7 @@
    i32.const 0
    i32.const 1312
    i32.const 561
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -15909,7 +15909,7 @@
    i32.const 0
    i32.const 1312
    i32.const 562
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -15923,7 +15923,7 @@
    i32.const 0
    i32.const 1312
    i32.const 563
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -15937,7 +15937,7 @@
    i32.const 0
    i32.const 1312
    i32.const 564
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -15951,7 +15951,7 @@
    i32.const 0
    i32.const 1312
    i32.const 565
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -15964,7 +15964,7 @@
    i32.const 0
    i32.const 1312
    i32.const 567
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -15979,7 +15979,7 @@
    i32.const 0
    i32.const 1312
    i32.const 568
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -15994,7 +15994,7 @@
    i32.const 0
    i32.const 1312
    i32.const 569
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -16009,7 +16009,7 @@
    i32.const 0
    i32.const 1312
    i32.const 570
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -16023,7 +16023,7 @@
    i32.const 0
    i32.const 1312
    i32.const 571
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -16037,7 +16037,7 @@
    i32.const 0
    i32.const 1312
    i32.const 572
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -16051,7 +16051,7 @@
    i32.const 0
    i32.const 1312
    i32.const 573
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -16065,7 +16065,7 @@
    i32.const 0
    i32.const 1312
    i32.const 574
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -16079,7 +16079,7 @@
    i32.const 0
    i32.const 1312
    i32.const 575
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -16093,7 +16093,7 @@
    i32.const 0
    i32.const 1312
    i32.const 576
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -16111,7 +16111,7 @@
    i32.const 0
    i32.const 1312
    i32.const 580
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -16123,7 +16123,7 @@
    i32.const 0
    i32.const 1312
    i32.const 581
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -16137,7 +16137,7 @@
    i32.const 0
    i32.const 1312
    i32.const 582
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -16151,7 +16151,7 @@
    i32.const 0
    i32.const 1312
    i32.const 583
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -16165,7 +16165,7 @@
    i32.const 0
    i32.const 1312
    i32.const 584
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -16179,7 +16179,7 @@
    i32.const 0
    i32.const 1312
    i32.const 585
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -16193,7 +16193,7 @@
    i32.const 0
    i32.const 1312
    i32.const 586
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -16207,7 +16207,7 @@
    i32.const 0
    i32.const 1312
    i32.const 587
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -19298,7 +19298,7 @@
    i32.const 1040
    i32.const 1088
    i32.const 54
-   i32.const 42
+   i32.const 43
    call $~lib/builtins/abort
    unreachable
   end
@@ -19343,7 +19343,7 @@
    i32.const 1376
    i32.const 1440
    i32.const 1741
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -19362,7 +19362,7 @@
     i32.const 1040
     i32.const 1440
     i32.const 1750
-    i32.const 6
+    i32.const 7
     call $~lib/builtins/abort
     unreachable
    end
@@ -19377,7 +19377,7 @@
     i32.const 1040
     i32.const 1440
     i32.const 1755
-    i32.const 6
+    i32.const 7
     call $~lib/builtins/abort
     unreachable
    end
@@ -19530,7 +19530,7 @@
    i32.const 1376
    i32.const 1440
    i32.const 1741
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -19568,7 +19568,7 @@
      i32.const 0
      i32.const 1312
      i32.const 684
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -19652,7 +19652,7 @@
      i32.const 0
      i32.const 1312
      i32.const 684
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -19728,7 +19728,7 @@
    i32.const 1376
    i32.const 1440
    i32.const 1741
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -19766,7 +19766,7 @@
      i32.const 0
      i32.const 1312
      i32.const 684
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -19844,7 +19844,7 @@
    i32.const 1376
    i32.const 1440
    i32.const 1741
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -19855,7 +19855,7 @@
    i32.const 1040
    i32.const 1440
    i32.const 1746
-   i32.const 8
+   i32.const 9
    call $~lib/builtins/abort
    unreachable
   end
@@ -19891,7 +19891,7 @@
      i32.const 0
      i32.const 1312
      i32.const 684
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -19967,7 +19967,7 @@
    i32.const 1376
    i32.const 1440
    i32.const 1741
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -19978,7 +19978,7 @@
    i32.const 1040
    i32.const 1440
    i32.const 1746
-   i32.const 8
+   i32.const 9
    call $~lib/builtins/abort
    unreachable
   end
@@ -20014,7 +20014,7 @@
      i32.const 0
      i32.const 1312
      i32.const 684
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -20088,7 +20088,7 @@
    i32.const 1376
    i32.const 1440
    i32.const 1741
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -20099,7 +20099,7 @@
    i32.const 1040
    i32.const 1440
    i32.const 1746
-   i32.const 8
+   i32.const 9
    call $~lib/builtins/abort
    unreachable
   end
@@ -20135,7 +20135,7 @@
      i32.const 0
      i32.const 1312
      i32.const 684
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -20209,7 +20209,7 @@
    i32.const 1376
    i32.const 1440
    i32.const 1741
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -20220,7 +20220,7 @@
    i32.const 1040
    i32.const 1440
    i32.const 1746
-   i32.const 8
+   i32.const 9
    call $~lib/builtins/abort
    unreachable
   end
@@ -20256,7 +20256,7 @@
      i32.const 0
      i32.const 1312
      i32.const 684
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -20331,7 +20331,7 @@
    i32.const 1376
    i32.const 1440
    i32.const 1741
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -20342,7 +20342,7 @@
    i32.const 1040
    i32.const 1440
    i32.const 1746
-   i32.const 8
+   i32.const 9
    call $~lib/builtins/abort
    unreachable
   end
@@ -20378,7 +20378,7 @@
      i32.const 0
      i32.const 1312
      i32.const 684
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -20453,7 +20453,7 @@
    i32.const 1376
    i32.const 1440
    i32.const 1741
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -20464,7 +20464,7 @@
    i32.const 1040
    i32.const 1440
    i32.const 1746
-   i32.const 8
+   i32.const 9
    call $~lib/builtins/abort
    unreachable
   end
@@ -20500,7 +20500,7 @@
      i32.const 0
      i32.const 1312
      i32.const 684
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -20575,7 +20575,7 @@
    i32.const 1376
    i32.const 1440
    i32.const 1741
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -20586,7 +20586,7 @@
    i32.const 1040
    i32.const 1440
    i32.const 1746
-   i32.const 8
+   i32.const 9
    call $~lib/builtins/abort
    unreachable
   end
@@ -20622,7 +20622,7 @@
      i32.const 0
      i32.const 1312
      i32.const 684
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -20697,7 +20697,7 @@
    i32.const 1376
    i32.const 1440
    i32.const 1741
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -20708,7 +20708,7 @@
    i32.const 1040
    i32.const 1440
    i32.const 1746
-   i32.const 8
+   i32.const 9
    call $~lib/builtins/abort
    unreachable
   end
@@ -20744,7 +20744,7 @@
      i32.const 0
      i32.const 1312
      i32.const 684
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -20775,7 +20775,7 @@
    i32.const 1376
    i32.const 1440
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -20826,7 +20826,7 @@
    i32.const 0
    i32.const 1312
    i32.const 712
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -20859,7 +20859,7 @@
      i32.const 0
      i32.const 1312
      i32.const 718
-     i32.const 6
+     i32.const 7
      call $~lib/builtins/abort
      unreachable
     end
@@ -20887,7 +20887,7 @@
    i32.const 1376
    i32.const 1440
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -20937,7 +20937,7 @@
    i32.const 1376
    i32.const 1440
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -20965,7 +20965,7 @@
    i32.const 1376
    i32.const 1440
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -21017,7 +21017,7 @@
    i32.const 1376
    i32.const 1440
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -21281,7 +21281,7 @@
   i32.const 1376
   i32.const 1440
   i32.const 1775
-  i32.const 46
+  i32.const 47
   call $~lib/builtins/abort
   unreachable
  )
@@ -21307,7 +21307,7 @@
    i32.const 0
    i32.const 1312
    i32.const 712
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -21340,7 +21340,7 @@
      i32.const 0
      i32.const 1312
      i32.const 718
-     i32.const 6
+     i32.const 7
      call $~lib/builtins/abort
      unreachable
     end
@@ -21602,7 +21602,7 @@
   i32.const 1376
   i32.const 1440
   i32.const 1775
-  i32.const 46
+  i32.const 47
   call $~lib/builtins/abort
   unreachable
  )
@@ -21621,7 +21621,7 @@
    i32.const 0
    i32.const 1312
    i32.const 712
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -21654,7 +21654,7 @@
      i32.const 0
      i32.const 1312
      i32.const 718
-     i32.const 6
+     i32.const 7
      call $~lib/builtins/abort
      unreachable
     end
@@ -21676,7 +21676,7 @@
    i32.const 1376
    i32.const 1440
    i32.const 1774
-   i32.const 18
+   i32.const 19
    call $~lib/builtins/abort
    unreachable
   end
@@ -21693,7 +21693,7 @@
    i32.const 1376
    i32.const 1440
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -21760,7 +21760,7 @@
    i32.const 1376
    i32.const 1440
    i32.const 1774
-   i32.const 18
+   i32.const 19
    call $~lib/builtins/abort
    unreachable
   end
@@ -21777,7 +21777,7 @@
    i32.const 1376
    i32.const 1440
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -22195,7 +22195,7 @@
   i32.const 1376
   i32.const 1440
   i32.const 1775
-  i32.const 46
+  i32.const 47
   call $~lib/builtins/abort
   unreachable
  )
@@ -22214,7 +22214,7 @@
    i32.const 1376
    i32.const 1440
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -22270,7 +22270,7 @@
    i32.const 0
    i32.const 1312
    i32.const 712
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -22310,7 +22310,7 @@
      i32.const 0
      i32.const 1312
      i32.const 718
-     i32.const 6
+     i32.const 7
      call $~lib/builtins/abort
      unreachable
     end
@@ -22340,7 +22340,7 @@
    i32.const 1376
    i32.const 1440
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -22396,7 +22396,7 @@
    i32.const 1376
    i32.const 1440
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -22448,7 +22448,7 @@
    i32.const 1376
    i32.const 1440
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -22479,7 +22479,7 @@
    i32.const 1376
    i32.const 1440
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -22775,7 +22775,7 @@
   i32.const 1376
   i32.const 1440
   i32.const 1775
-  i32.const 46
+  i32.const 47
   call $~lib/builtins/abort
   unreachable
  )
@@ -22797,7 +22797,7 @@
    i32.const 0
    i32.const 1312
    i32.const 712
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -22837,7 +22837,7 @@
      i32.const 0
      i32.const 1312
      i32.const 718
-     i32.const 6
+     i32.const 7
      call $~lib/builtins/abort
      unreachable
     end
@@ -23107,7 +23107,7 @@
   i32.const 1376
   i32.const 1440
   i32.const 1775
-  i32.const 46
+  i32.const 47
   call $~lib/builtins/abort
   unreachable
  )
@@ -23119,7 +23119,7 @@
    i32.const 1376
    i32.const 1440
    i32.const 1774
-   i32.const 18
+   i32.const 19
    call $~lib/builtins/abort
    unreachable
   end
@@ -23136,7 +23136,7 @@
    i32.const 1376
    i32.const 1440
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -23169,7 +23169,7 @@
    i32.const 0
    i32.const 1312
    i32.const 712
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -23202,7 +23202,7 @@
      i32.const 0
      i32.const 1312
      i32.const 718
-     i32.const 6
+     i32.const 7
      call $~lib/builtins/abort
      unreachable
     end
@@ -23232,7 +23232,7 @@
    i32.const 1376
    i32.const 1440
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -23288,7 +23288,7 @@
    i32.const 1376
    i32.const 1440
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -23342,7 +23342,7 @@
    i32.const 1376
    i32.const 1440
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -23401,7 +23401,7 @@
    i32.const 1376
    i32.const 1440
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -23698,7 +23698,7 @@
   i32.const 1376
   i32.const 1440
   i32.const 1775
-  i32.const 46
+  i32.const 47
   call $~lib/builtins/abort
   unreachable
  )
@@ -23719,7 +23719,7 @@
    i32.const 0
    i32.const 1312
    i32.const 712
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -23752,7 +23752,7 @@
      i32.const 0
      i32.const 1312
      i32.const 718
-     i32.const 6
+     i32.const 7
      call $~lib/builtins/abort
      unreachable
     end
@@ -24023,7 +24023,7 @@
   i32.const 1376
   i32.const 1440
   i32.const 1775
-  i32.const 46
+  i32.const 47
   call $~lib/builtins/abort
   unreachable
  )
@@ -24042,7 +24042,7 @@
    i32.const 1376
    i32.const 1440
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -24106,7 +24106,7 @@
    i32.const 0
    i32.const 1312
    i32.const 712
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -24139,7 +24139,7 @@
      i32.const 0
      i32.const 1312
      i32.const 718
-     i32.const 6
+     i32.const 7
      call $~lib/builtins/abort
      unreachable
     end
@@ -24167,7 +24167,7 @@
    i32.const 1376
    i32.const 1440
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -24195,7 +24195,7 @@
    i32.const 1376
    i32.const 1440
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -24249,7 +24249,7 @@
    i32.const 1376
    i32.const 1440
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -24308,7 +24308,7 @@
    i32.const 1376
    i32.const 1440
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -24604,7 +24604,7 @@
   i32.const 1376
   i32.const 1440
   i32.const 1775
-  i32.const 46
+  i32.const 47
   call $~lib/builtins/abort
   unreachable
  )
@@ -24625,7 +24625,7 @@
    i32.const 0
    i32.const 1312
    i32.const 712
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -24658,7 +24658,7 @@
      i32.const 0
      i32.const 1312
      i32.const 718
-     i32.const 6
+     i32.const 7
      call $~lib/builtins/abort
      unreachable
     end
@@ -24928,7 +24928,7 @@
   i32.const 1376
   i32.const 1440
   i32.const 1775
-  i32.const 46
+  i32.const 47
   call $~lib/builtins/abort
   unreachable
  )
@@ -24950,7 +24950,7 @@
    i32.const 0
    i32.const 1312
    i32.const 712
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -24990,7 +24990,7 @@
      i32.const 0
      i32.const 1312
      i32.const 718
-     i32.const 6
+     i32.const 7
      call $~lib/builtins/abort
      unreachable
     end
@@ -25359,7 +25359,7 @@
   i32.const 1376
   i32.const 1440
   i32.const 1775
-  i32.const 46
+  i32.const 47
   call $~lib/builtins/abort
   unreachable
  )
@@ -25381,7 +25381,7 @@
    i32.const 0
    i32.const 1312
    i32.const 712
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -25419,7 +25419,7 @@
      i32.const 0
      i32.const 1312
      i32.const 718
-     i32.const 6
+     i32.const 7
      call $~lib/builtins/abort
      unreachable
     end
@@ -25832,7 +25832,7 @@
   i32.const 1376
   i32.const 1440
   i32.const 1775
-  i32.const 46
+  i32.const 47
   call $~lib/builtins/abort
   unreachable
  )
@@ -25895,7 +25895,7 @@
    i32.const 0
    i32.const 1312
    i32.const 95
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -25905,7 +25905,7 @@
    i32.const 0
    i32.const 1312
    i32.const 96
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -25917,7 +25917,7 @@
    i32.const 0
    i32.const 1312
    i32.const 97
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -25930,7 +25930,7 @@
    i32.const 0
    i32.const 1312
    i32.const 98
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -25943,7 +25943,7 @@
    i32.const 0
    i32.const 1312
    i32.const 99
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -25956,7 +25956,7 @@
    i32.const 0
    i32.const 1312
    i32.const 100
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -25977,7 +25977,7 @@
    i32.const 0
    i32.const 1312
    i32.const 103
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -25989,7 +25989,7 @@
    i32.const 0
    i32.const 1312
    i32.const 104
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -26001,7 +26001,7 @@
    i32.const 0
    i32.const 1312
    i32.const 105
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -26014,7 +26014,7 @@
    i32.const 0
    i32.const 1312
    i32.const 106
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -26071,7 +26071,7 @@
    i32.const 0
    i32.const 1312
    i32.const 122
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -26083,7 +26083,7 @@
    i32.const 0
    i32.const 1312
    i32.const 123
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -26095,7 +26095,7 @@
    i32.const 0
    i32.const 1312
    i32.const 124
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -26194,7 +26194,7 @@
    i32.const 0
    i32.const 1312
    i32.const 126
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -26221,7 +26221,7 @@
    i32.const 0
    i32.const 1312
    i32.const 135
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -26234,7 +26234,7 @@
    i32.const 0
    i32.const 1312
    i32.const 136
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -26247,7 +26247,7 @@
    i32.const 0
    i32.const 1312
    i32.const 137
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -26295,7 +26295,7 @@
    i32.const 0
    i32.const 1312
    i32.const 149
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -26319,7 +26319,7 @@
    i32.const 0
    i32.const 1312
    i32.const 152
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -26343,7 +26343,7 @@
    i32.const 0
    i32.const 1312
    i32.const 155
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -26367,7 +26367,7 @@
    i32.const 0
    i32.const 1312
    i32.const 158
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -26391,7 +26391,7 @@
    i32.const 0
    i32.const 1312
    i32.const 161
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -26413,7 +26413,7 @@
    i32.const 0
    i32.const 1312
    i32.const 165
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -26425,7 +26425,7 @@
    i32.const 0
    i32.const 1312
    i32.const 166
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -26437,7 +26437,7 @@
    i32.const 0
    i32.const 1312
    i32.const 167
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -26455,7 +26455,7 @@
    i32.const 0
    i32.const 1312
    i32.const 168
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -26473,7 +26473,7 @@
    i32.const 0
    i32.const 1312
    i32.const 169
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -26537,7 +26537,7 @@
    i32.const 0
    i32.const 1312
    i32.const 181
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -26561,7 +26561,7 @@
    i32.const 0
    i32.const 1312
    i32.const 184
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -26585,7 +26585,7 @@
    i32.const 0
    i32.const 1312
    i32.const 187
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -26609,7 +26609,7 @@
    i32.const 0
    i32.const 1312
    i32.const 190
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -26633,7 +26633,7 @@
    i32.const 0
    i32.const 1312
    i32.const 193
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -26657,7 +26657,7 @@
    i32.const 0
    i32.const 1312
    i32.const 197
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -26669,7 +26669,7 @@
    i32.const 0
    i32.const 1312
    i32.const 198
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -26681,7 +26681,7 @@
    i32.const 0
    i32.const 1312
    i32.const 199
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -26699,7 +26699,7 @@
    i32.const 0
    i32.const 1312
    i32.const 200
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -26717,7 +26717,7 @@
    i32.const 0
    i32.const 1312
    i32.const 201
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -26778,7 +26778,7 @@
    i32.const 0
    i32.const 1312
    i32.const 222
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -26790,7 +26790,7 @@
    i32.const 0
    i32.const 1312
    i32.const 223
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -26802,7 +26802,7 @@
    i32.const 0
    i32.const 1312
    i32.const 224
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -26814,7 +26814,7 @@
    i32.const 0
    i32.const 1312
    i32.const 225
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -26831,7 +26831,7 @@
    i32.const 0
    i32.const 1312
    i32.const 228
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -26843,7 +26843,7 @@
    i32.const 0
    i32.const 1312
    i32.const 229
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -26855,7 +26855,7 @@
    i32.const 0
    i32.const 1312
    i32.const 230
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -26867,7 +26867,7 @@
    i32.const 0
    i32.const 1312
    i32.const 231
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -26884,7 +26884,7 @@
    i32.const 0
    i32.const 1312
    i32.const 234
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -26896,7 +26896,7 @@
    i32.const 0
    i32.const 1312
    i32.const 235
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -26908,7 +26908,7 @@
    i32.const 0
    i32.const 1312
    i32.const 236
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -26920,7 +26920,7 @@
    i32.const 0
    i32.const 1312
    i32.const 237
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -26978,7 +26978,7 @@
    i32.const 0
    i32.const 1312
    i32.const 248
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -27008,7 +27008,7 @@
    i32.const 0
    i32.const 1312
    i32.const 250
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -27037,7 +27037,7 @@
    i32.const 0
    i32.const 1312
    i32.const 252
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -27066,7 +27066,7 @@
    i32.const 0
    i32.const 1312
    i32.const 254
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -27095,7 +27095,7 @@
    i32.const 0
    i32.const 1312
    i32.const 256
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -27124,7 +27124,7 @@
    i32.const 0
    i32.const 1312
    i32.const 258
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -27153,7 +27153,7 @@
    i32.const 0
    i32.const 1312
    i32.const 260
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -27182,7 +27182,7 @@
    i32.const 0
    i32.const 1312
    i32.const 262
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -27211,7 +27211,7 @@
    i32.const 0
    i32.const 1312
    i32.const 264
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -27240,7 +27240,7 @@
    i32.const 0
    i32.const 1312
    i32.const 266
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -27270,7 +27270,7 @@
    i32.const 0
    i32.const 1312
    i32.const 268
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -27300,7 +27300,7 @@
    i32.const 0
    i32.const 1312
    i32.const 270
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -27392,7 +27392,7 @@
    i32.const 0
    i32.const 1312
    i32.const 282
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -27404,7 +27404,7 @@
    i32.const 0
    i32.const 1312
    i32.const 283
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -27416,7 +27416,7 @@
    i32.const 0
    i32.const 1312
    i32.const 284
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -27433,7 +27433,7 @@
    i32.const 0
    i32.const 1312
    i32.const 287
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -27446,7 +27446,7 @@
    i32.const 0
    i32.const 1312
    i32.const 288
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -27460,7 +27460,7 @@
    i32.const 0
    i32.const 1312
    i32.const 289
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -27470,7 +27470,7 @@
    i32.const 0
    i32.const 1312
    i32.const 290
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -27482,7 +27482,7 @@
    i32.const 0
    i32.const 1312
    i32.const 291
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -27499,7 +27499,7 @@
    i32.const 0
    i32.const 1312
    i32.const 294
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -27513,7 +27513,7 @@
    i32.const 0
    i32.const 1312
    i32.const 295
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -27523,7 +27523,7 @@
    i32.const 0
    i32.const 1312
    i32.const 296
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -27535,7 +27535,7 @@
    i32.const 0
    i32.const 1312
    i32.const 297
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -27550,7 +27550,7 @@
    i32.const 0
    i32.const 1312
    i32.const 300
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -27567,7 +27567,7 @@
    i32.const 0
    i32.const 1312
    i32.const 301
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -27580,7 +27580,7 @@
    i32.const 0
    i32.const 1312
    i32.const 302
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -27593,7 +27593,7 @@
    i32.const 0
    i32.const 1312
    i32.const 303
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -30977,7 +30977,7 @@
                     i32.const 0
                     i32.const 1312
                     i32.const 607
-                    i32.const 2
+                    i32.const 3
                     call $~lib/builtins/abort
                     unreachable
                    end
@@ -31045,7 +31045,7 @@
                     i32.const 0
                     i32.const 1312
                     i32.const 608
-                    i32.const 2
+                    i32.const 3
                     call $~lib/builtins/abort
                     unreachable
                    end
@@ -31065,7 +31065,7 @@
                     i32.const 0
                     i32.const 1312
                     i32.const 613
-                    i32.const 2
+                    i32.const 3
                     call $~lib/builtins/abort
                     unreachable
                    end
@@ -31133,7 +31133,7 @@
                     i32.const 0
                     i32.const 1312
                     i32.const 614
-                    i32.const 2
+                    i32.const 3
                     call $~lib/builtins/abort
                     unreachable
                    end
@@ -31617,7 +31617,7 @@
                     i32.const 0
                     i32.const 1312
                     i32.const 691
-                    i32.const 2
+                    i32.const 3
                     call $~lib/builtins/abort
                     unreachable
                    end
@@ -31640,7 +31640,7 @@
                     i32.const 0
                     i32.const 1312
                     i32.const 695
-                    i32.const 2
+                    i32.const 3
                     call $~lib/builtins/abort
                     unreachable
                    end
@@ -31969,119 +31969,119 @@
                   i32.const 0
                   i32.const 1312
                   i32.const 323
-                  i32.const 2
+                  i32.const 3
                   call $~lib/builtins/abort
                   unreachable
                  end
                  i32.const 0
                  i32.const 1312
                  i32.const 344
-                 i32.const 2
+                 i32.const 3
                  call $~lib/builtins/abort
                  unreachable
                 end
                 i32.const 0
                 i32.const 1312
                 i32.const 365
-                i32.const 2
+                i32.const 3
                 call $~lib/builtins/abort
                 unreachable
                end
                i32.const 0
                i32.const 1312
                i32.const 366
-               i32.const 2
+               i32.const 3
                call $~lib/builtins/abort
                unreachable
               end
               i32.const 0
               i32.const 1312
               i32.const 367
-              i32.const 2
+              i32.const 3
               call $~lib/builtins/abort
               unreachable
              end
              i32.const 0
              i32.const 1312
              i32.const 415
-             i32.const 2
+             i32.const 3
              call $~lib/builtins/abort
              unreachable
             end
             i32.const 0
             i32.const 1312
             i32.const 417
-            i32.const 2
+            i32.const 3
             call $~lib/builtins/abort
             unreachable
            end
            i32.const 0
            i32.const 1312
            i32.const 438
-           i32.const 2
+           i32.const 3
            call $~lib/builtins/abort
            unreachable
           end
           i32.const 0
           i32.const 1312
           i32.const 440
-          i32.const 2
+          i32.const 3
           call $~lib/builtins/abort
           unreachable
          end
          i32.const 0
          i32.const 1312
          i32.const 461
-         i32.const 2
+         i32.const 3
          call $~lib/builtins/abort
          unreachable
         end
         i32.const 0
         i32.const 1312
         i32.const 463
-        i32.const 2
+        i32.const 3
         call $~lib/builtins/abort
         unreachable
        end
        i32.const 0
        i32.const 1312
        i32.const 495
-       i32.const 2
+       i32.const 3
        call $~lib/builtins/abort
        unreachable
       end
       i32.const 0
       i32.const 1312
       i32.const 629
-      i32.const 4
+      i32.const 5
       call $~lib/builtins/abort
       unreachable
      end
      i32.const 0
      i32.const 1312
      i32.const 630
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
     i32.const 0
     i32.const 1312
     i32.const 626
-    i32.const 4
+    i32.const 5
     call $~lib/builtins/abort
     unreachable
    end
    i32.const 0
    i32.const 1312
    i32.const 627
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
   i32.const 1376
   i32.const 1440
   i32.const 1775
-  i32.const 46
+  i32.const 47
   call $~lib/builtins/abort
   unreachable
  )
@@ -32114,7 +32114,7 @@
    i32.const 0
    i32.const 1264
    i32.const 122
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -32157,7 +32157,7 @@
     i32.const 0
     i32.const 1264
     i32.const 126
-    i32.const 17
+    i32.const 18
     call $~lib/builtins/abort
     unreachable
    end
@@ -32172,7 +32172,7 @@
     i32.const 0
     i32.const 1264
     i32.const 136
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end

--- a/tests/compiler/std/typedarray.untouched.wat
+++ b/tests/compiler/std/typedarray.untouched.wat
@@ -247,7 +247,7 @@
    i32.const 0
    i32.const 144
    i32.const 277
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -272,7 +272,7 @@
    i32.const 0
    i32.const 144
    i32.const 279
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -324,7 +324,7 @@
    i32.const 0
    i32.const 144
    i32.const 292
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -454,7 +454,7 @@
    i32.const 0
    i32.const 144
    i32.const 205
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -469,7 +469,7 @@
    i32.const 0
    i32.const 144
    i32.const 207
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -562,7 +562,7 @@
     i32.const 0
     i32.const 144
     i32.const 228
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -625,7 +625,7 @@
    i32.const 0
    i32.const 144
    i32.const 243
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -641,7 +641,7 @@
    i32.const 0
    i32.const 144
    i32.const 244
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -698,7 +698,7 @@
    i32.const 0
    i32.const 144
    i32.const 260
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -817,7 +817,7 @@
    i32.const 0
    i32.const 144
    i32.const 386
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -840,7 +840,7 @@
     i32.const 0
     i32.const 144
     i32.const 396
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -871,7 +871,7 @@
     i32.const 0
     i32.const 144
     i32.const 408
-    i32.const 4
+    i32.const 5
     call $~lib/builtins/abort
     unreachable
    end
@@ -1097,7 +1097,7 @@
    i32.const 192
    i32.const 144
    i32.const 461
-   i32.const 29
+   i32.const 30
    call $~lib/builtins/abort
    unreachable
   end
@@ -1191,7 +1191,7 @@
    i32.const 0
    i32.const 144
    i32.const 338
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1254,7 +1254,7 @@
      i32.const 0
      i32.const 144
      i32.const 351
-     i32.const 17
+     i32.const 18
      call $~lib/builtins/abort
      unreachable
     end
@@ -1399,7 +1399,7 @@
    i32.const 0
    i32.const 144
    i32.const 365
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1488,7 +1488,7 @@
    i32.const 0
    i32.const 144
    i32.const 501
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1529,7 +1529,7 @@
       i32.const 0
       i32.const 144
       i32.const 513
-      i32.const 19
+      i32.const 20
       call $~lib/builtins/abort
       unreachable
      end
@@ -1548,7 +1548,7 @@
      i32.const 0
      i32.const 144
      i32.const 518
-     i32.const 17
+     i32.const 18
      call $~lib/builtins/abort
      unreachable
     end
@@ -1565,7 +1565,7 @@
    i32.const 0
    i32.const 144
    i32.const 521
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1825,7 +1825,7 @@
    i32.const 0
    i32.const 256
    i32.const 109
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1846,7 +1846,7 @@
    i32.const 0
    i32.const 256
    i32.const 112
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1888,7 +1888,7 @@
    i32.const 32
    i32.const 80
    i32.const 23
-   i32.const 56
+   i32.const 57
    call $~lib/builtins/abort
    unreachable
   end
@@ -2214,7 +2214,7 @@
    i32.const 0
    i32.const 304
    i32.const 32
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2229,7 +2229,7 @@
    i32.const 0
    i32.const 304
    i32.const 33
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2242,7 +2242,7 @@
    i32.const 0
    i32.const 304
    i32.const 34
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2259,7 +2259,7 @@
    i32.const 0
    i32.const 304
    i32.const 37
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2274,7 +2274,7 @@
    i32.const 0
    i32.const 304
    i32.const 38
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2287,7 +2287,7 @@
    i32.const 0
    i32.const 304
    i32.const 39
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2304,7 +2304,7 @@
    i32.const 0
    i32.const 304
    i32.const 42
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2319,7 +2319,7 @@
    i32.const 0
    i32.const 304
    i32.const 43
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2332,7 +2332,7 @@
    i32.const 0
    i32.const 304
    i32.const 44
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2349,7 +2349,7 @@
    i32.const 0
    i32.const 304
    i32.const 47
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2364,7 +2364,7 @@
    i32.const 0
    i32.const 304
    i32.const 48
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2377,7 +2377,7 @@
    i32.const 0
    i32.const 304
    i32.const 49
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2394,7 +2394,7 @@
    i32.const 0
    i32.const 304
    i32.const 52
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2409,7 +2409,7 @@
    i32.const 0
    i32.const 304
    i32.const 53
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2422,7 +2422,7 @@
    i32.const 0
    i32.const 304
    i32.const 54
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2439,7 +2439,7 @@
    i32.const 0
    i32.const 304
    i32.const 57
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2454,7 +2454,7 @@
    i32.const 0
    i32.const 304
    i32.const 58
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2467,7 +2467,7 @@
    i32.const 0
    i32.const 304
    i32.const 59
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2484,7 +2484,7 @@
    i32.const 0
    i32.const 304
    i32.const 62
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2499,7 +2499,7 @@
    i32.const 0
    i32.const 304
    i32.const 63
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2512,7 +2512,7 @@
    i32.const 0
    i32.const 304
    i32.const 64
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2529,7 +2529,7 @@
    i32.const 0
    i32.const 304
    i32.const 67
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2544,7 +2544,7 @@
    i32.const 0
    i32.const 304
    i32.const 68
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2557,7 +2557,7 @@
    i32.const 0
    i32.const 304
    i32.const 69
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2574,7 +2574,7 @@
    i32.const 0
    i32.const 304
    i32.const 72
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2589,7 +2589,7 @@
    i32.const 0
    i32.const 304
    i32.const 73
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2602,7 +2602,7 @@
    i32.const 0
    i32.const 304
    i32.const 74
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2619,7 +2619,7 @@
    i32.const 0
    i32.const 304
    i32.const 77
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2634,7 +2634,7 @@
    i32.const 0
    i32.const 304
    i32.const 78
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2647,7 +2647,7 @@
    i32.const 0
    i32.const 304
    i32.const 79
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2664,7 +2664,7 @@
    i32.const 0
    i32.const 304
    i32.const 82
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2679,7 +2679,7 @@
    i32.const 0
    i32.const 304
    i32.const 83
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2692,7 +2692,7 @@
    i32.const 0
    i32.const 304
    i32.const 84
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2730,7 +2730,7 @@
    i32.const 368
    i32.const 432
    i32.const 675
-   i32.const 63
+   i32.const 64
    call $~lib/builtins/abort
    unreachable
   end
@@ -2754,7 +2754,7 @@
    i32.const 368
    i32.const 432
    i32.const 664
-   i32.const 63
+   i32.const 64
    call $~lib/builtins/abort
    unreachable
   end
@@ -2884,7 +2884,7 @@
    i32.const 368
    i32.const 432
    i32.const 1315
-   i32.const 63
+   i32.const 64
    call $~lib/builtins/abort
    unreachable
   end
@@ -3138,7 +3138,7 @@
    i32.const 0
    i32.const 144
    i32.const 581
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -3599,7 +3599,7 @@
    i32.const 368
    i32.const 432
    i32.const 1304
-   i32.const 63
+   i32.const 64
    call $~lib/builtins/abort
    unreachable
   end
@@ -3620,7 +3620,7 @@
    i32.const 368
    i32.const 432
    i32.const 291
-   i32.const 44
+   i32.const 45
    call $~lib/builtins/abort
    unreachable
   end
@@ -3652,7 +3652,7 @@
    i32.const 368
    i32.const 432
    i32.const 280
-   i32.const 44
+   i32.const 45
    call $~lib/builtins/abort
    unreachable
   end
@@ -3671,7 +3671,7 @@
    i32.const 368
    i32.const 432
    i32.const 35
-   i32.const 44
+   i32.const 45
    call $~lib/builtins/abort
    unreachable
   end
@@ -5075,7 +5075,7 @@
    i32.const 368
    i32.const 432
    i32.const 24
-   i32.const 44
+   i32.const 45
    call $~lib/builtins/abort
    unreachable
   end
@@ -5104,7 +5104,7 @@
    i32.const 368
    i32.const 528
    i32.const 104
-   i32.const 41
+   i32.const 42
    call $~lib/builtins/abort
    unreachable
   end
@@ -5411,7 +5411,7 @@
    i32.const 368
    i32.const 528
    i32.const 104
-   i32.const 41
+   i32.const 42
    call $~lib/builtins/abort
    unreachable
   end
@@ -5845,7 +5845,7 @@
    i32.const 0
    i32.const 304
    i32.const 323
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -5863,7 +5863,7 @@
    i32.const 368
    i32.const 432
    i32.const 163
-   i32.const 44
+   i32.const 45
    call $~lib/builtins/abort
    unreachable
   end
@@ -5981,7 +5981,7 @@
    i32.const 0
    i32.const 304
    i32.const 323
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -6097,7 +6097,7 @@
    i32.const 0
    i32.const 304
    i32.const 323
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -6117,7 +6117,7 @@
    i32.const 368
    i32.const 432
    i32.const 419
-   i32.const 63
+   i32.const 64
    call $~lib/builtins/abort
    unreachable
   end
@@ -6239,7 +6239,7 @@
    i32.const 0
    i32.const 304
    i32.const 323
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -6259,7 +6259,7 @@
    i32.const 368
    i32.const 432
    i32.const 547
-   i32.const 63
+   i32.const 64
    call $~lib/builtins/abort
    unreachable
   end
@@ -6379,7 +6379,7 @@
    i32.const 0
    i32.const 304
    i32.const 323
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -6493,7 +6493,7 @@
    i32.const 0
    i32.const 304
    i32.const 323
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -6513,7 +6513,7 @@
    i32.const 368
    i32.const 432
    i32.const 803
-   i32.const 63
+   i32.const 64
    call $~lib/builtins/abort
    unreachable
   end
@@ -6631,7 +6631,7 @@
    i32.const 0
    i32.const 304
    i32.const 323
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -6651,7 +6651,7 @@
    i32.const 368
    i32.const 432
    i32.const 931
-   i32.const 63
+   i32.const 64
    call $~lib/builtins/abort
    unreachable
   end
@@ -6770,7 +6770,7 @@
    i32.const 0
    i32.const 304
    i32.const 323
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -6790,7 +6790,7 @@
    i32.const 368
    i32.const 432
    i32.const 1059
-   i32.const 63
+   i32.const 64
    call $~lib/builtins/abort
    unreachable
   end
@@ -6909,7 +6909,7 @@
    i32.const 0
    i32.const 304
    i32.const 323
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -6929,7 +6929,7 @@
    i32.const 368
    i32.const 432
    i32.const 1187
-   i32.const 63
+   i32.const 64
    call $~lib/builtins/abort
    unreachable
   end
@@ -7048,7 +7048,7 @@
    i32.const 0
    i32.const 304
    i32.const 323
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -7163,7 +7163,7 @@
    i32.const 0
    i32.const 304
    i32.const 323
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -7280,7 +7280,7 @@
    i32.const 0
    i32.const 304
    i32.const 344
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -7395,7 +7395,7 @@
    i32.const 0
    i32.const 304
    i32.const 344
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -7510,7 +7510,7 @@
    i32.const 0
    i32.const 304
    i32.const 344
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -7627,7 +7627,7 @@
    i32.const 0
    i32.const 304
    i32.const 344
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -7742,7 +7742,7 @@
    i32.const 0
    i32.const 304
    i32.const 344
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -7855,7 +7855,7 @@
    i32.const 0
    i32.const 304
    i32.const 344
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -7968,7 +7968,7 @@
    i32.const 0
    i32.const 304
    i32.const 344
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -8082,7 +8082,7 @@
    i32.const 0
    i32.const 304
    i32.const 344
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -8196,7 +8196,7 @@
    i32.const 0
    i32.const 304
    i32.const 344
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -8310,7 +8310,7 @@
    i32.const 0
    i32.const 304
    i32.const 344
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -8424,7 +8424,7 @@
    i32.const 0
    i32.const 304
    i32.const 344
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -8566,7 +8566,7 @@
    i32.const 0
    i32.const 304
    i32.const 365
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -8580,7 +8580,7 @@
    i32.const 0
    i32.const 304
    i32.const 366
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -8594,7 +8594,7 @@
    i32.const 0
    i32.const 304
    i32.const 367
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -8711,7 +8711,7 @@
    i32.const 368
    i32.const 432
    i32.const 152
-   i32.const 44
+   i32.const 45
    call $~lib/builtins/abort
    unreachable
   end
@@ -8757,7 +8757,7 @@
    i32.const 0
    i32.const 304
    i32.const 365
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -8771,7 +8771,7 @@
    i32.const 0
    i32.const 304
    i32.const 366
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -8785,7 +8785,7 @@
    i32.const 0
    i32.const 304
    i32.const 367
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -8929,7 +8929,7 @@
    i32.const 0
    i32.const 304
    i32.const 365
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -8943,7 +8943,7 @@
    i32.const 0
    i32.const 304
    i32.const 366
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -8957,7 +8957,7 @@
    i32.const 0
    i32.const 304
    i32.const 367
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -9076,7 +9076,7 @@
    i32.const 368
    i32.const 432
    i32.const 408
-   i32.const 63
+   i32.const 64
    call $~lib/builtins/abort
    unreachable
   end
@@ -9124,7 +9124,7 @@
    i32.const 0
    i32.const 304
    i32.const 365
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -9138,7 +9138,7 @@
    i32.const 0
    i32.const 304
    i32.const 366
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -9152,7 +9152,7 @@
    i32.const 0
    i32.const 304
    i32.const 367
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -9271,7 +9271,7 @@
    i32.const 368
    i32.const 432
    i32.const 536
-   i32.const 63
+   i32.const 64
    call $~lib/builtins/abort
    unreachable
   end
@@ -9319,7 +9319,7 @@
    i32.const 0
    i32.const 304
    i32.const 365
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -9333,7 +9333,7 @@
    i32.const 0
    i32.const 304
    i32.const 366
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -9347,7 +9347,7 @@
    i32.const 0
    i32.const 304
    i32.const 367
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -9491,7 +9491,7 @@
    i32.const 0
    i32.const 304
    i32.const 365
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -9505,7 +9505,7 @@
    i32.const 0
    i32.const 304
    i32.const 366
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -9519,7 +9519,7 @@
    i32.const 0
    i32.const 304
    i32.const 367
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -9638,7 +9638,7 @@
    i32.const 368
    i32.const 432
    i32.const 792
-   i32.const 63
+   i32.const 64
    call $~lib/builtins/abort
    unreachable
   end
@@ -9686,7 +9686,7 @@
    i32.const 0
    i32.const 304
    i32.const 365
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -9700,7 +9700,7 @@
    i32.const 0
    i32.const 304
    i32.const 366
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -9714,7 +9714,7 @@
    i32.const 0
    i32.const 304
    i32.const 367
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -9833,7 +9833,7 @@
    i32.const 368
    i32.const 432
    i32.const 920
-   i32.const 63
+   i32.const 64
    call $~lib/builtins/abort
    unreachable
   end
@@ -9881,7 +9881,7 @@
    i32.const 0
    i32.const 304
    i32.const 365
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -9895,7 +9895,7 @@
    i32.const 0
    i32.const 304
    i32.const 366
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -9909,7 +9909,7 @@
    i32.const 0
    i32.const 304
    i32.const 367
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10028,7 +10028,7 @@
    i32.const 368
    i32.const 432
    i32.const 1048
-   i32.const 63
+   i32.const 64
    call $~lib/builtins/abort
    unreachable
   end
@@ -10076,7 +10076,7 @@
    i32.const 0
    i32.const 304
    i32.const 365
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10090,7 +10090,7 @@
    i32.const 0
    i32.const 304
    i32.const 366
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10104,7 +10104,7 @@
    i32.const 0
    i32.const 304
    i32.const 367
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10223,7 +10223,7 @@
    i32.const 368
    i32.const 432
    i32.const 1176
-   i32.const 63
+   i32.const 64
    call $~lib/builtins/abort
    unreachable
   end
@@ -10271,7 +10271,7 @@
    i32.const 0
    i32.const 304
    i32.const 365
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10285,7 +10285,7 @@
    i32.const 0
    i32.const 304
    i32.const 366
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10299,7 +10299,7 @@
    i32.const 0
    i32.const 304
    i32.const 367
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10443,7 +10443,7 @@
    i32.const 0
    i32.const 304
    i32.const 365
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10457,7 +10457,7 @@
    i32.const 0
    i32.const 304
    i32.const 366
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10471,7 +10471,7 @@
    i32.const 0
    i32.const 304
    i32.const 367
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10774,7 +10774,7 @@
    i32.const 0
    i32.const 304
    i32.const 390
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10787,7 +10787,7 @@
    i32.const 0
    i32.const 304
    i32.const 391
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10801,7 +10801,7 @@
    i32.const 0
    i32.const 304
    i32.const 392
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10815,7 +10815,7 @@
    i32.const 0
    i32.const 304
    i32.const 393
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -10829,7 +10829,7 @@
    i32.const 0
    i32.const 304
    i32.const 394
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11002,7 +11002,7 @@
    i32.const 0
    i32.const 304
    i32.const 390
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11015,7 +11015,7 @@
    i32.const 0
    i32.const 304
    i32.const 391
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11029,7 +11029,7 @@
    i32.const 0
    i32.const 304
    i32.const 392
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11043,7 +11043,7 @@
    i32.const 0
    i32.const 304
    i32.const 393
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11057,7 +11057,7 @@
    i32.const 0
    i32.const 304
    i32.const 394
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11230,7 +11230,7 @@
    i32.const 0
    i32.const 304
    i32.const 390
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11243,7 +11243,7 @@
    i32.const 0
    i32.const 304
    i32.const 391
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11257,7 +11257,7 @@
    i32.const 0
    i32.const 304
    i32.const 392
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11271,7 +11271,7 @@
    i32.const 0
    i32.const 304
    i32.const 393
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11285,7 +11285,7 @@
    i32.const 0
    i32.const 304
    i32.const 394
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11460,7 +11460,7 @@
    i32.const 0
    i32.const 304
    i32.const 390
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11473,7 +11473,7 @@
    i32.const 0
    i32.const 304
    i32.const 391
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11487,7 +11487,7 @@
    i32.const 0
    i32.const 304
    i32.const 392
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11501,7 +11501,7 @@
    i32.const 0
    i32.const 304
    i32.const 393
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11515,7 +11515,7 @@
    i32.const 0
    i32.const 304
    i32.const 394
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11688,7 +11688,7 @@
    i32.const 0
    i32.const 304
    i32.const 390
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11701,7 +11701,7 @@
    i32.const 0
    i32.const 304
    i32.const 391
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11715,7 +11715,7 @@
    i32.const 0
    i32.const 304
    i32.const 392
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11729,7 +11729,7 @@
    i32.const 0
    i32.const 304
    i32.const 393
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11743,7 +11743,7 @@
    i32.const 0
    i32.const 304
    i32.const 394
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11914,7 +11914,7 @@
    i32.const 0
    i32.const 304
    i32.const 390
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11927,7 +11927,7 @@
    i32.const 0
    i32.const 304
    i32.const 391
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11941,7 +11941,7 @@
    i32.const 0
    i32.const 304
    i32.const 392
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11955,7 +11955,7 @@
    i32.const 0
    i32.const 304
    i32.const 393
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -11969,7 +11969,7 @@
    i32.const 0
    i32.const 304
    i32.const 394
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12140,7 +12140,7 @@
    i32.const 0
    i32.const 304
    i32.const 390
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12153,7 +12153,7 @@
    i32.const 0
    i32.const 304
    i32.const 391
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12167,7 +12167,7 @@
    i32.const 0
    i32.const 304
    i32.const 392
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12181,7 +12181,7 @@
    i32.const 0
    i32.const 304
    i32.const 393
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12195,7 +12195,7 @@
    i32.const 0
    i32.const 304
    i32.const 394
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12366,7 +12366,7 @@
    i32.const 0
    i32.const 304
    i32.const 390
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12379,7 +12379,7 @@
    i32.const 0
    i32.const 304
    i32.const 391
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12393,7 +12393,7 @@
    i32.const 0
    i32.const 304
    i32.const 392
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12407,7 +12407,7 @@
    i32.const 0
    i32.const 304
    i32.const 393
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12421,7 +12421,7 @@
    i32.const 0
    i32.const 304
    i32.const 394
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12592,7 +12592,7 @@
    i32.const 0
    i32.const 304
    i32.const 390
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12605,7 +12605,7 @@
    i32.const 0
    i32.const 304
    i32.const 391
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12619,7 +12619,7 @@
    i32.const 0
    i32.const 304
    i32.const 392
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12633,7 +12633,7 @@
    i32.const 0
    i32.const 304
    i32.const 393
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12647,7 +12647,7 @@
    i32.const 0
    i32.const 304
    i32.const 394
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12818,7 +12818,7 @@
    i32.const 0
    i32.const 304
    i32.const 390
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12831,7 +12831,7 @@
    i32.const 0
    i32.const 304
    i32.const 391
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12845,7 +12845,7 @@
    i32.const 0
    i32.const 304
    i32.const 392
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12859,7 +12859,7 @@
    i32.const 0
    i32.const 304
    i32.const 393
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -12873,7 +12873,7 @@
    i32.const 0
    i32.const 304
    i32.const 394
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13044,7 +13044,7 @@
    i32.const 0
    i32.const 304
    i32.const 390
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13057,7 +13057,7 @@
    i32.const 0
    i32.const 304
    i32.const 391
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13071,7 +13071,7 @@
    i32.const 0
    i32.const 304
    i32.const 392
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13085,7 +13085,7 @@
    i32.const 0
    i32.const 304
    i32.const 393
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13099,7 +13099,7 @@
    i32.const 0
    i32.const 304
    i32.const 394
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13242,7 +13242,7 @@
    i32.const 0
    i32.const 304
    i32.const 415
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13257,7 +13257,7 @@
    i32.const 0
    i32.const 304
    i32.const 417
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13394,7 +13394,7 @@
    i32.const 0
    i32.const 304
    i32.const 415
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13409,7 +13409,7 @@
    i32.const 0
    i32.const 304
    i32.const 417
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13546,7 +13546,7 @@
    i32.const 0
    i32.const 304
    i32.const 415
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13561,7 +13561,7 @@
    i32.const 0
    i32.const 304
    i32.const 417
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13702,7 +13702,7 @@
    i32.const 0
    i32.const 304
    i32.const 415
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13717,7 +13717,7 @@
    i32.const 0
    i32.const 304
    i32.const 417
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13854,7 +13854,7 @@
    i32.const 0
    i32.const 304
    i32.const 415
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -13869,7 +13869,7 @@
    i32.const 0
    i32.const 304
    i32.const 417
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14002,7 +14002,7 @@
    i32.const 0
    i32.const 304
    i32.const 415
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14017,7 +14017,7 @@
    i32.const 0
    i32.const 304
    i32.const 417
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14150,7 +14150,7 @@
    i32.const 0
    i32.const 304
    i32.const 415
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14165,7 +14165,7 @@
    i32.const 0
    i32.const 304
    i32.const 417
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14298,7 +14298,7 @@
    i32.const 0
    i32.const 304
    i32.const 415
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14313,7 +14313,7 @@
    i32.const 0
    i32.const 304
    i32.const 417
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14446,7 +14446,7 @@
    i32.const 0
    i32.const 304
    i32.const 415
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14461,7 +14461,7 @@
    i32.const 0
    i32.const 304
    i32.const 417
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14594,7 +14594,7 @@
    i32.const 0
    i32.const 304
    i32.const 415
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14609,7 +14609,7 @@
    i32.const 0
    i32.const 304
    i32.const 417
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14742,7 +14742,7 @@
    i32.const 0
    i32.const 304
    i32.const 415
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14757,7 +14757,7 @@
    i32.const 0
    i32.const 304
    i32.const 417
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14898,7 +14898,7 @@
    i32.const 0
    i32.const 304
    i32.const 438
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -14914,7 +14914,7 @@
    i32.const 0
    i32.const 304
    i32.const 440
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -15051,7 +15051,7 @@
    i32.const 0
    i32.const 304
    i32.const 438
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -15067,7 +15067,7 @@
    i32.const 0
    i32.const 304
    i32.const 440
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -15204,7 +15204,7 @@
    i32.const 0
    i32.const 304
    i32.const 438
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -15220,7 +15220,7 @@
    i32.const 0
    i32.const 304
    i32.const 440
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -15361,7 +15361,7 @@
    i32.const 0
    i32.const 304
    i32.const 438
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -15377,7 +15377,7 @@
    i32.const 0
    i32.const 304
    i32.const 440
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -15514,7 +15514,7 @@
    i32.const 0
    i32.const 304
    i32.const 438
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -15530,7 +15530,7 @@
    i32.const 0
    i32.const 304
    i32.const 440
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -15663,7 +15663,7 @@
    i32.const 0
    i32.const 304
    i32.const 438
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -15679,7 +15679,7 @@
    i32.const 0
    i32.const 304
    i32.const 440
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -15812,7 +15812,7 @@
    i32.const 0
    i32.const 304
    i32.const 438
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -15828,7 +15828,7 @@
    i32.const 0
    i32.const 304
    i32.const 440
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -15961,7 +15961,7 @@
    i32.const 0
    i32.const 304
    i32.const 438
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -15977,7 +15977,7 @@
    i32.const 0
    i32.const 304
    i32.const 440
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -16110,7 +16110,7 @@
    i32.const 0
    i32.const 304
    i32.const 438
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -16126,7 +16126,7 @@
    i32.const 0
    i32.const 304
    i32.const 440
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -16259,7 +16259,7 @@
    i32.const 0
    i32.const 304
    i32.const 438
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -16275,7 +16275,7 @@
    i32.const 0
    i32.const 304
    i32.const 440
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -16408,7 +16408,7 @@
    i32.const 0
    i32.const 304
    i32.const 438
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -16424,7 +16424,7 @@
    i32.const 0
    i32.const 304
    i32.const 440
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -16570,7 +16570,7 @@
    i32.const 0
    i32.const 304
    i32.const 461
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -16585,7 +16585,7 @@
    i32.const 0
    i32.const 304
    i32.const 463
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -16727,7 +16727,7 @@
    i32.const 0
    i32.const 304
    i32.const 461
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -16742,7 +16742,7 @@
    i32.const 0
    i32.const 304
    i32.const 463
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -16884,7 +16884,7 @@
    i32.const 0
    i32.const 304
    i32.const 461
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -16899,7 +16899,7 @@
    i32.const 0
    i32.const 304
    i32.const 463
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -17045,7 +17045,7 @@
    i32.const 0
    i32.const 304
    i32.const 461
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -17060,7 +17060,7 @@
    i32.const 0
    i32.const 304
    i32.const 463
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -17202,7 +17202,7 @@
    i32.const 0
    i32.const 304
    i32.const 461
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -17217,7 +17217,7 @@
    i32.const 0
    i32.const 304
    i32.const 463
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -17355,7 +17355,7 @@
    i32.const 0
    i32.const 304
    i32.const 461
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -17370,7 +17370,7 @@
    i32.const 0
    i32.const 304
    i32.const 463
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -17508,7 +17508,7 @@
    i32.const 0
    i32.const 304
    i32.const 461
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -17523,7 +17523,7 @@
    i32.const 0
    i32.const 304
    i32.const 463
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -17661,7 +17661,7 @@
    i32.const 0
    i32.const 304
    i32.const 461
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -17676,7 +17676,7 @@
    i32.const 0
    i32.const 304
    i32.const 463
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -17814,7 +17814,7 @@
    i32.const 0
    i32.const 304
    i32.const 461
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -17829,7 +17829,7 @@
    i32.const 0
    i32.const 304
    i32.const 463
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -18215,7 +18215,7 @@
    i32.const 0
    i32.const 304
    i32.const 461
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -18230,7 +18230,7 @@
    i32.const 0
    i32.const 304
    i32.const 463
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -18622,7 +18622,7 @@
    i32.const 0
    i32.const 304
    i32.const 461
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -18637,7 +18637,7 @@
    i32.const 0
    i32.const 304
    i32.const 463
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -18671,7 +18671,7 @@
    i32.const 0
    i32.const 304
    i32.const 490
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -18683,7 +18683,7 @@
    i32.const 0
    i32.const 304
    i32.const 491
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -18695,7 +18695,7 @@
    i32.const 0
    i32.const 304
    i32.const 492
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -18809,7 +18809,7 @@
    i32.const 0
    i32.const 304
    i32.const 495
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -18839,7 +18839,7 @@
    i32.const 0
    i32.const 304
    i32.const 490
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -18851,7 +18851,7 @@
    i32.const 0
    i32.const 304
    i32.const 491
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -18863,7 +18863,7 @@
    i32.const 0
    i32.const 304
    i32.const 492
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -18971,7 +18971,7 @@
    i32.const 0
    i32.const 304
    i32.const 495
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -19001,7 +19001,7 @@
    i32.const 0
    i32.const 304
    i32.const 490
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -19013,7 +19013,7 @@
    i32.const 0
    i32.const 304
    i32.const 491
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -19025,7 +19025,7 @@
    i32.const 0
    i32.const 304
    i32.const 492
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -19133,7 +19133,7 @@
    i32.const 0
    i32.const 304
    i32.const 495
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -19167,7 +19167,7 @@
    i32.const 0
    i32.const 304
    i32.const 490
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -19179,7 +19179,7 @@
    i32.const 0
    i32.const 304
    i32.const 491
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -19191,7 +19191,7 @@
    i32.const 0
    i32.const 304
    i32.const 492
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -19305,7 +19305,7 @@
    i32.const 0
    i32.const 304
    i32.const 495
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -19335,7 +19335,7 @@
    i32.const 0
    i32.const 304
    i32.const 490
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -19347,7 +19347,7 @@
    i32.const 0
    i32.const 304
    i32.const 491
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -19359,7 +19359,7 @@
    i32.const 0
    i32.const 304
    i32.const 492
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -19467,7 +19467,7 @@
    i32.const 0
    i32.const 304
    i32.const 495
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -19493,7 +19493,7 @@
    i32.const 0
    i32.const 304
    i32.const 490
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -19505,7 +19505,7 @@
    i32.const 0
    i32.const 304
    i32.const 491
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -19517,7 +19517,7 @@
    i32.const 0
    i32.const 304
    i32.const 492
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -19619,7 +19619,7 @@
    i32.const 0
    i32.const 304
    i32.const 495
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -19645,7 +19645,7 @@
    i32.const 0
    i32.const 304
    i32.const 490
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -19657,7 +19657,7 @@
    i32.const 0
    i32.const 304
    i32.const 491
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -19669,7 +19669,7 @@
    i32.const 0
    i32.const 304
    i32.const 492
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -19771,7 +19771,7 @@
    i32.const 0
    i32.const 304
    i32.const 495
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -19798,7 +19798,7 @@
    i32.const 0
    i32.const 304
    i32.const 490
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -19810,7 +19810,7 @@
    i32.const 0
    i32.const 304
    i32.const 491
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -19822,7 +19822,7 @@
    i32.const 0
    i32.const 304
    i32.const 492
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -19927,7 +19927,7 @@
    i32.const 0
    i32.const 304
    i32.const 495
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -19954,7 +19954,7 @@
    i32.const 0
    i32.const 304
    i32.const 490
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -19966,7 +19966,7 @@
    i32.const 0
    i32.const 304
    i32.const 491
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -19978,7 +19978,7 @@
    i32.const 0
    i32.const 304
    i32.const 492
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -20083,7 +20083,7 @@
    i32.const 0
    i32.const 304
    i32.const 495
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -20110,7 +20110,7 @@
    i32.const 0
    i32.const 304
    i32.const 490
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -20122,7 +20122,7 @@
    i32.const 0
    i32.const 304
    i32.const 491
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -20134,7 +20134,7 @@
    i32.const 0
    i32.const 304
    i32.const 492
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -20239,7 +20239,7 @@
    i32.const 0
    i32.const 304
    i32.const 495
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -20266,7 +20266,7 @@
    i32.const 0
    i32.const 304
    i32.const 490
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -20278,7 +20278,7 @@
    i32.const 0
    i32.const 304
    i32.const 491
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -20290,7 +20290,7 @@
    i32.const 0
    i32.const 304
    i32.const 492
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -20395,7 +20395,7 @@
    i32.const 0
    i32.const 304
    i32.const 495
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -20564,7 +20564,7 @@
      i32.const 0
      i32.const 304
      i32.const 524
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -20592,7 +20592,7 @@
    i32.const 0
    i32.const 304
    i32.const 529
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -20606,7 +20606,7 @@
    i32.const 0
    i32.const 304
    i32.const 530
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -20620,7 +20620,7 @@
    i32.const 0
    i32.const 304
    i32.const 531
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -20634,7 +20634,7 @@
    i32.const 0
    i32.const 304
    i32.const 532
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -20914,7 +20914,7 @@
      i32.const 0
      i32.const 304
      i32.const 524
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -20942,7 +20942,7 @@
    i32.const 0
    i32.const 304
    i32.const 529
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -20956,7 +20956,7 @@
    i32.const 0
    i32.const 304
    i32.const 530
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -20970,7 +20970,7 @@
    i32.const 0
    i32.const 304
    i32.const 531
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -20984,7 +20984,7 @@
    i32.const 0
    i32.const 304
    i32.const 532
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -21264,7 +21264,7 @@
      i32.const 0
      i32.const 304
      i32.const 524
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -21292,7 +21292,7 @@
    i32.const 0
    i32.const 304
    i32.const 529
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -21306,7 +21306,7 @@
    i32.const 0
    i32.const 304
    i32.const 530
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -21320,7 +21320,7 @@
    i32.const 0
    i32.const 304
    i32.const 531
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -21334,7 +21334,7 @@
    i32.const 0
    i32.const 304
    i32.const 532
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -21620,7 +21620,7 @@
      i32.const 0
      i32.const 304
      i32.const 524
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -21648,7 +21648,7 @@
    i32.const 0
    i32.const 304
    i32.const 529
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -21662,7 +21662,7 @@
    i32.const 0
    i32.const 304
    i32.const 530
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -21676,7 +21676,7 @@
    i32.const 0
    i32.const 304
    i32.const 531
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -21690,7 +21690,7 @@
    i32.const 0
    i32.const 304
    i32.const 532
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -21970,7 +21970,7 @@
      i32.const 0
      i32.const 304
      i32.const 524
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -21998,7 +21998,7 @@
    i32.const 0
    i32.const 304
    i32.const 529
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -22012,7 +22012,7 @@
    i32.const 0
    i32.const 304
    i32.const 530
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -22026,7 +22026,7 @@
    i32.const 0
    i32.const 304
    i32.const 531
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -22040,7 +22040,7 @@
    i32.const 0
    i32.const 304
    i32.const 532
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -22207,7 +22207,7 @@
      i32.const 0
      i32.const 304
      i32.const 524
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -22235,7 +22235,7 @@
    i32.const 0
    i32.const 304
    i32.const 529
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -22249,7 +22249,7 @@
    i32.const 0
    i32.const 304
    i32.const 530
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -22263,7 +22263,7 @@
    i32.const 0
    i32.const 304
    i32.const 531
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -22277,7 +22277,7 @@
    i32.const 0
    i32.const 304
    i32.const 532
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -22551,7 +22551,7 @@
      i32.const 0
      i32.const 304
      i32.const 524
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -22579,7 +22579,7 @@
    i32.const 0
    i32.const 304
    i32.const 529
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -22593,7 +22593,7 @@
    i32.const 0
    i32.const 304
    i32.const 530
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -22607,7 +22607,7 @@
    i32.const 0
    i32.const 304
    i32.const 531
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -22621,7 +22621,7 @@
    i32.const 0
    i32.const 304
    i32.const 532
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -22898,7 +22898,7 @@
      i32.const 0
      i32.const 304
      i32.const 524
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -22926,7 +22926,7 @@
    i32.const 0
    i32.const 304
    i32.const 529
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -22940,7 +22940,7 @@
    i32.const 0
    i32.const 304
    i32.const 530
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -22954,7 +22954,7 @@
    i32.const 0
    i32.const 304
    i32.const 531
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -22968,7 +22968,7 @@
    i32.const 0
    i32.const 304
    i32.const 532
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -23245,7 +23245,7 @@
      i32.const 0
      i32.const 304
      i32.const 524
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -23273,7 +23273,7 @@
    i32.const 0
    i32.const 304
    i32.const 529
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -23287,7 +23287,7 @@
    i32.const 0
    i32.const 304
    i32.const 530
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -23301,7 +23301,7 @@
    i32.const 0
    i32.const 304
    i32.const 531
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -23315,7 +23315,7 @@
    i32.const 0
    i32.const 304
    i32.const 532
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -23592,7 +23592,7 @@
      i32.const 0
      i32.const 304
      i32.const 524
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -23620,7 +23620,7 @@
    i32.const 0
    i32.const 304
    i32.const 529
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -23634,7 +23634,7 @@
    i32.const 0
    i32.const 304
    i32.const 530
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -23648,7 +23648,7 @@
    i32.const 0
    i32.const 304
    i32.const 531
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -23662,7 +23662,7 @@
    i32.const 0
    i32.const 304
    i32.const 532
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -23832,7 +23832,7 @@
      i32.const 0
      i32.const 304
      i32.const 524
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -23860,7 +23860,7 @@
    i32.const 0
    i32.const 304
    i32.const 529
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -23874,7 +23874,7 @@
    i32.const 0
    i32.const 304
    i32.const 530
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -23888,7 +23888,7 @@
    i32.const 0
    i32.const 304
    i32.const 531
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -23902,7 +23902,7 @@
    i32.const 0
    i32.const 304
    i32.const 532
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -24194,7 +24194,7 @@
    i32.const 0
    i32.const 304
    i32.const 557
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -24209,7 +24209,7 @@
    i32.const 0
    i32.const 304
    i32.const 558
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -24224,7 +24224,7 @@
    i32.const 0
    i32.const 304
    i32.const 559
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -24239,7 +24239,7 @@
    i32.const 0
    i32.const 304
    i32.const 560
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -24254,7 +24254,7 @@
    i32.const 0
    i32.const 304
    i32.const 561
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -24269,7 +24269,7 @@
    i32.const 0
    i32.const 304
    i32.const 562
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -24284,7 +24284,7 @@
    i32.const 0
    i32.const 304
    i32.const 563
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -24299,7 +24299,7 @@
    i32.const 0
    i32.const 304
    i32.const 564
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -24314,7 +24314,7 @@
    i32.const 0
    i32.const 304
    i32.const 565
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -24331,7 +24331,7 @@
    i32.const 0
    i32.const 304
    i32.const 567
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -24348,7 +24348,7 @@
    i32.const 0
    i32.const 304
    i32.const 568
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -24365,7 +24365,7 @@
    i32.const 0
    i32.const 304
    i32.const 569
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -24382,7 +24382,7 @@
    i32.const 0
    i32.const 304
    i32.const 570
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -24397,7 +24397,7 @@
    i32.const 0
    i32.const 304
    i32.const 571
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -24412,7 +24412,7 @@
    i32.const 0
    i32.const 304
    i32.const 572
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -24427,7 +24427,7 @@
    i32.const 0
    i32.const 304
    i32.const 573
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -24442,7 +24442,7 @@
    i32.const 0
    i32.const 304
    i32.const 574
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -24457,7 +24457,7 @@
    i32.const 0
    i32.const 304
    i32.const 575
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -24472,7 +24472,7 @@
    i32.const 0
    i32.const 304
    i32.const 576
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -24492,7 +24492,7 @@
    i32.const 0
    i32.const 304
    i32.const 580
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -24507,7 +24507,7 @@
    i32.const 0
    i32.const 304
    i32.const 581
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -24522,7 +24522,7 @@
    i32.const 0
    i32.const 304
    i32.const 582
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -24537,7 +24537,7 @@
    i32.const 0
    i32.const 304
    i32.const 583
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -24552,7 +24552,7 @@
    i32.const 0
    i32.const 304
    i32.const 584
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -24567,7 +24567,7 @@
    i32.const 0
    i32.const 304
    i32.const 585
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -24582,7 +24582,7 @@
    i32.const 0
    i32.const 304
    i32.const 586
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -24597,7 +24597,7 @@
    i32.const 0
    i32.const 304
    i32.const 587
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -24877,7 +24877,7 @@
    i32.const 0
    i32.const 304
    i32.const 557
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -24892,7 +24892,7 @@
    i32.const 0
    i32.const 304
    i32.const 558
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -24907,7 +24907,7 @@
    i32.const 0
    i32.const 304
    i32.const 559
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -24922,7 +24922,7 @@
    i32.const 0
    i32.const 304
    i32.const 560
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -24937,7 +24937,7 @@
    i32.const 0
    i32.const 304
    i32.const 561
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -24952,7 +24952,7 @@
    i32.const 0
    i32.const 304
    i32.const 562
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -24967,7 +24967,7 @@
    i32.const 0
    i32.const 304
    i32.const 563
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -24982,7 +24982,7 @@
    i32.const 0
    i32.const 304
    i32.const 564
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -24997,7 +24997,7 @@
    i32.const 0
    i32.const 304
    i32.const 565
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -25014,7 +25014,7 @@
    i32.const 0
    i32.const 304
    i32.const 567
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -25031,7 +25031,7 @@
    i32.const 0
    i32.const 304
    i32.const 568
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -25048,7 +25048,7 @@
    i32.const 0
    i32.const 304
    i32.const 569
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -25065,7 +25065,7 @@
    i32.const 0
    i32.const 304
    i32.const 570
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -25080,7 +25080,7 @@
    i32.const 0
    i32.const 304
    i32.const 571
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -25095,7 +25095,7 @@
    i32.const 0
    i32.const 304
    i32.const 572
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -25110,7 +25110,7 @@
    i32.const 0
    i32.const 304
    i32.const 573
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -25125,7 +25125,7 @@
    i32.const 0
    i32.const 304
    i32.const 574
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -25140,7 +25140,7 @@
    i32.const 0
    i32.const 304
    i32.const 575
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -25155,7 +25155,7 @@
    i32.const 0
    i32.const 304
    i32.const 576
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -25175,7 +25175,7 @@
    i32.const 0
    i32.const 304
    i32.const 580
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -25190,7 +25190,7 @@
    i32.const 0
    i32.const 304
    i32.const 581
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -25205,7 +25205,7 @@
    i32.const 0
    i32.const 304
    i32.const 582
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -25220,7 +25220,7 @@
    i32.const 0
    i32.const 304
    i32.const 583
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -25235,7 +25235,7 @@
    i32.const 0
    i32.const 304
    i32.const 584
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -25250,7 +25250,7 @@
    i32.const 0
    i32.const 304
    i32.const 585
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -25265,7 +25265,7 @@
    i32.const 0
    i32.const 304
    i32.const 586
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -25280,7 +25280,7 @@
    i32.const 0
    i32.const 304
    i32.const 587
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -25560,7 +25560,7 @@
    i32.const 0
    i32.const 304
    i32.const 557
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -25575,7 +25575,7 @@
    i32.const 0
    i32.const 304
    i32.const 558
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -25590,7 +25590,7 @@
    i32.const 0
    i32.const 304
    i32.const 559
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -25605,7 +25605,7 @@
    i32.const 0
    i32.const 304
    i32.const 560
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -25620,7 +25620,7 @@
    i32.const 0
    i32.const 304
    i32.const 561
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -25635,7 +25635,7 @@
    i32.const 0
    i32.const 304
    i32.const 562
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -25650,7 +25650,7 @@
    i32.const 0
    i32.const 304
    i32.const 563
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -25665,7 +25665,7 @@
    i32.const 0
    i32.const 304
    i32.const 564
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -25680,7 +25680,7 @@
    i32.const 0
    i32.const 304
    i32.const 565
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -25697,7 +25697,7 @@
    i32.const 0
    i32.const 304
    i32.const 567
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -25714,7 +25714,7 @@
    i32.const 0
    i32.const 304
    i32.const 568
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -25731,7 +25731,7 @@
    i32.const 0
    i32.const 304
    i32.const 569
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -25748,7 +25748,7 @@
    i32.const 0
    i32.const 304
    i32.const 570
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -25763,7 +25763,7 @@
    i32.const 0
    i32.const 304
    i32.const 571
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -25778,7 +25778,7 @@
    i32.const 0
    i32.const 304
    i32.const 572
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -25793,7 +25793,7 @@
    i32.const 0
    i32.const 304
    i32.const 573
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -25808,7 +25808,7 @@
    i32.const 0
    i32.const 304
    i32.const 574
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -25823,7 +25823,7 @@
    i32.const 0
    i32.const 304
    i32.const 575
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -25838,7 +25838,7 @@
    i32.const 0
    i32.const 304
    i32.const 576
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -25858,7 +25858,7 @@
    i32.const 0
    i32.const 304
    i32.const 580
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -25873,7 +25873,7 @@
    i32.const 0
    i32.const 304
    i32.const 581
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -25888,7 +25888,7 @@
    i32.const 0
    i32.const 304
    i32.const 582
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -25903,7 +25903,7 @@
    i32.const 0
    i32.const 304
    i32.const 583
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -25918,7 +25918,7 @@
    i32.const 0
    i32.const 304
    i32.const 584
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -25933,7 +25933,7 @@
    i32.const 0
    i32.const 304
    i32.const 585
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -25948,7 +25948,7 @@
    i32.const 0
    i32.const 304
    i32.const 586
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -25963,7 +25963,7 @@
    i32.const 0
    i32.const 304
    i32.const 587
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -26249,7 +26249,7 @@
    i32.const 0
    i32.const 304
    i32.const 557
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -26264,7 +26264,7 @@
    i32.const 0
    i32.const 304
    i32.const 558
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -26279,7 +26279,7 @@
    i32.const 0
    i32.const 304
    i32.const 559
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -26294,7 +26294,7 @@
    i32.const 0
    i32.const 304
    i32.const 560
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -26309,7 +26309,7 @@
    i32.const 0
    i32.const 304
    i32.const 561
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -26324,7 +26324,7 @@
    i32.const 0
    i32.const 304
    i32.const 562
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -26339,7 +26339,7 @@
    i32.const 0
    i32.const 304
    i32.const 563
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -26354,7 +26354,7 @@
    i32.const 0
    i32.const 304
    i32.const 564
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -26369,7 +26369,7 @@
    i32.const 0
    i32.const 304
    i32.const 565
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -26386,7 +26386,7 @@
    i32.const 0
    i32.const 304
    i32.const 567
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -26403,7 +26403,7 @@
    i32.const 0
    i32.const 304
    i32.const 568
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -26420,7 +26420,7 @@
    i32.const 0
    i32.const 304
    i32.const 569
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -26437,7 +26437,7 @@
    i32.const 0
    i32.const 304
    i32.const 570
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -26452,7 +26452,7 @@
    i32.const 0
    i32.const 304
    i32.const 571
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -26467,7 +26467,7 @@
    i32.const 0
    i32.const 304
    i32.const 572
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -26482,7 +26482,7 @@
    i32.const 0
    i32.const 304
    i32.const 573
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -26497,7 +26497,7 @@
    i32.const 0
    i32.const 304
    i32.const 574
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -26512,7 +26512,7 @@
    i32.const 0
    i32.const 304
    i32.const 575
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -26527,7 +26527,7 @@
    i32.const 0
    i32.const 304
    i32.const 576
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -26547,7 +26547,7 @@
    i32.const 0
    i32.const 304
    i32.const 580
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -26562,7 +26562,7 @@
    i32.const 0
    i32.const 304
    i32.const 581
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -26577,7 +26577,7 @@
    i32.const 0
    i32.const 304
    i32.const 582
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -26592,7 +26592,7 @@
    i32.const 0
    i32.const 304
    i32.const 583
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -26607,7 +26607,7 @@
    i32.const 0
    i32.const 304
    i32.const 584
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -26622,7 +26622,7 @@
    i32.const 0
    i32.const 304
    i32.const 585
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -26637,7 +26637,7 @@
    i32.const 0
    i32.const 304
    i32.const 586
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -26652,7 +26652,7 @@
    i32.const 0
    i32.const 304
    i32.const 587
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -26932,7 +26932,7 @@
    i32.const 0
    i32.const 304
    i32.const 557
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -26947,7 +26947,7 @@
    i32.const 0
    i32.const 304
    i32.const 558
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -26962,7 +26962,7 @@
    i32.const 0
    i32.const 304
    i32.const 559
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -26977,7 +26977,7 @@
    i32.const 0
    i32.const 304
    i32.const 560
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -26992,7 +26992,7 @@
    i32.const 0
    i32.const 304
    i32.const 561
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -27007,7 +27007,7 @@
    i32.const 0
    i32.const 304
    i32.const 562
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -27022,7 +27022,7 @@
    i32.const 0
    i32.const 304
    i32.const 563
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -27037,7 +27037,7 @@
    i32.const 0
    i32.const 304
    i32.const 564
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -27052,7 +27052,7 @@
    i32.const 0
    i32.const 304
    i32.const 565
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -27069,7 +27069,7 @@
    i32.const 0
    i32.const 304
    i32.const 567
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -27086,7 +27086,7 @@
    i32.const 0
    i32.const 304
    i32.const 568
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -27103,7 +27103,7 @@
    i32.const 0
    i32.const 304
    i32.const 569
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -27120,7 +27120,7 @@
    i32.const 0
    i32.const 304
    i32.const 570
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -27135,7 +27135,7 @@
    i32.const 0
    i32.const 304
    i32.const 571
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -27150,7 +27150,7 @@
    i32.const 0
    i32.const 304
    i32.const 572
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -27165,7 +27165,7 @@
    i32.const 0
    i32.const 304
    i32.const 573
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -27180,7 +27180,7 @@
    i32.const 0
    i32.const 304
    i32.const 574
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -27195,7 +27195,7 @@
    i32.const 0
    i32.const 304
    i32.const 575
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -27210,7 +27210,7 @@
    i32.const 0
    i32.const 304
    i32.const 576
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -27230,7 +27230,7 @@
    i32.const 0
    i32.const 304
    i32.const 580
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -27245,7 +27245,7 @@
    i32.const 0
    i32.const 304
    i32.const 581
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -27260,7 +27260,7 @@
    i32.const 0
    i32.const 304
    i32.const 582
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -27275,7 +27275,7 @@
    i32.const 0
    i32.const 304
    i32.const 583
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -27290,7 +27290,7 @@
    i32.const 0
    i32.const 304
    i32.const 584
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -27305,7 +27305,7 @@
    i32.const 0
    i32.const 304
    i32.const 585
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -27320,7 +27320,7 @@
    i32.const 0
    i32.const 304
    i32.const 586
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -27335,7 +27335,7 @@
    i32.const 0
    i32.const 304
    i32.const 587
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -27609,7 +27609,7 @@
    i32.const 0
    i32.const 304
    i32.const 557
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -27624,7 +27624,7 @@
    i32.const 0
    i32.const 304
    i32.const 558
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -27639,7 +27639,7 @@
    i32.const 0
    i32.const 304
    i32.const 559
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -27654,7 +27654,7 @@
    i32.const 0
    i32.const 304
    i32.const 560
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -27669,7 +27669,7 @@
    i32.const 0
    i32.const 304
    i32.const 561
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -27684,7 +27684,7 @@
    i32.const 0
    i32.const 304
    i32.const 562
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -27699,7 +27699,7 @@
    i32.const 0
    i32.const 304
    i32.const 563
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -27714,7 +27714,7 @@
    i32.const 0
    i32.const 304
    i32.const 564
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -27729,7 +27729,7 @@
    i32.const 0
    i32.const 304
    i32.const 565
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -27746,7 +27746,7 @@
    i32.const 0
    i32.const 304
    i32.const 567
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -27763,7 +27763,7 @@
    i32.const 0
    i32.const 304
    i32.const 568
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -27780,7 +27780,7 @@
    i32.const 0
    i32.const 304
    i32.const 569
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -27797,7 +27797,7 @@
    i32.const 0
    i32.const 304
    i32.const 570
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -27812,7 +27812,7 @@
    i32.const 0
    i32.const 304
    i32.const 571
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -27827,7 +27827,7 @@
    i32.const 0
    i32.const 304
    i32.const 572
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -27842,7 +27842,7 @@
    i32.const 0
    i32.const 304
    i32.const 573
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -27857,7 +27857,7 @@
    i32.const 0
    i32.const 304
    i32.const 574
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -27872,7 +27872,7 @@
    i32.const 0
    i32.const 304
    i32.const 575
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -27887,7 +27887,7 @@
    i32.const 0
    i32.const 304
    i32.const 576
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -27907,7 +27907,7 @@
    i32.const 0
    i32.const 304
    i32.const 580
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -27922,7 +27922,7 @@
    i32.const 0
    i32.const 304
    i32.const 581
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -27937,7 +27937,7 @@
    i32.const 0
    i32.const 304
    i32.const 582
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -27952,7 +27952,7 @@
    i32.const 0
    i32.const 304
    i32.const 583
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -27967,7 +27967,7 @@
    i32.const 0
    i32.const 304
    i32.const 584
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -27982,7 +27982,7 @@
    i32.const 0
    i32.const 304
    i32.const 585
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -27997,7 +27997,7 @@
    i32.const 0
    i32.const 304
    i32.const 586
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -28012,7 +28012,7 @@
    i32.const 0
    i32.const 304
    i32.const 587
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -28286,7 +28286,7 @@
    i32.const 0
    i32.const 304
    i32.const 557
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -28301,7 +28301,7 @@
    i32.const 0
    i32.const 304
    i32.const 558
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -28316,7 +28316,7 @@
    i32.const 0
    i32.const 304
    i32.const 559
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -28331,7 +28331,7 @@
    i32.const 0
    i32.const 304
    i32.const 560
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -28346,7 +28346,7 @@
    i32.const 0
    i32.const 304
    i32.const 561
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -28361,7 +28361,7 @@
    i32.const 0
    i32.const 304
    i32.const 562
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -28376,7 +28376,7 @@
    i32.const 0
    i32.const 304
    i32.const 563
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -28391,7 +28391,7 @@
    i32.const 0
    i32.const 304
    i32.const 564
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -28406,7 +28406,7 @@
    i32.const 0
    i32.const 304
    i32.const 565
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -28423,7 +28423,7 @@
    i32.const 0
    i32.const 304
    i32.const 567
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -28440,7 +28440,7 @@
    i32.const 0
    i32.const 304
    i32.const 568
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -28457,7 +28457,7 @@
    i32.const 0
    i32.const 304
    i32.const 569
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -28474,7 +28474,7 @@
    i32.const 0
    i32.const 304
    i32.const 570
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -28489,7 +28489,7 @@
    i32.const 0
    i32.const 304
    i32.const 571
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -28504,7 +28504,7 @@
    i32.const 0
    i32.const 304
    i32.const 572
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -28519,7 +28519,7 @@
    i32.const 0
    i32.const 304
    i32.const 573
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -28534,7 +28534,7 @@
    i32.const 0
    i32.const 304
    i32.const 574
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -28549,7 +28549,7 @@
    i32.const 0
    i32.const 304
    i32.const 575
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -28564,7 +28564,7 @@
    i32.const 0
    i32.const 304
    i32.const 576
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -28584,7 +28584,7 @@
    i32.const 0
    i32.const 304
    i32.const 580
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -28599,7 +28599,7 @@
    i32.const 0
    i32.const 304
    i32.const 581
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -28614,7 +28614,7 @@
    i32.const 0
    i32.const 304
    i32.const 582
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -28629,7 +28629,7 @@
    i32.const 0
    i32.const 304
    i32.const 583
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -28644,7 +28644,7 @@
    i32.const 0
    i32.const 304
    i32.const 584
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -28659,7 +28659,7 @@
    i32.const 0
    i32.const 304
    i32.const 585
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -28674,7 +28674,7 @@
    i32.const 0
    i32.const 304
    i32.const 586
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -28689,7 +28689,7 @@
    i32.const 0
    i32.const 304
    i32.const 587
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -28964,7 +28964,7 @@
    i32.const 0
    i32.const 304
    i32.const 557
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -28979,7 +28979,7 @@
    i32.const 0
    i32.const 304
    i32.const 558
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -28994,7 +28994,7 @@
    i32.const 0
    i32.const 304
    i32.const 559
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -29009,7 +29009,7 @@
    i32.const 0
    i32.const 304
    i32.const 560
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -29024,7 +29024,7 @@
    i32.const 0
    i32.const 304
    i32.const 561
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -29039,7 +29039,7 @@
    i32.const 0
    i32.const 304
    i32.const 562
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -29054,7 +29054,7 @@
    i32.const 0
    i32.const 304
    i32.const 563
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -29069,7 +29069,7 @@
    i32.const 0
    i32.const 304
    i32.const 564
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -29084,7 +29084,7 @@
    i32.const 0
    i32.const 304
    i32.const 565
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -29101,7 +29101,7 @@
    i32.const 0
    i32.const 304
    i32.const 567
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -29118,7 +29118,7 @@
    i32.const 0
    i32.const 304
    i32.const 568
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -29135,7 +29135,7 @@
    i32.const 0
    i32.const 304
    i32.const 569
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -29152,7 +29152,7 @@
    i32.const 0
    i32.const 304
    i32.const 570
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -29167,7 +29167,7 @@
    i32.const 0
    i32.const 304
    i32.const 571
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -29182,7 +29182,7 @@
    i32.const 0
    i32.const 304
    i32.const 572
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -29197,7 +29197,7 @@
    i32.const 0
    i32.const 304
    i32.const 573
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -29212,7 +29212,7 @@
    i32.const 0
    i32.const 304
    i32.const 574
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -29227,7 +29227,7 @@
    i32.const 0
    i32.const 304
    i32.const 575
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -29242,7 +29242,7 @@
    i32.const 0
    i32.const 304
    i32.const 576
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -29262,7 +29262,7 @@
    i32.const 0
    i32.const 304
    i32.const 580
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -29277,7 +29277,7 @@
    i32.const 0
    i32.const 304
    i32.const 581
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -29292,7 +29292,7 @@
    i32.const 0
    i32.const 304
    i32.const 582
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -29307,7 +29307,7 @@
    i32.const 0
    i32.const 304
    i32.const 583
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -29322,7 +29322,7 @@
    i32.const 0
    i32.const 304
    i32.const 584
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -29337,7 +29337,7 @@
    i32.const 0
    i32.const 304
    i32.const 585
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -29352,7 +29352,7 @@
    i32.const 0
    i32.const 304
    i32.const 586
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -29367,7 +29367,7 @@
    i32.const 0
    i32.const 304
    i32.const 587
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -29642,7 +29642,7 @@
    i32.const 0
    i32.const 304
    i32.const 557
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -29657,7 +29657,7 @@
    i32.const 0
    i32.const 304
    i32.const 558
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -29672,7 +29672,7 @@
    i32.const 0
    i32.const 304
    i32.const 559
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -29687,7 +29687,7 @@
    i32.const 0
    i32.const 304
    i32.const 560
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -29702,7 +29702,7 @@
    i32.const 0
    i32.const 304
    i32.const 561
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -29717,7 +29717,7 @@
    i32.const 0
    i32.const 304
    i32.const 562
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -29732,7 +29732,7 @@
    i32.const 0
    i32.const 304
    i32.const 563
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -29747,7 +29747,7 @@
    i32.const 0
    i32.const 304
    i32.const 564
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -29762,7 +29762,7 @@
    i32.const 0
    i32.const 304
    i32.const 565
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -29779,7 +29779,7 @@
    i32.const 0
    i32.const 304
    i32.const 567
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -29796,7 +29796,7 @@
    i32.const 0
    i32.const 304
    i32.const 568
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -29813,7 +29813,7 @@
    i32.const 0
    i32.const 304
    i32.const 569
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -29830,7 +29830,7 @@
    i32.const 0
    i32.const 304
    i32.const 570
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -29845,7 +29845,7 @@
    i32.const 0
    i32.const 304
    i32.const 571
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -29860,7 +29860,7 @@
    i32.const 0
    i32.const 304
    i32.const 572
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -29875,7 +29875,7 @@
    i32.const 0
    i32.const 304
    i32.const 573
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -29890,7 +29890,7 @@
    i32.const 0
    i32.const 304
    i32.const 574
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -29905,7 +29905,7 @@
    i32.const 0
    i32.const 304
    i32.const 575
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -29920,7 +29920,7 @@
    i32.const 0
    i32.const 304
    i32.const 576
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -29940,7 +29940,7 @@
    i32.const 0
    i32.const 304
    i32.const 580
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -29955,7 +29955,7 @@
    i32.const 0
    i32.const 304
    i32.const 581
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -29970,7 +29970,7 @@
    i32.const 0
    i32.const 304
    i32.const 582
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -29985,7 +29985,7 @@
    i32.const 0
    i32.const 304
    i32.const 583
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -30000,7 +30000,7 @@
    i32.const 0
    i32.const 304
    i32.const 584
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -30015,7 +30015,7 @@
    i32.const 0
    i32.const 304
    i32.const 585
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -30030,7 +30030,7 @@
    i32.const 0
    i32.const 304
    i32.const 586
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -30045,7 +30045,7 @@
    i32.const 0
    i32.const 304
    i32.const 587
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -30320,7 +30320,7 @@
    i32.const 0
    i32.const 304
    i32.const 557
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -30335,7 +30335,7 @@
    i32.const 0
    i32.const 304
    i32.const 558
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -30350,7 +30350,7 @@
    i32.const 0
    i32.const 304
    i32.const 559
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -30365,7 +30365,7 @@
    i32.const 0
    i32.const 304
    i32.const 560
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -30380,7 +30380,7 @@
    i32.const 0
    i32.const 304
    i32.const 561
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -30395,7 +30395,7 @@
    i32.const 0
    i32.const 304
    i32.const 562
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -30410,7 +30410,7 @@
    i32.const 0
    i32.const 304
    i32.const 563
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -30425,7 +30425,7 @@
    i32.const 0
    i32.const 304
    i32.const 564
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -30440,7 +30440,7 @@
    i32.const 0
    i32.const 304
    i32.const 565
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -30457,7 +30457,7 @@
    i32.const 0
    i32.const 304
    i32.const 567
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -30474,7 +30474,7 @@
    i32.const 0
    i32.const 304
    i32.const 568
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -30491,7 +30491,7 @@
    i32.const 0
    i32.const 304
    i32.const 569
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -30508,7 +30508,7 @@
    i32.const 0
    i32.const 304
    i32.const 570
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -30523,7 +30523,7 @@
    i32.const 0
    i32.const 304
    i32.const 571
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -30538,7 +30538,7 @@
    i32.const 0
    i32.const 304
    i32.const 572
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -30553,7 +30553,7 @@
    i32.const 0
    i32.const 304
    i32.const 573
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -30568,7 +30568,7 @@
    i32.const 0
    i32.const 304
    i32.const 574
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -30583,7 +30583,7 @@
    i32.const 0
    i32.const 304
    i32.const 575
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -30598,7 +30598,7 @@
    i32.const 0
    i32.const 304
    i32.const 576
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -30618,7 +30618,7 @@
    i32.const 0
    i32.const 304
    i32.const 580
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -30633,7 +30633,7 @@
    i32.const 0
    i32.const 304
    i32.const 581
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -30648,7 +30648,7 @@
    i32.const 0
    i32.const 304
    i32.const 582
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -30663,7 +30663,7 @@
    i32.const 0
    i32.const 304
    i32.const 583
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -30678,7 +30678,7 @@
    i32.const 0
    i32.const 304
    i32.const 584
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -30693,7 +30693,7 @@
    i32.const 0
    i32.const 304
    i32.const 585
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -30708,7 +30708,7 @@
    i32.const 0
    i32.const 304
    i32.const 586
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -30723,7 +30723,7 @@
    i32.const 0
    i32.const 304
    i32.const 587
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -30998,7 +30998,7 @@
    i32.const 0
    i32.const 304
    i32.const 557
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -31013,7 +31013,7 @@
    i32.const 0
    i32.const 304
    i32.const 558
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -31028,7 +31028,7 @@
    i32.const 0
    i32.const 304
    i32.const 559
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -31043,7 +31043,7 @@
    i32.const 0
    i32.const 304
    i32.const 560
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -31058,7 +31058,7 @@
    i32.const 0
    i32.const 304
    i32.const 561
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -31073,7 +31073,7 @@
    i32.const 0
    i32.const 304
    i32.const 562
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -31088,7 +31088,7 @@
    i32.const 0
    i32.const 304
    i32.const 563
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -31103,7 +31103,7 @@
    i32.const 0
    i32.const 304
    i32.const 564
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -31118,7 +31118,7 @@
    i32.const 0
    i32.const 304
    i32.const 565
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -31135,7 +31135,7 @@
    i32.const 0
    i32.const 304
    i32.const 567
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -31152,7 +31152,7 @@
    i32.const 0
    i32.const 304
    i32.const 568
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -31169,7 +31169,7 @@
    i32.const 0
    i32.const 304
    i32.const 569
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -31186,7 +31186,7 @@
    i32.const 0
    i32.const 304
    i32.const 570
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -31201,7 +31201,7 @@
    i32.const 0
    i32.const 304
    i32.const 571
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -31216,7 +31216,7 @@
    i32.const 0
    i32.const 304
    i32.const 572
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -31231,7 +31231,7 @@
    i32.const 0
    i32.const 304
    i32.const 573
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -31246,7 +31246,7 @@
    i32.const 0
    i32.const 304
    i32.const 574
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -31261,7 +31261,7 @@
    i32.const 0
    i32.const 304
    i32.const 575
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -31276,7 +31276,7 @@
    i32.const 0
    i32.const 304
    i32.const 576
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -31296,7 +31296,7 @@
    i32.const 0
    i32.const 304
    i32.const 580
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -31311,7 +31311,7 @@
    i32.const 0
    i32.const 304
    i32.const 581
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -31326,7 +31326,7 @@
    i32.const 0
    i32.const 304
    i32.const 582
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -31341,7 +31341,7 @@
    i32.const 0
    i32.const 304
    i32.const 583
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -31356,7 +31356,7 @@
    i32.const 0
    i32.const 304
    i32.const 584
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -31371,7 +31371,7 @@
    i32.const 0
    i32.const 304
    i32.const 585
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -31386,7 +31386,7 @@
    i32.const 0
    i32.const 304
    i32.const 586
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -31401,7 +31401,7 @@
    i32.const 0
    i32.const 304
    i32.const 587
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -32495,7 +32495,7 @@
    i32.const 0
    i32.const 304
    i32.const 629
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -32509,7 +32509,7 @@
    i32.const 0
    i32.const 304
    i32.const 630
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -32822,7 +32822,7 @@
    i32.const 0
    i32.const 304
    i32.const 629
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -32836,7 +32836,7 @@
    i32.const 0
    i32.const 304
    i32.const 630
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -32912,7 +32912,7 @@
    i32.const 0
    i32.const 304
    i32.const 629
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -32926,7 +32926,7 @@
    i32.const 0
    i32.const 304
    i32.const 630
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -33239,7 +33239,7 @@
    i32.const 0
    i32.const 304
    i32.const 629
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -33253,7 +33253,7 @@
    i32.const 0
    i32.const 304
    i32.const 630
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -33532,7 +33532,7 @@
    i32.const 0
    i32.const 304
    i32.const 629
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -33546,7 +33546,7 @@
    i32.const 0
    i32.const 304
    i32.const 630
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -33835,7 +33835,7 @@
    i32.const 0
    i32.const 304
    i32.const 629
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -33849,7 +33849,7 @@
    i32.const 0
    i32.const 304
    i32.const 630
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -34118,7 +34118,7 @@
    i32.const 0
    i32.const 304
    i32.const 629
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -34132,7 +34132,7 @@
    i32.const 0
    i32.const 304
    i32.const 630
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -34718,7 +34718,7 @@
    i32.const 0
    i32.const 304
    i32.const 629
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -34732,7 +34732,7 @@
    i32.const 0
    i32.const 304
    i32.const 630
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -35093,7 +35093,7 @@
    i32.const 0
    i32.const 304
    i32.const 629
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -35107,7 +35107,7 @@
    i32.const 0
    i32.const 304
    i32.const 630
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -36714,7 +36714,7 @@
    i32.const 0
    i32.const 304
    i32.const 626
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -36728,7 +36728,7 @@
    i32.const 0
    i32.const 304
    i32.const 627
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -36947,7 +36947,7 @@
    i32.const 0
    i32.const 304
    i32.const 626
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -36961,7 +36961,7 @@
    i32.const 0
    i32.const 304
    i32.const 627
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -36983,7 +36983,7 @@
    i32.const 32
    i32.const 80
    i32.const 54
-   i32.const 42
+   i32.const 43
    call $~lib/builtins/abort
    unreachable
   end
@@ -37038,7 +37038,7 @@
    i32.const 368
    i32.const 432
    i32.const 1741
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -37059,7 +37059,7 @@
      i32.const 32
      i32.const 432
      i32.const 1746
-     i32.const 8
+     i32.const 9
      call $~lib/builtins/abort
      unreachable
     end
@@ -37073,7 +37073,7 @@
     i32.const 32
     i32.const 432
     i32.const 1750
-    i32.const 6
+    i32.const 7
     call $~lib/builtins/abort
     unreachable
    end
@@ -37093,7 +37093,7 @@
     i32.const 32
     i32.const 432
     i32.const 1755
-    i32.const 6
+    i32.const 7
     call $~lib/builtins/abort
     unreachable
    end
@@ -37265,7 +37265,7 @@
    i32.const 368
    i32.const 432
    i32.const 1741
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -37286,7 +37286,7 @@
      i32.const 32
      i32.const 432
      i32.const 1746
-     i32.const 8
+     i32.const 9
      call $~lib/builtins/abort
      unreachable
     end
@@ -37300,7 +37300,7 @@
     i32.const 32
     i32.const 432
     i32.const 1750
-    i32.const 6
+    i32.const 7
     call $~lib/builtins/abort
     unreachable
    end
@@ -37320,7 +37320,7 @@
     i32.const 32
     i32.const 432
     i32.const 1755
-    i32.const 6
+    i32.const 7
     call $~lib/builtins/abort
     unreachable
    end
@@ -37467,7 +37467,7 @@
      i32.const 0
      i32.const 304
      i32.const 684
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -37579,7 +37579,7 @@
      i32.const 0
      i32.const 304
      i32.const 684
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -37635,7 +37635,7 @@
    i32.const 368
    i32.const 432
    i32.const 1741
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -37656,7 +37656,7 @@
      i32.const 32
      i32.const 432
      i32.const 1746
-     i32.const 8
+     i32.const 9
      call $~lib/builtins/abort
      unreachable
     end
@@ -37670,7 +37670,7 @@
     i32.const 32
     i32.const 432
     i32.const 1750
-    i32.const 6
+    i32.const 7
     call $~lib/builtins/abort
     unreachable
    end
@@ -37690,7 +37690,7 @@
     i32.const 32
     i32.const 432
     i32.const 1755
-    i32.const 6
+    i32.const 7
     call $~lib/builtins/abort
     unreachable
    end
@@ -37835,7 +37835,7 @@
      i32.const 0
      i32.const 304
      i32.const 684
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -37891,7 +37891,7 @@
    i32.const 368
    i32.const 432
    i32.const 1741
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -37912,7 +37912,7 @@
      i32.const 32
      i32.const 432
      i32.const 1746
-     i32.const 8
+     i32.const 9
      call $~lib/builtins/abort
      unreachable
     end
@@ -37926,7 +37926,7 @@
     i32.const 32
     i32.const 432
     i32.const 1750
-    i32.const 6
+    i32.const 7
     call $~lib/builtins/abort
     unreachable
    end
@@ -37946,7 +37946,7 @@
     i32.const 32
     i32.const 432
     i32.const 1755
-    i32.const 6
+    i32.const 7
     call $~lib/builtins/abort
     unreachable
    end
@@ -38093,7 +38093,7 @@
      i32.const 0
      i32.const 304
      i32.const 684
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -38149,7 +38149,7 @@
    i32.const 368
    i32.const 432
    i32.const 1741
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -38170,7 +38170,7 @@
      i32.const 32
      i32.const 432
      i32.const 1746
-     i32.const 8
+     i32.const 9
      call $~lib/builtins/abort
      unreachable
     end
@@ -38184,7 +38184,7 @@
     i32.const 32
     i32.const 432
     i32.const 1750
-    i32.const 6
+    i32.const 7
     call $~lib/builtins/abort
     unreachable
    end
@@ -38204,7 +38204,7 @@
     i32.const 32
     i32.const 432
     i32.const 1755
-    i32.const 6
+    i32.const 7
     call $~lib/builtins/abort
     unreachable
    end
@@ -38349,7 +38349,7 @@
      i32.const 0
      i32.const 304
      i32.const 684
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -38405,7 +38405,7 @@
    i32.const 368
    i32.const 432
    i32.const 1741
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -38426,7 +38426,7 @@
      i32.const 32
      i32.const 432
      i32.const 1746
-     i32.const 8
+     i32.const 9
      call $~lib/builtins/abort
      unreachable
     end
@@ -38440,7 +38440,7 @@
     i32.const 32
     i32.const 432
     i32.const 1750
-    i32.const 6
+    i32.const 7
     call $~lib/builtins/abort
     unreachable
    end
@@ -38460,7 +38460,7 @@
     i32.const 32
     i32.const 432
     i32.const 1755
-    i32.const 6
+    i32.const 7
     call $~lib/builtins/abort
     unreachable
    end
@@ -38603,7 +38603,7 @@
      i32.const 0
      i32.const 304
      i32.const 684
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -38659,7 +38659,7 @@
    i32.const 368
    i32.const 432
    i32.const 1741
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -38680,7 +38680,7 @@
      i32.const 32
      i32.const 432
      i32.const 1746
-     i32.const 8
+     i32.const 9
      call $~lib/builtins/abort
      unreachable
     end
@@ -38694,7 +38694,7 @@
     i32.const 32
     i32.const 432
     i32.const 1750
-    i32.const 6
+    i32.const 7
     call $~lib/builtins/abort
     unreachable
    end
@@ -38714,7 +38714,7 @@
     i32.const 32
     i32.const 432
     i32.const 1755
-    i32.const 6
+    i32.const 7
     call $~lib/builtins/abort
     unreachable
    end
@@ -38857,7 +38857,7 @@
      i32.const 0
      i32.const 304
      i32.const 684
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -38913,7 +38913,7 @@
    i32.const 368
    i32.const 432
    i32.const 1741
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -38934,7 +38934,7 @@
      i32.const 32
      i32.const 432
      i32.const 1746
-     i32.const 8
+     i32.const 9
      call $~lib/builtins/abort
      unreachable
     end
@@ -38948,7 +38948,7 @@
     i32.const 32
     i32.const 432
     i32.const 1750
-    i32.const 6
+    i32.const 7
     call $~lib/builtins/abort
     unreachable
    end
@@ -38968,7 +38968,7 @@
     i32.const 32
     i32.const 432
     i32.const 1755
-    i32.const 6
+    i32.const 7
     call $~lib/builtins/abort
     unreachable
    end
@@ -39112,7 +39112,7 @@
      i32.const 0
      i32.const 304
      i32.const 684
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -39168,7 +39168,7 @@
    i32.const 368
    i32.const 432
    i32.const 1741
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -39189,7 +39189,7 @@
      i32.const 32
      i32.const 432
      i32.const 1746
-     i32.const 8
+     i32.const 9
      call $~lib/builtins/abort
      unreachable
     end
@@ -39203,7 +39203,7 @@
     i32.const 32
     i32.const 432
     i32.const 1750
-    i32.const 6
+    i32.const 7
     call $~lib/builtins/abort
     unreachable
    end
@@ -39223,7 +39223,7 @@
     i32.const 32
     i32.const 432
     i32.const 1755
-    i32.const 6
+    i32.const 7
     call $~lib/builtins/abort
     unreachable
    end
@@ -39367,7 +39367,7 @@
      i32.const 0
      i32.const 304
      i32.const 684
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -39423,7 +39423,7 @@
    i32.const 368
    i32.const 432
    i32.const 1741
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -39444,7 +39444,7 @@
      i32.const 32
      i32.const 432
      i32.const 1746
-     i32.const 8
+     i32.const 9
      call $~lib/builtins/abort
      unreachable
     end
@@ -39458,7 +39458,7 @@
     i32.const 32
     i32.const 432
     i32.const 1750
-    i32.const 6
+    i32.const 7
     call $~lib/builtins/abort
     unreachable
    end
@@ -39478,7 +39478,7 @@
     i32.const 32
     i32.const 432
     i32.const 1755
-    i32.const 6
+    i32.const 7
     call $~lib/builtins/abort
     unreachable
    end
@@ -39622,7 +39622,7 @@
      i32.const 0
      i32.const 304
      i32.const 684
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -39678,7 +39678,7 @@
    i32.const 368
    i32.const 432
    i32.const 1741
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -39699,7 +39699,7 @@
      i32.const 32
      i32.const 432
      i32.const 1746
-     i32.const 8
+     i32.const 9
      call $~lib/builtins/abort
      unreachable
     end
@@ -39713,7 +39713,7 @@
     i32.const 32
     i32.const 432
     i32.const 1750
-    i32.const 6
+    i32.const 7
     call $~lib/builtins/abort
     unreachable
    end
@@ -39733,7 +39733,7 @@
     i32.const 32
     i32.const 432
     i32.const 1755
-    i32.const 6
+    i32.const 7
     call $~lib/builtins/abort
     unreachable
    end
@@ -39877,7 +39877,7 @@
      i32.const 0
      i32.const 304
      i32.const 684
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -39930,7 +39930,7 @@
    i32.const 368
    i32.const 432
    i32.const 1774
-   i32.const 18
+   i32.const 19
    call $~lib/builtins/abort
    unreachable
   end
@@ -39949,7 +39949,7 @@
    i32.const 368
    i32.const 432
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -40025,7 +40025,7 @@
    i32.const 0
    i32.const 304
    i32.const 712
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -40067,7 +40067,7 @@
       i32.const 0
       i32.const 304
       i32.const 718
-      i32.const 6
+      i32.const 7
       call $~lib/builtins/abort
       unreachable
      end
@@ -40120,7 +40120,7 @@
    i32.const 368
    i32.const 432
    i32.const 1774
-   i32.const 18
+   i32.const 19
    call $~lib/builtins/abort
    unreachable
   end
@@ -40139,7 +40139,7 @@
    i32.const 368
    i32.const 432
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -40234,7 +40234,7 @@
    i32.const 368
    i32.const 432
    i32.const 1774
-   i32.const 18
+   i32.const 19
    call $~lib/builtins/abort
    unreachable
   end
@@ -40253,7 +40253,7 @@
    i32.const 368
    i32.const 432
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -40341,7 +40341,7 @@
    i32.const 368
    i32.const 432
    i32.const 1774
-   i32.const 18
+   i32.const 19
    call $~lib/builtins/abort
    unreachable
   end
@@ -40360,7 +40360,7 @@
    i32.const 368
    i32.const 432
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -40450,7 +40450,7 @@
    i32.const 368
    i32.const 432
    i32.const 1774
-   i32.const 18
+   i32.const 19
    call $~lib/builtins/abort
    unreachable
   end
@@ -40469,7 +40469,7 @@
    i32.const 368
    i32.const 432
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -40522,7 +40522,7 @@
    i32.const 368
    i32.const 432
    i32.const 1774
-   i32.const 18
+   i32.const 19
    call $~lib/builtins/abort
    unreachable
   end
@@ -40541,7 +40541,7 @@
    i32.const 368
    i32.const 432
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -40619,7 +40619,7 @@
    i32.const 368
    i32.const 432
    i32.const 1774
-   i32.const 18
+   i32.const 19
    call $~lib/builtins/abort
    unreachable
   end
@@ -40638,7 +40638,7 @@
    i32.const 368
    i32.const 432
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -40854,7 +40854,7 @@
    i32.const 368
    i32.const 432
    i32.const 1774
-   i32.const 18
+   i32.const 19
    call $~lib/builtins/abort
    unreachable
   end
@@ -40873,7 +40873,7 @@
    i32.const 368
    i32.const 432
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -40962,7 +40962,7 @@
    i32.const 0
    i32.const 304
    i32.const 712
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -41004,7 +41004,7 @@
       i32.const 0
       i32.const 304
       i32.const 718
-      i32.const 6
+      i32.const 7
       call $~lib/builtins/abort
       unreachable
      end
@@ -41053,7 +41053,7 @@
    i32.const 368
    i32.const 432
    i32.const 1774
-   i32.const 18
+   i32.const 19
    call $~lib/builtins/abort
    unreachable
   end
@@ -41072,7 +41072,7 @@
    i32.const 368
    i32.const 432
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -41167,7 +41167,7 @@
    i32.const 368
    i32.const 432
    i32.const 1774
-   i32.const 18
+   i32.const 19
    call $~lib/builtins/abort
    unreachable
   end
@@ -41186,7 +41186,7 @@
    i32.const 368
    i32.const 432
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -41270,7 +41270,7 @@
    i32.const 368
    i32.const 432
    i32.const 1774
-   i32.const 18
+   i32.const 19
    call $~lib/builtins/abort
    unreachable
   end
@@ -41289,7 +41289,7 @@
    i32.const 368
    i32.const 432
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -41379,7 +41379,7 @@
    i32.const 368
    i32.const 432
    i32.const 1774
-   i32.const 18
+   i32.const 19
    call $~lib/builtins/abort
    unreachable
   end
@@ -41398,7 +41398,7 @@
    i32.const 368
    i32.const 432
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -41451,7 +41451,7 @@
    i32.const 368
    i32.const 432
    i32.const 1774
-   i32.const 18
+   i32.const 19
    call $~lib/builtins/abort
    unreachable
   end
@@ -41470,7 +41470,7 @@
    i32.const 368
    i32.const 432
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -41548,7 +41548,7 @@
    i32.const 368
    i32.const 432
    i32.const 1774
-   i32.const 18
+   i32.const 19
    call $~lib/builtins/abort
    unreachable
   end
@@ -41567,7 +41567,7 @@
    i32.const 368
    i32.const 432
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -41784,7 +41784,7 @@
    i32.const 368
    i32.const 432
    i32.const 1774
-   i32.const 18
+   i32.const 19
    call $~lib/builtins/abort
    unreachable
   end
@@ -41803,7 +41803,7 @@
    i32.const 368
    i32.const 432
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -41893,7 +41893,7 @@
    i32.const 0
    i32.const 304
    i32.const 712
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -41935,7 +41935,7 @@
       i32.const 0
       i32.const 304
       i32.const 718
-      i32.const 6
+      i32.const 7
       call $~lib/builtins/abort
       unreachable
      end
@@ -41984,7 +41984,7 @@
    i32.const 368
    i32.const 432
    i32.const 1774
-   i32.const 18
+   i32.const 19
    call $~lib/builtins/abort
    unreachable
   end
@@ -42003,7 +42003,7 @@
    i32.const 368
    i32.const 432
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -42103,7 +42103,7 @@
    i32.const 368
    i32.const 432
    i32.const 1774
-   i32.const 18
+   i32.const 19
    call $~lib/builtins/abort
    unreachable
   end
@@ -42122,7 +42122,7 @@
    i32.const 368
    i32.const 432
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -42224,7 +42224,7 @@
    i32.const 368
    i32.const 432
    i32.const 1774
-   i32.const 18
+   i32.const 19
    call $~lib/builtins/abort
    unreachable
   end
@@ -42243,7 +42243,7 @@
    i32.const 368
    i32.const 432
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -42337,7 +42337,7 @@
    i32.const 368
    i32.const 432
    i32.const 1774
-   i32.const 18
+   i32.const 19
    call $~lib/builtins/abort
    unreachable
   end
@@ -42356,7 +42356,7 @@
    i32.const 368
    i32.const 432
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -42410,7 +42410,7 @@
    i32.const 368
    i32.const 432
    i32.const 1774
-   i32.const 18
+   i32.const 19
    call $~lib/builtins/abort
    unreachable
   end
@@ -42429,7 +42429,7 @@
    i32.const 368
    i32.const 432
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -42527,7 +42527,7 @@
    i32.const 368
    i32.const 432
    i32.const 1774
-   i32.const 18
+   i32.const 19
    call $~lib/builtins/abort
    unreachable
   end
@@ -42546,7 +42546,7 @@
    i32.const 368
    i32.const 432
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -42806,7 +42806,7 @@
    i32.const 368
    i32.const 432
    i32.const 1774
-   i32.const 18
+   i32.const 19
    call $~lib/builtins/abort
    unreachable
   end
@@ -42825,7 +42825,7 @@
    i32.const 368
    i32.const 432
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -42914,7 +42914,7 @@
    i32.const 0
    i32.const 304
    i32.const 712
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -42956,7 +42956,7 @@
       i32.const 0
       i32.const 304
       i32.const 718
-      i32.const 6
+      i32.const 7
       call $~lib/builtins/abort
       unreachable
      end
@@ -43005,7 +43005,7 @@
    i32.const 368
    i32.const 432
    i32.const 1774
-   i32.const 18
+   i32.const 19
    call $~lib/builtins/abort
    unreachable
   end
@@ -43024,7 +43024,7 @@
    i32.const 368
    i32.const 432
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -43119,7 +43119,7 @@
    i32.const 368
    i32.const 432
    i32.const 1774
-   i32.const 18
+   i32.const 19
    call $~lib/builtins/abort
    unreachable
   end
@@ -43138,7 +43138,7 @@
    i32.const 368
    i32.const 432
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -43222,7 +43222,7 @@
    i32.const 368
    i32.const 432
    i32.const 1774
-   i32.const 18
+   i32.const 19
    call $~lib/builtins/abort
    unreachable
   end
@@ -43241,7 +43241,7 @@
    i32.const 368
    i32.const 432
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -43336,7 +43336,7 @@
    i32.const 368
    i32.const 432
    i32.const 1774
-   i32.const 18
+   i32.const 19
    call $~lib/builtins/abort
    unreachable
   end
@@ -43355,7 +43355,7 @@
    i32.const 368
    i32.const 432
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -43433,7 +43433,7 @@
    i32.const 368
    i32.const 432
    i32.const 1774
-   i32.const 18
+   i32.const 19
    call $~lib/builtins/abort
    unreachable
   end
@@ -43452,7 +43452,7 @@
    i32.const 368
    i32.const 432
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -43505,7 +43505,7 @@
    i32.const 368
    i32.const 432
    i32.const 1774
-   i32.const 18
+   i32.const 19
    call $~lib/builtins/abort
    unreachable
   end
@@ -43524,7 +43524,7 @@
    i32.const 368
    i32.const 432
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -43770,7 +43770,7 @@
    i32.const 368
    i32.const 432
    i32.const 1774
-   i32.const 18
+   i32.const 19
    call $~lib/builtins/abort
    unreachable
   end
@@ -43789,7 +43789,7 @@
    i32.const 368
    i32.const 432
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -43878,7 +43878,7 @@
    i32.const 0
    i32.const 304
    i32.const 712
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -43920,7 +43920,7 @@
       i32.const 0
       i32.const 304
       i32.const 718
-      i32.const 6
+      i32.const 7
       call $~lib/builtins/abort
       unreachable
      end
@@ -43969,7 +43969,7 @@
    i32.const 368
    i32.const 432
    i32.const 1774
-   i32.const 18
+   i32.const 19
    call $~lib/builtins/abort
    unreachable
   end
@@ -43988,7 +43988,7 @@
    i32.const 368
    i32.const 432
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -44083,7 +44083,7 @@
    i32.const 368
    i32.const 432
    i32.const 1774
-   i32.const 18
+   i32.const 19
    call $~lib/builtins/abort
    unreachable
   end
@@ -44102,7 +44102,7 @@
    i32.const 368
    i32.const 432
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -44186,7 +44186,7 @@
    i32.const 368
    i32.const 432
    i32.const 1774
-   i32.const 18
+   i32.const 19
    call $~lib/builtins/abort
    unreachable
   end
@@ -44205,7 +44205,7 @@
    i32.const 368
    i32.const 432
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -44300,7 +44300,7 @@
    i32.const 368
    i32.const 432
    i32.const 1774
-   i32.const 18
+   i32.const 19
    call $~lib/builtins/abort
    unreachable
   end
@@ -44319,7 +44319,7 @@
    i32.const 368
    i32.const 432
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -44397,7 +44397,7 @@
    i32.const 368
    i32.const 432
    i32.const 1774
-   i32.const 18
+   i32.const 19
    call $~lib/builtins/abort
    unreachable
   end
@@ -44416,7 +44416,7 @@
    i32.const 368
    i32.const 432
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -44469,7 +44469,7 @@
    i32.const 368
    i32.const 432
    i32.const 1774
-   i32.const 18
+   i32.const 19
    call $~lib/builtins/abort
    unreachable
   end
@@ -44488,7 +44488,7 @@
    i32.const 368
    i32.const 432
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -44729,7 +44729,7 @@
    i32.const 368
    i32.const 432
    i32.const 1774
-   i32.const 18
+   i32.const 19
    call $~lib/builtins/abort
    unreachable
   end
@@ -44748,7 +44748,7 @@
    i32.const 368
    i32.const 432
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -44794,7 +44794,7 @@
    i32.const 0
    i32.const 304
    i32.const 712
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -44836,7 +44836,7 @@
       i32.const 0
       i32.const 304
       i32.const 718
-      i32.const 6
+      i32.const 7
       call $~lib/builtins/abort
       unreachable
      end
@@ -44885,7 +44885,7 @@
    i32.const 368
    i32.const 432
    i32.const 1774
-   i32.const 18
+   i32.const 19
    call $~lib/builtins/abort
    unreachable
   end
@@ -44904,7 +44904,7 @@
    i32.const 368
    i32.const 432
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -44999,7 +44999,7 @@
    i32.const 368
    i32.const 432
    i32.const 1774
-   i32.const 18
+   i32.const 19
    call $~lib/builtins/abort
    unreachable
   end
@@ -45018,7 +45018,7 @@
    i32.const 368
    i32.const 432
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -45102,7 +45102,7 @@
    i32.const 368
    i32.const 432
    i32.const 1774
-   i32.const 18
+   i32.const 19
    call $~lib/builtins/abort
    unreachable
   end
@@ -45121,7 +45121,7 @@
    i32.const 368
    i32.const 432
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -45216,7 +45216,7 @@
    i32.const 368
    i32.const 432
    i32.const 1774
-   i32.const 18
+   i32.const 19
    call $~lib/builtins/abort
    unreachable
   end
@@ -45235,7 +45235,7 @@
    i32.const 368
    i32.const 432
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -45318,7 +45318,7 @@
    i32.const 368
    i32.const 432
    i32.const 1774
-   i32.const 18
+   i32.const 19
    call $~lib/builtins/abort
    unreachable
   end
@@ -45337,7 +45337,7 @@
    i32.const 368
    i32.const 432
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -45420,7 +45420,7 @@
    i32.const 368
    i32.const 432
    i32.const 1774
-   i32.const 18
+   i32.const 19
    call $~lib/builtins/abort
    unreachable
   end
@@ -45439,7 +45439,7 @@
    i32.const 368
    i32.const 432
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -45680,7 +45680,7 @@
    i32.const 368
    i32.const 432
    i32.const 1774
-   i32.const 18
+   i32.const 19
    call $~lib/builtins/abort
    unreachable
   end
@@ -45699,7 +45699,7 @@
    i32.const 368
    i32.const 432
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -45758,7 +45758,7 @@
    i32.const 0
    i32.const 304
    i32.const 712
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -45800,7 +45800,7 @@
       i32.const 0
       i32.const 304
       i32.const 718
-      i32.const 6
+      i32.const 7
       call $~lib/builtins/abort
       unreachable
      end
@@ -45849,7 +45849,7 @@
    i32.const 368
    i32.const 432
    i32.const 1774
-   i32.const 18
+   i32.const 19
    call $~lib/builtins/abort
    unreachable
   end
@@ -45868,7 +45868,7 @@
    i32.const 368
    i32.const 432
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -45963,7 +45963,7 @@
    i32.const 368
    i32.const 432
    i32.const 1774
-   i32.const 18
+   i32.const 19
    call $~lib/builtins/abort
    unreachable
   end
@@ -45982,7 +45982,7 @@
    i32.const 368
    i32.const 432
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -46066,7 +46066,7 @@
    i32.const 368
    i32.const 432
    i32.const 1774
-   i32.const 18
+   i32.const 19
    call $~lib/builtins/abort
    unreachable
   end
@@ -46085,7 +46085,7 @@
    i32.const 368
    i32.const 432
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -46180,7 +46180,7 @@
    i32.const 368
    i32.const 432
    i32.const 1774
-   i32.const 18
+   i32.const 19
    call $~lib/builtins/abort
    unreachable
   end
@@ -46199,7 +46199,7 @@
    i32.const 368
    i32.const 432
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -46282,7 +46282,7 @@
    i32.const 368
    i32.const 432
    i32.const 1774
-   i32.const 18
+   i32.const 19
    call $~lib/builtins/abort
    unreachable
   end
@@ -46301,7 +46301,7 @@
    i32.const 368
    i32.const 432
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -46384,7 +46384,7 @@
    i32.const 368
    i32.const 432
    i32.const 1774
-   i32.const 18
+   i32.const 19
    call $~lib/builtins/abort
    unreachable
   end
@@ -46403,7 +46403,7 @@
    i32.const 368
    i32.const 432
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -46649,7 +46649,7 @@
    i32.const 368
    i32.const 432
    i32.const 1774
-   i32.const 18
+   i32.const 19
    call $~lib/builtins/abort
    unreachable
   end
@@ -46668,7 +46668,7 @@
    i32.const 368
    i32.const 432
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -46757,7 +46757,7 @@
    i32.const 0
    i32.const 304
    i32.const 712
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -46799,7 +46799,7 @@
       i32.const 0
       i32.const 304
       i32.const 718
-      i32.const 6
+      i32.const 7
       call $~lib/builtins/abort
       unreachable
      end
@@ -46848,7 +46848,7 @@
    i32.const 368
    i32.const 432
    i32.const 1774
-   i32.const 18
+   i32.const 19
    call $~lib/builtins/abort
    unreachable
   end
@@ -46867,7 +46867,7 @@
    i32.const 368
    i32.const 432
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -46957,7 +46957,7 @@
    i32.const 368
    i32.const 432
    i32.const 1774
-   i32.const 18
+   i32.const 19
    call $~lib/builtins/abort
    unreachable
   end
@@ -46976,7 +46976,7 @@
    i32.const 368
    i32.const 432
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -47030,7 +47030,7 @@
    i32.const 368
    i32.const 432
    i32.const 1774
-   i32.const 18
+   i32.const 19
    call $~lib/builtins/abort
    unreachable
   end
@@ -47049,7 +47049,7 @@
    i32.const 368
    i32.const 432
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -47144,7 +47144,7 @@
    i32.const 368
    i32.const 432
    i32.const 1774
-   i32.const 18
+   i32.const 19
    call $~lib/builtins/abort
    unreachable
   end
@@ -47163,7 +47163,7 @@
    i32.const 368
    i32.const 432
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -47246,7 +47246,7 @@
    i32.const 368
    i32.const 432
    i32.const 1774
-   i32.const 18
+   i32.const 19
    call $~lib/builtins/abort
    unreachable
   end
@@ -47265,7 +47265,7 @@
    i32.const 368
    i32.const 432
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -47348,7 +47348,7 @@
    i32.const 368
    i32.const 432
    i32.const 1774
-   i32.const 18
+   i32.const 19
    call $~lib/builtins/abort
    unreachable
   end
@@ -47367,7 +47367,7 @@
    i32.const 368
    i32.const 432
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -47613,7 +47613,7 @@
    i32.const 368
    i32.const 432
    i32.const 1774
-   i32.const 18
+   i32.const 19
    call $~lib/builtins/abort
    unreachable
   end
@@ -47632,7 +47632,7 @@
    i32.const 368
    i32.const 432
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -47721,7 +47721,7 @@
    i32.const 0
    i32.const 304
    i32.const 712
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -47763,7 +47763,7 @@
       i32.const 0
       i32.const 304
       i32.const 718
-      i32.const 6
+      i32.const 7
       call $~lib/builtins/abort
       unreachable
      end
@@ -47812,7 +47812,7 @@
    i32.const 368
    i32.const 432
    i32.const 1774
-   i32.const 18
+   i32.const 19
    call $~lib/builtins/abort
    unreachable
   end
@@ -47831,7 +47831,7 @@
    i32.const 368
    i32.const 432
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -47921,7 +47921,7 @@
    i32.const 368
    i32.const 432
    i32.const 1774
-   i32.const 18
+   i32.const 19
    call $~lib/builtins/abort
    unreachable
   end
@@ -47940,7 +47940,7 @@
    i32.const 368
    i32.const 432
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -47994,7 +47994,7 @@
    i32.const 368
    i32.const 432
    i32.const 1774
-   i32.const 18
+   i32.const 19
    call $~lib/builtins/abort
    unreachable
   end
@@ -48013,7 +48013,7 @@
    i32.const 368
    i32.const 432
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -48108,7 +48108,7 @@
    i32.const 368
    i32.const 432
    i32.const 1774
-   i32.const 18
+   i32.const 19
    call $~lib/builtins/abort
    unreachable
   end
@@ -48127,7 +48127,7 @@
    i32.const 368
    i32.const 432
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -48210,7 +48210,7 @@
    i32.const 368
    i32.const 432
    i32.const 1774
-   i32.const 18
+   i32.const 19
    call $~lib/builtins/abort
    unreachable
   end
@@ -48229,7 +48229,7 @@
    i32.const 368
    i32.const 432
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -48312,7 +48312,7 @@
    i32.const 368
    i32.const 432
    i32.const 1774
-   i32.const 18
+   i32.const 19
    call $~lib/builtins/abort
    unreachable
   end
@@ -48331,7 +48331,7 @@
    i32.const 368
    i32.const 432
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -48577,7 +48577,7 @@
    i32.const 368
    i32.const 432
    i32.const 1774
-   i32.const 18
+   i32.const 19
    call $~lib/builtins/abort
    unreachable
   end
@@ -48596,7 +48596,7 @@
    i32.const 368
    i32.const 432
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -48682,7 +48682,7 @@
    i32.const 0
    i32.const 304
    i32.const 712
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -48724,7 +48724,7 @@
       i32.const 0
       i32.const 304
       i32.const 718
-      i32.const 6
+      i32.const 7
       call $~lib/builtins/abort
       unreachable
      end
@@ -48767,7 +48767,7 @@
    i32.const 368
    i32.const 432
    i32.const 1774
-   i32.const 18
+   i32.const 19
    call $~lib/builtins/abort
    unreachable
   end
@@ -48786,7 +48786,7 @@
    i32.const 368
    i32.const 432
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -48839,7 +48839,7 @@
    i32.const 368
    i32.const 432
    i32.const 1774
-   i32.const 18
+   i32.const 19
    call $~lib/builtins/abort
    unreachable
   end
@@ -48858,7 +48858,7 @@
    i32.const 368
    i32.const 432
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -48942,7 +48942,7 @@
    i32.const 368
    i32.const 432
    i32.const 1774
-   i32.const 18
+   i32.const 19
    call $~lib/builtins/abort
    unreachable
   end
@@ -48961,7 +48961,7 @@
    i32.const 368
    i32.const 432
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -49045,7 +49045,7 @@
    i32.const 368
    i32.const 432
    i32.const 1774
-   i32.const 18
+   i32.const 19
    call $~lib/builtins/abort
    unreachable
   end
@@ -49064,7 +49064,7 @@
    i32.const 368
    i32.const 432
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -49148,7 +49148,7 @@
    i32.const 368
    i32.const 432
    i32.const 1774
-   i32.const 18
+   i32.const 19
    call $~lib/builtins/abort
    unreachable
   end
@@ -49167,7 +49167,7 @@
    i32.const 368
    i32.const 432
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -49399,7 +49399,7 @@
    i32.const 368
    i32.const 432
    i32.const 1774
-   i32.const 18
+   i32.const 19
    call $~lib/builtins/abort
    unreachable
   end
@@ -49418,7 +49418,7 @@
    i32.const 368
    i32.const 432
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -49504,7 +49504,7 @@
    i32.const 0
    i32.const 304
    i32.const 712
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -49544,7 +49544,7 @@
       i32.const 0
       i32.const 304
       i32.const 718
-      i32.const 6
+      i32.const 7
       call $~lib/builtins/abort
       unreachable
      end
@@ -49592,7 +49592,7 @@
    i32.const 368
    i32.const 432
    i32.const 1774
-   i32.const 18
+   i32.const 19
    call $~lib/builtins/abort
    unreachable
   end
@@ -49611,7 +49611,7 @@
    i32.const 368
    i32.const 432
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -49695,7 +49695,7 @@
    i32.const 368
    i32.const 432
    i32.const 1774
-   i32.const 18
+   i32.const 19
    call $~lib/builtins/abort
    unreachable
   end
@@ -49714,7 +49714,7 @@
    i32.const 368
    i32.const 432
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -49798,7 +49798,7 @@
    i32.const 368
    i32.const 432
    i32.const 1774
-   i32.const 18
+   i32.const 19
    call $~lib/builtins/abort
    unreachable
   end
@@ -49817,7 +49817,7 @@
    i32.const 368
    i32.const 432
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -49901,7 +49901,7 @@
    i32.const 368
    i32.const 432
    i32.const 1774
-   i32.const 18
+   i32.const 19
    call $~lib/builtins/abort
    unreachable
   end
@@ -49920,7 +49920,7 @@
    i32.const 368
    i32.const 432
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -50004,7 +50004,7 @@
    i32.const 368
    i32.const 432
    i32.const 1774
-   i32.const 18
+   i32.const 19
    call $~lib/builtins/abort
    unreachable
   end
@@ -50023,7 +50023,7 @@
    i32.const 368
    i32.const 432
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -50256,7 +50256,7 @@
    i32.const 368
    i32.const 432
    i32.const 1774
-   i32.const 18
+   i32.const 19
    call $~lib/builtins/abort
    unreachable
   end
@@ -50275,7 +50275,7 @@
    i32.const 368
    i32.const 432
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -50375,7 +50375,7 @@
    i32.const 368
    i32.const 432
    i32.const 1774
-   i32.const 18
+   i32.const 19
    call $~lib/builtins/abort
    unreachable
   end
@@ -50394,7 +50394,7 @@
    i32.const 368
    i32.const 432
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -50494,7 +50494,7 @@
    i32.const 368
    i32.const 432
    i32.const 1774
-   i32.const 18
+   i32.const 19
    call $~lib/builtins/abort
    unreachable
   end
@@ -50513,7 +50513,7 @@
    i32.const 368
    i32.const 432
    i32.const 1775
-   i32.const 46
+   i32.const 47
    call $~lib/builtins/abort
    unreachable
   end
@@ -50631,7 +50631,7 @@
    i32.const 0
    i32.const 304
    i32.const 95
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -50644,7 +50644,7 @@
    i32.const 0
    i32.const 304
    i32.const 96
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -50657,7 +50657,7 @@
    i32.const 0
    i32.const 304
    i32.const 97
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -50671,7 +50671,7 @@
    i32.const 0
    i32.const 304
    i32.const 98
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -50685,7 +50685,7 @@
    i32.const 0
    i32.const 304
    i32.const 99
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -50699,7 +50699,7 @@
    i32.const 0
    i32.const 304
    i32.const 100
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -50721,7 +50721,7 @@
    i32.const 0
    i32.const 304
    i32.const 103
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -50734,7 +50734,7 @@
    i32.const 0
    i32.const 304
    i32.const 104
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -50747,7 +50747,7 @@
    i32.const 0
    i32.const 304
    i32.const 105
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -50761,7 +50761,7 @@
    i32.const 0
    i32.const 304
    i32.const 106
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -50821,7 +50821,7 @@
    i32.const 0
    i32.const 304
    i32.const 122
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -50834,7 +50834,7 @@
    i32.const 0
    i32.const 304
    i32.const 123
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -50847,7 +50847,7 @@
    i32.const 0
    i32.const 304
    i32.const 124
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -50894,7 +50894,7 @@
    i32.const 0
    i32.const 304
    i32.const 126
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -50926,7 +50926,7 @@
    i32.const 0
    i32.const 304
    i32.const 135
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -50940,7 +50940,7 @@
    i32.const 0
    i32.const 304
    i32.const 136
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -50954,7 +50954,7 @@
    i32.const 0
    i32.const 304
    i32.const 137
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -51004,7 +51004,7 @@
    i32.const 0
    i32.const 304
    i32.const 149
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -51028,7 +51028,7 @@
    i32.const 0
    i32.const 304
    i32.const 152
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -51052,7 +51052,7 @@
    i32.const 0
    i32.const 304
    i32.const 155
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -51076,7 +51076,7 @@
    i32.const 0
    i32.const 304
    i32.const 158
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -51100,7 +51100,7 @@
    i32.const 0
    i32.const 304
    i32.const 161
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -51124,7 +51124,7 @@
    i32.const 0
    i32.const 304
    i32.const 165
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -51137,7 +51137,7 @@
    i32.const 0
    i32.const 304
    i32.const 166
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -51150,7 +51150,7 @@
    i32.const 0
    i32.const 304
    i32.const 167
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -51168,7 +51168,7 @@
    i32.const 0
    i32.const 304
    i32.const 168
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -51186,7 +51186,7 @@
    i32.const 0
    i32.const 304
    i32.const 169
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -51252,7 +51252,7 @@
    i32.const 0
    i32.const 304
    i32.const 181
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -51276,7 +51276,7 @@
    i32.const 0
    i32.const 304
    i32.const 184
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -51300,7 +51300,7 @@
    i32.const 0
    i32.const 304
    i32.const 187
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -51324,7 +51324,7 @@
    i32.const 0
    i32.const 304
    i32.const 190
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -51348,7 +51348,7 @@
    i32.const 0
    i32.const 304
    i32.const 193
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -51372,7 +51372,7 @@
    i32.const 0
    i32.const 304
    i32.const 197
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -51385,7 +51385,7 @@
    i32.const 0
    i32.const 304
    i32.const 198
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -51398,7 +51398,7 @@
    i32.const 0
    i32.const 304
    i32.const 199
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -51416,7 +51416,7 @@
    i32.const 0
    i32.const 304
    i32.const 200
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -51434,7 +51434,7 @@
    i32.const 0
    i32.const 304
    i32.const 201
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -51499,7 +51499,7 @@
    i32.const 0
    i32.const 304
    i32.const 222
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -51512,7 +51512,7 @@
    i32.const 0
    i32.const 304
    i32.const 223
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -51525,7 +51525,7 @@
    i32.const 0
    i32.const 304
    i32.const 224
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -51538,7 +51538,7 @@
    i32.const 0
    i32.const 304
    i32.const 225
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -51557,7 +51557,7 @@
    i32.const 0
    i32.const 304
    i32.const 228
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -51570,7 +51570,7 @@
    i32.const 0
    i32.const 304
    i32.const 229
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -51583,7 +51583,7 @@
    i32.const 0
    i32.const 304
    i32.const 230
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -51596,7 +51596,7 @@
    i32.const 0
    i32.const 304
    i32.const 231
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -51615,7 +51615,7 @@
    i32.const 0
    i32.const 304
    i32.const 234
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -51628,7 +51628,7 @@
    i32.const 0
    i32.const 304
    i32.const 235
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -51641,7 +51641,7 @@
    i32.const 0
    i32.const 304
    i32.const 236
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -51654,7 +51654,7 @@
    i32.const 0
    i32.const 304
    i32.const 237
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -51714,7 +51714,7 @@
    i32.const 0
    i32.const 304
    i32.const 248
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -51746,7 +51746,7 @@
    i32.const 0
    i32.const 304
    i32.const 250
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -51778,7 +51778,7 @@
    i32.const 0
    i32.const 304
    i32.const 252
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -51810,7 +51810,7 @@
    i32.const 0
    i32.const 304
    i32.const 254
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -51842,7 +51842,7 @@
    i32.const 0
    i32.const 304
    i32.const 256
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -51874,7 +51874,7 @@
    i32.const 0
    i32.const 304
    i32.const 258
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -51906,7 +51906,7 @@
    i32.const 0
    i32.const 304
    i32.const 260
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -51938,7 +51938,7 @@
    i32.const 0
    i32.const 304
    i32.const 262
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -51970,7 +51970,7 @@
    i32.const 0
    i32.const 304
    i32.const 264
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -52002,7 +52002,7 @@
    i32.const 0
    i32.const 304
    i32.const 266
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -52034,7 +52034,7 @@
    i32.const 0
    i32.const 304
    i32.const 268
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -52066,7 +52066,7 @@
    i32.const 0
    i32.const 304
    i32.const 270
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -52160,7 +52160,7 @@
    i32.const 0
    i32.const 304
    i32.const 282
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -52173,7 +52173,7 @@
    i32.const 0
    i32.const 304
    i32.const 283
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -52186,7 +52186,7 @@
    i32.const 0
    i32.const 304
    i32.const 284
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -52205,7 +52205,7 @@
    i32.const 0
    i32.const 304
    i32.const 287
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -52219,7 +52219,7 @@
    i32.const 0
    i32.const 304
    i32.const 288
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -52232,7 +52232,7 @@
    i32.const 0
    i32.const 304
    i32.const 289
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -52245,7 +52245,7 @@
    i32.const 0
    i32.const 304
    i32.const 290
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -52258,7 +52258,7 @@
    i32.const 0
    i32.const 304
    i32.const 291
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -52277,7 +52277,7 @@
    i32.const 0
    i32.const 304
    i32.const 294
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -52290,7 +52290,7 @@
    i32.const 0
    i32.const 304
    i32.const 295
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -52303,7 +52303,7 @@
    i32.const 0
    i32.const 304
    i32.const 296
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -52316,7 +52316,7 @@
    i32.const 0
    i32.const 304
    i32.const 297
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -52333,7 +52333,7 @@
    i32.const 0
    i32.const 304
    i32.const 300
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -52347,7 +52347,7 @@
    i32.const 0
    i32.const 304
    i32.const 301
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -52361,7 +52361,7 @@
    i32.const 0
    i32.const 304
    i32.const 302
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -52375,7 +52375,7 @@
    i32.const 0
    i32.const 304
    i32.const 303
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -52518,7 +52518,7 @@
    i32.const 0
    i32.const 304
    i32.const 607
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -52535,7 +52535,7 @@
    i32.const 0
    i32.const 304
    i32.const 608
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -52558,7 +52558,7 @@
    i32.const 0
    i32.const 304
    i32.const 613
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -52575,7 +52575,7 @@
    i32.const 0
    i32.const 304
    i32.const 614
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -52614,7 +52614,7 @@
    i32.const 0
    i32.const 304
    i32.const 691
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -52646,7 +52646,7 @@
    i32.const 0
    i32.const 304
    i32.const 695
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -52858,7 +52858,7 @@
    i32.const 0
    i32.const 256
    i32.const 122
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -52880,7 +52880,7 @@
     i32.const 0
     i32.const 256
     i32.const 126
-    i32.const 17
+    i32.const 18
     call $~lib/builtins/abort
     unreachable
    end
@@ -52896,7 +52896,7 @@
     i32.const 0
     i32.const 256
     i32.const 136
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -52928,7 +52928,7 @@
    i32.const 0
    i32.const 256
    i32.const 69
-   i32.const 15
+   i32.const 16
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/switch.optimized.wat
+++ b/tests/compiler/switch.optimized.wat
@@ -87,7 +87,7 @@
    i32.const 0
    i32.const 1040
    i32.const 10
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -99,7 +99,7 @@
    i32.const 0
    i32.const 1040
    i32.const 11
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -111,7 +111,7 @@
    i32.const 0
    i32.const 1040
    i32.const 12
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -123,7 +123,7 @@
    i32.const 0
    i32.const 1040
    i32.const 13
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -133,7 +133,7 @@
    i32.const 0
    i32.const 1040
    i32.const 14
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -143,7 +143,7 @@
    i32.const 0
    i32.const 1040
    i32.const 24
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -155,7 +155,7 @@
    i32.const 0
    i32.const 1040
    i32.const 25
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -167,7 +167,7 @@
    i32.const 0
    i32.const 1040
    i32.const 26
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -179,7 +179,7 @@
    i32.const 0
    i32.const 1040
    i32.const 27
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -189,7 +189,7 @@
    i32.const 0
    i32.const 1040
    i32.const 28
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -199,7 +199,7 @@
    i32.const 0
    i32.const 1040
    i32.const 38
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -211,7 +211,7 @@
    i32.const 0
    i32.const 1040
    i32.const 39
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -223,7 +223,7 @@
    i32.const 0
    i32.const 1040
    i32.const 40
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -235,7 +235,7 @@
    i32.const 0
    i32.const 1040
    i32.const 41
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -245,7 +245,7 @@
    i32.const 0
    i32.const 1040
    i32.const 42
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -257,7 +257,7 @@
    i32.const 0
    i32.const 1040
    i32.const 51
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -269,7 +269,7 @@
    i32.const 0
    i32.const 1040
    i32.const 52
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -281,7 +281,7 @@
    i32.const 0
    i32.const 1040
    i32.const 53
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -293,7 +293,7 @@
    i32.const 0
    i32.const 1040
    i32.const 62
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -305,7 +305,7 @@
    i32.const 0
    i32.const 1040
    i32.const 63
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -317,7 +317,7 @@
    i32.const 0
    i32.const 1040
    i32.const 64
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -329,7 +329,7 @@
    i32.const 0
    i32.const 1040
    i32.const 73
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -341,7 +341,7 @@
    i32.const 0
    i32.const 1040
    i32.const 74
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -353,7 +353,7 @@
    i32.const 0
    i32.const 1040
    i32.const 75
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -365,7 +365,7 @@
    i32.const 0
    i32.const 1040
    i32.const 84
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -377,7 +377,7 @@
    i32.const 0
    i32.const 1040
    i32.const 85
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -389,7 +389,7 @@
    i32.const 0
    i32.const 1040
    i32.const 86
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/switch.untouched.wat
+++ b/tests/compiler/switch.untouched.wat
@@ -166,7 +166,7 @@
    i32.const 0
    i32.const 32
    i32.const 10
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -179,7 +179,7 @@
    i32.const 0
    i32.const 32
    i32.const 11
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -192,7 +192,7 @@
    i32.const 0
    i32.const 32
    i32.const 12
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -205,7 +205,7 @@
    i32.const 0
    i32.const 32
    i32.const 13
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -218,7 +218,7 @@
    i32.const 0
    i32.const 32
    i32.const 14
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -231,7 +231,7 @@
    i32.const 0
    i32.const 32
    i32.const 24
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -244,7 +244,7 @@
    i32.const 0
    i32.const 32
    i32.const 25
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -257,7 +257,7 @@
    i32.const 0
    i32.const 32
    i32.const 26
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -270,7 +270,7 @@
    i32.const 0
    i32.const 32
    i32.const 27
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -283,7 +283,7 @@
    i32.const 0
    i32.const 32
    i32.const 28
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -296,7 +296,7 @@
    i32.const 0
    i32.const 32
    i32.const 38
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -309,7 +309,7 @@
    i32.const 0
    i32.const 32
    i32.const 39
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -322,7 +322,7 @@
    i32.const 0
    i32.const 32
    i32.const 40
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -335,7 +335,7 @@
    i32.const 0
    i32.const 32
    i32.const 41
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -348,7 +348,7 @@
    i32.const 0
    i32.const 32
    i32.const 42
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -361,7 +361,7 @@
    i32.const 0
    i32.const 32
    i32.const 51
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -374,7 +374,7 @@
    i32.const 0
    i32.const 32
    i32.const 52
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -387,7 +387,7 @@
    i32.const 0
    i32.const 32
    i32.const 53
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -400,7 +400,7 @@
    i32.const 0
    i32.const 32
    i32.const 62
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -413,7 +413,7 @@
    i32.const 0
    i32.const 32
    i32.const 63
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -426,7 +426,7 @@
    i32.const 0
    i32.const 32
    i32.const 64
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -439,7 +439,7 @@
    i32.const 0
    i32.const 32
    i32.const 73
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -452,7 +452,7 @@
    i32.const 0
    i32.const 32
    i32.const 74
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -465,7 +465,7 @@
    i32.const 0
    i32.const 32
    i32.const 75
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -478,7 +478,7 @@
    i32.const 0
    i32.const 32
    i32.const 84
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -491,7 +491,7 @@
    i32.const 0
    i32.const 32
    i32.const 85
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -504,7 +504,7 @@
    i32.const 0
    i32.const 32
    i32.const 86
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -517,7 +517,7 @@
    i32.const 0
    i32.const 32
    i32.const 92
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -530,7 +530,7 @@
    i32.const 0
    i32.const 32
    i32.const 93
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -543,7 +543,7 @@
    i32.const 0
    i32.const 32
    i32.const 94
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/typeof.optimized.wat
+++ b/tests/compiler/typeof.optimized.wat
@@ -147,7 +147,7 @@
    i32.const 0
    i32.const 1104
    i32.const 13
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -159,7 +159,7 @@
    i32.const 0
    i32.const 1104
    i32.const 14
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -171,7 +171,7 @@
    i32.const 0
    i32.const 1104
    i32.const 15
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -183,7 +183,7 @@
    i32.const 0
    i32.const 1104
    i32.const 16
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -195,7 +195,7 @@
    i32.const 0
    i32.const 1104
    i32.const 17
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -207,7 +207,7 @@
    i32.const 0
    i32.const 1104
    i32.const 19
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -219,7 +219,7 @@
    i32.const 0
    i32.const 1104
    i32.const 20
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -231,7 +231,7 @@
    i32.const 0
    i32.const 1104
    i32.const 21
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -243,7 +243,7 @@
    i32.const 0
    i32.const 1104
    i32.const 22
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -255,7 +255,7 @@
    i32.const 0
    i32.const 1104
    i32.const 23
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -267,7 +267,7 @@
    i32.const 0
    i32.const 1104
    i32.const 24
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -279,7 +279,7 @@
    i32.const 0
    i32.const 1104
    i32.const 27
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -291,7 +291,7 @@
    i32.const 0
    i32.const 1104
    i32.const 29
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -303,7 +303,7 @@
    i32.const 0
    i32.const 1104
    i32.const 31
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -315,7 +315,7 @@
    i32.const 0
    i32.const 1104
    i32.const 33
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -327,7 +327,7 @@
    i32.const 0
    i32.const 1104
    i32.const 35
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -339,7 +339,7 @@
    i32.const 0
    i32.const 1104
    i32.const 37
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -351,7 +351,7 @@
    i32.const 0
    i32.const 1104
    i32.const 39
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -417,7 +417,7 @@
    i32.const 0
    i32.const 1104
    i32.const 41
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -429,7 +429,7 @@
    i32.const 0
    i32.const 1104
    i32.const 42
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -441,7 +441,7 @@
    i32.const 0
    i32.const 1104
    i32.const 46
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -453,7 +453,7 @@
    i32.const 0
    i32.const 1104
    i32.const 47
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -465,7 +465,7 @@
    i32.const 0
    i32.const 1104
    i32.const 48
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/typeof.untouched.wat
+++ b/tests/compiler/typeof.untouched.wat
@@ -373,7 +373,7 @@
    i32.const 0
    i32.const 96
    i32.const 13
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -385,7 +385,7 @@
    i32.const 0
    i32.const 96
    i32.const 14
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -397,7 +397,7 @@
    i32.const 0
    i32.const 96
    i32.const 15
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -409,7 +409,7 @@
    i32.const 0
    i32.const 96
    i32.const 16
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -421,7 +421,7 @@
    i32.const 0
    i32.const 96
    i32.const 17
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -433,7 +433,7 @@
    i32.const 0
    i32.const 96
    i32.const 19
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -445,7 +445,7 @@
    i32.const 0
    i32.const 96
    i32.const 20
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -457,7 +457,7 @@
    i32.const 0
    i32.const 96
    i32.const 21
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -469,7 +469,7 @@
    i32.const 0
    i32.const 96
    i32.const 22
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -481,7 +481,7 @@
    i32.const 0
    i32.const 96
    i32.const 23
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -493,7 +493,7 @@
    i32.const 0
    i32.const 96
    i32.const 24
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -505,7 +505,7 @@
    i32.const 0
    i32.const 96
    i32.const 27
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -517,7 +517,7 @@
    i32.const 0
    i32.const 96
    i32.const 29
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -529,7 +529,7 @@
    i32.const 0
    i32.const 96
    i32.const 31
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -541,7 +541,7 @@
    i32.const 0
    i32.const 96
    i32.const 33
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -553,7 +553,7 @@
    i32.const 0
    i32.const 96
    i32.const 35
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -565,7 +565,7 @@
    i32.const 0
    i32.const 96
    i32.const 37
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -577,7 +577,7 @@
    i32.const 0
    i32.const 96
    i32.const 39
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -602,7 +602,7 @@
    i32.const 0
    i32.const 96
    i32.const 41
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -614,7 +614,7 @@
    i32.const 0
    i32.const 96
    i32.const 42
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -626,7 +626,7 @@
    i32.const 0
    i32.const 96
    i32.const 46
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -638,7 +638,7 @@
    i32.const 0
    i32.const 96
    i32.const 47
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -650,7 +650,7 @@
    i32.const 0
    i32.const 96
    i32.const 48
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/wasi/abort.js
+++ b/tests/compiler/wasi/abort.js
@@ -8,7 +8,7 @@ exports.preInstantiate = function(imports, exports) {
       const messagePtr = new Uint32Array(memory.buffer)[ iov >>> 2     ];
       const messageLen = new Uint32Array(memory.buffer)[(iov >>> 2) + 1];
       const message = Array.from(new Uint8Array(memory.buffer, messagePtr, messageLen)).map(c => String.fromCharCode(c)).join("");
-      if (message != "abort: the message in wasi/abort.ts(4:2)\n") failed = "unexpected message: " + message;
+      if (message != "abort: the message in wasi/abort.ts(4:3)\n") failed = "unexpected message: " + message;
     },
     proc_exit: function(code) {
       if (code != 255) failed = "unexpected exit code: " + code;

--- a/tests/compiler/wasi/abort.optimized.wat
+++ b/tests/compiler/wasi/abort.optimized.wat
@@ -240,7 +240,7 @@
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
-  i32.const 2
+  i32.const 3
   local.set $1
   i32.const 4
   local.set $0
@@ -304,7 +304,7 @@
   local.tee $0
   i32.const 58
   i32.store8
-  i32.const 2
+  i32.const 3
   call $~lib/util/number/decimalCount32
   local.tee $2
   local.get $0

--- a/tests/compiler/wasi/abort.untouched.wat
+++ b/tests/compiler/wasi/abort.untouched.wat
@@ -471,7 +471,7 @@
    i32.const 32
    i32.const 80
    i32.const 4
-   i32.const 2
+   i32.const 3
    call $~lib/wasi/index/abort
    unreachable
   end

--- a/tests/compiler/wasi/seed.optimized.wat
+++ b/tests/compiler/wasi/seed.optimized.wat
@@ -295,7 +295,7 @@
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
-  i32.const 4
+  i32.const 5
   local.set $1
   i32.const 1406
   local.set $0
@@ -349,7 +349,7 @@
   local.tee $0
   i32.const 58
   i32.store8
-  i32.const 4
+  i32.const 5
   call $~lib/util/number/decimalCount32
   local.tee $2
   local.get $0

--- a/tests/compiler/wasi/seed.untouched.wat
+++ b/tests/compiler/wasi/seed.untouched.wat
@@ -613,7 +613,7 @@
    i32.const 0
    i32.const 32
    i32.const 1406
-   i32.const 4
+   i32.const 5
    call $~lib/wasi/index/abort
    unreachable
   end

--- a/tests/compiler/wasi/trace.optimized.wat
+++ b/tests/compiler/wasi/trace.optimized.wat
@@ -1897,7 +1897,7 @@
   i32.eqz
   if
    i32.const 70
-   i32.const 2
+   i32.const 3
    call $~lib/wasi/index/abort
    unreachable
   end
@@ -1910,7 +1910,7 @@
   i32.ne
   if
    i32.const 72
-   i32.const 13
+   i32.const 14
    call $~lib/wasi/index/abort
    unreachable
   end

--- a/tests/compiler/wasi/trace.untouched.wat
+++ b/tests/compiler/wasi/trace.untouched.wat
@@ -3429,7 +3429,7 @@
    i32.const 0
    i32.const 1472
    i32.const 70
-   i32.const 2
+   i32.const 3
    call $~lib/wasi/index/abort
    unreachable
   end
@@ -3446,7 +3446,7 @@
    i32.const 0
    i32.const 1472
    i32.const 72
-   i32.const 13
+   i32.const 14
    call $~lib/wasi/index/abort
    unreachable
   end

--- a/tests/compiler/while.optimized.wat
+++ b/tests/compiler/while.optimized.wat
@@ -58,7 +58,7 @@
      i32.const 0
      i32.const 1040
      i32.const 29
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -69,7 +69,7 @@
      i32.const 0
      i32.const 1040
      i32.const 30
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -81,7 +81,7 @@
    i32.const 0
    i32.const 1040
    i32.const 32
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -92,7 +92,7 @@
    i32.const 0
    i32.const 1040
    i32.const 33
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -103,7 +103,7 @@
    i32.const 0
    i32.const 1040
    i32.const 34
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -125,7 +125,7 @@
    i32.const 0
    i32.const 1072
    i32.const 277
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -147,7 +147,7 @@
    i32.const 0
    i32.const 1072
    i32.const 279
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -190,7 +190,7 @@
    i32.const 0
    i32.const 1072
    i32.const 292
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -286,7 +286,7 @@
    i32.const 0
    i32.const 1072
    i32.const 205
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -300,7 +300,7 @@
    i32.const 0
    i32.const 1072
    i32.const 207
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -373,7 +373,7 @@
     i32.const 0
     i32.const 1072
     i32.const 228
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -428,7 +428,7 @@
    i32.const 0
    i32.const 1072
    i32.const 243
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -443,7 +443,7 @@
    i32.const 0
    i32.const 1072
    i32.const 244
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -491,7 +491,7 @@
    i32.const 0
    i32.const 1072
    i32.const 260
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -574,7 +574,7 @@
    i32.const 0
    i32.const 1072
    i32.const 386
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -591,7 +591,7 @@
     i32.const 0
     i32.const 1072
     i32.const 396
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -619,7 +619,7 @@
     i32.const 0
     i32.const 1072
     i32.const 408
-    i32.const 4
+    i32.const 5
     call $~lib/builtins/abort
     unreachable
    end
@@ -790,7 +790,7 @@
      i32.const 0
      i32.const 1072
      i32.const 351
-     i32.const 17
+     i32.const 18
      call $~lib/builtins/abort
      unreachable
     end
@@ -819,7 +819,7 @@
    i32.const 0
    i32.const 1072
    i32.const 501
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -889,7 +889,7 @@
      i32.const 0
      i32.const 1072
      i32.const 513
-     i32.const 19
+     i32.const 20
      call $~lib/builtins/abort
      unreachable
     end
@@ -905,7 +905,7 @@
    i32.const 0
    i32.const 1072
    i32.const 521
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1012,7 +1012,7 @@
     i32.const 0
     i32.const 1184
     i32.const 109
-    i32.const 2
+    i32.const 3
     call $~lib/builtins/abort
     unreachable
    end
@@ -1031,7 +1031,7 @@
     i32.const 0
     i32.const 1184
     i32.const 112
-    i32.const 13
+    i32.const 14
     call $~lib/builtins/abort
     unreachable
    end
@@ -1076,7 +1076,7 @@
    i32.const 0
    i32.const 1040
    i32.const 10
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1087,7 +1087,7 @@
    i32.const 0
    i32.const 1040
    i32.const 11
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1102,7 +1102,7 @@
    i32.const 0
    i32.const 1040
    i32.const 39
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1134,7 +1134,7 @@
    i32.const 0
    i32.const 1040
    i32.const 45
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1145,7 +1145,7 @@
    i32.const 0
    i32.const 1040
    i32.const 46
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1171,7 +1171,7 @@
    i32.const 0
    i32.const 1040
    i32.const 58
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1195,7 +1195,7 @@
    i32.const 0
    i32.const 1040
    i32.const 72
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1230,7 +1230,7 @@
    i32.const 0
    i32.const 1040
    i32.const 117
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1267,7 +1267,7 @@
    i32.const 0
    i32.const 1040
    i32.const 135
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1276,7 +1276,7 @@
    i32.const 0
    i32.const 1040
    i32.const 136
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1323,7 +1323,7 @@
    i32.const 0
    i32.const 1040
    i32.const 151
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1332,7 +1332,7 @@
    i32.const 0
    i32.const 1040
    i32.const 152
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1346,7 +1346,7 @@
    i32.const 0
    i32.const 1040
    i32.const 157
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1390,7 +1390,7 @@
    i32.const 0
    i32.const 1040
    i32.const 171
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1399,7 +1399,7 @@
    i32.const 0
    i32.const 1040
    i32.const 172
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1413,7 +1413,7 @@
    i32.const 0
    i32.const 1040
    i32.const 177
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -1447,7 +1447,7 @@
    i32.const 0
    i32.const 1184
    i32.const 122
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1492,7 +1492,7 @@
     i32.const 0
     i32.const 1184
     i32.const 126
-    i32.const 17
+    i32.const 18
     call $~lib/builtins/abort
     unreachable
    end
@@ -1515,7 +1515,7 @@
     i32.const 0
     i32.const 1184
     i32.const 136
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end

--- a/tests/compiler/while.untouched.wat
+++ b/tests/compiler/while.untouched.wat
@@ -60,7 +60,7 @@
    i32.const 0
    i32.const 32
    i32.const 10
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -72,7 +72,7 @@
    i32.const 0
    i32.const 32
    i32.const 11
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -128,7 +128,7 @@
      i32.const 0
      i32.const 32
      i32.const 29
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -140,7 +140,7 @@
      i32.const 0
      i32.const 32
      i32.const 30
-     i32.const 4
+     i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
@@ -155,7 +155,7 @@
    i32.const 0
    i32.const 32
    i32.const 32
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -167,7 +167,7 @@
    i32.const 0
    i32.const 32
    i32.const 33
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -179,7 +179,7 @@
    i32.const 0
    i32.const 32
    i32.const 34
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -224,7 +224,7 @@
    i32.const 0
    i32.const 32
    i32.const 45
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -236,7 +236,7 @@
    i32.const 0
    i32.const 32
    i32.const 46
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -275,7 +275,7 @@
    i32.const 0
    i32.const 32
    i32.const 58
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -319,7 +319,7 @@
    i32.const 0
    i32.const 32
    i32.const 80
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -352,7 +352,7 @@
    i32.const 0
    i32.const 32
    i32.const 92
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -383,7 +383,7 @@
    i32.const 0
    i32.const 32
    i32.const 105
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -413,7 +413,7 @@
    i32.const 0
    i32.const 32
    i32.const 117
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -461,7 +461,7 @@
    i32.const 0
    i32.const 32
    i32.const 135
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -473,7 +473,7 @@
    i32.const 0
    i32.const 32
    i32.const 136
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -502,7 +502,7 @@
    i32.const 0
    i32.const 64
    i32.const 277
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -527,7 +527,7 @@
    i32.const 0
    i32.const 64
    i32.const 279
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -579,7 +579,7 @@
    i32.const 0
    i32.const 64
    i32.const 292
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -709,7 +709,7 @@
    i32.const 0
    i32.const 64
    i32.const 205
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -724,7 +724,7 @@
    i32.const 0
    i32.const 64
    i32.const 207
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -817,7 +817,7 @@
     i32.const 0
     i32.const 64
     i32.const 228
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -880,7 +880,7 @@
    i32.const 0
    i32.const 64
    i32.const 243
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -896,7 +896,7 @@
    i32.const 0
    i32.const 64
    i32.const 244
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -953,7 +953,7 @@
    i32.const 0
    i32.const 64
    i32.const 260
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1072,7 +1072,7 @@
    i32.const 0
    i32.const 64
    i32.const 386
-   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -1095,7 +1095,7 @@
     i32.const 0
     i32.const 64
     i32.const 396
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -1126,7 +1126,7 @@
     i32.const 0
     i32.const 64
     i32.const 408
-    i32.const 4
+    i32.const 5
     call $~lib/builtins/abort
     unreachable
    end
@@ -1352,7 +1352,7 @@
    i32.const 112
    i32.const 64
    i32.const 461
-   i32.const 29
+   i32.const 30
    call $~lib/builtins/abort
    unreachable
   end
@@ -1446,7 +1446,7 @@
    i32.const 0
    i32.const 64
    i32.const 338
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1509,7 +1509,7 @@
      i32.const 0
      i32.const 64
      i32.const 351
-     i32.const 17
+     i32.const 18
      call $~lib/builtins/abort
      unreachable
     end
@@ -1654,7 +1654,7 @@
    i32.const 0
    i32.const 64
    i32.const 365
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1743,7 +1743,7 @@
    i32.const 0
    i32.const 64
    i32.const 501
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1784,7 +1784,7 @@
       i32.const 0
       i32.const 64
       i32.const 513
-      i32.const 19
+      i32.const 20
       call $~lib/builtins/abort
       unreachable
      end
@@ -1803,7 +1803,7 @@
      i32.const 0
      i32.const 64
      i32.const 518
-     i32.const 17
+     i32.const 18
      call $~lib/builtins/abort
      unreachable
     end
@@ -1820,7 +1820,7 @@
    i32.const 0
    i32.const 64
    i32.const 521
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1871,7 +1871,7 @@
    i32.const 0
    i32.const 176
    i32.const 109
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -1892,7 +1892,7 @@
    i32.const 0
    i32.const 176
    i32.const 112
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -1989,7 +1989,7 @@
    i32.const 0
    i32.const 32
    i32.const 151
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2000,7 +2000,7 @@
    i32.const 0
    i32.const 32
    i32.const 152
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2068,7 +2068,7 @@
    i32.const 0
    i32.const 32
    i32.const 171
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2079,7 +2079,7 @@
    i32.const 0
    i32.const 32
    i32.const 172
-   i32.const 2
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -2098,7 +2098,7 @@
    i32.const 0
    i32.const 32
    i32.const 16
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2111,7 +2111,7 @@
    i32.const 0
    i32.const 32
    i32.const 39
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2124,7 +2124,7 @@
    i32.const 0
    i32.const 32
    i32.const 51
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2137,7 +2137,7 @@
    i32.const 0
    i32.const 32
    i32.const 63
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2149,7 +2149,7 @@
    i32.const 0
    i32.const 32
    i32.const 72
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2162,7 +2162,7 @@
    i32.const 0
    i32.const 32
    i32.const 85
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2175,7 +2175,7 @@
    i32.const 0
    i32.const 32
    i32.const 97
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2188,7 +2188,7 @@
    i32.const 0
    i32.const 32
    i32.const 109
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2201,7 +2201,7 @@
    i32.const 0
    i32.const 32
    i32.const 122
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2214,7 +2214,7 @@
    i32.const 0
    i32.const 32
    i32.const 141
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2227,7 +2227,7 @@
    i32.const 0
    i32.const 32
    i32.const 157
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2240,7 +2240,7 @@
    i32.const 0
    i32.const 32
    i32.const 177
-   i32.const 0
+   i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
@@ -2296,7 +2296,7 @@
    i32.const 0
    i32.const 176
    i32.const 122
-   i32.const 13
+   i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
@@ -2318,7 +2318,7 @@
     i32.const 0
     i32.const 176
     i32.const 126
-    i32.const 17
+    i32.const 18
     call $~lib/builtins/abort
     unreachable
    end
@@ -2334,7 +2334,7 @@
     i32.const 0
     i32.const 176
     i32.const 136
-    i32.const 15
+    i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
@@ -2366,7 +2366,7 @@
    i32.const 0
    i32.const 176
    i32.const 69
-   i32.const 15
+   i32.const 16
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/parser/class.ts.fixture.ts
+++ b/tests/parser/class.ts.fixture.ts
@@ -15,11 +15,11 @@ export class Invalid<T> {
   get instanceGetter<T>(a: i32) {}
   set instanceSetter<T>() {}
 }
-// ERROR 1092: "Type parameters cannot appear on a constructor declaration." in class.ts:15:13
-// ERROR 1110: "Type expected." in class.ts:18:20
-// ERROR 1094: "An accessor cannot have type parameters." in class.ts:23:20
-// ERROR 1054: "A 'get' accessor cannot have parameters." in class.ts:23:6
-// ERROR 1110: "Type expected." in class.ts:23:31
-// ERROR 1094: "An accessor cannot have type parameters." in class.ts:28:20
-// ERROR 1049: "A 'set' accessor must have exactly one parameter." in class.ts:28:6
-// ERROR 1095: "A 'set' accessor cannot have a return type annotation." in class.ts:28:25
+// ERROR 1092: "Type parameters cannot appear on a constructor declaration." in class.ts:15:14
+// ERROR 1110: "Type expected." in class.ts:18:21
+// ERROR 1094: "An accessor cannot have type parameters." in class.ts:23:21
+// ERROR 1054: "A 'get' accessor cannot have parameters." in class.ts:23:7
+// ERROR 1110: "Type expected." in class.ts:23:32
+// ERROR 1094: "An accessor cannot have type parameters." in class.ts:28:21
+// ERROR 1049: "A 'set' accessor must have exactly one parameter." in class.ts:28:7
+// ERROR 1095: "A 'set' accessor cannot have a return type annotation." in class.ts:28:26

--- a/tests/parser/continue-on-error.ts.fixture.ts
+++ b/tests/parser/continue-on-error.ts.fixture.ts
@@ -5,5 +5,5 @@ from;
 do {
   ;
 } while (false);
-// ERROR 1003: "Identifier expected." in continue-on-error.ts:2:0
-// ERROR 1005: "'(' expected." in continue-on-error.ts:4:0
+// ERROR 1003: "Identifier expected." in continue-on-error.ts:2:1
+// ERROR 1005: "'(' expected." in continue-on-error.ts:4:1

--- a/tests/parser/definite-assignment-assertion.ts
+++ b/tests/parser/definite-assignment-assertion.ts
@@ -1,9 +1,9 @@
 class C {
   x!: i32;
-  x!: i32 = 0;
-  static x!: i32;
+  x!: i32 = 0; // invalid
+  static x!: i32; // invlaid
 }
 function f(): void {
   let x!: i32;
-  let x!: i32 = 0;
+  let x!: i32 = 0; // invalid
 }

--- a/tests/parser/definite-assignment-assertion.ts.fixture.ts
+++ b/tests/parser/definite-assignment-assertion.ts.fixture.ts
@@ -7,6 +7,6 @@ function f(): void {
   let x!: i32;
   let x!: i32 = 0;
 }
-// ERROR 1255: "A definite assignment assertion '!' is not permitted in this context." in definite-assignment-assertion.ts:2:11
-// ERROR 1255: "A definite assignment assertion '!' is not permitted in this context." in definite-assignment-assertion.ts:3:15
+// ERROR 1255: "A definite assignment assertion '!' is not permitted in this context." in definite-assignment-assertion.ts:3:3
+// ERROR 1255: "A definite assignment assertion '!' is not permitted in this context." in definite-assignment-assertion.ts:4:3
 // ERROR 1255: "A definite assignment assertion '!' is not permitted in this context." in definite-assignment-assertion.ts:8:7

--- a/tests/parser/definite-assignment-assertion.ts.fixture.ts
+++ b/tests/parser/definite-assignment-assertion.ts.fixture.ts
@@ -7,6 +7,6 @@ function f(): void {
   let x!: i32;
   let x!: i32 = 0;
 }
-// ERROR 1255: "A definite assignment assertion '!' is not permitted in this context." in definite-assignment-assertion.ts:3:10
-// ERROR 1255: "A definite assignment assertion '!' is not permitted in this context." in definite-assignment-assertion.ts:4:14
-// ERROR 1255: "A definite assignment assertion '!' is not permitted in this context." in definite-assignment-assertion.ts:8:6
+// ERROR 1255: "A definite assignment assertion '!' is not permitted in this context." in definite-assignment-assertion.ts:2:11
+// ERROR 1255: "A definite assignment assertion '!' is not permitted in this context." in definite-assignment-assertion.ts:3:15
+// ERROR 1255: "A definite assignment assertion '!' is not permitted in this context." in definite-assignment-assertion.ts:8:7

--- a/tests/parser/function-type.ts.fixture.ts
+++ b/tests/parser/function-type.ts.fixture.ts
@@ -2,4 +2,4 @@ var a: () => void;
 var b: (a: i32, b: i32) => void;
 var c: (a: i32, b: i32) => (a: i32, b: i32) => void;
 var d: (a) => void;
-// ERROR 1110: "Type expected." in function-type.ts:4:9
+// ERROR 1110: "Type expected." in function-type.ts:4:10

--- a/tests/parser/namespace.ts.fixture.ts
+++ b/tests/parser/namespace.ts.fixture.ts
@@ -14,5 +14,5 @@ declare namespace A {
     }
   }
 }
-// ERROR 1039: "Initializers are not allowed in ambient contexts." in namespace.ts:6:31
-// ERROR 1183: "An implementation cannot be declared in ambient contexts." in namespace.ts:8:36
+// ERROR 1039: "Initializers are not allowed in ambient contexts." in namespace.ts:6:32
+// ERROR 1183: "An implementation cannot be declared in ambient contexts." in namespace.ts:8:37

--- a/tests/parser/numeric-separators.ts.fixture.ts
+++ b/tests/parser/numeric-separators.ts.fixture.ts
@@ -10,11 +10,11 @@
 41610;
 2302755;
 2302755;
-// ERROR 6188: "Numeric separators are not allowed here." in numeric-separators.ts:8:8
-// ERROR 6189: "Multiple consecutive numeric separators are not permitted." in numeric-separators.ts:9:3
-// ERROR 6188: "Numeric separators are not allowed here." in numeric-separators.ts:11:10
-// ERROR 6189: "Multiple consecutive numeric separators are not permitted." in numeric-separators.ts:12:5
-// ERROR 6188: "Numeric separators are not allowed here." in numeric-separators.ts:14:10
-// ERROR 6189: "Multiple consecutive numeric separators are not permitted." in numeric-separators.ts:15:5
-// ERROR 6188: "Numeric separators are not allowed here." in numeric-separators.ts:17:10
-// ERROR 6189: "Multiple consecutive numeric separators are not permitted." in numeric-separators.ts:18:5
+// ERROR 6188: "Numeric separators are not allowed here." in numeric-separators.ts:8:9
+// ERROR 6189: "Multiple consecutive numeric separators are not permitted." in numeric-separators.ts:9:4
+// ERROR 6188: "Numeric separators are not allowed here." in numeric-separators.ts:11:11
+// ERROR 6189: "Multiple consecutive numeric separators are not permitted." in numeric-separators.ts:12:6
+// ERROR 6188: "Numeric separators are not allowed here." in numeric-separators.ts:14:11
+// ERROR 6189: "Multiple consecutive numeric separators are not permitted." in numeric-separators.ts:15:6
+// ERROR 6188: "Numeric separators are not allowed here." in numeric-separators.ts:17:11
+// ERROR 6189: "Multiple consecutive numeric separators are not permitted." in numeric-separators.ts:18:6

--- a/tests/parser/optional-property.ts.fixture.ts
+++ b/tests/parser/optional-property.ts.fixture.ts
@@ -1,4 +1,4 @@
 class C {
   x: i32;
 }
-// ERROR 219: "Optional properties are not supported." in optional-property.ts:1:10
+// ERROR 219: "Optional properties are not supported." in optional-property.ts:2:3

--- a/tests/parser/optional-property.ts.fixture.ts
+++ b/tests/parser/optional-property.ts.fixture.ts
@@ -1,4 +1,4 @@
 class C {
   x: i32;
 }
-// ERROR 219: "Optional properties are not supported." in optional-property.ts:2:9
+// ERROR 219: "Optional properties are not supported." in optional-property.ts:1:10

--- a/tests/parser/optional-typeparameters.ts.fixture.ts
+++ b/tests/parser/optional-typeparameters.ts.fixture.ts
@@ -7,4 +7,4 @@ function a<T, U=i32>(): T {
 function a<T, U=i32, V>(): T {
   return 0;
 }
-// ERROR 2706: "Required type parameters may not follow optional type parameters." in optional-typeparameters.ts:3:19
+// ERROR 2706: "Required type parameters may not follow optional type parameters." in optional-typeparameters.ts:3:20

--- a/tests/parser/parameter-order.ts.fixture.ts
+++ b/tests/parser/parameter-order.ts.fixture.ts
@@ -3,6 +3,6 @@ function optionalValid(a: i32, b?: i32): void {}
 function restParameterMustBeLast(...a: Array<i32>, b: i32): void {}
 function optionalCannotPrecedeRequired(a?: i32, b: i32): void {}
 function optionalWithInitializerCannotPrecedeRequired(a?: i32 = 1, b: i32): void {}
-// ERROR 1014: "A rest parameter must be last in a parameter list." in parameter-order.ts:5:36
-// ERROR 1016: "A required parameter cannot follow an optional parameter." in parameter-order.ts:8:48
-// ERROR 1016: "A required parameter cannot follow an optional parameter." in parameter-order.ts:11:66
+// ERROR 1014: "A rest parameter must be last in a parameter list." in parameter-order.ts:5:37
+// ERROR 1016: "A required parameter cannot follow an optional parameter." in parameter-order.ts:8:49
+// ERROR 1016: "A required parameter cannot follow an optional parameter." in parameter-order.ts:11:67

--- a/tests/parser/regexp.ts.fixture.ts
+++ b/tests/parser/regexp.ts.fixture.ts
@@ -6,8 +6,8 @@ b / ig;
 /(abc)\//iig;
 /(abc)\//iX;
 false && /abc/gX.test(someString) || true;
-// ERROR 1161: "Unterminated regular expression literal." in regexp.ts:5:1
-// ERROR 1005: "'/' expected." in regexp.ts:5:0
-// ERROR 209: "Invalid regular expression flags." in regexp.ts:8:9
-// ERROR 209: "Invalid regular expression flags." in regexp.ts:9:9
-// ERROR 209: "Invalid regular expression flags." in regexp.ts:10:14
+// ERROR 1161: "Unterminated regular expression literal." in regexp.ts:5:2
+// ERROR 1005: "'/' expected." in regexp.ts:5:1
+// ERROR 209: "Invalid regular expression flags." in regexp.ts:8:10
+// ERROR 209: "Invalid regular expression flags." in regexp.ts:9:10
+// ERROR 209: "Invalid regular expression flags." in regexp.ts:10:15

--- a/tests/parser/var.ts.fixture.ts
+++ b/tests/parser/var.ts.fixture.ts
@@ -5,5 +5,5 @@ var d = 2;
 var e;
 const f: i32;
 const t = 0 < (c / 10);
-// ERROR 1110: "Type expected." in var.ts:7:5
-// ERROR 1155: "'const' declarations must be initialized." in var.ts:10:6
+// ERROR 1110: "Type expected." in var.ts:7:6
+// ERROR 1155: "'const' declarations must be initialized." in var.ts:10:7


### PR DESCRIPTION
Turned out that column numbers in diagnostics used to be off by one, starting at 0 instead of 1.

Also took the opportunity to implement a line cache aiding in determining the line number for a given source position using a little binary search instead of walking the source. Saves a second or so on the non-parallel test suite (~1.8%).

In turn I also removed the `Range#line` and `Range#column` properties in preparation of making the AST more easily serializable eventually.