### PR TITLE
Switch to initializer property

### DIFF
--- a/src/ast.ts
+++ b/src/ast.ts
@@ -685,7 +685,7 @@ export abstract class Node {
 
   static createEnumValueDeclaration(
     name: IdentifierExpression,
-    value: Expression | null,
+    initializer: Expression | null,
     flags: CommonFlags,
     range: Range
   ): EnumValueDeclaration {
@@ -694,7 +694,7 @@ export abstract class Node {
     node.range = range;
     node.flags = flags;
     node.name = name;
-    node.value = value;
+    node.initializer = initializer;
     return node;
   }
 
@@ -1848,8 +1848,6 @@ export class EnumDeclaration extends DeclarationStatement {
 
 /** Represents a value of an `enum` declaration. */
 export class EnumValueDeclaration extends VariableLikeDeclarationStatement {
-  /** Value expression. */
-  value: Expression | null;
 }
 
 /** Represents an `export import` statement of an interface. */

--- a/src/extra/ast.ts
+++ b/src/extra/ast.ts
@@ -1000,9 +1000,9 @@ export class ASTBuilder {
 
   visitEnumValueDeclaration(node: EnumValueDeclaration): void {
     this.visitIdentifierExpression(node.name);
-    if (node.value) {
+    if (node.initializer) {
       this.sb.push(" = ");
-      this.visitNode(node.value);
+      this.visitNode(node.initializer);
     }
   }
 

--- a/src/program.ts
+++ b/src/program.ts
@@ -2789,7 +2789,7 @@ export class EnumValue extends VariableLikeElement {
 
   /** Gets the associated value node. */
   get valueNode(): Expression | null {
-    return (<EnumValueDeclaration>this.declaration).value;
+    return (<EnumValueDeclaration>this.declaration).initializer;
   }
 
   /* @override */


### PR DESCRIPTION
This pull request is more of a question than a suggestion.

`EnumValueDeclaration` extends `VariableLikeDeclaration` and the `initializer` property remains unused. This change simply removes the `value` property and switches to use the `initializer` property, reducing memory usage for each `EnumValueDeclaration`.

Thoughts?