### PR TITLE
Change assertion failure to unreachable statement

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -7915,7 +7915,7 @@ export class Compiler extends DiagnosticEmitter {
           return module.unreachable();
         }
         let globalType = global.type;
-        if(globalType == Type.void) {
+        if (globalType == Type.void) {
           return module.unreachable();
         }
         if (global.is(CommonFlags.INLINED)) {

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -7915,7 +7915,9 @@ export class Compiler extends DiagnosticEmitter {
           return module.unreachable();
         }
         let globalType = global.type;
-        assert(globalType != Type.void);
+        if(globalType == Type.void) {
+          return module.unreachable();
+        }
         if (global.is(CommonFlags.INLINED)) {
           return this.compileInlineConstant(global, contextualType, constraints);
         }

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -1876,7 +1876,9 @@ export class Compiler extends DiagnosticEmitter {
             if (
               !element.is(CommonFlags.AMBIENT) && // delay imports
               !element.hasDecorator(DecoratorFlags.LAZY)
-            ) this.compileGlobal(<Global>element);
+            ) {
+              if (this.compileGlobal(<Global>element)) this.module.unreachable();
+            }
           }
         }
         break;
@@ -7915,9 +7917,6 @@ export class Compiler extends DiagnosticEmitter {
           return module.unreachable();
         }
         let globalType = global.type;
-        if (globalType == Type.void) {
-          return module.unreachable();
-        }
         if (global.is(CommonFlags.INLINED)) {
           return this.compileInlineConstant(global, contextualType, constraints);
         }

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -940,7 +940,6 @@ export class Compiler extends DiagnosticEmitter {
   /** Compiles a global variable. */
   compileGlobal(global: Global): bool {
     if (global.is(CommonFlags.COMPILED)) return true;
-    global.set(CommonFlags.COMPILED);
 
     var module = this.module;
     var initExpr: ExpressionRef = 0;
@@ -995,6 +994,7 @@ export class Compiler extends DiagnosticEmitter {
     if (global.is(CommonFlags.AMBIENT) && global.hasDecorator(DecoratorFlags.BUILTIN)) {
       if (global.internalName == BuiltinNames.heap_base) this.runtimeFeatures |= RuntimeFeatures.HEAP;
       else if (global.internalName == BuiltinNames.rtti_base) this.runtimeFeatures |= RuntimeFeatures.RTTI;
+      global.set(CommonFlags.COMPILED);
       return true;
     }
 
@@ -1140,6 +1140,7 @@ export class Compiler extends DiagnosticEmitter {
     } else if (!isDeclaredInline) { // compile normally
       module.addGlobal(internalName, nativeType, !isDeclaredConstant, initExpr);
     }
+    global.set(CommonFlags.COMPILED);
     return true;
   }
 


### PR DESCRIPTION
Issue: https://github.com/AssemblyScript/assemblyscript/issues/1165

Right now if you have a global which fails to resolve its own type, and is also used in another constant, you get an assertion failure which prevents any errors from being printed to the console.

This PR just returns unreachable instead of panicking, allowing error messages to be printed.

Example:
```typescript
const INNER: fake = 1;
const OUTER: i32 = SOME;
```
Before: AssertionFailure with stack trace
After:
```
ERROR TS2304: Cannot find name 'fake'.

 const INNER: fake = 1;
              ~~~~
 in main.ts(5,14)

ERROR: 1 compile error(s)
    at Object.main (/Users/duncanuszkay/src/github.com/Shopify/as-fork/assemblyscript/cli/asc.js:614:21)
    at /Users/duncanuszkay/src/github.com/Shopify/as-fork/assemblyscript/bin/asc:21:47
```

I don't think I need to add an error to the line where the assertion fails- there's not much useful information here since they didn't set their type to void, it's really just an internal thing. AFAIK there's no way to make this global void without causing another error, so the dev should always get enough information to fix the bug