### PR TITLE
Fix assertion when referencing a global within its own initializer

### DIFF
--- a/tests/compiler/assign-self.json
+++ b/tests/compiler/assign-self.json
@@ -1,0 +1,11 @@
+{
+  "asc_flags": [
+    "--runtime none"
+  ],
+  "stderr": [
+    "TS2304: Cannot find name 'a'.",
+    "TS2304: Cannot find name 'b'.",
+    "TS2304: Cannot find name 'c'.",
+    "EOF"
+  ]
+}

--- a/tests/compiler/assign-self.ts
+++ b/tests/compiler/assign-self.ts
@@ -1,0 +1,17 @@
+var a = (a = 4, 3);
+
+function testVar(): i32 {
+  var b = (b = 4, 3);
+  return b;
+}
+testVar();
+
+function testLet(): i32 {
+  {
+    let c = (c = 4, 3);
+    return c;
+  }
+}
+testLet();
+
+ERROR("EOF");


### PR DESCRIPTION
This should fix https://github.com/AssemblyScript/assemblyscript/issues/1186 by emitting a `Cannot find name 'x'.` diagnostic instead of aborting.