### PR TITLE
Remove option checking for v128 registration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -429,8 +429,7 @@
     "arrify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-      "dev": true
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
     },
     "asn1.js": {
       "version": "4.10.1",
@@ -2791,8 +2790,7 @@
     "make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "dev": true
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
     },
     "mamacro": {
       "version": "0.0.3",
@@ -2906,8 +2904,7 @@
     "minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "mississippi": {
       "version": "3.0.0",
@@ -2952,7 +2949,6 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       },
@@ -2960,8 +2956,7 @@
         "minimist": {
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         }
       }
     },
@@ -4200,7 +4195,6 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-6.2.0.tgz",
       "integrity": "sha512-ZNT+OEGfUNVMGkpIaDJJ44Zq3Yr0bkU/ugN1PHbU+/01Z7UV1fsELRiTx1KuQNvQ1A3pGh3y25iYF6jXgxV21A==",
-      "dev": true,
       "requires": {
         "arrify": "^1.0.0",
         "buffer-from": "^1.1.0",
@@ -4215,8 +4209,7 @@
         "diff": {
           "version": "3.5.0",
           "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-          "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
-          "dev": true
+          "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
         }
       }
     },
@@ -4750,8 +4743,7 @@
     "yn": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/yn/-/yn-2.0.0.tgz",
-      "integrity": "sha1-5a2ryKz0CPY4X8dklWhMiOavaJo=",
-      "dev": true
+      "integrity": "sha1-5a2ryKz0CPY4X8dklWhMiOavaJo="
     }
   }
 }

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -4218,9 +4218,15 @@ export class Compiler extends DiagnosticEmitter {
             break;
           }
           case TypeKind.V128: {
-            expr = module.unary(UnaryOp.AllTrueI8x16,
-              module.binary(BinaryOp.EqI8x16, leftExpr, rightExpr)
-            );
+            let features = module.getFeatures();
+            if (features & FeatureFlags.SIMD128) {
+              expr = module.unary(UnaryOp.AllTrueI8x16,
+                module.binary(BinaryOp.EqI8x16, leftExpr, rightExpr)
+              );
+            } else {
+              this.error(DiagnosticCode.Feature_0_is_not_enabled, expression.range, "SIMD");
+              expr = module.unreachable();
+            }
             break;
           }
           case TypeKind.ANYREF: {
@@ -4318,10 +4324,16 @@ export class Compiler extends DiagnosticEmitter {
             break;
           }
           case TypeKind.V128: {
-            expr = module.unary(UnaryOp.AnyTrueI8x16,
-              module.binary(BinaryOp.NeI8x16, leftExpr, rightExpr)
-            );
-            break;
+            let features = module.getFeatures();
+            if (features & FeatureFlags.SIMD128) {
+              expr = module.unary(UnaryOp.AnyTrueI8x16,
+                module.binary(BinaryOp.NeI8x16, leftExpr, rightExpr)
+              );
+              break;
+            } else {
+              this.error(DiagnosticCode.Feature_0_is_not_enabled, expression.range, "SIMD");
+              expr = module.unreachable();
+            }
           }
           case TypeKind.ANYREF: {
             // TODO: !ref.eq

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -4329,11 +4329,11 @@ export class Compiler extends DiagnosticEmitter {
               expr = module.unary(UnaryOp.AnyTrueI8x16,
                 module.binary(BinaryOp.NeI8x16, leftExpr, rightExpr)
               );
-              break;
             } else {
               this.error(DiagnosticCode.Feature_0_is_not_enabled, expression.range, "SIMD");
               expr = module.unreachable();
             }
+            break;
           }
           case TypeKind.ANYREF: {
             // TODO: !ref.eq

--- a/src/program.ts
+++ b/src/program.ts
@@ -725,7 +725,7 @@ export class Program extends DiagnosticEmitter {
       this.makeNativeTypeDeclaration(CommonNames.returnof, CommonFlags.EXPORT | CommonFlags.GENERIC),
       DecoratorFlags.BUILTIN
     ));
-    if (options.hasFeature(Feature.SIMD)) this.registerNativeType(CommonNames.v128, Type.v128);
+    this.registerNativeType(CommonNames.v128, Type.v128);
     if (options.hasFeature(Feature.REFERENCE_TYPES)) this.registerNativeType(CommonNames.anyref, Type.anyref);
 
     // register compiler hints


### PR DESCRIPTION
Fixes #1162 hopefully

This particular change doesn't break the test suite, and I believe something similar should also occur for the `anyref` feature as well.

What is the next step?