### PR TITLE
Change assert to allow blank strings

### DIFF
--- a/src/program.ts
+++ b/src/program.ts
@@ -1044,7 +1044,7 @@ export class Program extends DiagnosticEmitter {
       // TODO: for (let [alias, name] of globalAliases) {
       for (let _keys = Map_keys(globalAliases), i = 0, k = _keys.length; i < k; ++i) {
         let alias = unchecked(_keys[i]);
-        let name = changetype<string>(globalAliases.get(alias))
+        let name = changetype<string>(globalAliases.get(alias));
         assert(name != null);
         if (!name.length) continue; // explicitly disabled
         let firstChar = name.charCodeAt(0);

--- a/src/program.ts
+++ b/src/program.ts
@@ -1044,7 +1044,9 @@ export class Program extends DiagnosticEmitter {
       // TODO: for (let [alias, name] of globalAliases) {
       for (let _keys = Map_keys(globalAliases), i = 0, k = _keys.length; i < k; ++i) {
         let alias = unchecked(_keys[i]);
-        let name = assert(globalAliases.get(alias));
+        let name = globalAliases.get(alias);
+        assert(isString(name));
+        name = name!
         if (!name.length) continue; // explicitly disabled
         let firstChar = name.charCodeAt(0);
         if (firstChar >= CharCode._0 && firstChar <= CharCode._9) {

--- a/src/program.ts
+++ b/src/program.ts
@@ -1044,7 +1044,7 @@ export class Program extends DiagnosticEmitter {
       // TODO: for (let [alias, name] of globalAliases) {
       for (let _keys = Map_keys(globalAliases), i = 0, k = _keys.length; i < k; ++i) {
         let alias = unchecked(_keys[i]);
-        let name = changetype<string>(globalAliases.get(alias))!
+        let name = changetype<string>(globalAliases.get(alias))
         assert(name != null);
         if (!name.length) continue; // explicitly disabled
         let firstChar = name.charCodeAt(0);

--- a/src/program.ts
+++ b/src/program.ts
@@ -1045,6 +1045,7 @@ export class Program extends DiagnosticEmitter {
       for (let _keys = Map_keys(globalAliases), i = 0, k = _keys.length; i < k; ++i) {
         let alias = unchecked(_keys[i]);
         let name = changetype<string>(globalAliases.get(alias))!
+        assert(name != null);
         if (!name.length) continue; // explicitly disabled
         let firstChar = name.charCodeAt(0);
         if (firstChar >= CharCode._0 && firstChar <= CharCode._9) {

--- a/src/program.ts
+++ b/src/program.ts
@@ -1044,9 +1044,7 @@ export class Program extends DiagnosticEmitter {
       // TODO: for (let [alias, name] of globalAliases) {
       for (let _keys = Map_keys(globalAliases), i = 0, k = _keys.length; i < k; ++i) {
         let alias = unchecked(_keys[i]);
-        let name = globalAliases.get(alias);
-        assert(isString(name));
-        name = name!
+        let name = changetype<string>(globalAliases.get(alias))!
         if (!name.length) continue; // explicitly disabled
         let firstChar = name.charCodeAt(0);
         if (firstChar >= CharCode._0 && firstChar <= CharCode._9) {


### PR DESCRIPTION
Issue: https://github.com/AssemblyScript/assemblyscript/issues/1176

When using the documented `--use abort=`abort would be set to an empty string, which resulted in the call to global aliases returning ''. Then since blank strings are falsey, this assertion would fail.

I've changed the assertion to assert that the name is a string, which catches the case that the alias is missing but does not fail in the case of an empty string

examples:
If the name isn't found in the aliases table:
```typescript
//let alias = unchecked(_keys[i]);
let alias = "not the right key"
let name = globalAliases.get(alias);
assert(isString(name));
```
We get: `ERROR: AssertionError: assertion failed` as expected.

In the case where you specify an abort that does not match any export:
`ERROR: no such global element: main/nope` as before

In the case where you use a blank abort, compilation is successful.
