### PR TITLE
Added helpful error when missing type parameters

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -7941,6 +7941,16 @@ export class Compiler extends DiagnosticEmitter {
       }
       case ElementKind.FUNCTION_PROTOTYPE: {
         let functionPrototype = <FunctionPrototype>target;
+        let typeParameterNodes = functionPrototype.typeParameterNodes;
+
+        if(typeParameterNodes !== null && typeParameterNodes.length != 0) {
+          this.error(
+            DiagnosticCode.Expected_0_arguments_but_got_1,
+            expression.range, typeParameterNodes.length.toString(), "0"
+          );
+          return module.unreachable();
+        }
+
         let functionInstance = this.resolver.resolveFunction(
           functionPrototype,
           null,

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -7943,7 +7943,7 @@ export class Compiler extends DiagnosticEmitter {
         let functionPrototype = <FunctionPrototype>target;
         let typeParameterNodes = functionPrototype.typeParameterNodes;
 
-        if(typeParameterNodes !== null && typeParameterNodes.length != 0) {
+        if (typeParameterNodes !== null && typeParameterNodes.length != 0) {
           this.error(
             DiagnosticCode.Expected_0_arguments_but_got_1,
             expression.range, typeParameterNodes.length.toString(), "0"


### PR DESCRIPTION
Issue:  https://github.com/AssemblyScript/assemblyscript/issues/1181

When we were resolving a function from an identifier, we would call the `resolveFunction` method without any typeArguments. This guarantees an assertion failure in the event that the function requires type parameters.

This PR adds a check in the `compileIdentifierExpression` call just before it tries to resolve the function which will print out a nicer error message.

```typescript
function doit<T,X,O,N>(x: T): T {
  return x
}
export function test(x: i32): void {
  let x = doit<String("hey!");
}
```

## Before:
Results in:
```
ERROR: AssertionError: assertion failed
```

## After
Results in:
```typescript
ERROR TS2554: Expected 4 arguments, but got 0.

   let x = doit<String("hey!");
           ~~~~
 in main.ts(9,11)

ERROR AS225: Expression cannot be represented by a type.

   let x = doit<String("hey!");
                ~~~~~~~~~~~~~~
 in main.ts(9,16)
```