### PR TITLE
Update Binaryen and other dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,184 +25,183 @@
       }
     },
     "@types/node": {
-      "version": "13.9.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.1.tgz",
-      "integrity": "sha512-E6M6N0blf/jiZx8Q3nb0vNaswQeEyn0XlupO+xN6DtJ6r6IT4nXrTry7zhIfYvFCl3/8Cu6WIysmUBKiqV0bqQ==",
+      "version": "13.11.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.11.1.tgz",
+      "integrity": "sha512-eWQGP3qtxwL8FGneRrC5DwrJLGN4/dH1clNTuLfN81HCrxVtxRjygDTUoZJ5ASlDEeo0ppYFQjQIlXhtXpOn6g==",
       "dev": true
     },
     "@webassemblyjs/ast": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.8.5.tgz",
-      "integrity": "sha512-aJMfngIZ65+t71C3y2nBBg5FFG0Okt9m0XEgWZ7Ywgn1oMAT8cNwx00Uv1cQyHtidq0Xn94R4TAywO+LCQ+ZAQ==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.9.0.tgz",
+      "integrity": "sha512-C6wW5L+b7ogSDVqymbkkvuW9kruN//YisMED04xzeBBqjHa2FYnmvOlS6Xj68xWQRgWvI9cIglsjFowH/RJyEA==",
       "dev": true,
       "requires": {
-        "@webassemblyjs/helper-module-context": "1.8.5",
-        "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
-        "@webassemblyjs/wast-parser": "1.8.5"
+        "@webassemblyjs/helper-module-context": "1.9.0",
+        "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
+        "@webassemblyjs/wast-parser": "1.9.0"
       }
     },
     "@webassemblyjs/floating-point-hex-parser": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.8.5.tgz",
-      "integrity": "sha512-9p+79WHru1oqBh9ewP9zW95E3XAo+90oth7S5Re3eQnECGq59ly1Ri5tsIipKGpiStHsUYmY3zMLqtk3gTcOtQ==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.9.0.tgz",
+      "integrity": "sha512-TG5qcFsS8QB4g4MhrxK5TqfdNe7Ey/7YL/xN+36rRjl/BlGE/NcBvJcqsRgCP6Z92mRE+7N50pRIi8SmKUbcQA==",
       "dev": true
     },
     "@webassemblyjs/helper-api-error": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.8.5.tgz",
-      "integrity": "sha512-Za/tnzsvnqdaSPOUXHyKJ2XI7PDX64kWtURyGiJJZKVEdFOsdKUCPTNEVFZq3zJ2R0G5wc2PZ5gvdTRFgm81zA==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.9.0.tgz",
+      "integrity": "sha512-NcMLjoFMXpsASZFxJ5h2HZRcEhDkvnNFOAKneP5RbKRzaWJN36NC4jqQHKwStIhGXu5mUWlUUk7ygdtrO8lbmw==",
       "dev": true
     },
     "@webassemblyjs/helper-buffer": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.8.5.tgz",
-      "integrity": "sha512-Ri2R8nOS0U6G49Q86goFIPNgjyl6+oE1abW1pS84BuhP1Qcr5JqMwRFT3Ah3ADDDYGEgGs1iyb1DGX+kAi/c/Q==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.9.0.tgz",
+      "integrity": "sha512-qZol43oqhq6yBPx7YM3m9Bv7WMV9Eevj6kMi6InKOuZxhw+q9hOkvq5e/PpKSiLfyetpaBnogSbNCfBwyB00CA==",
       "dev": true
     },
     "@webassemblyjs/helper-code-frame": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.8.5.tgz",
-      "integrity": "sha512-VQAadSubZIhNpH46IR3yWO4kZZjMxN1opDrzePLdVKAZ+DFjkGD/rf4v1jap744uPVU6yjL/smZbRIIJTOUnKQ==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.9.0.tgz",
+      "integrity": "sha512-ERCYdJBkD9Vu4vtjUYe8LZruWuNIToYq/ME22igL+2vj2dQ2OOujIZr3MEFvfEaqKoVqpsFKAGsRdBSBjrIvZA==",
       "dev": true,
       "requires": {
-        "@webassemblyjs/wast-printer": "1.8.5"
+        "@webassemblyjs/wast-printer": "1.9.0"
       }
     },
     "@webassemblyjs/helper-fsm": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-fsm/-/helper-fsm-1.8.5.tgz",
-      "integrity": "sha512-kRuX/saORcg8se/ft6Q2UbRpZwP4y7YrWsLXPbbmtepKr22i8Z4O3V5QE9DbZK908dh5Xya4Un57SDIKwB9eow==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-fsm/-/helper-fsm-1.9.0.tgz",
+      "integrity": "sha512-OPRowhGbshCb5PxJ8LocpdX9Kl0uB4XsAjl6jH/dWKlk/mzsANvhwbiULsaiqT5GZGT9qinTICdj6PLuM5gslw==",
       "dev": true
     },
     "@webassemblyjs/helper-module-context": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-module-context/-/helper-module-context-1.8.5.tgz",
-      "integrity": "sha512-/O1B236mN7UNEU4t9X7Pj38i4VoU8CcMHyy3l2cV/kIF4U5KoHXDVqcDuOs1ltkac90IM4vZdHc52t1x8Yfs3g==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-module-context/-/helper-module-context-1.9.0.tgz",
+      "integrity": "sha512-MJCW8iGC08tMk2enck1aPW+BE5Cw8/7ph/VGZxwyvGbJwjktKkDK7vy7gAmMDx88D7mhDTCNKAW5tED+gZ0W8g==",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.8.5",
-        "mamacro": "^0.0.3"
+        "@webassemblyjs/ast": "1.9.0"
       }
     },
     "@webassemblyjs/helper-wasm-bytecode": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.8.5.tgz",
-      "integrity": "sha512-Cu4YMYG3Ddl72CbmpjU/wbP6SACcOPVbHN1dI4VJNJVgFwaKf1ppeFJrwydOG3NDHxVGuCfPlLZNyEdIYlQ6QQ==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.9.0.tgz",
+      "integrity": "sha512-R7FStIzyNcd7xKxCZH5lE0Bqy+hGTwS3LJjuv1ZVxd9O7eHCedSdrId/hMOd20I+v8wDXEn+bjfKDLzTepoaUw==",
       "dev": true
     },
     "@webassemblyjs/helper-wasm-section": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.8.5.tgz",
-      "integrity": "sha512-VV083zwR+VTrIWWtgIUpqfvVdK4ff38loRmrdDBgBT8ADXYsEZ5mPQ4Nde90N3UYatHdYoDIFb7oHzMncI02tA==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.9.0.tgz",
+      "integrity": "sha512-XnMB8l3ek4tvrKUUku+IVaXNHz2YsJyOOmz+MMkZvh8h1uSJpSen6vYnw3IoQ7WwEuAhL8Efjms1ZWjqh2agvw==",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.8.5",
-        "@webassemblyjs/helper-buffer": "1.8.5",
-        "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
-        "@webassemblyjs/wasm-gen": "1.8.5"
+        "@webassemblyjs/ast": "1.9.0",
+        "@webassemblyjs/helper-buffer": "1.9.0",
+        "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
+        "@webassemblyjs/wasm-gen": "1.9.0"
       }
     },
     "@webassemblyjs/ieee754": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.8.5.tgz",
-      "integrity": "sha512-aaCvQYrvKbY/n6wKHb/ylAJr27GglahUO89CcGXMItrOBqRarUMxWLJgxm9PJNuKULwN5n1csT9bYoMeZOGF3g==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.9.0.tgz",
+      "integrity": "sha512-dcX8JuYU/gvymzIHc9DgxTzUUTLexWwt8uCTWP3otys596io0L5aW02Gb1RjYpx2+0Jus1h4ZFqjla7umFniTg==",
       "dev": true,
       "requires": {
         "@xtuc/ieee754": "^1.2.0"
       }
     },
     "@webassemblyjs/leb128": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.8.5.tgz",
-      "integrity": "sha512-plYUuUwleLIziknvlP8VpTgO4kqNaH57Y3JnNa6DLpu/sGcP6hbVdfdX5aHAV716pQBKrfuU26BJK29qY37J7A==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.9.0.tgz",
+      "integrity": "sha512-ENVzM5VwV1ojs9jam6vPys97B/S65YQtv/aanqnU7D8aSoHFX8GyhGg0CMfyKNIHBuAVjy3tlzd5QMMINa7wpw==",
       "dev": true,
       "requires": {
         "@xtuc/long": "4.2.2"
       }
     },
     "@webassemblyjs/utf8": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.8.5.tgz",
-      "integrity": "sha512-U7zgftmQriw37tfD934UNInokz6yTmn29inT2cAetAsaU9YeVCveWEwhKL1Mg4yS7q//NGdzy79nlXh3bT8Kjw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.9.0.tgz",
+      "integrity": "sha512-GZbQlWtopBTP0u7cHrEx+73yZKrQoBMpwkGEIqlacljhXCkVM1kMQge/Mf+csMJAjEdSwhOyLAS0AoR3AG5P8w==",
       "dev": true
     },
     "@webassemblyjs/wasm-edit": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.8.5.tgz",
-      "integrity": "sha512-A41EMy8MWw5yvqj7MQzkDjU29K7UJq1VrX2vWLzfpRHt3ISftOXqrtojn7nlPsZ9Ijhp5NwuODuycSvfAO/26Q==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.9.0.tgz",
+      "integrity": "sha512-FgHzBm80uwz5M8WKnMTn6j/sVbqilPdQXTWraSjBwFXSYGirpkSWE2R9Qvz9tNiTKQvoKILpCuTjBKzOIm0nxw==",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.8.5",
-        "@webassemblyjs/helper-buffer": "1.8.5",
-        "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
-        "@webassemblyjs/helper-wasm-section": "1.8.5",
-        "@webassemblyjs/wasm-gen": "1.8.5",
-        "@webassemblyjs/wasm-opt": "1.8.5",
-        "@webassemblyjs/wasm-parser": "1.8.5",
-        "@webassemblyjs/wast-printer": "1.8.5"
+        "@webassemblyjs/ast": "1.9.0",
+        "@webassemblyjs/helper-buffer": "1.9.0",
+        "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
+        "@webassemblyjs/helper-wasm-section": "1.9.0",
+        "@webassemblyjs/wasm-gen": "1.9.0",
+        "@webassemblyjs/wasm-opt": "1.9.0",
+        "@webassemblyjs/wasm-parser": "1.9.0",
+        "@webassemblyjs/wast-printer": "1.9.0"
       }
     },
     "@webassemblyjs/wasm-gen": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.8.5.tgz",
-      "integrity": "sha512-BCZBT0LURC0CXDzj5FXSc2FPTsxwp3nWcqXQdOZE4U7h7i8FqtFK5Egia6f9raQLpEKT1VL7zr4r3+QX6zArWg==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.9.0.tgz",
+      "integrity": "sha512-cPE3o44YzOOHvlsb4+E9qSqjc9Qf9Na1OO/BHFy4OI91XDE14MjFN4lTMezzaIWdPqHnsTodGGNP+iRSYfGkjA==",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.8.5",
-        "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
-        "@webassemblyjs/ieee754": "1.8.5",
-        "@webassemblyjs/leb128": "1.8.5",
-        "@webassemblyjs/utf8": "1.8.5"
+        "@webassemblyjs/ast": "1.9.0",
+        "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
+        "@webassemblyjs/ieee754": "1.9.0",
+        "@webassemblyjs/leb128": "1.9.0",
+        "@webassemblyjs/utf8": "1.9.0"
       }
     },
     "@webassemblyjs/wasm-opt": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.8.5.tgz",
-      "integrity": "sha512-HKo2mO/Uh9A6ojzu7cjslGaHaUU14LdLbGEKqTR7PBKwT6LdPtLLh9fPY33rmr5wcOMrsWDbbdCHq4hQUdd37Q==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.9.0.tgz",
+      "integrity": "sha512-Qkjgm6Anhm+OMbIL0iokO7meajkzQD71ioelnfPEj6r4eOFuqm4YC3VBPqXjFyyNwowzbMD+hizmprP/Fwkl2A==",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.8.5",
-        "@webassemblyjs/helper-buffer": "1.8.5",
-        "@webassemblyjs/wasm-gen": "1.8.5",
-        "@webassemblyjs/wasm-parser": "1.8.5"
+        "@webassemblyjs/ast": "1.9.0",
+        "@webassemblyjs/helper-buffer": "1.9.0",
+        "@webassemblyjs/wasm-gen": "1.9.0",
+        "@webassemblyjs/wasm-parser": "1.9.0"
       }
     },
     "@webassemblyjs/wasm-parser": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.8.5.tgz",
-      "integrity": "sha512-pi0SYE9T6tfcMkthwcgCpL0cM9nRYr6/6fjgDtL6q/ZqKHdMWvxitRi5JcZ7RI4SNJJYnYNaWy5UUrHQy998lw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.9.0.tgz",
+      "integrity": "sha512-9+wkMowR2AmdSWQzsPEjFU7njh8HTO5MqO8vjwEHuM+AMHioNqSBONRdr0NQQ3dVQrzp0s8lTcYqzUdb7YgELA==",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.8.5",
-        "@webassemblyjs/helper-api-error": "1.8.5",
-        "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
-        "@webassemblyjs/ieee754": "1.8.5",
-        "@webassemblyjs/leb128": "1.8.5",
-        "@webassemblyjs/utf8": "1.8.5"
+        "@webassemblyjs/ast": "1.9.0",
+        "@webassemblyjs/helper-api-error": "1.9.0",
+        "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
+        "@webassemblyjs/ieee754": "1.9.0",
+        "@webassemblyjs/leb128": "1.9.0",
+        "@webassemblyjs/utf8": "1.9.0"
       }
     },
     "@webassemblyjs/wast-parser": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-parser/-/wast-parser-1.8.5.tgz",
-      "integrity": "sha512-daXC1FyKWHF1i11obK086QRlsMsY4+tIOKgBqI1lxAnkp9xe9YMcgOxm9kLe+ttjs5aWV2KKE1TWJCN57/Btsg==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-parser/-/wast-parser-1.9.0.tgz",
+      "integrity": "sha512-qsqSAP3QQ3LyZjNC/0jBJ/ToSxfYJ8kYyuiGvtn/8MK89VrNEfwj7BPQzJVHi0jGTRK2dGdJ5PRqhtjzoww+bw==",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.8.5",
-        "@webassemblyjs/floating-point-hex-parser": "1.8.5",
-        "@webassemblyjs/helper-api-error": "1.8.5",
-        "@webassemblyjs/helper-code-frame": "1.8.5",
-        "@webassemblyjs/helper-fsm": "1.8.5",
+        "@webassemblyjs/ast": "1.9.0",
+        "@webassemblyjs/floating-point-hex-parser": "1.9.0",
+        "@webassemblyjs/helper-api-error": "1.9.0",
+        "@webassemblyjs/helper-code-frame": "1.9.0",
+        "@webassemblyjs/helper-fsm": "1.9.0",
         "@xtuc/long": "4.2.2"
       }
     },
     "@webassemblyjs/wast-printer": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.8.5.tgz",
-      "integrity": "sha512-w0U0pD4EhlnvRyeJzBqaVSJAo9w/ce7/WPogeXLzGkO6hzhr4GnQIZ4W4uUt5b9ooAaXPtnXlj0gzsXEOUNYMg==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.9.0.tgz",
+      "integrity": "sha512-2J0nE95rHXHyQ24cWjMKJ1tqB/ds8z/cyeOZxJhcb+rW+SQASVjuznUSmdz5GpVJTzU8JkhYut0D3siFDD6wsA==",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.8.5",
-        "@webassemblyjs/wast-parser": "1.8.5",
+        "@webassemblyjs/ast": "1.9.0",
+        "@webassemblyjs/wast-parser": "1.9.0",
         "@xtuc/long": "4.2.2"
       }
     },
@@ -429,8 +428,7 @@
     "arrify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-      "dev": true
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
     },
     "asn1.js": {
       "version": "4.10.1",
@@ -568,9 +566,9 @@
       "dev": true
     },
     "binaryen": {
-      "version": "91.0.0-nightly.20200310",
-      "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-91.0.0-nightly.20200310.tgz",
-      "integrity": "sha512-MmDzq267aa61HdEQeYiz+7guJlsYk2/6NxWC8I4w1jijqDwoqyZZxi7UYnTH7QvfLrNdMjweEgfT7FHjkvkPmQ=="
+      "version": "91.0.0-nightly.20200414",
+      "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-91.0.0-nightly.20200414.tgz",
+      "integrity": "sha512-ISiX15PTxlEuM57XXt0Dt6Yts4BRIawWUnrx1RhVlReGd9kI4+MZyANTV+blkMBETRz1VnCHaUtQ7Syb/GHYKQ=="
     },
     "bindings": {
       "version": "1.5.0",
@@ -731,9 +729,9 @@
       "dev": true
     },
     "cacache": {
-      "version": "12.0.3",
-      "resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.3.tgz",
-      "integrity": "sha512-kqdmfXEGFepesTuROHMs3MpFLWrPkSSpRqOw80RCflZXy/khxaArvFrQ7uJxSUduzAufc6G0g1VUCOZXxWavPw==",
+      "version": "12.0.4",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.4.tgz",
+      "integrity": "sha512-a0tMB40oefvuInr4Cwb3GerbL9xTj1D5yg0T5xrjGCGyfvbxseIXX7BAO/u/hIXdafzOI5JC3wDwHyf24buOAQ==",
       "dev": true,
       "requires": {
         "bluebird": "^3.5.5",
@@ -1495,9 +1493,9 @@
       "dev": true
     },
     "figgy-pudding": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
-      "integrity": "sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.2.tgz",
+      "integrity": "sha512-0btnI/H8f2pavGMN8w40mlSKOfTK2SVJmBfBeVIj3kNw0swwgzyRq0d5TJVOwodFmtvpPeWPN/MCcfuWF0Ezbw==",
       "dev": true
     },
     "file-uri-to-path": {
@@ -1707,9 +1705,9 @@
       "dev": true
     },
     "fsevents": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.11.tgz",
-      "integrity": "sha512-+ux3lx6peh0BpvY0JebGyZoiR4D+oYzdPZMKJwkZ+sFkNJzpL7tXc/wehS49gUAxg3tmMHPHZkA8JU2rhhgDHw==",
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.12.tgz",
+      "integrity": "sha512-Ggd/Ktt7E7I8pxZRbGIs7vwqAPscSESMrCSkx2FtWeqmheJgCo2R74fTsZFCifr0VTPwqRpPv17+6b8Zp7th0Q==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -1763,7 +1761,7 @@
           }
         },
         "chownr": {
-          "version": "1.1.3",
+          "version": "1.1.4",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -1935,7 +1933,7 @@
           }
         },
         "minimist": {
-          "version": "0.0.8",
+          "version": "1.2.5",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -1960,12 +1958,12 @@
           }
         },
         "mkdirp": {
-          "version": "0.5.1",
+          "version": "0.5.3",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "minimist": "0.0.8"
+            "minimist": "^1.2.5"
           }
         },
         "ms": {
@@ -1975,7 +1973,7 @@
           "optional": true
         },
         "needle": {
-          "version": "2.4.0",
+          "version": "2.3.3",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -2004,7 +2002,7 @@
           }
         },
         "nopt": {
-          "version": "4.0.1",
+          "version": "4.0.3",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -2029,13 +2027,14 @@
           "optional": true
         },
         "npm-packlist": {
-          "version": "1.4.7",
+          "version": "1.4.8",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
             "ignore-walk": "^3.0.1",
-            "npm-bundled": "^1.0.1"
+            "npm-bundled": "^1.0.1",
+            "npm-normalize-package-bin": "^1.0.1"
           }
         },
         "npmlog": {
@@ -2115,18 +2114,10 @@
             "ini": "~1.3.0",
             "minimist": "^1.2.0",
             "strip-json-comments": "~2.0.1"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "1.2.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
           }
         },
         "readable-stream": {
-          "version": "2.3.6",
+          "version": "2.3.7",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -2791,14 +2782,7 @@
     "make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "dev": true
-    },
-    "mamacro": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/mamacro/-/mamacro-0.0.3.tgz",
-      "integrity": "sha512-qMEwh+UujcQ+kbz3T6V+wAmO2U8veoq2w+3wY8MquqwVA3jChfwY+Tk52GZKDfACEPjuZ7r2oJLejwpt8jtwTA==",
-      "dev": true
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
     },
     "map-age-cleaner": {
       "version": "0.1.3",
@@ -2906,8 +2890,7 @@
     "minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "mississippi": {
       "version": "3.0.0",
@@ -2952,7 +2935,6 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       },
@@ -2960,8 +2942,7 @@
         "minimist": {
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         }
       }
     },
@@ -3299,9 +3280,9 @@
       "dev": true
     },
     "picomatch": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.1.tgz",
-      "integrity": "sha512-ISBaA8xQNmwELC7eOjqFKMESB2VIqt4PPDD0nsS95b/9dZXvVKOlz9keMSnoGGKcOHXfTvDD6WMaRoSc9UuhRA==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
+      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
       "dev": true
     },
     "pify": {
@@ -4082,9 +4063,9 @@
       "dev": true
     },
     "terser": {
-      "version": "4.6.6",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-4.6.6.tgz",
-      "integrity": "sha512-4lYPyeNmstjIIESr/ysHg2vUPRGf2tzF9z2yYwnowXVuVzLEamPN1Gfrz7f8I9uEPuHcbFlW4PLIAsJoxXyJ1g==",
+      "version": "4.6.11",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-4.6.11.tgz",
+      "integrity": "sha512-76Ynm7OXUG5xhOpblhytE7X58oeNSmC8xnNhjWVo8CksHit0U0kO4hfNbPrrYwowLWFgM2n9L176VNx2QaHmtA==",
       "dev": true,
       "requires": {
         "commander": "^2.20.0",
@@ -4176,9 +4157,9 @@
       }
     },
     "ts-loader": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-6.2.1.tgz",
-      "integrity": "sha512-Dd9FekWuABGgjE1g0TlQJ+4dFUfYGbYcs52/HQObE0ZmUNjQlmLAS7xXsSzy23AMaMwipsx5sNHvoEpT2CZq1g==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-6.2.2.tgz",
+      "integrity": "sha512-HDo5kXZCBml3EUPcc7RlZOV/JGlLHwppTLEHb3SHnr5V7NXD4klMEkrhJe5wgRbaWsSXi+Y1SIBN/K9B6zWGWQ==",
       "dev": true,
       "requires": {
         "chalk": "^2.3.0",
@@ -4200,7 +4181,6 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-6.2.0.tgz",
       "integrity": "sha512-ZNT+OEGfUNVMGkpIaDJJ44Zq3Yr0bkU/ugN1PHbU+/01Z7UV1fsELRiTx1KuQNvQ1A3pGh3y25iYF6jXgxV21A==",
-      "dev": true,
       "requires": {
         "arrify": "^1.0.0",
         "buffer-from": "^1.1.0",
@@ -4215,8 +4195,7 @@
         "diff": {
           "version": "3.5.0",
           "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-          "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
-          "dev": true
+          "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
         }
       }
     },
@@ -4425,26 +4404,26 @@
       "dev": true
     },
     "watchpack": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.6.0.tgz",
-      "integrity": "sha512-i6dHe3EyLjMmDlU1/bGQpEw25XSjkJULPuAVKCbNRefQVq48yXKUpwg538F7AZTf9kyr57zj++pQFltUa5H7yA==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.6.1.tgz",
+      "integrity": "sha512-+IF9hfUFOrYOOaKyfaI7h7dquUIOgyEMoQMLA7OP5FxegKA2+XdXThAZ9TU2kucfhDH7rfMHs1oPYziVGWRnZA==",
       "dev": true,
       "requires": {
-        "chokidar": "^2.0.2",
+        "chokidar": "^2.1.8",
         "graceful-fs": "^4.1.2",
         "neo-async": "^2.5.0"
       }
     },
     "webpack": {
-      "version": "4.42.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.42.0.tgz",
-      "integrity": "sha512-EzJRHvwQyBiYrYqhyjW9AqM90dE4+s1/XtCfn7uWg6cS72zH+2VPFAlsnW0+W0cDi0XRjNKUMoJtpSi50+Ph6w==",
+      "version": "4.42.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.42.1.tgz",
+      "integrity": "sha512-SGfYMigqEfdGchGhFFJ9KyRpQKnipvEvjc1TwrXEPCM6H5Wywu10ka8o3KGrMzSMxMQKt8aCHUFh5DaQ9UmyRg==",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.8.5",
-        "@webassemblyjs/helper-module-context": "1.8.5",
-        "@webassemblyjs/wasm-edit": "1.8.5",
-        "@webassemblyjs/wasm-parser": "1.8.5",
+        "@webassemblyjs/ast": "1.9.0",
+        "@webassemblyjs/helper-module-context": "1.9.0",
+        "@webassemblyjs/wasm-edit": "1.9.0",
+        "@webassemblyjs/wasm-parser": "1.9.0",
         "acorn": "^6.2.1",
         "ajv": "^6.10.2",
         "ajv-keywords": "^3.4.1",
@@ -4456,7 +4435,7 @@
         "loader-utils": "^1.2.3",
         "memory-fs": "^0.4.1",
         "micromatch": "^3.1.10",
-        "mkdirp": "^0.5.1",
+        "mkdirp": "^0.5.3",
         "neo-async": "^2.6.1",
         "node-libs-browser": "^2.2.1",
         "schema-utils": "^1.0.0",
@@ -4567,6 +4546,15 @@
             "regex-not": "^1.0.0",
             "snapdragon": "^0.8.1",
             "to-regex": "^3.0.2"
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.5",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.5"
           }
         },
         "to-regex-range": {
@@ -4750,8 +4738,7 @@
     "yn": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/yn/-/yn-2.0.0.tgz",
-      "integrity": "sha1-5a2ryKz0CPY4X8dklWhMiOavaJo=",
-      "dev": true
+      "integrity": "sha1-5a2ryKz0CPY4X8dklWhMiOavaJo="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,23 +21,23 @@
     "url": "https://github.com/AssemblyScript/assemblyscript/issues"
   },
   "dependencies": {
-    "binaryen": "91.0.0-nightly.20200310",
+    "binaryen": "91.0.0-nightly.20200414",
     "long": "^4.0.0",
     "source-map-support": "^0.5.16",
     "ts-node": "^6.2.0"
   },
   "devDependencies": {
-    "@types/node": "^13.9.1",
+    "@types/node": "^13.11.1",
     "browser-process-hrtime": "^1.0.0",
     "diff": "^4.0.2",
     "glob": "^7.1.6",
     "physical-cpu-count": "^2.0.0",
     "source-map-support": "^0.5.16",
-    "ts-loader": "^6.2.1",
+    "ts-loader": "^6.2.2",
     "ts-node": "^6.2.0",
     "tslint": "^5.20.1",
     "typescript": "^3.8.3",
-    "webpack": "^4.42.0",
+    "webpack": "^4.42.1",
     "webpack-cli": "^3.3.11"
   },
   "main": "index.js",

--- a/scripts/update-constants.js
+++ b/scripts/update-constants.js
@@ -8,7 +8,7 @@ const srcfile = path.join(__dirname, "..", "src", "module.ts");
 var src = fs.readFileSync(srcfile, "utf8");
 
 binaryen.ready.then(() => {
-  src = src.replace(/enum (\w+) \{([^}]*)\}/g, function($0) {
+  src = src.replace(/(?:enum|namespace) (\w+) \{([^}]*)\}/g, function($0) {
     return $0.replace(/(\w+)[ ]+=[ ]+([^,;\n]+)/g, function($0, key, val) {
       var match = val.match(/\b(_Binaryen\w+)\b/);
       if (match) {

--- a/src/builtins.ts
+++ b/src/builtins.ts
@@ -2607,8 +2607,8 @@ function builtin_assert(ctx: BuiltinContext): ExpressionRef {
 
   // if the assertion can be proven statically, omit it
   if (getExpressionId(arg0 = module.precomputeExpression(arg0)) == ExpressionId.Const) {
-    switch (getExpressionType(arg0)) {
-      case NativeType.I32: {
+    switch (<u32>getExpressionType(arg0)) {
+      case <u32>NativeType.I32: {
         if (getConstValueI32(arg0) != 0) {
           if (contextualType == Type.void) {
             compiler.currentType = Type.void;
@@ -2618,7 +2618,7 @@ function builtin_assert(ctx: BuiltinContext): ExpressionRef {
         }
         break;
       }
-      case NativeType.I64: {
+      case <u32>NativeType.I64: {
         if (getConstValueI64Low(arg0) != 0 || getConstValueI64High(arg0) != 0) {
           if (contextualType == Type.void) {
             compiler.currentType = Type.void;
@@ -2628,7 +2628,7 @@ function builtin_assert(ctx: BuiltinContext): ExpressionRef {
         }
         break;
       }
-      case NativeType.F32: {
+      case <u32>NativeType.F32: {
         if (getConstValueF32(arg0) != 0) {
           if (contextualType == Type.void) {
             compiler.currentType = Type.void;
@@ -2638,7 +2638,7 @@ function builtin_assert(ctx: BuiltinContext): ExpressionRef {
         }
         break;
       }
-      case NativeType.F64: {
+      case <u32>NativeType.F64: {
         if (getConstValueF64(arg0) != 0) {
           if (contextualType == Type.void) {
             compiler.currentType = Type.void;

--- a/src/builtins.ts
+++ b/src/builtins.ts
@@ -346,6 +346,7 @@ export namespace BuiltinNames {
   export const v128_bitselect = "~lib/builtins/v128.bitselect";
   export const v128_any_true = "~lib/builtins/v128.any_true";
   export const v128_all_true = "~lib/builtins/v128.all_true";
+  export const v128_bitmask = "~lib/builtins/v128.bitmask";
   export const v128_min = "~lib/builtins/v128.min";
   export const v128_max = "~lib/builtins/v128.max";
   export const v128_dot = "~lib/builtins/v128.dot";
@@ -385,6 +386,7 @@ export namespace BuiltinNames {
   export const i8x16_max_s = "~lib/builtins/i8x16.max_s";
   export const i8x16_max_u = "~lib/builtins/i8x16.max_u";
   export const i8x16_avgr_u = "~lib/builtins/i8x16.avgr_u";
+  export const i8x16_abs = "~lib/builtins/i8x16.abs";
   export const i8x16_neg = "~lib/builtins/i8x16.neg";
   export const i8x16_add_saturate_s = "~lib/builtins/i8x16.add_saturate_s";
   export const i8x16_add_saturate_u = "~lib/builtins/i8x16.add_saturate_u";
@@ -395,6 +397,7 @@ export namespace BuiltinNames {
   export const i8x16_shr_u = "~lib/builtins/i8x16.shr_u";
   export const i8x16_any_true = "~lib/builtins/i8x16.any_true";
   export const i8x16_all_true = "~lib/builtins/i8x16.all_true";
+  export const i8x16_bitmask = "~lib/builtins/i8x16.bitmask";
   export const i8x16_eq = "~lib/builtins/i8x16.eq";
   export const i8x16_ne = "~lib/builtins/i8x16.ne";
   export const i8x16_lt_s = "~lib/builtins/i8x16.lt_s";
@@ -420,6 +423,7 @@ export namespace BuiltinNames {
   export const i16x8_max_s = "~lib/builtins/i16x8.max_s";
   export const i16x8_max_u = "~lib/builtins/i16x8.max_u";
   export const i16x8_avgr_u = "~lib/builtins/i16x8.avgr_u";
+  export const i16x8_abs = "~lib/builtins/i16x8.abs";
   export const i16x8_neg = "~lib/builtins/i16x8.neg";
   export const i16x8_add_saturate_s = "~lib/builtins/i16x8.add_saturate_s";
   export const i16x8_add_saturate_u = "~lib/builtins/i16x8.add_saturate_u";
@@ -430,6 +434,7 @@ export namespace BuiltinNames {
   export const i16x8_shr_u = "~lib/builtins/i16x8.shr_u";
   export const i16x8_any_true = "~lib/builtins/i16x8.any_true";
   export const i16x8_all_true = "~lib/builtins/i16x8.all_true";
+  export const i16x8_bitmask = "~lib/builtins/i16x8.bitmask";
   export const i16x8_eq = "~lib/builtins/i16x8.eq";
   export const i16x8_ne = "~lib/builtins/i16x8.ne";
   export const i16x8_lt_s = "~lib/builtins/i16x8.lt_s";
@@ -460,12 +465,14 @@ export namespace BuiltinNames {
   export const i32x4_max_s = "~lib/builtins/i32x4.max_s";
   export const i32x4_max_u = "~lib/builtins/i32x4.max_u";
   export const i32x4_dot_i16x8_s = "~lib/builtins/i32x4.dot_i16x8_s";
+  export const i32x4_abs = "~lib/builtins/i32x4.abs";
   export const i32x4_neg = "~lib/builtins/i32x4.neg";
   export const i32x4_shl = "~lib/builtins/i32x4.shl";
   export const i32x4_shr_s = "~lib/builtins/i32x4.shr_s";
   export const i32x4_shr_u = "~lib/builtins/i32x4.shr_u";
   export const i32x4_any_true = "~lib/builtins/i32x4.any_true";
   export const i32x4_all_true = "~lib/builtins/i32x4.all_true";
+  export const i32x4_bitmask = "~lib/builtins/i32x4.bitmask";
   export const i32x4_eq = "~lib/builtins/i32x4.eq";
   export const i32x4_ne = "~lib/builtins/i32x4.ne";
   export const i32x4_lt_s = "~lib/builtins/i32x4.lt_s";
@@ -4398,6 +4405,20 @@ function builtin_v128_abs(ctx: BuiltinContext): ExpressionRef {
   var arg0 = compiler.compileExpression(operands[0], Type.v128, Constraints.CONV_IMPLICIT);
   if (!type.is(TypeFlags.REFERENCE)) {
     switch (type.kind) {
+      case TypeKind.I8: return module.unary(UnaryOp.AbsI8x16, arg0);
+      case TypeKind.I16: return module.unary(UnaryOp.AbsI16x8, arg0);
+      case TypeKind.ISIZE: {
+        if (compiler.options.isWasm64) break;
+        // fall-through
+      }
+      case TypeKind.I32: return module.unary(UnaryOp.AbsI32x4, arg0);
+      case TypeKind.USIZE: {
+        if (compiler.options.isWasm64) break;
+        // fall-through
+      }
+      case TypeKind.U8:
+      case TypeKind.U16:
+      case TypeKind.U32: return arg0;
       case TypeKind.F32: return module.unary(UnaryOp.AbsF32x4, arg0);
       case TypeKind.F64: return module.unary(UnaryOp.AbsF64x2, arg0);
     }
@@ -4843,6 +4864,45 @@ function builtin_v128_all_true(ctx: BuiltinContext): ExpressionRef {
   return module.unreachable();
 }
 builtins.set(BuiltinNames.v128_all_true, builtin_v128_all_true);
+
+// v128.bitmask<T!>(a: v128) -> i32
+function builtin_v128_bitmask(ctx: BuiltinContext): ExpressionRef {
+  var compiler = ctx.compiler;
+  var module = compiler.module;
+  if (
+    checkFeatureEnabled(ctx, Feature.SIMD) |
+    checkTypeRequired(ctx) |
+    checkArgsRequired(ctx, 1)
+  ) {
+    compiler.currentType = Type.i32;
+    return module.unreachable();
+  }
+  var operands = ctx.operands;
+  var type = ctx.typeArguments![0];
+  var arg0 = compiler.compileExpression(operands[0], Type.v128, Constraints.CONV_IMPLICIT);
+  compiler.currentType = Type.i32;
+  if (!type.is(TypeFlags.REFERENCE)) {
+    switch (type.kind) {
+      case TypeKind.I8:
+      case TypeKind.U8: return module.unary(UnaryOp.BitmaskI8x16, arg0);
+      case TypeKind.I16:
+      case TypeKind.U16: return module.unary(UnaryOp.BitmaskI16x8, arg0);
+      case TypeKind.ISIZE:
+      case TypeKind.USIZE: {
+        if (compiler.options.isWasm64) break;
+        // fall-through
+      }
+      case TypeKind.I32:
+      case TypeKind.U32: return module.unary(UnaryOp.BitmaskI32x4, arg0);
+    }
+  }
+  compiler.error(
+    DiagnosticCode.Operation_0_cannot_be_applied_to_type_1,
+    ctx.reportNode.typeArgumentsRange, "v128.bitmask", type.toString()
+  );
+  return module.unreachable();
+}
+builtins.set(BuiltinNames.v128_bitmask, builtin_v128_bitmask);
 
 // v128.qfma<T!>(a: v128, b: v128, c: v128) -> v128
 function builtin_v128_qfma(ctx: BuiltinContext): ExpressionRef {
@@ -6225,6 +6285,15 @@ function builtin_i8x16_avgr_u(ctx: BuiltinContext): ExpressionRef {
 }
 builtins.set(BuiltinNames.i8x16_avgr_u, builtin_i8x16_avgr_u);
 
+// i8x16.abs -> v128.abs<i8>
+function builtin_i8x16_abs(ctx: BuiltinContext): ExpressionRef {
+  checkTypeAbsent(ctx);
+  ctx.typeArguments = [ Type.i8 ];
+  ctx.contextualType = Type.v128;
+  return builtin_v128_abs(ctx);
+}
+builtins.set(BuiltinNames.i8x16_abs, builtin_i8x16_abs);
+
 // i8x16.neg -> v128.neg<i8>
 function builtin_i8x16_neg(ctx: BuiltinContext): ExpressionRef {
   checkTypeAbsent(ctx);
@@ -6314,6 +6383,15 @@ function builtin_i8x16_all_true(ctx: BuiltinContext): ExpressionRef {
   return builtin_v128_all_true(ctx);
 }
 builtins.set(BuiltinNames.i8x16_all_true, builtin_i8x16_all_true);
+
+// i8x16.bitmask -> v128.bitmask<i8>
+function builtin_i8x16_bitmask(ctx: BuiltinContext): ExpressionRef {
+  checkTypeAbsent(ctx);
+  ctx.typeArguments = [ Type.i8 ];
+  ctx.contextualType = Type.i32;
+  return builtin_v128_bitmask(ctx);
+}
+builtins.set(BuiltinNames.i8x16_bitmask, builtin_i8x16_bitmask);
 
 // i8x16.eq -> v128.eq<i8>
 function builtin_i8x16_eq(ctx: BuiltinContext): ExpressionRef {
@@ -6531,6 +6609,15 @@ function builtin_i16x8_avgr_u(ctx: BuiltinContext): ExpressionRef {
 }
 builtins.set(BuiltinNames.i16x8_avgr_u, builtin_i16x8_avgr_u);
 
+// i16x8.abs -> v128.abs<i16>
+function builtin_i16x8_abs(ctx: BuiltinContext): ExpressionRef {
+  checkTypeAbsent(ctx);
+  ctx.typeArguments = [ Type.i16 ];
+  ctx.contextualType = Type.v128;
+  return builtin_v128_abs(ctx);
+}
+builtins.set(BuiltinNames.i16x8_abs, builtin_i16x8_abs);
+
 // i16x8.neg -> v128.neg<i16>
 function builtin_i16x8_neg(ctx: BuiltinContext): ExpressionRef {
   checkTypeAbsent(ctx);
@@ -6620,6 +6707,15 @@ function builtin_i16x8_all_true(ctx: BuiltinContext): ExpressionRef {
   return builtin_v128_all_true(ctx);
 }
 builtins.set(BuiltinNames.i16x8_all_true, builtin_i16x8_all_true);
+
+// i16x8.bitmask -> v128.bitmask<i16>
+function builtin_i16x8_bitmask(ctx: BuiltinContext): ExpressionRef {
+  checkTypeAbsent(ctx);
+  ctx.typeArguments = [ Type.i16 ];
+  ctx.contextualType = Type.i32;
+  return builtin_v128_bitmask(ctx);
+}
+builtins.set(BuiltinNames.i16x8_bitmask, builtin_i16x8_bitmask);
 
 // i16x8.eq -> v128.eq<i16>
 function builtin_i16x8_eq(ctx: BuiltinContext): ExpressionRef {
@@ -6882,6 +6978,15 @@ function builtin_i32x4_dot_i16x8_s(ctx: BuiltinContext): ExpressionRef {
 }
 builtins.set(BuiltinNames.i32x4_dot_i16x8_s, builtin_i32x4_dot_i16x8_s);
 
+// i32x4.abs -> v128.abs<i32>
+function builtin_i32x4_abs(ctx: BuiltinContext): ExpressionRef {
+  checkTypeAbsent(ctx);
+  ctx.typeArguments = [ Type.i32 ];
+  ctx.contextualType = Type.v128;
+  return builtin_v128_abs(ctx);
+}
+builtins.set(BuiltinNames.i32x4_abs, builtin_i32x4_abs);
+
 // i32x4.neg -> v128.neg<i32>
 function builtin_i32x4_neg(ctx: BuiltinContext): ExpressionRef {
   checkTypeAbsent(ctx);
@@ -6935,6 +7040,15 @@ function builtin_i32x4_all_true(ctx: BuiltinContext): ExpressionRef {
   return builtin_v128_all_true(ctx);
 }
 builtins.set(BuiltinNames.i32x4_all_true, builtin_i32x4_all_true);
+
+// i32x4.bitmask -> v128.bitmask<i32>
+function builtin_i32x4_bitmask(ctx: BuiltinContext): ExpressionRef {
+  checkTypeAbsent(ctx);
+  ctx.typeArguments = [ Type.i32 ];
+  ctx.contextualType = Type.i32;
+  return builtin_v128_bitmask(ctx);
+}
+builtins.set(BuiltinNames.i32x4_bitmask, builtin_i32x4_bitmask);
 
 // i32x4.eq -> v128.eq<i32>
 function builtin_i32x4_eq(ctx: BuiltinContext): ExpressionRef {

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -1084,13 +1084,13 @@ export class Compiler extends DiagnosticEmitter {
         } else {
           assert(getExpressionId(initExpr) == ExpressionId.Const);
           let exprType = getExpressionType(initExpr);
-          switch (exprType) {
-            case NativeType.I32: {
+          switch (<u32>exprType) {
+            case <u32>NativeType.I32: {
               global.constantValueKind = ConstantValueKind.INTEGER;
               global.constantIntegerValue = i64_new(getConstValueI32(initExpr), 0);
               break;
             }
-            case NativeType.I64: {
+            case <u32>NativeType.I64: {
               global.constantValueKind = ConstantValueKind.INTEGER;
               global.constantIntegerValue = i64_new(
                 getConstValueI64Low(initExpr),
@@ -1098,12 +1098,12 @@ export class Compiler extends DiagnosticEmitter {
               );
               break;
             }
-            case NativeType.F32: {
+            case <u32>NativeType.F32: {
               global.constantValueKind = ConstantValueKind.FLOAT;
               global.constantFloatValue = getConstValueF32(initExpr);
               break;
             }
-            case NativeType.F64: {
+            case <u32>NativeType.F64: {
               global.constantValueKind = ConstantValueKind.FLOAT;
               global.constantFloatValue = getConstValueF64(initExpr);
               break;
@@ -1731,8 +1731,8 @@ export class Compiler extends DiagnosticEmitter {
     program.writeRuntimeHeader(buf, 0, id, byteLength);
     var pos = runtimeHeaderSize;
     var nativeType = elementType.toNativeType();
-    switch (nativeType) {
-      case NativeType.I32: {
+    switch (<u32>nativeType) {
+      case <u32>NativeType.I32: {
         switch (byteSize) {
           case 1: {
             for (let i = 0; i < length; ++i) {
@@ -1768,7 +1768,7 @@ export class Compiler extends DiagnosticEmitter {
         }
         break;
       }
-      case NativeType.I64: {
+      case <u32>NativeType.I64: {
         for (let i = 0; i < length; ++i) {
           let value = values[i];
           assert(getExpressionType(value) == nativeType);
@@ -1778,7 +1778,7 @@ export class Compiler extends DiagnosticEmitter {
         }
         break;
       }
-      case NativeType.F32: {
+      case <u32>NativeType.F32: {
         for (let i = 0; i < length; ++i) {
           let value = values[i];
           assert(getExpressionType(value) == nativeType);
@@ -1788,7 +1788,7 @@ export class Compiler extends DiagnosticEmitter {
         }
         break;
       }
-      case NativeType.F64: {
+      case <u32>NativeType.F64: {
         for (let i = 0; i < length; ++i) {
           let value = values[i];
           assert(getExpressionType(value) == nativeType);
@@ -2913,8 +2913,8 @@ export class Compiler extends DiagnosticEmitter {
           initExpr = module.precomputeExpression(initExpr);
           if (getExpressionId(initExpr) == ExpressionId.Const) {
             let local = new Local(name, -1, type, flow.parentFunction);
-            switch (getExpressionType(initExpr)) {
-              case NativeType.I32: {
+            switch (<u32>getExpressionType(initExpr)) {
+              case <u32>NativeType.I32: {
                 local.setConstantIntegerValue(
                   i64_new(
                     getConstValueI32(initExpr),
@@ -2924,7 +2924,7 @@ export class Compiler extends DiagnosticEmitter {
                 );
                 break;
               }
-              case NativeType.I64: {
+              case <u32>NativeType.I64: {
                 local.setConstantIntegerValue(
                   i64_new(
                     getConstValueI64Low(initExpr),
@@ -2934,11 +2934,11 @@ export class Compiler extends DiagnosticEmitter {
                 );
                 break;
               }
-              case NativeType.F32: {
+              case <u32>NativeType.F32: {
                 local.setConstantFloatValue(<f64>getConstValueF32(initExpr), type);
                 break;
               }
-              case NativeType.F64: {
+              case <u32>NativeType.F64: {
                 local.setConstantFloatValue(getConstValueF64(initExpr), type);
                 break;
               }

--- a/src/flow.ts
+++ b/src/flow.ts
@@ -283,14 +283,14 @@ export class Flow {
   getTempLocal(type: Type, except: Set<i32> | null = null): Local {
     var parentFunction = this.parentFunction;
     var temps: Local[] | null;
-    switch (type.toNativeType()) {
-      case NativeType.I32: { temps = parentFunction.tempI32s; break; }
-      case NativeType.I64: { temps = parentFunction.tempI64s; break; }
-      case NativeType.F32: { temps = parentFunction.tempF32s; break; }
-      case NativeType.F64: { temps = parentFunction.tempF64s; break; }
-      case NativeType.V128: { temps = parentFunction.tempV128s; break; }
-      case NativeType.Anyref: { temps = parentFunction.tempAnyrefs; break; }
-      case NativeType.Exnref: { temps = parentFunction.tempExnrefs; break; }
+    switch (<u32>type.toNativeType()) {
+      case <u32>NativeType.I32: { temps = parentFunction.tempI32s; break; }
+      case <u32>NativeType.I64: { temps = parentFunction.tempI64s; break; }
+      case <u32>NativeType.F32: { temps = parentFunction.tempF32s; break; }
+      case <u32>NativeType.F64: { temps = parentFunction.tempF64s; break; }
+      case <u32>NativeType.V128: { temps = parentFunction.tempV128s; break; }
+      case <u32>NativeType.Anyref: { temps = parentFunction.tempAnyrefs; break; }
+      case <u32>NativeType.Exnref: { temps = parentFunction.tempExnrefs; break; }
       default: throw new Error("concrete type expected");
     }
     var local: Local;
@@ -341,44 +341,44 @@ export class Flow {
     var parentFunction = this.parentFunction;
     var temps: Local[];
     assert(local.type != null); // internal error
-    switch (local.type.toNativeType()) {
-      case NativeType.I32: {
+    switch (<u32>local.type.toNativeType()) {
+      case <u32>NativeType.I32: {
         let tempI32s = parentFunction.tempI32s;
         if (tempI32s) temps = tempI32s;
         else parentFunction.tempI32s = temps = [];
         break;
       }
-      case NativeType.I64: {
+      case <u32>NativeType.I64: {
         let tempI64s = parentFunction.tempI64s;
         if (tempI64s) temps = tempI64s;
         else parentFunction.tempI64s = temps = [];
         break;
       }
-      case NativeType.F32: {
+      case <u32>NativeType.F32: {
         let tempF32s = parentFunction.tempF32s;
         if (tempF32s) temps = tempF32s;
         else parentFunction.tempF32s = temps = [];
         break;
       }
-      case NativeType.F64: {
+      case <u32>NativeType.F64: {
         let tempF64s = parentFunction.tempF64s;
         if (tempF64s) temps = tempF64s;
         else parentFunction.tempF64s = temps = [];
         break;
       }
-      case NativeType.V128: {
+      case <u32>NativeType.V128: {
         let tempV128s = parentFunction.tempV128s;
         if (tempV128s) temps = tempV128s;
         else parentFunction.tempV128s = temps = [];
         break;
       }
-      case NativeType.Anyref: {
+      case <u32>NativeType.Anyref: {
         let tempAnyrefs = parentFunction.tempAnyrefs;
         if (tempAnyrefs) temps = tempAnyrefs;
         else parentFunction.tempAnyrefs = temps = [];
         break;
       }
-      case NativeType.Exnref: {
+      case <u32>NativeType.Exnref: {
         let tempExnrefs = parentFunction.tempExnrefs;
         if (tempExnrefs) temps = tempExnrefs;
         else parentFunction.tempExnrefs = temps = [];
@@ -1255,11 +1255,11 @@ export class Flow {
       // overflows if the value cannot be represented in the target type
       case ExpressionId.Const: {
         let value: i32 = 0;
-        switch (getExpressionType(expr)) {
-          case NativeType.I32: { value = getConstValueI32(expr); break; }
-          case NativeType.I64: { value = getConstValueI64Low(expr); break; } // discards upper bits
-          case NativeType.F32: { value = i32(getConstValueF32(expr)); break; }
-          case NativeType.F64: { value = i32(getConstValueF64(expr)); break; }
+        switch (<u32>getExpressionType(expr)) {
+          case <u32>NativeType.I32: { value = getConstValueI32(expr); break; }
+          case <u32>NativeType.I64: { value = getConstValueI64Low(expr); break; } // discards upper bits
+          case <u32>NativeType.F32: { value = i32(getConstValueF32(expr)); break; }
+          case <u32>NativeType.F64: { value = i32(getConstValueF64(expr)); break; }
           default: assert(false);
         }
         switch (type.kind) {

--- a/src/glue/binaryen.d.ts
+++ b/src/glue/binaryen.d.ts
@@ -25,7 +25,7 @@ export declare function __f64_load(ptr: usize): f64;
 
 type BinaryenIndex = u32;
 
-type BinaryenType = i32;
+type BinaryenType = usize;
 
 export declare function _BinaryenTypeNone(): BinaryenType;
 export declare function _BinaryenTypeInt32(): BinaryenType;
@@ -106,6 +106,8 @@ export declare function _BinaryenTryId(): BinaryenExpressionId;
 export declare function _BinaryenThrowId(): BinaryenExpressionId;
 export declare function _BinaryenRethrowId(): BinaryenExpressionId;
 export declare function _BinaryenBrOnExnId(): BinaryenExpressionId;
+export declare function _BinaryenTupleMakeId(): BinaryenExpressionId;
+export declare function _BinaryenTupleExtractId(): BinaryenExpressionId;
 export declare function _BinaryenPushId(): BinaryenExpressionId;
 export declare function _BinaryenPopId(): BinaryenExpressionId;
 
@@ -342,9 +344,11 @@ export declare function _BinaryenOrVec128(): BinaryenOp;
 export declare function _BinaryenXorVec128(): BinaryenOp;
 export declare function _BinaryenAndNotVec128(): BinaryenOp;
 export declare function _BinaryenBitselectVec128(): BinaryenOp;
+export declare function _BinaryenAbsVecI8x16(): BinaryenOp;
 export declare function _BinaryenNegVecI8x16(): BinaryenOp;
 export declare function _BinaryenAnyTrueVecI8x16(): BinaryenOp;
 export declare function _BinaryenAllTrueVecI8x16(): BinaryenOp;
+export declare function _BinaryenBitmaskVecI8x16(): BinaryenOp;
 export declare function _BinaryenShlVecI8x16(): BinaryenOp;
 export declare function _BinaryenShrSVecI8x16(): BinaryenOp;
 export declare function _BinaryenShrUVecI8x16(): BinaryenOp;
@@ -360,9 +364,11 @@ export declare function _BinaryenMinUVecI8x16(): BinaryenOp;
 export declare function _BinaryenMaxSVecI8x16(): BinaryenOp;
 export declare function _BinaryenMaxUVecI8x16(): BinaryenOp;
 export declare function _BinaryenAvgrUVecI8x16(): BinaryenOp;
+export declare function _BinaryenAbsVecI16x8(): BinaryenOp;
 export declare function _BinaryenNegVecI16x8(): BinaryenOp;
 export declare function _BinaryenAnyTrueVecI16x8(): BinaryenOp;
 export declare function _BinaryenAllTrueVecI16x8(): BinaryenOp;
+export declare function _BinaryenBitmaskVecI16x8(): BinaryenOp;
 export declare function _BinaryenShlVecI16x8(): BinaryenOp;
 export declare function _BinaryenShrSVecI16x8(): BinaryenOp;
 export declare function _BinaryenShrUVecI16x8(): BinaryenOp;
@@ -378,9 +384,11 @@ export declare function _BinaryenMinUVecI16x8(): BinaryenOp;
 export declare function _BinaryenMaxSVecI16x8(): BinaryenOp;
 export declare function _BinaryenMaxUVecI16x8(): BinaryenOp;
 export declare function _BinaryenAvgrUVecI16x8(): BinaryenOp;
+export declare function _BinaryenAbsVecI32x4(): BinaryenOp;
 export declare function _BinaryenNegVecI32x4(): BinaryenOp;
 export declare function _BinaryenAnyTrueVecI32x4(): BinaryenOp;
 export declare function _BinaryenAllTrueVecI32x4(): BinaryenOp;
+export declare function _BinaryenBitmaskVecI32x4(): BinaryenOp;
 export declare function _BinaryenShlVecI32x4(): BinaryenOp;
 export declare function _BinaryenShrSVecI32x4(): BinaryenOp;
 export declare function _BinaryenShrUVecI32x4(): BinaryenOp;
@@ -510,6 +518,13 @@ export declare function _BinaryenTry(module: BinaryenModuleRef, body: BinaryenEx
 export declare function _BinaryenThrow(module: BinaryenModuleRef, event: usize, operands: usize, numOperands: BinaryenIndex): BinaryenExpressionRef;
 export declare function _BinaryenRethrow(module: BinaryenModuleRef, exnref: BinaryenExpressionRef): BinaryenExpressionRef;
 export declare function _BinaryenBrOnExn(module: BinaryenModuleRef, name: usize, eventName: usize, exnref: BinaryenExpressionRef): BinaryenExpressionRef;
+
+export declare function _BinaryenTupleMake(module: BinaryenModuleRef, operands: usize, numOperands: BinaryenIndex): BinaryenExpressionRef;
+export declare function _BinaryenTupleMakeGetNumOperands(expr: BinaryenExpressionRef): BinaryenIndex;
+export declare function _BinaryenTupleMakeGetOperand(expr: BinaryenExpressionRef, index: BinaryenIndex): BinaryenExpressionRef;
+export declare function _BinaryenTupleExtract(module: BinaryenModuleRef, tuple: BinaryenExpressionRef, index: BinaryenIndex): BinaryenExpressionRef;
+export declare function _BinaryenTupleExtractGetTuple(expr: BinaryenExpressionRef): BinaryenExpressionRef;
+export declare function _BinaryenTupleExtractGetIndex(expr: BinaryenExpressionRef): BinaryenIndex;
 
 export declare function _BinaryenPush(module: BinaryenModuleRef, value: BinaryenExpressionRef): BinaryenExpressionRef;
 export declare function _BinaryenPop(module: BinaryenModuleRef, type: BinaryenType): BinaryenExpressionRef;

--- a/src/module.ts
+++ b/src/module.ts
@@ -1518,28 +1518,28 @@ export class Module {
 
     switch (binaryen._BinaryenExpressionGetId(expr)) {
       case ExpressionId.Const: {
-        switch (binaryen._BinaryenExpressionGetType(expr)) {
-          case NativeType.I32: {
+        switch (<u32>binaryen._BinaryenExpressionGetType(expr)) {
+          case <u32>NativeType.I32: {
             return this.i32(binaryen._BinaryenConstGetValueI32(expr));
           }
-          case NativeType.I64: {
+          case <u32>NativeType.I64: {
             return this.i64(
               binaryen._BinaryenConstGetValueI64Low(expr),
               binaryen._BinaryenConstGetValueI64High(expr)
             );
           }
-          case NativeType.F32: {
+          case <u32>NativeType.F32: {
             return this.f32(binaryen._BinaryenConstGetValueF32(expr));
           }
-          case NativeType.F64: {
+          case <u32>NativeType.F64: {
             return this.f64(binaryen._BinaryenConstGetValueF64(expr));
           }
-          case NativeType.V128: {
+          case <u32>NativeType.V128: {
             // TODO
             return 0;
           }
           // Not possible to clone an anyref as it is opaque
-          case NativeType.Anyref: {
+          case <u32>NativeType.Anyref: {
             return 0;
           }
           default: {
@@ -1849,7 +1849,7 @@ export function getFunctionName(func: FunctionRef): string | null {
   return readString(binaryen._BinaryenFunctionGetName(func));
 }
 
-export function getFunctionParams(func: FunctionRef): Index {
+export function getFunctionParams(func: FunctionRef): NativeType {
   return binaryen._BinaryenFunctionGetParams(func);
 }
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -28,6 +28,7 @@ export type Index = u32;
 // that this essentially fixes the compiler to specific versions of Binaryen
 // sometimes, because these constants can differ between Binaryen versions.
 
+export type NativeType = usize;
 export namespace NativeType {
   export const None: NativeType = 0 /* _BinaryenTypeNone */;
   export const Unreachable: NativeType = 1 /* _BinaryenTypeUnreachable */;
@@ -42,7 +43,6 @@ export namespace NativeType {
   export const Exnref: NativeType = 10 /* _BinaryenTypeExnref */;
   export const Auto: NativeType = -1 /* _BinaryenTypeAuto */;
 }
-export type NativeType = binaryen.BinaryenType;
 
 export enum FeatureFlags {
   MVP = 0 /* _BinaryenFeatureMVP */,
@@ -1064,7 +1064,7 @@ export class Module {
     body: ExpressionRef
   ): FunctionRef {
     var cStr = this.allocStringCached(name);
-    var cArr = allocI32Array(varTypes);
+    var cArr = allocPtrArray(varTypes);
     var ret = binaryen._BinaryenAddFunction(this.ref, cStr, params, results, cArr, varTypes ? varTypes.length : 0, body);
     binaryen._free(cArr);
     return ret;
@@ -1087,7 +1087,7 @@ export class Module {
   addTemporaryFunction(result: NativeType, paramTypes: NativeType[] | null, body: ExpressionRef): FunctionRef {
     this.hasTemporaryFunction = assert(!this.hasTemporaryFunction);
     var tempName = this.allocStringCached("");
-    var cArr = allocI32Array(paramTypes);
+    var cArr = allocPtrArray(paramTypes);
     var ret = binaryen._BinaryenAddFunction(this.ref,
       tempName,
       createType(paramTypes),
@@ -1631,7 +1631,7 @@ export function createType(types: NativeType[] | null): NativeType {
     case 0: return NativeType.None;
     case 1: return types[0];
   }
-  var cArr = allocI32Array(types);
+  var cArr = allocPtrArray(types);
   var ret = binaryen._BinaryenTypeCreate(cArr, types.length);
   binaryen._free(cArr);
   return ret;

--- a/src/module.ts
+++ b/src/module.ts
@@ -28,20 +28,21 @@ export type Index = u32;
 // that this essentially fixes the compiler to specific versions of Binaryen
 // sometimes, because these constants can differ between Binaryen versions.
 
-export enum NativeType {
-  None = 0 /* _BinaryenTypeNone */,
-  Unreachable = 1 /* _BinaryenTypeUnreachable */,
-  I32 = 2 /* _BinaryenTypeInt32 */,
-  I64 = 3 /* _BinaryenTypeInt64 */,
-  F32 = 4 /* _BinaryenTypeFloat32 */,
-  F64 = 5 /* _BinaryenTypeFloat64 */,
-  V128 = 6 /* _BinaryenTypeVec128 */,
-  Funcref = 7 /* _BinaryenTypeFuncref */,
-  Anyref = 8 /* _BinaryenTypeAnyref */,
-  Nullref = 9 /* _BinaryenTypeNullref */,
-  Exnref = 10 /* _BinaryenTypeExnref */,
-  Auto = -1 /* _BinaryenTypeAuto */
+export namespace NativeType {
+  export const None: NativeType = 0 /* _BinaryenTypeNone */;
+  export const Unreachable: NativeType = 1 /* _BinaryenTypeUnreachable */;
+  export const I32: NativeType = 2 /* _BinaryenTypeInt32 */;
+  export const I64: NativeType = 3 /* _BinaryenTypeInt64 */;
+  export const F32: NativeType = 4 /* _BinaryenTypeFloat32 */;
+  export const F64: NativeType = 5 /* _BinaryenTypeFloat64 */;
+  export const V128: NativeType = 6 /* _BinaryenTypeVec128 */;
+  export const Funcref: NativeType = 7 /* _BinaryenTypeFuncref */;
+  export const Anyref: NativeType = 8 /* _BinaryenTypeAnyref */;
+  export const Nullref: NativeType = 9 /* _BinaryenTypeNullref */;
+  export const Exnref: NativeType = 10 /* _BinaryenTypeExnref */;
+  export const Auto: NativeType = -1 /* _BinaryenTypeAuto */;
 }
+export type NativeType = binaryen.BinaryenType;
 
 export enum FeatureFlags {
   MVP = 0 /* _BinaryenFeatureMVP */,
@@ -105,7 +106,9 @@ export enum ExpressionId {
   Try = 43 /* _BinaryenTryId */,
   Throw = 44 /* _BinaryenThrowId */,
   Rethrow = 45 /* _BinaryenRethrowId */,
-  BrOnExn = 46 /* _BinaryenBrOnExnId */
+  BrOnExn = 46 /* _BinaryenBrOnExnId */,
+  TupleMake = 47 /* _BinaryenTupleMakeId */,
+  TupleExtract = 48 /* _BinaryenTupleExtractId */
 }
 
 export enum UnaryOp {
@@ -182,40 +185,46 @@ export enum UnaryOp {
   SplatF32x4 = 64 /* _BinaryenSplatVecF32x4 */,
   SplatF64x2 = 65 /* _BinaryenSplatVecF64x2 */,
   NotV128 = 66 /* _BinaryenNotVec128 */,
-  NegI8x16 = 67 /* _BinaryenNegVecI8x16 */,
-  AnyTrueI8x16 = 68 /* _BinaryenAnyTrueVecI8x16 */,
-  AllTrueI8x16 = 69 /* _BinaryenAllTrueVecI8x16 */,
-  NegI16x8 = 70 /* _BinaryenNegVecI16x8 */,
-  AnyTrueI16x8 = 71 /* _BinaryenAnyTrueVecI16x8 */,
-  AllTrueI16x8 = 72 /* _BinaryenAllTrueVecI16x8 */,
-  NegI32x4 = 73 /* _BinaryenNegVecI32x4 */,
-  AnyTrueI32x4 = 74 /* _BinaryenAnyTrueVecI32x4 */,
-  AllTrueI32x4 = 75 /* _BinaryenAllTrueVecI32x4 */,
-  NegI64x2 = 76 /* _BinaryenNegVecI64x2 */,
-  AnyTrueI64x2 = 77 /* _BinaryenAnyTrueVecI64x2 */,
-  AllTrueI64x2 = 78 /* _BinaryenAllTrueVecI64x2 */,
-  AbsF32x4 = 79 /* _BinaryenAbsVecF32x4 */,
-  NegF32x4 = 80 /* _BinaryenNegVecF32x4 */,
-  SqrtF32x4 = 81 /* _BinaryenSqrtVecF32x4 */,
-  AbsF64x2 = 82 /* _BinaryenAbsVecF64x2 */,
-  NegF64x2 = 83 /* _BinaryenNegVecF64x2 */,
-  SqrtF64x2 = 84 /* _BinaryenSqrtVecF64x2 */,
-  TruncSatF32x4ToI32x4 = 85 /* _BinaryenTruncSatSVecF32x4ToVecI32x4 */,
-  TruncSatF32x4ToU32x4 = 86 /* _BinaryenTruncSatUVecF32x4ToVecI32x4 */,
-  TruncSatF64x2ToI64x2 = 87 /* _BinaryenTruncSatSVecF64x2ToVecI64x2 */,
-  TruncSatF64x2ToU64x2 = 88 /* _BinaryenTruncSatUVecF64x2ToVecI64x2 */,
-  ConvertI32x4ToF32x4 = 89 /* _BinaryenConvertSVecI32x4ToVecF32x4 */,
-  ConvertU32x4ToF32x4 = 90 /* _BinaryenConvertUVecI32x4ToVecF32x4 */,
-  ConvertI64x2ToF64x2 = 91 /* _BinaryenConvertSVecI64x2ToVecF64x2 */,
-  ConvertU64x2ToF64x2 = 92 /* _BinaryenConvertUVecI64x2ToVecF64x2 */,
-  WidenLowI8x16ToI16x8 = 93 /* _BinaryenWidenLowSVecI8x16ToVecI16x8 */,
-  WidenHighI8x16ToI16x8 = 94 /* _BinaryenWidenHighSVecI8x16ToVecI16x8 */,
-  WidenLowU8x16ToU16x8 = 95 /* _BinaryenWidenLowUVecI8x16ToVecI16x8 */,
-  WidenHighU8x16ToU16x8 = 96 /* _BinaryenWidenHighUVecI8x16ToVecI16x8 */,
-  WidenLowI16x8ToI32x4 = 97 /* _BinaryenWidenLowSVecI16x8ToVecI32x4 */,
-  WidenHighI16x8ToI32x4 = 98 /* _BinaryenWidenHighSVecI16x8ToVecI32x4 */,
-  WidenLowU16x8ToU32x4 = 99 /* _BinaryenWidenLowUVecI16x8ToVecI32x4 */,
-  WidenHighU16x8ToU32x4 = 100 /* _BinaryenWidenHighUVecI16x8ToVecI32x4 */
+  AbsI8x16 = 67 /* __BinaryenAbsVecI8x16 */,
+  NegI8x16 = 68 /* _BinaryenNegVecI8x16 */,
+  AnyTrueI8x16 = 69 /* _BinaryenAnyTrueVecI8x16 */,
+  AllTrueI8x16 = 70 /* _BinaryenAllTrueVecI8x16 */,
+  BitmaskI8x16 = 71 /* __BinaryenBitmaskVecI8x16 */,
+  AbsI16x8 = 72 /* __BinaryenAbsVecI16x8 */,
+  NegI16x8 = 73 /* _BinaryenNegVecI16x8 */,
+  AnyTrueI16x8 = 74 /* _BinaryenAnyTrueVecI16x8 */,
+  AllTrueI16x8 = 75 /* _BinaryenAllTrueVecI16x8 */,
+  BitmaskI16x8 = 76 /* _BinaryenBitmaskVecI16x8 */,
+  AbsI32x4 = 77 /* _BinaryenAbsVecI32x4 */,
+  NegI32x4 = 78 /* _BinaryenNegVecI32x4 */,
+  AnyTrueI32x4 = 79 /* _BinaryenAnyTrueVecI32x4 */,
+  AllTrueI32x4 = 80 /* _BinaryenAllTrueVecI32x4 */,
+  BitmaskI32x4 = 81 /* _BinaryenBitmaskVecI32x4 */,
+  NegI64x2 = 82 /* _BinaryenNegVecI64x2 */,
+  AnyTrueI64x2 = 83 /* _BinaryenAnyTrueVecI64x2 */,
+  AllTrueI64x2 = 84 /* _BinaryenAllTrueVecI64x2 */,
+  AbsF32x4 = 85 /* _BinaryenAbsVecF32x4 */,
+  NegF32x4 = 86 /* _BinaryenNegVecF32x4 */,
+  SqrtF32x4 = 87 /* _BinaryenSqrtVecF32x4 */,
+  AbsF64x2 = 88 /* _BinaryenAbsVecF64x2 */,
+  NegF64x2 = 89 /* _BinaryenNegVecF64x2 */,
+  SqrtF64x2 = 90 /* _BinaryenSqrtVecF64x2 */,
+  TruncSatF32x4ToI32x4 = 91 /* _BinaryenTruncSatSVecF32x4ToVecI32x4 */,
+  TruncSatF32x4ToU32x4 = 92 /* _BinaryenTruncSatUVecF32x4ToVecI32x4 */,
+  TruncSatF64x2ToI64x2 = 93 /* _BinaryenTruncSatSVecF64x2ToVecI64x2 */,
+  TruncSatF64x2ToU64x2 = 94 /* _BinaryenTruncSatUVecF64x2ToVecI64x2 */,
+  ConvertI32x4ToF32x4 = 95 /* _BinaryenConvertSVecI32x4ToVecF32x4 */,
+  ConvertU32x4ToF32x4 = 96 /* _BinaryenConvertUVecI32x4ToVecF32x4 */,
+  ConvertI64x2ToF64x2 = 97 /* _BinaryenConvertSVecI64x2ToVecF64x2 */,
+  ConvertU64x2ToF64x2 = 98 /* _BinaryenConvertUVecI64x2ToVecF64x2 */,
+  WidenLowI8x16ToI16x8 = 99 /* _BinaryenWidenLowSVecI8x16ToVecI16x8 */,
+  WidenHighI8x16ToI16x8 = 100 /* _BinaryenWidenHighSVecI8x16ToVecI16x8 */,
+  WidenLowU8x16ToU16x8 = 101 /* _BinaryenWidenLowUVecI8x16ToVecI16x8 */,
+  WidenHighU8x16ToU16x8 = 102 /* _BinaryenWidenHighUVecI8x16ToVecI16x8 */,
+  WidenLowI16x8ToI32x4 = 103 /* _BinaryenWidenLowSVecI16x8ToVecI32x4 */,
+  WidenHighI16x8ToI32x4 = 104 /* _BinaryenWidenHighSVecI16x8ToVecI32x4 */,
+  WidenLowU16x8ToU32x4 = 105 /* _BinaryenWidenLowUVecI16x8ToVecI32x4 */,
+  WidenHighU16x8ToU32x4 = 106 /* _BinaryenWidenHighUVecI16x8ToVecI32x4 */
 }
 
 export enum BinaryOp {

--- a/src/module.ts
+++ b/src/module.ts
@@ -1002,6 +1002,19 @@ export class Module {
     return binaryen._BinaryenRefFunc(this.ref, cStr);
   }
 
+  // tuples (pseudo instructions)
+
+  tuple_make(operands: ExpressionRef[]): ExpressionRef {
+    var cArr = allocPtrArray(operands);
+    var ret = binaryen._BinaryenTupleMake(this.ref, cArr, operands.length);
+    binaryen._free(cArr);
+    return ret;
+  }
+
+  tuple_extract(tuple: ExpressionRef, index: Index): ExpressionRef {
+    return binaryen._BinaryenTupleExtract(this.ref, tuple, index);
+  }
+
   // globals
 
   addGlobal(
@@ -2384,6 +2397,15 @@ export function traverse<T>(expr: ExpressionRef, data: T, visit: (expr: Expressi
     }
     case ExpressionId.BrOnExn: {
       visit(binaryen._BinaryenBrOnExnGetExnref(expr), data);
+      break;
+    }
+    case ExpressionId.TupleMake: {
+      for (let i: Index = 0, n = binaryen._BinaryenTupleMakeGetNumOperands(expr); i < n; ++i) {
+        visit(binaryen._BinaryenTupleMakeGetOperand(expr, i), data);
+      }
+      break;
+    }
+    case ExpressionId.TupleExtract: {
       break;
     }
     default: assert(false);

--- a/std/assembly/builtins.ts
+++ b/std/assembly/builtins.ts
@@ -1083,6 +1083,10 @@ export namespace v128 {
 
   // @ts-ignore: decorator
   @builtin
+  export declare function bitmask<T>(a: v128): i32;
+
+  // @ts-ignore: decorator
+  @builtin
   export declare function min<T>(a: v128, b: v128): v128;
 
   // @ts-ignore: decorator
@@ -1217,6 +1221,10 @@ export namespace i8x16 {
 
   // @ts-ignore: decorator
   @builtin
+  export declare function abs(a: v128): v128;
+
+  // @ts-ignore: decorator
+  @builtin
   export declare function neg(a: v128): v128;
 
   // @ts-ignore: decorator
@@ -1254,6 +1262,10 @@ export namespace i8x16 {
   // @ts-ignore: decorator
   @builtin
   export declare function all_true(a: v128): bool;
+
+  // @ts-ignore: decorator
+  @builtin
+  export declare function bitmask(a: v128): i32;
 
   // @ts-ignore: decorator
   @builtin
@@ -1360,6 +1372,10 @@ export namespace i16x8 {
 
   // @ts-ignore: decorator
   @builtin
+  export declare function abs(a: v128): v128;
+
+  // @ts-ignore: decorator
+  @builtin
   export declare function neg(a: v128): v128;
 
   // @ts-ignore: decorator
@@ -1397,6 +1413,10 @@ export namespace i16x8 {
   // @ts-ignore: decorator
   @builtin
   export declare function all_true(a: v128): bool;
+
+  // @ts-ignore: decorator
+  @builtin
+  export declare function bitmask(a: v128): i32;
 
   // @ts-ignore: decorator
   @builtin
@@ -1523,6 +1543,10 @@ export namespace i32x4 {
 
   // @ts-ignore: decorator
   @builtin
+  export declare function abs(a: v128): v128;
+
+  // @ts-ignore: decorator
+  @builtin
   export declare function neg(a: v128): v128;
 
   // @ts-ignore: decorator
@@ -1544,6 +1568,10 @@ export namespace i32x4 {
   // @ts-ignore: decorator
   @builtin
   export declare function all_true(a: v128): bool;
+
+  // @ts-ignore: decorator
+  @builtin
+  export declare function bitmask(a: v128): i32;
 
   // @ts-ignore: decorator
   @builtin

--- a/std/assembly/index.d.ts
+++ b/std/assembly/index.d.ts
@@ -591,6 +591,8 @@ declare namespace v128 {
   export function any_true<T>(a: v128): bool;
   /** Reduces a vector to a scalar indicating whether all lanes are considered `true`. */
   export function all_true<T>(a: v128): bool;
+  /** Extracts the high bit of each lane and produces a scalar mask with all bits concatenated. */
+  export function bitmask<T>(a: v128): i32;
   /** Computes the minimum of each lane. */
   export function min<T>(a: v128, b: v128): v128;
   /** Computes the maximum of each lane. */
@@ -657,6 +659,8 @@ declare namespace i8x16 {
   export function max_u(a: v128, b: v128): v128;
   /** Computes the unsigned average of each 8-bit integer lane. */
   export function avgr_u(a: v128, b: v128): v128;
+  /** Compules the absolute value of each 8-bit integer lane. */
+  export function abs(a: v128): v128;
   /** Negates each 8-bit integer lane. */
   export function neg(a: v128): v128;
   /** Adds each 8-bit integer lane using signed saturation. */
@@ -677,6 +681,8 @@ declare namespace i8x16 {
   export function any_true(a: v128): bool;
   /** Reduces a vector to a scalar indicating whether all 8-bit integer lanes are considered `true`. */
   export function all_true(a: v128): bool;
+  /** Extracts the high bit of each 8-bit integer lane and produces a scalar mask with all bits concatenated. */
+  export function bitmask(a: v128): i32;
   /** Computes which 8-bit integer lanes are equal. */
   export function eq(a: v128, b: v128): v128;
   /** Computes which 8-bit integer lanes are not equal. */
@@ -729,6 +735,8 @@ declare namespace i16x8 {
   export function max_u(a: v128, b: v128): v128;
   /** Computes the unsigned average of each 16-bit integer lane. */
   export function avgr_u(a: v128, b: v128): v128;
+  /** Compules the absolute value of each 16-bit integer lane. */
+  export function abs(a: v128): v128;
   /** Negates each 16-bit integer lane. */
   export function neg(a: v128): v128;
   /** Adds each 16-bit integer lane using signed saturation. */
@@ -749,6 +757,8 @@ declare namespace i16x8 {
   export function any_true(a: v128): bool;
   /** Reduces a vector to a scalar indicating whether all 16-bit integer lanes are considered `true`. */
   export function all_true(a: v128): bool;
+  /** Extracts the high bit of each 16-bit integer lane and produces a scalar mask with all bits concatenated. */
+  export function bitmask(a: v128): i32;
   /** Computes which 16-bit integer lanes are equal. */
   export function eq(a: v128, b: v128): v128;
   /** Computes which 16-bit integer lanes are not equal. */
@@ -811,6 +821,8 @@ declare namespace i32x4 {
   export function max_u(a: v128, b: v128): v128;
   /** Computes the dot product of two 16-bit integer lanes each, yielding 32-bit integer lanes. */
   export function dot_i16x8_s(a: v128, b: v128): v128;
+  /** Compules the absolute value of each 32-bit integer lane. */
+  export function abs(a: v128): v128;
   /** Negates each 32-bit integer lane. */
   export function neg(a: v128): v128;
   /** Performs a bitwise left shift on each 32-bit integer lane by a scalar. */
@@ -823,6 +835,8 @@ declare namespace i32x4 {
   export function any_true(a: v128): bool;
   /** Reduces a vector to a scalar indicating whether all 32-bit integer lanes are considered `true`. */
   export function all_true(a: v128): bool;
+  /** Extracts the high bit of each 32-bit integer lane and produces a scalar mask with all bits concatenated. */
+  export function bitmask(a: v128): i32;
   /** Computes which 32-bit integer lanes are equal. */
   export function eq(a: v128, b: v128): v128;
   /** Computes which 32-bit integer lanes are not equal. */

--- a/tests/compiler/abi.optimized.wat
+++ b/tests/compiler/abi.optimized.wat
@@ -1,22 +1,12 @@
 (module
- (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
  (memory $0 1)
  (data (i32.const 1024) "\0c\00\00\00\01\00\00\00\01\00\00\00\0c\00\00\00a\00b\00i\00.\00t\00s")
- (global $abi/condition (mut i32) (i32.const 0))
- (global $abi/y (mut i32) (i32.const 0))
  (export "memory" (memory $0))
  (export "exported" (func $abi/exported))
  (export "exportedExported" (func $abi/exported))
  (export "exportedInternal" (func $abi/exported))
- (start $~start)
- (func $abi/exported (; 0 ;) (result i32)
+ (func $abi/exported (result i32)
   i32.const -128
- )
- (func $~start (; 1 ;)
-  i32.const 1
-  global.set $abi/condition
-  i32.const 0
-  global.set $abi/y
  )
 )

--- a/tests/compiler/abi.untouched.wat
+++ b/tests/compiler/abi.untouched.wat
@@ -13,10 +13,10 @@
  (export "exportedExported" (func $abi/exportedExported))
  (export "exportedInternal" (func $abi/exportedInternal))
  (start $~start)
- (func $abi/internal (; 1 ;) (result i32)
+ (func $abi/internal (result i32)
   i32.const 128
  )
- (func $start:abi (; 2 ;)
+ (func $start:abi
   (local $0 i32)
   (local $1 i32)
   call $abi/internal
@@ -181,24 +181,24 @@
    unreachable
   end
  )
- (func $abi/exported (; 3 ;) (result i32)
+ (func $abi/exported (result i32)
   i32.const 128
   i32.const 24
   i32.shl
   i32.const 24
   i32.shr_s
  )
- (func $abi/exportedExported (; 4 ;) (result i32)
+ (func $abi/exportedExported (result i32)
   call $abi/exported
  )
- (func $abi/exportedInternal (; 5 ;) (result i32)
+ (func $abi/exportedInternal (result i32)
   call $abi/internal
   i32.const 24
   i32.shl
   i32.const 24
   i32.shr_s
  )
- (func $~start (; 6 ;)
+ (func $~start
   call $start:abi
  )
 )

--- a/tests/compiler/asc-constants.untouched.wat
+++ b/tests/compiler/asc-constants.untouched.wat
@@ -19,7 +19,7 @@
  (global $~lib/ASC_FEATURE_MULTI_VALUE i32 (i32.const 0))
  (export "memory" (memory $0))
  (start $~start)
- (func $start:asc-constants (; 0 ;)
+ (func $start:asc-constants
   i32.const 0
   drop
   i32.const 0
@@ -51,7 +51,7 @@
   i32.const 0
   drop
  )
- (func $~start (; 1 ;)
+ (func $~start
   call $start:asc-constants
  )
 )

--- a/tests/compiler/assert-nonnull.optimized.wat
+++ b/tests/compiler/assert-nonnull.optimized.wat
@@ -10,7 +10,6 @@
  (data (i32.const 1152) "\1a\00\00\00\01\00\00\00\01\00\00\00\1a\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00.\00t\00s")
  (data (i32.const 1200) "^\00\00\00\01\00\00\00\01\00\00\00^\00\00\00E\00l\00e\00m\00e\00n\00t\00 \00t\00y\00p\00e\00 \00m\00u\00s\00t\00 \00b\00e\00 \00n\00u\00l\00l\00a\00b\00l\00e\00 \00i\00f\00 \00a\00r\00r\00a\00y\00 \00i\00s\00 \00h\00o\00l\00e\00y")
  (table $0 1 funcref)
- (global $~argumentsLength (mut i32) (i32.const 0))
  (export "__setArgumentsLength" (func $~setArgumentsLength))
  (export "memory" (memory $0))
  (export "testVar" (func $assert-nonnull/testVar))
@@ -25,7 +24,7 @@
  (export "testRet" (func $assert-nonnull/testRet))
  (export "testObjFn" (func $assert-nonnull/testObjFn))
  (export "testObjRet" (func $assert-nonnull/testObjRet))
- (func $assert-nonnull/testVar (; 1 ;) (param $0 i32) (result i32)
+ (func $assert-nonnull/testVar (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -38,7 +37,7 @@
   end
   local.get $0
  )
- (func $assert-nonnull/testObj (; 2 ;) (param $0 i32) (result i32)
+ (func $assert-nonnull/testObj (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -52,7 +51,7 @@
   local.get $0
   i32.load
  )
- (func $assert-nonnull/testProp (; 3 ;) (param $0 i32) (result i32)
+ (func $assert-nonnull/testProp (param $0 i32) (result i32)
   local.get $0
   i32.load
   local.tee $0
@@ -67,7 +66,7 @@
   end
   local.get $0
  )
- (func $assert-nonnull/testArr (; 4 ;) (param $0 i32) (result i32)
+ (func $assert-nonnull/testArr (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -105,7 +104,7 @@
   end
   local.get $0
  )
- (func $~lib/array/Array<assert-nonnull/Foo | null>#__get (; 5 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<assert-nonnull/Foo | null>#__get (param $0 i32) (result i32)
   i32.const 0
   local.get $0
   i32.load offset=12
@@ -122,7 +121,7 @@
   i32.load offset=4
   i32.load
  )
- (func $assert-nonnull/testElem (; 6 ;) (param $0 i32) (result i32)
+ (func $assert-nonnull/testElem (param $0 i32) (result i32)
   local.get $0
   call $~lib/array/Array<assert-nonnull/Foo | null>#__get
   local.tee $0
@@ -137,7 +136,7 @@
   end
   local.get $0
  )
- (func $assert-nonnull/testAll (; 7 ;) (param $0 i32) (result i32)
+ (func $assert-nonnull/testAll (param $0 i32) (result i32)
   (local $1 i32)
   block $folding-inner0
    local.get $0
@@ -163,7 +162,7 @@
   call $~lib/builtins/abort
   unreachable
  )
- (func $assert-nonnull/testAll2 (; 8 ;) (param $0 i32) (result i32)
+ (func $assert-nonnull/testAll2 (param $0 i32) (result i32)
   (local $1 i32)
   block $folding-inner0
    local.get $0
@@ -189,17 +188,14 @@
   call $~lib/builtins/abort
   unreachable
  )
- (func $~setArgumentsLength (; 9 ;) (param $0 i32)
-  local.get $0
-  global.set $~argumentsLength
+ (func $~setArgumentsLength (param $0 i32)
+  nop
  )
- (func $assert-nonnull/testFn (; 10 ;) (param $0 i32) (result i32)
-  i32.const 0
-  global.set $~argumentsLength
+ (func $assert-nonnull/testFn (param $0 i32) (result i32)
   local.get $0
   call_indirect (type $none_=>_i32)
  )
- (func $assert-nonnull/testFn2 (; 11 ;) (param $0 i32) (result i32)
+ (func $assert-nonnull/testFn2 (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -210,15 +206,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 0
-  global.set $~argumentsLength
   local.get $0
   call_indirect (type $none_=>_i32)
  )
- (func $assert-nonnull/testRet (; 12 ;) (param $0 i32) (result i32)
+ (func $assert-nonnull/testRet (param $0 i32) (result i32)
   (local $1 i32)
-  i32.const 0
-  global.set $~argumentsLength
   local.get $0
   call_indirect (type $none_=>_i32)
   local.tee $0
@@ -233,17 +225,13 @@
    unreachable
   end
  )
- (func $assert-nonnull/testObjFn (; 13 ;) (param $0 i32) (result i32)
-  i32.const 0
-  global.set $~argumentsLength
+ (func $assert-nonnull/testObjFn (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   call_indirect (type $none_=>_i32)
  )
- (func $assert-nonnull/testObjRet (; 14 ;) (param $0 i32) (result i32)
+ (func $assert-nonnull/testObjRet (param $0 i32) (result i32)
   (local $1 i32)
-  i32.const 0
-  global.set $~argumentsLength
   local.get $0
   i32.load offset=4
   call_indirect (type $none_=>_i32)

--- a/tests/compiler/assert-nonnull.untouched.wat
+++ b/tests/compiler/assert-nonnull.untouched.wat
@@ -26,13 +26,13 @@
  (export "testRet" (func $assert-nonnull/testRet))
  (export "testObjFn" (func $assert-nonnull/testObjFn))
  (export "testObjRet" (func $assert-nonnull/testObjRet))
- (func $~lib/rt/stub/__retain (; 1 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/stub/__retain (param $0 i32) (result i32)
   local.get $0
  )
- (func $~lib/rt/stub/__release (; 2 ;) (param $0 i32)
+ (func $~lib/rt/stub/__release (param $0 i32)
   nop
  )
- (func $assert-nonnull/testVar (; 3 ;) (param $0 i32) (result i32)
+ (func $assert-nonnull/testVar (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   call $~lib/rt/stub/__retain
@@ -55,7 +55,7 @@
   call $~lib/rt/stub/__release
   local.get $1
  )
- (func $assert-nonnull/testObj (; 4 ;) (param $0 i32) (result i32)
+ (func $assert-nonnull/testObj (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   call $~lib/rt/stub/__retain
@@ -79,7 +79,7 @@
   call $~lib/rt/stub/__release
   local.get $1
  )
- (func $assert-nonnull/testProp (; 5 ;) (param $0 i32) (result i32)
+ (func $assert-nonnull/testProp (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   call $~lib/rt/stub/__retain
@@ -103,7 +103,7 @@
   call $~lib/rt/stub/__release
   local.get $1
  )
- (func $~lib/array/Array<assert-nonnull/Foo>#__unchecked_get (; 6 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<assert-nonnull/Foo>#__unchecked_get (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -113,7 +113,7 @@
   i32.load
   call $~lib/rt/stub/__retain
  )
- (func $~lib/array/Array<assert-nonnull/Foo>#__get (; 7 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<assert-nonnull/Foo>#__get (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   local.get $0
@@ -145,7 +145,7 @@
   end
   local.get $2
  )
- (func $assert-nonnull/testArr (; 8 ;) (param $0 i32) (result i32)
+ (func $assert-nonnull/testArr (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   call $~lib/rt/stub/__retain
@@ -169,7 +169,7 @@
   call $~lib/rt/stub/__release
   local.get $1
  )
- (func $~lib/array/Array<assert-nonnull/Foo | null>#__unchecked_get (; 9 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<assert-nonnull/Foo | null>#__unchecked_get (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -179,7 +179,7 @@
   i32.load
   call $~lib/rt/stub/__retain
  )
- (func $~lib/array/Array<assert-nonnull/Foo | null>#__get (; 10 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<assert-nonnull/Foo | null>#__get (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   local.get $0
@@ -199,7 +199,7 @@
   local.set $2
   local.get $2
  )
- (func $assert-nonnull/testElem (; 11 ;) (param $0 i32) (result i32)
+ (func $assert-nonnull/testElem (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   call $~lib/rt/stub/__retain
@@ -224,7 +224,7 @@
   call $~lib/rt/stub/__release
   local.get $1
  )
- (func $assert-nonnull/testAll (; 12 ;) (param $0 i32) (result i32)
+ (func $assert-nonnull/testAll (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -276,7 +276,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $assert-nonnull/testAll2 (; 13 ;) (param $0 i32) (result i32)
+ (func $assert-nonnull/testAll2 (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -328,11 +328,11 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $~setArgumentsLength (; 14 ;) (param $0 i32)
+ (func $~setArgumentsLength (param $0 i32)
   local.get $0
   global.set $~argumentsLength
  )
- (func $assert-nonnull/testFn (; 15 ;) (param $0 i32) (result i32)
+ (func $assert-nonnull/testFn (param $0 i32) (result i32)
   (local $1 i32)
   i32.const 0
   global.set $~argumentsLength
@@ -340,7 +340,7 @@
   call_indirect (type $none_=>_i32)
   local.tee $1
  )
- (func $assert-nonnull/testFn2 (; 16 ;) (param $0 i32) (result i32)
+ (func $assert-nonnull/testFn2 (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -362,7 +362,7 @@
   call_indirect (type $none_=>_i32)
   local.tee $1
  )
- (func $assert-nonnull/testRet (; 17 ;) (param $0 i32) (result i32)
+ (func $assert-nonnull/testRet (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   i32.const 0
@@ -387,7 +387,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $assert-nonnull/testObjFn (; 18 ;) (param $0 i32) (result i32)
+ (func $assert-nonnull/testObjFn (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -404,7 +404,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $assert-nonnull/testObjRet (; 19 ;) (param $0 i32) (result i32)
+ (func $assert-nonnull/testObjRet (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0

--- a/tests/compiler/binary.optimized.wat
+++ b/tests/compiler/binary.optimized.wat
@@ -3,14 +3,13 @@
  (type $f32_=>_f32 (func (param f32) (result f32)))
  (type $f64_=>_f64 (func (param f64) (result f64)))
  (memory $0 0)
- (global $binary/b (mut i32) (i32.const 0))
  (global $binary/i (mut i32) (i32.const 0))
  (global $binary/I (mut i64) (i64.const 0))
  (global $binary/f (mut f32) (f32.const 0))
  (global $binary/F (mut f64) (f64.const 0))
  (export "memory" (memory $0))
  (start $~start)
- (func $~lib/math/NativeMathf.mod (; 0 ;) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.mod (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -154,7 +153,7 @@
   local.get $0
   f32.mul
  )
- (func $~lib/math/NativeMath.mod (; 1 ;) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.mod (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i64)
   (local $3 i64)
@@ -305,35 +304,11 @@
   local.get $0
   f64.mul
  )
- (func $start:binary (; 2 ;)
+ (func $start:binary
   global.get $binary/i
   i32.const 1
   i32.rem_s
   drop
-  global.get $binary/i
-  i32.const 1
-  i32.lt_s
-  global.set $binary/b
-  global.get $binary/i
-  i32.const 1
-  i32.gt_s
-  global.set $binary/b
-  global.get $binary/i
-  i32.const 1
-  i32.le_s
-  global.set $binary/b
-  global.get $binary/i
-  i32.const 1
-  i32.ge_s
-  global.set $binary/b
-  global.get $binary/i
-  i32.const 1
-  i32.eq
-  global.set $binary/b
-  global.get $binary/i
-  i32.const 1
-  i32.eq
-  global.set $binary/b
   global.get $binary/i
   i32.const 1
   i32.add
@@ -416,30 +391,6 @@
   drop
   global.get $binary/I
   i64.const 1
-  i64.lt_s
-  global.set $binary/b
-  global.get $binary/I
-  i64.const 1
-  i64.gt_s
-  global.set $binary/b
-  global.get $binary/I
-  i64.const 1
-  i64.le_s
-  global.set $binary/b
-  global.get $binary/I
-  i64.const 1
-  i64.ge_s
-  global.set $binary/b
-  global.get $binary/I
-  i64.const 1
-  i64.eq
-  global.set $binary/b
-  global.get $binary/I
-  i64.const 1
-  i64.eq
-  global.set $binary/b
-  global.get $binary/I
-  i64.const 1
   i64.add
   global.set $binary/I
   global.get $binary/I
@@ -519,30 +470,6 @@
   drop
   global.get $binary/f
   f32.const 1
-  f32.lt
-  global.set $binary/b
-  global.get $binary/f
-  f32.const 1
-  f32.gt
-  global.set $binary/b
-  global.get $binary/f
-  f32.const 1
-  f32.le
-  global.set $binary/b
-  global.get $binary/f
-  f32.const 1
-  f32.ge
-  global.set $binary/b
-  global.get $binary/f
-  f32.const 1
-  f32.eq
-  global.set $binary/b
-  global.get $binary/f
-  f32.const 1
-  f32.eq
-  global.set $binary/b
-  global.get $binary/f
-  f32.const 1
   f32.add
   global.set $binary/f
   global.get $binary/f
@@ -568,30 +495,6 @@
   drop
   global.get $binary/F
   f64.const 1
-  f64.lt
-  global.set $binary/b
-  global.get $binary/F
-  f64.const 1
-  f64.gt
-  global.set $binary/b
-  global.get $binary/F
-  f64.const 1
-  f64.le
-  global.set $binary/b
-  global.get $binary/F
-  f64.const 1
-  f64.ge
-  global.set $binary/b
-  global.get $binary/F
-  f64.const 1
-  f64.eq
-  global.set $binary/b
-  global.get $binary/F
-  f64.const 1
-  f64.eq
-  global.set $binary/b
-  global.get $binary/F
-  f64.const 1
   f64.add
   global.set $binary/F
   global.get $binary/F
@@ -613,7 +516,7 @@
   call $~lib/math/NativeMath.mod
   global.set $binary/F
  )
- (func $~start (; 3 ;)
+ (func $~start
   call $start:binary
  )
 )

--- a/tests/compiler/binary.untouched.wat
+++ b/tests/compiler/binary.untouched.wat
@@ -17,7 +17,7 @@
  (global $binary/F (mut f64) (f64.const 0))
  (export "memory" (memory $0))
  (start $~start)
- (func $~lib/math/NativeMath.pow (; 0 ;) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.pow (param $0 f64) (param $1 f64) (result f64)
   (local $2 f64)
   (local $3 f64)
   (local $4 i32)
@@ -977,7 +977,7 @@
   end
   return
  )
- (func $~lib/math/NativeMathf.mod (; 1 ;) (param $0 f32) (param $1 f32) (result f32)
+ (func $~lib/math/NativeMathf.mod (param $0 f32) (param $1 f32) (result f32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1225,7 +1225,7 @@
   local.get $2
   f32.reinterpret_i32
  )
- (func $~lib/math/NativeMathf.pow (; 2 ;) (param $0 f32) (param $1 f32) (result f32)
+ (func $~lib/math/NativeMathf.pow (param $0 f32) (param $1 f32) (result f32)
   (local $2 f32)
   (local $3 f32)
   (local $4 i32)
@@ -1811,7 +1811,7 @@
   end
   return
  )
- (func $~lib/math/NativeMath.mod (; 3 ;) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.mod (param $0 f64) (param $1 f64) (result f64)
   (local $2 i64)
   (local $3 i64)
   (local $4 i64)
@@ -2065,7 +2065,7 @@
   local.get $2
   f64.reinterpret_i64
  )
- (func $start:binary (; 4 ;)
+ (func $start:binary
   global.get $binary/i
   i32.const 1
   i32.lt_s
@@ -2673,7 +2673,7 @@
   call $~lib/math/NativeMath.pow
   global.set $binary/F
  )
- (func $~start (; 5 ;)
+ (func $~start
   call $start:binary
  )
 )

--- a/tests/compiler/bool.untouched.wat
+++ b/tests/compiler/bool.untouched.wat
@@ -14,7 +14,7 @@
  (global $bool/uu (mut i32) (i32.const 2))
  (export "memory" (memory $0))
  (start $~start)
- (func $start:bool (; 1 ;)
+ (func $start:bool
   global.get $bool/i
   i32.const 0
   i32.ne
@@ -114,7 +114,7 @@
    unreachable
   end
  )
- (func $~start (; 2 ;)
+ (func $~start
   call $start:bool
  )
 )

--- a/tests/compiler/builtins.optimized.wat
+++ b/tests/compiler/builtins.optimized.wat
@@ -31,18 +31,14 @@
  (data (i32.const 1680) "\n\00\00\00\01\00\00\00\01\00\00\00\n\00\00\00u\00s\00i\00z\00e")
  (data (i32.const 1712) "\08\00\00\00\01\00\00\00\01\00\00\00\08\00\00\00v\00o\00i\00d")
  (data (i32.const 1744) "\14\00\00\00\01\00\00\00\01\00\00\00\14\00\00\00s\00o\00m\00e\00 \00v\00a\00l\00u\00e")
- (global $builtins/b (mut i32) (i32.const 0))
  (global $builtins/i (mut i32) (i32.const 0))
  (global $builtins/I (mut i64) (i64.const 0))
  (global $builtins/f (mut f32) (f32.const 0))
  (global $builtins/F (mut f64) (f64.const 0))
- (global $builtins/u (mut i32) (i32.const 0))
- (global $builtins/U (mut i64) (i64.const 0))
- (global $builtins/s (mut i32) (i32.const 0))
  (export "memory" (memory $0))
  (export "test" (func $start:builtins~anonymous|0))
  (start $~start)
- (func $~lib/atomics/Atomics.isLockFree (; 2 ;) (param $0 i32) (result i32)
+ (func $~lib/atomics/Atomics.isLockFree (param $0 i32) (result i32)
   i32.const 1
   local.get $0
   i32.const 4
@@ -57,7 +53,7 @@
   select
   select
  )
- (func $~lib/string/String#get:length (; 3 ;) (param $0 i32) (result i32)
+ (func $~lib/string/String#get:length (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub
@@ -65,7 +61,7 @@
   i32.const 1
   i32.shr_u
  )
- (func $~lib/util/string/compareImpl (; 4 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/compareImpl (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -141,7 +137,7 @@
   end
   i32.const 0
  )
- (func $~lib/string/String.__eq (; 5 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__eq (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -173,10 +169,10 @@
   end
   i32.const 0
  )
- (func $start:builtins~anonymous|0 (; 6 ;)
+ (func $start:builtins~anonymous|0
   nop
  )
- (func $start:builtins (; 7 ;)
+ (func $start:builtins
   i32.const 31
   global.set $builtins/i
   i32.const 0
@@ -231,10 +227,6 @@
   global.set $builtins/f
   f32.const 1
   global.set $builtins/f
-  i32.const 0
-  global.set $builtins/b
-  i32.const 1
-  global.set $builtins/b
   f64.const nan:0x8000000000000
   global.set $builtins/F
   f64.const inf
@@ -257,10 +249,6 @@
   global.set $builtins/F
   f64.const 1
   global.set $builtins/F
-  i32.const 0
-  global.set $builtins/b
-  i32.const 1
-  global.set $builtins/b
   f64.const 0
   global.set $builtins/F
   f32.const 1
@@ -365,22 +353,22 @@
   global.set $builtins/i
   i32.const 8
   i32.load8_u
-  global.set $builtins/u
+  drop
   i32.const 8
   i32.load16_u
-  global.set $builtins/u
+  drop
   i32.const 8
   i32.load
-  global.set $builtins/u
+  drop
   i32.const 8
   i32.load8_s
-  global.set $builtins/u
+  drop
   i32.const 8
   i32.load16_s
-  global.set $builtins/u
+  drop
   i32.const 8
   i32.load
-  global.set $builtins/u
+  drop
   i32.const 8
   i64.load8_s
   global.set $builtins/I
@@ -395,16 +383,16 @@
   global.set $builtins/I
   i32.const 8
   i64.load8_u
-  global.set $builtins/U
+  drop
   i32.const 8
   i64.load16_u
-  global.set $builtins/U
+  drop
   i32.const 8
   i64.load32_u
-  global.set $builtins/U
+  drop
   i32.const 8
   i64.load
-  global.set $builtins/U
+  drop
   i32.const 8
   i32.const 1
   i32.store8
@@ -443,10 +431,10 @@
   memory.grow
   drop
   memory.size
-  global.set $builtins/s
+  drop
   i32.const 1
   memory.grow
-  global.set $builtins/s
+  drop
   i32.const 10
   global.set $builtins/i
   i64.const 200
@@ -849,7 +837,7 @@
    unreachable
   end
  )
- (func $~start (; 8 ;)
+ (func $~start
   call $start:builtins
  )
 )

--- a/tests/compiler/builtins.untouched.wat
+++ b/tests/compiler/builtins.untouched.wat
@@ -77,7 +77,7 @@
  (export "memory" (memory $0))
  (export "test" (func $builtins/test))
  (start $~start)
- (func $~lib/atomics/Atomics.isLockFree (; 2 ;) (param $0 i32) (result i32)
+ (func $~lib/atomics/Atomics.isLockFree (param $0 i32) (result i32)
   local.get $0
   i32.const 1
   i32.eq
@@ -96,13 +96,13 @@
    i32.eq
   end
  )
- (func $~lib/rt/stub/__retain (; 3 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/stub/__retain (param $0 i32) (result i32)
   local.get $0
  )
- (func $~lib/rt/stub/__release (; 4 ;) (param $0 i32)
+ (func $~lib/rt/stub/__release (param $0 i32)
   nop
  )
- (func $~lib/string/String#get:length (; 5 ;) (param $0 i32) (result i32)
+ (func $~lib/string/String#get:length (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub
@@ -110,7 +110,7 @@
   i32.const 1
   i32.shr_u
  )
- (func $~lib/util/string/compareImpl (; 6 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
+ (func $~lib/util/string/compareImpl (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
@@ -232,7 +232,7 @@
   call $~lib/rt/stub/__release
   local.get $7
  )
- (func $~lib/string/String.__eq (; 7 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__eq (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -305,13 +305,13 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $start:builtins~anonymous|0 (; 8 ;)
+ (func $start:builtins~anonymous|0
   nop
  )
- (func $start:builtins~anonymous|1 (; 9 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $start:builtins~anonymous|1 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   nop
  )
- (func $start:builtins (; 10 ;)
+ (func $start:builtins
   (local $0 i32)
   (local $1 i32)
   (local $2 i64)
@@ -1869,10 +1869,10 @@
    unreachable
   end
  )
- (func $builtins/test (; 11 ;)
+ (func $builtins/test
   nop
  )
- (func $~start (; 12 ;)
+ (func $~start
   call $start:builtins
  )
 )

--- a/tests/compiler/call-inferred.optimized.wat
+++ b/tests/compiler/call-inferred.optimized.wat
@@ -1,18 +1,10 @@
 (module
- (type $none_=>_none (func))
  (type $i32_=>_none (func (param i32)))
  (memory $0 1)
  (data (i32.const 1024) " \00\00\00\01\00\00\00\01\00\00\00 \00\00\00c\00a\00l\00l\00-\00i\00n\00f\00e\00r\00r\00e\00d\00.\00t\00s")
- (global $~argumentsLength (mut i32) (i32.const 0))
  (export "__setArgumentsLength" (func $~setArgumentsLength))
  (export "memory" (memory $0))
- (start $~start)
- (func $~setArgumentsLength (; 0 ;) (param $0 i32)
-  local.get $0
-  global.set $~argumentsLength
- )
- (func $~start (; 1 ;)
-  i32.const 0
-  global.set $~argumentsLength
+ (func $~setArgumentsLength (param $0 i32)
+  nop
  )
 )

--- a/tests/compiler/call-inferred.untouched.wat
+++ b/tests/compiler/call-inferred.untouched.wat
@@ -13,19 +13,19 @@
  (export "__setArgumentsLength" (func $~setArgumentsLength))
  (export "memory" (memory $0))
  (start $~start)
- (func $call-inferred/foo<i32> (; 1 ;) (param $0 i32) (result i32)
+ (func $call-inferred/foo<i32> (param $0 i32) (result i32)
   local.get $0
  )
- (func $call-inferred/foo<f64> (; 2 ;) (param $0 f64) (result f64)
+ (func $call-inferred/foo<f64> (param $0 f64) (result f64)
   local.get $0
  )
- (func $call-inferred/foo<f32> (; 3 ;) (param $0 f32) (result f32)
+ (func $call-inferred/foo<f32> (param $0 f32) (result f32)
   local.get $0
  )
- (func $call-inferred/bar<f32> (; 4 ;) (param $0 f32) (result f32)
+ (func $call-inferred/bar<f32> (param $0 f32) (result f32)
   local.get $0
  )
- (func $call-inferred/bar<f32>|trampoline (; 5 ;) (param $0 f32) (result f32)
+ (func $call-inferred/bar<f32>|trampoline (param $0 f32) (result f32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -40,11 +40,11 @@
   local.get $0
   call $call-inferred/bar<f32>
  )
- (func $~setArgumentsLength (; 6 ;) (param $0 i32)
+ (func $~setArgumentsLength (param $0 i32)
   local.get $0
   global.set $~argumentsLength
  )
- (func $start:call-inferred (; 7 ;)
+ (func $start:call-inferred
   i32.const 42
   call $call-inferred/foo<i32>
   i32.const 42
@@ -100,7 +100,7 @@
    unreachable
   end
  )
- (func $~start (; 8 ;)
+ (func $~start
   call $start:call-inferred
  )
 )

--- a/tests/compiler/call-optional.optimized.wat
+++ b/tests/compiler/call-optional.optimized.wat
@@ -10,14 +10,14 @@
  (export "__setArgumentsLength" (func $~setArgumentsLength))
  (export "memory" (memory $0))
  (start $~start)
- (func $call-optional/opt (; 1 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $call-optional/opt (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $2
   local.get $0
   local.get $1
   i32.add
   i32.add
  )
- (func $call-optional/opt|trampoline (; 2 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $call-optional/opt|trampoline (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $2of2
    block $1of2
     block $0of2
@@ -40,11 +40,11 @@
   local.get $2
   call $call-optional/opt
  )
- (func $~setArgumentsLength (; 3 ;) (param $0 i32)
+ (func $~setArgumentsLength (param $0 i32)
   local.get $0
   global.set $~argumentsLength
  )
- (func $start:call-optional (; 4 ;)
+ (func $start:call-optional
   i32.const 1
   global.set $~argumentsLength
   i32.const 3
@@ -136,7 +136,7 @@
    unreachable
   end
  )
- (func $~start (; 5 ;)
+ (func $~start
   call $start:call-optional
  )
 )

--- a/tests/compiler/call-optional.untouched.wat
+++ b/tests/compiler/call-optional.untouched.wat
@@ -13,14 +13,14 @@
  (export "__setArgumentsLength" (func $~setArgumentsLength))
  (export "memory" (memory $0))
  (start $~start)
- (func $call-optional/opt (; 1 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $call-optional/opt (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   local.get $1
   i32.add
   local.get $2
   i32.add
  )
- (func $call-optional/opt|trampoline (; 2 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $call-optional/opt|trampoline (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $2of2
    block $1of2
     block $0of2
@@ -43,11 +43,11 @@
   local.get $2
   call $call-optional/opt
  )
- (func $~setArgumentsLength (; 3 ;) (param $0 i32)
+ (func $~setArgumentsLength (param $0 i32)
   local.get $0
   global.set $~argumentsLength
  )
- (func $start:call-optional (; 4 ;)
+ (func $start:call-optional
   i32.const 1
   global.set $~argumentsLength
   i32.const 3
@@ -152,7 +152,7 @@
    unreachable
   end
  )
- (func $~start (; 5 ;)
+ (func $~start
   call $start:call-optional
  )
 )

--- a/tests/compiler/call-super.optimized.wat
+++ b/tests/compiler/call-super.optimized.wat
@@ -5,11 +5,10 @@
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 1024) "\1a\00\00\00\01\00\00\00\01\00\00\00\1a\00\00\00c\00a\00l\00l\00-\00s\00u\00p\00e\00r\00.\00t\00s")
- (global $~lib/rt/stub/startOffset (mut i32) (i32.const 0))
  (global $~lib/rt/stub/offset (mut i32) (i32.const 0))
  (export "memory" (memory $0))
  (start $~start)
- (func $~lib/rt/stub/__alloc (; 1 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/stub/__alloc (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -93,10 +92,8 @@
   i32.store offset=12
   local.get $4
  )
- (func $~start (; 2 ;)
+ (func $~start
   (local $0 i32)
-  i32.const 1072
-  global.set $~lib/rt/stub/startOffset
   i32.const 1072
   global.set $~lib/rt/stub/offset
   i32.const 8

--- a/tests/compiler/call-super.untouched.wat
+++ b/tests/compiler/call-super.untouched.wat
@@ -13,7 +13,7 @@
  (global $~lib/heap/__heap_base i32 (i32.const 60))
  (export "memory" (memory $0))
  (start $~start)
- (func $~lib/rt/stub/maybeGrowMemory (; 1 ;) (param $0 i32)
+ (func $~lib/rt/stub/maybeGrowMemory (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -67,7 +67,7 @@
   local.get $0
   global.set $~lib/rt/stub/offset
  )
- (func $~lib/rt/stub/__alloc (; 2 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/stub/__alloc (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -120,10 +120,10 @@
   i32.store offset=12
   local.get $2
  )
- (func $~lib/rt/stub/__retain (; 3 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/stub/__retain (param $0 i32) (result i32)
   local.get $0
  )
- (func $call-super/A#constructor (; 4 ;) (param $0 i32) (result i32)
+ (func $call-super/A#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -151,7 +151,7 @@
   end
   local.get $0
  )
- (func $call-super/B#constructor (; 5 ;) (param $0 i32) (result i32)
+ (func $call-super/B#constructor (param $0 i32) (result i32)
   local.get $0
   if (result i32)
    local.get $0
@@ -194,10 +194,10 @@
   end
   local.get $0
  )
- (func $~lib/rt/stub/__release (; 6 ;) (param $0 i32)
+ (func $~lib/rt/stub/__release (param $0 i32)
   nop
  )
- (func $call-super/test1 (; 7 ;)
+ (func $call-super/test1
   (local $0 i32)
   i32.const 0
   call $call-super/B#constructor
@@ -231,7 +231,7 @@
   local.get $0
   call $~lib/rt/stub/__release
  )
- (func $call-super/C#constructor (; 8 ;) (param $0 i32) (result i32)
+ (func $call-super/C#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -246,7 +246,7 @@
   i32.store
   local.get $0
  )
- (func $call-super/D#constructor (; 9 ;) (param $0 i32) (result i32)
+ (func $call-super/D#constructor (param $0 i32) (result i32)
   local.get $0
   if (result i32)
    local.get $0
@@ -289,7 +289,7 @@
   end
   local.get $0
  )
- (func $call-super/test2 (; 10 ;)
+ (func $call-super/test2
   (local $0 i32)
   i32.const 0
   call $call-super/D#constructor
@@ -323,7 +323,7 @@
   local.get $0
   call $~lib/rt/stub/__release
  )
- (func $call-super/E#constructor (; 11 ;) (param $0 i32) (result i32)
+ (func $call-super/E#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -351,7 +351,7 @@
   end
   local.get $0
  )
- (func $call-super/F#constructor (; 12 ;) (param $0 i32) (result i32)
+ (func $call-super/F#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -369,7 +369,7 @@
   i32.store offset=4
   local.get $0
  )
- (func $call-super/test3 (; 13 ;)
+ (func $call-super/test3
   (local $0 i32)
   i32.const 0
   call $call-super/F#constructor
@@ -403,7 +403,7 @@
   local.get $0
   call $~lib/rt/stub/__release
  )
- (func $call-super/G#constructor (; 14 ;) (param $0 i32) (result i32)
+ (func $call-super/G#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -418,7 +418,7 @@
   i32.store
   local.get $0
  )
- (func $call-super/H#constructor (; 15 ;) (param $0 i32) (result i32)
+ (func $call-super/H#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -436,7 +436,7 @@
   i32.store offset=4
   local.get $0
  )
- (func $call-super/test4 (; 16 ;)
+ (func $call-super/test4
   (local $0 i32)
   i32.const 0
   call $call-super/H#constructor
@@ -470,7 +470,7 @@
   local.get $0
   call $~lib/rt/stub/__release
  )
- (func $call-super/I#constructor (; 17 ;) (param $0 i32) (result i32)
+ (func $call-super/I#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -485,7 +485,7 @@
   i32.store
   local.get $0
  )
- (func $call-super/J#constructor (; 18 ;) (param $0 i32) (result i32)
+ (func $call-super/J#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -503,7 +503,7 @@
   i32.store offset=4
   local.get $0
  )
- (func $call-super/test5 (; 19 ;)
+ (func $call-super/test5
   (local $0 i32)
   i32.const 0
   call $call-super/J#constructor
@@ -537,7 +537,7 @@
   local.get $0
   call $~lib/rt/stub/__release
  )
- (func $start:call-super (; 20 ;)
+ (func $start:call-super
   global.get $~lib/heap/__heap_base
   i32.const 15
   i32.add
@@ -554,7 +554,7 @@
   call $call-super/test4
   call $call-super/test5
  )
- (func $~start (; 21 ;)
+ (func $~start
   call $start:call-super
  )
 )

--- a/tests/compiler/class-extends.optimized.wat
+++ b/tests/compiler/class-extends.optimized.wat
@@ -3,7 +3,7 @@
  (memory $0 0)
  (export "memory" (memory $0))
  (export "test" (func $class-extends/test))
- (func $class-extends/test (; 0 ;) (param $0 i32)
+ (func $class-extends/test (param $0 i32)
   local.get $0
   i32.load
   drop

--- a/tests/compiler/class-extends.untouched.wat
+++ b/tests/compiler/class-extends.untouched.wat
@@ -5,13 +5,13 @@
  (table $0 1 funcref)
  (export "memory" (memory $0))
  (export "test" (func $class-extends/test))
- (func $~lib/rt/stub/__retain (; 0 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/stub/__retain (param $0 i32) (result i32)
   local.get $0
  )
- (func $~lib/rt/stub/__release (; 1 ;) (param $0 i32)
+ (func $~lib/rt/stub/__release (param $0 i32)
   nop
  )
- (func $class-extends/test (; 2 ;) (param $0 i32)
+ (func $class-extends/test (param $0 i32)
   local.get $0
   call $~lib/rt/stub/__retain
   local.set $0

--- a/tests/compiler/class-overloading.optimized.wat
+++ b/tests/compiler/class-overloading.optimized.wat
@@ -3,7 +3,7 @@
  (memory $0 0)
  (export "memory" (memory $0))
  (export "test" (func $class-overloading/test))
- (func $class-overloading/test (; 0 ;) (param $0 i32)
+ (func $class-overloading/test (param $0 i32)
   nop
  )
 )

--- a/tests/compiler/class-overloading.untouched.wat
+++ b/tests/compiler/class-overloading.untouched.wat
@@ -7,16 +7,16 @@
  (export "memory" (memory $0))
  (export "test" (func $class-overloading/test))
  (start $~start)
- (func $~lib/rt/stub/__retain (; 0 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/stub/__retain (param $0 i32) (result i32)
   local.get $0
  )
- (func $class-overloading/Foo#baz (; 1 ;) (param $0 i32)
+ (func $class-overloading/Foo#baz (param $0 i32)
   nop
  )
- (func $~lib/rt/stub/__release (; 2 ;) (param $0 i32)
+ (func $~lib/rt/stub/__release (param $0 i32)
   nop
  )
- (func $class-overloading/test (; 3 ;) (param $0 i32)
+ (func $class-overloading/test (param $0 i32)
   local.get $0
   call $~lib/rt/stub/__retain
   local.set $0
@@ -25,11 +25,11 @@
   local.get $0
   call $~lib/rt/stub/__release
  )
- (func $start:class-overloading (; 4 ;)
+ (func $start:class-overloading
   i32.const 0
   call $class-overloading/test
  )
- (func $~start (; 5 ;)
+ (func $~start
   call $start:class-overloading
  )
 )

--- a/tests/compiler/class-static-function.optimized.wat
+++ b/tests/compiler/class-static-function.optimized.wat
@@ -1,18 +1,10 @@
 (module
- (type $none_=>_none (func))
  (type $i32_=>_none (func (param i32)))
  (memory $0 1)
  (data (i32.const 1024) "0\00\00\00\01\00\00\00\01\00\00\000\00\00\00c\00l\00a\00s\00s\00-\00s\00t\00a\00t\00i\00c\00-\00f\00u\00n\00c\00t\00i\00o\00n\00.\00t\00s")
- (global $~argumentsLength (mut i32) (i32.const 0))
  (export "__setArgumentsLength" (func $~setArgumentsLength))
  (export "memory" (memory $0))
- (start $~start)
- (func $~setArgumentsLength (; 0 ;) (param $0 i32)
-  local.get $0
-  global.set $~argumentsLength
- )
- (func $~start (; 1 ;)
-  i32.const 0
-  global.set $~argumentsLength
+ (func $~setArgumentsLength (param $0 i32)
+  nop
  )
 )

--- a/tests/compiler/class-static-function.untouched.wat
+++ b/tests/compiler/class-static-function.untouched.wat
@@ -13,20 +13,20 @@
  (export "__setArgumentsLength" (func $~setArgumentsLength))
  (export "memory" (memory $0))
  (start $~start)
- (func $class-static-function/Example.staticFunc (; 1 ;) (result i32)
+ (func $class-static-function/Example.staticFunc (result i32)
   i32.const 42
  )
- (func $~setArgumentsLength (; 2 ;) (param $0 i32)
+ (func $~setArgumentsLength (param $0 i32)
   local.get $0
   global.set $~argumentsLength
  )
- (func $class-static-function/call (; 3 ;) (param $0 i32) (result i32)
+ (func $class-static-function/call (param $0 i32) (result i32)
   i32.const 0
   global.set $~argumentsLength
   local.get $0
   call_indirect (type $none_=>_i32)
  )
- (func $start:class-static-function (; 4 ;)
+ (func $start:class-static-function
   i32.const 1
   call $class-static-function/call
   i32.const 42
@@ -41,7 +41,7 @@
    unreachable
   end
  )
- (func $~start (; 5 ;)
+ (func $~start
   call $start:class-static-function
  )
 )

--- a/tests/compiler/class.optimized.wat
+++ b/tests/compiler/class.optimized.wat
@@ -5,13 +5,12 @@
  (memory $0 1)
  (data (i32.const 1024) "\1c\00\00\00\01\00\00\00\01\00\00\00\1c\00\00\00I\00n\00v\00a\00l\00i\00d\00 \00l\00e\00n\00g\00t\00h")
  (data (i32.const 1072) "\1a\00\00\00\01\00\00\00\01\00\00\00\1a\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00.\00t\00s")
- (global $~lib/rt/stub/startOffset (mut i32) (i32.const 0))
  (global $~lib/rt/stub/offset (mut i32) (i32.const 0))
  (export "memory" (memory $0))
  (export "test" (func $class/test))
  (export "testGenericInitializer" (func $class/testGenericInitializer))
  (start $~start)
- (func $class/test (; 0 ;) (param $0 i32) (result i32)
+ (func $class/test (param $0 i32) (result i32)
   local.get $0
   i32.load
   drop
@@ -32,7 +31,7 @@
   i32.store8 offset=6
   local.get $0
  )
- (func $~lib/rt/stub/__alloc (; 1 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/stub/__alloc (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -116,7 +115,7 @@
   i32.store offset=12
   local.get $4
  )
- (func $class/testGenericInitializer (; 2 ;)
+ (func $class/testGenericInitializer
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -160,9 +159,7 @@
   local.get $0
   i32.store
  )
- (func $~start (; 3 ;)
-  i32.const 1120
-  global.set $~lib/rt/stub/startOffset
+ (func $~start
   i32.const 1120
   global.set $~lib/rt/stub/offset
  )

--- a/tests/compiler/class.untouched.wat
+++ b/tests/compiler/class.untouched.wat
@@ -22,14 +22,14 @@
  (export "test" (func $class/test))
  (export "testGenericInitializer" (func $class/testGenericInitializer))
  (start $~start)
- (func $class/Animal.add (; 1 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $class/Animal.add (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.add
   global.get $class/Animal.ONE
   i32.add
  )
- (func $class/Animal.sub<f32> (; 2 ;) (param $0 f32) (param $1 f32) (result f32)
+ (func $class/Animal.sub<f32> (param $0 f32) (param $1 f32) (result f32)
   local.get $0
   local.get $1
   f32.sub
@@ -37,7 +37,7 @@
   f32.convert_i32_s
   f32.add
  )
- (func $start:class (; 3 ;)
+ (func $start:class
   global.get $class/Animal.ONE
   drop
   i32.const 1
@@ -49,17 +49,17 @@
   call $class/Animal.sub<f32>
   drop
  )
- (func $~lib/rt/stub/__retain (; 4 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/stub/__retain (param $0 i32) (result i32)
   local.get $0
  )
- (func $class/Animal<f64>#instanceAdd (; 5 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $class/Animal<f64>#instanceAdd (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $1
   local.get $2
   i32.add
   global.get $class/Animal.ONE
   i32.add
  )
- (func $class/Animal<f64>#instanceSub<f32> (; 6 ;) (param $0 i32) (param $1 f32) (param $2 f32) (result f32)
+ (func $class/Animal<f64>#instanceSub<f32> (param $0 i32) (param $1 f32) (param $2 f32) (result f32)
   local.get $1
   local.get $2
   f32.sub
@@ -67,10 +67,10 @@
   f32.convert_i32_s
   f32.add
  )
- (func $~lib/rt/stub/__release (; 7 ;) (param $0 i32)
+ (func $~lib/rt/stub/__release (param $0 i32)
   nop
  )
- (func $class/test (; 8 ;) (param $0 i32) (result i32)
+ (func $class/test (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -124,7 +124,7 @@
   call $~lib/rt/stub/__release
   local.get $3
  )
- (func $~lib/rt/stub/maybeGrowMemory (; 9 ;) (param $0 i32)
+ (func $~lib/rt/stub/maybeGrowMemory (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -178,7 +178,7 @@
   local.get $0
   global.set $~lib/rt/stub/offset
  )
- (func $~lib/rt/stub/__alloc (; 10 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/stub/__alloc (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -231,7 +231,7 @@
   i32.store offset=12
   local.get $2
  )
- (func $~lib/memory/memory.fill (; 11 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/memory/memory.fill (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -440,7 +440,7 @@
    end
   end
  )
- (func $~lib/array/Array<i32>#constructor (; 12 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#constructor (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -518,7 +518,7 @@
   i32.store offset=12
   local.get $0
  )
- (func $class/GenericInitializer<i32>#constructor (; 13 ;) (param $0 i32) (result i32)
+ (func $class/GenericInitializer<i32>#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -535,12 +535,12 @@
   i32.store
   local.get $0
  )
- (func $class/testGenericInitializer (; 14 ;)
+ (func $class/testGenericInitializer
   i32.const 0
   call $class/GenericInitializer<i32>#constructor
   call $~lib/rt/stub/__release
  )
- (func $~start (; 15 ;)
+ (func $~start
   call $start:class
   global.get $~lib/heap/__heap_base
   i32.const 15

--- a/tests/compiler/comma.optimized.wat
+++ b/tests/compiler/comma.optimized.wat
@@ -8,7 +8,7 @@
  (global $comma/b (mut i32) (i32.const 0))
  (export "memory" (memory $0))
  (start $~start)
- (func $start:comma (; 1 ;)
+ (func $start:comma
   (local $0 i32)
   (local $1 i32)
   global.get $comma/a
@@ -130,7 +130,7 @@
    unreachable
   end
  )
- (func $~start (; 2 ;)
+ (func $~start
   call $start:comma
  )
 )

--- a/tests/compiler/comma.untouched.wat
+++ b/tests/compiler/comma.untouched.wat
@@ -9,7 +9,7 @@
  (global $comma/b (mut i32) (i32.const 0))
  (export "memory" (memory $0))
  (start $~start)
- (func $start:comma (; 1 ;)
+ (func $start:comma
   (local $0 i32)
   (local $1 i32)
   global.get $comma/a
@@ -181,7 +181,7 @@
   i32.const 3
   drop
  )
- (func $~start (; 2 ;)
+ (func $~start
   call $start:comma
  )
 )

--- a/tests/compiler/constructor.optimized.wat
+++ b/tests/compiler/constructor.optimized.wat
@@ -2,21 +2,10 @@
  (type $none_=>_none (func))
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (memory $0 0)
- (global $~lib/rt/stub/startOffset (mut i32) (i32.const 0))
  (global $~lib/rt/stub/offset (mut i32) (i32.const 0))
- (global $constructor/emptyCtor (mut i32) (i32.const 0))
- (global $constructor/emptyCtorWithFieldInit (mut i32) (i32.const 0))
- (global $constructor/emptyCtorWithFieldNoInit (mut i32) (i32.const 0))
- (global $constructor/none (mut i32) (i32.const 0))
- (global $constructor/justFieldInit (mut i32) (i32.const 0))
- (global $constructor/justFieldNoInit (mut i32) (i32.const 0))
- (global $constructor/ctorReturns (mut i32) (i32.const 0))
- (global $constructor/ctorConditionallyReturns (mut i32) (i32.const 0))
- (global $constructor/ctorAllocates (mut i32) (i32.const 0))
- (global $constructor/ctorConditionallyAllocates (mut i32) (i32.const 0))
  (export "memory" (memory $0))
  (start $~start)
- (func $~lib/rt/stub/__alloc (; 0 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/stub/__alloc (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -100,72 +89,50 @@
   i32.store offset=12
   local.get $4
  )
- (func $~start (; 1 ;)
-  (local $0 i32)
-  i32.const 1024
-  global.set $~lib/rt/stub/startOffset
+ (func $~start
   i32.const 1024
   global.set $~lib/rt/stub/offset
   i32.const 0
   i32.const 3
   call $~lib/rt/stub/__alloc
-  global.set $constructor/emptyCtor
+  drop
   i32.const 4
   i32.const 4
   call $~lib/rt/stub/__alloc
-  local.tee $0
   i32.const 1
   i32.store
-  local.get $0
-  global.set $constructor/emptyCtorWithFieldInit
   i32.const 4
   i32.const 5
   call $~lib/rt/stub/__alloc
-  local.tee $0
   i32.const 0
   i32.store
-  local.get $0
-  global.set $constructor/emptyCtorWithFieldNoInit
   i32.const 0
   i32.const 6
   call $~lib/rt/stub/__alloc
-  global.set $constructor/none
+  drop
   i32.const 4
   i32.const 7
   call $~lib/rt/stub/__alloc
-  local.tee $0
   i32.const 1
   i32.store
-  local.get $0
-  global.set $constructor/justFieldInit
   i32.const 4
   i32.const 8
   call $~lib/rt/stub/__alloc
-  local.tee $0
   i32.const 0
   i32.store
-  local.get $0
-  global.set $constructor/justFieldNoInit
-  i32.const 0
-  global.set $constructor/ctorReturns
-  i32.const 0
-  global.set $constructor/ctorConditionallyReturns
   i32.const 0
   i32.const 11
   call $~lib/rt/stub/__alloc
-  global.set $constructor/ctorAllocates
+  drop
   i32.const 0
   i32.const 12
   call $~lib/rt/stub/__alloc
-  local.tee $0
   i32.eqz
   if
    i32.const 0
    i32.const 12
    call $~lib/rt/stub/__alloc
-   local.set $0
+   drop
   end
-  local.get $0
-  global.set $constructor/ctorConditionallyAllocates
  )
 )

--- a/tests/compiler/constructor.untouched.wat
+++ b/tests/compiler/constructor.untouched.wat
@@ -21,7 +21,7 @@
  (global $~lib/heap/__heap_base i32 (i32.const 8))
  (export "memory" (memory $0))
  (start $~start)
- (func $~lib/rt/stub/maybeGrowMemory (; 0 ;) (param $0 i32)
+ (func $~lib/rt/stub/maybeGrowMemory (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -75,7 +75,7 @@
   local.get $0
   global.set $~lib/rt/stub/offset
  )
- (func $~lib/rt/stub/__alloc (; 1 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/stub/__alloc (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -128,10 +128,10 @@
   i32.store offset=12
   local.get $2
  )
- (func $~lib/rt/stub/__retain (; 2 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/stub/__retain (param $0 i32) (result i32)
   local.get $0
  )
- (func $constructor/EmptyCtor#constructor (; 3 ;) (param $0 i32) (result i32)
+ (func $constructor/EmptyCtor#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -143,7 +143,7 @@
   end
   local.get $0
  )
- (func $constructor/EmptyCtorWithFieldInit#constructor (; 4 ;) (param $0 i32) (result i32)
+ (func $constructor/EmptyCtorWithFieldInit#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -158,7 +158,7 @@
   i32.store
   local.get $0
  )
- (func $constructor/EmptyCtorWithFieldNoInit#constructor (; 5 ;) (param $0 i32) (result i32)
+ (func $constructor/EmptyCtorWithFieldNoInit#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -173,7 +173,7 @@
   i32.store
   local.get $0
  )
- (func $constructor/None#constructor (; 6 ;) (param $0 i32) (result i32)
+ (func $constructor/None#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -185,7 +185,7 @@
   end
   local.get $0
  )
- (func $constructor/JustFieldInit#constructor (; 7 ;) (param $0 i32) (result i32)
+ (func $constructor/JustFieldInit#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -200,7 +200,7 @@
   i32.store
   local.get $0
  )
- (func $constructor/JustFieldNoInit#constructor (; 8 ;) (param $0 i32) (result i32)
+ (func $constructor/JustFieldNoInit#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -215,11 +215,11 @@
   i32.store
   local.get $0
  )
- (func $constructor/CtorReturns#constructor (; 9 ;) (param $0 i32) (result i32)
+ (func $constructor/CtorReturns#constructor (param $0 i32) (result i32)
   i32.const 0
   call $~lib/rt/stub/__retain
  )
- (func $constructor/CtorConditionallyReturns#constructor (; 10 ;) (param $0 i32) (result i32)
+ (func $constructor/CtorConditionallyReturns#constructor (param $0 i32) (result i32)
   global.get $constructor/b
   if
    i32.const 0
@@ -237,7 +237,7 @@
   end
   local.get $0
  )
- (func $constructor/CtorAllocates#constructor (; 11 ;) (param $0 i32) (result i32)
+ (func $constructor/CtorAllocates#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -251,7 +251,7 @@
   drop
   local.get $0
  )
- (func $constructor/CtorConditionallyAllocates#constructor (; 12 ;) (param $0 i32) (result i32)
+ (func $constructor/CtorConditionallyAllocates#constructor (param $0 i32) (result i32)
   global.get $constructor/b
   if
    local.get $0
@@ -277,7 +277,7 @@
   end
   local.get $0
  )
- (func $start:constructor (; 13 ;)
+ (func $start:constructor
   global.get $~lib/heap/__heap_base
   i32.const 15
   i32.add
@@ -319,7 +319,7 @@
   call $constructor/CtorConditionallyAllocates#constructor
   global.set $constructor/ctorConditionallyAllocates
  )
- (func $~start (; 14 ;)
+ (func $~start
   call $start:constructor
  )
 )

--- a/tests/compiler/continue.optimized.wat
+++ b/tests/compiler/continue.optimized.wat
@@ -3,7 +3,7 @@
  (memory $0 0)
  (export "memory" (memory $0))
  (export "testInherit" (func $continue/testInherit))
- (func $continue/testInherit (; 0 ;) (param $0 i32)
+ (func $continue/testInherit (param $0 i32)
   (local $1 i32)
   loop $for-loop|0
    local.get $1

--- a/tests/compiler/continue.untouched.wat
+++ b/tests/compiler/continue.untouched.wat
@@ -4,7 +4,7 @@
  (table $0 1 funcref)
  (export "memory" (memory $0))
  (export "testInherit" (func $continue/testInherit))
- (func $continue/testInherit (; 0 ;) (param $0 i32)
+ (func $continue/testInherit (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   i32.const 0

--- a/tests/compiler/declare.optimized.wat
+++ b/tests/compiler/declare.optimized.wat
@@ -10,7 +10,7 @@
  (data (i32.const 1024) "\14\00\00\00\01\00\00\00\01\00\00\00\14\00\00\00d\00e\00c\00l\00a\00r\00e\00.\00t\00s")
  (export "memory" (memory $0))
  (start $~start)
- (func $~start (; 3 ;)
+ (func $~start
   call $declare/externalFunction
   global.get $declare/externalConstant
   i32.const 1

--- a/tests/compiler/declare.untouched.wat
+++ b/tests/compiler/declare.untouched.wat
@@ -11,7 +11,7 @@
  (table $0 1 funcref)
  (export "memory" (memory $0))
  (start $~start)
- (func $start:declare (; 3 ;)
+ (func $start:declare
   call $declare/externalFunction
   global.get $declare/externalConstant
   i32.const 1
@@ -39,7 +39,7 @@
    unreachable
   end
  )
- (func $~start (; 4 ;)
+ (func $~start
   call $start:declare
  )
 )

--- a/tests/compiler/do.optimized.wat
+++ b/tests/compiler/do.optimized.wat
@@ -22,7 +22,7 @@
  (global $~started (mut i32) (i32.const 0))
  (export "_start" (func $~start))
  (export "memory" (memory $0))
- (func $do/testNested (; 5 ;)
+ (func $do/testNested
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -105,7 +105,7 @@
   i32.const 1
   global.set $do/ran
  )
- (func $~lib/rt/tlsf/removeBlock (; 6 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/removeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -267,7 +267,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/insertBlock (; 7 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/insertBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -546,7 +546,7 @@
   i32.or
   i32.store offset=4
  )
- (func $~lib/rt/tlsf/addMemory (; 8 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $2
@@ -660,7 +660,7 @@
   local.get $1
   call $~lib/rt/tlsf/insertBlock
  )
- (func $~lib/rt/tlsf/maybeInitialize (; 9 ;) (result i32)
+ (func $~lib/rt/tlsf/maybeInitialize (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -747,7 +747,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/tlsf/searchBlock (; 10 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/tlsf/searchBlock (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   nop
@@ -805,7 +805,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/allocateBlock (; 11 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/tlsf/allocateBlock (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -977,7 +977,7 @@
   call $~lib/rt/rtrace/onalloc
   local.get $1
  )
- (func $do/Ref#constructor (; 12 ;) (result i32)
+ (func $do/Ref#constructor (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -1033,7 +1033,7 @@
   end
   local.get $1
  )
- (func $~lib/rt/pure/__release (; 13 ;) (param $0 i32)
+ (func $~lib/rt/pure/__release (param $0 i32)
   local.get $0
   i32.const 1216
   i32.gt_u
@@ -1044,7 +1044,7 @@
    call $~lib/rt/pure/decrement
   end
  )
- (func $start:do (; 14 ;)
+ (func $start:do
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -1389,7 +1389,7 @@
    unreachable
   end
  )
- (func $~start (; 15 ;)
+ (func $~start
   global.get $~started
   if
    return
@@ -1399,7 +1399,7 @@
   end
   call $start:do
  )
- (func $~lib/rt/pure/decrement (; 16 ;) (param $0 i32)
+ (func $~lib/rt/pure/decrement (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0

--- a/tests/compiler/do.untouched.wat
+++ b/tests/compiler/do.untouched.wat
@@ -28,7 +28,7 @@
  (global $~lib/heap/__heap_base i32 (i32.const 208))
  (export "_start" (func $~start))
  (export "memory" (memory $0))
- (func $do/testSimple (; 5 ;)
+ (func $do/testSimple
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -77,7 +77,7 @@
   i32.const 1
   global.set $do/ran
  )
- (func $do/testEmpty (; 6 ;)
+ (func $do/testEmpty
   (local $0 i32)
   (local $1 i32)
   i32.const 10
@@ -109,7 +109,7 @@
   i32.const 1
   global.set $do/ran
  )
- (func $do/testNested (; 7 ;)
+ (func $do/testNested
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -211,7 +211,7 @@
   i32.const 1
   global.set $do/ran
  )
- (func $do/testAlwaysTrue (; 8 ;)
+ (func $do/testAlwaysTrue
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -248,7 +248,7 @@
   i32.const 1
   global.set $do/ran
  )
- (func $do/testAlwaysTrueNeverBreaks (; 9 ;) (result i32)
+ (func $do/testAlwaysTrueNeverBreaks (result i32)
   (local $0 i32)
   i32.const 0
   local.set $0
@@ -267,7 +267,7 @@
   end
   unreachable
  )
- (func $do/testAlwaysFalse (; 10 ;)
+ (func $do/testAlwaysFalse
   (local $0 i32)
   i32.const 0
   local.set $0
@@ -292,7 +292,7 @@
   i32.const 1
   global.set $do/ran
  )
- (func $do/testAlwaysBreaks (; 11 ;)
+ (func $do/testAlwaysBreaks
   (local $0 i32)
   i32.const 0
   local.set $0
@@ -321,7 +321,7 @@
   i32.const 1
   global.set $do/ran
  )
- (func $do/testAlwaysReturns (; 12 ;)
+ (func $do/testAlwaysReturns
   (local $0 i32)
   i32.const 0
   local.set $0
@@ -336,7 +336,7 @@
   end
   unreachable
  )
- (func $do/testContinue (; 13 ;)
+ (func $do/testContinue
   (local $0 i32)
   i32.const 0
   local.set $0
@@ -370,7 +370,7 @@
   i32.const 1
   global.set $do/ran
  )
- (func $do/testNestedContinue (; 14 ;)
+ (func $do/testNestedContinue
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -436,7 +436,7 @@
   i32.const 1
   global.set $do/ran
  )
- (func $~lib/rt/tlsf/removeBlock (; 15 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/removeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -646,7 +646,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/insertBlock (; 16 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/insertBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -996,7 +996,7 @@
   local.get $7
   i32.store offset=4
  )
- (func $~lib/rt/tlsf/addMemory (; 17 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1144,7 +1144,7 @@
   call $~lib/rt/tlsf/insertBlock
   i32.const 1
  )
- (func $~lib/rt/tlsf/maybeInitialize (; 18 ;) (result i32)
+ (func $~lib/rt/tlsf/maybeInitialize (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -1298,7 +1298,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/tlsf/prepareSize (; 19 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/tlsf/prepareSize (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -1327,7 +1327,7 @@
   i32.gt_u
   select
  )
- (func $~lib/rt/tlsf/searchBlock (; 20 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/searchBlock (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1510,7 +1510,7 @@
   end
   local.get $7
  )
- (func $~lib/rt/tlsf/growMemory (; 21 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/growMemory (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1594,7 +1594,7 @@
   call $~lib/rt/tlsf/addMemory
   drop
  )
- (func $~lib/rt/tlsf/prepareBlock (; 22 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/rt/tlsf/prepareBlock (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1689,7 +1689,7 @@
    i32.store
   end
  )
- (func $~lib/rt/tlsf/allocateBlock (; 23 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/allocateBlock (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   global.get $~lib/rt/tlsf/collectLock
@@ -1800,7 +1800,7 @@
   call $~lib/rt/rtrace/onalloc
   local.get $4
  )
- (func $~lib/rt/tlsf/__alloc (; 24 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/__alloc (param $0 i32) (param $1 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
   local.get $0
   local.get $1
@@ -1808,7 +1808,7 @@
   i32.const 16
   i32.add
  )
- (func $~lib/rt/pure/increment (; 25 ;) (param $0 i32)
+ (func $~lib/rt/pure/increment (param $0 i32)
   (local $1 i32)
   local.get $0
   i32.load offset=4
@@ -1853,7 +1853,7 @@
    unreachable
   end
  )
- (func $~lib/rt/pure/__retain (; 26 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/pure/__retain (param $0 i32) (result i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.gt_u
@@ -1865,7 +1865,7 @@
   end
   local.get $0
  )
- (func $do/Ref#constructor (; 27 ;) (param $0 i32) (result i32)
+ (func $do/Ref#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -1877,7 +1877,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/pure/__release (; 28 ;) (param $0 i32)
+ (func $~lib/rt/pure/__release (param $0 i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.gt_u
@@ -1888,7 +1888,7 @@
    call $~lib/rt/pure/decrement
   end
  )
- (func $do/testRef (; 29 ;)
+ (func $do/testRef
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -1962,11 +1962,11 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $do/getRef (; 30 ;) (result i32)
+ (func $do/getRef (result i32)
   i32.const 0
   call $do/Ref#constructor
  )
- (func $do/testRefAutorelease (; 31 ;)
+ (func $do/testRefAutorelease
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -2038,7 +2038,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $start:do (; 32 ;)
+ (func $start:do
   i32.const 0
   global.set $do/ran
   call $do/testSimple
@@ -2195,7 +2195,7 @@
    unreachable
   end
  )
- (func $~start (; 33 ;)
+ (func $~start
   global.get $~started
   if
    return
@@ -2205,10 +2205,10 @@
   end
   call $start:do
  )
- (func $~lib/rt/pure/__collect (; 34 ;)
+ (func $~lib/rt/pure/__collect
   return
  )
- (func $~lib/rt/tlsf/freeBlock (; 35 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/freeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $1
   i32.load
@@ -2224,7 +2224,7 @@
   local.get $1
   call $~lib/rt/rtrace/onfree
  )
- (func $~lib/rt/pure/decrement (; 36 ;) (param $0 i32)
+ (func $~lib/rt/pure/decrement (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -2301,7 +2301,7 @@
    i32.store offset=4
   end
  )
- (func $~lib/rt/pure/__visit (; 37 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/pure/__visit (param $0 i32) (param $1 i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.lt_u
@@ -2325,7 +2325,7 @@
   i32.sub
   call $~lib/rt/pure/decrement
  )
- (func $~lib/rt/__visit_members (; 38 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/__visit_members (param $0 i32) (param $1 i32)
   (local $2 i32)
   block $switch$1$default
    block $switch$1$case$4

--- a/tests/compiler/enum.optimized.wat
+++ b/tests/compiler/enum.optimized.wat
@@ -1,5 +1,4 @@
 (module
- (type $none_=>_none (func))
  (memory $0 0)
  (global $enum/Implicit.ZERO i32 (i32.const 0))
  (global $enum/Implicit.ONE i32 (i32.const 1))
@@ -25,8 +24,6 @@
  (global $enum/MixedConst.ONE i32 (i32.const 1))
  (global $enum/MixedConst.THREE i32 (i32.const 3))
  (global $enum/MixedConst.FOUR i32 (i32.const 4))
- (global $enum/NonConstant.ZERO (mut i32) (i32.const 0))
- (global $enum/NonConstant.ONE (mut i32) (i32.const 0))
  (global $enum/SelfReference.ZERO i32 (i32.const 0))
  (global $enum/SelfReference.ONE i32 (i32.const 1))
  (global $enum/SelfReferenceConst.ZERO i32 (i32.const 0))
@@ -60,11 +57,4 @@
  (export "SelfReference.ONE" (global $enum/SelfReference.ONE))
  (export "SelfReferenceConst.ZERO" (global $enum/SelfReferenceConst.ZERO))
  (export "SelfReferenceConst.ONE" (global $enum/SelfReferenceConst.ONE))
- (start $~start)
- (func $~start (; 0 ;)
-  i32.const 0
-  global.set $enum/NonConstant.ZERO
-  i32.const 1
-  global.set $enum/NonConstant.ONE
- )
 )

--- a/tests/compiler/enum.untouched.wat
+++ b/tests/compiler/enum.untouched.wat
@@ -64,10 +64,10 @@
  (export "SelfReferenceConst.ZERO" (global $enum/SelfReferenceConst.ZERO))
  (export "SelfReferenceConst.ONE" (global $enum/SelfReferenceConst.ONE))
  (start $~start)
- (func $enum/getZero (; 0 ;) (result i32)
+ (func $enum/getZero (result i32)
   i32.const 0
  )
- (func $start:enum (; 1 ;)
+ (func $start:enum
   call $enum/getZero
   global.set $enum/NonConstant.ZERO
   call $enum/getZero
@@ -79,7 +79,7 @@
   global.get $enum/NonConstant.ONE
   drop
  )
- (func $~start (; 2 ;)
+ (func $~start
   call $start:enum
  )
 )

--- a/tests/compiler/export-default.optimized.wat
+++ b/tests/compiler/export-default.optimized.wat
@@ -4,7 +4,7 @@
  (export "memory" (memory $0))
  (export "theDefault" (func $export-default/theDefault))
  (export "default" (func $export-default/theDefault))
- (func $export-default/theDefault (; 0 ;)
+ (func $export-default/theDefault
   nop
  )
 )

--- a/tests/compiler/export-default.untouched.wat
+++ b/tests/compiler/export-default.untouched.wat
@@ -5,7 +5,7 @@
  (export "memory" (memory $0))
  (export "theDefault" (func $export-default/theDefault))
  (export "default" (func $export-default/theDefault))
- (func $export-default/theDefault (; 0 ;)
+ (func $export-default/theDefault
   nop
  )
 )

--- a/tests/compiler/export.optimized.wat
+++ b/tests/compiler/export.optimized.wat
@@ -14,22 +14,22 @@
  (export "renamed_c" (global $export/c))
  (export "ns.two" (func $export/ns.one))
  (export "default.two" (func $export/ns.one))
- (func $export/add (; 0 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $export/add (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.add
  )
- (func $export/sub (; 1 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $export/sub (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.sub
  )
- (func $export/mul (; 2 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $export/mul (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.mul
  )
- (func $export/ns.one (; 3 ;)
+ (func $export/ns.one
   nop
  )
 )

--- a/tests/compiler/export.untouched.wat
+++ b/tests/compiler/export.untouched.wat
@@ -15,25 +15,25 @@
  (export "renamed_c" (global $export/c))
  (export "ns.two" (func $export/ns.two))
  (export "default.two" (func $export/ns.two))
- (func $export/add (; 0 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $export/add (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.add
  )
- (func $export/sub (; 1 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $export/sub (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.sub
  )
- (func $export/mul (; 2 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $export/mul (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.mul
  )
- (func $export/ns.one (; 3 ;)
+ (func $export/ns.one
   nop
  )
- (func $export/ns.two (; 4 ;)
+ (func $export/ns.two
   nop
  )
 )

--- a/tests/compiler/exportimport-table.optimized.wat
+++ b/tests/compiler/exportimport-table.optimized.wat
@@ -5,7 +5,7 @@
  (memory $0 0)
  (export "memory" (memory $0))
  (export "table" (table $0))
- (func $start:exportimport-table~anonymous|0 (; 0 ;)
+ (func $start:exportimport-table~anonymous|0
   nop
  )
 )

--- a/tests/compiler/exportimport-table.untouched.wat
+++ b/tests/compiler/exportimport-table.untouched.wat
@@ -7,14 +7,14 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $~start)
- (func $start:exportimport-table~anonymous|0 (; 0 ;)
+ (func $start:exportimport-table~anonymous|0
   nop
  )
- (func $start:exportimport-table (; 1 ;)
+ (func $start:exportimport-table
   global.get $exportimport-table/f
   drop
  )
- (func $~start (; 2 ;)
+ (func $~start
   call $start:exportimport-table
  )
 )

--- a/tests/compiler/exports.optimized.wat
+++ b/tests/compiler/exports.optimized.wat
@@ -13,7 +13,6 @@
  (global $exports/Car.TIRES i32 (i32.const 4))
  (global $exports/vehicles.Car.TIRES i32 (i32.const 4))
  (global $exports/outer.inner.a i32 (i32.const 42))
- (global $~lib/rt/stub/startOffset (mut i32) (i32.const 0))
  (global $~lib/rt/stub/offset (mut i32) (i32.const 0))
  (global $~argumentsLength (mut i32) (i32.const 0))
  (global $exports/Car i32 (i32.const 3))
@@ -47,20 +46,20 @@
  (export "vehicles.Car.getNumTires" (func $exports/Car.getNumTires))
  (export "outer.inner.a" (global $exports/outer.inner.a))
  (start $~start)
- (func $exports/add (; 0 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $exports/add (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.add
  )
- (func $exports/subOpt (; 1 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $exports/subOpt (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.sub
  )
- (func $exports/Car.getNumTires (; 2 ;) (result i32)
+ (func $exports/Car.getNumTires (result i32)
   i32.const 4
  )
- (func $~lib/rt/stub/__alloc (; 3 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/stub/__alloc (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -126,25 +125,23 @@
   i32.store offset=12
   local.get $3
  )
- (func $exports/Car#get:doors (; 4 ;) (param $0 i32) (result i32)
+ (func $exports/Car#get:doors (param $0 i32) (result i32)
   local.get $0
   i32.load
  )
- (func $exports/Car#set:doors (; 5 ;) (param $0 i32) (param $1 i32)
+ (func $exports/Car#set:doors (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
   i32.store
  )
- (func $exports/Car#openDoors (; 6 ;) (param $0 i32)
+ (func $exports/Car#openDoors (param $0 i32)
   nop
  )
- (func $~start (; 7 ;)
-  i32.const 1024
-  global.set $~lib/rt/stub/startOffset
+ (func $~start
   i32.const 1024
   global.set $~lib/rt/stub/offset
  )
- (func $exports/subOpt|trampoline (; 8 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $exports/subOpt|trampoline (param $0 i32) (param $1 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -162,11 +159,11 @@
   local.get $1
   i32.sub
  )
- (func $~setArgumentsLength (; 9 ;) (param $0 i32)
+ (func $~setArgumentsLength (param $0 i32)
   local.get $0
   global.set $~argumentsLength
  )
- (func $exports/Car#constructor|trampoline (; 10 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $exports/Car#constructor|trampoline (param $0 i32) (param $1 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -193,7 +190,7 @@
   i32.store
   local.get $0
  )
- (func $exports/vehicles.Car#constructor|trampoline (; 11 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $exports/vehicles.Car#constructor|trampoline (param $0 i32) (param $1 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange

--- a/tests/compiler/exports.untouched.wat
+++ b/tests/compiler/exports.untouched.wat
@@ -49,25 +49,25 @@
  (export "vehicles.Car.getNumTires" (func $exports/vehicles.Car.getNumTires))
  (export "outer.inner.a" (global $exports/outer.inner.a))
  (start $~start)
- (func $exports/add (; 0 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $exports/add (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.add
  )
- (func $exports/subOpt (; 1 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $exports/subOpt (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.sub
  )
- (func $exports/math.sub (; 2 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $exports/math.sub (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.sub
  )
- (func $exports/Car.getNumTires (; 3 ;) (result i32)
+ (func $exports/Car.getNumTires (result i32)
   global.get $exports/Car.TIRES
  )
- (func $~lib/rt/stub/maybeGrowMemory (; 4 ;) (param $0 i32)
+ (func $~lib/rt/stub/maybeGrowMemory (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -121,7 +121,7 @@
   local.get $0
   global.set $~lib/rt/stub/offset
  )
- (func $~lib/rt/stub/__alloc (; 5 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/stub/__alloc (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -174,10 +174,10 @@
   i32.store offset=12
   local.get $2
  )
- (func $~lib/rt/stub/__retain (; 6 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/stub/__retain (param $0 i32) (result i32)
   local.get $0
  )
- (func $exports/Car#constructor (; 7 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $exports/Car#constructor (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -195,31 +195,31 @@
   i32.store
   local.get $0
  )
- (func $exports/Car#get:doors (; 8 ;) (param $0 i32) (result i32)
+ (func $exports/Car#get:doors (param $0 i32) (result i32)
   local.get $0
   i32.load
  )
- (func $exports/Car#set:doors (; 9 ;) (param $0 i32) (param $1 i32)
+ (func $exports/Car#set:doors (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
   i32.store
  )
- (func $exports/Car#get:numDoors (; 10 ;) (param $0 i32) (result i32)
+ (func $exports/Car#get:numDoors (param $0 i32) (result i32)
   local.get $0
   i32.load
  )
- (func $exports/Car#set:numDoors (; 11 ;) (param $0 i32) (param $1 i32)
+ (func $exports/Car#set:numDoors (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
   i32.store
  )
- (func $exports/Car#openDoors (; 12 ;) (param $0 i32)
+ (func $exports/Car#openDoors (param $0 i32)
   nop
  )
- (func $exports/vehicles.Car.getNumTires (; 13 ;) (result i32)
+ (func $exports/vehicles.Car.getNumTires (result i32)
   global.get $exports/vehicles.Car.TIRES
  )
- (func $exports/vehicles.Car#constructor (; 14 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $exports/vehicles.Car#constructor (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -237,28 +237,28 @@
   i32.store
   local.get $0
  )
- (func $exports/vehicles.Car#get:doors (; 15 ;) (param $0 i32) (result i32)
+ (func $exports/vehicles.Car#get:doors (param $0 i32) (result i32)
   local.get $0
   i32.load
  )
- (func $exports/vehicles.Car#set:doors (; 16 ;) (param $0 i32) (param $1 i32)
+ (func $exports/vehicles.Car#set:doors (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
   i32.store
  )
- (func $exports/vehicles.Car#get:numDoors (; 17 ;) (param $0 i32) (result i32)
+ (func $exports/vehicles.Car#get:numDoors (param $0 i32) (result i32)
   local.get $0
   i32.load
  )
- (func $exports/vehicles.Car#set:numDoors (; 18 ;) (param $0 i32) (param $1 i32)
+ (func $exports/vehicles.Car#set:numDoors (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
   i32.store
  )
- (func $exports/vehicles.Car#openDoors (; 19 ;) (param $0 i32)
+ (func $exports/vehicles.Car#openDoors (param $0 i32)
   nop
  )
- (func $~start (; 20 ;)
+ (func $~start
   global.get $~lib/heap/__heap_base
   i32.const 15
   i32.add
@@ -270,7 +270,7 @@
   global.get $~lib/rt/stub/startOffset
   global.set $~lib/rt/stub/offset
  )
- (func $exports/subOpt|trampoline (; 21 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $exports/subOpt|trampoline (param $0 i32) (param $1 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -288,11 +288,11 @@
   local.get $1
   call $exports/subOpt
  )
- (func $~setArgumentsLength (; 22 ;) (param $0 i32)
+ (func $~setArgumentsLength (param $0 i32)
   local.get $0
   global.set $~argumentsLength
  )
- (func $exports/Car#constructor|trampoline (; 23 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $exports/Car#constructor|trampoline (param $0 i32) (param $1 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -308,7 +308,7 @@
   local.get $1
   call $exports/Car#constructor
  )
- (func $exports/vehicles.Car#constructor|trampoline (; 24 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $exports/vehicles.Car#constructor|trampoline (param $0 i32) (param $1 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange

--- a/tests/compiler/exportstar.optimized.wat
+++ b/tests/compiler/exportstar.optimized.wat
@@ -14,22 +14,22 @@
  (export "renamed_c" (global $export/c))
  (export "ns.two" (func $export/ns.one))
  (export "default.two" (func $export/ns.one))
- (func $export/add (; 0 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $export/add (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.add
  )
- (func $export/sub (; 1 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $export/sub (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.sub
  )
- (func $export/mul (; 2 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $export/mul (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.mul
  )
- (func $export/ns.one (; 3 ;)
+ (func $export/ns.one
   nop
  )
 )

--- a/tests/compiler/exportstar.untouched.wat
+++ b/tests/compiler/exportstar.untouched.wat
@@ -15,25 +15,25 @@
  (export "renamed_c" (global $export/c))
  (export "ns.two" (func $export/ns.two))
  (export "default.two" (func $export/ns.two))
- (func $export/add (; 0 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $export/add (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.add
  )
- (func $export/sub (; 1 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $export/sub (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.sub
  )
- (func $export/mul (; 2 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $export/mul (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.mul
  )
- (func $export/ns.one (; 3 ;)
+ (func $export/ns.one
   nop
  )
- (func $export/ns.two (; 4 ;)
+ (func $export/ns.two
   nop
  )
 )

--- a/tests/compiler/extends-baseaggregate.optimized.wat
+++ b/tests/compiler/extends-baseaggregate.optimized.wat
@@ -30,7 +30,7 @@
  (global $~lib/rt/pure/END (mut i32) (i32.const 0))
  (export "memory" (memory $0))
  (start $~start)
- (func $~lib/rt/tlsf/removeBlock (; 1 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/removeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -192,7 +192,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/insertBlock (; 2 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/insertBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -471,7 +471,7 @@
   i32.or
   i32.store offset=4
  )
- (func $~lib/rt/tlsf/addMemory (; 3 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $2
@@ -585,7 +585,7 @@
   local.get $1
   call $~lib/rt/tlsf/insertBlock
  )
- (func $~lib/rt/tlsf/maybeInitialize (; 4 ;) (result i32)
+ (func $~lib/rt/tlsf/maybeInitialize (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -672,7 +672,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/tlsf/prepareSize (; 5 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/tlsf/prepareSize (param $0 i32) (result i32)
   local.get $0
   i32.const 1073741808
   i32.ge_u
@@ -696,7 +696,7 @@
   i32.gt_u
   select
  )
- (func $~lib/rt/tlsf/searchBlock (; 6 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/searchBlock (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   i32.const 256
@@ -825,7 +825,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/prepareBlock (; 7 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/rt/tlsf/prepareBlock (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $1
@@ -900,7 +900,7 @@
    i32.store
   end
  )
- (func $~lib/rt/tlsf/allocateBlock (; 8 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/allocateBlock (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1039,7 +1039,7 @@
   call $~lib/rt/tlsf/prepareBlock
   local.get $3
  )
- (func $~lib/rt/tlsf/__alloc (; 9 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/__alloc (param $0 i32) (param $1 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
   local.get $0
   local.get $1
@@ -1047,7 +1047,7 @@
   i32.const 16
   i32.add
  )
- (func $~lib/rt/pure/__retain (; 10 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/pure/__retain (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -1096,7 +1096,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/tlsf/checkUsedBlock (; 11 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/tlsf/checkUsedBlock (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   i32.const 16
@@ -1138,7 +1138,7 @@
   end
   local.get $1
  )
- (func $~lib/memory/memory.copy (; 12 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/memory/memory.copy (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   block $~lib/util/memory/memmove|inlined.0
@@ -1311,7 +1311,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/freeBlock (; 13 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/freeBlock (param $0 i32) (param $1 i32)
   local.get $1
   local.get $1
   i32.load
@@ -1322,7 +1322,7 @@
   local.get $1
   call $~lib/rt/tlsf/insertBlock
  )
- (func $~lib/rt/tlsf/reallocateBlock (; 14 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/reallocateBlock (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1422,7 +1422,7 @@
   end
   local.get $3
  )
- (func $~lib/memory/memory.fill (; 15 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/memory/memory.fill (param $0 i32) (param $1 i32)
   (local $2 i32)
   block $~lib/util/memory/memset|inlined.0
    local.get $1
@@ -1580,7 +1580,7 @@
    end
   end
  )
- (func $start:extends-baseaggregate (; 16 ;)
+ (func $start:extends-baseaggregate
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -1693,10 +1693,10 @@
    call $~lib/rt/pure/decrement
   end
  )
- (func $~start (; 17 ;)
+ (func $~start
   call $start:extends-baseaggregate
  )
- (func $~lib/rt/pure/markGray (; 18 ;) (param $0 i32)
+ (func $~lib/rt/pure/markGray (param $0 i32)
   (local $1 i32)
   local.get $0
   i32.load offset=4
@@ -1720,7 +1720,7 @@
    call $~lib/rt/__visit_members
   end
  )
- (func $~lib/rt/pure/scanBlack (; 19 ;) (param $0 i32)
+ (func $~lib/rt/pure/scanBlack (param $0 i32)
   local.get $0
   local.get $0
   i32.load offset=4
@@ -1733,7 +1733,7 @@
   i32.const 4
   call $~lib/rt/__visit_members
  )
- (func $~lib/rt/pure/scan (; 20 ;) (param $0 i32)
+ (func $~lib/rt/pure/scan (param $0 i32)
   (local $1 i32)
   local.get $0
   i32.load offset=4
@@ -1767,7 +1767,7 @@
    end
   end
  )
- (func $~lib/rt/pure/collectWhite (; 21 ;) (param $0 i32)
+ (func $~lib/rt/pure/collectWhite (param $0 i32)
   (local $1 i32)
   local.get $0
   i32.load offset=4
@@ -1800,7 +1800,7 @@
    call $~lib/rt/tlsf/freeBlock
   end
  )
- (func $~lib/rt/pure/__collect (; 22 ;)
+ (func $~lib/rt/pure/__collect
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -1921,7 +1921,7 @@
   local.get $0
   global.set $~lib/rt/pure/CUR
  )
- (func $~lib/rt/pure/decrement (; 23 ;) (param $0 i32)
+ (func $~lib/rt/pure/decrement (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -2078,7 +2078,7 @@
    end
   end
  )
- (func $~lib/rt/pure/__visit (; 24 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/pure/__visit (param $0 i32) (param $1 i32)
   local.get $0
   i32.const 1564
   i32.lt_u
@@ -2181,7 +2181,7 @@
    unreachable
   end
  )
- (func $~lib/array/Array<extends-baseaggregate/B1>#__visit_impl (; 25 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<extends-baseaggregate/B1>#__visit_impl (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2219,7 +2219,7 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/rt/__visit_members (; 26 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/__visit_members (param $0 i32) (param $1 i32)
   block $switch$1$default
    block $switch$1$case$10
     block $switch$1$case$9

--- a/tests/compiler/extends-baseaggregate.untouched.wat
+++ b/tests/compiler/extends-baseaggregate.untouched.wat
@@ -37,7 +37,7 @@
  (global $~lib/heap/__heap_base i32 (i32.const 556))
  (export "memory" (memory $0))
  (start $~start)
- (func $~lib/rt/tlsf/removeBlock (; 1 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/removeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -247,7 +247,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/insertBlock (; 2 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/insertBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -597,7 +597,7 @@
   local.get $7
   i32.store offset=4
  )
- (func $~lib/rt/tlsf/addMemory (; 3 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -745,7 +745,7 @@
   call $~lib/rt/tlsf/insertBlock
   i32.const 1
  )
- (func $~lib/rt/tlsf/maybeInitialize (; 4 ;) (result i32)
+ (func $~lib/rt/tlsf/maybeInitialize (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -899,7 +899,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/tlsf/prepareSize (; 5 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/tlsf/prepareSize (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -928,7 +928,7 @@
   i32.gt_u
   select
  )
- (func $~lib/rt/tlsf/searchBlock (; 6 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/searchBlock (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1111,7 +1111,7 @@
   end
   local.get $7
  )
- (func $~lib/rt/tlsf/growMemory (; 7 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/growMemory (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1195,7 +1195,7 @@
   call $~lib/rt/tlsf/addMemory
   drop
  )
- (func $~lib/rt/tlsf/prepareBlock (; 8 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/rt/tlsf/prepareBlock (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1290,7 +1290,7 @@
    i32.store
   end
  )
- (func $~lib/rt/tlsf/allocateBlock (; 9 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/allocateBlock (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   global.get $~lib/rt/tlsf/collectLock
@@ -1399,7 +1399,7 @@
   call $~lib/rt/tlsf/prepareBlock
   local.get $4
  )
- (func $~lib/rt/tlsf/__alloc (; 10 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/__alloc (param $0 i32) (param $1 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
   local.get $0
   local.get $1
@@ -1407,7 +1407,7 @@
   i32.const 16
   i32.add
  )
- (func $~lib/rt/pure/increment (; 11 ;) (param $0 i32)
+ (func $~lib/rt/pure/increment (param $0 i32)
   (local $1 i32)
   local.get $0
   i32.load offset=4
@@ -1450,7 +1450,7 @@
    unreachable
   end
  )
- (func $~lib/rt/pure/__retain (; 12 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/pure/__retain (param $0 i32) (result i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.gt_u
@@ -1462,7 +1462,7 @@
   end
   local.get $0
  )
- (func $extends-baseaggregate/A1#constructor (; 13 ;) (param $0 i32) (result i32)
+ (func $extends-baseaggregate/A1#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -1483,7 +1483,7 @@
   i32.store offset=16
   local.get $0
  )
- (func $extends-baseaggregate/A2#constructor (; 14 ;) (param $0 i32) (result i32)
+ (func $extends-baseaggregate/A2#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -1498,7 +1498,7 @@
   local.set $0
   local.get $0
  )
- (func $~lib/rt/tlsf/checkUsedBlock (; 15 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/tlsf/checkUsedBlock (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   i32.const 16
@@ -1544,7 +1544,7 @@
   end
   local.get $1
  )
- (func $~lib/util/memory/memcpy (; 16 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/memory/memcpy (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2568,7 +2568,7 @@
    i32.store8
   end
  )
- (func $~lib/memory/memory.copy (; 17 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/memory/memory.copy (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2788,7 +2788,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/freeBlock (; 18 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/freeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $1
   i32.load
@@ -2802,7 +2802,7 @@
   local.get $1
   call $~lib/rt/tlsf/insertBlock
  )
- (func $~lib/rt/tlsf/reallocateBlock (; 19 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/reallocateBlock (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2918,7 +2918,7 @@
   end
   local.get $8
  )
- (func $~lib/rt/tlsf/__realloc (; 20 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/__realloc (param $0 i32) (param $1 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
   local.get $0
   call $~lib/rt/tlsf/checkUsedBlock
@@ -2927,7 +2927,7 @@
   i32.const 16
   i32.add
  )
- (func $~lib/memory/memory.fill (; 21 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/memory/memory.fill (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3136,7 +3136,7 @@
    end
   end
  )
- (func $~lib/array/ensureSize (; 22 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/ensureSize (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3198,7 +3198,7 @@
    i32.store offset=8
   end
  )
- (func $~lib/rt/pure/__release (; 23 ;) (param $0 i32)
+ (func $~lib/rt/pure/__release (param $0 i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.gt_u
@@ -3209,7 +3209,7 @@
    call $~lib/rt/pure/decrement
   end
  )
- (func $~lib/array/Array<extends-baseaggregate/A2>#push (; 24 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<extends-baseaggregate/A2>#push (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3245,7 +3245,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $start:extends-baseaggregate (; 25 ;)
+ (func $start:extends-baseaggregate
   (local $0 i32)
   (local $1 i32)
   global.get $extends-baseaggregate/poolA
@@ -3257,10 +3257,10 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~start (; 26 ;)
+ (func $~start
   call $start:extends-baseaggregate
  )
- (func $~lib/rt/pure/markGray (; 27 ;) (param $0 i32)
+ (func $~lib/rt/pure/markGray (param $0 i32)
   (local $1 i32)
   local.get $0
   i32.load offset=4
@@ -3287,7 +3287,7 @@
    call $~lib/rt/__visit_members
   end
  )
- (func $~lib/rt/pure/scanBlack (; 28 ;) (param $0 i32)
+ (func $~lib/rt/pure/scanBlack (param $0 i32)
   local.get $0
   local.get $0
   i32.load offset=4
@@ -3304,7 +3304,7 @@
   i32.const 4
   call $~lib/rt/__visit_members
  )
- (func $~lib/rt/pure/scan (; 29 ;) (param $0 i32)
+ (func $~lib/rt/pure/scan (param $0 i32)
   (local $1 i32)
   local.get $0
   i32.load offset=4
@@ -3341,7 +3341,7 @@
    end
   end
  )
- (func $~lib/rt/pure/collectWhite (; 30 ;) (param $0 i32)
+ (func $~lib/rt/pure/collectWhite (param $0 i32)
   (local $1 i32)
   local.get $0
   i32.load offset=4
@@ -3379,7 +3379,7 @@
    call $~lib/rt/tlsf/freeBlock
   end
  )
- (func $~lib/rt/pure/__collect (; 31 ;)
+ (func $~lib/rt/pure/__collect
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -3520,7 +3520,7 @@
   local.get $0
   global.set $~lib/rt/pure/CUR
  )
- (func $~lib/rt/__typeinfo (; 32 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/__typeinfo (param $0 i32) (result i32)
   (local $1 i32)
   global.get $~lib/rt/__rtti_base
   local.set $1
@@ -3545,13 +3545,13 @@
   i32.add
   i32.load
  )
- (func $~lib/rt/tlsf/__free (; 33 ;) (param $0 i32)
+ (func $~lib/rt/tlsf/__free (param $0 i32)
   call $~lib/rt/tlsf/maybeInitialize
   local.get $0
   call $~lib/rt/tlsf/checkUsedBlock
   call $~lib/rt/tlsf/freeBlock
  )
- (func $~lib/rt/pure/growRoots (; 34 ;)
+ (func $~lib/rt/pure/growRoots
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -3601,7 +3601,7 @@
   i32.add
   global.set $~lib/rt/pure/END
  )
- (func $~lib/rt/pure/appendRoot (; 35 ;) (param $0 i32)
+ (func $~lib/rt/pure/appendRoot (param $0 i32)
   (local $1 i32)
   global.get $~lib/rt/pure/CUR
   local.set $1
@@ -3621,7 +3621,7 @@
   i32.add
   global.set $~lib/rt/pure/CUR
  )
- (func $~lib/rt/pure/decrement (; 36 ;) (param $0 i32)
+ (func $~lib/rt/pure/decrement (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -3723,7 +3723,7 @@
    end
   end
  )
- (func $~lib/rt/pure/__visit (; 37 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/pure/__visit (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -3853,7 +3853,7 @@
    end
   end
  )
- (func $~lib/array/Array<extends-baseaggregate/B1>#__visit_impl (; 38 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<extends-baseaggregate/B1>#__visit_impl (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3896,7 +3896,7 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/array/Array<extends-baseaggregate/A2>#__visit_impl (; 39 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<extends-baseaggregate/A2>#__visit_impl (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3939,7 +3939,7 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/rt/__visit_members (; 40 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/__visit_members (param $0 i32) (param $1 i32)
   (local $2 i32)
   block $switch$1$default
    block $switch$1$case$10

--- a/tests/compiler/extends-recursive.optimized.wat
+++ b/tests/compiler/extends-recursive.optimized.wat
@@ -3,7 +3,6 @@
  (type $i32_i32_=>_none (func (param i32 i32)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
  (memory $0 0)
- (global $~lib/rt/stub/startOffset (mut i32) (i32.const 0))
  (global $~lib/rt/stub/offset (mut i32) (i32.const 0))
  (global $extends-recursive/Child i32 (i32.const 3))
  (export "memory" (memory $0))
@@ -11,11 +10,11 @@
  (export "Child#get:child" (func $extends-recursive/Parent#get:child))
  (export "Child#set:child" (func $extends-recursive/Parent#set:child))
  (start $~start)
- (func $extends-recursive/Parent#get:child (; 0 ;) (param $0 i32) (result i32)
+ (func $extends-recursive/Parent#get:child (param $0 i32) (result i32)
   local.get $0
   i32.load
  )
- (func $extends-recursive/Parent#set:child (; 1 ;) (param $0 i32) (param $1 i32)
+ (func $extends-recursive/Parent#set:child (param $0 i32) (param $1 i32)
   local.get $0
   i32.load
   drop
@@ -23,9 +22,7 @@
   local.get $1
   i32.store
  )
- (func $~start (; 2 ;)
-  i32.const 1024
-  global.set $~lib/rt/stub/startOffset
+ (func $~start
   i32.const 1024
   global.set $~lib/rt/stub/offset
  )

--- a/tests/compiler/extends-recursive.untouched.wat
+++ b/tests/compiler/extends-recursive.untouched.wat
@@ -15,7 +15,7 @@
  (export "Child#get:child" (func $extends-recursive/Parent#get:child))
  (export "Child#set:child" (func $extends-recursive/Parent#set:child))
  (start $~start)
- (func $~lib/rt/stub/maybeGrowMemory (; 0 ;) (param $0 i32)
+ (func $~lib/rt/stub/maybeGrowMemory (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -69,7 +69,7 @@
   local.get $0
   global.set $~lib/rt/stub/offset
  )
- (func $~lib/rt/stub/__alloc (; 1 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/stub/__alloc (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -122,10 +122,10 @@
   i32.store offset=12
   local.get $2
  )
- (func $~lib/rt/stub/__retain (; 2 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/stub/__retain (param $0 i32) (result i32)
   local.get $0
  )
- (func $extends-recursive/Parent#constructor (; 3 ;) (param $0 i32) (result i32)
+ (func $extends-recursive/Parent#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -141,7 +141,7 @@
   i32.store
   local.get $0
  )
- (func $extends-recursive/Child#constructor (; 4 ;) (param $0 i32) (result i32)
+ (func $extends-recursive/Child#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -156,15 +156,15 @@
   local.set $0
   local.get $0
  )
- (func $extends-recursive/Parent#get:child (; 5 ;) (param $0 i32) (result i32)
+ (func $extends-recursive/Parent#get:child (param $0 i32) (result i32)
   local.get $0
   i32.load
   call $~lib/rt/stub/__retain
  )
- (func $~lib/rt/stub/__release (; 6 ;) (param $0 i32)
+ (func $~lib/rt/stub/__release (param $0 i32)
   nop
  )
- (func $extends-recursive/Parent#set:child (; 7 ;) (param $0 i32) (param $1 i32)
+ (func $extends-recursive/Parent#set:child (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -182,7 +182,7 @@
   local.get $1
   i32.store
  )
- (func $~start (; 8 ;)
+ (func $~start
   global.get $~lib/heap/__heap_base
   i32.const 15
   i32.add

--- a/tests/compiler/features/js-bigint-integration.optimized.wat
+++ b/tests/compiler/features/js-bigint-integration.optimized.wat
@@ -13,10 +13,10 @@
  (export "memory" (memory $0))
  (export "internalValue" (global $features/js-bigint-integration/internalValue))
  (export "getInternalValue" (func $features/js-bigint-integration/getInternalValue))
- (func $features/js-bigint-integration/getInternalValue (; 2 ;) (result i64)
+ (func $features/js-bigint-integration/getInternalValue (result i64)
   i64.const 9007199254740991
  )
- (func $~start (; 3 ;)
+ (func $~start
   global.get $~started
   if
    return

--- a/tests/compiler/features/js-bigint-integration.untouched.wat
+++ b/tests/compiler/features/js-bigint-integration.untouched.wat
@@ -14,7 +14,7 @@
  (export "memory" (memory $0))
  (export "internalValue" (global $features/js-bigint-integration/internalValue))
  (export "getInternalValue" (func $features/js-bigint-integration/getInternalValue))
- (func $start:features/js-bigint-integration (; 2 ;)
+ (func $start:features/js-bigint-integration
   global.get $features/js-bigint-integration/externalValue
   i64.const 9007199254740991
   i64.eq
@@ -40,10 +40,10 @@
    unreachable
   end
  )
- (func $features/js-bigint-integration/getInternalValue (; 3 ;) (result i64)
+ (func $features/js-bigint-integration/getInternalValue (result i64)
   global.get $features/js-bigint-integration/internalValue
  )
- (func $~start (; 4 ;)
+ (func $~start
   global.get $~started
   if
    return

--- a/tests/compiler/features/mutable-globals.optimized.wat
+++ b/tests/compiler/features/mutable-globals.optimized.wat
@@ -11,7 +11,7 @@
  (export "memory" (memory $0))
  (export "external" (global $features/mutable-globals/external))
  (export "internal" (global $features/mutable-globals/internal))
- (func $~start (; 1 ;)
+ (func $~start
   global.get $~started
   if
    return

--- a/tests/compiler/features/mutable-globals.untouched.wat
+++ b/tests/compiler/features/mutable-globals.untouched.wat
@@ -12,7 +12,7 @@
  (export "memory" (memory $0))
  (export "external" (global $features/mutable-globals/external))
  (export "internal" (global $features/mutable-globals/internal))
- (func $start:features/mutable-globals (; 1 ;)
+ (func $start:features/mutable-globals
   global.get $features/mutable-globals/external
   i32.const 123
   i32.eq
@@ -70,7 +70,7 @@
    unreachable
   end
  )
- (func $~start (; 2 ;)
+ (func $~start
   global.get $~started
   if
    return

--- a/tests/compiler/features/reference-types.optimized.wat
+++ b/tests/compiler/features/reference-types.optimized.wat
@@ -1,6 +1,6 @@
 (module
- (type $none_=>_none (func))
  (type $anyref_=>_anyref (func (param anyref) (result anyref)))
+ (type $none_=>_none (func))
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $anyref_=>_none (func (param anyref)))
  (type $anyref_anyref_=>_i32 (func (param anyref anyref) (result i32)))
@@ -15,22 +15,17 @@
  (memory $0 1)
  (data (i32.const 1024) "6\00\00\00\01\00\00\00\01\00\00\006\00\00\00f\00e\00a\00t\00u\00r\00e\00s\00/\00r\00e\00f\00e\00r\00e\00n\00c\00e\00-\00t\00y\00p\00e\00s\00.\00t\00s")
  (global $features/reference-types/nullGlobal (mut anyref) (ref.null))
- (global $features/reference-types/nullGlobalInit (mut anyref) (ref.null))
- (global $features/reference-types/funcGlobal (mut anyref) (ref.null))
  (export "memory" (memory $0))
  (export "external" (func $features/reference-types/external))
  (export "internal" (func $features/reference-types/internal))
  (start $~start)
- (func $features/reference-types/someFunc (; 5 ;)
-  nop
- )
- (func $features/reference-types/internal (; 6 ;) (param $0 anyref) (result anyref)
+ (func $features/reference-types/internal (param $0 anyref) (result anyref)
   local.get $0
   call $features/reference-types/external
   call $features/reference-types/external
   call $features/reference-types/external
  )
- (func $~start (; 7 ;)
+ (func $~start
   global.get $features/reference-types/someObject
   global.get $features/reference-types/someKey
   call $~lib/bindings/Reflect/has
@@ -64,9 +59,5 @@
   end
   ref.null
   global.set $features/reference-types/nullGlobal
-  ref.null
-  global.set $features/reference-types/nullGlobalInit
-  ref.func $features/reference-types/someFunc
-  global.set $features/reference-types/funcGlobal
  )
 )

--- a/tests/compiler/features/reference-types.untouched.wat
+++ b/tests/compiler/features/reference-types.untouched.wat
@@ -22,10 +22,10 @@
  (export "external" (func $features/reference-types/external))
  (export "internal" (func $features/reference-types/internal))
  (start $~start)
- (func $features/reference-types/someFunc (; 5 ;)
+ (func $features/reference-types/someFunc
   nop
  )
- (func $start:features/reference-types (; 6 ;)
+ (func $start:features/reference-types
   (local $0 anyref)
   (local $1 anyref)
   global.get $features/reference-types/someObject
@@ -141,7 +141,7 @@
   ref.func $features/reference-types/someFunc
   local.set $1
  )
- (func $features/reference-types/internal (; 7 ;) (param $0 anyref) (result anyref)
+ (func $features/reference-types/internal (param $0 anyref) (result anyref)
   (local $1 anyref)
   (local $2 anyref)
   (local $3 anyref)
@@ -156,7 +156,7 @@
   local.set $3
   local.get $3
  )
- (func $~start (; 8 ;)
+ (func $~start
   call $start:features/reference-types
  )
 )

--- a/tests/compiler/features/simd.optimized.wat
+++ b/tests/compiler/features/simd.optimized.wat
@@ -5,11 +5,10 @@
  (memory $0 1)
  (data (i32.const 1024) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00s\00t\00u\00b\00.\00t\00s")
  (data (i32.const 1072) " \00\00\00\01\00\00\00\01\00\00\00 \00\00\00f\00e\00a\00t\00u\00r\00e\00s\00/\00s\00i\00m\00d\00.\00t\00s")
- (global $~lib/rt/stub/startOffset (mut i32) (i32.const 0))
  (global $~lib/rt/stub/offset (mut i32) (i32.const 0))
  (export "memory" (memory $0))
  (start $~start)
- (func $features/simd/test_v128 (; 1 ;)
+ (func $features/simd/test_v128
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -119,9 +118,7 @@
    global.set $~lib/rt/stub/offset
   end
  )
- (func $~start (; 2 ;)
-  i32.const 1120
-  global.set $~lib/rt/stub/startOffset
+ (func $~start
   i32.const 1120
   global.set $~lib/rt/stub/offset
   call $features/simd/test_v128

--- a/tests/compiler/features/simd.untouched.wat
+++ b/tests/compiler/features/simd.untouched.wat
@@ -19,7 +19,7 @@
  (global $~lib/heap/__heap_base i32 (i32.const 112))
  (export "memory" (memory $0))
  (start $~start)
- (func $~lib/rt/stub/maybeGrowMemory (; 1 ;) (param $0 i32)
+ (func $~lib/rt/stub/maybeGrowMemory (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -73,7 +73,7 @@
   local.get $0
   global.set $~lib/rt/stub/offset
  )
- (func $~lib/rt/stub/__alloc (; 2 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/stub/__alloc (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -126,7 +126,7 @@
   i32.store offset=12
   local.get $2
  )
- (func $~lib/rt/stub/__free (; 3 ;) (param $0 i32)
+ (func $~lib/rt/stub/__free (param $0 i32)
   (local $1 i32)
   local.get $0
   i32.const 0
@@ -176,7 +176,7 @@
    global.set $~lib/rt/stub/offset
   end
  )
- (func $features/simd/test_v128 (; 4 ;)
+ (func $features/simd/test_v128
   (local $0 i32)
   i32.const 64
   i32.const 0
@@ -189,7 +189,7 @@
   local.get $0
   call $~lib/rt/stub/__free
  )
- (func $features/simd/test_i8x16 (; 5 ;)
+ (func $features/simd/test_i8x16
   (local $0 v128)
   (local $1 v128)
   (local $2 v128)
@@ -570,7 +570,7 @@
    unreachable
   end
  )
- (func $features/simd/test_i16x8 (; 6 ;)
+ (func $features/simd/test_i16x8
   (local $0 v128)
   (local $1 v128)
   (local $2 v128)
@@ -951,7 +951,7 @@
    unreachable
   end
  )
- (func $features/simd/test_i32x4 (; 7 ;)
+ (func $features/simd/test_i32x4
   (local $0 v128)
   (local $1 v128)
   (local $2 v128)
@@ -1309,7 +1309,7 @@
    unreachable
   end
  )
- (func $features/simd/test_i64x2 (; 8 ;)
+ (func $features/simd/test_i64x2
   (local $0 v128)
   (local $1 v128)
   (local $2 v128)
@@ -1461,7 +1461,7 @@
    unreachable
   end
  )
- (func $features/simd/test_f32x4 (; 9 ;)
+ (func $features/simd/test_f32x4
   (local $0 v128)
   (local $1 v128)
   (local $2 v128)
@@ -1839,7 +1839,7 @@
    unreachable
   end
  )
- (func $features/simd/test_f64x2 (; 10 ;)
+ (func $features/simd/test_f64x2
   (local $0 v128)
   (local $1 v128)
   (local $2 v128)
@@ -2217,7 +2217,7 @@
    unreachable
   end
  )
- (func $features/simd/test_v8x16 (; 11 ;)
+ (func $features/simd/test_v8x16
   (local $0 v128)
   (local $1 v128)
   (local $2 v128)
@@ -2262,16 +2262,16 @@
    unreachable
   end
  )
- (func $features/simd/test_v16x8 (; 12 ;)
+ (func $features/simd/test_v16x8
   nop
  )
- (func $features/simd/test_v32x4 (; 13 ;)
+ (func $features/simd/test_v32x4
   nop
  )
- (func $features/simd/test_v64x2 (; 14 ;)
+ (func $features/simd/test_v64x2
   nop
  )
- (func $start:features/simd (; 15 ;)
+ (func $start:features/simd
   global.get $~lib/heap/__heap_base
   i32.const 15
   i32.add
@@ -2294,7 +2294,7 @@
   call $features/simd/test_v32x4
   call $features/simd/test_v64x2
  )
- (func $~start (; 16 ;)
+ (func $~start
   call $start:features/simd
  )
 )

--- a/tests/compiler/features/threads.optimized.wat
+++ b/tests/compiler/features/threads.optimized.wat
@@ -3,7 +3,7 @@
  (memory $0 (shared 1 1))
  (export "memory" (memory $0))
  (start $~start)
- (func $features/threads/testAtomic (; 0 ;)
+ (func $features/threads/testAtomic
   i32.const 0
   i32.atomic.load8_u
   drop
@@ -285,7 +285,7 @@
   i64.atomic.rmw.cmpxchg offset=8
   drop
  )
- (func $features/threads/testAtomicAsm (; 1 ;)
+ (func $features/threads/testAtomicAsm
   i32.const 0
   i32.atomic.load8_u
   drop
@@ -532,7 +532,7 @@
   i64.atomic.rmw.cmpxchg
   drop
  )
- (func $~start (; 2 ;)
+ (func $~start
   call $features/threads/testAtomic
   call $features/threads/testAtomicAsm
  )

--- a/tests/compiler/features/threads.untouched.wat
+++ b/tests/compiler/features/threads.untouched.wat
@@ -5,7 +5,7 @@
  (global $~lib/ASC_FEATURE_THREADS i32 (i32.const 1))
  (export "memory" (memory $0))
  (start $~start)
- (func $features/threads/testAtomic (; 0 ;)
+ (func $features/threads/testAtomic
   i32.const 0
   i32.atomic.load8_u
   drop
@@ -287,7 +287,7 @@
   i64.atomic.rmw.cmpxchg offset=8
   drop
  )
- (func $features/threads/testAtomicAsm (; 1 ;)
+ (func $features/threads/testAtomicAsm
   i32.const 0
   i32.atomic.load8_u
   drop
@@ -534,11 +534,11 @@
   i64.atomic.rmw.cmpxchg
   drop
  )
- (func $start:features/threads (; 2 ;)
+ (func $start:features/threads
   call $features/threads/testAtomic
   call $features/threads/testAtomicAsm
  )
- (func $~start (; 3 ;)
+ (func $~start
   call $start:features/threads
  )
 )

--- a/tests/compiler/for.optimized.wat
+++ b/tests/compiler/for.optimized.wat
@@ -22,7 +22,7 @@
  (global $~started (mut i32) (i32.const 0))
  (export "_start" (func $~start))
  (export "memory" (memory $0))
- (func $for/testNestedContinue (; 5 ;)
+ (func $for/testNestedContinue
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -102,7 +102,7 @@
   i32.const 1
   global.set $for/ran
  )
- (func $~lib/rt/tlsf/removeBlock (; 6 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/removeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -264,7 +264,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/insertBlock (; 7 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/insertBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -543,7 +543,7 @@
   i32.or
   i32.store offset=4
  )
- (func $~lib/rt/tlsf/addMemory (; 8 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $2
@@ -657,7 +657,7 @@
   local.get $1
   call $~lib/rt/tlsf/insertBlock
  )
- (func $~lib/rt/tlsf/maybeInitialize (; 9 ;) (result i32)
+ (func $~lib/rt/tlsf/maybeInitialize (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -744,7 +744,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/tlsf/searchBlock (; 10 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/tlsf/searchBlock (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   nop
@@ -802,7 +802,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/allocateBlock (; 11 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/tlsf/allocateBlock (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -974,7 +974,7 @@
   call $~lib/rt/rtrace/onalloc
   local.get $1
  )
- (func $for/Ref#constructor (; 12 ;) (result i32)
+ (func $for/Ref#constructor (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -1030,7 +1030,7 @@
   end
   local.get $1
  )
- (func $~lib/rt/pure/__release (; 13 ;) (param $0 i32)
+ (func $~lib/rt/pure/__release (param $0 i32)
   local.get $0
   i32.const 1216
   i32.gt_u
@@ -1041,7 +1041,7 @@
    call $~lib/rt/pure/decrement
   end
  )
- (func $start:for (; 14 ;)
+ (func $start:for
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -1398,7 +1398,7 @@
    unreachable
   end
  )
- (func $~start (; 15 ;)
+ (func $~start
   global.get $~started
   if
    return
@@ -1408,7 +1408,7 @@
   end
   call $start:for
  )
- (func $~lib/rt/pure/decrement (; 16 ;) (param $0 i32)
+ (func $~lib/rt/pure/decrement (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0

--- a/tests/compiler/for.untouched.wat
+++ b/tests/compiler/for.untouched.wat
@@ -28,7 +28,7 @@
  (global $~lib/heap/__heap_base i32 (i32.const 208))
  (export "_start" (func $~start))
  (export "memory" (memory $0))
- (func $for/testInitExpression (; 5 ;)
+ (func $for/testInitExpression
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -62,7 +62,7 @@
   i32.const 1
   global.set $for/ran
  )
- (func $for/testInitStatement (; 6 ;)
+ (func $for/testInitStatement
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -96,7 +96,7 @@
   i32.const 1
   global.set $for/ran
  )
- (func $for/testEmpty (; 7 ;)
+ (func $for/testEmpty
   (local $0 i32)
   (local $1 i32)
   i32.const 10
@@ -131,7 +131,7 @@
   i32.const 1
   global.set $for/ran
  )
- (func $for/testConditionOmitted (; 8 ;)
+ (func $for/testConditionOmitted
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -171,7 +171,7 @@
   i32.const 1
   global.set $for/ran
  )
- (func $for/testAllOmitted (; 9 ;)
+ (func $for/testAllOmitted
   (local $0 i32)
   (local $1 i32)
   i32.const 10
@@ -210,7 +210,7 @@
   i32.const 1
   global.set $for/ran
  )
- (func $for/testAlwaysTrue (; 10 ;)
+ (func $for/testAlwaysTrue
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -249,11 +249,11 @@
   i32.const 1
   global.set $for/ran
  )
- (func $for/testAlwaysFalse (; 11 ;)
+ (func $for/testAlwaysFalse
   i32.const 1
   global.set $for/ran
  )
- (func $for/testAlwaysContinues (; 12 ;)
+ (func $for/testAlwaysContinues
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -290,7 +290,7 @@
   i32.const 1
   global.set $for/ran
  )
- (func $for/testAlwaysBreaks (; 13 ;)
+ (func $for/testAlwaysBreaks
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -322,7 +322,7 @@
   i32.const 1
   global.set $for/ran
  )
- (func $for/testAlwaysReturns (; 14 ;)
+ (func $for/testAlwaysReturns
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -350,7 +350,7 @@
    unreachable
   end
  )
- (func $for/testNestedContinue (; 15 ;)
+ (func $for/testNestedContinue
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -451,7 +451,7 @@
   i32.const 1
   global.set $for/ran
  )
- (func $~lib/rt/tlsf/removeBlock (; 16 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/removeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -661,7 +661,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/insertBlock (; 17 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/insertBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1011,7 +1011,7 @@
   local.get $7
   i32.store offset=4
  )
- (func $~lib/rt/tlsf/addMemory (; 18 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1159,7 +1159,7 @@
   call $~lib/rt/tlsf/insertBlock
   i32.const 1
  )
- (func $~lib/rt/tlsf/maybeInitialize (; 19 ;) (result i32)
+ (func $~lib/rt/tlsf/maybeInitialize (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -1313,7 +1313,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/tlsf/prepareSize (; 20 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/tlsf/prepareSize (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -1342,7 +1342,7 @@
   i32.gt_u
   select
  )
- (func $~lib/rt/tlsf/searchBlock (; 21 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/searchBlock (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1525,7 +1525,7 @@
   end
   local.get $7
  )
- (func $~lib/rt/tlsf/growMemory (; 22 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/growMemory (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1609,7 +1609,7 @@
   call $~lib/rt/tlsf/addMemory
   drop
  )
- (func $~lib/rt/tlsf/prepareBlock (; 23 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/rt/tlsf/prepareBlock (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1704,7 +1704,7 @@
    i32.store
   end
  )
- (func $~lib/rt/tlsf/allocateBlock (; 24 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/allocateBlock (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   global.get $~lib/rt/tlsf/collectLock
@@ -1815,7 +1815,7 @@
   call $~lib/rt/rtrace/onalloc
   local.get $4
  )
- (func $~lib/rt/tlsf/__alloc (; 25 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/__alloc (param $0 i32) (param $1 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
   local.get $0
   local.get $1
@@ -1823,7 +1823,7 @@
   i32.const 16
   i32.add
  )
- (func $~lib/rt/pure/increment (; 26 ;) (param $0 i32)
+ (func $~lib/rt/pure/increment (param $0 i32)
   (local $1 i32)
   local.get $0
   i32.load offset=4
@@ -1868,7 +1868,7 @@
    unreachable
   end
  )
- (func $~lib/rt/pure/__retain (; 27 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/pure/__retain (param $0 i32) (result i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.gt_u
@@ -1880,7 +1880,7 @@
   end
   local.get $0
  )
- (func $for/Ref#constructor (; 28 ;) (param $0 i32) (result i32)
+ (func $for/Ref#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -1892,7 +1892,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/pure/__release (; 29 ;) (param $0 i32)
+ (func $~lib/rt/pure/__release (param $0 i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.gt_u
@@ -1903,7 +1903,7 @@
    call $~lib/rt/pure/decrement
   end
  )
- (func $for/testRef (; 30 ;)
+ (func $for/testRef
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -1980,11 +1980,11 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $for/getRef (; 31 ;) (result i32)
+ (func $for/getRef (result i32)
   i32.const 0
   call $for/Ref#constructor
  )
- (func $for/testRefAutorelease (; 32 ;)
+ (func $for/testRefAutorelease
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -2071,7 +2071,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $start:for (; 33 ;)
+ (func $start:for
   i32.const 0
   global.set $for/ran
   call $for/testInitExpression
@@ -2242,7 +2242,7 @@
    unreachable
   end
  )
- (func $~start (; 34 ;)
+ (func $~start
   global.get $~started
   if
    return
@@ -2252,10 +2252,10 @@
   end
   call $start:for
  )
- (func $~lib/rt/pure/__collect (; 35 ;)
+ (func $~lib/rt/pure/__collect
   return
  )
- (func $~lib/rt/tlsf/freeBlock (; 36 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/freeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $1
   i32.load
@@ -2271,7 +2271,7 @@
   local.get $1
   call $~lib/rt/rtrace/onfree
  )
- (func $~lib/rt/pure/decrement (; 37 ;) (param $0 i32)
+ (func $~lib/rt/pure/decrement (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -2348,7 +2348,7 @@
    i32.store offset=4
   end
  )
- (func $~lib/rt/pure/__visit (; 38 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/pure/__visit (param $0 i32) (param $1 i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.lt_u
@@ -2372,7 +2372,7 @@
   i32.sub
   call $~lib/rt/pure/decrement
  )
- (func $~lib/rt/__visit_members (; 39 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/__visit_members (param $0 i32) (param $1 i32)
   (local $2 i32)
   block $switch$1$default
    block $switch$1$case$4

--- a/tests/compiler/function-expression.optimized.wat
+++ b/tests/compiler/function-expression.optimized.wat
@@ -1,101 +1,10 @@
 (module
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
- (type $none_=>_none (func))
- (type $i32_=>_i32 (func (param i32) (result i32)))
  (type $i32_=>_none (func (param i32)))
- (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
- (type $none_=>_i32 (func (result i32)))
- (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 1024) ",\00\00\00\01\00\00\00\01\00\00\00,\00\00\00f\00u\00n\00c\00t\00i\00o\00n\00-\00e\00x\00p\00r\00e\00s\00s\00i\00o\00n\00.\00t\00s")
- (table $0 12 funcref)
- (elem (i32.const 1) $start:function-expression~anonymous|0 $start:function-expression~anonymous|0 $start:function-expression~someName $start:function-expression~anonymous|2 $start:function-expression~anonymous|3 $start:function-expression~anonymous|4 $start:function-expression~anonymous|5 $start:function-expression~anonymous|3 $start:function-expression~anonymous|4 $start:function-expression~anonymous|5 $start:function-expression~anonymous|2)
- (global $~argumentsLength (mut i32) (i32.const 0))
  (export "__setArgumentsLength" (func $~setArgumentsLength))
  (export "memory" (memory $0))
- (start $~start)
- (func $start:function-expression~anonymous|0 (; 1 ;) (param $0 i32) (result i32)
-  local.get $0
- )
- (func $~setArgumentsLength (; 2 ;) (param $0 i32)
-  local.get $0
-  global.set $~argumentsLength
- )
- (func $start:function-expression~someName (; 3 ;)
+ (func $~setArgumentsLength (param $0 i32)
   nop
- )
- (func $start:function-expression~anonymous|2 (; 4 ;) (result i32)
-  i32.const 1
- )
- (func $start:function-expression~anonymous|3 (; 5 ;) (param $0 i32) (param $1 i32) (result i32)
-  local.get $0
-  local.get $1
-  i32.add
- )
- (func $function-expression/testOmitted (; 6 ;) (param $0 i32) (result i32)
-  i32.const 2
-  global.set $~argumentsLength
-  i32.const 1
-  i32.const 2
-  local.get $0
-  call_indirect (type $i32_i32_=>_i32)
- )
- (func $start:function-expression~anonymous|4 (; 7 ;) (param $0 i32) (param $1 i32) (result i32)
-  local.get $0
- )
- (func $start:function-expression~anonymous|5 (; 8 ;) (param $0 i32) (param $1 i32) (result i32)
-  i32.const 42
- )
- (func $~start (; 9 ;)
-  i32.const 1
-  global.set $~argumentsLength
-  i32.const 1
-  global.set $~argumentsLength
-  i32.const 0
-  global.set $~argumentsLength
-  i32.const 0
-  global.set $~argumentsLength
-  i32.const 5
-  call $function-expression/testOmitted
-  i32.const 3
-  i32.ne
-  if
-   i32.const 0
-   i32.const 1040
-   i32.const 21
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i32.const 6
-  call $function-expression/testOmitted
-  i32.const 1
-  i32.ne
-  if
-   i32.const 0
-   i32.const 1040
-   i32.const 22
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i32.const 7
-  call $function-expression/testOmitted
-  i32.const 42
-  i32.ne
-  if
-   i32.const 0
-   i32.const 1040
-   i32.const 23
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i32.const 2
-  global.set $~argumentsLength
-  i32.const 2
-  global.set $~argumentsLength
-  i32.const 2
-  global.set $~argumentsLength
  )
 )

--- a/tests/compiler/function-expression.untouched.wat
+++ b/tests/compiler/function-expression.untouched.wat
@@ -18,28 +18,28 @@
  (export "__setArgumentsLength" (func $~setArgumentsLength))
  (export "memory" (memory $0))
  (start $~start)
- (func $start:function-expression~anonymous|0 (; 1 ;) (param $0 i32) (result i32)
+ (func $start:function-expression~anonymous|0 (param $0 i32) (result i32)
   local.get $0
  )
- (func $~setArgumentsLength (; 2 ;) (param $0 i32)
+ (func $~setArgumentsLength (param $0 i32)
   local.get $0
   global.set $~argumentsLength
  )
- (func $start:function-expression~anonymous|1 (; 3 ;) (param $0 i32) (result i32)
+ (func $start:function-expression~anonymous|1 (param $0 i32) (result i32)
   local.get $0
  )
- (func $start:function-expression~someName (; 4 ;)
+ (func $start:function-expression~someName
   nop
  )
- (func $start:function-expression~anonymous|2 (; 5 ;) (result i32)
+ (func $start:function-expression~anonymous|2 (result i32)
   i32.const 1
  )
- (func $start:function-expression~anonymous|3 (; 6 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $start:function-expression~anonymous|3 (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.add
  )
- (func $function-expression/testOmitted (; 7 ;) (param $0 i32) (result i32)
+ (func $function-expression/testOmitted (param $0 i32) (result i32)
   i32.const 2
   global.set $~argumentsLength
   i32.const 1
@@ -47,36 +47,36 @@
   local.get $0
   call_indirect (type $i32_i32_=>_i32)
  )
- (func $start:function-expression~anonymous|4 (; 8 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $start:function-expression~anonymous|4 (param $0 i32) (param $1 i32) (result i32)
   local.get $0
  )
- (func $start:function-expression~anonymous|5 (; 9 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $start:function-expression~anonymous|5 (param $0 i32) (param $1 i32) (result i32)
   i32.const 42
  )
- (func $function-expression/testOmittedReturn1~anonymous|0 (; 10 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $function-expression/testOmittedReturn1~anonymous|0 (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.add
  )
- (func $function-expression/testOmittedReturn1 (; 11 ;) (result i32)
+ (func $function-expression/testOmittedReturn1 (result i32)
   i32.const 8
  )
- (func $function-expression/testOmittedReturn2~anonymous|0 (; 12 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $function-expression/testOmittedReturn2~anonymous|0 (param $0 i32) (param $1 i32) (result i32)
   local.get $0
  )
- (func $function-expression/testOmittedReturn2 (; 13 ;) (result i32)
+ (func $function-expression/testOmittedReturn2 (result i32)
   i32.const 9
  )
- (func $function-expression/testOmittedReturn3~anonymous|0 (; 14 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $function-expression/testOmittedReturn3~anonymous|0 (param $0 i32) (param $1 i32) (result i32)
   i32.const 42
  )
- (func $function-expression/testOmittedReturn3 (; 15 ;) (result i32)
+ (func $function-expression/testOmittedReturn3 (result i32)
   i32.const 10
  )
- (func $function-expression/testNullable~anonymous|0 (; 16 ;) (result i32)
+ (func $function-expression/testNullable~anonymous|0 (result i32)
   i32.const 1
  )
- (func $function-expression/testNullable (; 17 ;) (param $0 i32) (result i32)
+ (func $function-expression/testNullable (param $0 i32) (result i32)
   local.get $0
   if
    i32.const 11
@@ -87,7 +87,7 @@
   end
   unreachable
  )
- (func $start:function-expression (; 18 ;)
+ (func $start:function-expression
   i32.const 1
   global.set $~argumentsLength
   i32.const 1
@@ -243,7 +243,7 @@
    unreachable
   end
  )
- (func $~start (; 19 ;)
+ (func $~start
   call $start:function-expression
  )
 )

--- a/tests/compiler/function-types.optimized.wat
+++ b/tests/compiler/function-types.optimized.wat
@@ -1,9 +1,8 @@
 (module
- (type $none_=>_none (func))
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
+ (type $none_=>_none (func))
  (type $i32_=>_none (func (param i32)))
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
- (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (type $i64_i64_=>_i64 (func (param i64 i64) (result i64)))
  (type $f64_f64_=>_f64 (func (param f64 f64) (result f64)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
@@ -11,54 +10,32 @@
  (data (i32.const 1024) "\"\00\00\00\01\00\00\00\01\00\00\00\"\00\00\00f\00u\00n\00c\00t\00i\00o\00n\00-\00t\00y\00p\00e\00s\00.\00t\00s")
  (table $0 5 funcref)
  (elem (i32.const 1) $function-types/makeAdder<i32>~anonymous|0 $function-types/makeAdder<i64>~anonymous|0 $function-types/makeAdder<f64>~anonymous|0 $function-types/makeAdder<i32>~anonymous|0)
- (global $function-types/i32Adder (mut i32) (i32.const 0))
- (global $~argumentsLength (mut i32) (i32.const 0))
- (global $function-types/i64Adder (mut i32) (i32.const 0))
  (export "__setArgumentsLength" (func $~setArgumentsLength))
  (export "memory" (memory $0))
  (start $~start)
- (func $function-types/makeAdder<i32>~anonymous|0 (; 1 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $function-types/makeAdder<i32>~anonymous|0 (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.add
  )
- (func $~setArgumentsLength (; 2 ;) (param $0 i32)
-  local.get $0
-  global.set $~argumentsLength
+ (func $~setArgumentsLength (param $0 i32)
+  nop
  )
- (func $function-types/makeAdder<i64>~anonymous|0 (; 3 ;) (param $0 i64) (param $1 i64) (result i64)
+ (func $function-types/makeAdder<i64>~anonymous|0 (param $0 i64) (param $1 i64) (result i64)
   local.get $0
   local.get $1
   i64.add
  )
- (func $function-types/makeAdder<f64>~anonymous|0 (; 4 ;) (param $0 f64) (param $1 f64) (result f64)
+ (func $function-types/makeAdder<f64>~anonymous|0 (param $0 f64) (param $1 f64) (result f64)
   local.get $0
   local.get $1
   f64.add
  )
- (func $function-types/doAddWithFn<i32> (; 5 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  i32.const 2
-  global.set $~argumentsLength
-  local.get $0
-  local.get $1
-  local.get $2
-  call_indirect (type $i32_i32_=>_i32)
- )
- (func $start:function-types (; 6 ;)
-  i32.const 1
-  global.set $function-types/i32Adder
-  i32.const 2
-  global.set $~argumentsLength
-  i32.const 2
-  global.set $function-types/i64Adder
-  i32.const 2
-  global.set $~argumentsLength
-  i32.const 2
-  global.set $~argumentsLength
+ (func $~start
   i32.const 2
   i32.const 3
   i32.const 1
-  call $function-types/doAddWithFn<i32>
+  call_indirect (type $i32_i32_=>_i32)
   i32.const 5
   i32.ne
   if
@@ -69,12 +46,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 2
-  global.set $~argumentsLength
   i32.const 4
   i32.const 5
   i32.const 4
-  call $function-types/doAddWithFn<i32>
+  call_indirect (type $i32_i32_=>_i32)
   i32.const 9
   i32.ne
   if
@@ -85,12 +60,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 2
-  global.set $~argumentsLength
   i32.const 1
   i32.const 2
   i32.const 1
-  call $function-types/doAddWithFn<i32>
+  call_indirect (type $i32_i32_=>_i32)
   i32.const 3
   i32.ne
   if
@@ -104,7 +77,7 @@
   i32.const 1
   i32.const 2
   i32.const 1
-  call $function-types/doAddWithFn<i32>
+  call_indirect (type $i32_i32_=>_i32)
   i32.const 3
   i32.ne
   if
@@ -115,8 +88,5 @@
    call $~lib/builtins/abort
    unreachable
   end
- )
- (func $~start (; 7 ;)
-  call $start:function-types
  )
 )

--- a/tests/compiler/function-types.untouched.wat
+++ b/tests/compiler/function-types.untouched.wat
@@ -18,35 +18,35 @@
  (export "__setArgumentsLength" (func $~setArgumentsLength))
  (export "memory" (memory $0))
  (start $~start)
- (func $function-types/makeAdder<i32>~anonymous|0 (; 1 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $function-types/makeAdder<i32>~anonymous|0 (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.add
  )
- (func $function-types/makeAdder<i32> (; 2 ;) (result i32)
+ (func $function-types/makeAdder<i32> (result i32)
   i32.const 1
  )
- (func $~setArgumentsLength (; 3 ;) (param $0 i32)
+ (func $~setArgumentsLength (param $0 i32)
   local.get $0
   global.set $~argumentsLength
  )
- (func $function-types/makeAdder<i64>~anonymous|0 (; 4 ;) (param $0 i64) (param $1 i64) (result i64)
+ (func $function-types/makeAdder<i64>~anonymous|0 (param $0 i64) (param $1 i64) (result i64)
   local.get $0
   local.get $1
   i64.add
  )
- (func $function-types/makeAdder<i64> (; 5 ;) (result i32)
+ (func $function-types/makeAdder<i64> (result i32)
   i32.const 2
  )
- (func $function-types/makeAdder<f64>~anonymous|0 (; 6 ;) (param $0 f64) (param $1 f64) (result f64)
+ (func $function-types/makeAdder<f64>~anonymous|0 (param $0 f64) (param $1 f64) (result f64)
   local.get $0
   local.get $1
   f64.add
  )
- (func $function-types/makeAdder<f64> (; 7 ;) (result i32)
+ (func $function-types/makeAdder<f64> (result i32)
   i32.const 3
  )
- (func $function-types/doAddWithFn<i32> (; 8 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $function-types/doAddWithFn<i32> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   i32.const 2
   global.set $~argumentsLength
   local.get $0
@@ -54,7 +54,7 @@
   local.get $2
   call_indirect (type $i32_i32_=>_i32)
  )
- (func $function-types/doAdd<i32> (; 9 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $function-types/doAdd<i32> (param $0 i32) (param $1 i32) (result i32)
   i32.const 2
   global.set $~argumentsLength
   local.get $0
@@ -62,12 +62,12 @@
   call $function-types/makeAdder<i32>
   call_indirect (type $i32_i32_=>_i32)
  )
- (func $function-types/addI32 (; 10 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $function-types/addI32 (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.add
  )
- (func $function-types/makeAndAdd<i32> (; 11 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $function-types/makeAndAdd<i32> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   i32.const 2
   global.set $~argumentsLength
   local.get $0
@@ -75,7 +75,7 @@
   local.get $2
   call_indirect (type $i32_i32_=>_i32)
  )
- (func $function-types/makeAndAdd<i32>|trampoline (; 12 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $function-types/makeAndAdd<i32>|trampoline (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -94,7 +94,7 @@
   local.get $2
   call $function-types/makeAndAdd<i32>
  )
- (func $start:function-types (; 13 ;)
+ (func $start:function-types
   call $function-types/makeAdder<i32>
   global.set $function-types/i32Adder
   i32.const 2
@@ -227,7 +227,7 @@
    unreachable
   end
  )
- (func $~start (; 14 ;)
+ (func $~start
   call $start:function-types
  )
 )

--- a/tests/compiler/function.untouched.wat
+++ b/tests/compiler/function.untouched.wat
@@ -18,70 +18,70 @@
  (table $0 1 funcref)
  (export "memory" (memory $0))
  (start $~start)
- (func $function/_ (; 0 ;)
+ (func $function/_
   nop
  )
- (func $function/v (; 1 ;)
+ (func $function/v
   return
  )
- (func $function/i (; 2 ;) (result i32)
+ (func $function/i (result i32)
   i32.const 0
  )
- (func $function/j (; 3 ;) (result i64)
+ (func $function/j (result i64)
   i64.const 0
  )
- (func $function/f (; 4 ;) (result f32)
+ (func $function/f (result f32)
   f32.const 0
  )
- (func $function/d (; 5 ;) (result f64)
+ (func $function/d (result f64)
   f64.const 0
  )
- (func $function/i_ (; 6 ;) (param $0 i32)
+ (func $function/i_ (param $0 i32)
   nop
  )
- (func $function/iv (; 7 ;) (param $0 i32)
+ (func $function/iv (param $0 i32)
   return
  )
- (func $function/ii (; 8 ;) (param $0 i32) (result i32)
+ (func $function/ii (param $0 i32) (result i32)
   local.get $0
  )
- (func $function/jj (; 9 ;) (param $0 i64) (result i64)
+ (func $function/jj (param $0 i64) (result i64)
   local.get $0
  )
- (func $function/ff (; 10 ;) (param $0 f32) (result f32)
+ (func $function/ff (param $0 f32) (result f32)
   local.get $0
  )
- (func $function/dd (; 11 ;) (param $0 f64) (result f64)
+ (func $function/dd (param $0 f64) (result f64)
   local.get $0
  )
- (func $function/ii_ (; 12 ;) (param $0 i32) (param $1 i32)
+ (func $function/ii_ (param $0 i32) (param $1 i32)
   nop
  )
- (func $function/iiv (; 13 ;) (param $0 i32) (param $1 i32)
+ (func $function/iiv (param $0 i32) (param $1 i32)
   return
  )
- (func $function/iii (; 14 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $function/iii (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.add
  )
- (func $function/jjj (; 15 ;) (param $0 i64) (param $1 i32) (result i64)
+ (func $function/jjj (param $0 i64) (param $1 i32) (result i64)
   local.get $0
   local.get $1
   i64.extend_i32_s
   i64.add
  )
- (func $function/fff (; 16 ;) (param $0 f32) (param $1 f32) (result f32)
+ (func $function/fff (param $0 f32) (param $1 f32) (result f32)
   local.get $0
   local.get $1
   f32.add
  )
- (func $function/ddd (; 17 ;) (param $0 f64) (param $1 f64) (result f64)
+ (func $function/ddd (param $0 f64) (param $1 f64) (result f64)
   local.get $0
   local.get $1
   f64.add
  )
- (func $start:function (; 18 ;)
+ (func $start:function
   call $function/_
   call $function/v
   call $function/i
@@ -131,7 +131,7 @@
   call $function/ddd
   drop
  )
- (func $~start (; 19 ;)
+ (func $~start
   call $start:function
  )
 )

--- a/tests/compiler/getter-call.optimized.wat
+++ b/tests/compiler/getter-call.optimized.wat
@@ -3,18 +3,15 @@
  (type $i32_=>_none (func (param i32)))
  (type $none_=>_i32 (func (result i32)))
  (memory $0 0)
- (global $~lib/rt/stub/startOffset (mut i32) (i32.const 0))
  (global $~lib/rt/stub/offset (mut i32) (i32.const 0))
- (global $~argumentsLength (mut i32) (i32.const 0))
  (export "__setArgumentsLength" (func $~setArgumentsLength))
  (export "memory" (memory $0))
  (export "test" (func $getter-call/test))
  (start $~start)
- (func $~setArgumentsLength (; 0 ;) (param $0 i32)
-  local.get $0
-  global.set $~argumentsLength
+ (func $~setArgumentsLength (param $0 i32)
+  nop
  )
- (func $getter-call/test (; 1 ;) (result i32)
+ (func $getter-call/test (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -78,13 +75,9 @@
   local.get $0
   i32.const 0
   i32.store offset=12
-  i32.const 0
-  global.set $~argumentsLength
   i32.const 42
  )
- (func $~start (; 2 ;)
-  i32.const 1024
-  global.set $~lib/rt/stub/startOffset
+ (func $~start
   i32.const 1024
   global.set $~lib/rt/stub/offset
  )

--- a/tests/compiler/getter-call.untouched.wat
+++ b/tests/compiler/getter-call.untouched.wat
@@ -15,7 +15,7 @@
  (export "memory" (memory $0))
  (export "test" (func $getter-call/test))
  (start $~start)
- (func $~lib/rt/stub/maybeGrowMemory (; 0 ;) (param $0 i32)
+ (func $~lib/rt/stub/maybeGrowMemory (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -69,7 +69,7 @@
   local.get $0
   global.set $~lib/rt/stub/offset
  )
- (func $~lib/rt/stub/__alloc (; 1 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/stub/__alloc (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -122,10 +122,10 @@
   i32.store offset=12
   local.get $2
  )
- (func $~lib/rt/stub/__retain (; 2 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/stub/__retain (param $0 i32) (result i32)
   local.get $0
  )
- (func $getter-call/C#constructor (; 3 ;) (param $0 i32) (result i32)
+ (func $getter-call/C#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -137,20 +137,20 @@
   end
   local.get $0
  )
- (func $getter-call/C#get:x~anonymous|0 (; 4 ;) (result i32)
+ (func $getter-call/C#get:x~anonymous|0 (result i32)
   i32.const 42
  )
- (func $getter-call/C#get:x (; 5 ;) (param $0 i32) (result i32)
+ (func $getter-call/C#get:x (param $0 i32) (result i32)
   i32.const 1
  )
- (func $~setArgumentsLength (; 6 ;) (param $0 i32)
+ (func $~setArgumentsLength (param $0 i32)
   local.get $0
   global.set $~argumentsLength
  )
- (func $~lib/rt/stub/__release (; 7 ;) (param $0 i32)
+ (func $~lib/rt/stub/__release (param $0 i32)
   nop
  )
- (func $getter-call/test (; 8 ;) (result i32)
+ (func $getter-call/test (result i32)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -166,7 +166,7 @@
   call $~lib/rt/stub/__release
   local.get $1
  )
- (func $~start (; 9 ;)
+ (func $~start
   global.get $~lib/heap/__heap_base
   i32.const 15
   i32.add

--- a/tests/compiler/getter-setter.optimized.wat
+++ b/tests/compiler/getter-setter.optimized.wat
@@ -7,7 +7,7 @@
  (global $getter-setter/Foo._bar (mut i32) (i32.const 0))
  (export "memory" (memory $0))
  (start $~start)
- (func $~start (; 1 ;)
+ (func $~start
   global.get $getter-setter/Foo._bar
   if
    i32.const 0

--- a/tests/compiler/getter-setter.untouched.wat
+++ b/tests/compiler/getter-setter.untouched.wat
@@ -10,14 +10,14 @@
  (global $getter-setter/Foo._bar (mut i32) (i32.const 0))
  (export "memory" (memory $0))
  (start $~start)
- (func $getter-setter/Foo.bar.get:bar (; 1 ;) (result i32)
+ (func $getter-setter/Foo.bar.get:bar (result i32)
   global.get $getter-setter/Foo._bar
  )
- (func $getter-setter/Foo.bar.set:bar (; 2 ;) (param $0 i32)
+ (func $getter-setter/Foo.bar.set:bar (param $0 i32)
   local.get $0
   global.set $getter-setter/Foo._bar
  )
- (func $start:getter-setter (; 3 ;)
+ (func $start:getter-setter
   call $getter-setter/Foo.bar.get:bar
   i32.const 0
   i32.eq
@@ -59,7 +59,7 @@
    unreachable
   end
  )
- (func $~start (; 4 ;)
+ (func $~start
   call $start:getter-setter
  )
 )

--- a/tests/compiler/i64-polyfill.optimized.wat
+++ b/tests/compiler/i64-polyfill.optimized.wat
@@ -37,13 +37,13 @@
  (export "gt_u" (func $../../lib/i64/assembly/i64/gt_u))
  (export "ge_s" (func $../../lib/i64/assembly/i64/ge_s))
  (export "ge_u" (func $../../lib/i64/assembly/i64/ge_u))
- (func $../../lib/i64/assembly/i64/getHi (; 0 ;) (result i32)
+ (func $../../lib/i64/assembly/i64/getHi (result i32)
   global.get $../../lib/i64/assembly/i64/hi
  )
- (func $../../lib/i64/assembly/i64/getLo (; 1 ;) (result i32)
+ (func $../../lib/i64/assembly/i64/getLo (result i32)
   global.get $../../lib/i64/assembly/i64/lo
  )
- (func $../../lib/i64/assembly/i64/clz (; 2 ;) (param $0 i32) (param $1 i32)
+ (func $../../lib/i64/assembly/i64/clz (param $0 i32) (param $1 i32)
   local.get $0
   i64.extend_i32_u
   local.get $1
@@ -57,7 +57,7 @@
   i32.const 0
   global.set $../../lib/i64/assembly/i64/hi
  )
- (func $../../lib/i64/assembly/i64/ctz (; 3 ;) (param $0 i32) (param $1 i32)
+ (func $../../lib/i64/assembly/i64/ctz (param $0 i32) (param $1 i32)
   local.get $0
   i64.extend_i32_u
   local.get $1
@@ -71,7 +71,7 @@
   i32.const 0
   global.set $../../lib/i64/assembly/i64/hi
  )
- (func $../../lib/i64/assembly/i64/popcnt (; 4 ;) (param $0 i32) (param $1 i32)
+ (func $../../lib/i64/assembly/i64/popcnt (param $0 i32) (param $1 i32)
   local.get $0
   i64.extend_i32_u
   local.get $1
@@ -85,7 +85,7 @@
   i32.const 0
   global.set $../../lib/i64/assembly/i64/hi
  )
- (func $../../lib/i64/assembly/i64/eqz (; 5 ;) (param $0 i32) (param $1 i32)
+ (func $../../lib/i64/assembly/i64/eqz (param $0 i32) (param $1 i32)
   local.get $0
   i64.extend_i32_u
   local.get $1
@@ -98,7 +98,7 @@
   i32.const 0
   global.set $../../lib/i64/assembly/i64/hi
  )
- (func $../../lib/i64/assembly/i64/add (; 6 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../lib/i64/assembly/i64/add (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -124,7 +124,7 @@
   i32.wrap_i64
   global.set $../../lib/i64/assembly/i64/hi
  )
- (func $../../lib/i64/assembly/i64/sub (; 7 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../lib/i64/assembly/i64/sub (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -150,7 +150,7 @@
   i32.wrap_i64
   global.set $../../lib/i64/assembly/i64/hi
  )
- (func $../../lib/i64/assembly/i64/mul (; 8 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../lib/i64/assembly/i64/mul (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -176,7 +176,7 @@
   i32.wrap_i64
   global.set $../../lib/i64/assembly/i64/hi
  )
- (func $../../lib/i64/assembly/i64/div_s (; 9 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../lib/i64/assembly/i64/div_s (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -202,7 +202,7 @@
   i32.wrap_i64
   global.set $../../lib/i64/assembly/i64/hi
  )
- (func $../../lib/i64/assembly/i64/div_u (; 10 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../lib/i64/assembly/i64/div_u (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -228,7 +228,7 @@
   i32.wrap_i64
   global.set $../../lib/i64/assembly/i64/hi
  )
- (func $../../lib/i64/assembly/i64/rem_s (; 11 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../lib/i64/assembly/i64/rem_s (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -254,7 +254,7 @@
   i32.wrap_i64
   global.set $../../lib/i64/assembly/i64/hi
  )
- (func $../../lib/i64/assembly/i64/rem_u (; 12 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../lib/i64/assembly/i64/rem_u (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -280,7 +280,7 @@
   i32.wrap_i64
   global.set $../../lib/i64/assembly/i64/hi
  )
- (func $../../lib/i64/assembly/i64/and (; 13 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../lib/i64/assembly/i64/and (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -306,7 +306,7 @@
   i32.wrap_i64
   global.set $../../lib/i64/assembly/i64/hi
  )
- (func $../../lib/i64/assembly/i64/or (; 14 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../lib/i64/assembly/i64/or (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -332,7 +332,7 @@
   i32.wrap_i64
   global.set $../../lib/i64/assembly/i64/hi
  )
- (func $../../lib/i64/assembly/i64/xor (; 15 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../lib/i64/assembly/i64/xor (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -358,7 +358,7 @@
   i32.wrap_i64
   global.set $../../lib/i64/assembly/i64/hi
  )
- (func $../../lib/i64/assembly/i64/shl (; 16 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../lib/i64/assembly/i64/shl (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -384,7 +384,7 @@
   i32.wrap_i64
   global.set $../../lib/i64/assembly/i64/hi
  )
- (func $../../lib/i64/assembly/i64/shr_s (; 17 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../lib/i64/assembly/i64/shr_s (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -410,7 +410,7 @@
   i32.wrap_i64
   global.set $../../lib/i64/assembly/i64/hi
  )
- (func $../../lib/i64/assembly/i64/shr_u (; 18 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../lib/i64/assembly/i64/shr_u (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -436,7 +436,7 @@
   i32.wrap_i64
   global.set $../../lib/i64/assembly/i64/hi
  )
- (func $../../lib/i64/assembly/i64/rotl (; 19 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../lib/i64/assembly/i64/rotl (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -462,7 +462,7 @@
   i32.wrap_i64
   global.set $../../lib/i64/assembly/i64/hi
  )
- (func $../../lib/i64/assembly/i64/rotr (; 20 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../lib/i64/assembly/i64/rotr (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -488,7 +488,7 @@
   i32.wrap_i64
   global.set $../../lib/i64/assembly/i64/hi
  )
- (func $../../lib/i64/assembly/i64/eq (; 21 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../lib/i64/assembly/i64/eq (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   local.get $0
   i64.extend_i32_u
   local.get $1
@@ -508,7 +508,7 @@
   i32.const 0
   global.set $../../lib/i64/assembly/i64/hi
  )
- (func $../../lib/i64/assembly/i64/ne (; 22 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../lib/i64/assembly/i64/ne (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   local.get $0
   i64.extend_i32_u
   local.get $1
@@ -528,7 +528,7 @@
   i32.const 0
   global.set $../../lib/i64/assembly/i64/hi
  )
- (func $../../lib/i64/assembly/i64/lt_s (; 23 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../lib/i64/assembly/i64/lt_s (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   local.get $0
   i64.extend_i32_u
   local.get $1
@@ -548,7 +548,7 @@
   i32.const 0
   global.set $../../lib/i64/assembly/i64/hi
  )
- (func $../../lib/i64/assembly/i64/lt_u (; 24 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../lib/i64/assembly/i64/lt_u (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   local.get $0
   i64.extend_i32_u
   local.get $1
@@ -568,7 +568,7 @@
   i32.const 0
   global.set $../../lib/i64/assembly/i64/hi
  )
- (func $../../lib/i64/assembly/i64/le_s (; 25 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../lib/i64/assembly/i64/le_s (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   local.get $0
   i64.extend_i32_u
   local.get $1
@@ -588,7 +588,7 @@
   i32.const 0
   global.set $../../lib/i64/assembly/i64/hi
  )
- (func $../../lib/i64/assembly/i64/le_u (; 26 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../lib/i64/assembly/i64/le_u (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   local.get $0
   i64.extend_i32_u
   local.get $1
@@ -608,7 +608,7 @@
   i32.const 0
   global.set $../../lib/i64/assembly/i64/hi
  )
- (func $../../lib/i64/assembly/i64/gt_s (; 27 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../lib/i64/assembly/i64/gt_s (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   local.get $0
   i64.extend_i32_u
   local.get $1
@@ -628,7 +628,7 @@
   i32.const 0
   global.set $../../lib/i64/assembly/i64/hi
  )
- (func $../../lib/i64/assembly/i64/gt_u (; 28 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../lib/i64/assembly/i64/gt_u (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   local.get $0
   i64.extend_i32_u
   local.get $1
@@ -648,7 +648,7 @@
   i32.const 0
   global.set $../../lib/i64/assembly/i64/hi
  )
- (func $../../lib/i64/assembly/i64/ge_s (; 29 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../lib/i64/assembly/i64/ge_s (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   local.get $0
   i64.extend_i32_u
   local.get $1
@@ -668,7 +668,7 @@
   i32.const 0
   global.set $../../lib/i64/assembly/i64/hi
  )
- (func $../../lib/i64/assembly/i64/ge_u (; 30 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../lib/i64/assembly/i64/ge_u (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   local.get $0
   i64.extend_i32_u
   local.get $1

--- a/tests/compiler/i64-polyfill.untouched.wat
+++ b/tests/compiler/i64-polyfill.untouched.wat
@@ -38,13 +38,13 @@
  (export "gt_u" (func $../../lib/i64/assembly/i64/gt_u))
  (export "ge_s" (func $../../lib/i64/assembly/i64/ge_s))
  (export "ge_u" (func $../../lib/i64/assembly/i64/ge_u))
- (func $../../lib/i64/assembly/i64/getHi (; 0 ;) (result i32)
+ (func $../../lib/i64/assembly/i64/getHi (result i32)
   global.get $../../lib/i64/assembly/i64/hi
  )
- (func $../../lib/i64/assembly/i64/getLo (; 1 ;) (result i32)
+ (func $../../lib/i64/assembly/i64/getLo (result i32)
   global.get $../../lib/i64/assembly/i64/lo
  )
- (func $../../lib/i64/assembly/i64/clz (; 2 ;) (param $0 i32) (param $1 i32)
+ (func $../../lib/i64/assembly/i64/clz (param $0 i32) (param $1 i32)
   (local $2 i64)
   local.get $0
   i64.extend_i32_u
@@ -61,7 +61,7 @@
   i32.const 0
   global.set $../../lib/i64/assembly/i64/hi
  )
- (func $../../lib/i64/assembly/i64/ctz (; 3 ;) (param $0 i32) (param $1 i32)
+ (func $../../lib/i64/assembly/i64/ctz (param $0 i32) (param $1 i32)
   (local $2 i64)
   local.get $0
   i64.extend_i32_u
@@ -78,7 +78,7 @@
   i32.const 0
   global.set $../../lib/i64/assembly/i64/hi
  )
- (func $../../lib/i64/assembly/i64/popcnt (; 4 ;) (param $0 i32) (param $1 i32)
+ (func $../../lib/i64/assembly/i64/popcnt (param $0 i32) (param $1 i32)
   (local $2 i64)
   local.get $0
   i64.extend_i32_u
@@ -95,7 +95,7 @@
   i32.const 0
   global.set $../../lib/i64/assembly/i64/hi
  )
- (func $../../lib/i64/assembly/i64/eqz (; 5 ;) (param $0 i32) (param $1 i32)
+ (func $../../lib/i64/assembly/i64/eqz (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i64.extend_i32_u
@@ -113,7 +113,7 @@
   i32.const 0
   global.set $../../lib/i64/assembly/i64/hi
  )
- (func $../../lib/i64/assembly/i64/add (; 6 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../lib/i64/assembly/i64/add (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -140,7 +140,7 @@
   i32.wrap_i64
   global.set $../../lib/i64/assembly/i64/hi
  )
- (func $../../lib/i64/assembly/i64/sub (; 7 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../lib/i64/assembly/i64/sub (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -167,7 +167,7 @@
   i32.wrap_i64
   global.set $../../lib/i64/assembly/i64/hi
  )
- (func $../../lib/i64/assembly/i64/mul (; 8 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../lib/i64/assembly/i64/mul (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -194,7 +194,7 @@
   i32.wrap_i64
   global.set $../../lib/i64/assembly/i64/hi
  )
- (func $../../lib/i64/assembly/i64/div_s (; 9 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../lib/i64/assembly/i64/div_s (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -221,7 +221,7 @@
   i32.wrap_i64
   global.set $../../lib/i64/assembly/i64/hi
  )
- (func $../../lib/i64/assembly/i64/div_u (; 10 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../lib/i64/assembly/i64/div_u (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -248,7 +248,7 @@
   i32.wrap_i64
   global.set $../../lib/i64/assembly/i64/hi
  )
- (func $../../lib/i64/assembly/i64/rem_s (; 11 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../lib/i64/assembly/i64/rem_s (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -275,7 +275,7 @@
   i32.wrap_i64
   global.set $../../lib/i64/assembly/i64/hi
  )
- (func $../../lib/i64/assembly/i64/rem_u (; 12 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../lib/i64/assembly/i64/rem_u (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -302,7 +302,7 @@
   i32.wrap_i64
   global.set $../../lib/i64/assembly/i64/hi
  )
- (func $../../lib/i64/assembly/i64/and (; 13 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../lib/i64/assembly/i64/and (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -329,7 +329,7 @@
   i32.wrap_i64
   global.set $../../lib/i64/assembly/i64/hi
  )
- (func $../../lib/i64/assembly/i64/or (; 14 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../lib/i64/assembly/i64/or (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -356,7 +356,7 @@
   i32.wrap_i64
   global.set $../../lib/i64/assembly/i64/hi
  )
- (func $../../lib/i64/assembly/i64/xor (; 15 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../lib/i64/assembly/i64/xor (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -383,7 +383,7 @@
   i32.wrap_i64
   global.set $../../lib/i64/assembly/i64/hi
  )
- (func $../../lib/i64/assembly/i64/shl (; 16 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../lib/i64/assembly/i64/shl (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -410,7 +410,7 @@
   i32.wrap_i64
   global.set $../../lib/i64/assembly/i64/hi
  )
- (func $../../lib/i64/assembly/i64/shr_s (; 17 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../lib/i64/assembly/i64/shr_s (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -437,7 +437,7 @@
   i32.wrap_i64
   global.set $../../lib/i64/assembly/i64/hi
  )
- (func $../../lib/i64/assembly/i64/shr_u (; 18 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../lib/i64/assembly/i64/shr_u (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -464,7 +464,7 @@
   i32.wrap_i64
   global.set $../../lib/i64/assembly/i64/hi
  )
- (func $../../lib/i64/assembly/i64/rotl (; 19 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../lib/i64/assembly/i64/rotl (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -491,7 +491,7 @@
   i32.wrap_i64
   global.set $../../lib/i64/assembly/i64/hi
  )
- (func $../../lib/i64/assembly/i64/rotr (; 20 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../lib/i64/assembly/i64/rotr (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -518,7 +518,7 @@
   i32.wrap_i64
   global.set $../../lib/i64/assembly/i64/hi
  )
- (func $../../lib/i64/assembly/i64/eq (; 21 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../lib/i64/assembly/i64/eq (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   local.get $0
   i64.extend_i32_u
@@ -541,7 +541,7 @@
   i32.const 0
   global.set $../../lib/i64/assembly/i64/hi
  )
- (func $../../lib/i64/assembly/i64/ne (; 22 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../lib/i64/assembly/i64/ne (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   local.get $0
   i64.extend_i32_u
@@ -564,7 +564,7 @@
   i32.const 0
   global.set $../../lib/i64/assembly/i64/hi
  )
- (func $../../lib/i64/assembly/i64/lt_s (; 23 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../lib/i64/assembly/i64/lt_s (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   local.get $0
   i64.extend_i32_u
@@ -587,7 +587,7 @@
   i32.const 0
   global.set $../../lib/i64/assembly/i64/hi
  )
- (func $../../lib/i64/assembly/i64/lt_u (; 24 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../lib/i64/assembly/i64/lt_u (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   local.get $0
   i64.extend_i32_u
@@ -610,7 +610,7 @@
   i32.const 0
   global.set $../../lib/i64/assembly/i64/hi
  )
- (func $../../lib/i64/assembly/i64/le_s (; 25 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../lib/i64/assembly/i64/le_s (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   local.get $0
   i64.extend_i32_u
@@ -633,7 +633,7 @@
   i32.const 0
   global.set $../../lib/i64/assembly/i64/hi
  )
- (func $../../lib/i64/assembly/i64/le_u (; 26 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../lib/i64/assembly/i64/le_u (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   local.get $0
   i64.extend_i32_u
@@ -656,7 +656,7 @@
   i32.const 0
   global.set $../../lib/i64/assembly/i64/hi
  )
- (func $../../lib/i64/assembly/i64/gt_s (; 27 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../lib/i64/assembly/i64/gt_s (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   local.get $0
   i64.extend_i32_u
@@ -679,7 +679,7 @@
   i32.const 0
   global.set $../../lib/i64/assembly/i64/hi
  )
- (func $../../lib/i64/assembly/i64/gt_u (; 28 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../lib/i64/assembly/i64/gt_u (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   local.get $0
   i64.extend_i32_u
@@ -702,7 +702,7 @@
   i32.const 0
   global.set $../../lib/i64/assembly/i64/hi
  )
- (func $../../lib/i64/assembly/i64/ge_s (; 29 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../lib/i64/assembly/i64/ge_s (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   local.get $0
   i64.extend_i32_u
@@ -725,7 +725,7 @@
   i32.const 0
   global.set $../../lib/i64/assembly/i64/hi
  )
- (func $../../lib/i64/assembly/i64/ge_u (; 30 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../lib/i64/assembly/i64/ge_u (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   local.get $0
   i64.extend_i32_u

--- a/tests/compiler/if.optimized.wat
+++ b/tests/compiler/if.optimized.wat
@@ -12,13 +12,13 @@
  (export "ifThenElseBlock" (func $if/ifThenElse))
  (export "ifAlwaysReturns" (func $if/ifAlwaysReturns))
  (start $~start)
- (func $if/ifThenElse (; 1 ;) (param $0 i32) (result i32)
+ (func $if/ifThenElse (param $0 i32) (result i32)
   i32.const 1
   i32.const 0
   local.get $0
   select
  )
- (func $if/ifThen (; 2 ;) (param $0 i32) (result i32)
+ (func $if/ifThen (param $0 i32) (result i32)
   local.get $0
   if
    i32.const 1
@@ -26,7 +26,7 @@
   end
   i32.const 0
  )
- (func $if/ifAlwaysReturns (; 3 ;) (param $0 i32) (result i32)
+ (func $if/ifAlwaysReturns (param $0 i32) (result i32)
   local.get $0
   if (result i32)
    i32.const 1
@@ -39,7 +39,7 @@
    unreachable
   end
  )
- (func $~start (; 4 ;)
+ (func $~start
   i32.const 0
   call $if/ifThen
   if

--- a/tests/compiler/if.untouched.wat
+++ b/tests/compiler/if.untouched.wat
@@ -13,7 +13,7 @@
  (export "ifThenElseBlock" (func $if/ifThenElseBlock))
  (export "ifAlwaysReturns" (func $if/ifAlwaysReturns))
  (start $~start)
- (func $if/ifThenElse (; 1 ;) (param $0 i32) (result i32)
+ (func $if/ifThenElse (param $0 i32) (result i32)
   local.get $0
   if
    i32.const 1
@@ -24,7 +24,7 @@
   end
   unreachable
  )
- (func $if/ifThen (; 2 ;) (param $0 i32) (result i32)
+ (func $if/ifThen (param $0 i32) (result i32)
   local.get $0
   if
    i32.const 1
@@ -32,7 +32,7 @@
   end
   i32.const 0
  )
- (func $if/ifThenElseBlock (; 3 ;) (param $0 i32) (result i32)
+ (func $if/ifThenElseBlock (param $0 i32) (result i32)
   local.get $0
   if
    i32.const 1
@@ -43,7 +43,7 @@
   end
   unreachable
  )
- (func $start:if (; 4 ;)
+ (func $start:if
   i32.const 0
   call $if/ifThenElse
   i32.const 0
@@ -123,7 +123,7 @@
    unreachable
   end
  )
- (func $if/ifAlwaysReturns (; 5 ;) (param $0 i32) (result i32)
+ (func $if/ifAlwaysReturns (param $0 i32) (result i32)
   local.get $0
   if
    i32.const 1
@@ -138,7 +138,7 @@
   end
   unreachable
  )
- (func $~start (; 6 ;)
+ (func $~start
   call $start:if
  )
 )

--- a/tests/compiler/implicit-getter-setter.optimized.wat
+++ b/tests/compiler/implicit-getter-setter.optimized.wat
@@ -37,7 +37,7 @@
  (export "Managed#get:foo" (func $implicit-getter-setter/Managed#get:foo))
  (export "Managed#set:foo" (func $implicit-getter-setter/Managed#set:foo))
  (export "Managed#constructor" (func $implicit-getter-setter/Managed#constructor))
- (func $~lib/rt/tlsf/removeBlock (; 5 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/removeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -199,7 +199,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/insertBlock (; 6 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/insertBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -478,7 +478,7 @@
   i32.or
   i32.store offset=4
  )
- (func $~lib/rt/tlsf/addMemory (; 7 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $2
@@ -592,7 +592,7 @@
   local.get $1
   call $~lib/rt/tlsf/insertBlock
  )
- (func $~lib/rt/tlsf/maybeInitialize (; 8 ;) (result i32)
+ (func $~lib/rt/tlsf/maybeInitialize (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -679,7 +679,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/tlsf/searchBlock (; 9 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/searchBlock (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   i32.const 256
@@ -808,7 +808,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/prepareBlock (; 10 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/rt/tlsf/prepareBlock (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $1
@@ -883,7 +883,7 @@
    i32.store
   end
  )
- (func $~lib/rt/tlsf/allocateBlock (; 11 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/allocateBlock (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1043,7 +1043,7 @@
   call $~lib/rt/rtrace/onalloc
   local.get $3
  )
- (func $~lib/rt/tlsf/__alloc (; 12 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/__alloc (param $0 i32) (param $1 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
   local.get $0
   local.get $1
@@ -1051,7 +1051,7 @@
   i32.const 16
   i32.add
  )
- (func $~lib/rt/pure/__retain (; 13 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/pure/__retain (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -1102,7 +1102,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/pure/__release (; 14 ;) (param $0 i32)
+ (func $~lib/rt/pure/__release (param $0 i32)
   local.get $0
   i32.const 1228
   i32.gt_u
@@ -1113,7 +1113,7 @@
    call $~lib/rt/pure/decrement
   end
  )
- (func $implicit-getter-setter/Basic#constructor (; 15 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $implicit-getter-setter/Basic#constructor (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -1128,16 +1128,16 @@
   i32.store
   local.get $0
  )
- (func $implicit-getter-setter/Basic#get:val (; 16 ;) (param $0 i32) (result i32)
+ (func $implicit-getter-setter/Basic#get:val (param $0 i32) (result i32)
   local.get $0
   i32.load
  )
- (func $implicit-getter-setter/Basic#set:val (; 17 ;) (param $0 i32) (param $1 i32)
+ (func $implicit-getter-setter/Basic#set:val (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
   i32.store
  )
- (func $implicit-getter-setter/Managed#constructor (; 18 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $implicit-getter-setter/Managed#constructor (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -1153,12 +1153,12 @@
   i32.store
   local.get $0
  )
- (func $implicit-getter-setter/Managed#get:foo (; 19 ;) (param $0 i32) (result i32)
+ (func $implicit-getter-setter/Managed#get:foo (param $0 i32) (result i32)
   local.get $0
   i32.load
   call $~lib/rt/pure/__retain
  )
- (func $implicit-getter-setter/Managed#set:foo (; 20 ;) (param $0 i32) (param $1 i32)
+ (func $implicit-getter-setter/Managed#set:foo (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $1
   local.get $0
@@ -1177,10 +1177,10 @@
   local.get $1
   i32.store
  )
- (func $~lib/rt/pure/__collect (; 21 ;)
+ (func $~lib/rt/pure/__collect
   nop
  )
- (func $~lib/rt/pure/decrement (; 22 ;) (param $0 i32)
+ (func $~lib/rt/pure/decrement (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0

--- a/tests/compiler/implicit-getter-setter.untouched.wat
+++ b/tests/compiler/implicit-getter-setter.untouched.wat
@@ -41,7 +41,7 @@
  (export "Managed#get:foo" (func $implicit-getter-setter/Managed#get:foo))
  (export "Managed#set:foo" (func $implicit-getter-setter/Managed#set:foo))
  (export "Managed#constructor" (func $implicit-getter-setter/Managed#constructor))
- (func $~lib/rt/tlsf/removeBlock (; 5 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/removeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -251,7 +251,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/insertBlock (; 6 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/insertBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -601,7 +601,7 @@
   local.get $7
   i32.store offset=4
  )
- (func $~lib/rt/tlsf/addMemory (; 7 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -749,7 +749,7 @@
   call $~lib/rt/tlsf/insertBlock
   i32.const 1
  )
- (func $~lib/rt/tlsf/maybeInitialize (; 8 ;) (result i32)
+ (func $~lib/rt/tlsf/maybeInitialize (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -903,7 +903,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/tlsf/prepareSize (; 9 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/tlsf/prepareSize (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -932,7 +932,7 @@
   i32.gt_u
   select
  )
- (func $~lib/rt/tlsf/searchBlock (; 10 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/searchBlock (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1115,7 +1115,7 @@
   end
   local.get $7
  )
- (func $~lib/rt/tlsf/growMemory (; 11 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/growMemory (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1199,7 +1199,7 @@
   call $~lib/rt/tlsf/addMemory
   drop
  )
- (func $~lib/rt/tlsf/prepareBlock (; 12 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/rt/tlsf/prepareBlock (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1294,7 +1294,7 @@
    i32.store
   end
  )
- (func $~lib/rt/tlsf/allocateBlock (; 13 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/allocateBlock (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   global.get $~lib/rt/tlsf/collectLock
@@ -1405,7 +1405,7 @@
   call $~lib/rt/rtrace/onalloc
   local.get $4
  )
- (func $~lib/rt/tlsf/__alloc (; 14 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/__alloc (param $0 i32) (param $1 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
   local.get $0
   local.get $1
@@ -1413,7 +1413,7 @@
   i32.const 16
   i32.add
  )
- (func $~lib/rt/pure/increment (; 15 ;) (param $0 i32)
+ (func $~lib/rt/pure/increment (param $0 i32)
   (local $1 i32)
   local.get $0
   i32.load offset=4
@@ -1458,7 +1458,7 @@
    unreachable
   end
  )
- (func $~lib/rt/pure/__retain (; 16 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/pure/__retain (param $0 i32) (result i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.gt_u
@@ -1470,7 +1470,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/pure/__release (; 17 ;) (param $0 i32)
+ (func $~lib/rt/pure/__release (param $0 i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.gt_u
@@ -1481,7 +1481,7 @@
    call $~lib/rt/pure/decrement
   end
  )
- (func $implicit-getter-setter/Basic#constructor (; 18 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $implicit-getter-setter/Basic#constructor (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -1496,16 +1496,16 @@
   i32.store
   local.get $0
  )
- (func $implicit-getter-setter/Basic#get:val (; 19 ;) (param $0 i32) (result i32)
+ (func $implicit-getter-setter/Basic#get:val (param $0 i32) (result i32)
   local.get $0
   i32.load
  )
- (func $implicit-getter-setter/Basic#set:val (; 20 ;) (param $0 i32) (param $1 i32)
+ (func $implicit-getter-setter/Basic#set:val (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
   i32.store
  )
- (func $implicit-getter-setter/Managed#constructor (; 21 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $implicit-getter-setter/Managed#constructor (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   call $~lib/rt/pure/__retain
   local.set $1
@@ -1526,12 +1526,12 @@
   call $~lib/rt/pure/__release
   local.get $0
  )
- (func $implicit-getter-setter/Managed#get:foo (; 22 ;) (param $0 i32) (result i32)
+ (func $implicit-getter-setter/Managed#get:foo (param $0 i32) (result i32)
   local.get $0
   i32.load
   call $~lib/rt/pure/__retain
  )
- (func $implicit-getter-setter/Managed#set:foo (; 23 ;) (param $0 i32) (param $1 i32)
+ (func $implicit-getter-setter/Managed#set:foo (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -1549,10 +1549,10 @@
   local.get $1
   i32.store
  )
- (func $~lib/rt/pure/__collect (; 24 ;)
+ (func $~lib/rt/pure/__collect
   return
  )
- (func $~lib/rt/tlsf/freeBlock (; 25 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/freeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $1
   i32.load
@@ -1568,7 +1568,7 @@
   local.get $1
   call $~lib/rt/rtrace/onfree
  )
- (func $~lib/rt/pure/decrement (; 26 ;) (param $0 i32)
+ (func $~lib/rt/pure/decrement (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -1645,7 +1645,7 @@
    i32.store offset=4
   end
  )
- (func $~lib/rt/pure/__visit (; 27 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/pure/__visit (param $0 i32) (param $1 i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.lt_u
@@ -1669,7 +1669,7 @@
   i32.sub
   call $~lib/rt/pure/decrement
  )
- (func $~lib/rt/__visit_members (; 28 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/__visit_members (param $0 i32) (param $1 i32)
   (local $2 i32)
   block $switch$1$default
    block $switch$1$case$4

--- a/tests/compiler/import.untouched.wat
+++ b/tests/compiler/import.untouched.wat
@@ -8,28 +8,28 @@
  (global $export/c i32 (i32.const 3))
  (export "memory" (memory $0))
  (start $~start)
- (func $export/add (; 0 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $export/add (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.add
  )
- (func $export/sub (; 1 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $export/sub (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.sub
  )
- (func $export/mul (; 2 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $export/mul (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.mul
  )
- (func $export/ns.two (; 3 ;)
+ (func $export/ns.two
   nop
  )
- (func $export-default/theDefault (; 4 ;)
+ (func $export-default/theDefault
   nop
  )
- (func $start:import (; 5 ;)
+ (func $start:import
   global.get $export/a
   global.get $export/b
   call $export/add
@@ -59,7 +59,7 @@
   call $export/ns.two
   call $export-default/theDefault
  )
- (func $~start (; 6 ;)
+ (func $~start
   call $start:import
  )
 )

--- a/tests/compiler/infer-array.optimized.wat
+++ b/tests/compiler/infer-array.optimized.wat
@@ -25,11 +25,10 @@
  (data (i32.const 1568) "\04\00\00\00\01\00\00\00\00\00\00\00\04\00\00\00\01")
  (data (i32.const 1600) "\04\00\00\00\01\00\00\00\00\00\00\00\04\00\00\00\02")
  (data (i32.const 1632) "^\00\00\00\01\00\00\00\01\00\00\00^\00\00\00E\00l\00e\00m\00e\00n\00t\00 \00t\00y\00p\00e\00 \00m\00u\00s\00t\00 \00b\00e\00 \00n\00u\00l\00l\00a\00b\00l\00e\00 \00i\00f\00 \00a\00r\00r\00a\00y\00 \00i\00s\00 \00h\00o\00l\00e\00y")
- (global $~lib/rt/stub/startOffset (mut i32) (i32.const 0))
  (global $~lib/rt/stub/offset (mut i32) (i32.const 0))
  (export "memory" (memory $0))
  (start $~start)
- (func $~lib/rt/stub/__alloc (; 1 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/stub/__alloc (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -113,7 +112,7 @@
   i32.store offset=12
   local.get $4
  )
- (func $~lib/memory/memory.copy (; 2 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/memory/memory.copy (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   block $~lib/util/memory/memmove|inlined.0
@@ -286,7 +285,7 @@
    end
   end
  )
- (func $~lib/rt/__allocArray (; 3 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $~lib/rt/__allocArray (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -323,12 +322,10 @@
   i32.store offset=12
   local.get $2
  )
- (func $start:infer-array (; 4 ;)
+ (func $start:infer-array
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
-  i32.const 1744
-  global.set $~lib/rt/stub/startOffset
   i32.const 1744
   global.set $~lib/rt/stub/offset
   i32.const 3
@@ -502,7 +499,7 @@
   call $~lib/builtins/abort
   unreachable
  )
- (func $~start (; 5 ;)
+ (func $~start
   call $start:infer-array
  )
 )

--- a/tests/compiler/infer-array.untouched.wat
+++ b/tests/compiler/infer-array.untouched.wat
@@ -35,7 +35,7 @@
  (global $~lib/heap/__heap_base i32 (i32.const 736))
  (export "memory" (memory $0))
  (start $~start)
- (func $~lib/rt/stub/maybeGrowMemory (; 1 ;) (param $0 i32)
+ (func $~lib/rt/stub/maybeGrowMemory (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -89,7 +89,7 @@
   local.get $0
   global.set $~lib/rt/stub/offset
  )
- (func $~lib/rt/stub/__alloc (; 2 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/stub/__alloc (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -142,7 +142,7 @@
   i32.store offset=12
   local.get $2
  )
- (func $~lib/util/memory/memcpy (; 3 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/memory/memcpy (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1166,7 +1166,7 @@
    i32.store8
   end
  )
- (func $~lib/memory/memory.copy (; 4 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/memory/memory.copy (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1386,7 +1386,7 @@
    end
   end
  )
- (func $~lib/rt/__allocBuffer (; 5 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/__allocBuffer (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $0
   local.get $1
@@ -1401,10 +1401,10 @@
   end
   local.get $3
  )
- (func $~lib/rt/stub/__retain (; 6 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/stub/__retain (param $0 i32) (result i32)
   local.get $0
  )
- (func $~lib/rt/__allocArray (; 7 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $~lib/rt/__allocArray (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -1436,7 +1436,7 @@
   i32.store offset=12
   local.get $4
  )
- (func $~lib/array/Array<i32>#__unchecked_get (; 8 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#__unchecked_get (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -1445,7 +1445,7 @@
   i32.add
   i32.load
  )
- (func $~lib/array/Array<i32>#__get (; 9 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#__get (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   local.get $0
@@ -1465,10 +1465,10 @@
   local.set $2
   local.get $2
  )
- (func $~lib/rt/stub/__release (; 10 ;) (param $0 i32)
+ (func $~lib/rt/stub/__release (param $0 i32)
   nop
  )
- (func $~lib/array/Array<f64>#__unchecked_get (; 11 ;) (param $0 i32) (param $1 i32) (result f64)
+ (func $~lib/array/Array<f64>#__unchecked_get (param $0 i32) (param $1 i32) (result f64)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -1477,7 +1477,7 @@
   i32.add
   f64.load
  )
- (func $~lib/array/Array<f64>#__get (; 12 ;) (param $0 i32) (param $1 i32) (result f64)
+ (func $~lib/array/Array<f64>#__get (param $0 i32) (param $1 i32) (result f64)
   (local $2 f64)
   local.get $1
   local.get $0
@@ -1497,7 +1497,7 @@
   local.set $2
   local.get $2
  )
- (func $~lib/array/Array<u32>#__unchecked_get (; 13 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u32>#__unchecked_get (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -1506,7 +1506,7 @@
   i32.add
   i32.load
  )
- (func $~lib/array/Array<u32>#__get (; 14 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u32>#__get (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   local.get $0
@@ -1526,7 +1526,7 @@
   local.set $2
   local.get $2
  )
- (func $~lib/array/Array<f32>#__unchecked_get (; 15 ;) (param $0 i32) (param $1 i32) (result f32)
+ (func $~lib/array/Array<f32>#__unchecked_get (param $0 i32) (param $1 i32) (result f32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -1535,7 +1535,7 @@
   i32.add
   f32.load
  )
- (func $~lib/array/Array<f32>#__get (; 16 ;) (param $0 i32) (param $1 i32) (result f32)
+ (func $~lib/array/Array<f32>#__get (param $0 i32) (param $1 i32) (result f32)
   (local $2 f32)
   local.get $1
   local.get $0
@@ -1555,7 +1555,7 @@
   local.set $2
   local.get $2
  )
- (func $infer-array/Ref#constructor (; 17 ;) (param $0 i32) (result i32)
+ (func $infer-array/Ref#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -1567,7 +1567,7 @@
   end
   local.get $0
  )
- (func $~lib/array/Array<infer-array/Ref | null>#__unchecked_get (; 18 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<infer-array/Ref | null>#__unchecked_get (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -1577,7 +1577,7 @@
   i32.load
   call $~lib/rt/stub/__retain
  )
- (func $~lib/array/Array<infer-array/Ref | null>#__get (; 19 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<infer-array/Ref | null>#__get (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   local.get $0
@@ -1597,7 +1597,7 @@
   local.set $2
   local.get $2
  )
- (func $~lib/array/Array<~lib/string/String | null>#__unchecked_get (; 20 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/string/String | null>#__unchecked_get (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -1607,7 +1607,7 @@
   i32.load
   call $~lib/rt/stub/__retain
  )
- (func $~lib/array/Array<~lib/string/String | null>#__get (; 21 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/string/String | null>#__get (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   local.get $0
@@ -1627,7 +1627,7 @@
   local.set $2
   local.get $2
  )
- (func $~lib/array/Array<usize>#__unchecked_get (; 22 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<usize>#__unchecked_get (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -1636,7 +1636,7 @@
   i32.add
   i32.load
  )
- (func $~lib/array/Array<usize>#__get (; 23 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<usize>#__get (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   local.get $0
@@ -1656,7 +1656,7 @@
   local.set $2
   local.get $2
  )
- (func $~lib/array/Array<~lib/array/Array<i32>>#__unchecked_get (; 24 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<i32>>#__unchecked_get (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -1666,7 +1666,7 @@
   i32.load
   call $~lib/rt/stub/__retain
  )
- (func $~lib/array/Array<~lib/array/Array<i32>>#__get (; 25 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<i32>>#__get (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   local.get $0
@@ -1698,7 +1698,7 @@
   end
   local.get $2
  )
- (func $start:infer-array (; 26 ;)
+ (func $start:infer-array
   (local $0 i32)
   (local $1 i32)
   (local $2 f32)
@@ -1954,7 +1954,7 @@
   local.get $1
   call $~lib/rt/stub/__release
  )
- (func $~start (; 27 ;)
+ (func $~start
   call $start:infer-array
  )
 )

--- a/tests/compiler/infer-generic.optimized.wat
+++ b/tests/compiler/infer-generic.optimized.wat
@@ -8,7 +8,6 @@
  (data (i32.const 1024) " \00\00\00\01\00\00\00\01\00\00\00 \00\00\00i\00n\00f\00e\00r\00-\00g\00e\00n\00e\00r\00i\00c\00.\00t\00s")
  (data (i32.const 1072) "\0c\00\00\00\01\00\00\00\00\00\00\00\0c\00\00\00\00\00\80?\00\00\00@\00\00@@")
  (data (i32.const 1104) "\10\00\00\00\01\00\00\00\03\00\00\00\10\00\00\00@\04\00\00@\04\00\00\0c\00\00\00\03")
- (global $~argumentsLength (mut i32) (i32.const 0))
  (export "__setArgumentsLength" (func $~setArgumentsLength))
  (export "memory" (memory $0))
  (export "test1" (func $infer-generic/test1))
@@ -16,7 +15,7 @@
  (export "test3" (func $infer-generic/test2))
  (export "test4" (func $infer-generic/test2))
  (start $~start)
- (func $start:infer-generic~anonymous|0 (; 0 ;) (param $0 i32) (param $1 f32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:infer-generic~anonymous|0 (param $0 i32) (param $1 f32) (param $2 i32) (param $3 i32) (result i32)
   local.get $1
   f32.const 0
   f32.ne
@@ -24,17 +23,16 @@
   local.get $0
   select
  )
- (func $~setArgumentsLength (; 1 ;) (param $0 i32)
-  local.get $0
-  global.set $~argumentsLength
+ (func $~setArgumentsLength (param $0 i32)
+  nop
  )
- (func $infer-generic/test1 (; 2 ;) (param $0 f32) (result f32)
-  local.get $0
- )
- (func $infer-generic/test2 (; 3 ;) (param $0 i32) (result i32)
+ (func $infer-generic/test1 (param $0 f32) (result f32)
   local.get $0
  )
- (func $~start (; 4 ;)
+ (func $infer-generic/test2 (param $0 i32) (result i32)
+  local.get $0
+ )
+ (func $~start
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -54,8 +52,6 @@
    select
    i32.lt_s
    if
-    i32.const 4
-    global.set $~argumentsLength
     local.get $1
     i32.const 1124
     i32.load

--- a/tests/compiler/infer-generic.untouched.wat
+++ b/tests/compiler/infer-generic.untouched.wat
@@ -23,18 +23,18 @@
  (export "test3" (func $infer-generic/test3))
  (export "test4" (func $infer-generic/test4))
  (start $~start)
- (func $infer-generic/inferCompatible<f64> (; 1 ;) (param $0 f64) (param $1 f64) (result i32)
+ (func $infer-generic/inferCompatible<f64> (param $0 f64) (param $1 f64) (result i32)
   local.get $0
   local.get $1
   f64.eq
  )
- (func $~lib/rt/stub/__retain (; 2 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/stub/__retain (param $0 i32) (result i32)
   local.get $0
  )
- (func $~lib/rt/stub/__release (; 3 ;) (param $0 i32)
+ (func $~lib/rt/stub/__release (param $0 i32)
   nop
  )
- (func $start:infer-generic~anonymous|0 (; 4 ;) (param $0 i32) (param $1 f32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:infer-generic~anonymous|0 (param $0 i32) (param $1 f32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/stub/__retain
@@ -52,11 +52,11 @@
   call $~lib/rt/stub/__release
   local.get $4
  )
- (func $~setArgumentsLength (; 5 ;) (param $0 i32)
+ (func $~setArgumentsLength (param $0 i32)
   local.get $0
   global.set $~argumentsLength
  )
- (func $~lib/array/Array<f32>#reduce<bool> (; 6 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/array/Array<f32>#reduce<bool> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -108,7 +108,7 @@
   end
   local.get $3
  )
- (func $start:infer-generic (; 7 ;)
+ (func $start:infer-generic
   (local $0 i32)
   (local $1 i32)
   f64.const 1
@@ -129,20 +129,20 @@
   call $~lib/array/Array<f32>#reduce<bool>
   drop
  )
- (func $infer-generic/inferPlain<f32> (; 8 ;) (param $0 f32) (result f32)
+ (func $infer-generic/inferPlain<f32> (param $0 f32) (result f32)
   local.get $0
  )
- (func $infer-generic/test1 (; 9 ;) (param $0 f32) (result f32)
+ (func $infer-generic/test1 (param $0 f32) (result f32)
   local.get $0
   call $infer-generic/inferPlain<f32>
  )
- (func $infer-generic/inferEncapsulatedClass<f32> (; 10 ;) (param $0 i32) (result i32)
+ (func $infer-generic/inferEncapsulatedClass<f32> (param $0 i32) (result i32)
   local.get $0
   call $~lib/rt/stub/__retain
   local.set $0
   local.get $0
  )
- (func $infer-generic/test2 (; 11 ;) (param $0 i32) (result i32)
+ (func $infer-generic/test2 (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   call $~lib/rt/stub/__retain
@@ -154,21 +154,21 @@
   call $~lib/rt/stub/__release
   local.get $1
  )
- (func $infer-generic/inferEncapsulatedFunction<f32,f64> (; 12 ;) (param $0 i32) (result i32)
+ (func $infer-generic/inferEncapsulatedFunction<f32,f64> (param $0 i32) (result i32)
   local.get $0
  )
- (func $infer-generic/test3 (; 13 ;) (param $0 i32) (result i32)
+ (func $infer-generic/test3 (param $0 i32) (result i32)
   local.get $0
   call $infer-generic/inferEncapsulatedFunction<f32,f64>
  )
- (func $infer-generic/inferEncapsulatedFunctionMixed<f32,f64> (; 14 ;) (param $0 i32) (result i32)
+ (func $infer-generic/inferEncapsulatedFunctionMixed<f32,f64> (param $0 i32) (result i32)
   local.get $0
  )
- (func $infer-generic/test4 (; 15 ;) (param $0 i32) (result i32)
+ (func $infer-generic/test4 (param $0 i32) (result i32)
   local.get $0
   call $infer-generic/inferEncapsulatedFunctionMixed<f32,f64>
  )
- (func $~start (; 16 ;)
+ (func $~start
   call $start:infer-generic
  )
 )

--- a/tests/compiler/infer-type.optimized.wat
+++ b/tests/compiler/infer-type.optimized.wat
@@ -1,22 +1,10 @@
 (module
  (type $none_=>_none (func))
  (memory $0 0)
- (global $infer-type/ri (mut i32) (i32.const 0))
- (global $infer-type/rI (mut i64) (i64.const 0))
- (global $infer-type/rf (mut f32) (f32.const 0))
- (global $infer-type/rF (mut f64) (f64.const 0))
  (export "memory" (memory $0))
  (start $~start)
- (func $~start (; 0 ;)
+ (func $~start
   (local $0 i32)
-  i32.const 0
-  global.set $infer-type/ri
-  i64.const 0
-  global.set $infer-type/rI
-  f32.const 0
-  global.set $infer-type/rf
-  f64.const 0
-  global.set $infer-type/rF
   loop $for-loop|0
    local.get $0
    i32.const 10

--- a/tests/compiler/infer-type.untouched.wat
+++ b/tests/compiler/infer-type.untouched.wat
@@ -17,7 +17,7 @@
  (global $infer-type/inferu (mut i32) (i32.const 2147483647))
  (export "memory" (memory $0))
  (start $~start)
- (func $infer-type/locals (; 0 ;)
+ (func $infer-type/locals
   (local $0 i32)
   (local $1 i64)
   (local $2 f64)
@@ -37,19 +37,19 @@
   global.get $infer-type/F
   local.set $5
  )
- (func $infer-type/reti (; 1 ;) (result i32)
+ (func $infer-type/reti (result i32)
   i32.const 0
  )
- (func $infer-type/retI (; 2 ;) (result i64)
+ (func $infer-type/retI (result i64)
   i64.const 0
  )
- (func $infer-type/retf (; 3 ;) (result f32)
+ (func $infer-type/retf (result f32)
   f32.const 0
  )
- (func $infer-type/refF (; 4 ;) (result f64)
+ (func $infer-type/refF (result f64)
   f64.const 0
  )
- (func $start:infer-type (; 5 ;)
+ (func $start:infer-type
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -95,7 +95,7 @@
    end
   end
  )
- (func $~start (; 6 ;)
+ (func $~start
   call $start:infer-type
  )
 )

--- a/tests/compiler/inlining-blocklocals.optimized.wat
+++ b/tests/compiler/inlining-blocklocals.optimized.wat
@@ -5,15 +5,12 @@
  (memory $0 1)
  (data (i32.const 1024) ".\00\00\00\01\00\00\00\01\00\00\00.\00\00\00i\00n\00l\00i\00n\00i\00n\00g\00-\00b\00l\00o\00c\00k\00l\00o\00c\00a\00l\00s\00.\00t\00s")
  (global $inlining-blocklocals/b (mut i32) (i32.const 2))
- (global $inlining-blocklocals/theCall_a (mut i32) (i32.const 0))
  (global $inlining-blocklocals/theCall_b (mut i32) (i32.const 0))
  (global $inlining-blocklocals/theCall_c (mut i32) (i32.const 0))
  (export "memory" (memory $0))
  (start $~start)
- (func $~start (; 1 ;)
+ (func $~start
   (local $0 i32)
-  i32.const 1
-  global.set $inlining-blocklocals/theCall_a
   global.get $inlining-blocklocals/b
   local.tee $0
   i32.const 1

--- a/tests/compiler/inlining-blocklocals.untouched.wat
+++ b/tests/compiler/inlining-blocklocals.untouched.wat
@@ -11,7 +11,7 @@
  (global $inlining-blocklocals/theCall_c (mut i32) (i32.const 0))
  (export "memory" (memory $0))
  (start $~start)
- (func $inlining-blocklocals/test (; 1 ;)
+ (func $inlining-blocklocals/test
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -92,10 +92,10 @@
    unreachable
   end
  )
- (func $start:inlining-blocklocals (; 2 ;)
+ (func $start:inlining-blocklocals
   call $inlining-blocklocals/test
  )
- (func $~start (; 3 ;)
+ (func $~start
   call $start:inlining-blocklocals
  )
 )

--- a/tests/compiler/inlining-recursive.optimized.wat
+++ b/tests/compiler/inlining-recursive.optimized.wat
@@ -5,10 +5,10 @@
  (export "foo" (func $inlining-recursive/foo))
  (export "bar" (func $inlining-recursive/baz))
  (export "baz" (func $inlining-recursive/baz))
- (func $inlining-recursive/foo (; 0 ;)
+ (func $inlining-recursive/foo
   call $inlining-recursive/foo
  )
- (func $inlining-recursive/baz (; 1 ;)
+ (func $inlining-recursive/baz
   call $inlining-recursive/baz
  )
 )

--- a/tests/compiler/inlining-recursive.untouched.wat
+++ b/tests/compiler/inlining-recursive.untouched.wat
@@ -6,13 +6,13 @@
  (export "foo" (func $inlining-recursive/foo))
  (export "bar" (func $inlining-recursive/bar))
  (export "baz" (func $inlining-recursive/baz))
- (func $inlining-recursive/foo (; 0 ;)
+ (func $inlining-recursive/foo
   call $inlining-recursive/foo
  )
- (func $inlining-recursive/baz (; 1 ;)
+ (func $inlining-recursive/baz
   call $inlining-recursive/bar
  )
- (func $inlining-recursive/bar (; 2 ;)
+ (func $inlining-recursive/bar
   call $inlining-recursive/baz
  )
 )

--- a/tests/compiler/inlining.optimized.wat
+++ b/tests/compiler/inlining.optimized.wat
@@ -7,21 +7,18 @@
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 1024) "\16\00\00\00\01\00\00\00\01\00\00\00\16\00\00\00i\00n\00l\00i\00n\00i\00n\00g\00.\00t\00s")
- (global $~argumentsLength (mut i32) (i32.const 0))
- (global $~lib/rt/stub/startOffset (mut i32) (i32.const 0))
  (global $~lib/rt/stub/offset (mut i32) (i32.const 0))
  (export "__setArgumentsLength" (func $~setArgumentsLength))
  (export "memory" (memory $0))
  (export "test" (func $inlining/test))
  (start $~start)
- (func $inlining/test (; 1 ;) (result i32)
+ (func $inlining/test (result i32)
   i32.const 3
  )
- (func $~setArgumentsLength (; 2 ;) (param $0 i32)
-  local.get $0
-  global.set $~argumentsLength
+ (func $~setArgumentsLength (param $0 i32)
+  nop
  )
- (func $~lib/rt/stub/__alloc (; 3 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/stub/__alloc (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -105,7 +102,7 @@
   i32.store offset=12
   local.get $4
  )
- (func $inlining/test_ctor (; 4 ;)
+ (func $inlining/test_ctor
   (local $0 i32)
   i32.const 16
   i32.const 4
@@ -185,11 +182,7 @@
    unreachable
   end
  )
- (func $~start (; 5 ;)
-  i32.const 1
-  global.set $~argumentsLength
-  i32.const 1072
-  global.set $~lib/rt/stub/startOffset
+ (func $~start
   i32.const 1072
   global.set $~lib/rt/stub/offset
   call $inlining/test_ctor

--- a/tests/compiler/inlining.untouched.wat
+++ b/tests/compiler/inlining.untouched.wat
@@ -19,25 +19,25 @@
  (export "memory" (memory $0))
  (export "test" (func $inlining/test))
  (start $~start)
- (func $inlining/test (; 1 ;) (result i32)
+ (func $inlining/test (result i32)
   global.get $inlining/constantGlobal
   i32.const 2
   i32.add
  )
- (func $inlining/func_fe~anonymous|0 (; 2 ;) (param $0 i32) (result i32)
+ (func $inlining/func_fe~anonymous|0 (param $0 i32) (result i32)
   local.get $0
  )
- (func $~setArgumentsLength (; 3 ;) (param $0 i32)
+ (func $~setArgumentsLength (param $0 i32)
   local.get $0
   global.set $~argumentsLength
  )
- (func $~lib/rt/stub/__retain (; 4 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/stub/__retain (param $0 i32) (result i32)
   local.get $0
  )
- (func $~lib/rt/stub/__release (; 5 ;) (param $0 i32)
+ (func $~lib/rt/stub/__release (param $0 i32)
   nop
  )
- (func $inlining/test_funcs (; 6 ;)
+ (func $inlining/test_funcs
   (local $0 f32)
   (local $1 f64)
   (local $2 i32)
@@ -280,7 +280,7 @@
   local.get $7
   call $~lib/rt/stub/__release
  )
- (func $~lib/rt/stub/maybeGrowMemory (; 7 ;) (param $0 i32)
+ (func $~lib/rt/stub/maybeGrowMemory (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -334,7 +334,7 @@
   local.get $0
   global.set $~lib/rt/stub/offset
  )
- (func $~lib/rt/stub/__alloc (; 8 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/stub/__alloc (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -387,7 +387,7 @@
   i32.store offset=12
   local.get $2
  )
- (func $inlining/test_ctor (; 9 ;)
+ (func $inlining/test_ctor
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -495,7 +495,7 @@
   local.get $4
   call $~lib/rt/stub/__release
  )
- (func $start:inlining (; 10 ;)
+ (func $start:inlining
   call $inlining/test
   i32.const 3
   i32.eq
@@ -521,7 +521,7 @@
   global.set $~lib/rt/stub/offset
   call $inlining/test_ctor
  )
- (func $~start (; 11 ;)
+ (func $~start
   call $start:inlining
  )
 )

--- a/tests/compiler/instanceof-class.optimized.wat
+++ b/tests/compiler/instanceof-class.optimized.wat
@@ -7,13 +7,11 @@
  (memory $0 1)
  (data (i32.const 1024) "&\00\00\00\01\00\00\00\01\00\00\00&\00\00\00i\00n\00s\00t\00a\00n\00c\00e\00o\00f\00-\00c\00l\00a\00s\00s\00.\00t\00s")
  (data (i32.const 1088) "\07\00\00\00 \00\00\00\00\00\00\00 \00\00\00\00\00\00\00 \00\00\00\00\00\00\00 \00\00\00\04\00\00\00 \00\00\00\00\00\00\00 \00\00\00\00\00\00\00 \00\00\00\05")
- (global $~lib/rt/stub/startOffset (mut i32) (i32.const 0))
  (global $~lib/rt/stub/offset (mut i32) (i32.const 0))
- (global $instanceof-class/a (mut i32) (i32.const 0))
  (global $instanceof-class/b (mut i32) (i32.const 0))
  (export "memory" (memory $0))
  (start $~start)
- (func $~lib/rt/stub/__alloc (; 1 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/stub/__alloc (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -79,23 +77,18 @@
   i32.store offset=12
   local.get $3
  )
- (func $~start (; 2 ;)
+ (func $~start
   (local $0 i32)
-  i32.const 1152
-  global.set $~lib/rt/stub/startOffset
   i32.const 1152
   global.set $~lib/rt/stub/offset
   i32.const 3
   call $~lib/rt/stub/__alloc
-  local.tee $0
   i32.eqz
   if
    i32.const 4
    call $~lib/rt/stub/__alloc
-   local.set $0
+   drop
   end
-  local.get $0
-  global.set $instanceof-class/a
   i32.const 6
   call $~lib/rt/stub/__alloc
   local.tee $0
@@ -138,7 +131,7 @@
    unreachable
   end
  )
- (func $~lib/rt/__instanceof (; 3 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/__instanceof (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub

--- a/tests/compiler/instanceof-class.untouched.wat
+++ b/tests/compiler/instanceof-class.untouched.wat
@@ -17,7 +17,7 @@
  (global $~lib/heap/__heap_base i32 (i32.const 140))
  (export "memory" (memory $0))
  (start $~start)
- (func $~lib/rt/stub/maybeGrowMemory (; 1 ;) (param $0 i32)
+ (func $~lib/rt/stub/maybeGrowMemory (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -71,7 +71,7 @@
   local.get $0
   global.set $~lib/rt/stub/offset
  )
- (func $~lib/rt/stub/__alloc (; 2 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/stub/__alloc (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -124,10 +124,10 @@
   i32.store offset=12
   local.get $2
  )
- (func $~lib/rt/stub/__retain (; 3 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/stub/__retain (param $0 i32) (result i32)
   local.get $0
  )
- (func $instanceof-class/Parent<i32>#constructor (; 4 ;) (param $0 i32) (result i32)
+ (func $instanceof-class/Parent<i32>#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -139,7 +139,7 @@
   end
   local.get $0
  )
- (func $instanceof-class/Child<i32>#constructor (; 5 ;) (param $0 i32) (result i32)
+ (func $instanceof-class/Child<i32>#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -154,7 +154,7 @@
   local.set $0
   local.get $0
  )
- (func $instanceof-class/Parent<f32>#constructor (; 6 ;) (param $0 i32) (result i32)
+ (func $instanceof-class/Parent<f32>#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -166,7 +166,7 @@
   end
   local.get $0
  )
- (func $instanceof-class/Child<f32>#constructor (; 7 ;) (param $0 i32) (result i32)
+ (func $instanceof-class/Child<f32>#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -181,7 +181,7 @@
   local.set $0
   local.get $0
  )
- (func $start:instanceof-class (; 8 ;)
+ (func $start:instanceof-class
   global.get $~lib/heap/__heap_base
   i32.const 15
   i32.add
@@ -210,10 +210,10 @@
    unreachable
   end
  )
- (func $~start (; 9 ;)
+ (func $~start
   call $start:instanceof-class
  )
- (func $~lib/rt/__instanceof (; 10 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/__instanceof (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -253,7 +253,7 @@
   end
   i32.const 0
  )
- (func $instanceof-class/Child~instanceof (; 11 ;) (param $0 i32) (result i32)
+ (func $instanceof-class/Child~instanceof (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if

--- a/tests/compiler/instanceof.optimized.wat
+++ b/tests/compiler/instanceof.optimized.wat
@@ -7,7 +7,7 @@
  (global $instanceof/an (mut i32) (i32.const 0))
  (export "memory" (memory $0))
  (start $~start)
- (func $~start (; 1 ;)
+ (func $~start
   global.get $instanceof/an
   if
    i32.const 0

--- a/tests/compiler/instanceof.untouched.wat
+++ b/tests/compiler/instanceof.untouched.wat
@@ -17,29 +17,29 @@
  (global $instanceof/an (mut i32) (i32.const 0))
  (export "memory" (memory $0))
  (start $~start)
- (func $instanceof/isI32<i32> (; 1 ;) (param $0 i32) (result i32)
+ (func $instanceof/isI32<i32> (param $0 i32) (result i32)
   i32.const 1
   return
  )
- (func $instanceof/isI32<f64> (; 2 ;) (param $0 f64) (result i32)
+ (func $instanceof/isI32<f64> (param $0 f64) (result i32)
   i32.const 0
   return
  )
- (func $instanceof/isI32<u32> (; 3 ;) (param $0 i32) (result i32)
+ (func $instanceof/isI32<u32> (param $0 i32) (result i32)
   i32.const 0
   return
  )
- (func $instanceof/isI32<u16> (; 4 ;) (param $0 i32) (result i32)
+ (func $instanceof/isI32<u16> (param $0 i32) (result i32)
   i32.const 0
   return
  )
- (func $~lib/rt/stub/__retain (; 5 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/stub/__retain (param $0 i32) (result i32)
   local.get $0
  )
- (func $~lib/rt/stub/__release (; 6 ;) (param $0 i32)
+ (func $~lib/rt/stub/__release (param $0 i32)
   nop
  )
- (func $start:instanceof (; 7 ;)
+ (func $start:instanceof
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -129,7 +129,7 @@
    unreachable
   end
  )
- (func $~start (; 8 ;)
+ (func $~start
   call $start:instanceof
  )
 )

--- a/tests/compiler/issues/1095.optimized.wat
+++ b/tests/compiler/issues/1095.optimized.wat
@@ -21,7 +21,7 @@
  (global $~lib/rt/tlsf/collectLock (mut i32) (i32.const 0))
  (export "memory" (memory $0))
  (start $~start)
- (func $~lib/rt/tlsf/removeBlock (; 5 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/removeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -183,7 +183,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/insertBlock (; 6 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/insertBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -462,7 +462,7 @@
   i32.or
   i32.store offset=4
  )
- (func $~lib/rt/tlsf/addMemory (; 7 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $2
@@ -576,7 +576,7 @@
   local.get $1
   call $~lib/rt/tlsf/insertBlock
  )
- (func $~lib/rt/tlsf/maybeInitialize (; 8 ;) (result i32)
+ (func $~lib/rt/tlsf/maybeInitialize (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -663,7 +663,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/tlsf/searchBlock (; 9 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/tlsf/searchBlock (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   nop
@@ -721,7 +721,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/allocateBlock (; 10 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/tlsf/allocateBlock (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -893,7 +893,7 @@
   call $~lib/rt/rtrace/onalloc
   local.get $1
  )
- (func $~lib/rt/pure/__retain (; 11 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/pure/__retain (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -944,7 +944,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/pure/__release (; 12 ;) (param $0 i32)
+ (func $~lib/rt/pure/__release (param $0 i32)
   local.get $0
   i32.const 1260
   i32.gt_u
@@ -955,7 +955,7 @@
    call $~lib/rt/pure/decrement
   end
  )
- (func $~start (; 13 ;)
+ (func $~start
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -997,7 +997,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/rt/pure/decrement (; 14 ;) (param $0 i32)
+ (func $~lib/rt/pure/decrement (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0

--- a/tests/compiler/issues/1095.untouched.wat
+++ b/tests/compiler/issues/1095.untouched.wat
@@ -27,7 +27,7 @@
  (global $~lib/heap/__heap_base i32 (i32.const 252))
  (export "memory" (memory $0))
  (start $~start)
- (func $~lib/rt/tlsf/removeBlock (; 5 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/removeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -237,7 +237,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/insertBlock (; 6 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/insertBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -587,7 +587,7 @@
   local.get $7
   i32.store offset=4
  )
- (func $~lib/rt/tlsf/addMemory (; 7 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -735,7 +735,7 @@
   call $~lib/rt/tlsf/insertBlock
   i32.const 1
  )
- (func $~lib/rt/tlsf/maybeInitialize (; 8 ;) (result i32)
+ (func $~lib/rt/tlsf/maybeInitialize (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -889,7 +889,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/tlsf/prepareSize (; 9 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/tlsf/prepareSize (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -918,7 +918,7 @@
   i32.gt_u
   select
  )
- (func $~lib/rt/tlsf/searchBlock (; 10 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/searchBlock (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1101,7 +1101,7 @@
   end
   local.get $7
  )
- (func $~lib/rt/tlsf/growMemory (; 11 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/growMemory (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1185,7 +1185,7 @@
   call $~lib/rt/tlsf/addMemory
   drop
  )
- (func $~lib/rt/tlsf/prepareBlock (; 12 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/rt/tlsf/prepareBlock (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1280,7 +1280,7 @@
    i32.store
   end
  )
- (func $~lib/rt/tlsf/allocateBlock (; 13 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/allocateBlock (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   global.get $~lib/rt/tlsf/collectLock
@@ -1391,7 +1391,7 @@
   call $~lib/rt/rtrace/onalloc
   local.get $4
  )
- (func $~lib/rt/tlsf/__alloc (; 14 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/__alloc (param $0 i32) (param $1 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
   local.get $0
   local.get $1
@@ -1399,7 +1399,7 @@
   i32.const 16
   i32.add
  )
- (func $~lib/rt/pure/increment (; 15 ;) (param $0 i32)
+ (func $~lib/rt/pure/increment (param $0 i32)
   (local $1 i32)
   local.get $0
   i32.load offset=4
@@ -1444,7 +1444,7 @@
    unreachable
   end
  )
- (func $~lib/rt/pure/__retain (; 16 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/pure/__retain (param $0 i32) (result i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.gt_u
@@ -1456,7 +1456,7 @@
   end
   local.get $0
  )
- (func $issues/1095/Foo#constructor (; 17 ;) (param $0 i32) (result i32)
+ (func $issues/1095/Foo#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -1471,7 +1471,7 @@
   i32.store
   local.get $0
  )
- (func $~lib/rt/pure/__release (; 18 ;) (param $0 i32)
+ (func $~lib/rt/pure/__release (param $0 i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.gt_u
@@ -1482,7 +1482,7 @@
    call $~lib/rt/pure/decrement
   end
  )
- (func $issues/1095/test (; 19 ;) (param $0 i32)
+ (func $issues/1095/test (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -1521,7 +1521,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $start:issues/1095 (; 20 ;)
+ (func $start:issues/1095
   (local $0 i32)
   i32.const 0
   call $issues/1095/Foo#constructor
@@ -1530,13 +1530,13 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~start (; 21 ;)
+ (func $~start
   call $start:issues/1095
  )
- (func $~lib/rt/pure/__collect (; 22 ;)
+ (func $~lib/rt/pure/__collect
   return
  )
- (func $~lib/rt/tlsf/freeBlock (; 23 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/freeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $1
   i32.load
@@ -1552,7 +1552,7 @@
   local.get $1
   call $~lib/rt/rtrace/onfree
  )
- (func $~lib/rt/pure/decrement (; 24 ;) (param $0 i32)
+ (func $~lib/rt/pure/decrement (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -1629,7 +1629,7 @@
    i32.store offset=4
   end
  )
- (func $~lib/rt/pure/__visit (; 25 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/pure/__visit (param $0 i32) (param $1 i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.lt_u
@@ -1653,7 +1653,7 @@
   i32.sub
   call $~lib/rt/pure/decrement
  )
- (func $~lib/rt/__visit_members (; 26 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/__visit_members (param $0 i32) (param $1 i32)
   (local $2 i32)
   block $switch$1$default
    block $switch$1$case$4

--- a/tests/compiler/limits.untouched.wat
+++ b/tests/compiler/limits.untouched.wat
@@ -30,7 +30,7 @@
  (global $~lib/builtins/f64.MAX_SAFE_INTEGER f64 (f64.const 9007199254740991))
  (export "memory" (memory $0))
  (start $~start)
- (func $start:limits (; 0 ;)
+ (func $start:limits
   global.get $~lib/builtins/i8.MIN_VALUE
   drop
   global.get $~lib/builtins/i8.MAX_VALUE
@@ -84,7 +84,7 @@
   global.get $~lib/builtins/f64.MAX_SAFE_INTEGER
   drop
  )
- (func $~start (; 1 ;)
+ (func $~start
   call $start:limits
  )
 )

--- a/tests/compiler/literals.untouched.wat
+++ b/tests/compiler/literals.untouched.wat
@@ -4,7 +4,7 @@
  (table $0 1 funcref)
  (export "memory" (memory $0))
  (start $~start)
- (func $start:literals (; 0 ;)
+ (func $start:literals
   i32.const 0
   drop
   i32.const 1
@@ -94,7 +94,7 @@
   i32.const 0
   drop
  )
- (func $~start (; 1 ;)
+ (func $~start
   call $start:literals
  )
 )

--- a/tests/compiler/logical.optimized.wat
+++ b/tests/compiler/logical.optimized.wat
@@ -1,45 +1,5 @@
 (module
- (type $none_=>_none (func))
  (memory $0 1)
  (data (i32.const 1024) "\14\00\00\00\01\00\00\00\01\00\00\00\14\00\00\00l\00o\00g\00i\00c\00a\00l\00.\00t\00s")
- (global $logical/i (mut i32) (i32.const 0))
- (global $logical/I (mut i64) (i64.const 0))
- (global $logical/f (mut f32) (f32.const 0))
- (global $logical/F (mut f64) (f64.const 0))
  (export "memory" (memory $0))
- (start $~start)
- (func $~start (; 0 ;)
-  i32.const 2
-  global.set $logical/i
-  i32.const 1
-  global.set $logical/i
-  i64.const 2
-  global.set $logical/I
-  i64.const 1
-  global.set $logical/I
-  f32.const 2
-  global.set $logical/f
-  f32.const 1
-  global.set $logical/f
-  f64.const 2
-  global.set $logical/F
-  f64.const 1
-  global.set $logical/F
-  f32.const 1
-  global.set $logical/f
-  f32.const 1
-  global.set $logical/f
-  f64.const 1
-  global.set $logical/F
-  f64.const 1
-  global.set $logical/F
-  f32.const nan:0x400000
-  global.set $logical/f
-  f32.const nan:0x400000
-  global.set $logical/f
-  f64.const nan:0x8000000000000
-  global.set $logical/F
-  f64.const nan:0x8000000000000
-  global.set $logical/F
- )
 )

--- a/tests/compiler/logical.untouched.wat
+++ b/tests/compiler/logical.untouched.wat
@@ -12,7 +12,7 @@
  (global $logical/F (mut f64) (f64.const 0))
  (export "memory" (memory $0))
  (start $~start)
- (func $logical/testShortcutAnd (; 1 ;) (param $0 i64) (param $1 i32) (result i32)
+ (func $logical/testShortcutAnd (param $0 i64) (param $1 i32) (result i32)
   local.get $0
   i64.const 0
   i64.ne
@@ -25,7 +25,7 @@
    i32.const 0
   end
  )
- (func $logical/testShortcutOr (; 2 ;) (param $0 i64) (param $1 i32) (result i32)
+ (func $logical/testShortcutOr (param $0 i64) (param $1 i32) (result i32)
   local.get $0
   i64.const 0
   i64.ne
@@ -38,7 +38,7 @@
    i64.ne
   end
  )
- (func $start:logical (; 3 ;)
+ (func $start:logical
   (local $0 f64)
   (local $1 f32)
   i32.const 0
@@ -542,7 +542,7 @@
    unreachable
   end
  )
- (func $~start (; 4 ;)
+ (func $~start
   call $start:logical
  )
 )

--- a/tests/compiler/loop-flow.optimized.wat
+++ b/tests/compiler/loop-flow.optimized.wat
@@ -20,10 +20,10 @@
  (export "doThrow" (func $loop-flow/doThrow))
  (export "doAny" (func $loop-flow/doAny))
  (start $~start)
- (func $loop-flow/whileReturn (; 1 ;) (result i32)
+ (func $loop-flow/whileReturn (result i32)
   i32.const 1
  )
- (func $loop-flow/whileAny (; 2 ;) (param $0 i32) (result i32)
+ (func $loop-flow/whileAny (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   i32.const 1
@@ -47,7 +47,7 @@
    end
   end
  )
- (func $loop-flow/forAny (; 3 ;) (param $0 i32) (result i32)
+ (func $loop-flow/forAny (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   i32.const 1
@@ -73,7 +73,7 @@
    end
   end
  )
- (func $loop-flow/doAny (; 4 ;) (param $0 i32) (result i32)
+ (func $loop-flow/doAny (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   i32.const 1
@@ -97,7 +97,7 @@
    end
   end
  )
- (func $loop-flow/whileThrow (; 5 ;) (result i32)
+ (func $loop-flow/whileThrow (result i32)
   i32.const 1088
   i32.const 1040
   i32.const 11
@@ -105,13 +105,13 @@
   call $~lib/builtins/abort
   unreachable
  )
- (func $loop-flow/whileContinue (; 6 ;) (result i32)
+ (func $loop-flow/whileContinue (result i32)
   loop $while-continue|0
    br $while-continue|0
   end
   unreachable
  )
- (func $loop-flow/forThrow (; 7 ;) (result i32)
+ (func $loop-flow/forThrow (result i32)
   i32.const 1088
   i32.const 1040
   i32.const 41
@@ -119,7 +119,7 @@
   call $~lib/builtins/abort
   unreachable
  )
- (func $loop-flow/doThrow (; 8 ;) (result i32)
+ (func $loop-flow/doThrow (result i32)
   i32.const 1088
   i32.const 1040
   i32.const 71
@@ -127,7 +127,7 @@
   call $~lib/builtins/abort
   unreachable
  )
- (func $~start (; 9 ;)
+ (func $~start
   i32.const 1
   call $loop-flow/whileAny
   i32.const 1

--- a/tests/compiler/loop-flow.untouched.wat
+++ b/tests/compiler/loop-flow.untouched.wat
@@ -21,7 +21,7 @@
  (export "doThrow" (func $loop-flow/doThrow))
  (export "doAny" (func $loop-flow/doAny))
  (start $~start)
- (func $loop-flow/whileReturn (; 1 ;) (result i32)
+ (func $loop-flow/whileReturn (result i32)
   (local $0 i32)
   loop $while-continue|0
    i32.const 1
@@ -34,7 +34,7 @@
   end
   unreachable
  )
- (func $loop-flow/whileAny (; 2 ;) (param $0 i32) (result i32)
+ (func $loop-flow/whileAny (param $0 i32) (result i32)
   (local $1 i32)
   loop $while-continue|0
    i32.const 1
@@ -68,7 +68,7 @@
   end
   unreachable
  )
- (func $loop-flow/forReturn (; 3 ;) (result i32)
+ (func $loop-flow/forReturn (result i32)
   (local $0 i32)
   loop $for-loop|0
    i32.const 1
@@ -81,7 +81,7 @@
   end
   unreachable
  )
- (func $loop-flow/forAny (; 4 ;) (param $0 i32) (result i32)
+ (func $loop-flow/forAny (param $0 i32) (result i32)
   (local $1 i32)
   loop $for-loop|0
    i32.const 1
@@ -118,14 +118,14 @@
   end
   unreachable
  )
- (func $loop-flow/doReturn (; 5 ;) (result i32)
+ (func $loop-flow/doReturn (result i32)
   loop $do-continue|0
    i32.const 1
    return
   end
   unreachable
  )
- (func $loop-flow/doAny (; 6 ;) (param $0 i32) (result i32)
+ (func $loop-flow/doAny (param $0 i32) (result i32)
   loop $do-continue|0
    local.get $0
    i32.const 1
@@ -153,7 +153,7 @@
   end
   unreachable
  )
- (func $start:loop-flow (; 7 ;)
+ (func $start:loop-flow
   call $loop-flow/whileReturn
   i32.const 1
   i32.eq
@@ -230,7 +230,7 @@
    unreachable
   end
  )
- (func $loop-flow/whileThrow (; 8 ;) (result i32)
+ (func $loop-flow/whileThrow (result i32)
   (local $0 i32)
   loop $while-continue|0
    i32.const 1
@@ -247,7 +247,7 @@
   end
   unreachable
  )
- (func $loop-flow/whileContinue (; 9 ;) (result i32)
+ (func $loop-flow/whileContinue (result i32)
   (local $0 i32)
   loop $while-continue|0
    i32.const 1
@@ -259,7 +259,7 @@
   end
   unreachable
  )
- (func $loop-flow/forThrow (; 10 ;) (result i32)
+ (func $loop-flow/forThrow (result i32)
   (local $0 i32)
   loop $for-loop|0
    i32.const 1
@@ -276,7 +276,7 @@
   end
   unreachable
  )
- (func $loop-flow/forContinue (; 11 ;) (result i32)
+ (func $loop-flow/forContinue (result i32)
   (local $0 i32)
   loop $for-loop|0
    i32.const 1
@@ -291,7 +291,7 @@
   end
   unreachable
  )
- (func $loop-flow/doThrow (; 12 ;) (result i32)
+ (func $loop-flow/doThrow (result i32)
   loop $do-continue|0
    i32.const 80
    i32.const 32
@@ -302,7 +302,7 @@
   end
   unreachable
  )
- (func $~start (; 13 ;)
+ (func $~start
   call $start:loop-flow
  )
 )

--- a/tests/compiler/loop-wrap.optimized.wat
+++ b/tests/compiler/loop-wrap.optimized.wat
@@ -6,7 +6,7 @@
  (export "testAlwaysWrapped" (func $loop-wrap/testAlwaysWrapped))
  (export "testFirstWrapped" (func $loop-wrap/testFirstWrapped))
  (export "testSubsequentWrapped" (func $loop-wrap/testSubsequentWrapped))
- (func $loop-wrap/testAlwaysWrapped (; 0 ;)
+ (func $loop-wrap/testAlwaysWrapped
   (local $0 i32)
   loop $do-continue|0
    local.get $0
@@ -23,7 +23,7 @@
    end
   end
  )
- (func $loop-wrap/testFirstWrapped (; 1 ;)
+ (func $loop-wrap/testFirstWrapped
   (local $0 i32)
   loop $do-continue|1
    local.get $0
@@ -42,7 +42,7 @@
    end
   end
  )
- (func $loop-wrap/testSubsequentWrapped (; 2 ;) (param $0 i32)
+ (func $loop-wrap/testSubsequentWrapped (param $0 i32)
   loop $do-continue|0
    local.get $0
    i32.const 255

--- a/tests/compiler/loop-wrap.untouched.wat
+++ b/tests/compiler/loop-wrap.untouched.wat
@@ -7,7 +7,7 @@
  (export "testAlwaysWrapped" (func $loop-wrap/testAlwaysWrapped))
  (export "testFirstWrapped" (func $loop-wrap/testFirstWrapped))
  (export "testSubsequentWrapped" (func $loop-wrap/testSubsequentWrapped))
- (func $loop-wrap/testAlwaysWrapped (; 0 ;)
+ (func $loop-wrap/testAlwaysWrapped
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -32,7 +32,7 @@
    end
   end
  )
- (func $loop-wrap/testFirstWrapped (; 1 ;)
+ (func $loop-wrap/testFirstWrapped
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -59,7 +59,7 @@
    end
   end
  )
- (func $loop-wrap/testSubsequentWrapped (; 2 ;) (param $0 i32)
+ (func $loop-wrap/testSubsequentWrapped (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0

--- a/tests/compiler/managed-cast.optimized.wat
+++ b/tests/compiler/managed-cast.optimized.wat
@@ -23,7 +23,7 @@
  (global $~started (mut i32) (i32.const 0))
  (export "_start" (func $~start))
  (export "memory" (memory $0))
- (func $~lib/rt/tlsf/removeBlock (; 5 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/removeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -185,7 +185,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/insertBlock (; 6 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/insertBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -464,7 +464,7 @@
   i32.or
   i32.store offset=4
  )
- (func $~lib/rt/tlsf/addMemory (; 7 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $2
@@ -578,7 +578,7 @@
   local.get $1
   call $~lib/rt/tlsf/insertBlock
  )
- (func $~lib/rt/tlsf/maybeInitialize (; 8 ;) (result i32)
+ (func $~lib/rt/tlsf/maybeInitialize (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -665,7 +665,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/tlsf/searchBlock (; 9 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/tlsf/searchBlock (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   nop
@@ -723,7 +723,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/allocateBlock (; 10 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/allocateBlock (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   global.get $~lib/rt/tlsf/collectLock
@@ -894,14 +894,14 @@
   call $~lib/rt/rtrace/onalloc
   local.get $2
  )
- (func $~lib/rt/tlsf/__alloc (; 11 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/tlsf/__alloc (param $0 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
   local.get $0
   call $~lib/rt/tlsf/allocateBlock
   i32.const 16
   i32.add
  )
- (func $~lib/rt/pure/__retain (; 12 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/pure/__retain (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -952,7 +952,7 @@
   end
   local.get $0
  )
- (func $managed-cast/Cat#constructor (; 13 ;) (result i32)
+ (func $managed-cast/Cat#constructor (result i32)
   (local $0 i32)
   i32.const 3
   call $~lib/rt/tlsf/__alloc
@@ -967,7 +967,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/pure/__release (; 14 ;) (param $0 i32)
+ (func $~lib/rt/pure/__release (param $0 i32)
   local.get $0
   i32.const 1276
   i32.gt_u
@@ -978,7 +978,7 @@
    call $~lib/rt/pure/decrement
   end
  )
- (func $~lib/rt/__instanceof (; 15 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/__instanceof (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub
@@ -1008,7 +1008,7 @@
   end
   i32.const 0
  )
- (func $~start (; 16 ;)
+ (func $~start
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -1113,7 +1113,7 @@
   local.get $7
   call $~lib/rt/pure/__release
  )
- (func $~lib/rt/pure/decrement (; 17 ;) (param $0 i32)
+ (func $~lib/rt/pure/decrement (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0

--- a/tests/compiler/managed-cast.untouched.wat
+++ b/tests/compiler/managed-cast.untouched.wat
@@ -29,7 +29,7 @@
  (global $~lib/heap/__heap_base i32 (i32.const 268))
  (export "_start" (func $~start))
  (export "memory" (memory $0))
- (func $~lib/rt/tlsf/removeBlock (; 5 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/removeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -239,7 +239,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/insertBlock (; 6 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/insertBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -589,7 +589,7 @@
   local.get $7
   i32.store offset=4
  )
- (func $~lib/rt/tlsf/addMemory (; 7 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -737,7 +737,7 @@
   call $~lib/rt/tlsf/insertBlock
   i32.const 1
  )
- (func $~lib/rt/tlsf/maybeInitialize (; 8 ;) (result i32)
+ (func $~lib/rt/tlsf/maybeInitialize (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -891,7 +891,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/tlsf/prepareSize (; 9 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/tlsf/prepareSize (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -920,7 +920,7 @@
   i32.gt_u
   select
  )
- (func $~lib/rt/tlsf/searchBlock (; 10 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/searchBlock (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1103,7 +1103,7 @@
   end
   local.get $7
  )
- (func $~lib/rt/tlsf/growMemory (; 11 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/growMemory (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1187,7 +1187,7 @@
   call $~lib/rt/tlsf/addMemory
   drop
  )
- (func $~lib/rt/tlsf/prepareBlock (; 12 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/rt/tlsf/prepareBlock (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1282,7 +1282,7 @@
    i32.store
   end
  )
- (func $~lib/rt/tlsf/allocateBlock (; 13 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/allocateBlock (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   global.get $~lib/rt/tlsf/collectLock
@@ -1393,7 +1393,7 @@
   call $~lib/rt/rtrace/onalloc
   local.get $4
  )
- (func $~lib/rt/tlsf/__alloc (; 14 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/__alloc (param $0 i32) (param $1 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
   local.get $0
   local.get $1
@@ -1401,7 +1401,7 @@
   i32.const 16
   i32.add
  )
- (func $~lib/rt/pure/increment (; 15 ;) (param $0 i32)
+ (func $~lib/rt/pure/increment (param $0 i32)
   (local $1 i32)
   local.get $0
   i32.load offset=4
@@ -1446,7 +1446,7 @@
    unreachable
   end
  )
- (func $~lib/rt/pure/__retain (; 16 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/pure/__retain (param $0 i32) (result i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.gt_u
@@ -1458,7 +1458,7 @@
   end
   local.get $0
  )
- (func $managed-cast/Animal#constructor (; 17 ;) (param $0 i32) (result i32)
+ (func $managed-cast/Animal#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -1470,7 +1470,7 @@
   end
   local.get $0
  )
- (func $managed-cast/Cat#constructor (; 18 ;) (param $0 i32) (result i32)
+ (func $managed-cast/Cat#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -1485,10 +1485,10 @@
   local.set $0
   local.get $0
  )
- (func $managed-cast/Animal#tame (; 19 ;) (param $0 i32)
+ (func $managed-cast/Animal#tame (param $0 i32)
   nop
  )
- (func $~lib/rt/pure/__release (; 20 ;) (param $0 i32)
+ (func $~lib/rt/pure/__release (param $0 i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.gt_u
@@ -1499,7 +1499,7 @@
    call $~lib/rt/pure/decrement
   end
  )
- (func $managed-cast/testDowncast (; 21 ;) (param $0 i32)
+ (func $managed-cast/testDowncast (param $0 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $0
@@ -1508,7 +1508,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $managed-cast/testDowncastFromNullable (; 22 ;) (param $0 i32)
+ (func $managed-cast/testDowncastFromNullable (param $0 i32)
   (local $1 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -1529,7 +1529,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $managed-cast/testDowncastToNullable (; 23 ;) (param $0 i32)
+ (func $managed-cast/testDowncastToNullable (param $0 i32)
   (local $1 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -1547,7 +1547,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $managed-cast/testDowncastFromToNullable (; 24 ;) (param $0 i32)
+ (func $managed-cast/testDowncastFromToNullable (param $0 i32)
   (local $1 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -1565,7 +1565,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/rt/__instanceof (; 25 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/__instanceof (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1605,10 +1605,10 @@
   end
   i32.const 0
  )
- (func $managed-cast/Cat#meow (; 26 ;) (param $0 i32)
+ (func $managed-cast/Cat#meow (param $0 i32)
   nop
  )
- (func $managed-cast/testUpcast (; 27 ;) (param $0 i32)
+ (func $managed-cast/testUpcast (param $0 i32)
   (local $1 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -1631,7 +1631,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $managed-cast/testUpcastFromNullable (; 28 ;) (param $0 i32)
+ (func $managed-cast/testUpcastFromNullable (param $0 i32)
   (local $1 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -1665,7 +1665,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $managed-cast/testUpcastToNullable (; 29 ;) (param $0 i32)
+ (func $managed-cast/testUpcastToNullable (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -1697,7 +1697,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $managed-cast/testUpcastFromToNullable (; 30 ;) (param $0 i32)
+ (func $managed-cast/testUpcastFromToNullable (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -1729,7 +1729,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $start:managed-cast (; 31 ;)
+ (func $start:managed-cast
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -1787,7 +1787,7 @@
   local.get $7
   call $~lib/rt/pure/__release
  )
- (func $~start (; 32 ;)
+ (func $~start
   global.get $~started
   if
    return
@@ -1797,10 +1797,10 @@
   end
   call $start:managed-cast
  )
- (func $~lib/rt/pure/__collect (; 33 ;)
+ (func $~lib/rt/pure/__collect
   return
  )
- (func $~lib/rt/tlsf/freeBlock (; 34 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/freeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $1
   i32.load
@@ -1816,7 +1816,7 @@
   local.get $1
   call $~lib/rt/rtrace/onfree
  )
- (func $~lib/rt/pure/decrement (; 35 ;) (param $0 i32)
+ (func $~lib/rt/pure/decrement (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -1893,7 +1893,7 @@
    i32.store offset=4
   end
  )
- (func $~lib/rt/pure/__visit (; 36 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/pure/__visit (param $0 i32) (param $1 i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.lt_u
@@ -1917,7 +1917,7 @@
   i32.sub
   call $~lib/rt/pure/decrement
  )
- (func $~lib/rt/__visit_members (; 37 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/__visit_members (param $0 i32) (param $1 i32)
   (local $2 i32)
   block $switch$1$default
    block $switch$1$case$4

--- a/tests/compiler/mandelbrot.optimized.wat
+++ b/tests/compiler/mandelbrot.optimized.wat
@@ -4,7 +4,7 @@
  (memory $0 0)
  (export "memory" (memory $0))
  (export "computeLine" (func $../../examples/mandelbrot/assembly/index/computeLine))
- (func $~lib/math/NativeMath.log (; 0 ;) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.log (param $0 f64) (result f64)
   (local $1 i32)
   (local $2 i64)
   (local $3 f64)
@@ -171,7 +171,7 @@
   f64.mul
   f64.add
  )
- (func $~lib/math/NativeMath.log2 (; 1 ;) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.log2 (param $0 f64) (result f64)
   (local $1 i32)
   (local $2 i64)
   (local $3 f64)
@@ -368,7 +368,7 @@
   local.get $7
   f64.add
  )
- (func $../../examples/mandelbrot/assembly/index/computeLine (; 2 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/mandelbrot/assembly/index/computeLine (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 f64)
   (local $5 f64)
   (local $6 f64)

--- a/tests/compiler/mandelbrot.untouched.wat
+++ b/tests/compiler/mandelbrot.untouched.wat
@@ -11,7 +11,7 @@
  (global $~lib/ASC_SHRINK_LEVEL i32 (i32.const 0))
  (export "memory" (memory $0))
  (export "computeLine" (func $../../examples/mandelbrot/assembly/index/computeLine))
- (func $~lib/math/NativeMath.log (; 0 ;) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.log (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 i64)
   (local $3 f64)
@@ -329,7 +329,7 @@
   end
   return
  )
- (func $~lib/math/NativeMath.log2 (; 1 ;) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.log2 (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 i64)
   (local $3 f64)
@@ -672,7 +672,7 @@
   end
   return
  )
- (func $../../examples/mandelbrot/assembly/index/computeLine (; 2 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/mandelbrot/assembly/index/computeLine (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 f64)
   (local $5 f64)
   (local $6 i32)

--- a/tests/compiler/many-locals.optimized.wat
+++ b/tests/compiler/many-locals.optimized.wat
@@ -9,17 +9,17 @@
  (export "testI32" (func $many-locals/testI32))
  (export "testI8" (func $many-locals/testI8))
  (start $~start)
- (func $many-locals/testI32 (; 1 ;) (param $0 i32) (result i32)
+ (func $many-locals/testI32 (param $0 i32) (result i32)
   local.get $0
  )
- (func $many-locals/testI8 (; 2 ;) (param $0 i32) (result i32)
+ (func $many-locals/testI8 (param $0 i32) (result i32)
   local.get $0
   i32.const 24
   i32.shl
   i32.const 24
   i32.shr_s
  )
- (func $~start (; 3 ;)
+ (func $~start
   i32.const 42
   call $many-locals/testI8
   i32.const 42

--- a/tests/compiler/many-locals.untouched.wat
+++ b/tests/compiler/many-locals.untouched.wat
@@ -10,7 +10,7 @@
  (export "testI32" (func $many-locals/testI32))
  (export "testI8" (func $many-locals/testI8))
  (start $~start)
- (func $many-locals/testI32 (; 1 ;) (param $0 i32) (result i32)
+ (func $many-locals/testI32 (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -397,7 +397,7 @@
   local.set $128
   local.get $128
  )
- (func $many-locals/testI8 (; 2 ;) (param $0 i32) (result i32)
+ (func $many-locals/testI8 (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -788,7 +788,7 @@
   i32.const 24
   i32.shr_s
  )
- (func $start:many-locals (; 3 ;)
+ (func $start:many-locals
   i32.const 42
   call $many-locals/testI32
   i32.const 42
@@ -816,7 +816,7 @@
    unreachable
   end
  )
- (func $~start (; 4 ;)
+ (func $~start
   call $start:many-locals
  )
 )

--- a/tests/compiler/memcpy.optimized.wat
+++ b/tests/compiler/memcpy.optimized.wat
@@ -9,7 +9,7 @@
  (export "memory" (memory $0))
  (export "memcpy" (func $memcpy/memcpy))
  (start $~start)
- (func $memcpy/memcpy (; 1 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $memcpy/memcpy (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -827,7 +827,7 @@
   end
   local.get $5
  )
- (func $start:memcpy (; 2 ;)
+ (func $start:memcpy
   i32.const 8
   i64.const 1229782938247303441
   i64.store
@@ -1003,7 +1003,7 @@
    unreachable
   end
  )
- (func $~start (; 3 ;)
+ (func $~start
   call $start:memcpy
  )
 )

--- a/tests/compiler/memcpy.untouched.wat
+++ b/tests/compiler/memcpy.untouched.wat
@@ -11,7 +11,7 @@
  (export "memory" (memory $0))
  (export "memcpy" (func $memcpy/memcpy))
  (start $~start)
- (func $memcpy/memcpy (; 1 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $memcpy/memcpy (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1040,7 +1040,7 @@
   end
   local.get $3
  )
- (func $start:memcpy (; 2 ;)
+ (func $start:memcpy
   global.get $memcpy/base
   i64.const 1229782938247303441
   i64.store
@@ -1246,7 +1246,7 @@
    unreachable
   end
  )
- (func $~start (; 3 ;)
+ (func $~start
   call $start:memcpy
  )
 )

--- a/tests/compiler/memmove.optimized.wat
+++ b/tests/compiler/memmove.optimized.wat
@@ -8,7 +8,7 @@
  (global $memmove/dest (mut i32) (i32.const 0))
  (export "memory" (memory $0))
  (start $~start)
- (func $memmove/memmove (; 1 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $memmove/memmove (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -190,7 +190,7 @@
   end
   local.get $5
  )
- (func $start:memmove (; 2 ;)
+ (func $start:memmove
   i32.const 8
   i64.const 1229782938247303441
   i64.store
@@ -366,7 +366,7 @@
    unreachable
   end
  )
- (func $~start (; 3 ;)
+ (func $~start
   call $start:memmove
  )
 )

--- a/tests/compiler/memmove.untouched.wat
+++ b/tests/compiler/memmove.untouched.wat
@@ -10,7 +10,7 @@
  (global $memmove/dest (mut i32) (i32.const 0))
  (export "memory" (memory $0))
  (start $~start)
- (func $memmove/memmove (; 1 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $memmove/memmove (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -205,7 +205,7 @@
   end
   local.get $3
  )
- (func $start:memmove (; 2 ;)
+ (func $start:memmove
   global.get $memmove/base
   i64.const 1229782938247303441
   i64.store
@@ -411,7 +411,7 @@
    unreachable
   end
  )
- (func $~start (; 3 ;)
+ (func $~start
   call $start:memmove
  )
 )

--- a/tests/compiler/memset.optimized.wat
+++ b/tests/compiler/memset.optimized.wat
@@ -8,7 +8,7 @@
  (global $memset/dest (mut i32) (i32.const 0))
  (export "memory" (memory $0))
  (start $~start)
- (func $memset/memset (; 1 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $memset/memset (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i64)
   block $folding-inner0
@@ -207,7 +207,7 @@
    end
   end
  )
- (func $start:memset (; 2 ;)
+ (func $start:memset
   i32.const 1060
   global.set $memset/dest
   i32.const 1060
@@ -293,7 +293,7 @@
    unreachable
   end
  )
- (func $~start (; 3 ;)
+ (func $~start
   call $start:memset
  )
 )

--- a/tests/compiler/memset.untouched.wat
+++ b/tests/compiler/memset.untouched.wat
@@ -10,7 +10,7 @@
  (global $~lib/heap/__heap_base i32 (i32.const 52))
  (export "memory" (memory $0))
  (start $~start)
- (func $memset/memset (; 1 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $memset/memset (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -273,7 +273,7 @@
   end
   local.get $3
  )
- (func $start:memset (; 2 ;)
+ (func $start:memset
   global.get $~lib/heap/__heap_base
   global.set $memset/dest
   global.get $memset/dest
@@ -375,7 +375,7 @@
    unreachable
   end
  )
- (func $~start (; 3 ;)
+ (func $~start
   call $start:memset
  )
 )

--- a/tests/compiler/merge.untouched.wat
+++ b/tests/compiler/merge.untouched.wat
@@ -14,55 +14,55 @@
  (global $merge/namespaceEnum.val i32 (i32.const 2))
  (export "memory" (memory $0))
  (start $~start)
- (func $merge/namespaceType.test (; 0 ;)
+ (func $merge/namespaceType.test
   nop
  )
- (func $merge/typeNamespace.test (; 1 ;)
+ (func $merge/typeNamespace.test
   nop
  )
- (func $merge/functionType (; 2 ;)
+ (func $merge/functionType
   nop
  )
- (func $merge/typeFunction (; 3 ;)
+ (func $merge/typeFunction
   nop
  )
- (func $merge/classNamespace.test1 (; 4 ;)
+ (func $merge/classNamespace.test1
   nop
  )
- (func $merge/classNamespace.test2 (; 5 ;)
+ (func $merge/classNamespace.test2
   nop
  )
- (func $merge/namespaceClass.test1 (; 6 ;)
+ (func $merge/namespaceClass.test1
   nop
  )
- (func $merge/namespaceClass.test2 (; 7 ;)
+ (func $merge/namespaceClass.test2
   nop
  )
- (func $merge/functionNamespace (; 8 ;)
+ (func $merge/functionNamespace
   nop
  )
- (func $merge/functionNamespace.test (; 9 ;)
+ (func $merge/functionNamespace.test
   nop
  )
- (func $merge/namespaceFunction.test (; 10 ;)
+ (func $merge/namespaceFunction.test
   nop
  )
- (func $merge/namespaceFunction (; 11 ;)
+ (func $merge/namespaceFunction
   nop
  )
- (func $merge/enumNamespace.test (; 12 ;)
+ (func $merge/enumNamespace.test
   nop
  )
- (func $merge/namespaceEnum.test (; 13 ;)
+ (func $merge/namespaceEnum.test
   nop
  )
- (func $merge/namespaceNamespace.test1 (; 14 ;)
+ (func $merge/namespaceNamespace.test1
   nop
  )
- (func $merge/namespaceNamespace.test2 (; 15 ;)
+ (func $merge/namespaceNamespace.test2
   nop
  )
- (func $start:merge (; 16 ;)
+ (func $start:merge
   global.get $merge/globalType
   drop
   global.get $merge/typeGlobal
@@ -88,7 +88,7 @@
   call $merge/namespaceNamespace.test1
   call $merge/namespaceNamespace.test2
  )
- (func $~start (; 17 ;)
+ (func $~start
   call $start:merge
  )
 )

--- a/tests/compiler/named-export-default.optimized.wat
+++ b/tests/compiler/named-export-default.optimized.wat
@@ -3,7 +3,7 @@
  (memory $0 0)
  (export "memory" (memory $0))
  (export "default" (func $named-export-default/get3))
- (func $named-export-default/get3 (; 0 ;) (result i32)
+ (func $named-export-default/get3 (result i32)
   i32.const 3
  )
 )

--- a/tests/compiler/named-export-default.untouched.wat
+++ b/tests/compiler/named-export-default.untouched.wat
@@ -4,7 +4,7 @@
  (table $0 1 funcref)
  (export "memory" (memory $0))
  (export "default" (func $named-export-default/get3))
- (func $named-export-default/get3 (; 0 ;) (result i32)
+ (func $named-export-default/get3 (result i32)
   i32.const 3
  )
 )

--- a/tests/compiler/named-import-default.optimized.wat
+++ b/tests/compiler/named-import-default.optimized.wat
@@ -3,7 +3,7 @@
  (memory $0 0)
  (export "memory" (memory $0))
  (export "getValue" (func $named-import-default/getValue))
- (func $named-import-default/getValue (; 0 ;) (result i32)
+ (func $named-import-default/getValue (result i32)
   i32.const 3
  )
 )

--- a/tests/compiler/named-import-default.untouched.wat
+++ b/tests/compiler/named-import-default.untouched.wat
@@ -4,10 +4,10 @@
  (table $0 1 funcref)
  (export "memory" (memory $0))
  (export "getValue" (func $named-import-default/getValue))
- (func $named-export-default/get3 (; 0 ;) (result i32)
+ (func $named-export-default/get3 (result i32)
   i32.const 3
  )
- (func $named-import-default/getValue (; 1 ;) (result i32)
+ (func $named-import-default/getValue (result i32)
   call $named-export-default/get3
  )
 )

--- a/tests/compiler/namespace.optimized.wat
+++ b/tests/compiler/namespace.optimized.wat
@@ -1,14 +1,4 @@
 (module
- (type $none_=>_none (func))
  (memory $0 0)
- (global $namespace/Outer.Inner.anotherVar (mut i32) (i32.const 0))
- (global $namespace/Outer.Inner.evenAnotherVar (mut i32) (i32.const 0))
  (export "memory" (memory $0))
- (start $~start)
- (func $~start (; 0 ;)
-  i32.const 0
-  global.set $namespace/Outer.Inner.anotherVar
-  i32.const 1
-  global.set $namespace/Outer.Inner.evenAnotherVar
- )
 )

--- a/tests/compiler/namespace.untouched.wat
+++ b/tests/compiler/namespace.untouched.wat
@@ -11,13 +11,13 @@
  (global $namespace/Outer.Inner.anEnum.TWO i32 (i32.const 2))
  (export "memory" (memory $0))
  (start $~start)
- (func $namespace/Outer.Inner.aFunc (; 0 ;) (result i32)
+ (func $namespace/Outer.Inner.aFunc (result i32)
   global.get $namespace/Outer.Inner.aVar
  )
- (func $namespace/Joined.anotherFunc (; 1 ;) (result i32)
+ (func $namespace/Joined.anotherFunc (result i32)
   i32.const 3
  )
- (func $start:namespace (; 2 ;)
+ (func $start:namespace
   global.get $namespace/Outer.Inner.aVar
   global.set $namespace/Outer.Inner.anotherVar
   global.get $namespace/Outer.outerVar
@@ -33,7 +33,7 @@
   call $namespace/Joined.anotherFunc
   drop
  )
- (func $~start (; 3 ;)
+ (func $~start
   call $start:namespace
  )
 )

--- a/tests/compiler/new.optimized.wat
+++ b/tests/compiler/new.optimized.wat
@@ -1,15 +1,11 @@
 (module
  (type $none_=>_none (func))
- (type $i32_=>_i32 (func (param i32) (result i32)))
+ (type $i32_=>_none (func (param i32)))
  (memory $0 0)
- (global $new/ref (mut i32) (i32.const 0))
- (global $~lib/rt/stub/startOffset (mut i32) (i32.const 0))
  (global $~lib/rt/stub/offset (mut i32) (i32.const 0))
- (global $new/gen (mut i32) (i32.const 0))
- (global $new/ref2 (mut i32) (i32.const 0))
  (export "memory" (memory $0))
  (start $~start)
- (func $~lib/rt/stub/__alloc (; 0 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/stub/__alloc (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -17,18 +13,18 @@
   global.get $~lib/rt/stub/offset
   i32.const 16
   i32.add
-  local.tee $3
+  local.tee $4
   i32.const 16
   i32.add
   local.tee $1
   memory.size
-  local.tee $4
+  local.tee $3
   i32.const 16
   i32.shl
   local.tee $2
   i32.gt_u
   if
-   local.get $4
+   local.get $3
    local.get $1
    local.get $2
    i32.sub
@@ -39,7 +35,7 @@
    i32.const 16
    i32.shr_u
    local.tee $2
-   local.get $4
+   local.get $3
    local.get $2
    i32.gt_s
    select
@@ -58,7 +54,7 @@
   end
   local.get $1
   global.set $~lib/rt/stub/offset
-  local.get $3
+  local.get $4
   i32.const 16
   i32.sub
   local.tee $1
@@ -73,36 +69,25 @@
   local.get $1
   i32.const 0
   i32.store offset=12
-  local.get $3
  )
- (func $~start (; 1 ;)
-  i32.const 1024
-  global.set $~lib/rt/stub/startOffset
+ (func $~start
   i32.const 1024
   global.set $~lib/rt/stub/offset
   i32.const 3
   call $~lib/rt/stub/__alloc
-  global.set $new/ref
   i32.const 3
   call $~lib/rt/stub/__alloc
-  global.set $new/ref
   i32.const 3
   call $~lib/rt/stub/__alloc
-  global.set $new/ref
   i32.const 4
   call $~lib/rt/stub/__alloc
-  global.set $new/gen
   i32.const 4
   call $~lib/rt/stub/__alloc
-  global.set $new/gen
   i32.const 5
   call $~lib/rt/stub/__alloc
-  global.set $new/ref2
   i32.const 5
   call $~lib/rt/stub/__alloc
-  global.set $new/ref2
   i32.const 5
   call $~lib/rt/stub/__alloc
-  global.set $new/ref2
  )
 )

--- a/tests/compiler/new.untouched.wat
+++ b/tests/compiler/new.untouched.wat
@@ -13,7 +13,7 @@
  (global $~lib/heap/__heap_base i32 (i32.const 8))
  (export "memory" (memory $0))
  (start $~start)
- (func $~lib/rt/stub/maybeGrowMemory (; 0 ;) (param $0 i32)
+ (func $~lib/rt/stub/maybeGrowMemory (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -67,7 +67,7 @@
   local.get $0
   global.set $~lib/rt/stub/offset
  )
- (func $~lib/rt/stub/__alloc (; 1 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/stub/__alloc (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -120,10 +120,10 @@
   i32.store offset=12
   local.get $2
  )
- (func $~lib/rt/stub/__retain (; 2 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/stub/__retain (param $0 i32) (result i32)
   local.get $0
  )
- (func $new/Ref#constructor (; 3 ;) (param $0 i32) (result i32)
+ (func $new/Ref#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -135,14 +135,14 @@
   end
   local.get $0
  )
- (func $~lib/rt/stub/__release (; 4 ;) (param $0 i32)
+ (func $~lib/rt/stub/__release (param $0 i32)
   nop
  )
- (func $new/Ref#get:ref (; 5 ;) (param $0 i32) (result i32)
+ (func $new/Ref#get:ref (param $0 i32) (result i32)
   local.get $0
   call $~lib/rt/stub/__retain
  )
- (func $new/Gen<i32>#constructor (; 6 ;) (param $0 i32) (result i32)
+ (func $new/Gen<i32>#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -154,11 +154,11 @@
   end
   local.get $0
  )
- (func $new/Gen<i32>#get:gen (; 7 ;) (param $0 i32) (result i32)
+ (func $new/Gen<i32>#get:gen (param $0 i32) (result i32)
   local.get $0
   call $~lib/rt/stub/__retain
  )
- (func $new/ns.Ref#constructor (; 8 ;) (param $0 i32) (result i32)
+ (func $new/ns.Ref#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -170,11 +170,11 @@
   end
   local.get $0
  )
- (func $new/ns.Ref#get:ref (; 9 ;) (param $0 i32) (result i32)
+ (func $new/ns.Ref#get:ref (param $0 i32) (result i32)
   local.get $0
   call $~lib/rt/stub/__retain
  )
- (func $start:new (; 10 ;)
+ (func $start:new
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -295,7 +295,7 @@
   local.get $5
   call $~lib/rt/stub/__release
  )
- (func $~start (; 11 ;)
+ (func $~start
   call $start:new
  )
 )

--- a/tests/compiler/number.optimized.wat
+++ b/tests/compiler/number.optimized.wat
@@ -31,17 +31,13 @@
  (data (i32.const 2480) "\08\00\00\00\01\00\00\00\01\00\00\00\08\00\00\00t\00r\00u\00e")
  (data (i32.const 2512) "\n\00\00\00\01\00\00\00\01\00\00\00\n\00\00\00f\00a\00l\00s\00e")
  (global $number/a (mut i32) (i32.const 1))
- (global $~lib/rt/stub/startOffset (mut i32) (i32.const 0))
  (global $~lib/rt/stub/offset (mut i32) (i32.const 0))
- (global $~lib/util/number/_frc_plus (mut i64) (i64.const 0))
- (global $~lib/util/number/_frc_minus (mut i64) (i64.const 0))
- (global $~lib/util/number/_exp (mut i32) (i32.const 0))
  (global $~lib/util/number/_K (mut i32) (i32.const 0))
  (global $~lib/util/number/_frc_pow (mut i64) (i64.const 0))
  (global $~lib/util/number/_exp_pow (mut i32) (i32.const 0))
  (export "memory" (memory $0))
  (start $~start)
- (func $~lib/util/number/decimalCount32 (; 1 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/decimalCount32 (param $0 i32) (result i32)
   local.get $0
   i32.const 10
   i32.ge_u
@@ -83,7 +79,7 @@
   i32.lt_u
   select
  )
- (func $~lib/rt/stub/__alloc (; 2 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/stub/__alloc (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -167,7 +163,7 @@
   i32.store offset=12
   local.get $3
  )
- (func $~lib/util/number/utoa_simple<u32> (; 3 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/number/utoa_simple<u32> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   loop $do-continue|0
    local.get $1
@@ -194,7 +190,7 @@
    br_if $do-continue|0
   end
  )
- (func $~lib/number/I32#toString (; 4 ;) (param $0 i32) (result i32)
+ (func $~lib/number/I32#toString (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -233,7 +229,7 @@
    i32.const 1040
   end
  )
- (func $~lib/string/String#get:length (; 5 ;) (param $0 i32) (result i32)
+ (func $~lib/string/String#get:length (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub
@@ -241,7 +237,7 @@
   i32.const 1
   i32.shr_u
  )
- (func $~lib/util/string/compareImpl (; 6 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/compareImpl (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -317,7 +313,7 @@
   end
   i32.const 0
  )
- (func $~lib/string/String.__eq (; 7 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__eq (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -349,7 +345,7 @@
   end
   i32.const 0
  )
- (func $~lib/util/number/genDigits (; 8 ;) (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (result i32)
+ (func $~lib/util/number/genDigits (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (result i32)
   (local $6 i32)
   (local $7 i64)
   (local $8 i32)
@@ -737,7 +733,7 @@
   i32.store16
   local.get $8
  )
- (func $~lib/memory/memory.copy (; 9 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/memory/memory.copy (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   block $~lib/util/memory/memmove|inlined.0
@@ -910,7 +906,7 @@
    end
   end
  )
- (func $~lib/util/number/prettify (; 10 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/prettify (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   i32.eqz
@@ -1155,17 +1151,11 @@
    end
   end
  )
- (func $~lib/util/number/dtoa_core (; 11 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/dtoa_core (param $0 i32) (result i32)
   (local $1 i64)
   (local $2 i64)
   (local $3 i64)
   (local $4 f64)
-  i64.const -9223372036854774784
-  global.set $~lib/util/number/_frc_plus
-  i64.const 9223372036854775296
-  global.set $~lib/util/number/_frc_minus
-  i32.const -62
-  global.set $~lib/util/number/_exp
   i32.const -4
   global.set $~lib/util/number/_K
   i32.const 1648
@@ -1279,7 +1269,7 @@
   global.get $~lib/util/number/_K
   call $~lib/util/number/prettify
  )
- (func $~lib/util/number/dtoa (; 12 ;) (result i32)
+ (func $~lib/util/number/dtoa (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -1409,7 +1399,7 @@
   end
   local.get $0
  )
- (func $~lib/number/F32.isSafeInteger (; 13 ;) (param $0 f32) (result i32)
+ (func $~lib/number/F32.isSafeInteger (param $0 f32) (result i32)
   local.get $0
   f32.trunc
   local.get $0
@@ -1421,7 +1411,7 @@
   f32.le
   select
  )
- (func $~lib/number/F32.isInteger (; 14 ;) (param $0 f32) (result i32)
+ (func $~lib/number/F32.isInteger (param $0 f32) (result i32)
   (local $1 i32)
   local.get $0
   f32.trunc
@@ -1435,7 +1425,7 @@
   f32.eq
   select
  )
- (func $~lib/number/F64.isSafeInteger (; 15 ;) (param $0 f64) (result i32)
+ (func $~lib/number/F64.isSafeInteger (param $0 f64) (result i32)
   local.get $0
   f64.trunc
   local.get $0
@@ -1447,7 +1437,7 @@
   f64.le
   select
  )
- (func $~lib/number/F64.isInteger (; 16 ;) (param $0 f64) (result i32)
+ (func $~lib/number/F64.isInteger (param $0 f64) (result i32)
   (local $1 i32)
   local.get $0
   f64.trunc
@@ -1461,10 +1451,8 @@
   f64.eq
   select
  )
- (func $start:number (; 17 ;)
+ (func $start:number
   (local $0 i32)
-  i32.const 2544
-  global.set $~lib/rt/stub/startOffset
   i32.const 2544
   global.set $~lib/rt/stub/offset
   global.get $number/a
@@ -2066,7 +2054,7 @@
    unreachable
   end
  )
- (func $~start (; 18 ;)
+ (func $~start
   call $start:number
  )
 )

--- a/tests/compiler/number.untouched.wat
+++ b/tests/compiler/number.untouched.wat
@@ -56,7 +56,7 @@
  (global $~lib/heap/__heap_base i32 (i32.const 1948))
  (export "memory" (memory $0))
  (start $~start)
- (func $~lib/util/number/decimalCount32 (; 1 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/decimalCount32 (param $0 i32) (result i32)
   local.get $0
   i32.const 100000
   i32.lt_u
@@ -111,7 +111,7 @@
   end
   unreachable
  )
- (func $~lib/rt/stub/maybeGrowMemory (; 2 ;) (param $0 i32)
+ (func $~lib/rt/stub/maybeGrowMemory (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -165,7 +165,7 @@
   local.get $0
   global.set $~lib/rt/stub/offset
  )
- (func $~lib/rt/stub/__alloc (; 3 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/stub/__alloc (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -218,7 +218,7 @@
   i32.store offset=12
   local.get $2
  )
- (func $~lib/util/number/utoa32_lut (; 4 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/number/utoa32_lut (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -358,10 +358,10 @@
    i32.store16
   end
  )
- (func $~lib/rt/stub/__retain (; 5 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/stub/__retain (param $0 i32) (result i32)
   local.get $0
  )
- (func $~lib/util/number/itoa32 (; 6 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/itoa32 (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -415,19 +415,19 @@
   local.get $3
   call $~lib/rt/stub/__retain
  )
- (func $~lib/util/number/itoa<i32> (; 7 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/itoa<i32> (param $0 i32) (result i32)
   local.get $0
   call $~lib/util/number/itoa32
   return
  )
- (func $~lib/number/I32#toString (; 8 ;) (param $0 i32) (result i32)
+ (func $~lib/number/I32#toString (param $0 i32) (result i32)
   local.get $0
   call $~lib/util/number/itoa<i32>
  )
- (func $~lib/rt/stub/__release (; 9 ;) (param $0 i32)
+ (func $~lib/rt/stub/__release (param $0 i32)
   nop
  )
- (func $~lib/string/String#get:length (; 10 ;) (param $0 i32) (result i32)
+ (func $~lib/string/String#get:length (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub
@@ -435,7 +435,7 @@
   i32.const 1
   i32.shr_u
  )
- (func $~lib/util/string/compareImpl (; 11 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
+ (func $~lib/util/string/compareImpl (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
@@ -557,7 +557,7 @@
   call $~lib/rt/stub/__release
   local.get $7
  )
- (func $~lib/string/String.__eq (; 12 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__eq (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -630,7 +630,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $~lib/util/number/genDigits (; 13 ;) (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (param $6 i32) (result i32)
+ (func $~lib/util/number/genDigits (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (param $6 i32) (result i32)
   (local $7 i32)
   (local $8 i64)
   (local $9 i64)
@@ -1133,7 +1133,7 @@
   end
   unreachable
  )
- (func $~lib/util/memory/memcpy (; 14 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/memory/memcpy (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2157,7 +2157,7 @@
    i32.store8
   end
  )
- (func $~lib/memory/memory.copy (; 15 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/memory/memory.copy (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2377,7 +2377,7 @@
    end
   end
  )
- (func $~lib/util/number/prettify (; 16 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/prettify (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2694,7 +2694,7 @@
   end
   unreachable
  )
- (func $~lib/util/number/dtoa_core (; 17 ;) (param $0 i32) (param $1 f64) (result i32)
+ (func $~lib/util/number/dtoa_core (param $0 i32) (param $1 f64) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3120,7 +3120,7 @@
   local.get $2
   i32.add
  )
- (func $~lib/string/String#substring (; 18 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/string/String#substring (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3227,7 +3227,7 @@
   local.get $11
   call $~lib/rt/stub/__retain
  )
- (func $~lib/rt/stub/__free (; 19 ;) (param $0 i32)
+ (func $~lib/rt/stub/__free (param $0 i32)
   (local $1 i32)
   local.get $0
   i32.const 0
@@ -3277,7 +3277,7 @@
    global.set $~lib/rt/stub/offset
   end
  )
- (func $~lib/util/number/dtoa (; 20 ;) (param $0 f64) (result i32)
+ (func $~lib/util/number/dtoa (param $0 f64) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -3338,11 +3338,11 @@
   call $~lib/rt/stub/__free
   local.get $3
  )
- (func $~lib/number/F64#toString (; 21 ;) (param $0 f64) (param $1 i32) (result i32)
+ (func $~lib/number/F64#toString (param $0 f64) (param $1 i32) (result i32)
   local.get $0
   call $~lib/util/number/dtoa
  )
- (func $~lib/number/Bool#toString (; 22 ;) (param $0 i32) (result i32)
+ (func $~lib/number/Bool#toString (param $0 i32) (result i32)
   local.get $0
   if (result i32)
    i32.const 1904
@@ -3350,7 +3350,7 @@
    i32.const 1936
   end
  )
- (func $~lib/number/F32.isSafeInteger (; 23 ;) (param $0 f32) (result i32)
+ (func $~lib/number/F32.isSafeInteger (param $0 f32) (result i32)
   local.get $0
   f32.abs
   global.get $~lib/builtins/f32.MAX_SAFE_INTEGER
@@ -3364,7 +3364,7 @@
    i32.const 0
   end
  )
- (func $~lib/number/F32.isInteger (; 24 ;) (param $0 f32) (result i32)
+ (func $~lib/number/F32.isInteger (param $0 f32) (result i32)
   local.get $0
   local.get $0
   f32.sub
@@ -3379,7 +3379,7 @@
    i32.const 0
   end
  )
- (func $~lib/number/F64.isSafeInteger (; 25 ;) (param $0 f64) (result i32)
+ (func $~lib/number/F64.isSafeInteger (param $0 f64) (result i32)
   local.get $0
   f64.abs
   global.get $~lib/builtins/f64.MAX_SAFE_INTEGER
@@ -3393,7 +3393,7 @@
    i32.const 0
   end
  )
- (func $~lib/number/F64.isInteger (; 26 ;) (param $0 f64) (result i32)
+ (func $~lib/number/F64.isInteger (param $0 f64) (result i32)
   local.get $0
   local.get $0
   f64.sub
@@ -3408,7 +3408,7 @@
    i32.const 0
   end
  )
- (func $start:number (; 27 ;)
+ (func $start:number
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -4174,7 +4174,7 @@
   local.get $10
   call $~lib/rt/stub/__release
  )
- (func $~start (; 28 ;)
+ (func $~start
   call $start:number
  )
 )

--- a/tests/compiler/optional-typeparameters.optimized.wat
+++ b/tests/compiler/optional-typeparameters.optimized.wat
@@ -1,14 +1,11 @@
 (module
  (type $none_=>_none (func))
- (type $i32_=>_i32 (func (param i32) (result i32)))
+ (type $i32_=>_none (func (param i32)))
  (memory $0 0)
- (global $~lib/rt/stub/startOffset (mut i32) (i32.const 0))
  (global $~lib/rt/stub/offset (mut i32) (i32.const 0))
- (global $optional-typeparameters/tConcrete (mut i32) (i32.const 0))
- (global $optional-typeparameters/tDerived (mut i32) (i32.const 0))
  (export "memory" (memory $0))
  (start $~start)
- (func $~lib/rt/stub/__alloc (; 0 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/stub/__alloc (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -16,18 +13,18 @@
   global.get $~lib/rt/stub/offset
   i32.const 16
   i32.add
-  local.tee $3
+  local.tee $4
   i32.const 16
   i32.add
   local.tee $1
   memory.size
-  local.tee $4
+  local.tee $3
   i32.const 16
   i32.shl
   local.tee $2
   i32.gt_u
   if
-   local.get $4
+   local.get $3
    local.get $1
    local.get $2
    i32.sub
@@ -38,7 +35,7 @@
    i32.const 16
    i32.shr_u
    local.tee $2
-   local.get $4
+   local.get $3
    local.get $2
    i32.gt_s
    select
@@ -57,7 +54,7 @@
   end
   local.get $1
   global.set $~lib/rt/stub/offset
-  local.get $3
+  local.get $4
   i32.const 16
   i32.sub
   local.tee $1
@@ -72,18 +69,13 @@
   local.get $1
   i32.const 0
   i32.store offset=12
-  local.get $3
  )
- (func $~start (; 1 ;)
-  i32.const 1024
-  global.set $~lib/rt/stub/startOffset
+ (func $~start
   i32.const 1024
   global.set $~lib/rt/stub/offset
   i32.const 3
   call $~lib/rt/stub/__alloc
-  global.set $optional-typeparameters/tConcrete
   i32.const 4
   call $~lib/rt/stub/__alloc
-  global.set $optional-typeparameters/tDerived
  )
 )

--- a/tests/compiler/optional-typeparameters.untouched.wat
+++ b/tests/compiler/optional-typeparameters.untouched.wat
@@ -14,13 +14,13 @@
  (global $~lib/heap/__heap_base i32 (i32.const 8))
  (export "memory" (memory $0))
  (start $~start)
- (func $optional-typeparameters/testConcrete<i32,i32> (; 0 ;) (param $0 i32) (result i32)
+ (func $optional-typeparameters/testConcrete<i32,i32> (param $0 i32) (result i32)
   local.get $0
  )
- (func $optional-typeparameters/testDerived<i32,i32> (; 1 ;) (param $0 i32) (result i32)
+ (func $optional-typeparameters/testDerived<i32,i32> (param $0 i32) (result i32)
   local.get $0
  )
- (func $~lib/rt/stub/maybeGrowMemory (; 2 ;) (param $0 i32)
+ (func $~lib/rt/stub/maybeGrowMemory (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -74,7 +74,7 @@
   local.get $0
   global.set $~lib/rt/stub/offset
  )
- (func $~lib/rt/stub/__alloc (; 3 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/stub/__alloc (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -127,10 +127,10 @@
   i32.store offset=12
   local.get $2
  )
- (func $~lib/rt/stub/__retain (; 4 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/stub/__retain (param $0 i32) (result i32)
   local.get $0
  )
- (func $optional-typeparameters/TestConcrete<i32,i32>#constructor (; 5 ;) (param $0 i32) (result i32)
+ (func $optional-typeparameters/TestConcrete<i32,i32>#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -142,12 +142,12 @@
   end
   local.get $0
  )
- (func $optional-typeparameters/TestConcrete<i32,i32>#test<i32> (; 6 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $optional-typeparameters/TestConcrete<i32,i32>#test<i32> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $1
   local.get $2
   i32.add
  )
- (func $optional-typeparameters/TestDerived<f64,f64>#constructor (; 7 ;) (param $0 i32) (result i32)
+ (func $optional-typeparameters/TestDerived<f64,f64>#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -159,12 +159,12 @@
   end
   local.get $0
  )
- (func $optional-typeparameters/TestDerived<f64,f64>#test<f64> (; 8 ;) (param $0 i32) (param $1 f64) (param $2 f64) (result f64)
+ (func $optional-typeparameters/TestDerived<f64,f64>#test<f64> (param $0 i32) (param $1 f64) (param $2 f64) (result f64)
   local.get $1
   local.get $2
   f64.add
  )
- (func $start:optional-typeparameters (; 9 ;)
+ (func $start:optional-typeparameters
   i32.const 1
   call $optional-typeparameters/testConcrete<i32,i32>
   drop
@@ -198,7 +198,7 @@
   call $optional-typeparameters/TestDerived<f64,f64>#test<f64>
   drop
  )
- (func $~start (; 10 ;)
+ (func $~start
   call $start:optional-typeparameters
  )
 )

--- a/tests/compiler/overflow.untouched.wat
+++ b/tests/compiler/overflow.untouched.wat
@@ -7,7 +7,7 @@
  (table $0 1 funcref)
  (export "memory" (memory $0))
  (start $~start)
- (func $start:overflow (; 1 ;)
+ (func $start:overflow
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -728,7 +728,7 @@
    unreachable
   end
  )
- (func $~start (; 2 ;)
+ (func $~start
   call $start:overflow
  )
 )

--- a/tests/compiler/portable-conversions.untouched.wat
+++ b/tests/compiler/portable-conversions.untouched.wat
@@ -11,7 +11,7 @@
  (global $portable-conversions/F (mut f64) (f64.const 1))
  (export "memory" (memory $0))
  (start $~start)
- (func $start:portable-conversions (; 1 ;)
+ (func $start:portable-conversions
   global.get $portable-conversions/i
   i32.const 24
   i32.shl
@@ -633,7 +633,7 @@
    unreachable
   end
  )
- (func $~start (; 2 ;)
+ (func $~start
   call $start:portable-conversions
  )
 )

--- a/tests/compiler/possibly-null.optimized.wat
+++ b/tests/compiler/possibly-null.optimized.wat
@@ -21,10 +21,10 @@
  (export "testLogicalOrMulti" (func $possibly-null/testLogicalAndMulti))
  (export "testAssign" (func $possibly-null/testLogicalAndMulti))
  (export "testNeverNull" (func $possibly-null/testTrue))
- (func $possibly-null/testTrue (; 0 ;) (param $0 i32)
+ (func $possibly-null/testTrue (param $0 i32)
   nop
  )
- (func $possibly-null/testWhile (; 1 ;) (param $0 i32)
+ (func $possibly-null/testWhile (param $0 i32)
   loop $while-continue|0
    local.get $0
    if
@@ -34,7 +34,7 @@
    end
   end
  )
- (func $possibly-null/testWhile2 (; 2 ;) (param $0 i32) (param $1 i32)
+ (func $possibly-null/testWhile2 (param $0 i32) (param $1 i32)
   loop $while-continue|0
    local.get $0
    if
@@ -44,7 +44,7 @@
    end
   end
  )
- (func $possibly-null/testWhile3 (; 3 ;) (param $0 i32) (param $1 i32)
+ (func $possibly-null/testWhile3 (param $0 i32) (param $1 i32)
   loop $while-continue|0
    local.get $0
    if
@@ -57,7 +57,7 @@
    end
   end
  )
- (func $possibly-null/testLogicalAndMulti (; 4 ;) (param $0 i32) (param $1 i32)
+ (func $possibly-null/testLogicalAndMulti (param $0 i32) (param $1 i32)
   nop
  )
 )

--- a/tests/compiler/possibly-null.untouched.wat
+++ b/tests/compiler/possibly-null.untouched.wat
@@ -23,13 +23,13 @@
  (export "testLogicalOrMulti" (func $possibly-null/testLogicalOrMulti))
  (export "testAssign" (func $possibly-null/testAssign))
  (export "testNeverNull" (func $possibly-null/testNeverNull))
- (func $~lib/rt/stub/__retain (; 0 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/stub/__retain (param $0 i32) (result i32)
   local.get $0
  )
- (func $~lib/rt/stub/__release (; 1 ;) (param $0 i32)
+ (func $~lib/rt/stub/__release (param $0 i32)
   nop
  )
- (func $possibly-null/testTrue (; 2 ;) (param $0 i32)
+ (func $possibly-null/testTrue (param $0 i32)
   local.get $0
   call $~lib/rt/stub/__retain
   local.set $0
@@ -40,7 +40,7 @@
   local.get $0
   call $~lib/rt/stub/__release
  )
- (func $possibly-null/testFalseElse (; 3 ;) (param $0 i32)
+ (func $possibly-null/testFalseElse (param $0 i32)
   local.get $0
   call $~lib/rt/stub/__retain
   local.set $0
@@ -56,7 +56,7 @@
   local.get $0
   call $~lib/rt/stub/__release
  )
- (func $possibly-null/testFalseContinuation (; 4 ;) (param $0 i32)
+ (func $possibly-null/testFalseContinuation (param $0 i32)
   local.get $0
   call $~lib/rt/stub/__retain
   local.set $0
@@ -70,7 +70,7 @@
   local.get $0
   call $~lib/rt/stub/__release
  )
- (func $possibly-null/testNeNull (; 5 ;) (param $0 i32)
+ (func $possibly-null/testNeNull (param $0 i32)
   local.get $0
   call $~lib/rt/stub/__retain
   local.set $0
@@ -83,7 +83,7 @@
   local.get $0
   call $~lib/rt/stub/__release
  )
- (func $possibly-null/testEqNullElse (; 6 ;) (param $0 i32)
+ (func $possibly-null/testEqNullElse (param $0 i32)
   local.get $0
   call $~lib/rt/stub/__retain
   local.set $0
@@ -100,7 +100,7 @@
   local.get $0
   call $~lib/rt/stub/__release
  )
- (func $possibly-null/testEqNullContinuation (; 7 ;) (param $0 i32)
+ (func $possibly-null/testEqNullContinuation (param $0 i32)
   local.get $0
   call $~lib/rt/stub/__retain
   local.set $0
@@ -115,7 +115,7 @@
   local.get $0
   call $~lib/rt/stub/__release
  )
- (func $possibly-null/testNotEqNull (; 8 ;) (param $0 i32)
+ (func $possibly-null/testNotEqNull (param $0 i32)
   local.get $0
   call $~lib/rt/stub/__retain
   local.set $0
@@ -129,7 +129,7 @@
   local.get $0
   call $~lib/rt/stub/__release
  )
- (func $possibly-null/testNotNeNullElse (; 9 ;) (param $0 i32)
+ (func $possibly-null/testNotNeNullElse (param $0 i32)
   local.get $0
   call $~lib/rt/stub/__retain
   local.set $0
@@ -147,7 +147,7 @@
   local.get $0
   call $~lib/rt/stub/__release
  )
- (func $possibly-null/testNotNeNullContinuation (; 10 ;) (param $0 i32)
+ (func $possibly-null/testNotNeNullContinuation (param $0 i32)
   local.get $0
   call $~lib/rt/stub/__retain
   local.set $0
@@ -163,7 +163,7 @@
   local.get $0
   call $~lib/rt/stub/__release
  )
- (func $possibly-null/testWhile (; 11 ;) (param $0 i32)
+ (func $possibly-null/testWhile (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -195,7 +195,7 @@
   local.get $0
   call $~lib/rt/stub/__release
  )
- (func $possibly-null/testWhile2 (; 12 ;) (param $0 i32) (param $1 i32)
+ (func $possibly-null/testWhile2 (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -232,7 +232,7 @@
   local.get $1
   call $~lib/rt/stub/__release
  )
- (func $possibly-null/testWhile3 (; 13 ;) (param $0 i32) (param $1 i32)
+ (func $possibly-null/testWhile3 (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -272,13 +272,13 @@
   local.get $1
   call $~lib/rt/stub/__release
  )
- (func $possibly-null/requireNonNull (; 14 ;) (param $0 i32) (result i32)
+ (func $possibly-null/requireNonNull (param $0 i32) (result i32)
   local.get $0
   call $~lib/rt/stub/__retain
   local.set $0
   local.get $0
  )
- (func $possibly-null/testLogicalAnd (; 15 ;) (param $0 i32)
+ (func $possibly-null/testLogicalAnd (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -300,7 +300,7 @@
   local.get $0
   call $~lib/rt/stub/__release
  )
- (func $possibly-null/testLogicalOr (; 16 ;) (param $0 i32)
+ (func $possibly-null/testLogicalOr (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -325,7 +325,7 @@
   local.get $0
   call $~lib/rt/stub/__release
  )
- (func $possibly-null/testLogicalAndMulti (; 17 ;) (param $0 i32) (param $1 i32)
+ (func $possibly-null/testLogicalAndMulti (param $0 i32) (param $1 i32)
   local.get $0
   call $~lib/rt/stub/__retain
   local.set $0
@@ -348,7 +348,7 @@
   local.get $1
   call $~lib/rt/stub/__release
  )
- (func $possibly-null/testLogicalOrMulti (; 18 ;) (param $0 i32) (param $1 i32)
+ (func $possibly-null/testLogicalOrMulti (param $0 i32) (param $1 i32)
   local.get $0
   call $~lib/rt/stub/__retain
   local.set $0
@@ -373,7 +373,7 @@
   local.get $1
   call $~lib/rt/stub/__release
  )
- (func $possibly-null/testAssign (; 19 ;) (param $0 i32) (param $1 i32)
+ (func $possibly-null/testAssign (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -401,7 +401,7 @@
   local.get $1
   call $~lib/rt/stub/__release
  )
- (func $possibly-null/testNeverNull (; 20 ;) (param $0 i32)
+ (func $possibly-null/testNeverNull (param $0 i32)
   local.get $0
   call $~lib/rt/stub/__retain
   local.set $0

--- a/tests/compiler/rc/global-init.optimized.wat
+++ b/tests/compiler/rc/global-init.optimized.wat
@@ -1,21 +1,7 @@
 (module
- (type $none_=>_none (func))
  (memory $0 1)
  (data (i32.const 1028) "\01\00\00\00\01")
  (data (i32.const 1040) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00p\00u\00r\00e\00.\00t\00s")
  (data (i32.const 1088) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s")
- (global $rc/global-init/a (mut i32) (i32.const 0))
- (global $rc/global-init/b (mut i32) (i32.const 0))
  (export "memory" (memory $0))
- (start $~start)
- (func $~start (; 0 ;)
-  i32.const 1040
-  global.set $rc/global-init/a
-  i32.const 1040
-  global.set $rc/global-init/b
-  i32.const 0
-  global.set $rc/global-init/a
-  i32.const 0
-  global.set $rc/global-init/b
- )
 )

--- a/tests/compiler/rc/global-init.untouched.wat
+++ b/tests/compiler/rc/global-init.untouched.wat
@@ -20,10 +20,10 @@
  (global $~lib/heap/__heap_base i32 (i32.const 128))
  (export "memory" (memory $0))
  (start $~start)
- (func $rc/global-init/getRef (; 4 ;) (result i32)
+ (func $rc/global-init/getRef (result i32)
   i32.const 32
  )
- (func $~lib/rt/pure/increment (; 5 ;) (param $0 i32)
+ (func $~lib/rt/pure/increment (param $0 i32)
   (local $1 i32)
   local.get $0
   i32.load offset=4
@@ -68,7 +68,7 @@
    unreachable
   end
  )
- (func $~lib/rt/pure/__retain (; 6 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/pure/__retain (param $0 i32) (result i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.gt_u
@@ -80,7 +80,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/pure/__release (; 7 ;) (param $0 i32)
+ (func $~lib/rt/pure/__release (param $0 i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.gt_u
@@ -91,7 +91,7 @@
    call $~lib/rt/pure/decrement
   end
  )
- (func $start:rc/global-init (; 8 ;)
+ (func $start:rc/global-init
   (local $0 i32)
   (local $1 i32)
   call $rc/global-init/getRef
@@ -127,10 +127,10 @@
   local.get $1
   global.set $rc/global-init/b
  )
- (func $~start (; 9 ;)
+ (func $~start
   call $start:rc/global-init
  )
- (func $~lib/rt/tlsf/removeBlock (; 10 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/removeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -340,7 +340,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/insertBlock (; 11 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/insertBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -690,7 +690,7 @@
   local.get $7
   i32.store offset=4
  )
- (func $~lib/rt/tlsf/freeBlock (; 12 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/freeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $1
   i32.load
@@ -706,7 +706,7 @@
   local.get $1
   call $~lib/rt/rtrace/onfree
  )
- (func $~lib/rt/pure/decrement (; 13 ;) (param $0 i32)
+ (func $~lib/rt/pure/decrement (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -783,7 +783,7 @@
    i32.store offset=4
   end
  )
- (func $~lib/rt/pure/__visit (; 14 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/pure/__visit (param $0 i32) (param $1 i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.lt_u
@@ -807,7 +807,7 @@
   i32.sub
   call $~lib/rt/pure/decrement
  )
- (func $~lib/rt/__visit_members (; 15 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/__visit_members (param $0 i32) (param $1 i32)
   (local $2 i32)
   block $switch$1$default
    block $switch$1$case$4

--- a/tests/compiler/rc/local-init.optimized.wat
+++ b/tests/compiler/rc/local-init.optimized.wat
@@ -20,7 +20,7 @@
  (global $~lib/rt/tlsf/collectLock (mut i32) (i32.const 0))
  (export "memory" (memory $0))
  (start $~start)
- (func $~lib/rt/tlsf/removeBlock (; 5 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/removeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -182,7 +182,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/insertBlock (; 6 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/insertBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -461,7 +461,7 @@
   i32.or
   i32.store offset=4
  )
- (func $~lib/rt/tlsf/addMemory (; 7 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $2
@@ -575,7 +575,7 @@
   local.get $1
   call $~lib/rt/tlsf/insertBlock
  )
- (func $~lib/rt/tlsf/maybeInitialize (; 8 ;) (result i32)
+ (func $~lib/rt/tlsf/maybeInitialize (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -662,7 +662,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/tlsf/searchBlock (; 9 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/tlsf/searchBlock (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   nop
@@ -720,7 +720,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/allocateBlock (; 10 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/tlsf/allocateBlock (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -892,7 +892,7 @@
   call $~lib/rt/rtrace/onalloc
   local.get $1
  )
- (func $~start (; 11 ;)
+ (func $~start
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -956,7 +956,7 @@
    call $~lib/rt/pure/decrement
   end
  )
- (func $~lib/rt/pure/decrement (; 12 ;) (param $0 i32)
+ (func $~lib/rt/pure/decrement (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0

--- a/tests/compiler/rc/local-init.untouched.wat
+++ b/tests/compiler/rc/local-init.untouched.wat
@@ -26,7 +26,7 @@
  (global $~lib/heap/__heap_base i32 (i32.const 192))
  (export "memory" (memory $0))
  (start $~start)
- (func $~lib/rt/pure/__release (; 5 ;) (param $0 i32)
+ (func $~lib/rt/pure/__release (param $0 i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.gt_u
@@ -37,10 +37,10 @@
    call $~lib/rt/pure/decrement
   end
  )
- (func $rc/local-init/getRef (; 6 ;) (result i32)
+ (func $rc/local-init/getRef (result i32)
   i32.const 32
  )
- (func $~lib/rt/tlsf/removeBlock (; 7 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/removeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -250,7 +250,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/insertBlock (; 8 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/insertBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -600,7 +600,7 @@
   local.get $7
   i32.store offset=4
  )
- (func $~lib/rt/tlsf/addMemory (; 9 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -748,7 +748,7 @@
   call $~lib/rt/tlsf/insertBlock
   i32.const 1
  )
- (func $~lib/rt/tlsf/maybeInitialize (; 10 ;) (result i32)
+ (func $~lib/rt/tlsf/maybeInitialize (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -902,7 +902,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/tlsf/prepareSize (; 11 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/tlsf/prepareSize (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -931,7 +931,7 @@
   i32.gt_u
   select
  )
- (func $~lib/rt/tlsf/searchBlock (; 12 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/searchBlock (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1114,7 +1114,7 @@
   end
   local.get $7
  )
- (func $~lib/rt/tlsf/growMemory (; 13 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/growMemory (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1198,7 +1198,7 @@
   call $~lib/rt/tlsf/addMemory
   drop
  )
- (func $~lib/rt/tlsf/prepareBlock (; 14 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/rt/tlsf/prepareBlock (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1293,7 +1293,7 @@
    i32.store
   end
  )
- (func $~lib/rt/tlsf/allocateBlock (; 15 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/allocateBlock (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   global.get $~lib/rt/tlsf/collectLock
@@ -1404,7 +1404,7 @@
   call $~lib/rt/rtrace/onalloc
   local.get $4
  )
- (func $~lib/rt/tlsf/__alloc (; 16 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/__alloc (param $0 i32) (param $1 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
   local.get $0
   local.get $1
@@ -1412,7 +1412,7 @@
   i32.const 16
   i32.add
  )
- (func $~lib/rt/pure/increment (; 17 ;) (param $0 i32)
+ (func $~lib/rt/pure/increment (param $0 i32)
   (local $1 i32)
   local.get $0
   i32.load offset=4
@@ -1457,7 +1457,7 @@
    unreachable
   end
  )
- (func $~lib/rt/pure/__retain (; 18 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/pure/__retain (param $0 i32) (result i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.gt_u
@@ -1469,7 +1469,7 @@
   end
   local.get $0
  )
- (func $rc/local-init/Ref#constructor (; 19 ;) (param $0 i32) (result i32)
+ (func $rc/local-init/Ref#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -1481,7 +1481,7 @@
   end
   local.get $0
  )
- (func $start:rc/local-init (; 20 ;)
+ (func $start:rc/local-init
   (local $0 i32)
   i32.const 32
   local.set $0
@@ -1497,10 +1497,10 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~start (; 21 ;)
+ (func $~start
   call $start:rc/local-init
  )
- (func $~lib/rt/tlsf/freeBlock (; 22 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/freeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $1
   i32.load
@@ -1516,7 +1516,7 @@
   local.get $1
   call $~lib/rt/rtrace/onfree
  )
- (func $~lib/rt/pure/decrement (; 23 ;) (param $0 i32)
+ (func $~lib/rt/pure/decrement (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -1593,10 +1593,10 @@
    i32.store offset=4
   end
  )
- (func $~lib/rt/pure/__collect (; 24 ;)
+ (func $~lib/rt/pure/__collect
   return
  )
- (func $~lib/rt/pure/__visit (; 25 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/pure/__visit (param $0 i32) (param $1 i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.lt_u
@@ -1620,7 +1620,7 @@
   i32.sub
   call $~lib/rt/pure/decrement
  )
- (func $~lib/rt/__visit_members (; 26 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/__visit_members (param $0 i32) (param $1 i32)
   (local $2 i32)
   block $switch$1$default
    block $switch$1$case$4

--- a/tests/compiler/rc/logical-and-mismatch.optimized.wat
+++ b/tests/compiler/rc/logical-and-mismatch.optimized.wat
@@ -20,7 +20,7 @@
  (global $rc/logical-and-mismatch/gloRef (mut i32) (i32.const 0))
  (export "memory" (memory $0))
  (start $~start)
- (func $~lib/rt/tlsf/removeBlock (; 5 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/removeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -182,7 +182,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/insertBlock (; 6 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/insertBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -461,7 +461,7 @@
   i32.or
   i32.store offset=4
  )
- (func $~lib/rt/tlsf/addMemory (; 7 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $2
@@ -575,7 +575,7 @@
   local.get $1
   call $~lib/rt/tlsf/insertBlock
  )
- (func $~lib/rt/tlsf/maybeInitialize (; 8 ;) (result i32)
+ (func $~lib/rt/tlsf/maybeInitialize (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -662,7 +662,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/tlsf/searchBlock (; 9 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/tlsf/searchBlock (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   nop
@@ -720,7 +720,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/allocateBlock (; 10 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/tlsf/allocateBlock (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -892,7 +892,7 @@
   call $~lib/rt/rtrace/onalloc
   local.get $1
  )
- (func $~lib/rt/pure/__retain (; 11 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/pure/__retain (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -943,14 +943,14 @@
   end
   local.get $0
  )
- (func $rc/logical-and-mismatch/Ref#constructor (; 12 ;) (result i32)
+ (func $rc/logical-and-mismatch/Ref#constructor (result i32)
   call $~lib/rt/tlsf/maybeInitialize
   call $~lib/rt/tlsf/allocateBlock
   i32.const 16
   i32.add
   call $~lib/rt/pure/__retain
  )
- (func $~lib/rt/pure/__release (; 13 ;) (param $0 i32)
+ (func $~lib/rt/pure/__release (param $0 i32)
   local.get $0
   i32.const 1184
   i32.gt_u
@@ -961,7 +961,7 @@
    call $~lib/rt/pure/decrement
   end
  )
- (func $~start (; 14 ;)
+ (func $~start
   (local $0 i32)
   call $rc/logical-and-mismatch/Ref#constructor
   global.set $rc/logical-and-mismatch/gloRef
@@ -998,7 +998,7 @@
   global.get $rc/logical-and-mismatch/gloRef
   call $~lib/rt/pure/__release
  )
- (func $~lib/rt/pure/decrement (; 15 ;) (param $0 i32)
+ (func $~lib/rt/pure/decrement (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0

--- a/tests/compiler/rc/logical-and-mismatch.untouched.wat
+++ b/tests/compiler/rc/logical-and-mismatch.untouched.wat
@@ -26,7 +26,7 @@
  (global $~lib/heap/__heap_base i32 (i32.const 176))
  (export "memory" (memory $0))
  (start $~start)
- (func $~lib/rt/tlsf/removeBlock (; 5 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/removeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -236,7 +236,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/insertBlock (; 6 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/insertBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -586,7 +586,7 @@
   local.get $7
   i32.store offset=4
  )
- (func $~lib/rt/tlsf/addMemory (; 7 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -734,7 +734,7 @@
   call $~lib/rt/tlsf/insertBlock
   i32.const 1
  )
- (func $~lib/rt/tlsf/maybeInitialize (; 8 ;) (result i32)
+ (func $~lib/rt/tlsf/maybeInitialize (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -888,7 +888,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/tlsf/prepareSize (; 9 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/tlsf/prepareSize (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -917,7 +917,7 @@
   i32.gt_u
   select
  )
- (func $~lib/rt/tlsf/searchBlock (; 10 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/searchBlock (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1100,7 +1100,7 @@
   end
   local.get $7
  )
- (func $~lib/rt/tlsf/growMemory (; 11 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/growMemory (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1184,7 +1184,7 @@
   call $~lib/rt/tlsf/addMemory
   drop
  )
- (func $~lib/rt/tlsf/prepareBlock (; 12 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/rt/tlsf/prepareBlock (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1279,7 +1279,7 @@
    i32.store
   end
  )
- (func $~lib/rt/tlsf/allocateBlock (; 13 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/allocateBlock (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   global.get $~lib/rt/tlsf/collectLock
@@ -1390,7 +1390,7 @@
   call $~lib/rt/rtrace/onalloc
   local.get $4
  )
- (func $~lib/rt/tlsf/__alloc (; 14 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/__alloc (param $0 i32) (param $1 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
   local.get $0
   local.get $1
@@ -1398,7 +1398,7 @@
   i32.const 16
   i32.add
  )
- (func $~lib/rt/pure/increment (; 15 ;) (param $0 i32)
+ (func $~lib/rt/pure/increment (param $0 i32)
   (local $1 i32)
   local.get $0
   i32.load offset=4
@@ -1443,7 +1443,7 @@
    unreachable
   end
  )
- (func $~lib/rt/pure/__retain (; 16 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/pure/__retain (param $0 i32) (result i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.gt_u
@@ -1455,7 +1455,7 @@
   end
   local.get $0
  )
- (func $rc/logical-and-mismatch/Ref#constructor (; 17 ;) (param $0 i32) (result i32)
+ (func $rc/logical-and-mismatch/Ref#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -1467,11 +1467,11 @@
   end
   local.get $0
  )
- (func $rc/logical-and-mismatch/getRef (; 18 ;) (result i32)
+ (func $rc/logical-and-mismatch/getRef (result i32)
   i32.const 0
   call $rc/logical-and-mismatch/Ref#constructor
  )
- (func $~lib/rt/pure/__release (; 19 ;) (param $0 i32)
+ (func $~lib/rt/pure/__release (param $0 i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.gt_u
@@ -1482,7 +1482,7 @@
    call $~lib/rt/pure/decrement
   end
  )
- (func $start:rc/logical-and-mismatch (; 20 ;)
+ (func $start:rc/logical-and-mismatch
   (local $0 i32)
   i32.const 0
   call $rc/logical-and-mismatch/Ref#constructor
@@ -1537,13 +1537,13 @@
   global.get $rc/logical-and-mismatch/gloRef
   call $~lib/rt/pure/__release
  )
- (func $~start (; 21 ;)
+ (func $~start
   call $start:rc/logical-and-mismatch
  )
- (func $~lib/rt/pure/__collect (; 22 ;)
+ (func $~lib/rt/pure/__collect
   return
  )
- (func $~lib/rt/tlsf/freeBlock (; 23 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/freeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $1
   i32.load
@@ -1559,7 +1559,7 @@
   local.get $1
   call $~lib/rt/rtrace/onfree
  )
- (func $~lib/rt/pure/decrement (; 24 ;) (param $0 i32)
+ (func $~lib/rt/pure/decrement (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -1636,7 +1636,7 @@
    i32.store offset=4
   end
  )
- (func $~lib/rt/pure/__visit (; 25 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/pure/__visit (param $0 i32) (param $1 i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.lt_u
@@ -1660,7 +1660,7 @@
   i32.sub
   call $~lib/rt/pure/decrement
  )
- (func $~lib/rt/__visit_members (; 26 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/__visit_members (param $0 i32) (param $1 i32)
   (local $2 i32)
   block $switch$1$default
    block $switch$1$case$4

--- a/tests/compiler/rc/logical-or-mismatch.optimized.wat
+++ b/tests/compiler/rc/logical-or-mismatch.optimized.wat
@@ -20,7 +20,7 @@
  (global $rc/logical-or-mismatch/gloRef (mut i32) (i32.const 0))
  (export "memory" (memory $0))
  (start $~start)
- (func $~lib/rt/tlsf/removeBlock (; 5 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/removeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -182,7 +182,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/insertBlock (; 6 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/insertBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -461,7 +461,7 @@
   i32.or
   i32.store offset=4
  )
- (func $~lib/rt/tlsf/addMemory (; 7 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $2
@@ -575,7 +575,7 @@
   local.get $1
   call $~lib/rt/tlsf/insertBlock
  )
- (func $~lib/rt/tlsf/maybeInitialize (; 8 ;) (result i32)
+ (func $~lib/rt/tlsf/maybeInitialize (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -662,7 +662,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/tlsf/searchBlock (; 9 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/tlsf/searchBlock (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   nop
@@ -720,7 +720,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/allocateBlock (; 10 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/tlsf/allocateBlock (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -892,7 +892,7 @@
   call $~lib/rt/rtrace/onalloc
   local.get $1
  )
- (func $~lib/rt/pure/__retain (; 11 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/pure/__retain (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -943,14 +943,14 @@
   end
   local.get $0
  )
- (func $rc/logical-or-mismatch/Ref#constructor (; 12 ;) (result i32)
+ (func $rc/logical-or-mismatch/Ref#constructor (result i32)
   call $~lib/rt/tlsf/maybeInitialize
   call $~lib/rt/tlsf/allocateBlock
   i32.const 16
   i32.add
   call $~lib/rt/pure/__retain
  )
- (func $~lib/rt/pure/__release (; 13 ;) (param $0 i32)
+ (func $~lib/rt/pure/__release (param $0 i32)
   local.get $0
   i32.const 1184
   i32.gt_u
@@ -961,7 +961,7 @@
    call $~lib/rt/pure/decrement
   end
  )
- (func $~start (; 14 ;)
+ (func $~start
   (local $0 i32)
   call $rc/logical-or-mismatch/Ref#constructor
   global.set $rc/logical-or-mismatch/gloRef
@@ -1000,7 +1000,7 @@
   global.get $rc/logical-or-mismatch/gloRef
   call $~lib/rt/pure/__release
  )
- (func $~lib/rt/pure/decrement (; 15 ;) (param $0 i32)
+ (func $~lib/rt/pure/decrement (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0

--- a/tests/compiler/rc/logical-or-mismatch.untouched.wat
+++ b/tests/compiler/rc/logical-or-mismatch.untouched.wat
@@ -26,7 +26,7 @@
  (global $~lib/heap/__heap_base i32 (i32.const 176))
  (export "memory" (memory $0))
  (start $~start)
- (func $~lib/rt/tlsf/removeBlock (; 5 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/removeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -236,7 +236,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/insertBlock (; 6 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/insertBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -586,7 +586,7 @@
   local.get $7
   i32.store offset=4
  )
- (func $~lib/rt/tlsf/addMemory (; 7 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -734,7 +734,7 @@
   call $~lib/rt/tlsf/insertBlock
   i32.const 1
  )
- (func $~lib/rt/tlsf/maybeInitialize (; 8 ;) (result i32)
+ (func $~lib/rt/tlsf/maybeInitialize (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -888,7 +888,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/tlsf/prepareSize (; 9 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/tlsf/prepareSize (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -917,7 +917,7 @@
   i32.gt_u
   select
  )
- (func $~lib/rt/tlsf/searchBlock (; 10 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/searchBlock (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1100,7 +1100,7 @@
   end
   local.get $7
  )
- (func $~lib/rt/tlsf/growMemory (; 11 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/growMemory (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1184,7 +1184,7 @@
   call $~lib/rt/tlsf/addMemory
   drop
  )
- (func $~lib/rt/tlsf/prepareBlock (; 12 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/rt/tlsf/prepareBlock (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1279,7 +1279,7 @@
    i32.store
   end
  )
- (func $~lib/rt/tlsf/allocateBlock (; 13 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/allocateBlock (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   global.get $~lib/rt/tlsf/collectLock
@@ -1390,7 +1390,7 @@
   call $~lib/rt/rtrace/onalloc
   local.get $4
  )
- (func $~lib/rt/tlsf/__alloc (; 14 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/__alloc (param $0 i32) (param $1 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
   local.get $0
   local.get $1
@@ -1398,7 +1398,7 @@
   i32.const 16
   i32.add
  )
- (func $~lib/rt/pure/increment (; 15 ;) (param $0 i32)
+ (func $~lib/rt/pure/increment (param $0 i32)
   (local $1 i32)
   local.get $0
   i32.load offset=4
@@ -1443,7 +1443,7 @@
    unreachable
   end
  )
- (func $~lib/rt/pure/__retain (; 16 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/pure/__retain (param $0 i32) (result i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.gt_u
@@ -1455,7 +1455,7 @@
   end
   local.get $0
  )
- (func $rc/logical-or-mismatch/Ref#constructor (; 17 ;) (param $0 i32) (result i32)
+ (func $rc/logical-or-mismatch/Ref#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -1467,11 +1467,11 @@
   end
   local.get $0
  )
- (func $rc/logical-or-mismatch/getRef (; 18 ;) (result i32)
+ (func $rc/logical-or-mismatch/getRef (result i32)
   i32.const 0
   call $rc/logical-or-mismatch/Ref#constructor
  )
- (func $~lib/rt/pure/__release (; 19 ;) (param $0 i32)
+ (func $~lib/rt/pure/__release (param $0 i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.gt_u
@@ -1482,7 +1482,7 @@
    call $~lib/rt/pure/decrement
   end
  )
- (func $start:rc/logical-or-mismatch (; 20 ;)
+ (func $start:rc/logical-or-mismatch
   (local $0 i32)
   i32.const 0
   call $rc/logical-or-mismatch/Ref#constructor
@@ -1537,13 +1537,13 @@
   global.get $rc/logical-or-mismatch/gloRef
   call $~lib/rt/pure/__release
  )
- (func $~start (; 21 ;)
+ (func $~start
   call $start:rc/logical-or-mismatch
  )
- (func $~lib/rt/pure/__collect (; 22 ;)
+ (func $~lib/rt/pure/__collect
   return
  )
- (func $~lib/rt/tlsf/freeBlock (; 23 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/freeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $1
   i32.load
@@ -1559,7 +1559,7 @@
   local.get $1
   call $~lib/rt/rtrace/onfree
  )
- (func $~lib/rt/pure/decrement (; 24 ;) (param $0 i32)
+ (func $~lib/rt/pure/decrement (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -1636,7 +1636,7 @@
    i32.store offset=4
   end
  )
- (func $~lib/rt/pure/__visit (; 25 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/pure/__visit (param $0 i32) (param $1 i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.lt_u
@@ -1660,7 +1660,7 @@
   i32.sub
   call $~lib/rt/pure/decrement
  )
- (func $~lib/rt/__visit_members (; 26 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/__visit_members (param $0 i32) (param $1 i32)
   (local $2 i32)
   block $switch$1$default
    block $switch$1$case$4

--- a/tests/compiler/rc/optimize.optimized.wat
+++ b/tests/compiler/rc/optimize.optimized.wat
@@ -47,19 +47,19 @@
  (export "FinalizeARC.eliminates.unnecessaryStaticRelease" (func $rc/optimize/eliminated_v))
  (export "FinalizeARC.keeps.dynamicRetain" (func $rc/optimize/FinalizeARC.keeps.dynamicRetain))
  (export "FinalizeARC.keeps.dynamicRelease" (func $rc/optimize/FinalizeARC.keeps.dynamicRelease))
- (func $rc/optimize/eliminated_v (; 5 ;)
+ (func $rc/optimize/eliminated_v
   nop
  )
- (func $rc/optimize/eliminated_vi (; 6 ;) (param $0 i32)
+ (func $rc/optimize/eliminated_vi (param $0 i32)
   nop
  )
- (func $rc/optimize/eliminated_vii (; 7 ;) (param $0 i32) (param $1 i32)
+ (func $rc/optimize/eliminated_vii (param $0 i32) (param $1 i32)
   nop
  )
- (func $rc/optimize/eliminated_viii (; 8 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $rc/optimize/eliminated_viii (param $0 i32) (param $1 i32) (param $2 i32)
   nop
  )
- (func $~lib/rt/pure/__retain (; 9 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/pure/__retain (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -110,7 +110,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/tlsf/removeBlock (; 10 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/removeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -272,7 +272,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/insertBlock (; 11 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/insertBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -551,7 +551,7 @@
   i32.or
   i32.store offset=4
  )
- (func $~lib/rt/tlsf/addMemory (; 12 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $2
@@ -665,7 +665,7 @@
   local.get $1
   call $~lib/rt/tlsf/insertBlock
  )
- (func $~lib/rt/tlsf/maybeInitialize (; 13 ;) (result i32)
+ (func $~lib/rt/tlsf/maybeInitialize (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -752,7 +752,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/tlsf/searchBlock (; 14 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/tlsf/searchBlock (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   nop
@@ -810,7 +810,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/allocateBlock (; 15 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/tlsf/allocateBlock (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -982,14 +982,14 @@
   call $~lib/rt/rtrace/onalloc
   local.get $1
  )
- (func $rc/optimize/getRef (; 16 ;) (result i32)
+ (func $rc/optimize/getRef (result i32)
   call $~lib/rt/tlsf/maybeInitialize
   call $~lib/rt/tlsf/allocateBlock
   i32.const 16
   i32.add
   call $~lib/rt/pure/__retain
  )
- (func $~lib/rt/pure/__release (; 17 ;) (param $0 i32)
+ (func $~lib/rt/pure/__release (param $0 i32)
   local.get $0
   i32.const 1204
   i32.gt_u
@@ -1000,14 +1000,14 @@
    call $~lib/rt/pure/decrement
   end
  )
- (func $rc/optimize/eliminated_rr (; 18 ;) (param $0 i32) (result i32)
+ (func $rc/optimize/eliminated_rr (param $0 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
   call $~lib/rt/tlsf/allocateBlock
   i32.const 16
   i32.add
   call $~lib/rt/pure/__retain
  )
- (func $rc/optimize/OptimizeARC.eliminates.balancedInsideOutsideLoopWithBranch (; 19 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $rc/optimize/OptimizeARC.eliminates.balancedInsideOutsideLoopWithBranch (param $0 i32) (param $1 i32) (param $2 i32)
   loop $while-continue|0
    local.get $1
    if
@@ -1019,7 +1019,7 @@
    end
   end
  )
- (func $rc/optimize/OptimizeARC.keeps.partialRetains (; 20 ;) (param $0 i32) (param $1 i32)
+ (func $rc/optimize/OptimizeARC.keeps.partialRetains (param $0 i32) (param $1 i32)
   local.get $1
   if (result i32)
    local.get $0
@@ -1029,7 +1029,7 @@
   end
   call $~lib/rt/pure/__release
  )
- (func $rc/optimize/OptimizeARC.keeps.reachesReturn (; 21 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $rc/optimize/OptimizeARC.keeps.reachesReturn (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $0
@@ -1042,16 +1042,16 @@
   call $~lib/rt/pure/__release
   i32.const 0
  )
- (func $rc/optimize/FinalizeARC.keeps.dynamicRetain (; 22 ;) (param $0 i32)
+ (func $rc/optimize/FinalizeARC.keeps.dynamicRetain (param $0 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   drop
  )
- (func $rc/optimize/FinalizeARC.keeps.dynamicRelease (; 23 ;) (param $0 i32)
+ (func $rc/optimize/FinalizeARC.keeps.dynamicRelease (param $0 i32)
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/rt/pure/decrement (; 24 ;) (param $0 i32)
+ (func $~lib/rt/pure/decrement (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0

--- a/tests/compiler/rc/optimize.untouched.wat
+++ b/tests/compiler/rc/optimize.untouched.wat
@@ -52,19 +52,19 @@
  (export "FinalizeARC.eliminates.unnecessaryStaticRelease" (func $rc/optimize/FinalizeARC.eliminates.unnecessaryStaticRelease))
  (export "FinalizeARC.keeps.dynamicRetain" (func $rc/optimize/FinalizeARC.keeps.dynamicRetain))
  (export "FinalizeARC.keeps.dynamicRelease" (func $rc/optimize/FinalizeARC.keeps.dynamicRelease))
- (func $rc/optimize/eliminated_v (; 5 ;)
+ (func $rc/optimize/eliminated_v
   nop
  )
- (func $rc/optimize/eliminated_vi (; 6 ;) (param $0 i32)
+ (func $rc/optimize/eliminated_vi (param $0 i32)
   nop
  )
- (func $rc/optimize/eliminated_vii (; 7 ;) (param $0 i32) (param $1 i32)
+ (func $rc/optimize/eliminated_vii (param $0 i32) (param $1 i32)
   nop
  )
- (func $rc/optimize/eliminated_viii (; 8 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $rc/optimize/eliminated_viii (param $0 i32) (param $1 i32) (param $2 i32)
   nop
  )
- (func $~lib/rt/pure/increment (; 9 ;) (param $0 i32)
+ (func $~lib/rt/pure/increment (param $0 i32)
   (local $1 i32)
   local.get $0
   i32.load offset=4
@@ -109,7 +109,7 @@
    unreachable
   end
  )
- (func $~lib/rt/pure/__retain (; 10 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/pure/__retain (param $0 i32) (result i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.gt_u
@@ -121,7 +121,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/tlsf/removeBlock (; 11 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/removeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -331,7 +331,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/insertBlock (; 12 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/insertBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -681,7 +681,7 @@
   local.get $7
   i32.store offset=4
  )
- (func $~lib/rt/tlsf/addMemory (; 13 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -829,7 +829,7 @@
   call $~lib/rt/tlsf/insertBlock
   i32.const 1
  )
- (func $~lib/rt/tlsf/maybeInitialize (; 14 ;) (result i32)
+ (func $~lib/rt/tlsf/maybeInitialize (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -983,7 +983,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/tlsf/prepareSize (; 15 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/tlsf/prepareSize (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -1012,7 +1012,7 @@
   i32.gt_u
   select
  )
- (func $~lib/rt/tlsf/searchBlock (; 16 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/searchBlock (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1195,7 +1195,7 @@
   end
   local.get $7
  )
- (func $~lib/rt/tlsf/growMemory (; 17 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/growMemory (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1279,7 +1279,7 @@
   call $~lib/rt/tlsf/addMemory
   drop
  )
- (func $~lib/rt/tlsf/prepareBlock (; 18 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/rt/tlsf/prepareBlock (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1374,7 +1374,7 @@
    i32.store
   end
  )
- (func $~lib/rt/tlsf/allocateBlock (; 19 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/allocateBlock (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   global.get $~lib/rt/tlsf/collectLock
@@ -1485,7 +1485,7 @@
   call $~lib/rt/rtrace/onalloc
   local.get $4
  )
- (func $~lib/rt/tlsf/__alloc (; 20 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/__alloc (param $0 i32) (param $1 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
   local.get $0
   local.get $1
@@ -1493,7 +1493,7 @@
   i32.const 16
   i32.add
  )
- (func $rc/optimize/Ref#constructor (; 21 ;) (param $0 i32) (result i32)
+ (func $rc/optimize/Ref#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -1505,11 +1505,11 @@
   end
   local.get $0
  )
- (func $rc/optimize/getRef (; 22 ;) (result i32)
+ (func $rc/optimize/getRef (result i32)
   i32.const 0
   call $rc/optimize/Ref#constructor
  )
- (func $~lib/rt/pure/__release (; 23 ;) (param $0 i32)
+ (func $~lib/rt/pure/__release (param $0 i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.gt_u
@@ -1520,7 +1520,7 @@
    call $~lib/rt/pure/decrement
   end
  )
- (func $rc/optimize/eliminated_rr (; 24 ;) (param $0 i32) (result i32)
+ (func $rc/optimize/eliminated_rr (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -1531,14 +1531,14 @@
   call $~lib/rt/pure/__release
   local.get $1
  )
- (func $rc/optimize/OptimizeARC.eliminates.linearArgument (; 25 ;) (param $0 i32)
+ (func $rc/optimize/OptimizeARC.eliminates.linearArgument (param $0 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $0
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $rc/optimize/OptimizeARC.eliminates.linearLocal (; 26 ;) (param $0 i32)
+ (func $rc/optimize/OptimizeARC.eliminates.linearLocal (param $0 i32)
   (local $1 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -1546,7 +1546,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $rc/optimize/OptimizeARC.eliminates.linearChain (; 27 ;) (param $0 i32)
+ (func $rc/optimize/OptimizeARC.eliminates.linearChain (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -1566,7 +1566,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $rc/optimize/OptimizeARC.eliminates.balancedReleases (; 28 ;) (param $0 i32) (param $1 i32)
+ (func $rc/optimize/OptimizeARC.eliminates.balancedReleases (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -1580,7 +1580,7 @@
    call $~lib/rt/pure/__release
   end
  )
- (func $rc/optimize/OptimizeARC.eliminates.partialReleases (; 29 ;) (param $0 i32) (param $1 i32)
+ (func $rc/optimize/OptimizeARC.eliminates.partialReleases (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -1591,7 +1591,7 @@
    call $~lib/rt/pure/__release
   end
  )
- (func $rc/optimize/OptimizeARC.eliminates.balancedRetains (; 30 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $rc/optimize/OptimizeARC.eliminates.balancedRetains (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $1
   if
@@ -1613,7 +1613,7 @@
   local.get $3
   call $~lib/rt/pure/__release
  )
- (func $rc/optimize/OptimizeARC.eliminates.balancedInsideLoop (; 31 ;) (param $0 i32) (param $1 i32)
+ (func $rc/optimize/OptimizeARC.eliminates.balancedInsideLoop (param $0 i32) (param $1 i32)
   (local $2 i32)
   loop $while-continue|0
    local.get $1
@@ -1629,7 +1629,7 @@
    end
   end
  )
- (func $rc/optimize/OptimizeARC.eliminates.balancedOutsideLoop (; 32 ;) (param $0 i32) (param $1 i32)
+ (func $rc/optimize/OptimizeARC.eliminates.balancedOutsideLoop (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -1645,7 +1645,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $rc/optimize/OptimizeARC.eliminates.balancedInsideOutsideLoop (; 33 ;) (param $0 i32) (param $1 i32)
+ (func $rc/optimize/OptimizeARC.eliminates.balancedInsideOutsideLoop (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -1666,7 +1666,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $rc/optimize/OptimizeARC.eliminates.balancedInsideOutsideLoopWithBranch (; 34 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $rc/optimize/OptimizeARC.eliminates.balancedInsideOutsideLoopWithBranch (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -1693,7 +1693,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $rc/optimize/OptimizeARC.eliminates.replace (; 35 ;) (param $0 i32) (param $1 i32)
+ (func $rc/optimize/OptimizeARC.eliminates.replace (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -1721,7 +1721,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $rc/optimize/OptimizeARC.eliminates.replaceAlreadyRetained (; 36 ;) (param $0 i32) (result i32)
+ (func $rc/optimize/OptimizeARC.eliminates.replaceAlreadyRetained (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -1734,7 +1734,7 @@
   local.set $0
   local.get $0
  )
- (func $rc/optimize/OptimizeARC.keeps.partialRetains (; 37 ;) (param $0 i32) (param $1 i32)
+ (func $rc/optimize/OptimizeARC.keeps.partialRetains (param $0 i32) (param $1 i32)
   local.get $1
   if
    local.get $0
@@ -1744,7 +1744,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $rc/optimize/OptimizeARC.keeps.reachesReturn (; 38 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $rc/optimize/OptimizeARC.keeps.reachesReturn (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $0
@@ -1757,45 +1757,45 @@
   call $~lib/rt/pure/__release
   i32.const 0
  )
- (func $rc/optimize/FinalizeARC.eliminates.unnecessaryAllocation (; 39 ;)
+ (func $rc/optimize/FinalizeARC.eliminates.unnecessaryAllocation
   i32.const 1
   i32.const 0
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
   call $~lib/rt/pure/__release
  )
- (func $rc/optimize/FinalizeARC.eliminates.unnecessaryPair (; 40 ;) (param $0 i32)
+ (func $rc/optimize/FinalizeARC.eliminates.unnecessaryPair (param $0 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   call $~lib/rt/pure/__release
  )
- (func $rc/optimize/FinalizeARC.eliminates.unnecessaryStaticPair (; 41 ;)
+ (func $rc/optimize/FinalizeARC.eliminates.unnecessaryStaticPair
   i32.const 192
   call $~lib/rt/pure/__retain
   call $~lib/rt/pure/__release
  )
- (func $rc/optimize/FinalizeARC.eliminates.unnecessaryStaticRetain (; 42 ;)
+ (func $rc/optimize/FinalizeARC.eliminates.unnecessaryStaticRetain
   i32.const 192
   call $~lib/rt/pure/__retain
   drop
  )
- (func $rc/optimize/FinalizeARC.eliminates.unnecessaryStaticRelease (; 43 ;)
+ (func $rc/optimize/FinalizeARC.eliminates.unnecessaryStaticRelease
   i32.const 192
   call $~lib/rt/pure/__release
  )
- (func $rc/optimize/FinalizeARC.keeps.dynamicRetain (; 44 ;) (param $0 i32)
+ (func $rc/optimize/FinalizeARC.keeps.dynamicRetain (param $0 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $0
  )
- (func $rc/optimize/FinalizeARC.keeps.dynamicRelease (; 45 ;) (param $0 i32)
+ (func $rc/optimize/FinalizeARC.keeps.dynamicRelease (param $0 i32)
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/rt/pure/__collect (; 46 ;)
+ (func $~lib/rt/pure/__collect
   return
  )
- (func $~lib/rt/tlsf/freeBlock (; 47 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/freeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $1
   i32.load
@@ -1811,7 +1811,7 @@
   local.get $1
   call $~lib/rt/rtrace/onfree
  )
- (func $~lib/rt/pure/decrement (; 48 ;) (param $0 i32)
+ (func $~lib/rt/pure/decrement (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -1888,7 +1888,7 @@
    i32.store offset=4
   end
  )
- (func $~lib/rt/pure/__visit (; 49 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/pure/__visit (param $0 i32) (param $1 i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.lt_u
@@ -1912,7 +1912,7 @@
   i32.sub
   call $~lib/rt/pure/decrement
  )
- (func $~lib/rt/__visit_members (; 50 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/__visit_members (param $0 i32) (param $1 i32)
   (local $2 i32)
   block $switch$1$default
    block $switch$1$case$4

--- a/tests/compiler/rc/rereturn.optimized.wat
+++ b/tests/compiler/rc/rereturn.optimized.wat
@@ -23,7 +23,7 @@
  (export "__release" (func $~lib/rt/pure/__release))
  (export "__collect" (func $~start))
  (export "__rtti_base" (global $~lib/rt/__rtti_base))
- (func $~lib/rt/tlsf/removeBlock (; 1 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/removeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -185,7 +185,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/insertBlock (; 2 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/insertBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -464,7 +464,7 @@
   i32.or
   i32.store offset=4
  )
- (func $~lib/rt/tlsf/addMemory (; 3 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $2
@@ -578,7 +578,7 @@
   local.get $1
   call $~lib/rt/tlsf/insertBlock
  )
- (func $~lib/rt/tlsf/maybeInitialize (; 4 ;) (result i32)
+ (func $~lib/rt/tlsf/maybeInitialize (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -665,7 +665,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/tlsf/searchBlock (; 5 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/searchBlock (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   i32.const 256
@@ -794,7 +794,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/prepareBlock (; 6 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/rt/tlsf/prepareBlock (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $1
@@ -869,7 +869,7 @@
    i32.store
   end
  )
- (func $~lib/rt/tlsf/allocateBlock (; 7 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/allocateBlock (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1027,7 +1027,7 @@
   call $~lib/rt/tlsf/prepareBlock
   local.get $3
  )
- (func $~lib/rt/tlsf/__alloc (; 8 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/__alloc (param $0 i32) (param $1 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
   local.get $0
   local.get $1
@@ -1035,7 +1035,7 @@
   i32.const 16
   i32.add
  )
- (func $~lib/rt/pure/__retain (; 9 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/pure/__retain (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -1084,7 +1084,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/pure/__release (; 10 ;) (param $0 i32)
+ (func $~lib/rt/pure/__release (param $0 i32)
   local.get $0
   i32.const 1220
   i32.gt_u
@@ -1095,10 +1095,10 @@
    call $~lib/rt/pure/decrement
   end
  )
- (func $~start (; 11 ;)
+ (func $~start
   nop
  )
- (func $~lib/rt/pure/decrement (; 12 ;) (param $0 i32)
+ (func $~lib/rt/pure/decrement (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0

--- a/tests/compiler/rc/rereturn.untouched.wat
+++ b/tests/compiler/rc/rereturn.untouched.wat
@@ -28,7 +28,7 @@
  (export "__collect" (func $~lib/rt/pure/__collect))
  (export "__rtti_base" (global $~lib/rt/__rtti_base))
  (start $~start)
- (func $~lib/rt/tlsf/removeBlock (; 1 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/removeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -238,7 +238,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/insertBlock (; 2 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/insertBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -588,7 +588,7 @@
   local.get $7
   i32.store offset=4
  )
- (func $~lib/rt/tlsf/addMemory (; 3 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -736,7 +736,7 @@
   call $~lib/rt/tlsf/insertBlock
   i32.const 1
  )
- (func $~lib/rt/tlsf/maybeInitialize (; 4 ;) (result i32)
+ (func $~lib/rt/tlsf/maybeInitialize (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -890,7 +890,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/tlsf/prepareSize (; 5 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/tlsf/prepareSize (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -919,7 +919,7 @@
   i32.gt_u
   select
  )
- (func $~lib/rt/tlsf/searchBlock (; 6 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/searchBlock (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1102,7 +1102,7 @@
   end
   local.get $7
  )
- (func $~lib/rt/tlsf/growMemory (; 7 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/growMemory (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1186,7 +1186,7 @@
   call $~lib/rt/tlsf/addMemory
   drop
  )
- (func $~lib/rt/tlsf/prepareBlock (; 8 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/rt/tlsf/prepareBlock (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1281,7 +1281,7 @@
    i32.store
   end
  )
- (func $~lib/rt/tlsf/allocateBlock (; 9 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/allocateBlock (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   global.get $~lib/rt/tlsf/collectLock
@@ -1390,7 +1390,7 @@
   call $~lib/rt/tlsf/prepareBlock
   local.get $4
  )
- (func $~lib/rt/tlsf/__alloc (; 10 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/__alloc (param $0 i32) (param $1 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
   local.get $0
   local.get $1
@@ -1398,7 +1398,7 @@
   i32.const 16
   i32.add
  )
- (func $~lib/rt/pure/increment (; 11 ;) (param $0 i32)
+ (func $~lib/rt/pure/increment (param $0 i32)
   (local $1 i32)
   local.get $0
   i32.load offset=4
@@ -1441,7 +1441,7 @@
    unreachable
   end
  )
- (func $~lib/rt/pure/__retain (; 12 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/pure/__retain (param $0 i32) (result i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.gt_u
@@ -1453,7 +1453,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/pure/__release (; 13 ;) (param $0 i32)
+ (func $~lib/rt/pure/__release (param $0 i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.gt_u
@@ -1464,7 +1464,7 @@
    call $~lib/rt/pure/decrement
   end
  )
- (func $rc/rereturn/Ref#constructor (; 14 ;) (param $0 i32) (result i32)
+ (func $rc/rereturn/Ref#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -1476,24 +1476,24 @@
   end
   local.get $0
  )
- (func $rc/rereturn/getRef (; 15 ;) (result i32)
+ (func $rc/rereturn/getRef (result i32)
   i32.const 0
   call $rc/rereturn/Ref#constructor
  )
- (func $rc/rereturn/rereturnRef (; 16 ;) (result i32)
+ (func $rc/rereturn/rereturnRef (result i32)
   call $rc/rereturn/getRef
  )
- (func $start:rc/rereturn (; 17 ;)
+ (func $start:rc/rereturn
   call $rc/rereturn/rereturnRef
   call $~lib/rt/pure/__release
  )
- (func $~start (; 18 ;)
+ (func $~start
   call $start:rc/rereturn
  )
- (func $~lib/rt/pure/__collect (; 19 ;)
+ (func $~lib/rt/pure/__collect
   return
  )
- (func $~lib/rt/tlsf/freeBlock (; 20 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/freeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $1
   i32.load
@@ -1507,7 +1507,7 @@
   local.get $1
   call $~lib/rt/tlsf/insertBlock
  )
- (func $~lib/rt/pure/decrement (; 21 ;) (param $0 i32)
+ (func $~lib/rt/pure/decrement (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -1582,7 +1582,7 @@
    i32.store offset=4
   end
  )
- (func $~lib/rt/pure/__visit (; 22 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/pure/__visit (param $0 i32) (param $1 i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.lt_u
@@ -1606,7 +1606,7 @@
   i32.sub
   call $~lib/rt/pure/decrement
  )
- (func $~lib/rt/__visit_members (; 23 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/__visit_members (param $0 i32) (param $1 i32)
   (local $2 i32)
   block $switch$1$default
    block $switch$1$case$4

--- a/tests/compiler/rc/ternary-mismatch.optimized.wat
+++ b/tests/compiler/rc/ternary-mismatch.optimized.wat
@@ -22,7 +22,7 @@
  (export "test1" (func $rc/ternary-mismatch/test1))
  (export "test2" (func $rc/ternary-mismatch/test2))
  (start $~start)
- (func $~lib/rt/tlsf/removeBlock (; 5 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/removeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -184,7 +184,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/insertBlock (; 6 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/insertBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -463,7 +463,7 @@
   i32.or
   i32.store offset=4
  )
- (func $~lib/rt/tlsf/addMemory (; 7 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $2
@@ -577,7 +577,7 @@
   local.get $1
   call $~lib/rt/tlsf/insertBlock
  )
- (func $~lib/rt/tlsf/maybeInitialize (; 8 ;) (result i32)
+ (func $~lib/rt/tlsf/maybeInitialize (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -664,7 +664,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/tlsf/searchBlock (; 9 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/tlsf/searchBlock (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   nop
@@ -722,7 +722,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/allocateBlock (; 10 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/tlsf/allocateBlock (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -894,7 +894,7 @@
   call $~lib/rt/rtrace/onalloc
   local.get $1
  )
- (func $~lib/rt/pure/__retain (; 11 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/pure/__retain (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -945,14 +945,14 @@
   end
   local.get $0
  )
- (func $rc/ternary-mismatch/Ref#constructor (; 12 ;) (result i32)
+ (func $rc/ternary-mismatch/Ref#constructor (result i32)
   call $~lib/rt/tlsf/maybeInitialize
   call $~lib/rt/tlsf/allocateBlock
   i32.const 16
   i32.add
   call $~lib/rt/pure/__retain
  )
- (func $rc/ternary-mismatch/test1 (; 13 ;) (param $0 i32) (result i32)
+ (func $rc/ternary-mismatch/test1 (param $0 i32) (result i32)
   local.get $0
   if (result i32)
    call $rc/ternary-mismatch/Ref#constructor
@@ -961,7 +961,7 @@
    call $~lib/rt/pure/__retain
   end
  )
- (func $~lib/rt/pure/__release (; 14 ;) (param $0 i32)
+ (func $~lib/rt/pure/__release (param $0 i32)
   local.get $0
   i32.const 1184
   i32.gt_u
@@ -972,7 +972,7 @@
    call $~lib/rt/pure/decrement
   end
  )
- (func $rc/ternary-mismatch/test2 (; 15 ;) (param $0 i32) (result i32)
+ (func $rc/ternary-mismatch/test2 (param $0 i32) (result i32)
   local.get $0
   if (result i32)
    global.get $rc/ternary-mismatch/gloRef
@@ -981,7 +981,7 @@
    call $rc/ternary-mismatch/Ref#constructor
   end
  )
- (func $~start (; 16 ;)
+ (func $~start
   call $rc/ternary-mismatch/Ref#constructor
   global.set $rc/ternary-mismatch/gloRef
   i32.const 1
@@ -999,7 +999,7 @@
   global.get $rc/ternary-mismatch/gloRef
   call $~lib/rt/pure/__release
  )
- (func $~lib/rt/pure/decrement (; 17 ;) (param $0 i32)
+ (func $~lib/rt/pure/decrement (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0

--- a/tests/compiler/rc/ternary-mismatch.untouched.wat
+++ b/tests/compiler/rc/ternary-mismatch.untouched.wat
@@ -28,7 +28,7 @@
  (export "test1" (func $rc/ternary-mismatch/test1))
  (export "test2" (func $rc/ternary-mismatch/test2))
  (start $~start)
- (func $~lib/rt/tlsf/removeBlock (; 5 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/removeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -238,7 +238,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/insertBlock (; 6 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/insertBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -588,7 +588,7 @@
   local.get $7
   i32.store offset=4
  )
- (func $~lib/rt/tlsf/addMemory (; 7 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -736,7 +736,7 @@
   call $~lib/rt/tlsf/insertBlock
   i32.const 1
  )
- (func $~lib/rt/tlsf/maybeInitialize (; 8 ;) (result i32)
+ (func $~lib/rt/tlsf/maybeInitialize (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -890,7 +890,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/tlsf/prepareSize (; 9 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/tlsf/prepareSize (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -919,7 +919,7 @@
   i32.gt_u
   select
  )
- (func $~lib/rt/tlsf/searchBlock (; 10 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/searchBlock (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1102,7 +1102,7 @@
   end
   local.get $7
  )
- (func $~lib/rt/tlsf/growMemory (; 11 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/growMemory (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1186,7 +1186,7 @@
   call $~lib/rt/tlsf/addMemory
   drop
  )
- (func $~lib/rt/tlsf/prepareBlock (; 12 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/rt/tlsf/prepareBlock (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1281,7 +1281,7 @@
    i32.store
   end
  )
- (func $~lib/rt/tlsf/allocateBlock (; 13 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/allocateBlock (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   global.get $~lib/rt/tlsf/collectLock
@@ -1392,7 +1392,7 @@
   call $~lib/rt/rtrace/onalloc
   local.get $4
  )
- (func $~lib/rt/tlsf/__alloc (; 14 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/__alloc (param $0 i32) (param $1 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
   local.get $0
   local.get $1
@@ -1400,7 +1400,7 @@
   i32.const 16
   i32.add
  )
- (func $~lib/rt/pure/increment (; 15 ;) (param $0 i32)
+ (func $~lib/rt/pure/increment (param $0 i32)
   (local $1 i32)
   local.get $0
   i32.load offset=4
@@ -1445,7 +1445,7 @@
    unreachable
   end
  )
- (func $~lib/rt/pure/__retain (; 16 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/pure/__retain (param $0 i32) (result i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.gt_u
@@ -1457,7 +1457,7 @@
   end
   local.get $0
  )
- (func $rc/ternary-mismatch/Ref#constructor (; 17 ;) (param $0 i32) (result i32)
+ (func $rc/ternary-mismatch/Ref#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -1469,11 +1469,11 @@
   end
   local.get $0
  )
- (func $rc/ternary-mismatch/getRef (; 18 ;) (result i32)
+ (func $rc/ternary-mismatch/getRef (result i32)
   i32.const 0
   call $rc/ternary-mismatch/Ref#constructor
  )
- (func $rc/ternary-mismatch/test1 (; 19 ;) (param $0 i32) (result i32)
+ (func $rc/ternary-mismatch/test1 (param $0 i32) (result i32)
   local.get $0
   if (result i32)
    call $rc/ternary-mismatch/getRef
@@ -1482,7 +1482,7 @@
    call $~lib/rt/pure/__retain
   end
  )
- (func $~lib/rt/pure/__release (; 20 ;) (param $0 i32)
+ (func $~lib/rt/pure/__release (param $0 i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.gt_u
@@ -1493,7 +1493,7 @@
    call $~lib/rt/pure/decrement
   end
  )
- (func $rc/ternary-mismatch/test2 (; 21 ;) (param $0 i32) (result i32)
+ (func $rc/ternary-mismatch/test2 (param $0 i32) (result i32)
   local.get $0
   if (result i32)
    global.get $rc/ternary-mismatch/gloRef
@@ -1502,7 +1502,7 @@
    call $rc/ternary-mismatch/getRef
   end
  )
- (func $start:rc/ternary-mismatch (; 22 ;)
+ (func $start:rc/ternary-mismatch
   i32.const 0
   call $rc/ternary-mismatch/Ref#constructor
   global.set $rc/ternary-mismatch/gloRef
@@ -1521,13 +1521,13 @@
   global.get $rc/ternary-mismatch/gloRef
   call $~lib/rt/pure/__release
  )
- (func $~start (; 23 ;)
+ (func $~start
   call $start:rc/ternary-mismatch
  )
- (func $~lib/rt/pure/__collect (; 24 ;)
+ (func $~lib/rt/pure/__collect
   return
  )
- (func $~lib/rt/tlsf/freeBlock (; 25 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/freeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $1
   i32.load
@@ -1543,7 +1543,7 @@
   local.get $1
   call $~lib/rt/rtrace/onfree
  )
- (func $~lib/rt/pure/decrement (; 26 ;) (param $0 i32)
+ (func $~lib/rt/pure/decrement (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -1620,7 +1620,7 @@
    i32.store offset=4
   end
  )
- (func $~lib/rt/pure/__visit (; 27 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/pure/__visit (param $0 i32) (param $1 i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.lt_u
@@ -1644,7 +1644,7 @@
   i32.sub
   call $~lib/rt/pure/decrement
  )
- (func $~lib/rt/__visit_members (; 28 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/__visit_members (param $0 i32) (param $1 i32)
   (local $2 i32)
   block $switch$1$default
    block $switch$1$case$4

--- a/tests/compiler/recursive.optimized.wat
+++ b/tests/compiler/recursive.optimized.wat
@@ -3,7 +3,7 @@
  (memory $0 0)
  (export "memory" (memory $0))
  (export "fib" (func $recursive/fib))
- (func $recursive/fib (; 0 ;) (param $0 i32) (result i32)
+ (func $recursive/fib (param $0 i32) (result i32)
   local.get $0
   i32.const 1
   i32.le_s

--- a/tests/compiler/recursive.untouched.wat
+++ b/tests/compiler/recursive.untouched.wat
@@ -4,7 +4,7 @@
  (table $0 1 funcref)
  (export "memory" (memory $0))
  (export "fib" (func $recursive/fib))
- (func $recursive/fib (; 0 ;) (param $0 i32) (result i32)
+ (func $recursive/fib (param $0 i32) (result i32)
   local.get $0
   i32.const 1
   i32.le_s

--- a/tests/compiler/reexport.optimized.wat
+++ b/tests/compiler/reexport.optimized.wat
@@ -25,22 +25,22 @@
  (export "exportstar.renamed_c" (global $export/c))
  (export "exportstar.ns.two" (func $export/ns.one))
  (export "exportstar.default.two" (func $export/ns.one))
- (func $export/add (; 0 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $export/add (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.add
  )
- (func $export/mul (; 1 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $export/mul (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.mul
  )
- (func $export/sub (; 2 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $export/sub (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.sub
  )
- (func $export/ns.one (; 3 ;)
+ (func $export/ns.one
   nop
  )
 )

--- a/tests/compiler/reexport.untouched.wat
+++ b/tests/compiler/reexport.untouched.wat
@@ -27,17 +27,17 @@
  (export "exportstar.ns.two" (func $export/ns.two))
  (export "exportstar.default.two" (func $export/ns.two))
  (start $~start)
- (func $export/add (; 0 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $export/add (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.add
  )
- (func $export/mul (; 1 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $export/mul (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.mul
  )
- (func $start:reexport (; 2 ;)
+ (func $start:reexport
   i32.const 1
   i32.const 2
   call $export/add
@@ -47,18 +47,18 @@
   i32.add
   drop
  )
- (func $export/sub (; 3 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $export/sub (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.sub
  )
- (func $export/ns.one (; 4 ;)
+ (func $export/ns.one
   nop
  )
- (func $export/ns.two (; 5 ;)
+ (func $export/ns.two
   nop
  )
- (func $~start (; 6 ;)
+ (func $~start
   call $start:reexport
  )
 )

--- a/tests/compiler/rereexport.untouched.wat
+++ b/tests/compiler/rereexport.untouched.wat
@@ -12,17 +12,17 @@
  (export "renamed_b" (global $export/b))
  (export "renamed_renamed_b" (global $export/b))
  (start $~start)
- (func $export/add (; 0 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $export/add (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.add
  )
- (func $export/mul (; 1 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $export/mul (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.mul
  )
- (func $start:reexport (; 2 ;)
+ (func $start:reexport
   i32.const 1
   i32.const 2
   call $export/add
@@ -32,10 +32,10 @@
   i32.add
   drop
  )
- (func $start:rereexport (; 3 ;)
+ (func $start:rereexport
   call $start:reexport
  )
- (func $~start (; 4 ;)
+ (func $~start
   call $start:rereexport
  )
 )

--- a/tests/compiler/resolve-access.optimized.wat
+++ b/tests/compiler/resolve-access.optimized.wat
@@ -13,14 +13,13 @@
  (data (i32.const 1056) "$\00\00\00\01\00\00\00\01\00\00\00$\00\00\00I\00n\00d\00e\00x\00 \00o\00u\00t\00 \00o\00f\00 \00r\00a\00n\00g\00e")
  (data (i32.const 1120) "\1a\00\00\00\01\00\00\00\01\00\00\00\1a\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00.\00t\00s")
  (data (i32.const 1168) "\02\00\00\00\01\00\00\00\01\00\00\00\02\00\00\000")
- (global $~lib/rt/stub/startOffset (mut i32) (i32.const 0))
  (global $~lib/rt/stub/offset (mut i32) (i32.const 0))
  (export "memory" (memory $0))
  (export "arrayAccess" (func $resolve-access/arrayAccess))
  (export "fieldAccess" (func $resolve-access/fieldAccess))
  (export "propertyAccess" (func $resolve-access/propertyAccess))
  (start $~start)
- (func $~lib/rt/stub/__alloc (; 1 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/stub/__alloc (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -104,7 +103,7 @@
   i32.store offset=12
   local.get $4
  )
- (func $~lib/memory/memory.copy (; 2 ;) (param $0 i32)
+ (func $~lib/memory/memory.copy (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -275,7 +274,7 @@
    end
   end
  )
- (func $~lib/util/number/decimalCount32 (; 3 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/decimalCount32 (param $0 i32) (result i32)
   local.get $0
   i32.const 10
   i32.ge_u
@@ -317,7 +316,7 @@
   i32.lt_u
   select
  )
- (func $~lib/util/number/utoa_simple<u32> (; 4 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/number/utoa_simple<u32> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   loop $do-continue|0
    local.get $1
@@ -344,7 +343,7 @@
    br_if $do-continue|0
   end
  )
- (func $~lib/util/number/utoa64 (; 5 ;) (param $0 i64) (result i32)
+ (func $~lib/util/number/utoa64 (param $0 i64) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -454,7 +453,7 @@
   end
   local.get $3
  )
- (func $resolve-access/arrayAccess (; 6 ;) (result i32)
+ (func $resolve-access/arrayAccess (result i32)
   (local $0 i32)
   (local $1 i32)
   i32.const 16
@@ -495,7 +494,7 @@
   i64.load
   call $~lib/util/number/utoa64
  )
- (func $resolve-access/Container#constructor (; 7 ;) (result i32)
+ (func $resolve-access/Container#constructor (result i32)
   (local $0 i32)
   i32.const 8
   i32.const 5
@@ -505,7 +504,7 @@
   i64.store
   local.get $0
  )
- (func $resolve-access/fieldAccess (; 8 ;) (result i32)
+ (func $resolve-access/fieldAccess (result i32)
   (local $0 i32)
   call $resolve-access/Container#constructor
   local.tee $0
@@ -515,7 +514,7 @@
   i64.load
   call $~lib/util/number/utoa64
  )
- (func $resolve-access/propertyAccess (; 9 ;) (result i32)
+ (func $resolve-access/propertyAccess (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -545,9 +544,7 @@
   end
   local.get $0
  )
- (func $~start (; 10 ;)
-  i32.const 1200
-  global.set $~lib/rt/stub/startOffset
+ (func $~start
   i32.const 1200
   global.set $~lib/rt/stub/offset
  )

--- a/tests/compiler/resolve-access.untouched.wat
+++ b/tests/compiler/resolve-access.untouched.wat
@@ -29,7 +29,7 @@
  (export "fieldAccess" (func $resolve-access/fieldAccess))
  (export "propertyAccess" (func $resolve-access/propertyAccess))
  (start $~start)
- (func $~lib/rt/stub/maybeGrowMemory (; 1 ;) (param $0 i32)
+ (func $~lib/rt/stub/maybeGrowMemory (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -83,7 +83,7 @@
   local.get $0
   global.set $~lib/rt/stub/offset
  )
- (func $~lib/rt/stub/__alloc (; 2 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/stub/__alloc (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -136,7 +136,7 @@
   i32.store offset=12
   local.get $2
  )
- (func $~lib/util/memory/memcpy (; 3 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/memory/memcpy (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1160,7 +1160,7 @@
    i32.store8
   end
  )
- (func $~lib/memory/memory.copy (; 4 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/memory/memory.copy (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1380,7 +1380,7 @@
    end
   end
  )
- (func $~lib/rt/__allocBuffer (; 5 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/__allocBuffer (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $0
   local.get $1
@@ -1395,10 +1395,10 @@
   end
   local.get $3
  )
- (func $~lib/rt/stub/__retain (; 6 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/stub/__retain (param $0 i32) (result i32)
   local.get $0
  )
- (func $~lib/rt/__allocArray (; 7 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $~lib/rt/__allocArray (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -1430,7 +1430,7 @@
   i32.store offset=12
   local.get $4
  )
- (func $~lib/array/Array<u64>#__unchecked_get (; 8 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $~lib/array/Array<u64>#__unchecked_get (param $0 i32) (param $1 i32) (result i64)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -1439,7 +1439,7 @@
   i32.add
   i64.load
  )
- (func $~lib/array/Array<u64>#__get (; 9 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $~lib/array/Array<u64>#__get (param $0 i32) (param $1 i32) (result i64)
   (local $2 i64)
   local.get $1
   local.get $0
@@ -1459,7 +1459,7 @@
   local.set $2
   local.get $2
  )
- (func $~lib/util/number/decimalCount32 (; 10 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/decimalCount32 (param $0 i32) (result i32)
   local.get $0
   i32.const 100000
   i32.lt_u
@@ -1514,7 +1514,7 @@
   end
   unreachable
  )
- (func $~lib/util/number/utoa32_lut (; 11 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/number/utoa32_lut (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1654,7 +1654,7 @@
    i32.store16
   end
  )
- (func $~lib/util/number/decimalCount64High (; 12 ;) (param $0 i64) (result i32)
+ (func $~lib/util/number/decimalCount64High (param $0 i64) (result i32)
   local.get $0
   i64.const 1000000000000000
   i64.lt_u
@@ -1713,7 +1713,7 @@
   end
   unreachable
  )
- (func $~lib/util/number/utoa64_lut (; 13 ;) (param $0 i32) (param $1 i64) (param $2 i32)
+ (func $~lib/util/number/utoa64_lut (param $0 i32) (param $1 i64) (param $2 i32)
   (local $3 i32)
   (local $4 i64)
   (local $5 i32)
@@ -1836,7 +1836,7 @@
   local.get $2
   call $~lib/util/number/utoa32_lut
  )
- (func $~lib/util/number/utoa64 (; 14 ;) (param $0 i64) (result i32)
+ (func $~lib/util/number/utoa64 (param $0 i64) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -1902,19 +1902,19 @@
   local.get $1
   call $~lib/rt/stub/__retain
  )
- (func $~lib/util/number/itoa<u64> (; 15 ;) (param $0 i64) (result i32)
+ (func $~lib/util/number/itoa<u64> (param $0 i64) (result i32)
   local.get $0
   call $~lib/util/number/utoa64
   return
  )
- (func $~lib/number/U64#toString (; 16 ;) (param $0 i64) (result i32)
+ (func $~lib/number/U64#toString (param $0 i64) (result i32)
   local.get $0
   call $~lib/util/number/itoa<u64>
  )
- (func $~lib/rt/stub/__release (; 17 ;) (param $0 i32)
+ (func $~lib/rt/stub/__release (param $0 i32)
   nop
  )
- (func $resolve-access/arrayAccess (; 18 ;) (result i32)
+ (func $resolve-access/arrayAccess (result i32)
   (local $0 i32)
   (local $1 i32)
   i32.const 1
@@ -1933,7 +1933,7 @@
   call $~lib/rt/stub/__release
   local.get $0
  )
- (func $resolve-access/Container#constructor (; 19 ;) (param $0 i32) (result i32)
+ (func $resolve-access/Container#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -1948,7 +1948,7 @@
   i64.store
   local.get $0
  )
- (func $resolve-access/fieldAccess (; 20 ;) (result i32)
+ (func $resolve-access/fieldAccess (result i32)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -1965,12 +1965,12 @@
   call $~lib/rt/stub/__release
   local.get $1
  )
- (func $resolve-access/Container#toU32 (; 21 ;) (param $0 i32) (result i32)
+ (func $resolve-access/Container#toU32 (param $0 i32) (result i32)
   local.get $0
   i64.load
   i32.wrap_i64
  )
- (func $~lib/util/number/utoa32 (; 22 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/utoa32 (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -2004,16 +2004,16 @@
   local.get $2
   call $~lib/rt/stub/__retain
  )
- (func $~lib/util/number/itoa<u32> (; 23 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/itoa<u32> (param $0 i32) (result i32)
   local.get $0
   call $~lib/util/number/utoa32
   return
  )
- (func $~lib/number/U32#toString (; 24 ;) (param $0 i32) (result i32)
+ (func $~lib/number/U32#toString (param $0 i32) (result i32)
   local.get $0
   call $~lib/util/number/itoa<u32>
  )
- (func $resolve-access/propertyAccess (; 25 ;) (result i32)
+ (func $resolve-access/propertyAccess (result i32)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -2030,7 +2030,7 @@
   call $~lib/rt/stub/__release
   local.get $1
  )
- (func $~start (; 26 ;)
+ (func $~start
   global.get $~lib/heap/__heap_base
   i32.const 15
   i32.add

--- a/tests/compiler/resolve-binary.optimized.wat
+++ b/tests/compiler/resolve-binary.optimized.wat
@@ -42,21 +42,15 @@
  (data (i32.const 2912) "\06\00\00\00\01\00\00\00\01\00\00\00\06\00\00\00r\00e\00m")
  (data (i32.const 2944) "\06\00\00\00\01\00\00\00\01\00\00\00\06\00\00\00p\00o\00w")
  (global $resolve-binary/a (mut i32) (i32.const 0))
- (global $resolve-binary/f (mut f64) (f64.const 0))
- (global $~lib/rt/stub/startOffset (mut i32) (i32.const 0))
  (global $~lib/rt/stub/offset (mut i32) (i32.const 0))
- (global $~lib/util/number/_frc_plus (mut i64) (i64.const 0))
- (global $~lib/util/number/_frc_minus (mut i64) (i64.const 0))
- (global $~lib/util/number/_exp (mut i32) (i32.const 0))
  (global $~lib/util/number/_K (mut i32) (i32.const 0))
  (global $~lib/util/number/_frc_pow (mut i64) (i64.const 0))
  (global $~lib/util/number/_exp_pow (mut i32) (i32.const 0))
- (global $resolve-binary/foo (mut i32) (i32.const 0))
  (global $resolve-binary/bar (mut i32) (i32.const 0))
  (global $resolve-binary/bar2 (mut i32) (i32.const 0))
  (export "memory" (memory $0))
  (start $~start)
- (func $~lib/string/String#get:length (; 1 ;) (param $0 i32) (result i32)
+ (func $~lib/string/String#get:length (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub
@@ -64,7 +58,7 @@
   i32.const 1
   i32.shr_u
  )
- (func $~lib/util/string/compareImpl (; 2 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/compareImpl (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -140,7 +134,7 @@
   end
   i32.const 0
  )
- (func $~lib/string/String.__eq (; 3 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__eq (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -172,7 +166,7 @@
   end
   i32.const 0
  )
- (func $~lib/util/number/decimalCount32 (; 4 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/decimalCount32 (param $0 i32) (result i32)
   local.get $0
   i32.const 10
   i32.ge_u
@@ -214,7 +208,7 @@
   i32.lt_u
   select
  )
- (func $~lib/rt/stub/__alloc (; 5 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/stub/__alloc (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -298,7 +292,7 @@
   i32.store offset=12
   local.get $4
  )
- (func $~lib/util/number/utoa_simple<u32> (; 6 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/number/utoa_simple<u32> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   loop $do-continue|0
    local.get $1
@@ -325,7 +319,7 @@
    br_if $do-continue|0
   end
  )
- (func $~lib/number/I32#toString (; 7 ;) (param $0 i32) (result i32)
+ (func $~lib/number/I32#toString (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -365,7 +359,7 @@
    i32.const 1200
   end
  )
- (func $~lib/util/number/genDigits (; 8 ;) (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (result i32)
+ (func $~lib/util/number/genDigits (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (result i32)
   (local $6 i32)
   (local $7 i64)
   (local $8 i32)
@@ -753,7 +747,7 @@
   i32.store16
   local.get $8
  )
- (func $~lib/memory/memory.copy (; 9 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/memory/memory.copy (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   block $~lib/util/memory/memmove|inlined.0
@@ -926,7 +920,7 @@
    end
   end
  )
- (func $~lib/util/number/prettify (; 10 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/prettify (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   i32.eqz
@@ -1171,17 +1165,10 @@
    end
   end
  )
- (func $~lib/util/number/dtoa_core (; 11 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/dtoa_core (param $0 i32) (result i32)
   (local $1 i64)
   (local $2 i64)
   (local $3 i64)
-  (local $4 f64)
-  i64.const -9223372036854774784
-  global.set $~lib/util/number/_frc_plus
-  i64.const 9223372036854775296
-  global.set $~lib/util/number/_frc_minus
-  i32.const -61
-  global.set $~lib/util/number/_exp
   i32.const -4
   global.set $~lib/util/number/_K
   i32.const 1792
@@ -1295,7 +1282,7 @@
   global.get $~lib/util/number/_K
   call $~lib/util/number/prettify
  )
- (func $~lib/string/String#substring (; 12 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String#substring (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1367,7 +1354,7 @@
   call $~lib/memory/memory.copy
   local.get $2
  )
- (func $~lib/util/number/dtoa (; 13 ;) (result i32)
+ (func $~lib/util/number/dtoa (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -1428,7 +1415,7 @@
    global.set $~lib/rt/stub/offset
   end
  )
- (func $start:resolve-binary (; 14 ;)
+ (func $start:resolve-binary
   i32.const 1040
   i32.const 1040
   call $~lib/string/String.__eq
@@ -1526,8 +1513,6 @@
    unreachable
   end
   i32.const 2976
-  global.set $~lib/rt/stub/startOffset
-  i32.const 2976
   global.set $~lib/rt/stub/offset
   i32.const 1
   global.set $resolve-binary/a
@@ -1595,10 +1580,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 2
-  global.set $resolve-binary/f
-  f64.const 4
-  global.set $resolve-binary/f
   call $~lib/util/number/dtoa
   i32.const 2480
   call $~lib/string/String.__eq
@@ -1957,7 +1938,7 @@
   i32.const 0
   i32.const 6
   call $~lib/rt/stub/__alloc
-  global.set $resolve-binary/foo
+  drop
   i32.const 2608
   i32.const 2608
   call $~lib/string/String.__eq
@@ -2135,7 +2116,7 @@
    unreachable
   end
  )
- (func $~start (; 15 ;)
+ (func $~start
   call $start:resolve-binary
  )
 )

--- a/tests/compiler/resolve-binary.untouched.wat
+++ b/tests/compiler/resolve-binary.untouched.wat
@@ -68,7 +68,7 @@
  (global $~lib/heap/__heap_base i32 (i32.const 8552))
  (export "memory" (memory $0))
  (start $~start)
- (func $~lib/number/Bool#toString (; 1 ;) (param $0 i32) (result i32)
+ (func $~lib/number/Bool#toString (param $0 i32) (result i32)
   local.get $0
   if (result i32)
    i32.const 32
@@ -76,13 +76,13 @@
    i32.const 64
   end
  )
- (func $~lib/rt/stub/__retain (; 2 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/stub/__retain (param $0 i32) (result i32)
   local.get $0
  )
- (func $~lib/rt/stub/__release (; 3 ;) (param $0 i32)
+ (func $~lib/rt/stub/__release (param $0 i32)
   nop
  )
- (func $~lib/string/String#get:length (; 4 ;) (param $0 i32) (result i32)
+ (func $~lib/string/String#get:length (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub
@@ -90,7 +90,7 @@
   i32.const 1
   i32.shr_u
  )
- (func $~lib/util/string/compareImpl (; 5 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
+ (func $~lib/util/string/compareImpl (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
@@ -212,7 +212,7 @@
   call $~lib/rt/stub/__release
   local.get $7
  )
- (func $~lib/string/String.__eq (; 6 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__eq (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -285,7 +285,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $~lib/util/number/decimalCount32 (; 7 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/decimalCount32 (param $0 i32) (result i32)
   local.get $0
   i32.const 100000
   i32.lt_u
@@ -340,7 +340,7 @@
   end
   unreachable
  )
- (func $~lib/rt/stub/maybeGrowMemory (; 8 ;) (param $0 i32)
+ (func $~lib/rt/stub/maybeGrowMemory (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -394,7 +394,7 @@
   local.get $0
   global.set $~lib/rt/stub/offset
  )
- (func $~lib/rt/stub/__alloc (; 9 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/stub/__alloc (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -447,7 +447,7 @@
   i32.store offset=12
   local.get $2
  )
- (func $~lib/util/number/utoa32_lut (; 10 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/number/utoa32_lut (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -587,7 +587,7 @@
    i32.store16
   end
  )
- (func $~lib/util/number/itoa32 (; 11 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/itoa32 (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -641,16 +641,16 @@
   local.get $3
   call $~lib/rt/stub/__retain
  )
- (func $~lib/util/number/itoa<i32> (; 12 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/itoa<i32> (param $0 i32) (result i32)
   local.get $0
   call $~lib/util/number/itoa32
   return
  )
- (func $~lib/number/I32#toString (; 13 ;) (param $0 i32) (result i32)
+ (func $~lib/number/I32#toString (param $0 i32) (result i32)
   local.get $0
   call $~lib/util/number/itoa<i32>
  )
- (func $~lib/math/NativeMath.pow (; 14 ;) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.pow (param $0 f64) (param $1 f64) (result f64)
   (local $2 f64)
   (local $3 f64)
   (local $4 i32)
@@ -1610,7 +1610,7 @@
   end
   return
  )
- (func $~lib/util/number/genDigits (; 15 ;) (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (param $6 i32) (result i32)
+ (func $~lib/util/number/genDigits (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (param $6 i32) (result i32)
   (local $7 i32)
   (local $8 i64)
   (local $9 i64)
@@ -2113,7 +2113,7 @@
   end
   unreachable
  )
- (func $~lib/util/memory/memcpy (; 16 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/memory/memcpy (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3137,7 +3137,7 @@
    i32.store8
   end
  )
- (func $~lib/memory/memory.copy (; 17 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/memory/memory.copy (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3357,7 +3357,7 @@
    end
   end
  )
- (func $~lib/util/number/prettify (; 18 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/prettify (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3674,7 +3674,7 @@
   end
   unreachable
  )
- (func $~lib/util/number/dtoa_core (; 19 ;) (param $0 i32) (param $1 f64) (result i32)
+ (func $~lib/util/number/dtoa_core (param $0 i32) (param $1 f64) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4100,7 +4100,7 @@
   local.get $2
   i32.add
  )
- (func $~lib/string/String#substring (; 20 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/string/String#substring (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -4207,7 +4207,7 @@
   local.get $11
   call $~lib/rt/stub/__retain
  )
- (func $~lib/rt/stub/__free (; 21 ;) (param $0 i32)
+ (func $~lib/rt/stub/__free (param $0 i32)
   (local $1 i32)
   local.get $0
   i32.const 0
@@ -4257,7 +4257,7 @@
    global.set $~lib/rt/stub/offset
   end
  )
- (func $~lib/util/number/dtoa (; 22 ;) (param $0 f64) (result i32)
+ (func $~lib/util/number/dtoa (param $0 f64) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -4318,11 +4318,11 @@
   call $~lib/rt/stub/__free
   local.get $3
  )
- (func $~lib/number/F64#toString (; 23 ;) (param $0 f64) (param $1 i32) (result i32)
+ (func $~lib/number/F64#toString (param $0 f64) (param $1 i32) (result i32)
   local.get $0
   call $~lib/util/number/dtoa
  )
- (func $resolve-binary/Foo#constructor (; 24 ;) (param $0 i32) (result i32)
+ (func $resolve-binary/Foo#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -4334,7 +4334,7 @@
   end
   local.get $0
  )
- (func $resolve-binary/Foo#lt (; 25 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $resolve-binary/Foo#lt (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   call $~lib/rt/stub/__retain
@@ -4345,11 +4345,11 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $~lib/string/String#toString (; 26 ;) (param $0 i32) (result i32)
+ (func $~lib/string/String#toString (param $0 i32) (result i32)
   local.get $0
   call $~lib/rt/stub/__retain
  )
- (func $resolve-binary/Foo#gt (; 27 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $resolve-binary/Foo#gt (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   call $~lib/rt/stub/__retain
@@ -4360,7 +4360,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $resolve-binary/Foo#le (; 28 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $resolve-binary/Foo#le (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   call $~lib/rt/stub/__retain
@@ -4371,7 +4371,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $resolve-binary/Foo#ge (; 29 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $resolve-binary/Foo#ge (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   call $~lib/rt/stub/__retain
@@ -4382,7 +4382,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $resolve-binary/Foo#eq (; 30 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $resolve-binary/Foo#eq (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   call $~lib/rt/stub/__retain
@@ -4393,7 +4393,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $resolve-binary/Foo#ne (; 31 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $resolve-binary/Foo#ne (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   call $~lib/rt/stub/__retain
@@ -4404,7 +4404,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $resolve-binary/Foo#add (; 32 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $resolve-binary/Foo#add (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   call $~lib/rt/stub/__retain
@@ -4415,7 +4415,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $resolve-binary/Foo.sub (; 33 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $resolve-binary/Foo.sub (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/stub/__retain
@@ -4431,7 +4431,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $resolve-binary/Foo#mul (; 34 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $resolve-binary/Foo#mul (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   call $~lib/rt/stub/__retain
@@ -4442,7 +4442,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $resolve-binary/Foo#div (; 35 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $resolve-binary/Foo#div (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   call $~lib/rt/stub/__retain
@@ -4453,7 +4453,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $resolve-binary/Foo#rem (; 36 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $resolve-binary/Foo#rem (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   call $~lib/rt/stub/__retain
@@ -4464,7 +4464,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $resolve-binary/Foo#pow (; 37 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $resolve-binary/Foo#pow (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   call $~lib/rt/stub/__retain
@@ -4475,7 +4475,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $resolve-binary/Bar#constructor (; 38 ;) (param $0 i32) (result i32)
+ (func $resolve-binary/Bar#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -4487,17 +4487,17 @@
   end
   local.get $0
  )
- (func $resolve-binary/Bar#add (; 39 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $resolve-binary/Bar#add (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   call $~lib/rt/stub/__retain
   local.set $1
   local.get $1
  )
- (func $resolve-binary/Bar#self (; 40 ;) (param $0 i32) (result i32)
+ (func $resolve-binary/Bar#self (param $0 i32) (result i32)
   local.get $0
   call $~lib/rt/stub/__retain
  )
- (func $start:resolve-binary (; 41 ;)
+ (func $start:resolve-binary
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -5531,7 +5531,7 @@
   local.get $62
   call $~lib/rt/stub/__release
  )
- (func $~start (; 42 ;)
+ (func $~start
   call $start:resolve-binary
  )
 )

--- a/tests/compiler/resolve-elementaccess.optimized.wat
+++ b/tests/compiler/resolve-elementaccess.optimized.wat
@@ -34,7 +34,6 @@
  (data (i32.const 2640) "\02\00\00\00\01\00\00\00\01\00\00\00\02\00\00\001")
  (data (i32.const 2672) "\02\00\00\00\01\00\00\00\01\00\00\00\02\00\00\002")
  (data (i32.const 2704) "\04\00\00\00\01\00\00\00\01\00\00\00\04\00\00\001\001")
- (global $~lib/rt/stub/startOffset (mut i32) (i32.const 0))
  (global $~lib/rt/stub/offset (mut i32) (i32.const 0))
  (global $resolve-elementaccess/arr (mut i32) (i32.const 0))
  (global $~lib/util/number/_frc_plus (mut i64) (i64.const 0))
@@ -46,7 +45,7 @@
  (global $resolve-elementaccess/buf (mut i32) (i32.const 0))
  (export "memory" (memory $0))
  (start $~start)
- (func $~lib/rt/stub/__alloc (; 1 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/stub/__alloc (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -130,7 +129,7 @@
   i32.store offset=12
   local.get $4
  )
- (func $~lib/memory/memory.fill (; 2 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/memory/memory.fill (param $0 i32) (param $1 i32)
   (local $2 i32)
   block $~lib/util/memory/memset|inlined.0
    local.get $1
@@ -288,7 +287,7 @@
    end
   end
  )
- (func $~lib/arraybuffer/ArrayBufferView#constructor (; 3 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBufferView#constructor (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   i32.const 2
   i32.const 1073741808
@@ -343,7 +342,7 @@
   i32.store offset=8
   local.get $0
  )
- (func $~lib/typedarray/Float32Array#__set (; 4 ;) (param $0 i32) (param $1 i32) (param $2 f32)
+ (func $~lib/typedarray/Float32Array#__set (param $0 i32) (param $1 i32) (param $2 f32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -367,7 +366,7 @@
   local.get $2
   f32.store
  )
- (func $~lib/typedarray/Float32Array#__get (; 5 ;) (param $0 i32) (param $1 i32) (result f32)
+ (func $~lib/typedarray/Float32Array#__get (param $0 i32) (param $1 i32) (result f32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -390,7 +389,7 @@
   i32.add
   f32.load
  )
- (func $~lib/util/number/decimalCount32 (; 6 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/decimalCount32 (param $0 i32) (result i32)
   local.get $0
   i32.const 10
   i32.ge_u
@@ -432,7 +431,7 @@
   i32.lt_u
   select
  )
- (func $~lib/util/number/genDigits (; 7 ;) (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (param $6 i32) (result i32)
+ (func $~lib/util/number/genDigits (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (param $6 i32) (result i32)
   (local $7 i32)
   (local $8 i64)
   (local $9 i64)
@@ -823,7 +822,7 @@
    local.get $6
   end
  )
- (func $~lib/memory/memory.copy (; 8 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/memory/memory.copy (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   block $~lib/util/memory/memmove|inlined.0
@@ -996,7 +995,7 @@
    end
   end
  )
- (func $~lib/util/number/utoa_simple<u32> (; 9 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/number/utoa_simple<u32> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   loop $do-continue|0
    local.get $1
@@ -1023,7 +1022,7 @@
    br_if $do-continue|0
   end
  )
- (func $~lib/util/number/prettify (; 10 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/prettify (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   i32.eqz
@@ -1268,7 +1267,7 @@
    end
   end
  )
- (func $~lib/util/number/dtoa_core (; 11 ;) (param $0 i32) (param $1 f64) (result i32)
+ (func $~lib/util/number/dtoa_core (param $0 i32) (param $1 f64) (result i32)
   (local $2 i64)
   (local $3 i64)
   (local $4 i32)
@@ -1560,7 +1559,7 @@
   local.get $7
   i32.add
  )
- (func $~lib/string/String#get:length (; 12 ;) (param $0 i32) (result i32)
+ (func $~lib/string/String#get:length (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub
@@ -1568,7 +1567,7 @@
   i32.const 1
   i32.shr_u
  )
- (func $~lib/string/String#substring (; 13 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String#substring (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1640,7 +1639,7 @@
   call $~lib/memory/memory.copy
   local.get $2
  )
- (func $~lib/util/number/dtoa (; 14 ;) (param $0 f64) (result i32)
+ (func $~lib/util/number/dtoa (param $0 f64) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -1730,7 +1729,7 @@
    global.set $~lib/rt/stub/offset
   end
  )
- (func $~lib/util/string/compareImpl (; 15 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/compareImpl (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -1806,7 +1805,7 @@
   end
   i32.const 0
  )
- (func $~lib/string/String.__eq (; 16 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__eq (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -1838,7 +1837,7 @@
   end
   i32.const 0
  )
- (func $~lib/typedarray/Uint8Array#__set (; 17 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint8Array#__set (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -1858,7 +1857,7 @@
   local.get $2
   i32.store8
  )
- (func $~lib/typedarray/Uint8Array#__get (; 18 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#__get (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -1877,7 +1876,7 @@
   i32.add
   i32.load8_u
  )
- (func $~lib/number/U8#toString (; 19 ;) (param $0 i32) (result i32)
+ (func $~lib/number/U8#toString (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   block $__inlined_func$~lib/util/number/utoa32
@@ -1905,10 +1904,8 @@
   end
   local.get $0
  )
- (func $start:resolve-elementaccess (; 20 ;)
+ (func $start:resolve-elementaccess
   (local $0 i32)
-  i32.const 2736
-  global.set $~lib/rt/stub/startOffset
   i32.const 2736
   global.set $~lib/rt/stub/offset
   i32.const 12
@@ -2007,14 +2004,13 @@
   i32.const 7
   call $~lib/rt/stub/__alloc
   local.tee $0
-  i32.eqz
-  if
+  if (result i32)
+   local.get $0
+  else
    i32.const 12
    i32.const 8
    call $~lib/rt/stub/__alloc
-   local.set $0
   end
-  local.get $0
   i32.const 0
   call $~lib/arraybuffer/ArrayBufferView#constructor
   global.set $resolve-elementaccess/buf
@@ -2102,7 +2098,7 @@
    unreachable
   end
  )
- (func $~start (; 21 ;)
+ (func $~start
   call $start:resolve-elementaccess
  )
 )

--- a/tests/compiler/resolve-elementaccess.untouched.wat
+++ b/tests/compiler/resolve-elementaccess.untouched.wat
@@ -52,7 +52,7 @@
  (global $~lib/heap/__heap_base i32 (i32.const 2132))
  (export "memory" (memory $0))
  (start $~start)
- (func $~lib/rt/stub/maybeGrowMemory (; 1 ;) (param $0 i32)
+ (func $~lib/rt/stub/maybeGrowMemory (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -106,7 +106,7 @@
   local.get $0
   global.set $~lib/rt/stub/offset
  )
- (func $~lib/rt/stub/__alloc (; 2 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/stub/__alloc (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -159,7 +159,7 @@
   i32.store offset=12
   local.get $2
  )
- (func $~lib/memory/memory.fill (; 3 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/memory/memory.fill (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -368,13 +368,13 @@
    end
   end
  )
- (func $~lib/rt/stub/__retain (; 4 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/stub/__retain (param $0 i32) (result i32)
   local.get $0
  )
- (func $~lib/rt/stub/__release (; 5 ;) (param $0 i32)
+ (func $~lib/rt/stub/__release (param $0 i32)
   nop
  )
- (func $~lib/arraybuffer/ArrayBufferView#constructor (; 6 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBufferView#constructor (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -446,7 +446,7 @@
   i32.store offset=8
   local.get $0
  )
- (func $~lib/typedarray/Float32Array#constructor (; 7 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#constructor (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   if (result i32)
    local.get $0
@@ -462,7 +462,7 @@
   local.set $0
   local.get $0
  )
- (func $~lib/typedarray/Float32Array#__set (; 8 ;) (param $0 i32) (param $1 i32) (param $2 f32)
+ (func $~lib/typedarray/Float32Array#__set (param $0 i32) (param $1 i32) (param $2 f32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -486,7 +486,7 @@
   local.get $2
   f32.store
  )
- (func $~lib/typedarray/Float32Array#__get (; 9 ;) (param $0 i32) (param $1 i32) (result f32)
+ (func $~lib/typedarray/Float32Array#__get (param $0 i32) (param $1 i32) (result f32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -509,7 +509,7 @@
   i32.add
   f32.load
  )
- (func $~lib/util/number/decimalCount32 (; 10 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/decimalCount32 (param $0 i32) (result i32)
   local.get $0
   i32.const 100000
   i32.lt_u
@@ -564,7 +564,7 @@
   end
   unreachable
  )
- (func $~lib/util/number/genDigits (; 11 ;) (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (param $6 i32) (result i32)
+ (func $~lib/util/number/genDigits (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (param $6 i32) (result i32)
   (local $7 i32)
   (local $8 i64)
   (local $9 i64)
@@ -1067,7 +1067,7 @@
   end
   unreachable
  )
- (func $~lib/util/memory/memcpy (; 12 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/memory/memcpy (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2091,7 +2091,7 @@
    i32.store8
   end
  )
- (func $~lib/memory/memory.copy (; 13 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/memory/memory.copy (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2311,7 +2311,7 @@
    end
   end
  )
- (func $~lib/util/number/utoa32_lut (; 14 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/number/utoa32_lut (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2451,7 +2451,7 @@
    i32.store16
   end
  )
- (func $~lib/util/number/prettify (; 15 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/prettify (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2768,7 +2768,7 @@
   end
   unreachable
  )
- (func $~lib/util/number/dtoa_core (; 16 ;) (param $0 i32) (param $1 f64) (result i32)
+ (func $~lib/util/number/dtoa_core (param $0 i32) (param $1 f64) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3194,7 +3194,7 @@
   local.get $2
   i32.add
  )
- (func $~lib/string/String#get:length (; 17 ;) (param $0 i32) (result i32)
+ (func $~lib/string/String#get:length (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub
@@ -3202,7 +3202,7 @@
   i32.const 1
   i32.shr_u
  )
- (func $~lib/string/String#substring (; 18 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/string/String#substring (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3309,7 +3309,7 @@
   local.get $11
   call $~lib/rt/stub/__retain
  )
- (func $~lib/rt/stub/__free (; 19 ;) (param $0 i32)
+ (func $~lib/rt/stub/__free (param $0 i32)
   (local $1 i32)
   local.get $0
   i32.const 0
@@ -3359,7 +3359,7 @@
    global.set $~lib/rt/stub/offset
   end
  )
- (func $~lib/util/number/dtoa (; 20 ;) (param $0 f64) (result i32)
+ (func $~lib/util/number/dtoa (param $0 f64) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -3420,12 +3420,12 @@
   call $~lib/rt/stub/__free
   local.get $3
  )
- (func $~lib/number/F32#toString (; 21 ;) (param $0 f32) (result i32)
+ (func $~lib/number/F32#toString (param $0 f32) (result i32)
   local.get $0
   f64.promote_f32
   call $~lib/util/number/dtoa
  )
- (func $~lib/util/string/compareImpl (; 22 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
+ (func $~lib/util/string/compareImpl (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
@@ -3547,7 +3547,7 @@
   call $~lib/rt/stub/__release
   local.get $7
  )
- (func $~lib/string/String.__eq (; 23 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__eq (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -3620,7 +3620,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $~lib/typedarray/Uint8Array#constructor (; 24 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#constructor (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   if (result i32)
    local.get $0
@@ -3636,7 +3636,7 @@
   local.set $0
   local.get $0
  )
- (func $resolve-elementaccess/Buffer#constructor (; 25 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $resolve-elementaccess/Buffer#constructor (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -3652,7 +3652,7 @@
   local.set $0
   local.get $0
  )
- (func $~lib/typedarray/Uint8Array#__set (; 26 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint8Array#__set (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -3672,7 +3672,7 @@
   local.get $2
   i32.store8
  )
- (func $~lib/typedarray/Uint8Array#__get (; 27 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#__get (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -3691,7 +3691,7 @@
   i32.add
   i32.load8_u
  )
- (func $~lib/util/number/utoa32 (; 28 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/utoa32 (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -3725,18 +3725,18 @@
   local.get $2
   call $~lib/rt/stub/__retain
  )
- (func $~lib/util/number/itoa<u8> (; 29 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/itoa<u8> (param $0 i32) (result i32)
   local.get $0
   i32.const 255
   i32.and
   call $~lib/util/number/utoa32
   return
  )
- (func $~lib/number/U8#toString (; 30 ;) (param $0 i32) (result i32)
+ (func $~lib/number/U8#toString (param $0 i32) (result i32)
   local.get $0
   call $~lib/util/number/itoa<u8>
  )
- (func $start:resolve-elementaccess (; 31 ;)
+ (func $start:resolve-elementaccess
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -3948,7 +3948,7 @@
   local.get $4
   call $~lib/rt/stub/__release
  )
- (func $~start (; 32 ;)
+ (func $~start
   call $start:resolve-elementaccess
  )
 )

--- a/tests/compiler/resolve-function-expression.optimized.wat
+++ b/tests/compiler/resolve-function-expression.optimized.wat
@@ -10,17 +10,14 @@
  (data (i32.const 1024) "<\00\00\00\01\00\00\00\01\00\00\00<\00\00\00r\00e\00s\00o\00l\00v\00e\00-\00f\00u\00n\00c\00t\00i\00o\00n\00-\00e\00x\00p\00r\00e\00s\00s\00i\00o\00n\00.\00t\00s")
  (data (i32.const 1104) "\02\00\00\00\01\00\00\00\01\00\00\00\02\00\00\000")
  (data (i32.const 1136) "\04\00\00\00\01\00\00\00\01\00\00\00\04\00\00\004\002")
- (global $~argumentsLength (mut i32) (i32.const 0))
- (global $~lib/rt/stub/startOffset (mut i32) (i32.const 0))
  (global $~lib/rt/stub/offset (mut i32) (i32.const 0))
  (export "__setArgumentsLength" (func $~setArgumentsLength))
  (export "memory" (memory $0))
  (start $~start)
- (func $~setArgumentsLength (; 1 ;) (param $0 i32)
-  local.get $0
-  global.set $~argumentsLength
+ (func $~setArgumentsLength (param $0 i32)
+  nop
  )
- (func $~lib/util/number/itoa32 (; 2 ;) (result i32)
+ (func $~lib/util/number/itoa32 (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -118,7 +115,7 @@
   end
   local.get $4
  )
- (func $~lib/string/String#get:length (; 3 ;) (param $0 i32) (result i32)
+ (func $~lib/string/String#get:length (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub
@@ -126,7 +123,7 @@
   i32.const 1
   i32.shr_u
  )
- (func $~lib/util/string/compareImpl (; 4 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/compareImpl (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -201,19 +198,11 @@
   end
   i32.const 0
  )
- (func $~start (; 5 ;)
+ (func $~start
   (local $0 i32)
   (local $1 i32)
-  i32.const 1
-  global.set $~argumentsLength
-  i32.const 1
-  global.set $~argumentsLength
-  i32.const 1168
-  global.set $~lib/rt/stub/startOffset
   i32.const 1168
   global.set $~lib/rt/stub/offset
-  i32.const 1
-  global.set $~argumentsLength
   block $__inlined_func$~lib/string/String.__eq (result i32)
    i32.const 1
    call $~lib/util/number/itoa32

--- a/tests/compiler/resolve-function-expression.untouched.wat
+++ b/tests/compiler/resolve-function-expression.untouched.wat
@@ -22,26 +22,26 @@
  (export "__setArgumentsLength" (func $~setArgumentsLength))
  (export "memory" (memory $0))
  (start $~start)
- (func $start:resolve-function-expression~anonymous|0 (; 1 ;) (param $0 i32) (result i32)
+ (func $start:resolve-function-expression~anonymous|0 (param $0 i32) (result i32)
   local.get $0
   i32.const 40
   i32.add
  )
- (func $~setArgumentsLength (; 2 ;) (param $0 i32)
+ (func $~setArgumentsLength (param $0 i32)
   local.get $0
   global.set $~argumentsLength
  )
- (func $start:resolve-function-expression~anonymous|1 (; 3 ;) (param $0 i32) (result i32)
+ (func $start:resolve-function-expression~anonymous|1 (param $0 i32) (result i32)
   local.get $0
   i32.const 41
   i32.add
  )
- (func $start:resolve-function-expression~anonymous|2 (; 4 ;) (param $0 i32) (result i32)
+ (func $start:resolve-function-expression~anonymous|2 (param $0 i32) (result i32)
   local.get $0
   i32.const 42
   i32.add
  )
- (func $~lib/util/number/decimalCount32 (; 5 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/decimalCount32 (param $0 i32) (result i32)
   local.get $0
   i32.const 100000
   i32.lt_u
@@ -96,7 +96,7 @@
   end
   unreachable
  )
- (func $~lib/rt/stub/maybeGrowMemory (; 6 ;) (param $0 i32)
+ (func $~lib/rt/stub/maybeGrowMemory (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -150,7 +150,7 @@
   local.get $0
   global.set $~lib/rt/stub/offset
  )
- (func $~lib/rt/stub/__alloc (; 7 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/stub/__alloc (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -203,7 +203,7 @@
   i32.store offset=12
   local.get $2
  )
- (func $~lib/util/number/utoa32_lut (; 8 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/number/utoa32_lut (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -343,10 +343,10 @@
    i32.store16
   end
  )
- (func $~lib/rt/stub/__retain (; 9 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/stub/__retain (param $0 i32) (result i32)
   local.get $0
  )
- (func $~lib/util/number/itoa32 (; 10 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/itoa32 (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -400,19 +400,19 @@
   local.get $3
   call $~lib/rt/stub/__retain
  )
- (func $~lib/util/number/itoa<i32> (; 11 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/itoa<i32> (param $0 i32) (result i32)
   local.get $0
   call $~lib/util/number/itoa32
   return
  )
- (func $~lib/number/I32#toString (; 12 ;) (param $0 i32) (result i32)
+ (func $~lib/number/I32#toString (param $0 i32) (result i32)
   local.get $0
   call $~lib/util/number/itoa<i32>
  )
- (func $~lib/rt/stub/__release (; 13 ;) (param $0 i32)
+ (func $~lib/rt/stub/__release (param $0 i32)
   nop
  )
- (func $~lib/string/String#get:length (; 14 ;) (param $0 i32) (result i32)
+ (func $~lib/string/String#get:length (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub
@@ -420,7 +420,7 @@
   i32.const 1
   i32.shr_u
  )
- (func $~lib/util/string/compareImpl (; 15 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
+ (func $~lib/util/string/compareImpl (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
@@ -542,7 +542,7 @@
   call $~lib/rt/stub/__release
   local.get $7
  )
- (func $~lib/string/String.__eq (; 16 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__eq (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -615,7 +615,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $start:resolve-function-expression (; 17 ;)
+ (func $start:resolve-function-expression
   (local $0 i32)
   i32.const 1
   global.set $~argumentsLength
@@ -680,7 +680,7 @@
   local.get $0
   call $~lib/rt/stub/__release
  )
- (func $~start (; 18 ;)
+ (func $~start
   call $start:resolve-function-expression
  )
 )

--- a/tests/compiler/resolve-nested.optimized.wat
+++ b/tests/compiler/resolve-nested.optimized.wat
@@ -5,7 +5,6 @@
  (type $i32_i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32 i32)))
  (type $i32_i32_i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32 i32 i32)))
  (memory $0 0)
- (global $~lib/rt/stub/startOffset (mut i32) (i32.const 0))
  (global $~lib/rt/stub/offset (mut i32) (i32.const 0))
  (global $resolve-nested/Outer.InnerClass i32 (i32.const 4))
  (global $resolve-nested/Outer.Inner.EvenInnerClass i32 (i32.const 5))
@@ -18,7 +17,7 @@
  (export "Outer.inner" (func $resolve-nested/Outer.inner))
  (export "outer" (func $resolve-nested/outer))
  (start $~start)
- (func $~lib/rt/stub/__alloc (; 0 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/stub/__alloc (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -84,7 +83,7 @@
   i32.store offset=12
   local.get $3
  )
- (func $resolve-nested/Outer.InnerClass#constructor (; 1 ;) (param $0 i32) (result i32)
+ (func $resolve-nested/Outer.InnerClass#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -94,7 +93,7 @@
   end
   local.get $0
  )
- (func $resolve-nested/Outer.Inner.EvenInnerClass#constructor (; 2 ;) (param $0 i32) (result i32)
+ (func $resolve-nested/Outer.Inner.EvenInnerClass#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -104,18 +103,16 @@
   end
   local.get $0
  )
- (func $resolve-nested/Outer.Inner.evenInner (; 3 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (param $5 i32)
+ (func $resolve-nested/Outer.Inner.evenInner (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (param $5 i32)
   nop
  )
- (func $resolve-nested/Outer.inner (; 4 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32)
+ (func $resolve-nested/Outer.inner (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32)
   nop
  )
- (func $resolve-nested/outer (; 5 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $resolve-nested/outer (param $0 i32) (param $1 i32) (param $2 i32)
   nop
  )
- (func $~start (; 6 ;)
-  i32.const 1024
-  global.set $~lib/rt/stub/startOffset
+ (func $~start
   i32.const 1024
   global.set $~lib/rt/stub/offset
  )

--- a/tests/compiler/resolve-nested.untouched.wat
+++ b/tests/compiler/resolve-nested.untouched.wat
@@ -36,7 +36,7 @@
  (export "Outer.inner" (func $resolve-nested/Outer.inner))
  (export "outer" (func $resolve-nested/outer))
  (start $~start)
- (func $~lib/rt/stub/maybeGrowMemory (; 0 ;) (param $0 i32)
+ (func $~lib/rt/stub/maybeGrowMemory (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -90,7 +90,7 @@
   local.get $0
   global.set $~lib/rt/stub/offset
  )
- (func $~lib/rt/stub/__alloc (; 1 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/stub/__alloc (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -143,10 +143,10 @@
   i32.store offset=12
   local.get $2
  )
- (func $~lib/rt/stub/__retain (; 2 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/stub/__retain (param $0 i32) (result i32)
   local.get $0
  )
- (func $resolve-nested/Outer.InnerClass#constructor (; 3 ;) (param $0 i32) (result i32)
+ (func $resolve-nested/Outer.InnerClass#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -158,7 +158,7 @@
   end
   local.get $0
  )
- (func $resolve-nested/Outer.Inner.EvenInnerClass#constructor (; 4 ;) (param $0 i32) (result i32)
+ (func $resolve-nested/Outer.Inner.EvenInnerClass#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -170,10 +170,10 @@
   end
   local.get $0
  )
- (func $~lib/rt/stub/__release (; 5 ;) (param $0 i32)
+ (func $~lib/rt/stub/__release (param $0 i32)
   nop
  )
- (func $resolve-nested/Outer.Inner.evenInner (; 6 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (param $5 i32)
+ (func $resolve-nested/Outer.Inner.evenInner (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (param $5 i32)
   local.get $0
   call $~lib/rt/stub/__retain
   local.set $0
@@ -205,7 +205,7 @@
   local.get $5
   call $~lib/rt/stub/__release
  )
- (func $resolve-nested/Outer.inner (; 7 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32)
+ (func $resolve-nested/Outer.inner (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32)
   local.get $0
   call $~lib/rt/stub/__retain
   local.set $0
@@ -232,7 +232,7 @@
   local.get $4
   call $~lib/rt/stub/__release
  )
- (func $resolve-nested/outer (; 8 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $resolve-nested/outer (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $0
   call $~lib/rt/stub/__retain
   local.set $0
@@ -249,7 +249,7 @@
   local.get $2
   call $~lib/rt/stub/__release
  )
- (func $~start (; 9 ;)
+ (func $~start
   global.get $~lib/heap/__heap_base
   i32.const 15
   i32.add

--- a/tests/compiler/resolve-new.optimized.wat
+++ b/tests/compiler/resolve-new.optimized.wat
@@ -1,13 +1,10 @@
 (module
  (type $none_=>_none (func))
- (type $none_=>_i32 (func (result i32)))
  (memory $0 0)
- (global $~lib/rt/stub/startOffset (mut i32) (i32.const 0))
  (global $~lib/rt/stub/offset (mut i32) (i32.const 0))
- (global $resolve-new/foo (mut i32) (i32.const 0))
  (export "memory" (memory $0))
  (start $~start)
- (func $resolve-new/Foo#constructor (; 0 ;) (result i32)
+ (func $resolve-new/Foo#constructor
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -15,18 +12,18 @@
   global.get $~lib/rt/stub/offset
   i32.const 16
   i32.add
-  local.tee $2
+  local.tee $3
   i32.const 16
   i32.add
   local.tee $0
   memory.size
-  local.tee $3
+  local.tee $2
   i32.const 16
   i32.shl
   local.tee $1
   i32.gt_u
   if
-   local.get $3
+   local.get $2
    local.get $0
    local.get $1
    i32.sub
@@ -37,7 +34,7 @@
    i32.const 16
    i32.shr_u
    local.tee $1
-   local.get $3
+   local.get $2
    local.get $1
    i32.gt_s
    select
@@ -56,7 +53,7 @@
   end
   local.get $0
   global.set $~lib/rt/stub/offset
-  local.get $2
+  local.get $3
   i32.const 16
   i32.sub
   local.tee $0
@@ -71,16 +68,11 @@
   local.get $0
   i32.const 0
   i32.store offset=12
-  local.get $2
  )
- (func $~start (; 1 ;)
-  i32.const 1024
-  global.set $~lib/rt/stub/startOffset
+ (func $~start
   i32.const 1024
   global.set $~lib/rt/stub/offset
   call $resolve-new/Foo#constructor
-  global.set $resolve-new/foo
   call $resolve-new/Foo#constructor
-  drop
  )
 )

--- a/tests/compiler/resolve-new.untouched.wat
+++ b/tests/compiler/resolve-new.untouched.wat
@@ -11,7 +11,7 @@
  (global $~lib/heap/__heap_base i32 (i32.const 8))
  (export "memory" (memory $0))
  (start $~start)
- (func $~lib/rt/stub/maybeGrowMemory (; 0 ;) (param $0 i32)
+ (func $~lib/rt/stub/maybeGrowMemory (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -65,7 +65,7 @@
   local.get $0
   global.set $~lib/rt/stub/offset
  )
- (func $~lib/rt/stub/__alloc (; 1 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/stub/__alloc (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -118,10 +118,10 @@
   i32.store offset=12
   local.get $2
  )
- (func $~lib/rt/stub/__retain (; 2 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/stub/__retain (param $0 i32) (result i32)
   local.get $0
  )
- (func $resolve-new/Foo#constructor (; 3 ;) (param $0 i32) (result i32)
+ (func $resolve-new/Foo#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -133,13 +133,13 @@
   end
   local.get $0
  )
- (func $resolve-new/Foo#bar (; 4 ;) (param $0 i32)
+ (func $resolve-new/Foo#bar (param $0 i32)
   nop
  )
- (func $~lib/rt/stub/__release (; 5 ;) (param $0 i32)
+ (func $~lib/rt/stub/__release (param $0 i32)
   nop
  )
- (func $start:resolve-new (; 6 ;)
+ (func $start:resolve-new
   (local $0 i32)
   global.get $~lib/heap/__heap_base
   i32.const 15
@@ -161,7 +161,7 @@
   local.get $0
   call $~lib/rt/stub/__release
  )
- (func $~start (; 7 ;)
+ (func $~start
   call $start:resolve-new
  )
 )

--- a/tests/compiler/resolve-propertyaccess.optimized.wat
+++ b/tests/compiler/resolve-propertyaccess.optimized.wat
@@ -18,11 +18,10 @@
  (data (i32.const 1360) "\02\00\00\00\01\00\00\00\01\00\00\00\02\00\00\005")
  (data (i32.const 1392) "\04\00\00\00\01\00\00\00\01\00\00\00\04\00\00\005\005")
  (data (i32.const 1424) "\02\00\00\00\01\00\00\00\01\00\00\00\02\00\00\006")
- (global $~lib/rt/stub/startOffset (mut i32) (i32.const 0))
  (global $~lib/rt/stub/offset (mut i32) (i32.const 0))
  (export "memory" (memory $0))
  (start $~start)
- (func $~lib/rt/stub/__alloc (; 1 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/stub/__alloc (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -106,7 +105,7 @@
   i32.store offset=12
   local.get $4
  )
- (func $~lib/util/number/itoa32 (; 2 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/itoa32 (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -209,7 +208,7 @@
   end
   local.get $3
  )
- (func $~lib/string/String#get:length (; 3 ;) (param $0 i32) (result i32)
+ (func $~lib/string/String#get:length (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub
@@ -217,7 +216,7 @@
   i32.const 1
   i32.shr_u
  )
- (func $~lib/util/string/compareImpl (; 4 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/compareImpl (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -293,7 +292,7 @@
   end
   i32.const 0
  )
- (func $~lib/string/String.__eq (; 5 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__eq (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -325,10 +324,8 @@
   end
   i32.const 0
  )
- (func $start:resolve-propertyaccess (; 6 ;)
+ (func $start:resolve-propertyaccess
   (local $0 i32)
-  i32.const 1456
-  global.set $~lib/rt/stub/startOffset
   i32.const 1456
   global.set $~lib/rt/stub/offset
   i32.const 1
@@ -469,7 +466,7 @@
    unreachable
   end
  )
- (func $~start (; 7 ;)
+ (func $~start
   call $start:resolve-propertyaccess
  )
 )

--- a/tests/compiler/resolve-propertyaccess.untouched.wat
+++ b/tests/compiler/resolve-propertyaccess.untouched.wat
@@ -37,7 +37,7 @@
  (global $~lib/heap/__heap_base i32 (i32.const 852))
  (export "memory" (memory $0))
  (start $~start)
- (func $~lib/util/number/decimalCount32 (; 1 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/decimalCount32 (param $0 i32) (result i32)
   local.get $0
   i32.const 100000
   i32.lt_u
@@ -92,7 +92,7 @@
   end
   unreachable
  )
- (func $~lib/rt/stub/maybeGrowMemory (; 2 ;) (param $0 i32)
+ (func $~lib/rt/stub/maybeGrowMemory (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -146,7 +146,7 @@
   local.get $0
   global.set $~lib/rt/stub/offset
  )
- (func $~lib/rt/stub/__alloc (; 3 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/stub/__alloc (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -199,7 +199,7 @@
   i32.store offset=12
   local.get $2
  )
- (func $~lib/util/number/utoa32_lut (; 4 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/number/utoa32_lut (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -339,10 +339,10 @@
    i32.store16
   end
  )
- (func $~lib/rt/stub/__retain (; 5 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/stub/__retain (param $0 i32) (result i32)
   local.get $0
  )
- (func $~lib/util/number/itoa32 (; 6 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/itoa32 (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -396,19 +396,19 @@
   local.get $3
   call $~lib/rt/stub/__retain
  )
- (func $~lib/util/number/itoa<i32> (; 7 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/itoa<i32> (param $0 i32) (result i32)
   local.get $0
   call $~lib/util/number/itoa32
   return
  )
- (func $~lib/number/I32#toString (; 8 ;) (param $0 i32) (result i32)
+ (func $~lib/number/I32#toString (param $0 i32) (result i32)
   local.get $0
   call $~lib/util/number/itoa<i32>
  )
- (func $~lib/rt/stub/__release (; 9 ;) (param $0 i32)
+ (func $~lib/rt/stub/__release (param $0 i32)
   nop
  )
- (func $~lib/string/String#get:length (; 10 ;) (param $0 i32) (result i32)
+ (func $~lib/string/String#get:length (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub
@@ -416,7 +416,7 @@
   i32.const 1
   i32.shr_u
  )
- (func $~lib/util/string/compareImpl (; 11 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
+ (func $~lib/util/string/compareImpl (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
@@ -538,7 +538,7 @@
   call $~lib/rt/stub/__release
   local.get $7
  )
- (func $~lib/string/String.__eq (; 12 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__eq (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -611,7 +611,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $resolve-propertyaccess/Class#constructor (; 13 ;) (param $0 i32) (result i32)
+ (func $resolve-propertyaccess/Class#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -626,7 +626,7 @@
   i32.store
   local.get $0
  )
- (func $start:resolve-propertyaccess (; 14 ;)
+ (func $start:resolve-propertyaccess
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -815,7 +815,7 @@
   local.get $8
   call $~lib/rt/stub/__release
  )
- (func $~start (; 15 ;)
+ (func $~start
   call $start:resolve-propertyaccess
  )
 )

--- a/tests/compiler/resolve-ternary.optimized.wat
+++ b/tests/compiler/resolve-ternary.optimized.wat
@@ -29,13 +29,9 @@
  (data (i32.const 2480) "\06\00\00\00 \00\00\00\00\00\00\00 \00\00\00\00\00\00\00 \00\00\00\00\00\00\00$\02\00\00\00\00\00\00\a4\08\00\00\00\00\00\00$\01")
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/collectLock (mut i32) (i32.const 0))
- (global $~lib/util/number/_frc_plus (mut i64) (i64.const 0))
- (global $~lib/util/number/_frc_minus (mut i64) (i64.const 0))
- (global $~lib/util/number/_exp (mut i32) (i32.const 0))
  (global $~lib/util/number/_K (mut i32) (i32.const 0))
  (global $~lib/util/number/_frc_pow (mut i64) (i64.const 0))
  (global $~lib/util/number/_exp_pow (mut i32) (i32.const 0))
- (global $~argumentsLength (mut i32) (i32.const 0))
  (global $~lib/rt/__rtti_base i32 (i32.const 2480))
  (export "__setArgumentsLength" (func $~setArgumentsLength))
  (export "memory" (memory $0))
@@ -45,7 +41,7 @@
  (export "__collect" (func $~lib/rt/pure/__collect))
  (export "__rtti_base" (global $~lib/rt/__rtti_base))
  (start $~start)
- (func $~lib/rt/tlsf/removeBlock (; 1 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/removeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -207,7 +203,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/insertBlock (; 2 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/insertBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -486,7 +482,7 @@
   i32.or
   i32.store offset=4
  )
- (func $~lib/rt/tlsf/addMemory (; 3 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $2
@@ -600,7 +596,7 @@
   local.get $1
   call $~lib/rt/tlsf/insertBlock
  )
- (func $~lib/rt/tlsf/maybeInitialize (; 4 ;) (result i32)
+ (func $~lib/rt/tlsf/maybeInitialize (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -687,7 +683,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/tlsf/searchBlock (; 5 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/searchBlock (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   i32.const 256
@@ -816,7 +812,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/prepareBlock (; 6 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/rt/tlsf/prepareBlock (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $1
@@ -891,7 +887,7 @@
    i32.store
   end
  )
- (func $~lib/rt/tlsf/allocateBlock (; 7 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/allocateBlock (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1049,7 +1045,7 @@
   call $~lib/rt/tlsf/prepareBlock
   local.get $3
  )
- (func $~lib/rt/tlsf/__alloc (; 8 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/__alloc (param $0 i32) (param $1 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
   local.get $0
   local.get $1
@@ -1057,7 +1053,7 @@
   i32.const 16
   i32.add
  )
- (func $~lib/rt/pure/__retain (; 9 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/pure/__retain (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -1106,7 +1102,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/pure/__release (; 10 ;) (param $0 i32)
+ (func $~lib/rt/pure/__release (param $0 i32)
   local.get $0
   i32.const 2532
   i32.gt_u
@@ -1117,7 +1113,7 @@
    call $~lib/rt/pure/decrement
   end
  )
- (func $~lib/util/number/decimalCount32 (; 11 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/decimalCount32 (param $0 i32) (result i32)
   local.get $0
   i32.const 10
   i32.ge_u
@@ -1159,7 +1155,7 @@
   i32.lt_u
   select
  )
- (func $~lib/util/number/utoa_simple<u32> (; 12 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/number/utoa_simple<u32> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   loop $do-continue|0
    local.get $1
@@ -1186,7 +1182,7 @@
    br_if $do-continue|0
   end
  )
- (func $~lib/string/String#get:length (; 13 ;) (param $0 i32) (result i32)
+ (func $~lib/string/String#get:length (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub
@@ -1194,7 +1190,7 @@
   i32.const 1
   i32.shr_u
  )
- (func $~lib/util/string/compareImpl (; 14 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/compareImpl (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -1270,7 +1266,7 @@
   end
   i32.const 0
  )
- (func $~lib/string/String.__eq (; 15 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__eq (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -1304,7 +1300,7 @@
   call $~lib/util/string/compareImpl
   i32.eqz
  )
- (func $~lib/util/number/genDigits (; 16 ;) (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (result i32)
+ (func $~lib/util/number/genDigits (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (result i32)
   (local $6 i32)
   (local $7 i64)
   (local $8 i32)
@@ -1692,7 +1688,7 @@
   i32.store16
   local.get $8
  )
- (func $~lib/memory/memory.copy (; 17 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/memory/memory.copy (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   block $~lib/util/memory/memmove|inlined.0
@@ -1865,7 +1861,7 @@
    end
   end
  )
- (func $~lib/util/number/prettify (; 18 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/prettify (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   i32.eqz
@@ -2110,17 +2106,11 @@
    end
   end
  )
- (func $~lib/util/number/dtoa_core (; 19 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/dtoa_core (param $0 i32) (result i32)
   (local $1 i64)
   (local $2 i64)
   (local $3 i64)
   (local $4 f64)
-  i64.const -9223372036854774784
-  global.set $~lib/util/number/_frc_plus
-  i64.const 9223372036854775296
-  global.set $~lib/util/number/_frc_minus
-  i32.const -63
-  global.set $~lib/util/number/_exp
   i32.const -4
   global.set $~lib/util/number/_K
   i32.const 1824
@@ -2234,7 +2224,7 @@
   global.get $~lib/util/number/_K
   call $~lib/util/number/prettify
  )
- (func $~lib/string/String#substring (; 20 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String#substring (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2308,7 +2298,7 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~lib/rt/tlsf/freeBlock (; 21 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/freeBlock (param $0 i32) (param $1 i32)
   local.get $1
   local.get $1
   i32.load
@@ -2319,11 +2309,10 @@
   local.get $1
   call $~lib/rt/tlsf/insertBlock
  )
- (func $~setArgumentsLength (; 22 ;) (param $0 i32)
-  local.get $0
-  global.set $~argumentsLength
+ (func $~setArgumentsLength (param $0 i32)
+  nop
  )
- (func $start:resolve-ternary (; 23 ;)
+ (func $start:resolve-ternary
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -2427,24 +2416,18 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1
-  global.set $~argumentsLength
-  i32.const 1
-  global.set $~argumentsLength
-  i32.const 1
-  global.set $~argumentsLength
   local.get $3
   call $~lib/rt/pure/__release
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~start (; 24 ;)
+ (func $~start
   call $start:resolve-ternary
  )
- (func $~lib/rt/pure/__collect (; 25 ;)
+ (func $~lib/rt/pure/__collect
   nop
  )
- (func $~lib/rt/pure/decrement (; 26 ;) (param $0 i32)
+ (func $~lib/rt/pure/decrement (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0

--- a/tests/compiler/resolve-ternary.untouched.wat
+++ b/tests/compiler/resolve-ternary.untouched.wat
@@ -59,7 +59,7 @@
  (export "__collect" (func $~lib/rt/pure/__collect))
  (export "__rtti_base" (global $~lib/rt/__rtti_base))
  (start $~start)
- (func $~lib/rt/tlsf/removeBlock (; 1 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/removeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -269,7 +269,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/insertBlock (; 2 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/insertBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -619,7 +619,7 @@
   local.get $7
   i32.store offset=4
  )
- (func $~lib/rt/tlsf/addMemory (; 3 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -767,7 +767,7 @@
   call $~lib/rt/tlsf/insertBlock
   i32.const 1
  )
- (func $~lib/rt/tlsf/maybeInitialize (; 4 ;) (result i32)
+ (func $~lib/rt/tlsf/maybeInitialize (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -921,7 +921,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/tlsf/prepareSize (; 5 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/tlsf/prepareSize (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -950,7 +950,7 @@
   i32.gt_u
   select
  )
- (func $~lib/rt/tlsf/searchBlock (; 6 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/searchBlock (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1133,7 +1133,7 @@
   end
   local.get $7
  )
- (func $~lib/rt/tlsf/growMemory (; 7 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/growMemory (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1217,7 +1217,7 @@
   call $~lib/rt/tlsf/addMemory
   drop
  )
- (func $~lib/rt/tlsf/prepareBlock (; 8 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/rt/tlsf/prepareBlock (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1312,7 +1312,7 @@
    i32.store
   end
  )
- (func $~lib/rt/tlsf/allocateBlock (; 9 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/allocateBlock (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   global.get $~lib/rt/tlsf/collectLock
@@ -1421,7 +1421,7 @@
   call $~lib/rt/tlsf/prepareBlock
   local.get $4
  )
- (func $~lib/rt/tlsf/__alloc (; 10 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/__alloc (param $0 i32) (param $1 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
   local.get $0
   local.get $1
@@ -1429,7 +1429,7 @@
   i32.const 16
   i32.add
  )
- (func $~lib/rt/pure/increment (; 11 ;) (param $0 i32)
+ (func $~lib/rt/pure/increment (param $0 i32)
   (local $1 i32)
   local.get $0
   i32.load offset=4
@@ -1472,7 +1472,7 @@
    unreachable
   end
  )
- (func $~lib/rt/pure/__retain (; 12 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/pure/__retain (param $0 i32) (result i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.gt_u
@@ -1484,7 +1484,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/pure/__release (; 13 ;) (param $0 i32)
+ (func $~lib/rt/pure/__release (param $0 i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.gt_u
@@ -1495,7 +1495,7 @@
    call $~lib/rt/pure/decrement
   end
  )
- (func $~lib/util/number/decimalCount32 (; 14 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/decimalCount32 (param $0 i32) (result i32)
   local.get $0
   i32.const 100000
   i32.lt_u
@@ -1550,7 +1550,7 @@
   end
   unreachable
  )
- (func $~lib/util/number/utoa32_lut (; 15 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/number/utoa32_lut (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1690,7 +1690,7 @@
    i32.store16
   end
  )
- (func $~lib/util/number/itoa32 (; 16 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/itoa32 (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -1744,16 +1744,16 @@
   local.get $3
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/itoa<i32> (; 17 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/itoa<i32> (param $0 i32) (result i32)
   local.get $0
   call $~lib/util/number/itoa32
   return
  )
- (func $~lib/number/I32#toString (; 18 ;) (param $0 i32) (result i32)
+ (func $~lib/number/I32#toString (param $0 i32) (result i32)
   local.get $0
   call $~lib/util/number/itoa<i32>
  )
- (func $~lib/string/String#get:length (; 19 ;) (param $0 i32) (result i32)
+ (func $~lib/string/String#get:length (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub
@@ -1761,7 +1761,7 @@
   i32.const 1
   i32.shr_u
  )
- (func $~lib/util/string/compareImpl (; 20 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
+ (func $~lib/util/string/compareImpl (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
@@ -1883,7 +1883,7 @@
   call $~lib/rt/pure/__release
   local.get $7
  )
- (func $~lib/string/String.__eq (; 21 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__eq (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -1956,7 +1956,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/util/number/genDigits (; 22 ;) (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (param $6 i32) (result i32)
+ (func $~lib/util/number/genDigits (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (param $6 i32) (result i32)
   (local $7 i32)
   (local $8 i64)
   (local $9 i64)
@@ -2459,7 +2459,7 @@
   end
   unreachable
  )
- (func $~lib/util/memory/memcpy (; 23 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/memory/memcpy (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3483,7 +3483,7 @@
    i32.store8
   end
  )
- (func $~lib/memory/memory.copy (; 24 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/memory/memory.copy (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3703,7 +3703,7 @@
    end
   end
  )
- (func $~lib/util/number/prettify (; 25 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/prettify (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -4020,7 +4020,7 @@
   end
   unreachable
  )
- (func $~lib/util/number/dtoa_core (; 26 ;) (param $0 i32) (param $1 f64) (result i32)
+ (func $~lib/util/number/dtoa_core (param $0 i32) (param $1 f64) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4446,7 +4446,7 @@
   local.get $2
   i32.add
  )
- (func $~lib/string/String#substring (; 27 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/string/String#substring (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -4553,7 +4553,7 @@
   local.get $11
   call $~lib/rt/pure/__retain
  )
- (func $~lib/rt/tlsf/checkUsedBlock (; 28 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/tlsf/checkUsedBlock (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   i32.const 16
@@ -4599,7 +4599,7 @@
   end
   local.get $1
  )
- (func $~lib/rt/tlsf/freeBlock (; 29 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/freeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $1
   i32.load
@@ -4613,13 +4613,13 @@
   local.get $1
   call $~lib/rt/tlsf/insertBlock
  )
- (func $~lib/rt/tlsf/__free (; 30 ;) (param $0 i32)
+ (func $~lib/rt/tlsf/__free (param $0 i32)
   call $~lib/rt/tlsf/maybeInitialize
   local.get $0
   call $~lib/rt/tlsf/checkUsedBlock
   call $~lib/rt/tlsf/freeBlock
  )
- (func $~lib/util/number/dtoa (; 31 ;) (param $0 f64) (result i32)
+ (func $~lib/util/number/dtoa (param $0 f64) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -4680,35 +4680,35 @@
   call $~lib/rt/tlsf/__free
   local.get $3
  )
- (func $~lib/number/F64#toString (; 32 ;) (param $0 f64) (param $1 i32) (result i32)
+ (func $~lib/number/F64#toString (param $0 f64) (param $1 i32) (result i32)
   local.get $0
   call $~lib/util/number/dtoa
  )
- (func $start:resolve-ternary~anonymous|0 (; 33 ;) (param $0 i32) (result i32)
+ (func $start:resolve-ternary~anonymous|0 (param $0 i32) (result i32)
   local.get $0
   i32.const 1
   i32.add
  )
- (func $start:resolve-ternary~anonymous|1 (; 34 ;) (param $0 i32) (result i32)
+ (func $start:resolve-ternary~anonymous|1 (param $0 i32) (result i32)
   local.get $0
   i32.const 2
   i32.add
  )
- (func $~setArgumentsLength (; 35 ;) (param $0 i32)
+ (func $~setArgumentsLength (param $0 i32)
   local.get $0
   global.set $~argumentsLength
  )
- (func $resolve-ternary/g1 (; 36 ;) (param $0 i32) (result i32)
+ (func $resolve-ternary/g1 (param $0 i32) (result i32)
   local.get $0
   i32.const 3
   i32.add
  )
- (func $resolve-ternary/g2 (; 37 ;) (param $0 i32) (result i32)
+ (func $resolve-ternary/g2 (param $0 i32) (result i32)
   local.get $0
   i32.const 4
   i32.add
  )
- (func $start:resolve-ternary (; 38 ;)
+ (func $start:resolve-ternary
   (local $0 i32)
   (local $1 i32)
   global.get $resolve-ternary/b
@@ -4818,13 +4818,13 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~start (; 39 ;)
+ (func $~start
   call $start:resolve-ternary
  )
- (func $~lib/rt/pure/__collect (; 40 ;)
+ (func $~lib/rt/pure/__collect
   return
  )
- (func $~lib/rt/pure/decrement (; 41 ;) (param $0 i32)
+ (func $~lib/rt/pure/decrement (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -4899,7 +4899,7 @@
    i32.store offset=4
   end
  )
- (func $~lib/rt/pure/__visit (; 42 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/pure/__visit (param $0 i32) (param $1 i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.lt_u
@@ -4923,16 +4923,16 @@
   i32.sub
   call $~lib/rt/pure/decrement
  )
- (func $~lib/staticarray/StaticArray<u32>#__visit_impl (; 43 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/staticarray/StaticArray<u32>#__visit_impl (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/staticarray/StaticArray<u64>#__visit_impl (; 44 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/staticarray/StaticArray<u64>#__visit_impl (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/staticarray/StaticArray<i16>#__visit_impl (; 45 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/staticarray/StaticArray<i16>#__visit_impl (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/rt/__visit_members (; 46 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/__visit_members (param $0 i32) (param $1 i32)
   (local $2 i32)
   block $switch$1$default
    block $switch$1$case$7

--- a/tests/compiler/resolve-unary.optimized.wat
+++ b/tests/compiler/resolve-unary.optimized.wat
@@ -22,15 +22,13 @@
  (data (i32.const 1456) "\06\00\00\00\01\00\00\00\01\00\00\00\06\00\00\00-\00-\00i")
  (data (i32.const 1488) "\06\00\00\00\01\00\00\00\01\00\00\00\06\00\00\00i\00+\00+")
  (data (i32.const 1520) "\06\00\00\00\01\00\00\00\01\00\00\00\06\00\00\00i\00-\00-")
- (global $~lib/rt/stub/startOffset (mut i32) (i32.const 0))
  (global $~lib/rt/stub/offset (mut i32) (i32.const 0))
  (global $resolve-unary/a (mut i32) (i32.const 1))
  (global $resolve-unary/b (mut i32) (i32.const 1))
  (global $resolve-unary/foo (mut i32) (i32.const 0))
- (global $resolve-unary/bar (mut i32) (i32.const 0))
  (export "memory" (memory $0))
  (start $~start)
- (func $~lib/rt/stub/__alloc (; 1 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/stub/__alloc (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -114,7 +112,7 @@
   i32.store offset=12
   local.get $4
  )
- (func $~lib/util/number/itoa32 (; 2 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/itoa32 (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -217,7 +215,7 @@
   end
   local.get $3
  )
- (func $~lib/string/String#get:length (; 3 ;) (param $0 i32) (result i32)
+ (func $~lib/string/String#get:length (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub
@@ -225,7 +223,7 @@
   i32.const 1
   i32.shr_u
  )
- (func $~lib/util/string/compareImpl (; 4 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/compareImpl (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -301,7 +299,7 @@
   end
   i32.const 0
  )
- (func $~lib/string/String.__eq (; 5 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__eq (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -333,10 +331,8 @@
   end
   i32.const 0
  )
- (func $start:resolve-unary (; 6 ;)
+ (func $start:resolve-unary
   (local $0 i32)
-  i32.const 1552
-  global.set $~lib/rt/stub/startOffset
   i32.const 1552
   global.set $~lib/rt/stub/offset
   i32.const -1
@@ -563,7 +559,7 @@
   i32.const 0
   i32.const 4
   call $~lib/rt/stub/__alloc
-  global.set $resolve-unary/bar
+  drop
   i32.const 1440
   i32.const 1440
   call $~lib/string/String.__eq
@@ -613,7 +609,7 @@
    unreachable
   end
  )
- (func $~start (; 7 ;)
+ (func $~start
   call $start:resolve-unary
  )
 )

--- a/tests/compiler/resolve-unary.untouched.wat
+++ b/tests/compiler/resolve-unary.untouched.wat
@@ -36,7 +36,7 @@
  (global $~lib/heap/__heap_base i32 (i32.const 952))
  (export "memory" (memory $0))
  (start $~start)
- (func $~lib/util/number/decimalCount32 (; 1 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/decimalCount32 (param $0 i32) (result i32)
   local.get $0
   i32.const 100000
   i32.lt_u
@@ -91,7 +91,7 @@
   end
   unreachable
  )
- (func $~lib/rt/stub/maybeGrowMemory (; 2 ;) (param $0 i32)
+ (func $~lib/rt/stub/maybeGrowMemory (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -145,7 +145,7 @@
   local.get $0
   global.set $~lib/rt/stub/offset
  )
- (func $~lib/rt/stub/__alloc (; 3 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/stub/__alloc (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -198,7 +198,7 @@
   i32.store offset=12
   local.get $2
  )
- (func $~lib/util/number/utoa32_lut (; 4 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/number/utoa32_lut (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -338,10 +338,10 @@
    i32.store16
   end
  )
- (func $~lib/rt/stub/__retain (; 5 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/stub/__retain (param $0 i32) (result i32)
   local.get $0
  )
- (func $~lib/util/number/itoa32 (; 6 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/itoa32 (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -395,19 +395,19 @@
   local.get $3
   call $~lib/rt/stub/__retain
  )
- (func $~lib/util/number/itoa<i32> (; 7 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/itoa<i32> (param $0 i32) (result i32)
   local.get $0
   call $~lib/util/number/itoa32
   return
  )
- (func $~lib/number/I32#toString (; 8 ;) (param $0 i32) (result i32)
+ (func $~lib/number/I32#toString (param $0 i32) (result i32)
   local.get $0
   call $~lib/util/number/itoa<i32>
  )
- (func $~lib/rt/stub/__release (; 9 ;) (param $0 i32)
+ (func $~lib/rt/stub/__release (param $0 i32)
   nop
  )
- (func $~lib/string/String#get:length (; 10 ;) (param $0 i32) (result i32)
+ (func $~lib/string/String#get:length (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub
@@ -415,7 +415,7 @@
   i32.const 1
   i32.shr_u
  )
- (func $~lib/util/string/compareImpl (; 11 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
+ (func $~lib/util/string/compareImpl (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
@@ -537,7 +537,7 @@
   call $~lib/rt/stub/__release
   local.get $7
  )
- (func $~lib/string/String.__eq (; 12 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__eq (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -610,7 +610,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $~lib/number/Bool#toString (; 13 ;) (param $0 i32) (result i32)
+ (func $~lib/number/Bool#toString (param $0 i32) (result i32)
   local.get $0
   if (result i32)
    i32.const 624
@@ -618,7 +618,7 @@
    i32.const 656
   end
  )
- (func $resolve-unary/Foo#constructor (; 14 ;) (param $0 i32) (result i32)
+ (func $resolve-unary/Foo#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -630,43 +630,43 @@
   end
   local.get $0
  )
- (func $resolve-unary/Foo#plus (; 15 ;) (param $0 i32) (result i32)
+ (func $resolve-unary/Foo#plus (param $0 i32) (result i32)
   i32.const 720
  )
- (func $~lib/string/String#toString (; 16 ;) (param $0 i32) (result i32)
+ (func $~lib/string/String#toString (param $0 i32) (result i32)
   local.get $0
   call $~lib/rt/stub/__retain
  )
- (func $resolve-unary/Foo#minus (; 17 ;) (param $0 i32) (result i32)
+ (func $resolve-unary/Foo#minus (param $0 i32) (result i32)
   i32.const 752
  )
- (func $resolve-unary/Foo#prefix_inc (; 18 ;) (param $0 i32) (result i32)
+ (func $resolve-unary/Foo#prefix_inc (param $0 i32) (result i32)
   local.get $0
   call $~lib/rt/stub/__retain
  )
- (func $resolve-unary/Foo#self (; 19 ;) (param $0 i32) (result i32)
+ (func $resolve-unary/Foo#self (param $0 i32) (result i32)
   local.get $0
   call $~lib/rt/stub/__retain
  )
- (func $resolve-unary/Foo#prefix_dec (; 20 ;) (param $0 i32) (result i32)
+ (func $resolve-unary/Foo#prefix_dec (param $0 i32) (result i32)
   local.get $0
   call $~lib/rt/stub/__retain
  )
- (func $resolve-unary/Foo#not (; 21 ;) (param $0 i32) (result i32)
+ (func $resolve-unary/Foo#not (param $0 i32) (result i32)
   i32.const 784
  )
- (func $resolve-unary/Foo#bitwise_not (; 22 ;) (param $0 i32) (result i32)
+ (func $resolve-unary/Foo#bitwise_not (param $0 i32) (result i32)
   i32.const 816
  )
- (func $resolve-unary/Foo#postfix_inc (; 23 ;) (param $0 i32) (result i32)
+ (func $resolve-unary/Foo#postfix_inc (param $0 i32) (result i32)
   local.get $0
   call $~lib/rt/stub/__retain
  )
- (func $resolve-unary/Foo#postfix_dec (; 24 ;) (param $0 i32) (result i32)
+ (func $resolve-unary/Foo#postfix_dec (param $0 i32) (result i32)
   local.get $0
   call $~lib/rt/stub/__retain
  )
- (func $resolve-unary/Bar#constructor (; 25 ;) (param $0 i32) (result i32)
+ (func $resolve-unary/Bar#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -678,7 +678,7 @@
   end
   local.get $0
  )
- (func $resolve-unary/Bar.prefix_inc (; 26 ;) (param $0 i32) (result i32)
+ (func $resolve-unary/Bar.prefix_inc (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   call $~lib/rt/stub/__retain
@@ -689,7 +689,7 @@
   call $~lib/rt/stub/__release
   local.get $1
  )
- (func $resolve-unary/Bar.prefix_dec (; 27 ;) (param $0 i32) (result i32)
+ (func $resolve-unary/Bar.prefix_dec (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   call $~lib/rt/stub/__retain
@@ -700,7 +700,7 @@
   call $~lib/rt/stub/__release
   local.get $1
  )
- (func $resolve-unary/Bar.postfix_inc (; 28 ;) (param $0 i32) (result i32)
+ (func $resolve-unary/Bar.postfix_inc (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   call $~lib/rt/stub/__retain
@@ -711,7 +711,7 @@
   call $~lib/rt/stub/__release
   local.get $1
  )
- (func $resolve-unary/Bar.postfix_dec (; 29 ;) (param $0 i32) (result i32)
+ (func $resolve-unary/Bar.postfix_dec (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   call $~lib/rt/stub/__retain
@@ -722,7 +722,7 @@
   call $~lib/rt/stub/__release
   local.get $1
  )
- (func $start:resolve-unary (; 30 ;)
+ (func $start:resolve-unary
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -1238,7 +1238,7 @@
   local.get $32
   call $~lib/rt/stub/__release
  )
- (func $~start (; 31 ;)
+ (func $~start
   call $start:resolve-unary
  )
 )

--- a/tests/compiler/retain-i32.optimized.wat
+++ b/tests/compiler/retain-i32.optimized.wat
@@ -2,12 +2,9 @@
  (type $none_=>_none (func))
  (memory $0 1)
  (data (i32.const 1024) "\1a\00\00\00\01\00\00\00\01\00\00\00\1a\00\00\00r\00e\00t\00a\00i\00n\00-\00i\003\002\00.\00t\00s")
- (global $retain-i32/si (mut i32) (i32.const 0))
- (global $retain-i32/ui (mut i32) (i32.const 0))
- (global $retain-i32/ri (mut i32) (i32.const 0))
  (export "memory" (memory $0))
  (start $~start)
- (func $~start (; 0 ;)
+ (func $~start
   (local $0 i32)
   i32.const -128
   local.set $0
@@ -23,45 +20,9 @@
     br $for-loop|0
    end
   end
-  i32.const -1
-  global.set $retain-i32/si
-  i32.const -1
-  global.set $retain-i32/si
-  i32.const -2
-  global.set $retain-i32/si
-  i32.const -128
-  global.set $retain-i32/si
-  i32.const -128
-  global.set $retain-i32/si
-  i32.const -127
-  global.set $retain-i32/si
-  i32.const -128
-  global.set $retain-i32/si
-  i32.const 1
-  global.set $retain-i32/si
-  i32.const 1
-  global.set $retain-i32/si
-  i32.const 0
-  global.set $retain-i32/si
-  i32.const 1
-  global.set $retain-i32/si
-  i32.const 255
-  global.set $retain-i32/ui
-  i32.const 255
-  global.set $retain-i32/ui
-  i32.const 254
-  global.set $retain-i32/ui
-  i32.const 1
-  global.set $retain-i32/ui
-  i32.const 1
-  global.set $retain-i32/ui
-  i32.const 1
-  global.set $retain-i32/ui
-  i32.const 0
-  global.set $retain-i32/ui
   i32.const 0
   i32.load8_s
-  global.set $retain-i32/ri
+  drop
   i32.const 0
   i32.load8_s
   drop

--- a/tests/compiler/retain-i32.untouched.wat
+++ b/tests/compiler/retain-i32.untouched.wat
@@ -20,7 +20,7 @@
  (global $retain-i32/ri (mut i32) (i32.const 0))
  (export "memory" (memory $0))
  (start $~start)
- (func $retain-i32/test (; 1 ;) (param $0 i32) (param $1 i32)
+ (func $retain-i32/test (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
   i32.add
@@ -330,13 +330,13 @@
    unreachable
   end
  )
- (func $retain-i32/testLocalRetain (; 2 ;)
+ (func $retain-i32/testLocalRetain
   (local $0 i32)
   i32.const 0
   i32.load8_s
   local.set $0
  )
- (func $start:retain-i32 (; 3 ;)
+ (func $start:retain-i32
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -797,7 +797,7 @@
   global.set $retain-i32/ri
   call $retain-i32/testLocalRetain
  )
- (func $~start (; 4 ;)
+ (func $~start
   call $start:retain-i32
  )
 )

--- a/tests/compiler/retain-release-sanity.optimized.wat
+++ b/tests/compiler/retain-release-sanity.optimized.wat
@@ -36,7 +36,7 @@
  (global $~lib/rt/pure/END (mut i32) (i32.const 0))
  (export "memory" (memory $0))
  (start $~start)
- (func $~lib/rt/tlsf/removeBlock (; 6 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/removeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -198,7 +198,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/insertBlock (; 7 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/insertBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -477,7 +477,7 @@
   i32.or
   i32.store offset=4
  )
- (func $~lib/rt/tlsf/addMemory (; 8 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $2
@@ -591,7 +591,7 @@
   local.get $1
   call $~lib/rt/tlsf/insertBlock
  )
- (func $~lib/rt/tlsf/maybeInitialize (; 9 ;) (result i32)
+ (func $~lib/rt/tlsf/maybeInitialize (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -678,7 +678,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/tlsf/prepareSize (; 10 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/tlsf/prepareSize (param $0 i32) (result i32)
   local.get $0
   i32.const 1073741808
   i32.ge_u
@@ -702,7 +702,7 @@
   i32.gt_u
   select
  )
- (func $~lib/rt/tlsf/searchBlock (; 11 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/searchBlock (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   i32.const 256
@@ -831,7 +831,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/prepareBlock (; 12 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/rt/tlsf/prepareBlock (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $1
@@ -906,7 +906,7 @@
    i32.store
   end
  )
- (func $~lib/rt/tlsf/allocateBlock (; 13 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/allocateBlock (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1047,7 +1047,7 @@
   call $~lib/rt/rtrace/onalloc
   local.get $3
  )
- (func $~lib/rt/tlsf/__alloc (; 14 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/__alloc (param $0 i32) (param $1 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
   local.get $0
   local.get $1
@@ -1055,7 +1055,7 @@
   i32.const 16
   i32.add
  )
- (func $~lib/memory/memory.fill (; 15 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/memory/memory.fill (param $0 i32) (param $1 i32)
   (local $2 i32)
   block $~lib/util/memory/memset|inlined.0
    local.get $1
@@ -1213,7 +1213,7 @@
    end
   end
  )
- (func $~lib/rt/pure/__retain (; 16 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/pure/__retain (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -1264,7 +1264,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/pure/__release (; 17 ;) (param $0 i32)
+ (func $~lib/rt/pure/__release (param $0 i32)
   local.get $0
   i32.const 1652
   i32.gt_u
@@ -1275,7 +1275,7 @@
    call $~lib/rt/pure/decrement
   end
  )
- (func $~lib/rt/tlsf/checkUsedBlock (; 18 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/tlsf/checkUsedBlock (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   i32.const 16
@@ -1317,7 +1317,7 @@
   end
   local.get $1
  )
- (func $~lib/memory/memory.copy (; 19 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/memory/memory.copy (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   block $~lib/util/memory/memmove|inlined.0
@@ -1490,7 +1490,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/freeBlock (; 20 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/freeBlock (param $0 i32) (param $1 i32)
   local.get $1
   local.get $1
   i32.load
@@ -1503,7 +1503,7 @@
   local.get $1
   call $~lib/rt/rtrace/onfree
  )
- (func $~lib/rt/tlsf/reallocateBlock (; 21 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/reallocateBlock (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1606,7 +1606,7 @@
   end
   local.get $3
  )
- (func $~lib/array/ensureSize (; 22 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/ensureSize (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1665,7 +1665,7 @@
    i32.store offset=8
   end
  )
- (func $~lib/array/Array<i32>#push (; 23 ;) (param $0 i32)
+ (func $~lib/array/Array<i32>#push (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -1688,7 +1688,7 @@
   local.get $2
   i32.store offset=12
  )
- (func $~lib/string/String#get:length (; 24 ;) (param $0 i32) (result i32)
+ (func $~lib/string/String#get:length (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub
@@ -1696,7 +1696,7 @@
   i32.const 1
   i32.shr_u
  )
- (func $~lib/string/String.__concat (; 25 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__concat (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1759,7 +1759,7 @@
    local.get $1
   end
  )
- (func $start:retain-release-sanity (; 26 ;)
+ (func $start:retain-release-sanity
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -2116,10 +2116,10 @@
   call $~lib/rt/pure/__release
   call $~lib/rt/pure/__collect
  )
- (func $~start (; 27 ;)
+ (func $~start
   call $start:retain-release-sanity
  )
- (func $~lib/rt/pure/markGray (; 28 ;) (param $0 i32)
+ (func $~lib/rt/pure/markGray (param $0 i32)
   (local $1 i32)
   local.get $0
   i32.load offset=4
@@ -2143,7 +2143,7 @@
    call $~lib/rt/__visit_members
   end
  )
- (func $~lib/rt/pure/scanBlack (; 29 ;) (param $0 i32)
+ (func $~lib/rt/pure/scanBlack (param $0 i32)
   local.get $0
   local.get $0
   i32.load offset=4
@@ -2156,7 +2156,7 @@
   i32.const 4
   call $~lib/rt/__visit_members
  )
- (func $~lib/rt/pure/scan (; 30 ;) (param $0 i32)
+ (func $~lib/rt/pure/scan (param $0 i32)
   (local $1 i32)
   local.get $0
   i32.load offset=4
@@ -2190,7 +2190,7 @@
    end
   end
  )
- (func $~lib/rt/pure/collectWhite (; 31 ;) (param $0 i32)
+ (func $~lib/rt/pure/collectWhite (param $0 i32)
   (local $1 i32)
   local.get $0
   i32.load offset=4
@@ -2223,7 +2223,7 @@
    call $~lib/rt/tlsf/freeBlock
   end
  )
- (func $~lib/rt/pure/__collect (; 32 ;)
+ (func $~lib/rt/pure/__collect
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -2344,7 +2344,7 @@
   local.get $0
   global.set $~lib/rt/pure/CUR
  )
- (func $~lib/rt/pure/decrement (; 33 ;) (param $0 i32)
+ (func $~lib/rt/pure/decrement (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -2511,7 +2511,7 @@
    end
   end
  )
- (func $~lib/rt/pure/__visit (; 34 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/pure/__visit (param $0 i32) (param $1 i32)
   local.get $0
   i32.const 1652
   i32.lt_u
@@ -2614,7 +2614,7 @@
    unreachable
   end
  )
- (func $~lib/array/Array<~lib/string/String>#__visit_impl (; 35 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<~lib/string/String>#__visit_impl (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2652,7 +2652,7 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/rt/__visit_members (; 36 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/__visit_members (param $0 i32) (param $1 i32)
   block $switch$1$default
    block $switch$1$case$7
     block $switch$1$case$6

--- a/tests/compiler/retain-release-sanity.untouched.wat
+++ b/tests/compiler/retain-release-sanity.untouched.wat
@@ -42,7 +42,7 @@
  (global $~lib/heap/__heap_base i32 (i32.const 644))
  (export "memory" (memory $0))
  (start $~start)
- (func $~lib/rt/tlsf/removeBlock (; 6 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/removeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -252,7 +252,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/insertBlock (; 7 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/insertBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -602,7 +602,7 @@
   local.get $7
   i32.store offset=4
  )
- (func $~lib/rt/tlsf/addMemory (; 8 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -750,7 +750,7 @@
   call $~lib/rt/tlsf/insertBlock
   i32.const 1
  )
- (func $~lib/rt/tlsf/maybeInitialize (; 9 ;) (result i32)
+ (func $~lib/rt/tlsf/maybeInitialize (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -904,7 +904,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/tlsf/prepareSize (; 10 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/tlsf/prepareSize (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -933,7 +933,7 @@
   i32.gt_u
   select
  )
- (func $~lib/rt/tlsf/searchBlock (; 11 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/searchBlock (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1116,7 +1116,7 @@
   end
   local.get $7
  )
- (func $~lib/rt/tlsf/growMemory (; 12 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/growMemory (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1200,7 +1200,7 @@
   call $~lib/rt/tlsf/addMemory
   drop
  )
- (func $~lib/rt/tlsf/prepareBlock (; 13 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/rt/tlsf/prepareBlock (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1295,7 +1295,7 @@
    i32.store
   end
  )
- (func $~lib/rt/tlsf/allocateBlock (; 14 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/allocateBlock (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   global.get $~lib/rt/tlsf/collectLock
@@ -1406,7 +1406,7 @@
   call $~lib/rt/rtrace/onalloc
   local.get $4
  )
- (func $~lib/rt/tlsf/__alloc (; 15 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/__alloc (param $0 i32) (param $1 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
   local.get $0
   local.get $1
@@ -1414,7 +1414,7 @@
   i32.const 16
   i32.add
  )
- (func $~lib/memory/memory.fill (; 16 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/memory/memory.fill (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1623,7 +1623,7 @@
    end
   end
  )
- (func $~lib/rt/pure/increment (; 17 ;) (param $0 i32)
+ (func $~lib/rt/pure/increment (param $0 i32)
   (local $1 i32)
   local.get $0
   i32.load offset=4
@@ -1668,7 +1668,7 @@
    unreachable
   end
  )
- (func $~lib/rt/pure/__retain (; 18 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/pure/__retain (param $0 i32) (result i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.gt_u
@@ -1680,7 +1680,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/pure/__release (; 19 ;) (param $0 i32)
+ (func $~lib/rt/pure/__release (param $0 i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.gt_u
@@ -1691,7 +1691,7 @@
    call $~lib/rt/pure/decrement
   end
  )
- (func $~lib/array/Array<i32>#constructor (; 20 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#constructor (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1769,7 +1769,7 @@
   i32.store offset=12
   local.get $0
  )
- (func $~lib/rt/tlsf/checkUsedBlock (; 21 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/tlsf/checkUsedBlock (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   i32.const 16
@@ -1815,7 +1815,7 @@
   end
   local.get $1
  )
- (func $~lib/util/memory/memcpy (; 22 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/memory/memcpy (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2839,7 +2839,7 @@
    i32.store8
   end
  )
- (func $~lib/memory/memory.copy (; 23 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/memory/memory.copy (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3059,7 +3059,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/freeBlock (; 24 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/freeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $1
   i32.load
@@ -3075,7 +3075,7 @@
   local.get $1
   call $~lib/rt/rtrace/onfree
  )
- (func $~lib/rt/tlsf/reallocateBlock (; 25 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/reallocateBlock (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3194,7 +3194,7 @@
   end
   local.get $8
  )
- (func $~lib/rt/tlsf/__realloc (; 26 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/__realloc (param $0 i32) (param $1 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
   local.get $0
   call $~lib/rt/tlsf/checkUsedBlock
@@ -3203,7 +3203,7 @@
   i32.const 16
   i32.add
  )
- (func $~lib/array/ensureSize (; 27 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/ensureSize (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3265,7 +3265,7 @@
    i32.store offset=8
   end
  )
- (func $~lib/array/Array<i32>#push (; 28 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#push (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -3292,7 +3292,7 @@
   i32.store offset=12
   local.get $3
  )
- (func $~lib/array/Array<i32>#pop (; 29 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<i32>#pop (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -3325,7 +3325,7 @@
   i32.store offset=12
   local.get $2
  )
- (func $~lib/array/Array<~lib/array/Array<~lib/string/String>>#constructor (; 30 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<~lib/string/String>>#constructor (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3403,7 +3403,7 @@
   i32.store offset=12
   local.get $0
  )
- (func $~lib/array/Array<~lib/string/String>#constructor (; 31 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/string/String>#constructor (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3481,7 +3481,7 @@
   i32.store offset=12
   local.get $0
  )
- (func $~lib/array/Array<~lib/string/String>#push (; 32 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/string/String>#push (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3517,7 +3517,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/string/String#get:length (; 33 ;) (param $0 i32) (result i32)
+ (func $~lib/string/String#get:length (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub
@@ -3525,7 +3525,7 @@
   i32.const 1
   i32.shr_u
  )
- (func $~lib/string/String#concat (; 34 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String#concat (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3601,7 +3601,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/string/String.__concat (; 35 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__concat (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -3624,7 +3624,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $retain-release-sanity/A#constructor (; 36 ;) (param $0 i32) (result i32)
+ (func $retain-release-sanity/A#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -3639,7 +3639,7 @@
   i32.store
   local.get $0
  )
- (func $retain-release-sanity/B#constructor (; 37 ;) (param $0 i32) (result i32)
+ (func $retain-release-sanity/B#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -3654,7 +3654,7 @@
   i32.store
   local.get $0
  )
- (func $start:retain-release-sanity (; 38 ;)
+ (func $start:retain-release-sanity
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -3861,10 +3861,10 @@
   call $~lib/rt/pure/__release
   call $~lib/rt/pure/__collect
  )
- (func $~start (; 39 ;)
+ (func $~start
   call $start:retain-release-sanity
  )
- (func $~lib/rt/pure/markGray (; 40 ;) (param $0 i32)
+ (func $~lib/rt/pure/markGray (param $0 i32)
   (local $1 i32)
   local.get $0
   i32.load offset=4
@@ -3891,7 +3891,7 @@
    call $~lib/rt/__visit_members
   end
  )
- (func $~lib/rt/pure/scanBlack (; 41 ;) (param $0 i32)
+ (func $~lib/rt/pure/scanBlack (param $0 i32)
   local.get $0
   local.get $0
   i32.load offset=4
@@ -3908,7 +3908,7 @@
   i32.const 4
   call $~lib/rt/__visit_members
  )
- (func $~lib/rt/pure/scan (; 42 ;) (param $0 i32)
+ (func $~lib/rt/pure/scan (param $0 i32)
   (local $1 i32)
   local.get $0
   i32.load offset=4
@@ -3945,7 +3945,7 @@
    end
   end
  )
- (func $~lib/rt/pure/collectWhite (; 43 ;) (param $0 i32)
+ (func $~lib/rt/pure/collectWhite (param $0 i32)
   (local $1 i32)
   local.get $0
   i32.load offset=4
@@ -3983,7 +3983,7 @@
    call $~lib/rt/tlsf/freeBlock
   end
  )
- (func $~lib/rt/pure/__collect (; 44 ;)
+ (func $~lib/rt/pure/__collect
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -4124,7 +4124,7 @@
   local.get $0
   global.set $~lib/rt/pure/CUR
  )
- (func $~lib/rt/__typeinfo (; 45 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/__typeinfo (param $0 i32) (result i32)
   (local $1 i32)
   global.get $~lib/rt/__rtti_base
   local.set $1
@@ -4149,13 +4149,13 @@
   i32.add
   i32.load
  )
- (func $~lib/rt/tlsf/__free (; 46 ;) (param $0 i32)
+ (func $~lib/rt/tlsf/__free (param $0 i32)
   call $~lib/rt/tlsf/maybeInitialize
   local.get $0
   call $~lib/rt/tlsf/checkUsedBlock
   call $~lib/rt/tlsf/freeBlock
  )
- (func $~lib/rt/pure/growRoots (; 47 ;)
+ (func $~lib/rt/pure/growRoots
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -4213,7 +4213,7 @@
   i32.add
   global.set $~lib/rt/pure/END
  )
- (func $~lib/rt/pure/appendRoot (; 48 ;) (param $0 i32)
+ (func $~lib/rt/pure/appendRoot (param $0 i32)
   (local $1 i32)
   global.get $~lib/rt/pure/CUR
   local.set $1
@@ -4233,7 +4233,7 @@
   i32.add
   global.set $~lib/rt/pure/CUR
  )
- (func $~lib/rt/pure/decrement (; 49 ;) (param $0 i32)
+ (func $~lib/rt/pure/decrement (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -4337,7 +4337,7 @@
    end
   end
  )
- (func $~lib/rt/pure/__visit (; 50 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/pure/__visit (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -4467,13 +4467,13 @@
    end
   end
  )
- (func $~lib/array/Array<i32>#__visit_impl (; 51 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i32>#__visit_impl (param $0 i32) (param $1 i32)
   local.get $0
   i32.load
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/array/Array<~lib/string/String>#__visit_impl (; 52 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<~lib/string/String>#__visit_impl (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4516,7 +4516,7 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/array/Array<~lib/array/Array<~lib/string/String>>#__visit_impl (; 53 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<~lib/array/Array<~lib/string/String>>#__visit_impl (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4559,7 +4559,7 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/rt/__visit_members (; 54 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/__visit_members (param $0 i32) (param $1 i32)
   (local $2 i32)
   block $switch$1$default
    block $switch$1$case$7

--- a/tests/compiler/retain-release.optimized.wat
+++ b/tests/compiler/retain-release.optimized.wat
@@ -10,14 +10,11 @@
  (data (i32.const 1024) "\n\00\00\00\01\00\00\00\01\00\00\00\n\00\00\00e\00r\00r\00o\00r")
  (data (i32.const 1056) "\"\00\00\00\01\00\00\00\01\00\00\00\"\00\00\00r\00e\00t\00a\00i\00n\00-\00r\00e\00l\00e\00a\00s\00e\00.\00t\00s")
  (table $0 1 funcref)
- (global $~lib/rt/stub/startOffset (mut i32) (i32.const 0))
  (global $~lib/rt/stub/offset (mut i32) (i32.const 0))
  (global $retain-release/REF (mut i32) (i32.const 0))
- (global $retain-release/glo (mut i32) (i32.const 0))
  (global $retain-release/TARGET (mut i32) (i32.const 0))
- (global $~argumentsLength (mut i32) (i32.const 0))
  (global $~started (mut i32) (i32.const 0))
- (export "__setArgumentsLength" (func $~setArgumentsLength))
+ (export "__setArgumentsLength" (func $retain-release/takeRef))
  (export "_start" (func $~start))
  (export "memory" (memory $0))
  (export "returnRef" (func $retain-release/returnRef))
@@ -29,7 +26,7 @@
  (export "takeReturnRef" (func $retain-release/takeReturnRef))
  (export "provideReceiveRef" (func $retain-release/receiveRef))
  (export "newRef" (func $retain-release/newRef))
- (export "assignGlobal" (func $retain-release/assignGlobal))
+ (export "assignGlobal" (func $retain-release/receiveRef))
  (export "assignField" (func $retain-release/assignField))
  (export "scopeBlock" (func $retain-release/receiveRef))
  (export "scopeBlockToUninitialized" (func $retain-release/receiveRef))
@@ -57,7 +54,7 @@
  (export "provideRefIndirect" (func $retain-release/provideRefIndirect))
  (export "receiveRefIndirect" (func $retain-release/receiveRefIndirect))
  (export "receiveRefIndirectDrop" (func $retain-release/receiveRefIndirect))
- (func $~lib/rt/stub/__alloc (; 1 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/stub/__alloc (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -141,30 +138,25 @@
   i32.store offset=12
   local.get $4
  )
- (func $retain-release/returnRef (; 2 ;) (result i32)
+ (func $retain-release/returnRef (result i32)
   global.get $retain-release/REF
  )
- (func $retain-release/receiveRef (; 3 ;)
+ (func $retain-release/receiveRef
   nop
  )
- (func $retain-release/takeRef (; 4 ;) (param $0 i32)
+ (func $retain-release/takeRef (param $0 i32)
   nop
  )
- (func $retain-release/takeReturnRef (; 5 ;) (param $0 i32) (result i32)
+ (func $retain-release/takeReturnRef (param $0 i32) (result i32)
   local.get $0
  )
- (func $retain-release/newRef (; 6 ;)
+ (func $retain-release/newRef
   i32.const 0
   i32.const 3
   call $~lib/rt/stub/__alloc
   drop
  )
- (func $retain-release/assignGlobal (; 7 ;)
-  (local $0 i32)
-  global.get $retain-release/REF
-  global.set $retain-release/glo
- )
- (func $retain-release/assignField (; 8 ;)
+ (func $retain-release/assignField
   (local $0 i32)
   (local $1 i32)
   global.get $retain-release/REF
@@ -178,7 +170,7 @@
   local.get $0
   i32.store
  )
- (func $retain-release/scopeForComplex (; 9 ;) (param $0 i32)
+ (func $retain-release/scopeForComplex (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   loop $for-loop|0
@@ -204,7 +196,7 @@
    end
   end
  )
- (func $retain-release/scopeThrow (; 10 ;) (param $0 i32)
+ (func $retain-release/scopeThrow (param $0 i32)
   local.get $0
   if
    i32.const 1040
@@ -215,31 +207,23 @@
    unreachable
   end
  )
- (func $retain-release/scopeUnreachable (; 11 ;) (param $0 i32)
+ (func $retain-release/scopeUnreachable (param $0 i32)
   local.get $0
   if
    unreachable
   end
  )
- (func $~setArgumentsLength (; 12 ;) (param $0 i32)
-  local.get $0
-  global.set $~argumentsLength
- )
- (func $retain-release/provideRefIndirect (; 13 ;) (param $0 i32)
-  i32.const 1
-  global.set $~argumentsLength
+ (func $retain-release/provideRefIndirect (param $0 i32)
   global.get $retain-release/REF
   local.get $0
   call_indirect (type $i32_=>_none)
  )
- (func $retain-release/receiveRefIndirect (; 14 ;) (param $0 i32)
-  i32.const 0
-  global.set $~argumentsLength
+ (func $retain-release/receiveRefIndirect (param $0 i32)
   local.get $0
   call_indirect (type $none_=>_i32)
   drop
  )
- (func $~start (; 15 ;)
+ (func $~start
   (local $0 i32)
   global.get $~started
   if
@@ -248,8 +232,6 @@
    i32.const 1
    global.set $~started
   end
-  i32.const 1120
-  global.set $~lib/rt/stub/startOffset
   i32.const 1120
   global.set $~lib/rt/stub/offset
   i32.const 0

--- a/tests/compiler/retain-release.untouched.wat
+++ b/tests/compiler/retain-release.untouched.wat
@@ -58,7 +58,7 @@
  (export "provideRefIndirect" (func $retain-release/provideRefIndirect))
  (export "receiveRefIndirect" (func $retain-release/receiveRefIndirect))
  (export "receiveRefIndirectDrop" (func $retain-release/receiveRefIndirectDrop))
- (func $~lib/rt/stub/maybeGrowMemory (; 1 ;) (param $0 i32)
+ (func $~lib/rt/stub/maybeGrowMemory (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -112,7 +112,7 @@
   local.get $0
   global.set $~lib/rt/stub/offset
  )
- (func $~lib/rt/stub/__alloc (; 2 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/stub/__alloc (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -165,10 +165,10 @@
   i32.store offset=12
   local.get $2
  )
- (func $~lib/rt/stub/__retain (; 3 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/stub/__retain (param $0 i32) (result i32)
   local.get $0
  )
- (func $retain-release/Ref#constructor (; 4 ;) (param $0 i32) (result i32)
+ (func $retain-release/Ref#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -180,7 +180,7 @@
   end
   local.get $0
  )
- (func $retain-release/Target#constructor (; 5 ;) (param $0 i32) (result i32)
+ (func $retain-release/Target#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -195,7 +195,7 @@
   i32.store
   local.get $0
  )
- (func $start:retain-release (; 6 ;)
+ (func $start:retain-release
   global.get $~lib/heap/__heap_base
   i32.const 15
   i32.add
@@ -213,14 +213,14 @@
   call $retain-release/Target#constructor
   global.set $retain-release/TARGET
  )
- (func $retain-release/returnRef (; 7 ;) (result i32)
+ (func $retain-release/returnRef (result i32)
   global.get $retain-release/REF
   call $~lib/rt/stub/__retain
  )
- (func $~lib/rt/stub/__release (; 8 ;) (param $0 i32)
+ (func $~lib/rt/stub/__release (param $0 i32)
   nop
  )
- (func $retain-release/receiveRef (; 9 ;)
+ (func $retain-release/receiveRef
   (local $0 i32)
   call $retain-release/returnRef
   local.tee $0
@@ -229,35 +229,35 @@
   local.get $0
   call $~lib/rt/stub/__release
  )
- (func $retain-release/receiveRefDrop (; 10 ;)
+ (func $retain-release/receiveRefDrop
   call $retain-release/returnRef
   call $~lib/rt/stub/__release
  )
- (func $retain-release/receiveRefRetain (; 11 ;)
+ (func $retain-release/receiveRefRetain
   (local $0 i32)
   call $retain-release/returnRef
   local.set $0
   local.get $0
   call $~lib/rt/stub/__release
  )
- (func $retain-release/takeRef (; 12 ;) (param $0 i32)
+ (func $retain-release/takeRef (param $0 i32)
   local.get $0
   call $~lib/rt/stub/__retain
   local.set $0
   local.get $0
   call $~lib/rt/stub/__release
  )
- (func $retain-release/provideRef (; 13 ;)
+ (func $retain-release/provideRef
   global.get $retain-release/REF
   call $retain-release/takeRef
  )
- (func $retain-release/takeReturnRef (; 14 ;) (param $0 i32) (result i32)
+ (func $retain-release/takeReturnRef (param $0 i32) (result i32)
   local.get $0
   call $~lib/rt/stub/__retain
   local.set $0
   local.get $0
  )
- (func $retain-release/provideReceiveRef (; 15 ;)
+ (func $retain-release/provideReceiveRef
   (local $0 i32)
   global.get $retain-release/REF
   call $retain-release/takeReturnRef
@@ -267,12 +267,12 @@
   local.get $0
   call $~lib/rt/stub/__release
  )
- (func $retain-release/newRef (; 16 ;)
+ (func $retain-release/newRef
   i32.const 0
   call $retain-release/Ref#constructor
   call $~lib/rt/stub/__release
  )
- (func $retain-release/assignGlobal (; 17 ;)
+ (func $retain-release/assignGlobal
   (local $0 i32)
   (local $1 i32)
   global.get $retain-release/REF
@@ -290,7 +290,7 @@
   local.get $0
   global.set $retain-release/glo
  )
- (func $retain-release/assignField (; 18 ;)
+ (func $retain-release/assignField
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -312,7 +312,7 @@
   local.get $1
   i32.store
  )
- (func $retain-release/scopeBlock (; 19 ;)
+ (func $retain-release/scopeBlock
   (local $0 i32)
   global.get $retain-release/REF
   call $~lib/rt/stub/__retain
@@ -320,7 +320,7 @@
   local.get $0
   call $~lib/rt/stub/__release
  )
- (func $retain-release/scopeBlockToUninitialized (; 20 ;)
+ (func $retain-release/scopeBlockToUninitialized
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -349,7 +349,7 @@
   local.get $0
   call $~lib/rt/stub/__release
  )
- (func $retain-release/scopeBlockToInitialized (; 21 ;)
+ (func $retain-release/scopeBlockToInitialized
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -379,7 +379,7 @@
   local.get $0
   call $~lib/rt/stub/__release
  )
- (func $retain-release/scopeBlockToConditional (; 22 ;) (param $0 i32)
+ (func $retain-release/scopeBlockToConditional (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -425,14 +425,14 @@
   local.get $1
   call $~lib/rt/stub/__release
  )
- (func $retain-release/scopeTopLevelUninitialized (; 23 ;)
+ (func $retain-release/scopeTopLevelUninitialized
   (local $0 i32)
   i32.const 0
   local.set $0
   local.get $0
   call $~lib/rt/stub/__release
  )
- (func $retain-release/scopeTopLevelInitialized (; 24 ;)
+ (func $retain-release/scopeTopLevelInitialized
   (local $0 i32)
   global.get $retain-release/REF
   call $~lib/rt/stub/__retain
@@ -440,7 +440,7 @@
   local.get $0
   call $~lib/rt/stub/__release
  )
- (func $retain-release/scopeTopLevelConditional (; 25 ;) (param $0 i32)
+ (func $retain-release/scopeTopLevelConditional (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -466,7 +466,7 @@
   local.get $1
   call $~lib/rt/stub/__release
  )
- (func $retain-release/scopeIf (; 26 ;) (param $0 i32)
+ (func $retain-release/scopeIf (param $0 i32)
   (local $1 i32)
   local.get $0
   if
@@ -477,7 +477,7 @@
    call $~lib/rt/stub/__release
   end
  )
- (func $retain-release/scopeIfElse (; 27 ;) (param $0 i32)
+ (func $retain-release/scopeIfElse (param $0 i32)
   (local $1 i32)
   local.get $0
   if
@@ -494,7 +494,7 @@
    call $~lib/rt/stub/__release
   end
  )
- (func $retain-release/scopeWhile (; 28 ;) (param $0 i32)
+ (func $retain-release/scopeWhile (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   loop $while-continue|0
@@ -511,7 +511,7 @@
    end
   end
  )
- (func $retain-release/scopeDo (; 29 ;) (param $0 i32)
+ (func $retain-release/scopeDo (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   loop $do-continue|0
@@ -526,7 +526,7 @@
    br_if $do-continue|0
   end
  )
- (func $retain-release/scopeFor (; 30 ;) (param $0 i32)
+ (func $retain-release/scopeFor (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   loop $for-loop|0
@@ -543,7 +543,7 @@
    end
   end
  )
- (func $retain-release/scopeForComplex (; 31 ;) (param $0 i32)
+ (func $retain-release/scopeForComplex (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -603,7 +603,7 @@
    end
   end
  )
- (func $retain-release/scopeBreak (; 32 ;) (param $0 i32)
+ (func $retain-release/scopeBreak (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   block $while-break|0
@@ -622,7 +622,7 @@
    end
   end
  )
- (func $retain-release/scopeBreakNested (; 33 ;) (param $0 i32)
+ (func $retain-release/scopeBreakNested (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -656,7 +656,7 @@
    end
   end
  )
- (func $retain-release/scopeContinue (; 34 ;) (param $0 i32)
+ (func $retain-release/scopeContinue (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   loop $while-continue|0
@@ -673,7 +673,7 @@
    end
   end
  )
- (func $retain-release/scopeContinueNested (; 35 ;) (param $0 i32)
+ (func $retain-release/scopeContinueNested (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -705,7 +705,7 @@
    end
   end
  )
- (func $retain-release/scopeThrow (; 36 ;) (param $0 i32)
+ (func $retain-release/scopeThrow (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   loop $while-continue|0
@@ -727,7 +727,7 @@
    end
   end
  )
- (func $retain-release/scopeUnreachable (; 37 ;) (param $0 i32)
+ (func $retain-release/scopeUnreachable (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   loop $while-continue|0
@@ -742,7 +742,7 @@
    end
   end
  )
- (func $retain-release/callInline (; 38 ;)
+ (func $retain-release/callInline
   (local $0 i32)
   global.get $retain-release/REF
   call $~lib/rt/stub/__retain
@@ -750,7 +750,7 @@
   local.get $0
   call $~lib/rt/stub/__release
  )
- (func $retain-release/provideRefInline (; 39 ;)
+ (func $retain-release/provideRefInline
   (local $0 i32)
   global.get $retain-release/REF
   call $~lib/rt/stub/__retain
@@ -758,7 +758,7 @@
   local.get $0
   call $~lib/rt/stub/__release
  )
- (func $retain-release/receiveRefInline (; 40 ;)
+ (func $retain-release/receiveRefInline
   (local $0 i32)
   global.get $retain-release/REF
   call $~lib/rt/stub/__retain
@@ -768,23 +768,23 @@
   local.get $0
   call $~lib/rt/stub/__release
  )
- (func $retain-release/receiveRefInlineDrop (; 41 ;)
+ (func $retain-release/receiveRefInlineDrop
   global.get $retain-release/REF
   call $~lib/rt/stub/__retain
   call $~lib/rt/stub/__release
  )
- (func $~setArgumentsLength (; 42 ;) (param $0 i32)
+ (func $~setArgumentsLength (param $0 i32)
   local.get $0
   global.set $~argumentsLength
  )
- (func $retain-release/provideRefIndirect (; 43 ;) (param $0 i32)
+ (func $retain-release/provideRefIndirect (param $0 i32)
   i32.const 1
   global.set $~argumentsLength
   global.get $retain-release/REF
   local.get $0
   call_indirect (type $i32_=>_none)
  )
- (func $retain-release/receiveRefIndirect (; 44 ;) (param $0 i32)
+ (func $retain-release/receiveRefIndirect (param $0 i32)
   (local $1 i32)
   i32.const 0
   global.set $~argumentsLength
@@ -796,14 +796,14 @@
   local.get $1
   call $~lib/rt/stub/__release
  )
- (func $retain-release/receiveRefIndirectDrop (; 45 ;) (param $0 i32)
+ (func $retain-release/receiveRefIndirectDrop (param $0 i32)
   i32.const 0
   global.set $~argumentsLength
   local.get $0
   call_indirect (type $none_=>_i32)
   call $~lib/rt/stub/__release
  )
- (func $~start (; 46 ;)
+ (func $~start
   global.get $~started
   if
    return

--- a/tests/compiler/retain-return.optimized.wat
+++ b/tests/compiler/retain-return.optimized.wat
@@ -14,12 +14,11 @@
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/collectLock (mut i32) (i32.const 0))
  (global $retain-return/ref (mut i32) (i32.const 0))
- (global $~argumentsLength (mut i32) (i32.const 0))
  (global $~started (mut i32) (i32.const 0))
  (export "__setArgumentsLength" (func $~setArgumentsLength))
  (export "_start" (func $~start))
  (export "memory" (memory $0))
- (func $~lib/rt/tlsf/removeBlock (; 1 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/removeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -181,7 +180,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/insertBlock (; 2 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/insertBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -460,7 +459,7 @@
   i32.or
   i32.store offset=4
  )
- (func $~lib/rt/tlsf/addMemory (; 3 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $2
@@ -574,7 +573,7 @@
   local.get $1
   call $~lib/rt/tlsf/insertBlock
  )
- (func $~lib/rt/tlsf/maybeInitialize (; 4 ;) (result i32)
+ (func $~lib/rt/tlsf/maybeInitialize (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -661,7 +660,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/tlsf/searchBlock (; 5 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/tlsf/searchBlock (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   nop
@@ -719,7 +718,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/allocateBlock (; 6 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/tlsf/allocateBlock (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -889,7 +888,7 @@
   end
   local.get $1
  )
- (func $~lib/rt/pure/__retain (; 7 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/pure/__retain (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -938,14 +937,14 @@
   end
   local.get $0
  )
- (func $retain-return/Ref#constructor (; 8 ;) (result i32)
+ (func $retain-return/Ref#constructor (result i32)
   call $~lib/rt/tlsf/maybeInitialize
   call $~lib/rt/tlsf/allocateBlock
   i32.const 16
   i32.add
   call $~lib/rt/pure/__retain
  )
- (func $~lib/rt/pure/__release (; 9 ;) (param $0 i32)
+ (func $~lib/rt/pure/__release (param $0 i32)
   local.get $0
   i32.const 1184
   i32.gt_u
@@ -956,11 +955,10 @@
    call $~lib/rt/pure/decrement
   end
  )
- (func $~setArgumentsLength (; 10 ;) (param $0 i32)
-  local.get $0
-  global.set $~argumentsLength
+ (func $~setArgumentsLength (param $0 i32)
+  nop
  )
- (func $~start (; 11 ;)
+ (func $~start
   (local $0 i32)
   global.get $~started
   if
@@ -979,42 +977,18 @@
   call $~lib/rt/pure/__release
   call $retain-return/Ref#constructor
   global.set $retain-return/ref
-  i32.const 0
-  global.set $~argumentsLength
   call $retain-return/Ref#constructor
   call $~lib/rt/pure/__release
-  i32.const 0
-  global.set $~argumentsLength
   call $retain-return/Ref#constructor
   call $~lib/rt/pure/__release
-  i32.const 1
-  global.set $~argumentsLength
-  i32.const 1
-  global.set $~argumentsLength
-  i32.const 0
-  global.set $~argumentsLength
-  i32.const 0
-  global.set $~argumentsLength
-  i32.const 0
-  global.set $~argumentsLength
   call $retain-return/Ref#constructor
   call $~lib/rt/pure/__release
-  i32.const 0
-  global.set $~argumentsLength
   call $retain-return/Ref#constructor
   call $~lib/rt/pure/__release
-  i32.const 0
-  global.set $~argumentsLength
   call $retain-return/Ref#constructor
   call $~lib/rt/pure/__release
-  i32.const 0
-  global.set $~argumentsLength
   call $retain-return/Ref#constructor
   call $~lib/rt/pure/__release
-  i32.const 0
-  global.set $~argumentsLength
-  i32.const 0
-  global.set $~argumentsLength
   global.get $retain-return/ref
   local.tee $0
   if
@@ -1024,7 +998,7 @@
   i32.const 0
   global.set $retain-return/ref
  )
- (func $~lib/rt/pure/decrement (; 12 ;) (param $0 i32)
+ (func $~lib/rt/pure/decrement (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0

--- a/tests/compiler/retain-return.untouched.wat
+++ b/tests/compiler/retain-return.untouched.wat
@@ -32,7 +32,7 @@
  (export "__setArgumentsLength" (func $~setArgumentsLength))
  (export "_start" (func $~start))
  (export "memory" (memory $0))
- (func $~lib/rt/tlsf/removeBlock (; 1 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/removeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -242,7 +242,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/insertBlock (; 2 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/insertBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -592,7 +592,7 @@
   local.get $7
   i32.store offset=4
  )
- (func $~lib/rt/tlsf/addMemory (; 3 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -740,7 +740,7 @@
   call $~lib/rt/tlsf/insertBlock
   i32.const 1
  )
- (func $~lib/rt/tlsf/maybeInitialize (; 4 ;) (result i32)
+ (func $~lib/rt/tlsf/maybeInitialize (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -894,7 +894,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/tlsf/prepareSize (; 5 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/tlsf/prepareSize (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -923,7 +923,7 @@
   i32.gt_u
   select
  )
- (func $~lib/rt/tlsf/searchBlock (; 6 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/searchBlock (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1106,7 +1106,7 @@
   end
   local.get $7
  )
- (func $~lib/rt/tlsf/growMemory (; 7 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/growMemory (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1190,7 +1190,7 @@
   call $~lib/rt/tlsf/addMemory
   drop
  )
- (func $~lib/rt/tlsf/prepareBlock (; 8 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/rt/tlsf/prepareBlock (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1285,7 +1285,7 @@
    i32.store
   end
  )
- (func $~lib/rt/tlsf/allocateBlock (; 9 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/allocateBlock (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   global.get $~lib/rt/tlsf/collectLock
@@ -1394,7 +1394,7 @@
   call $~lib/rt/tlsf/prepareBlock
   local.get $4
  )
- (func $~lib/rt/tlsf/__alloc (; 10 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/__alloc (param $0 i32) (param $1 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
   local.get $0
   local.get $1
@@ -1402,7 +1402,7 @@
   i32.const 16
   i32.add
  )
- (func $~lib/rt/pure/increment (; 11 ;) (param $0 i32)
+ (func $~lib/rt/pure/increment (param $0 i32)
   (local $1 i32)
   local.get $0
   i32.load offset=4
@@ -1445,7 +1445,7 @@
    unreachable
   end
  )
- (func $~lib/rt/pure/__retain (; 12 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/pure/__retain (param $0 i32) (result i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.gt_u
@@ -1457,7 +1457,7 @@
   end
   local.get $0
  )
- (func $retain-return/Ref#constructor (; 13 ;) (param $0 i32) (result i32)
+ (func $retain-return/Ref#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -1469,11 +1469,11 @@
   end
   local.get $0
  )
- (func $retain-return/returnNew (; 14 ;) (result i32)
+ (func $retain-return/returnNew (result i32)
   i32.const 0
   call $retain-return/Ref#constructor
  )
- (func $~lib/rt/pure/__release (; 15 ;) (param $0 i32)
+ (func $~lib/rt/pure/__release (param $0 i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.gt_u
@@ -1484,51 +1484,51 @@
    call $~lib/rt/pure/decrement
   end
  )
- (func $retain-return/returnLocal (; 16 ;) (result i32)
+ (func $retain-return/returnLocal (result i32)
   (local $0 i32)
   i32.const 0
   call $retain-return/Ref#constructor
   local.set $0
   local.get $0
  )
- (func $retain-return/returnGlobal (; 17 ;) (result i32)
+ (func $retain-return/returnGlobal (result i32)
   global.get $retain-return/ref
   call $~lib/rt/pure/__retain
  )
- (func $start:retain-return~anonymous|0 (; 18 ;) (result i32)
+ (func $start:retain-return~anonymous|0 (result i32)
   i32.const 0
   call $retain-return/Ref#constructor
  )
- (func $~setArgumentsLength (; 19 ;) (param $0 i32)
+ (func $~setArgumentsLength (param $0 i32)
   local.get $0
   global.set $~argumentsLength
  )
- (func $start:retain-return~anonymous|1 (; 20 ;) (param $0 i32) (result i32)
+ (func $start:retain-return~anonymous|1 (param $0 i32) (result i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $0
   local.get $0
  )
- (func $start:retain-return~anonymous|2 (; 21 ;) (result i32)
+ (func $start:retain-return~anonymous|2 (result i32)
   global.get $retain-return/ref
   call $~lib/rt/pure/__retain
  )
- (func $start:retain-return~anonymous|3 (; 22 ;) (result i32)
+ (func $start:retain-return~anonymous|3 (result i32)
   i32.const 0
   call $retain-return/Ref#constructor
  )
- (func $start:retain-return~anonymous|4 (; 23 ;) (result i32)
+ (func $start:retain-return~anonymous|4 (result i32)
   (local $0 i32)
   i32.const 0
   call $retain-return/Ref#constructor
   local.set $0
   local.get $0
  )
- (func $start:retain-return~anonymous|5 (; 24 ;) (result i32)
+ (func $start:retain-return~anonymous|5 (result i32)
   global.get $retain-return/ref
   call $~lib/rt/pure/__retain
  )
- (func $start:retain-return (; 25 ;)
+ (func $start:retain-return
   (local $0 i32)
   (local $1 i32)
   call $retain-return/returnNew
@@ -1623,7 +1623,7 @@
   local.get $0
   global.set $retain-return/ref
  )
- (func $~start (; 26 ;)
+ (func $~start
   global.get $~started
   if
    return
@@ -1633,10 +1633,10 @@
   end
   call $start:retain-return
  )
- (func $~lib/rt/pure/__collect (; 27 ;)
+ (func $~lib/rt/pure/__collect
   return
  )
- (func $~lib/rt/tlsf/freeBlock (; 28 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/freeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $1
   i32.load
@@ -1650,7 +1650,7 @@
   local.get $1
   call $~lib/rt/tlsf/insertBlock
  )
- (func $~lib/rt/pure/decrement (; 29 ;) (param $0 i32)
+ (func $~lib/rt/pure/decrement (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -1725,7 +1725,7 @@
    i32.store offset=4
   end
  )
- (func $~lib/rt/pure/__visit (; 30 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/pure/__visit (param $0 i32) (param $1 i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.lt_u
@@ -1749,7 +1749,7 @@
   i32.sub
   call $~lib/rt/pure/decrement
  )
- (func $~lib/rt/__visit_members (; 31 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/__visit_members (param $0 i32) (param $1 i32)
   (local $2 i32)
   block $switch$1$default
    block $switch$1$case$4

--- a/tests/compiler/rt/flags.optimized.wat
+++ b/tests/compiler/rt/flags.optimized.wat
@@ -7,14 +7,14 @@
  (data (i32.const 1024) "$\00\00\00\01\00\00\00\01\00\00\00$\00\00\00I\00n\00d\00e\00x\00 \00o\00u\00t\00 \00o\00f\00 \00r\00a\00n\00g\00e")
  (data (i32.const 1088) "\14\00\00\00\01\00\00\00\01\00\00\00\14\00\00\00~\00l\00i\00b\00/\00r\00t\00.\00t\00s")
  (data (i32.const 1136) "\16\00\00\00\01\00\00\00\01\00\00\00\16\00\00\00r\00t\00/\00f\00l\00a\00g\00s\00.\00t\00s")
- (data (i32.const 1184) "D\00\00\00\10\00\00\00\00\00\00\00\10\00\00\00\00\00\00\00\10\00\00\00\00\00\00\001\04\00\00\02\00\00\001\00\00\00\02\00\00\001\00\00\00\02\00\00\00Q\04\00\00\02\00\00\00Q\00\00\00\02\00\00\00\91\04\00\00\02\00\00\00\91\00\00\00\02\00\00\00\11\05\00\00\02\00\00\00\11\01\00\00\02\00\00\00\91\0c\00\00\02\00\00\00\11\0d\00\00\02\00\00\002\04\00\00\00\00\00\002\00\00\00\00\00\00\00R\04\00\00\00\00\00\00R\00\00\00\00\00\00\00\92\04\00\00\00\00\00\00\92\00\00\00\00\00\00\00\12\05\00\00\00\00\00\00\12\01\00\00\00\00\00\00\92\0c\00\00\00\00\00\00\12\0d\00\00\00\00\00\00\12\02\00\00\00\00\00\00\10\00\00\00\00\00\00\00\92 \00\00\00\00\00\00\920\00\00\00\00\00\004\04\00\00\00\00\00\004\00\00\00\00\00\00\00T\04\00\00\00\00\00\00T\00\00\00\00\00\00\00\94\04\00\00\00\00\00\00\94\00\00\00\00\00\00\00\14\05\00\00\00\00\00\00\14\01\00\00\00\00\00\00\94\0c\00\00\00\00\00\00\14\0d\00\00\00\00\00\00\14\02\00\00\00\00\00\00\94 \00\00\00\00\00\00\940\00\00\00\00\00\008\04\04\00\00\00\00\00X\04\n\00\00\00\00\00\98\04\t\00\00\00\00\00\18\85\08\00\00\00\00\00\18B\08\00\00\00\00\008\04A\00\00\00\00\008\04a\00\00\00\00\00\98`\08\00\00\00\00\00\98p\08\00\00\00\00\00\980a\00\00\00\00\00\98\04\19\00\00\00\00\00\10")
- (data (i32.const 1644) "\82 \00\00\00\00\00\00\10")
- (data (i32.const 1668) "\84 \00\00\00\00\00\00\10")
- (data (i32.const 1692) "\88\04A")
- (data (i32.const 1708) "\88 \t\00\00\00\00\00\10\00\00\00\00\00\00\00\10")
+ (data (i32.const 1184) "D\00\00\00 \00\00\00\00\00\00\00 \00\00\00\00\00\00\00 \00\00\00\00\00\00\00a\08\00\00\02\00\00\00a\00\00\00\02\00\00\00a\00\00\00\02\00\00\00\a1\08\00\00\02\00\00\00\a1\00\00\00\02\00\00\00!\t\00\00\02\00\00\00!\01\00\00\02\00\00\00!\n\00\00\02\00\00\00!\02\00\00\02\00\00\00!\19\00\00\02\00\00\00!\1a\00\00\02\00\00\00b\08\00\00\00\00\00\00b\00\00\00\00\00\00\00\a2\08\00\00\00\00\00\00\a2\00\00\00\00\00\00\00\"\t\00\00\00\00\00\00\"\01\00\00\00\00\00\00\"\n\00\00\00\00\00\00\"\02\00\00\00\00\00\00\"\19\00\00\00\00\00\00\"\1a\00\00\00\00\00\00\"\04\00\00\00\00\00\00 \00\00\00\00\00\00\00\"A\00\00\00\00\00\00\"a\00\00\00\00\00\00h\08\00\00\00\00\00\00h\00\00\00\00\00\00\00\a8\08\00\00\00\00\00\00\a8\00\00\00\00\00\00\00(\t\00\00\00\00\00\00(\01\00\00\00\00\00\00(\n\00\00\00\00\00\00(\02\00\00\00\00\00\00(\19\00\00\00\00\00\00(\1a\00\00\00\00\00\00(\04\00\00\00\00\00\00(A\00\00\00\00\00\00(a\00\00\00\00\00\00p\08\08\00\00\00\00\00\b0\08\14\00\00\00\00\000\t\12\00\00\00\00\000\n\11\00\00\00\00\000\84\10\00\00\00\00\00p\08\82\00\00\00\00\00p\08\c2\00\00\00\00\000\c1\10\00\00\00\00\000\e1\10\00\00\00\00\000a\c2\00\00\00\00\000\t2\00\00\00\00\00 ")
+ (data (i32.const 1644) "\02A\00\00\00\00\00\00 ")
+ (data (i32.const 1668) "\08A\00\00\00\00\00\00 ")
+ (data (i32.const 1692) "\10\t\82")
+ (data (i32.const 1708) "\10A\12\00\00\00\00\00 \00\00\00\00\00\00\00 ")
  (export "memory" (memory $0))
  (start $~start)
- (func $~lib/rt/__typeinfo (; 1 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/__typeinfo (param $0 i32) (result i32)
   local.get $0
   i32.const 1184
   i32.load
@@ -34,251 +34,251 @@
   i32.add
   i32.load
  )
- (func $start:rt/flags (; 2 ;)
+ (func $start:rt/flags
   block $folding-inner0
    i32.const 3
    call $~lib/rt/__typeinfo
-   i32.const 1073
+   i32.const 2145
    i32.ne
    br_if $folding-inner0
    i32.const 4
    call $~lib/rt/__typeinfo
-   i32.const 49
+   i32.const 97
    i32.ne
    br_if $folding-inner0
    i32.const 5
    call $~lib/rt/__typeinfo
-   i32.const 49
+   i32.const 97
    i32.ne
    br_if $folding-inner0
    i32.const 6
    call $~lib/rt/__typeinfo
-   i32.const 1105
+   i32.const 2209
    i32.ne
    br_if $folding-inner0
    i32.const 7
    call $~lib/rt/__typeinfo
-   i32.const 81
+   i32.const 161
    i32.ne
    br_if $folding-inner0
    i32.const 8
    call $~lib/rt/__typeinfo
-   i32.const 1169
+   i32.const 2337
    i32.ne
    br_if $folding-inner0
    i32.const 9
    call $~lib/rt/__typeinfo
-   i32.const 145
+   i32.const 289
    i32.ne
    br_if $folding-inner0
    i32.const 10
    call $~lib/rt/__typeinfo
-   i32.const 1297
+   i32.const 2593
    i32.ne
    br_if $folding-inner0
    i32.const 11
    call $~lib/rt/__typeinfo
-   i32.const 273
+   i32.const 545
    i32.ne
    br_if $folding-inner0
    i32.const 12
    call $~lib/rt/__typeinfo
-   i32.const 3217
+   i32.const 6433
    i32.ne
    br_if $folding-inner0
    i32.const 13
    call $~lib/rt/__typeinfo
-   i32.const 3345
+   i32.const 6689
    i32.ne
    br_if $folding-inner0
    i32.const 14
    call $~lib/rt/__typeinfo
-   i32.const 1074
+   i32.const 2146
    i32.ne
    br_if $folding-inner0
    i32.const 15
    call $~lib/rt/__typeinfo
-   i32.const 50
+   i32.const 98
    i32.ne
    br_if $folding-inner0
    i32.const 16
    call $~lib/rt/__typeinfo
-   i32.const 1106
+   i32.const 2210
    i32.ne
    br_if $folding-inner0
    i32.const 17
    call $~lib/rt/__typeinfo
-   i32.const 82
+   i32.const 162
    i32.ne
    br_if $folding-inner0
    i32.const 18
    call $~lib/rt/__typeinfo
-   i32.const 1170
+   i32.const 2338
    i32.ne
    br_if $folding-inner0
    i32.const 19
    call $~lib/rt/__typeinfo
-   i32.const 146
+   i32.const 290
    i32.ne
    br_if $folding-inner0
    i32.const 20
    call $~lib/rt/__typeinfo
-   i32.const 1298
+   i32.const 2594
    i32.ne
    br_if $folding-inner0
    i32.const 21
    call $~lib/rt/__typeinfo
-   i32.const 274
+   i32.const 546
    i32.ne
    br_if $folding-inner0
    i32.const 22
    call $~lib/rt/__typeinfo
-   i32.const 3218
+   i32.const 6434
    i32.ne
    br_if $folding-inner0
    i32.const 23
    call $~lib/rt/__typeinfo
-   i32.const 3346
+   i32.const 6690
    i32.ne
    br_if $folding-inner0
    i32.const 24
    call $~lib/rt/__typeinfo
-   i32.const 530
+   i32.const 1058
    i32.ne
    br_if $folding-inner0
    i32.const 26
    call $~lib/rt/__typeinfo
-   i32.const 8338
+   i32.const 16674
    i32.ne
    br_if $folding-inner0
    i32.const 27
    call $~lib/rt/__typeinfo
-   i32.const 12434
+   i32.const 24866
    i32.ne
    br_if $folding-inner0
    i32.const 28
    call $~lib/rt/__typeinfo
-   i32.const 1076
+   i32.const 2152
    i32.ne
    br_if $folding-inner0
    i32.const 29
    call $~lib/rt/__typeinfo
-   i32.const 52
+   i32.const 104
    i32.ne
    br_if $folding-inner0
    i32.const 30
    call $~lib/rt/__typeinfo
-   i32.const 1108
+   i32.const 2216
    i32.ne
    br_if $folding-inner0
    i32.const 31
    call $~lib/rt/__typeinfo
-   i32.const 84
+   i32.const 168
    i32.ne
    br_if $folding-inner0
    i32.const 32
    call $~lib/rt/__typeinfo
-   i32.const 1172
+   i32.const 2344
    i32.ne
    br_if $folding-inner0
    i32.const 33
    call $~lib/rt/__typeinfo
-   i32.const 148
+   i32.const 296
    i32.ne
    br_if $folding-inner0
    i32.const 34
    call $~lib/rt/__typeinfo
-   i32.const 1300
+   i32.const 2600
    i32.ne
    br_if $folding-inner0
    i32.const 35
    call $~lib/rt/__typeinfo
-   i32.const 276
+   i32.const 552
    i32.ne
    br_if $folding-inner0
    i32.const 36
    call $~lib/rt/__typeinfo
-   i32.const 3220
+   i32.const 6440
    i32.ne
    br_if $folding-inner0
    i32.const 37
    call $~lib/rt/__typeinfo
-   i32.const 3348
+   i32.const 6696
    i32.ne
    br_if $folding-inner0
    i32.const 38
    call $~lib/rt/__typeinfo
-   i32.const 532
+   i32.const 1064
    i32.ne
    br_if $folding-inner0
    i32.const 39
    call $~lib/rt/__typeinfo
-   i32.const 8340
+   i32.const 16680
    i32.ne
    br_if $folding-inner0
    i32.const 40
    call $~lib/rt/__typeinfo
-   i32.const 12436
+   i32.const 24872
    i32.ne
    br_if $folding-inner0
    i32.const 41
    call $~lib/rt/__typeinfo
-   i32.const 263224
+   i32.const 526448
    i32.ne
    br_if $folding-inner0
    i32.const 42
    call $~lib/rt/__typeinfo
-   i32.const 656472
+   i32.const 1312944
    i32.ne
    br_if $folding-inner0
    i32.const 43
    call $~lib/rt/__typeinfo
-   i32.const 591000
+   i32.const 1182000
    i32.ne
    br_if $folding-inner0
    i32.const 44
    call $~lib/rt/__typeinfo
-   i32.const 558360
+   i32.const 1116720
    i32.ne
    br_if $folding-inner0
    i32.const 45
    call $~lib/rt/__typeinfo
-   i32.const 541208
+   i32.const 1082416
    i32.ne
    br_if $folding-inner0
    i32.const 46
    call $~lib/rt/__typeinfo
-   i32.const 4260920
+   i32.const 8521840
    i32.ne
    br_if $folding-inner0
    i32.const 47
    call $~lib/rt/__typeinfo
-   i32.const 6358072
+   i32.const 12716144
    i32.ne
    br_if $folding-inner0
    i32.const 48
    call $~lib/rt/__typeinfo
-   i32.const 549016
+   i32.const 1098032
    i32.ne
    br_if $folding-inner0
    i32.const 49
    call $~lib/rt/__typeinfo
-   i32.const 553112
+   i32.const 1106224
    i32.ne
    br_if $folding-inner0
    i32.const 50
    call $~lib/rt/__typeinfo
-   i32.const 6369432
+   i32.const 12738864
    i32.ne
    br_if $folding-inner0
    i32.const 51
    call $~lib/rt/__typeinfo
-   i32.const 1639576
+   i32.const 3279152
    i32.ne
    br_if $folding-inner0
    i32.const 52
    call $~lib/rt/__typeinfo
-   i32.const 16
+   i32.const 32
    i32.ne
    br_if $folding-inner0
    i32.const 53
@@ -292,7 +292,7 @@
    br_if $folding-inner0
    i32.const 58
    call $~lib/rt/__typeinfo
-   i32.const 16
+   i32.const 32
    i32.ne
    br_if $folding-inner0
    i32.const 59
@@ -300,7 +300,7 @@
    br_if $folding-inner0
    i32.const 61
    call $~lib/rt/__typeinfo
-   i32.const 16
+   i32.const 32
    i32.ne
    br_if $folding-inner0
    i32.const 62
@@ -311,12 +311,12 @@
    br_if $folding-inner0
    i32.const 66
    call $~lib/rt/__typeinfo
-   i32.const 16
+   i32.const 32
    i32.ne
    br_if $folding-inner0
    i32.const 67
    call $~lib/rt/__typeinfo
-   i32.const 16
+   i32.const 32
    i32.ne
    br_if $folding-inner0
    return
@@ -328,7 +328,7 @@
   call $~lib/builtins/abort
   unreachable
  )
- (func $~start (; 3 ;)
+ (func $~start
   call $start:rt/flags
  )
 )

--- a/tests/compiler/rt/flags.untouched.wat
+++ b/tests/compiler/rt/flags.untouched.wat
@@ -8,14 +8,14 @@
  (data (i32.const 16) "$\00\00\00\01\00\00\00\01\00\00\00$\00\00\00I\00n\00d\00e\00x\00 \00o\00u\00t\00 \00o\00f\00 \00r\00a\00n\00g\00e\00")
  (data (i32.const 80) "\14\00\00\00\01\00\00\00\01\00\00\00\14\00\00\00~\00l\00i\00b\00/\00r\00t\00.\00t\00s\00")
  (data (i32.const 128) "\16\00\00\00\01\00\00\00\01\00\00\00\16\00\00\00r\00t\00/\00f\00l\00a\00g\00s\00.\00t\00s\00")
- (data (i32.const 176) "D\00\00\00\10\00\00\00\00\00\00\00\10\00\00\00\00\00\00\00\10\00\00\00\00\00\00\001\04\00\00\02\00\00\001\00\00\00\02\00\00\001\00\00\00\02\00\00\00Q\04\00\00\02\00\00\00Q\00\00\00\02\00\00\00\91\04\00\00\02\00\00\00\91\00\00\00\02\00\00\00\11\05\00\00\02\00\00\00\11\01\00\00\02\00\00\00\91\0c\00\00\02\00\00\00\11\0d\00\00\02\00\00\002\04\00\00\00\00\00\002\00\00\00\00\00\00\00R\04\00\00\00\00\00\00R\00\00\00\00\00\00\00\92\04\00\00\00\00\00\00\92\00\00\00\00\00\00\00\12\05\00\00\00\00\00\00\12\01\00\00\00\00\00\00\92\0c\00\00\00\00\00\00\12\0d\00\00\00\00\00\00\12\02\00\00\00\00\00\00\10\00\00\00\00\00\00\00\92 \00\00\00\00\00\00\920\00\00\00\00\00\004\04\00\00\00\00\00\004\00\00\00\00\00\00\00T\04\00\00\00\00\00\00T\00\00\00\00\00\00\00\94\04\00\00\00\00\00\00\94\00\00\00\00\00\00\00\14\05\00\00\00\00\00\00\14\01\00\00\00\00\00\00\94\0c\00\00\00\00\00\00\14\0d\00\00\00\00\00\00\14\02\00\00\00\00\00\00\94 \00\00\00\00\00\00\940\00\00\00\00\00\008\04\04\00\00\00\00\00X\04\n\00\00\00\00\00\98\04\t\00\00\00\00\00\18\85\08\00\00\00\00\00\18B\08\00\00\00\00\008\04A\00\00\00\00\008\04a\00\00\00\00\00\98`\08\00\00\00\00\00\98p\08\00\00\00\00\00\980a\00\00\00\00\00\98\04\19\00\00\00\00\00\10\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\82 \00\00\00\00\00\00\10\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\84 \00\00\00\00\00\00\10\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\88\04A\00\00\00\00\00\00\00\00\00\00\00\00\00\88 \t\00\00\00\00\00\10\00\00\00\00\00\00\00\10\00\00\00\00\00\00\00")
+ (data (i32.const 176) "D\00\00\00 \00\00\00\00\00\00\00 \00\00\00\00\00\00\00 \00\00\00\00\00\00\00a\08\00\00\02\00\00\00a\00\00\00\02\00\00\00a\00\00\00\02\00\00\00\a1\08\00\00\02\00\00\00\a1\00\00\00\02\00\00\00!\t\00\00\02\00\00\00!\01\00\00\02\00\00\00!\n\00\00\02\00\00\00!\02\00\00\02\00\00\00!\19\00\00\02\00\00\00!\1a\00\00\02\00\00\00b\08\00\00\00\00\00\00b\00\00\00\00\00\00\00\a2\08\00\00\00\00\00\00\a2\00\00\00\00\00\00\00\"\t\00\00\00\00\00\00\"\01\00\00\00\00\00\00\"\n\00\00\00\00\00\00\"\02\00\00\00\00\00\00\"\19\00\00\00\00\00\00\"\1a\00\00\00\00\00\00\"\04\00\00\00\00\00\00 \00\00\00\00\00\00\00\"A\00\00\00\00\00\00\"a\00\00\00\00\00\00h\08\00\00\00\00\00\00h\00\00\00\00\00\00\00\a8\08\00\00\00\00\00\00\a8\00\00\00\00\00\00\00(\t\00\00\00\00\00\00(\01\00\00\00\00\00\00(\n\00\00\00\00\00\00(\02\00\00\00\00\00\00(\19\00\00\00\00\00\00(\1a\00\00\00\00\00\00(\04\00\00\00\00\00\00(A\00\00\00\00\00\00(a\00\00\00\00\00\00p\08\08\00\00\00\00\00\b0\08\14\00\00\00\00\000\t\12\00\00\00\00\000\n\11\00\00\00\00\000\84\10\00\00\00\00\00p\08\82\00\00\00\00\00p\08\c2\00\00\00\00\000\c1\10\00\00\00\00\000\e1\10\00\00\00\00\000a\c2\00\00\00\00\000\t2\00\00\00\00\00 \00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\02A\00\00\00\00\00\00 \00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\08A\00\00\00\00\00\00 \00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\10\t\82\00\00\00\00\00\00\00\00\00\00\00\00\00\10A\12\00\00\00\00\00 \00\00\00\00\00\00\00 \00\00\00\00\00\00\00")
  (table $0 1 funcref)
- (global $rt/flags/VALUE_ALIGN_REF i32 (i32.const 128))
- (global $rt/flags/KEY_ALIGN_REF i32 (i32.const 65536))
+ (global $rt/flags/VALUE_ALIGN_REF i32 (i32.const 256))
+ (global $rt/flags/KEY_ALIGN_REF i32 (i32.const 131072))
  (global $~lib/rt/__rtti_base i32 (i32.const 176))
  (export "memory" (memory $0))
  (start $~start)
- (func $~lib/rt/__typeinfo (; 1 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/__typeinfo (param $0 i32) (result i32)
   (local $1 i32)
   global.get $~lib/rt/__rtti_base
   local.set $1
@@ -40,7 +40,7 @@
   i32.add
   i32.load
  )
- (func $rt/flags/test<~lib/typedarray/Int8Array> (; 2 ;) (param $0 i32)
+ (func $rt/flags/test<~lib/typedarray/Int8Array> (param $0 i32)
   i32.const 3
   call $~lib/rt/__typeinfo
   local.get $0
@@ -55,7 +55,7 @@
    unreachable
   end
  )
- (func $rt/flags/test<~lib/typedarray/Uint8Array> (; 3 ;) (param $0 i32)
+ (func $rt/flags/test<~lib/typedarray/Uint8Array> (param $0 i32)
   i32.const 4
   call $~lib/rt/__typeinfo
   local.get $0
@@ -70,7 +70,7 @@
    unreachable
   end
  )
- (func $rt/flags/test<~lib/typedarray/Uint8ClampedArray> (; 4 ;) (param $0 i32)
+ (func $rt/flags/test<~lib/typedarray/Uint8ClampedArray> (param $0 i32)
   i32.const 5
   call $~lib/rt/__typeinfo
   local.get $0
@@ -85,7 +85,7 @@
    unreachable
   end
  )
- (func $rt/flags/test<~lib/typedarray/Int16Array> (; 5 ;) (param $0 i32)
+ (func $rt/flags/test<~lib/typedarray/Int16Array> (param $0 i32)
   i32.const 6
   call $~lib/rt/__typeinfo
   local.get $0
@@ -100,7 +100,7 @@
    unreachable
   end
  )
- (func $rt/flags/test<~lib/typedarray/Uint16Array> (; 6 ;) (param $0 i32)
+ (func $rt/flags/test<~lib/typedarray/Uint16Array> (param $0 i32)
   i32.const 7
   call $~lib/rt/__typeinfo
   local.get $0
@@ -115,7 +115,7 @@
    unreachable
   end
  )
- (func $rt/flags/test<~lib/typedarray/Int32Array> (; 7 ;) (param $0 i32)
+ (func $rt/flags/test<~lib/typedarray/Int32Array> (param $0 i32)
   i32.const 8
   call $~lib/rt/__typeinfo
   local.get $0
@@ -130,7 +130,7 @@
    unreachable
   end
  )
- (func $rt/flags/test<~lib/typedarray/Uint32Array> (; 8 ;) (param $0 i32)
+ (func $rt/flags/test<~lib/typedarray/Uint32Array> (param $0 i32)
   i32.const 9
   call $~lib/rt/__typeinfo
   local.get $0
@@ -145,7 +145,7 @@
    unreachable
   end
  )
- (func $rt/flags/test<~lib/typedarray/Int64Array> (; 9 ;) (param $0 i32)
+ (func $rt/flags/test<~lib/typedarray/Int64Array> (param $0 i32)
   i32.const 10
   call $~lib/rt/__typeinfo
   local.get $0
@@ -160,7 +160,7 @@
    unreachable
   end
  )
- (func $rt/flags/test<~lib/typedarray/Uint64Array> (; 10 ;) (param $0 i32)
+ (func $rt/flags/test<~lib/typedarray/Uint64Array> (param $0 i32)
   i32.const 11
   call $~lib/rt/__typeinfo
   local.get $0
@@ -175,7 +175,7 @@
    unreachable
   end
  )
- (func $rt/flags/test<~lib/typedarray/Float32Array> (; 11 ;) (param $0 i32)
+ (func $rt/flags/test<~lib/typedarray/Float32Array> (param $0 i32)
   i32.const 12
   call $~lib/rt/__typeinfo
   local.get $0
@@ -190,7 +190,7 @@
    unreachable
   end
  )
- (func $rt/flags/test<~lib/typedarray/Float64Array> (; 12 ;) (param $0 i32)
+ (func $rt/flags/test<~lib/typedarray/Float64Array> (param $0 i32)
   i32.const 13
   call $~lib/rt/__typeinfo
   local.get $0
@@ -205,7 +205,7 @@
    unreachable
   end
  )
- (func $rt/flags/test<~lib/array/Array<i8>> (; 13 ;) (param $0 i32)
+ (func $rt/flags/test<~lib/array/Array<i8>> (param $0 i32)
   i32.const 14
   call $~lib/rt/__typeinfo
   local.get $0
@@ -220,7 +220,7 @@
    unreachable
   end
  )
- (func $rt/flags/test<~lib/array/Array<u8>> (; 14 ;) (param $0 i32)
+ (func $rt/flags/test<~lib/array/Array<u8>> (param $0 i32)
   i32.const 15
   call $~lib/rt/__typeinfo
   local.get $0
@@ -235,7 +235,7 @@
    unreachable
   end
  )
- (func $rt/flags/test<~lib/array/Array<i16>> (; 15 ;) (param $0 i32)
+ (func $rt/flags/test<~lib/array/Array<i16>> (param $0 i32)
   i32.const 16
   call $~lib/rt/__typeinfo
   local.get $0
@@ -250,7 +250,7 @@
    unreachable
   end
  )
- (func $rt/flags/test<~lib/array/Array<u16>> (; 16 ;) (param $0 i32)
+ (func $rt/flags/test<~lib/array/Array<u16>> (param $0 i32)
   i32.const 17
   call $~lib/rt/__typeinfo
   local.get $0
@@ -265,7 +265,7 @@
    unreachable
   end
  )
- (func $rt/flags/test<~lib/array/Array<i32>> (; 17 ;) (param $0 i32)
+ (func $rt/flags/test<~lib/array/Array<i32>> (param $0 i32)
   i32.const 18
   call $~lib/rt/__typeinfo
   local.get $0
@@ -280,7 +280,7 @@
    unreachable
   end
  )
- (func $rt/flags/test<~lib/array/Array<u32>> (; 18 ;) (param $0 i32)
+ (func $rt/flags/test<~lib/array/Array<u32>> (param $0 i32)
   i32.const 19
   call $~lib/rt/__typeinfo
   local.get $0
@@ -295,7 +295,7 @@
    unreachable
   end
  )
- (func $rt/flags/test<~lib/array/Array<i64>> (; 19 ;) (param $0 i32)
+ (func $rt/flags/test<~lib/array/Array<i64>> (param $0 i32)
   i32.const 20
   call $~lib/rt/__typeinfo
   local.get $0
@@ -310,7 +310,7 @@
    unreachable
   end
  )
- (func $rt/flags/test<~lib/array/Array<u64>> (; 20 ;) (param $0 i32)
+ (func $rt/flags/test<~lib/array/Array<u64>> (param $0 i32)
   i32.const 21
   call $~lib/rt/__typeinfo
   local.get $0
@@ -325,7 +325,7 @@
    unreachable
   end
  )
- (func $rt/flags/test<~lib/array/Array<f32>> (; 21 ;) (param $0 i32)
+ (func $rt/flags/test<~lib/array/Array<f32>> (param $0 i32)
   i32.const 22
   call $~lib/rt/__typeinfo
   local.get $0
@@ -340,7 +340,7 @@
    unreachable
   end
  )
- (func $rt/flags/test<~lib/array/Array<f64>> (; 22 ;) (param $0 i32)
+ (func $rt/flags/test<~lib/array/Array<f64>> (param $0 i32)
   i32.const 23
   call $~lib/rt/__typeinfo
   local.get $0
@@ -355,7 +355,7 @@
    unreachable
   end
  )
- (func $rt/flags/test<~lib/array/Array<v128>> (; 23 ;) (param $0 i32)
+ (func $rt/flags/test<~lib/array/Array<v128>> (param $0 i32)
   i32.const 24
   call $~lib/rt/__typeinfo
   local.get $0
@@ -370,7 +370,7 @@
    unreachable
   end
  )
- (func $rt/flags/test<~lib/array/Array<rt/flags/Ref>> (; 24 ;) (param $0 i32)
+ (func $rt/flags/test<~lib/array/Array<rt/flags/Ref>> (param $0 i32)
   i32.const 26
   call $~lib/rt/__typeinfo
   local.get $0
@@ -385,7 +385,7 @@
    unreachable
   end
  )
- (func $rt/flags/test<~lib/array/Array<rt/flags/Ref | null>> (; 25 ;) (param $0 i32)
+ (func $rt/flags/test<~lib/array/Array<rt/flags/Ref | null>> (param $0 i32)
   i32.const 27
   call $~lib/rt/__typeinfo
   local.get $0
@@ -400,7 +400,7 @@
    unreachable
   end
  )
- (func $rt/flags/test<~lib/set/Set<i8>> (; 26 ;) (param $0 i32)
+ (func $rt/flags/test<~lib/set/Set<i8>> (param $0 i32)
   i32.const 28
   call $~lib/rt/__typeinfo
   local.get $0
@@ -415,7 +415,7 @@
    unreachable
   end
  )
- (func $rt/flags/test<~lib/set/Set<u8>> (; 27 ;) (param $0 i32)
+ (func $rt/flags/test<~lib/set/Set<u8>> (param $0 i32)
   i32.const 29
   call $~lib/rt/__typeinfo
   local.get $0
@@ -430,7 +430,7 @@
    unreachable
   end
  )
- (func $rt/flags/test<~lib/set/Set<i16>> (; 28 ;) (param $0 i32)
+ (func $rt/flags/test<~lib/set/Set<i16>> (param $0 i32)
   i32.const 30
   call $~lib/rt/__typeinfo
   local.get $0
@@ -445,7 +445,7 @@
    unreachable
   end
  )
- (func $rt/flags/test<~lib/set/Set<u16>> (; 29 ;) (param $0 i32)
+ (func $rt/flags/test<~lib/set/Set<u16>> (param $0 i32)
   i32.const 31
   call $~lib/rt/__typeinfo
   local.get $0
@@ -460,7 +460,7 @@
    unreachable
   end
  )
- (func $rt/flags/test<~lib/set/Set<i32>> (; 30 ;) (param $0 i32)
+ (func $rt/flags/test<~lib/set/Set<i32>> (param $0 i32)
   i32.const 32
   call $~lib/rt/__typeinfo
   local.get $0
@@ -475,7 +475,7 @@
    unreachable
   end
  )
- (func $rt/flags/test<~lib/set/Set<u32>> (; 31 ;) (param $0 i32)
+ (func $rt/flags/test<~lib/set/Set<u32>> (param $0 i32)
   i32.const 33
   call $~lib/rt/__typeinfo
   local.get $0
@@ -490,7 +490,7 @@
    unreachable
   end
  )
- (func $rt/flags/test<~lib/set/Set<i64>> (; 32 ;) (param $0 i32)
+ (func $rt/flags/test<~lib/set/Set<i64>> (param $0 i32)
   i32.const 34
   call $~lib/rt/__typeinfo
   local.get $0
@@ -505,7 +505,7 @@
    unreachable
   end
  )
- (func $rt/flags/test<~lib/set/Set<u64>> (; 33 ;) (param $0 i32)
+ (func $rt/flags/test<~lib/set/Set<u64>> (param $0 i32)
   i32.const 35
   call $~lib/rt/__typeinfo
   local.get $0
@@ -520,7 +520,7 @@
    unreachable
   end
  )
- (func $rt/flags/test<~lib/set/Set<f32>> (; 34 ;) (param $0 i32)
+ (func $rt/flags/test<~lib/set/Set<f32>> (param $0 i32)
   i32.const 36
   call $~lib/rt/__typeinfo
   local.get $0
@@ -535,7 +535,7 @@
    unreachable
   end
  )
- (func $rt/flags/test<~lib/set/Set<f64>> (; 35 ;) (param $0 i32)
+ (func $rt/flags/test<~lib/set/Set<f64>> (param $0 i32)
   i32.const 37
   call $~lib/rt/__typeinfo
   local.get $0
@@ -550,7 +550,7 @@
    unreachable
   end
  )
- (func $rt/flags/test<~lib/set/Set<v128>> (; 36 ;) (param $0 i32)
+ (func $rt/flags/test<~lib/set/Set<v128>> (param $0 i32)
   i32.const 38
   call $~lib/rt/__typeinfo
   local.get $0
@@ -565,7 +565,7 @@
    unreachable
   end
  )
- (func $rt/flags/test<~lib/set/Set<rt/flags/Ref>> (; 37 ;) (param $0 i32)
+ (func $rt/flags/test<~lib/set/Set<rt/flags/Ref>> (param $0 i32)
   i32.const 39
   call $~lib/rt/__typeinfo
   local.get $0
@@ -580,7 +580,7 @@
    unreachable
   end
  )
- (func $rt/flags/test<~lib/set/Set<rt/flags/Ref | null>> (; 38 ;) (param $0 i32)
+ (func $rt/flags/test<~lib/set/Set<rt/flags/Ref | null>> (param $0 i32)
   i32.const 40
   call $~lib/rt/__typeinfo
   local.get $0
@@ -595,7 +595,7 @@
    unreachable
   end
  )
- (func $rt/flags/test<~lib/map/Map<v128,i8>> (; 39 ;) (param $0 i32)
+ (func $rt/flags/test<~lib/map/Map<v128,i8>> (param $0 i32)
   i32.const 41
   call $~lib/rt/__typeinfo
   local.get $0
@@ -610,7 +610,7 @@
    unreachable
   end
  )
- (func $rt/flags/test<~lib/map/Map<i64,i16>> (; 40 ;) (param $0 i32)
+ (func $rt/flags/test<~lib/map/Map<i64,i16>> (param $0 i32)
   i32.const 42
   call $~lib/rt/__typeinfo
   local.get $0
@@ -625,7 +625,7 @@
    unreachable
   end
  )
- (func $rt/flags/test<~lib/map/Map<i32,i32>> (; 41 ;) (param $0 i32)
+ (func $rt/flags/test<~lib/map/Map<i32,i32>> (param $0 i32)
   i32.const 43
   call $~lib/rt/__typeinfo
   local.get $0
@@ -640,7 +640,7 @@
    unreachable
   end
  )
- (func $rt/flags/test<~lib/map/Map<i16,i64>> (; 42 ;) (param $0 i32)
+ (func $rt/flags/test<~lib/map/Map<i16,i64>> (param $0 i32)
   i32.const 44
   call $~lib/rt/__typeinfo
   local.get $0
@@ -655,7 +655,7 @@
    unreachable
   end
  )
- (func $rt/flags/test<~lib/map/Map<i8,v128>> (; 43 ;) (param $0 i32)
+ (func $rt/flags/test<~lib/map/Map<i8,v128>> (param $0 i32)
   i32.const 45
   call $~lib/rt/__typeinfo
   local.get $0
@@ -670,7 +670,7 @@
    unreachable
   end
  )
- (func $rt/flags/test<~lib/map/Map<rt/flags/Ref,i8>> (; 44 ;) (param $0 i32)
+ (func $rt/flags/test<~lib/map/Map<rt/flags/Ref,i8>> (param $0 i32)
   i32.const 46
   call $~lib/rt/__typeinfo
   local.get $0
@@ -685,7 +685,7 @@
    unreachable
   end
  )
- (func $rt/flags/test<~lib/map/Map<rt/flags/Ref | null,i8>> (; 45 ;) (param $0 i32)
+ (func $rt/flags/test<~lib/map/Map<rt/flags/Ref | null,i8>> (param $0 i32)
   i32.const 47
   call $~lib/rt/__typeinfo
   local.get $0
@@ -700,7 +700,7 @@
    unreachable
   end
  )
- (func $rt/flags/test<~lib/map/Map<i8,rt/flags/Ref>> (; 46 ;) (param $0 i32)
+ (func $rt/flags/test<~lib/map/Map<i8,rt/flags/Ref>> (param $0 i32)
   i32.const 48
   call $~lib/rt/__typeinfo
   local.get $0
@@ -715,7 +715,7 @@
    unreachable
   end
  )
- (func $rt/flags/test<~lib/map/Map<i8,rt/flags/Ref | null>> (; 47 ;) (param $0 i32)
+ (func $rt/flags/test<~lib/map/Map<i8,rt/flags/Ref | null>> (param $0 i32)
   i32.const 49
   call $~lib/rt/__typeinfo
   local.get $0
@@ -730,7 +730,7 @@
    unreachable
   end
  )
- (func $rt/flags/test<~lib/map/Map<rt/flags/Ref | null,rt/flags/Ref | null>> (; 48 ;) (param $0 i32)
+ (func $rt/flags/test<~lib/map/Map<rt/flags/Ref | null,rt/flags/Ref | null>> (param $0 i32)
   i32.const 50
   call $~lib/rt/__typeinfo
   local.get $0
@@ -745,7 +745,7 @@
    unreachable
   end
  )
- (func $rt/flags/test<~lib/map/Map<f32,i32>> (; 49 ;) (param $0 i32)
+ (func $rt/flags/test<~lib/map/Map<f32,i32>> (param $0 i32)
   i32.const 51
   call $~lib/rt/__typeinfo
   local.get $0
@@ -760,7 +760,7 @@
    unreachable
   end
  )
- (func $rt/flags/test<rt/flags/NoCycle> (; 50 ;) (param $0 i32)
+ (func $rt/flags/test<rt/flags/NoCycle> (param $0 i32)
   i32.const 52
   call $~lib/rt/__typeinfo
   local.get $0
@@ -775,7 +775,7 @@
    unreachable
   end
  )
- (func $rt/flags/test<rt/flags/DirectCycle> (; 51 ;) (param $0 i32)
+ (func $rt/flags/test<rt/flags/DirectCycle> (param $0 i32)
   i32.const 53
   call $~lib/rt/__typeinfo
   local.get $0
@@ -790,7 +790,7 @@
    unreachable
   end
  )
- (func $rt/flags/test<rt/flags/IndirectCycle> (; 52 ;) (param $0 i32)
+ (func $rt/flags/test<rt/flags/IndirectCycle> (param $0 i32)
   i32.const 54
   call $~lib/rt/__typeinfo
   local.get $0
@@ -805,7 +805,7 @@
    unreachable
   end
  )
- (func $rt/flags/test<rt/flags/IndirectCycleArray> (; 53 ;) (param $0 i32)
+ (func $rt/flags/test<rt/flags/IndirectCycleArray> (param $0 i32)
   i32.const 56
   call $~lib/rt/__typeinfo
   local.get $0
@@ -820,7 +820,7 @@
    unreachable
   end
  )
- (func $rt/flags/test<rt/flags/InnerCycleArray> (; 54 ;) (param $0 i32)
+ (func $rt/flags/test<rt/flags/InnerCycleArray> (param $0 i32)
   i32.const 58
   call $~lib/rt/__typeinfo
   local.get $0
@@ -835,7 +835,7 @@
    unreachable
   end
  )
- (func $rt/flags/test<rt/flags/IndirectCycleSet> (; 55 ;) (param $0 i32)
+ (func $rt/flags/test<rt/flags/IndirectCycleSet> (param $0 i32)
   i32.const 59
   call $~lib/rt/__typeinfo
   local.get $0
@@ -850,7 +850,7 @@
    unreachable
   end
  )
- (func $rt/flags/test<rt/flags/InnerCycleSet> (; 56 ;) (param $0 i32)
+ (func $rt/flags/test<rt/flags/InnerCycleSet> (param $0 i32)
   i32.const 61
   call $~lib/rt/__typeinfo
   local.get $0
@@ -865,7 +865,7 @@
    unreachable
   end
  )
- (func $rt/flags/test<rt/flags/IndirectCycleMapKey> (; 57 ;) (param $0 i32)
+ (func $rt/flags/test<rt/flags/IndirectCycleMapKey> (param $0 i32)
   i32.const 62
   call $~lib/rt/__typeinfo
   local.get $0
@@ -880,7 +880,7 @@
    unreachable
   end
  )
- (func $rt/flags/test<rt/flags/IndirectCycleMapValue> (; 58 ;) (param $0 i32)
+ (func $rt/flags/test<rt/flags/IndirectCycleMapValue> (param $0 i32)
   i32.const 64
   call $~lib/rt/__typeinfo
   local.get $0
@@ -895,7 +895,7 @@
    unreachable
   end
  )
- (func $rt/flags/test<rt/flags/InnerCycleMapKey> (; 59 ;) (param $0 i32)
+ (func $rt/flags/test<rt/flags/InnerCycleMapKey> (param $0 i32)
   i32.const 66
   call $~lib/rt/__typeinfo
   local.get $0
@@ -910,7 +910,7 @@
    unreachable
   end
  )
- (func $rt/flags/test<rt/flags/InnerCycleMapValue> (; 60 ;) (param $0 i32)
+ (func $rt/flags/test<rt/flags/InnerCycleMapValue> (param $0 i32)
   i32.const 67
   call $~lib/rt/__typeinfo
   local.get $0
@@ -925,428 +925,428 @@
    unreachable
   end
  )
- (func $start:rt/flags (; 61 ;)
+ (func $start:rt/flags
   i32.const 1
-  i32.const 16
-  i32.or
   i32.const 32
   i32.or
-  i32.const 1024
+  i32.const 64
+  i32.or
+  i32.const 2048
   i32.or
   call $rt/flags/test<~lib/typedarray/Int8Array>
   i32.const 1
-  i32.const 16
-  i32.or
   i32.const 32
+  i32.or
+  i32.const 64
   i32.or
   call $rt/flags/test<~lib/typedarray/Uint8Array>
   i32.const 1
-  i32.const 16
-  i32.or
   i32.const 32
+  i32.or
+  i32.const 64
   i32.or
   call $rt/flags/test<~lib/typedarray/Uint8ClampedArray>
   i32.const 1
-  i32.const 16
+  i32.const 32
   i32.or
-  i32.const 64
+  i32.const 128
   i32.or
-  i32.const 1024
+  i32.const 2048
   i32.or
   call $rt/flags/test<~lib/typedarray/Int16Array>
   i32.const 1
-  i32.const 16
+  i32.const 32
   i32.or
-  i32.const 64
+  i32.const 128
   i32.or
   call $rt/flags/test<~lib/typedarray/Uint16Array>
   i32.const 1
-  i32.const 16
+  i32.const 32
   i32.or
-  i32.const 128
+  i32.const 256
   i32.or
-  i32.const 1024
+  i32.const 2048
   i32.or
   call $rt/flags/test<~lib/typedarray/Int32Array>
   i32.const 1
-  i32.const 16
+  i32.const 32
   i32.or
-  i32.const 128
+  i32.const 256
   i32.or
   call $rt/flags/test<~lib/typedarray/Uint32Array>
   i32.const 1
-  i32.const 16
+  i32.const 32
   i32.or
-  i32.const 256
+  i32.const 512
   i32.or
-  i32.const 1024
+  i32.const 2048
   i32.or
   call $rt/flags/test<~lib/typedarray/Int64Array>
   i32.const 1
-  i32.const 16
+  i32.const 32
   i32.or
-  i32.const 256
+  i32.const 512
   i32.or
   call $rt/flags/test<~lib/typedarray/Uint64Array>
   i32.const 1
-  i32.const 16
+  i32.const 32
   i32.or
-  i32.const 128
-  i32.or
-  i32.const 1024
+  i32.const 256
   i32.or
   i32.const 2048
+  i32.or
+  i32.const 4096
   i32.or
   call $rt/flags/test<~lib/typedarray/Float32Array>
   i32.const 1
-  i32.const 16
+  i32.const 32
   i32.or
-  i32.const 256
-  i32.or
-  i32.const 1024
+  i32.const 512
   i32.or
   i32.const 2048
+  i32.or
+  i32.const 4096
   i32.or
   call $rt/flags/test<~lib/typedarray/Float64Array>
   i32.const 2
-  i32.const 16
-  i32.or
   i32.const 32
   i32.or
-  i32.const 1024
+  i32.const 64
+  i32.or
+  i32.const 2048
   i32.or
   call $rt/flags/test<~lib/array/Array<i8>>
   i32.const 2
-  i32.const 16
-  i32.or
   i32.const 32
+  i32.or
+  i32.const 64
   i32.or
   call $rt/flags/test<~lib/array/Array<u8>>
   i32.const 2
-  i32.const 16
+  i32.const 32
   i32.or
-  i32.const 64
+  i32.const 128
   i32.or
-  i32.const 1024
+  i32.const 2048
   i32.or
   call $rt/flags/test<~lib/array/Array<i16>>
   i32.const 2
-  i32.const 16
+  i32.const 32
   i32.or
-  i32.const 64
+  i32.const 128
   i32.or
   call $rt/flags/test<~lib/array/Array<u16>>
   i32.const 2
-  i32.const 16
+  i32.const 32
   i32.or
-  i32.const 128
+  i32.const 256
   i32.or
-  i32.const 1024
+  i32.const 2048
   i32.or
   call $rt/flags/test<~lib/array/Array<i32>>
   i32.const 2
-  i32.const 16
+  i32.const 32
   i32.or
-  i32.const 128
+  i32.const 256
   i32.or
   call $rt/flags/test<~lib/array/Array<u32>>
   i32.const 2
-  i32.const 16
+  i32.const 32
   i32.or
-  i32.const 256
+  i32.const 512
   i32.or
-  i32.const 1024
+  i32.const 2048
   i32.or
   call $rt/flags/test<~lib/array/Array<i64>>
   i32.const 2
-  i32.const 16
+  i32.const 32
   i32.or
-  i32.const 256
+  i32.const 512
   i32.or
   call $rt/flags/test<~lib/array/Array<u64>>
   i32.const 2
-  i32.const 16
+  i32.const 32
   i32.or
-  i32.const 128
-  i32.or
-  i32.const 1024
+  i32.const 256
   i32.or
   i32.const 2048
+  i32.or
+  i32.const 4096
   i32.or
   call $rt/flags/test<~lib/array/Array<f32>>
   i32.const 2
-  i32.const 16
+  i32.const 32
   i32.or
-  i32.const 256
-  i32.or
-  i32.const 1024
+  i32.const 512
   i32.or
   i32.const 2048
+  i32.or
+  i32.const 4096
   i32.or
   call $rt/flags/test<~lib/array/Array<f64>>
   i32.const 2
-  i32.const 16
+  i32.const 32
   i32.or
-  i32.const 512
+  i32.const 1024
   i32.or
   call $rt/flags/test<~lib/array/Array<v128>>
   i32.const 2
-  i32.const 16
+  i32.const 32
   i32.or
   global.get $rt/flags/VALUE_ALIGN_REF
   i32.or
-  i32.const 8192
+  i32.const 16384
   i32.or
   call $rt/flags/test<~lib/array/Array<rt/flags/Ref>>
   i32.const 2
-  i32.const 16
+  i32.const 32
   i32.or
   global.get $rt/flags/VALUE_ALIGN_REF
   i32.or
-  i32.const 4096
-  i32.or
   i32.const 8192
+  i32.or
+  i32.const 16384
   i32.or
   call $rt/flags/test<~lib/array/Array<rt/flags/Ref | null>>
-  i32.const 4
-  i32.const 16
-  i32.or
+  i32.const 8
   i32.const 32
   i32.or
-  i32.const 1024
+  i32.const 64
+  i32.or
+  i32.const 2048
   i32.or
   call $rt/flags/test<~lib/set/Set<i8>>
-  i32.const 4
-  i32.const 16
-  i32.or
+  i32.const 8
   i32.const 32
+  i32.or
+  i32.const 64
   i32.or
   call $rt/flags/test<~lib/set/Set<u8>>
-  i32.const 4
-  i32.const 16
+  i32.const 8
+  i32.const 32
   i32.or
-  i32.const 64
+  i32.const 128
   i32.or
-  i32.const 1024
+  i32.const 2048
   i32.or
   call $rt/flags/test<~lib/set/Set<i16>>
-  i32.const 4
-  i32.const 16
+  i32.const 8
+  i32.const 32
   i32.or
-  i32.const 64
+  i32.const 128
   i32.or
   call $rt/flags/test<~lib/set/Set<u16>>
-  i32.const 4
-  i32.const 16
+  i32.const 8
+  i32.const 32
   i32.or
-  i32.const 128
+  i32.const 256
   i32.or
-  i32.const 1024
+  i32.const 2048
   i32.or
   call $rt/flags/test<~lib/set/Set<i32>>
-  i32.const 4
-  i32.const 16
+  i32.const 8
+  i32.const 32
   i32.or
-  i32.const 128
+  i32.const 256
   i32.or
   call $rt/flags/test<~lib/set/Set<u32>>
-  i32.const 4
-  i32.const 16
-  i32.or
-  i32.const 256
-  i32.or
-  i32.const 1024
-  i32.or
-  call $rt/flags/test<~lib/set/Set<i64>>
-  i32.const 4
-  i32.const 16
-  i32.or
-  i32.const 256
-  i32.or
-  call $rt/flags/test<~lib/set/Set<u64>>
-  i32.const 4
-  i32.const 16
-  i32.or
-  i32.const 128
-  i32.or
-  i32.const 1024
-  i32.or
-  i32.const 2048
-  i32.or
-  call $rt/flags/test<~lib/set/Set<f32>>
-  i32.const 4
-  i32.const 16
-  i32.or
-  i32.const 256
-  i32.or
-  i32.const 1024
-  i32.or
-  i32.const 2048
-  i32.or
-  call $rt/flags/test<~lib/set/Set<f64>>
-  i32.const 4
-  i32.const 16
+  i32.const 8
+  i32.const 32
   i32.or
   i32.const 512
   i32.or
-  call $rt/flags/test<~lib/set/Set<v128>>
-  i32.const 4
-  i32.const 16
+  i32.const 2048
   i32.or
-  global.get $rt/flags/VALUE_ALIGN_REF
+  call $rt/flags/test<~lib/set/Set<i64>>
+  i32.const 8
+  i32.const 32
   i32.or
-  i32.const 8192
+  i32.const 512
   i32.or
-  call $rt/flags/test<~lib/set/Set<rt/flags/Ref>>
-  i32.const 4
-  i32.const 16
+  call $rt/flags/test<~lib/set/Set<u64>>
+  i32.const 8
+  i32.const 32
   i32.or
-  global.get $rt/flags/VALUE_ALIGN_REF
+  i32.const 256
+  i32.or
+  i32.const 2048
   i32.or
   i32.const 4096
   i32.or
-  i32.const 8192
-  i32.or
-  call $rt/flags/test<~lib/set/Set<rt/flags/Ref | null>>
+  call $rt/flags/test<~lib/set/Set<f32>>
   i32.const 8
-  i32.const 16
+  i32.const 32
   i32.or
-  i32.const 262144
+  i32.const 512
   i32.or
+  i32.const 2048
+  i32.or
+  i32.const 4096
+  i32.or
+  call $rt/flags/test<~lib/set/Set<f64>>
+  i32.const 8
   i32.const 32
   i32.or
   i32.const 1024
   i32.or
-  call $rt/flags/test<~lib/map/Map<v128,i8>>
+  call $rt/flags/test<~lib/set/Set<v128>>
   i32.const 8
-  i32.const 16
+  i32.const 32
   i32.or
-  i32.const 131072
+  global.get $rt/flags/VALUE_ALIGN_REF
+  i32.or
+  i32.const 16384
+  i32.or
+  call $rt/flags/test<~lib/set/Set<rt/flags/Ref>>
+  i32.const 8
+  i32.const 32
+  i32.or
+  global.get $rt/flags/VALUE_ALIGN_REF
+  i32.or
+  i32.const 8192
+  i32.or
+  i32.const 16384
+  i32.or
+  call $rt/flags/test<~lib/set/Set<rt/flags/Ref | null>>
+  i32.const 16
+  i32.const 32
   i32.or
   i32.const 524288
   i32.or
   i32.const 64
   i32.or
-  i32.const 1024
+  i32.const 2048
   i32.or
-  call $rt/flags/test<~lib/map/Map<i64,i16>>
-  i32.const 8
+  call $rt/flags/test<~lib/map/Map<v128,i8>>
   i32.const 16
-  i32.or
-  i32.const 65536
-  i32.or
-  i32.const 524288
-  i32.or
-  i32.const 128
-  i32.or
-  i32.const 1024
-  i32.or
-  call $rt/flags/test<~lib/map/Map<i32,i32>>
-  i32.const 8
-  i32.const 16
-  i32.or
-  i32.const 32768
-  i32.or
-  i32.const 524288
-  i32.or
-  i32.const 256
-  i32.or
-  i32.const 1024
-  i32.or
-  call $rt/flags/test<~lib/map/Map<i16,i64>>
-  i32.const 8
-  i32.const 16
-  i32.or
-  i32.const 16384
-  i32.or
-  i32.const 524288
-  i32.or
-  i32.const 512
-  i32.or
-  call $rt/flags/test<~lib/map/Map<i8,v128>>
-  i32.const 8
-  i32.const 16
-  i32.or
-  global.get $rt/flags/KEY_ALIGN_REF
-  i32.or
-  i32.const 4194304
-  i32.or
   i32.const 32
   i32.or
-  i32.const 1024
-  i32.or
-  call $rt/flags/test<~lib/map/Map<rt/flags/Ref,i8>>
-  i32.const 8
-  i32.const 16
-  i32.or
-  global.get $rt/flags/KEY_ALIGN_REF
-  i32.or
-  i32.const 2097152
-  i32.or
-  i32.const 4194304
-  i32.or
-  i32.const 32
-  i32.or
-  i32.const 1024
-  i32.or
-  call $rt/flags/test<~lib/map/Map<rt/flags/Ref | null,i8>>
-  i32.const 8
-  i32.const 16
-  i32.or
-  i32.const 16384
-  i32.or
-  i32.const 524288
-  i32.or
-  i32.const 8192
-  i32.or
-  global.get $rt/flags/VALUE_ALIGN_REF
-  i32.or
-  call $rt/flags/test<~lib/map/Map<i8,rt/flags/Ref>>
-  i32.const 8
-  i32.const 16
-  i32.or
-  i32.const 16384
-  i32.or
-  i32.const 524288
-  i32.or
-  i32.const 4096
-  i32.or
-  i32.const 8192
-  i32.or
-  global.get $rt/flags/VALUE_ALIGN_REF
-  i32.or
-  call $rt/flags/test<~lib/map/Map<i8,rt/flags/Ref | null>>
-  i32.const 8
-  i32.const 16
-  i32.or
-  i32.const 2097152
-  i32.or
-  i32.const 4194304
-  i32.or
-  global.get $rt/flags/KEY_ALIGN_REF
-  i32.or
-  i32.const 4096
-  i32.or
-  i32.const 8192
-  i32.or
-  global.get $rt/flags/VALUE_ALIGN_REF
-  i32.or
-  call $rt/flags/test<~lib/map/Map<rt/flags/Ref | null,rt/flags/Ref | null>>
-  i32.const 8
-  i32.const 16
-  i32.or
-  i32.const 65536
-  i32.or
-  i32.const 524288
+  i32.const 262144
   i32.or
   i32.const 1048576
   i32.or
   i32.const 128
   i32.or
+  i32.const 2048
+  i32.or
+  call $rt/flags/test<~lib/map/Map<i64,i16>>
+  i32.const 16
+  i32.const 32
+  i32.or
+  i32.const 131072
+  i32.or
+  i32.const 1048576
+  i32.or
+  i32.const 256
+  i32.or
+  i32.const 2048
+  i32.or
+  call $rt/flags/test<~lib/map/Map<i32,i32>>
+  i32.const 16
+  i32.const 32
+  i32.or
+  i32.const 65536
+  i32.or
+  i32.const 1048576
+  i32.or
+  i32.const 512
+  i32.or
+  i32.const 2048
+  i32.or
+  call $rt/flags/test<~lib/map/Map<i16,i64>>
+  i32.const 16
+  i32.const 32
+  i32.or
+  i32.const 32768
+  i32.or
+  i32.const 1048576
+  i32.or
   i32.const 1024
   i32.or
-  call $rt/flags/test<~lib/map/Map<f32,i32>>
+  call $rt/flags/test<~lib/map/Map<i8,v128>>
   i32.const 16
+  i32.const 32
+  i32.or
+  global.get $rt/flags/KEY_ALIGN_REF
+  i32.or
+  i32.const 8388608
+  i32.or
+  i32.const 64
+  i32.or
+  i32.const 2048
+  i32.or
+  call $rt/flags/test<~lib/map/Map<rt/flags/Ref,i8>>
+  i32.const 16
+  i32.const 32
+  i32.or
+  global.get $rt/flags/KEY_ALIGN_REF
+  i32.or
+  i32.const 4194304
+  i32.or
+  i32.const 8388608
+  i32.or
+  i32.const 64
+  i32.or
+  i32.const 2048
+  i32.or
+  call $rt/flags/test<~lib/map/Map<rt/flags/Ref | null,i8>>
+  i32.const 16
+  i32.const 32
+  i32.or
+  i32.const 32768
+  i32.or
+  i32.const 1048576
+  i32.or
+  i32.const 16384
+  i32.or
+  global.get $rt/flags/VALUE_ALIGN_REF
+  i32.or
+  call $rt/flags/test<~lib/map/Map<i8,rt/flags/Ref>>
+  i32.const 16
+  i32.const 32
+  i32.or
+  i32.const 32768
+  i32.or
+  i32.const 1048576
+  i32.or
+  i32.const 8192
+  i32.or
+  i32.const 16384
+  i32.or
+  global.get $rt/flags/VALUE_ALIGN_REF
+  i32.or
+  call $rt/flags/test<~lib/map/Map<i8,rt/flags/Ref | null>>
+  i32.const 16
+  i32.const 32
+  i32.or
+  i32.const 4194304
+  i32.or
+  i32.const 8388608
+  i32.or
+  global.get $rt/flags/KEY_ALIGN_REF
+  i32.or
+  i32.const 8192
+  i32.or
+  i32.const 16384
+  i32.or
+  global.get $rt/flags/VALUE_ALIGN_REF
+  i32.or
+  call $rt/flags/test<~lib/map/Map<rt/flags/Ref | null,rt/flags/Ref | null>>
+  i32.const 16
+  i32.const 32
+  i32.or
+  i32.const 131072
+  i32.or
+  i32.const 1048576
+  i32.or
+  i32.const 2097152
+  i32.or
+  i32.const 256
+  i32.or
+  i32.const 2048
+  i32.or
+  call $rt/flags/test<~lib/map/Map<f32,i32>>
+  i32.const 32
   call $rt/flags/test<rt/flags/NoCycle>
   i32.const 0
   call $rt/flags/test<rt/flags/DirectCycle>
@@ -1354,22 +1354,22 @@
   call $rt/flags/test<rt/flags/IndirectCycle>
   i32.const 0
   call $rt/flags/test<rt/flags/IndirectCycleArray>
-  i32.const 16
+  i32.const 32
   call $rt/flags/test<rt/flags/InnerCycleArray>
   i32.const 0
   call $rt/flags/test<rt/flags/IndirectCycleSet>
-  i32.const 16
+  i32.const 32
   call $rt/flags/test<rt/flags/InnerCycleSet>
   i32.const 0
   call $rt/flags/test<rt/flags/IndirectCycleMapKey>
   i32.const 0
   call $rt/flags/test<rt/flags/IndirectCycleMapValue>
-  i32.const 16
+  i32.const 32
   call $rt/flags/test<rt/flags/InnerCycleMapKey>
-  i32.const 16
+  i32.const 32
   call $rt/flags/test<rt/flags/InnerCycleMapValue>
  )
- (func $~start (; 62 ;)
+ (func $~start
   call $start:rt/flags
  )
 )

--- a/tests/compiler/rt/instanceof.optimized.wat
+++ b/tests/compiler/rt/instanceof.optimized.wat
@@ -7,7 +7,6 @@
  (memory $0 1)
  (data (i32.const 1024) " \00\00\00\01\00\00\00\01\00\00\00 \00\00\00r\00t\00/\00i\00n\00s\00t\00a\00n\00c\00e\00o\00f\00.\00t\00s")
  (data (i32.const 1072) "\06\00\00\00 \00\00\00\00\00\00\00 \00\00\00\00\00\00\00 \00\00\00\00\00\00\00 \00\00\00\00\00\00\00 \00\00\00\03\00\00\00 \00\00\00\04")
- (global $~lib/rt/stub/startOffset (mut i32) (i32.const 0))
  (global $~lib/rt/stub/offset (mut i32) (i32.const 0))
  (global $rt/instanceof/animal (mut i32) (i32.const 0))
  (global $rt/instanceof/cat (mut i32) (i32.const 0))
@@ -18,7 +17,7 @@
  (global $~started (mut i32) (i32.const 0))
  (export "_start" (func $~start))
  (export "memory" (memory $0))
- (func $~lib/rt/stub/__alloc (; 1 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/stub/__alloc (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -84,7 +83,7 @@
   i32.store offset=12
   local.get $3
  )
- (func $rt/instanceof/Animal#constructor (; 2 ;) (param $0 i32) (result i32)
+ (func $rt/instanceof/Animal#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -94,7 +93,7 @@
   end
   local.get $0
  )
- (func $rt/instanceof/Cat#constructor (; 3 ;) (param $0 i32) (result i32)
+ (func $rt/instanceof/Cat#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -105,7 +104,7 @@
   local.get $0
   call $rt/instanceof/Animal#constructor
  )
- (func $~lib/rt/__instanceof (; 4 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/__instanceof (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub
@@ -135,10 +134,8 @@
   end
   i32.const 0
  )
- (func $start:rt/instanceof (; 5 ;)
+ (func $start:rt/instanceof
   (local $0 i32)
-  i32.const 1136
-  global.set $~lib/rt/stub/startOffset
   i32.const 1136
   global.set $~lib/rt/stub/offset
   i32.const 0
@@ -402,7 +399,7 @@
    unreachable
   end
  )
- (func $~start (; 6 ;)
+ (func $~start
   global.get $~started
   if
    return

--- a/tests/compiler/rt/instanceof.untouched.wat
+++ b/tests/compiler/rt/instanceof.untouched.wat
@@ -25,7 +25,7 @@
  (global $~lib/heap/__heap_base i32 (i32.const 116))
  (export "_start" (func $~start))
  (export "memory" (memory $0))
- (func $~lib/rt/stub/maybeGrowMemory (; 1 ;) (param $0 i32)
+ (func $~lib/rt/stub/maybeGrowMemory (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -79,7 +79,7 @@
   local.get $0
   global.set $~lib/rt/stub/offset
  )
- (func $~lib/rt/stub/__alloc (; 2 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/stub/__alloc (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -132,10 +132,10 @@
   i32.store offset=12
   local.get $2
  )
- (func $~lib/rt/stub/__retain (; 3 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/stub/__retain (param $0 i32) (result i32)
   local.get $0
  )
- (func $rt/instanceof/Animal#constructor (; 4 ;) (param $0 i32) (result i32)
+ (func $rt/instanceof/Animal#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -147,7 +147,7 @@
   end
   local.get $0
  )
- (func $rt/instanceof/Cat#constructor (; 5 ;) (param $0 i32) (result i32)
+ (func $rt/instanceof/Cat#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -162,7 +162,7 @@
   local.set $0
   local.get $0
  )
- (func $rt/instanceof/BlackCat#constructor (; 6 ;) (param $0 i32) (result i32)
+ (func $rt/instanceof/BlackCat#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -177,7 +177,7 @@
   local.set $0
   local.get $0
  )
- (func $~lib/rt/__instanceof (; 7 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/__instanceof (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -217,7 +217,7 @@
   end
   i32.const 0
  )
- (func $start:rt/instanceof (; 8 ;)
+ (func $start:rt/instanceof
   (local $0 i32)
   global.get $~lib/heap/__heap_base
   i32.const 15
@@ -677,7 +677,7 @@
    unreachable
   end
  )
- (func $~start (; 9 ;)
+ (func $~start
   global.get $~started
   if
    return

--- a/tests/compiler/rt/stub-realloc.optimized.wat
+++ b/tests/compiler/rt/stub-realloc.optimized.wat
@@ -25,7 +25,7 @@
  (export "__collect" (func $~lib/rt/stub/__collect))
  (export "__reset" (func $~lib/rt/stub/__reset))
  (export "__rtti_base" (global $~lib/rt/__rtti_base))
- (func $~lib/rt/stub/maybeGrowMemory (; 1 ;) (param $0 i32)
+ (func $~lib/rt/stub/maybeGrowMemory (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -67,7 +67,7 @@
   local.get $0
   global.set $~lib/rt/stub/offset
  )
- (func $~lib/rt/stub/__alloc (; 2 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/stub/__alloc (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -112,20 +112,20 @@
   i32.store offset=12
   local.get $3
  )
- (func $~lib/rt/stub/__retain (; 3 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/stub/__retain (param $0 i32) (result i32)
   local.get $0
  )
- (func $~lib/rt/stub/__release (; 4 ;) (param $0 i32)
+ (func $~lib/rt/stub/__release (param $0 i32)
   nop
  )
- (func $~lib/rt/stub/__collect (; 5 ;)
+ (func $~lib/rt/stub/__collect
   nop
  )
- (func $~lib/rt/stub/__reset (; 6 ;)
+ (func $~lib/rt/stub/__reset
   global.get $~lib/rt/stub/startOffset
   global.set $~lib/rt/stub/offset
  )
- (func $~lib/memory/memory.copy (; 7 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/memory/memory.copy (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   block $~lib/util/memory/memmove|inlined.0
@@ -298,7 +298,7 @@
    end
   end
  )
- (func $~lib/rt/stub/__realloc (; 8 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/stub/__realloc (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -409,7 +409,7 @@
   i32.store offset=12
   local.get $0
  )
- (func $start:rt/stub-realloc (; 9 ;)
+ (func $start:rt/stub-realloc
   (local $0 i32)
   (local $1 i32)
   i32.const 10
@@ -585,7 +585,7 @@
    unreachable
   end
  )
- (func $~start (; 10 ;)
+ (func $~start
   global.get $~started
   if
    return

--- a/tests/compiler/rt/stub-realloc.untouched.wat
+++ b/tests/compiler/rt/stub-realloc.untouched.wat
@@ -28,7 +28,7 @@
  (export "__collect" (func $~lib/rt/stub/__collect))
  (export "__reset" (func $~lib/rt/stub/__reset))
  (export "__rtti_base" (global $~lib/rt/__rtti_base))
- (func $~lib/rt/stub/maybeGrowMemory (; 1 ;) (param $0 i32)
+ (func $~lib/rt/stub/maybeGrowMemory (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -82,7 +82,7 @@
   local.get $0
   global.set $~lib/rt/stub/offset
  )
- (func $~lib/rt/stub/__alloc (; 2 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/stub/__alloc (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -135,20 +135,20 @@
   i32.store offset=12
   local.get $2
  )
- (func $~lib/rt/stub/__retain (; 3 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/stub/__retain (param $0 i32) (result i32)
   local.get $0
  )
- (func $~lib/rt/stub/__release (; 4 ;) (param $0 i32)
+ (func $~lib/rt/stub/__release (param $0 i32)
   nop
  )
- (func $~lib/rt/stub/__collect (; 5 ;)
+ (func $~lib/rt/stub/__collect
   nop
  )
- (func $~lib/rt/stub/__reset (; 6 ;)
+ (func $~lib/rt/stub/__reset
   global.get $~lib/rt/stub/startOffset
   global.set $~lib/rt/stub/offset
  )
- (func $~lib/util/memory/memcpy (; 7 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/memory/memcpy (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1172,7 +1172,7 @@
    i32.store8
   end
  )
- (func $~lib/memory/memory.copy (; 8 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/memory/memory.copy (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1392,7 +1392,7 @@
    end
   end
  )
- (func $~lib/rt/stub/__realloc (; 9 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/stub/__realloc (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1515,7 +1515,7 @@
   i32.store offset=12
   local.get $0
  )
- (func $~lib/rt/stub/__free (; 10 ;) (param $0 i32)
+ (func $~lib/rt/stub/__free (param $0 i32)
   (local $1 i32)
   local.get $0
   i32.const 0
@@ -1565,7 +1565,7 @@
    global.set $~lib/rt/stub/offset
   end
  )
- (func $start:rt/stub-realloc (; 11 ;)
+ (func $start:rt/stub-realloc
   i32.const 10
   i32.const 0
   call $~lib/rt/stub/__alloc
@@ -1709,7 +1709,7 @@
    unreachable
   end
  )
- (func $~start (; 12 ;)
+ (func $~start
   global.get $~started
   if
    return

--- a/tests/compiler/runtime-full.optimized.wat
+++ b/tests/compiler/runtime-full.optimized.wat
@@ -23,7 +23,7 @@
  (export "__release" (func $~lib/rt/pure/__release))
  (export "__collect" (func $~lib/rt/pure/__collect))
  (export "__rtti_base" (global $~lib/rt/__rtti_base))
- (func $~lib/rt/tlsf/removeBlock (; 1 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/removeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -185,7 +185,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/insertBlock (; 2 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/insertBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -464,7 +464,7 @@
   i32.or
   i32.store offset=4
  )
- (func $~lib/rt/tlsf/addMemory (; 3 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $2
@@ -578,7 +578,7 @@
   local.get $1
   call $~lib/rt/tlsf/insertBlock
  )
- (func $~lib/rt/tlsf/maybeInitialize (; 4 ;) (result i32)
+ (func $~lib/rt/tlsf/maybeInitialize (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -665,7 +665,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/tlsf/searchBlock (; 5 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/searchBlock (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   i32.const 256
@@ -794,7 +794,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/prepareBlock (; 6 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/rt/tlsf/prepareBlock (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $1
@@ -869,7 +869,7 @@
    i32.store
   end
  )
- (func $~lib/rt/tlsf/allocateBlock (; 7 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/allocateBlock (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1027,7 +1027,7 @@
   call $~lib/rt/tlsf/prepareBlock
   local.get $3
  )
- (func $~lib/rt/tlsf/__alloc (; 8 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/__alloc (param $0 i32) (param $1 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
   local.get $0
   local.get $1
@@ -1035,7 +1035,7 @@
   i32.const 16
   i32.add
  )
- (func $~lib/rt/pure/__retain (; 9 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/pure/__retain (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -1084,7 +1084,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/pure/__release (; 10 ;) (param $0 i32)
+ (func $~lib/rt/pure/__release (param $0 i32)
   local.get $0
   i32.const 1212
   i32.gt_u
@@ -1095,10 +1095,10 @@
    call $~lib/rt/pure/decrement
   end
  )
- (func $~lib/rt/pure/__collect (; 11 ;)
+ (func $~lib/rt/pure/__collect
   nop
  )
- (func $~lib/rt/pure/decrement (; 12 ;) (param $0 i32)
+ (func $~lib/rt/pure/decrement (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0

--- a/tests/compiler/runtime-full.untouched.wat
+++ b/tests/compiler/runtime-full.untouched.wat
@@ -27,7 +27,7 @@
  (export "__release" (func $~lib/rt/pure/__release))
  (export "__collect" (func $~lib/rt/pure/__collect))
  (export "__rtti_base" (global $~lib/rt/__rtti_base))
- (func $~lib/rt/tlsf/removeBlock (; 1 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/removeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -237,7 +237,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/insertBlock (; 2 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/insertBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -587,7 +587,7 @@
   local.get $7
   i32.store offset=4
  )
- (func $~lib/rt/tlsf/addMemory (; 3 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -735,7 +735,7 @@
   call $~lib/rt/tlsf/insertBlock
   i32.const 1
  )
- (func $~lib/rt/tlsf/maybeInitialize (; 4 ;) (result i32)
+ (func $~lib/rt/tlsf/maybeInitialize (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -889,7 +889,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/tlsf/prepareSize (; 5 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/tlsf/prepareSize (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -918,7 +918,7 @@
   i32.gt_u
   select
  )
- (func $~lib/rt/tlsf/searchBlock (; 6 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/searchBlock (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1101,7 +1101,7 @@
   end
   local.get $7
  )
- (func $~lib/rt/tlsf/growMemory (; 7 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/growMemory (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1185,7 +1185,7 @@
   call $~lib/rt/tlsf/addMemory
   drop
  )
- (func $~lib/rt/tlsf/prepareBlock (; 8 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/rt/tlsf/prepareBlock (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1280,7 +1280,7 @@
    i32.store
   end
  )
- (func $~lib/rt/tlsf/allocateBlock (; 9 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/allocateBlock (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   global.get $~lib/rt/tlsf/collectLock
@@ -1389,7 +1389,7 @@
   call $~lib/rt/tlsf/prepareBlock
   local.get $4
  )
- (func $~lib/rt/tlsf/__alloc (; 10 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/__alloc (param $0 i32) (param $1 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
   local.get $0
   local.get $1
@@ -1397,7 +1397,7 @@
   i32.const 16
   i32.add
  )
- (func $~lib/rt/pure/increment (; 11 ;) (param $0 i32)
+ (func $~lib/rt/pure/increment (param $0 i32)
   (local $1 i32)
   local.get $0
   i32.load offset=4
@@ -1440,7 +1440,7 @@
    unreachable
   end
  )
- (func $~lib/rt/pure/__retain (; 12 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/pure/__retain (param $0 i32) (result i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.gt_u
@@ -1452,7 +1452,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/pure/__release (; 13 ;) (param $0 i32)
+ (func $~lib/rt/pure/__release (param $0 i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.gt_u
@@ -1463,10 +1463,10 @@
    call $~lib/rt/pure/decrement
   end
  )
- (func $~lib/rt/pure/__collect (; 14 ;)
+ (func $~lib/rt/pure/__collect
   return
  )
- (func $~lib/rt/tlsf/freeBlock (; 15 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/freeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $1
   i32.load
@@ -1480,7 +1480,7 @@
   local.get $1
   call $~lib/rt/tlsf/insertBlock
  )
- (func $~lib/rt/pure/decrement (; 16 ;) (param $0 i32)
+ (func $~lib/rt/pure/decrement (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -1555,7 +1555,7 @@
    i32.store offset=4
   end
  )
- (func $~lib/rt/pure/__visit (; 17 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/pure/__visit (param $0 i32) (param $1 i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.lt_u
@@ -1579,7 +1579,7 @@
   i32.sub
   call $~lib/rt/pure/decrement
  )
- (func $~lib/rt/__visit_members (; 18 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/__visit_members (param $0 i32) (param $1 i32)
   (local $2 i32)
   block $switch$1$default
    block $switch$1$case$4

--- a/tests/compiler/runtime-stub.optimized.wat
+++ b/tests/compiler/runtime-stub.optimized.wat
@@ -16,7 +16,7 @@
  (export "__reset" (func $~lib/rt/stub/__reset))
  (export "__rtti_base" (global $~lib/rt/__rtti_base))
  (start $~start)
- (func $~lib/rt/stub/__alloc (; 0 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/stub/__alloc (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -100,20 +100,20 @@
   i32.store offset=12
   local.get $4
  )
- (func $~lib/rt/stub/__retain (; 1 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/stub/__retain (param $0 i32) (result i32)
   local.get $0
  )
- (func $~lib/rt/stub/__release (; 2 ;) (param $0 i32)
+ (func $~lib/rt/stub/__release (param $0 i32)
   nop
  )
- (func $~lib/rt/stub/__collect (; 3 ;)
+ (func $~lib/rt/stub/__collect
   nop
  )
- (func $~lib/rt/stub/__reset (; 4 ;)
+ (func $~lib/rt/stub/__reset
   global.get $~lib/rt/stub/startOffset
   global.set $~lib/rt/stub/offset
  )
- (func $~start (; 5 ;)
+ (func $~start
   i32.const 1056
   global.set $~lib/rt/stub/startOffset
   i32.const 1056

--- a/tests/compiler/runtime-stub.untouched.wat
+++ b/tests/compiler/runtime-stub.untouched.wat
@@ -18,7 +18,7 @@
  (export "__reset" (func $~lib/rt/stub/__reset))
  (export "__rtti_base" (global $~lib/rt/__rtti_base))
  (start $~start)
- (func $~lib/rt/stub/maybeGrowMemory (; 0 ;) (param $0 i32)
+ (func $~lib/rt/stub/maybeGrowMemory (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -72,7 +72,7 @@
   local.get $0
   global.set $~lib/rt/stub/offset
  )
- (func $~lib/rt/stub/__alloc (; 1 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/stub/__alloc (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -125,20 +125,20 @@
   i32.store offset=12
   local.get $2
  )
- (func $~lib/rt/stub/__retain (; 2 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/stub/__retain (param $0 i32) (result i32)
   local.get $0
  )
- (func $~lib/rt/stub/__release (; 3 ;) (param $0 i32)
+ (func $~lib/rt/stub/__release (param $0 i32)
   nop
  )
- (func $~lib/rt/stub/__collect (; 4 ;)
+ (func $~lib/rt/stub/__collect
   nop
  )
- (func $~lib/rt/stub/__reset (; 5 ;)
+ (func $~lib/rt/stub/__reset
   global.get $~lib/rt/stub/startOffset
   global.set $~lib/rt/stub/offset
  )
- (func $~start (; 6 ;)
+ (func $~start
   global.get $~lib/heap/__heap_base
   i32.const 15
   i32.add

--- a/tests/compiler/scoped.optimized.wat
+++ b/tests/compiler/scoped.optimized.wat
@@ -3,7 +3,7 @@
  (memory $0 0)
  (export "memory" (memory $0))
  (start $~start)
- (func $~start (; 0 ;)
+ (func $~start
   (local $0 i32)
   (local $1 i32)
   loop $for-loop|0

--- a/tests/compiler/scoped.untouched.wat
+++ b/tests/compiler/scoped.untouched.wat
@@ -8,14 +8,14 @@
  (global $scoped/aStartFunctionLocal (mut i32) (i32.const 2))
  (export "memory" (memory $0))
  (start $~start)
- (func $scoped/fn (; 0 ;) (param $0 i32)
+ (func $scoped/fn (param $0 i32)
   (local $1 i32)
   i32.const 0
   local.set $1
   local.get $0
   local.set $1
  )
- (func $start:scoped (; 1 ;)
+ (func $start:scoped
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -63,7 +63,7 @@
   i32.const 42
   call $scoped/fn
  )
- (func $~start (; 2 ;)
+ (func $~start
   call $start:scoped
  )
 )

--- a/tests/compiler/static-this.untouched.wat
+++ b/tests/compiler/static-this.untouched.wat
@@ -9,10 +9,10 @@
  (global $static-this/Foo.bar (mut i32) (i32.const 42))
  (export "memory" (memory $0))
  (start $~start)
- (func $static-this/Foo.getBar (; 1 ;) (result i32)
+ (func $static-this/Foo.getBar (result i32)
   global.get $static-this/Foo.bar
  )
- (func $start:static-this (; 2 ;)
+ (func $start:static-this
   call $static-this/Foo.getBar
   i32.const 42
   i32.eq
@@ -26,7 +26,7 @@
    unreachable
   end
  )
- (func $~start (; 3 ;)
+ (func $~start
   call $start:static-this
  )
 )

--- a/tests/compiler/std/array-access.optimized.wat
+++ b/tests/compiler/std/array-access.optimized.wat
@@ -16,7 +16,7 @@
  (export "stringArrayMethodCall" (func $std/array-access/stringArrayMethodCall))
  (export "stringArrayArrayPropertyAccess" (func $std/array-access/stringArrayArrayPropertyAccess))
  (export "stringArrayArrayMethodCall" (func $std/array-access/stringArrayArrayMethodCall))
- (func $~lib/array/Array<~lib/array/Array<i32>>#__get (; 1 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<i32>>#__get (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -48,7 +48,7 @@
   end
   local.get $0
  )
- (func $std/array-access/i32ArrayArrayElementAccess (; 2 ;) (param $0 i32) (result i32)
+ (func $std/array-access/i32ArrayArrayElementAccess (param $0 i32) (result i32)
   i32.const 1
   local.get $0
   i32.const 0
@@ -68,7 +68,7 @@
   i32.load offset=4
   i32.load offset=4
  )
- (func $~lib/string/String#get:length (; 3 ;) (param $0 i32) (result i32)
+ (func $~lib/string/String#get:length (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub
@@ -76,13 +76,13 @@
   i32.const 1
   i32.shr_u
  )
- (func $std/array-access/stringArrayPropertyAccess (; 4 ;) (param $0 i32) (result i32)
+ (func $std/array-access/stringArrayPropertyAccess (param $0 i32) (result i32)
   local.get $0
   i32.const 0
   call $~lib/array/Array<~lib/array/Array<i32>>#__get
   call $~lib/string/String#get:length
  )
- (func $~lib/util/string/compareImpl (; 5 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/compareImpl (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   i32.const 1264
@@ -161,7 +161,7 @@
   end
   i32.const 0
  )
- (func $~lib/string/String#startsWith (; 6 ;) (param $0 i32) (result i32)
+ (func $~lib/string/String#startsWith (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -190,13 +190,13 @@
   call $~lib/util/string/compareImpl
   i32.eqz
  )
- (func $std/array-access/stringArrayMethodCall (; 7 ;) (param $0 i32) (result i32)
+ (func $std/array-access/stringArrayMethodCall (param $0 i32) (result i32)
   local.get $0
   i32.const 0
   call $~lib/array/Array<~lib/array/Array<i32>>#__get
   call $~lib/string/String#startsWith
  )
- (func $std/array-access/stringArrayArrayPropertyAccess (; 8 ;) (param $0 i32) (result i32)
+ (func $std/array-access/stringArrayArrayPropertyAccess (param $0 i32) (result i32)
   local.get $0
   i32.const 0
   call $~lib/array/Array<~lib/array/Array<i32>>#__get
@@ -204,7 +204,7 @@
   call $~lib/array/Array<~lib/array/Array<i32>>#__get
   call $~lib/string/String#get:length
  )
- (func $std/array-access/stringArrayArrayMethodCall (; 9 ;) (param $0 i32) (result i32)
+ (func $std/array-access/stringArrayArrayMethodCall (param $0 i32) (result i32)
   local.get $0
   i32.const 0
   call $~lib/array/Array<~lib/array/Array<i32>>#__get

--- a/tests/compiler/std/array-access.untouched.wat
+++ b/tests/compiler/std/array-access.untouched.wat
@@ -20,10 +20,10 @@
  (export "stringArrayMethodCall" (func $std/array-access/stringArrayMethodCall))
  (export "stringArrayArrayPropertyAccess" (func $std/array-access/stringArrayArrayPropertyAccess))
  (export "stringArrayArrayMethodCall" (func $std/array-access/stringArrayArrayMethodCall))
- (func $~lib/rt/stub/__retain (; 1 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/stub/__retain (param $0 i32) (result i32)
   local.get $0
  )
- (func $~lib/array/Array<~lib/array/Array<i32>>#__unchecked_get (; 2 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<i32>>#__unchecked_get (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -33,10 +33,10 @@
   i32.load
   call $~lib/rt/stub/__retain
  )
- (func $~lib/rt/stub/__release (; 3 ;) (param $0 i32)
+ (func $~lib/rt/stub/__release (param $0 i32)
   nop
  )
- (func $~lib/array/Array<~lib/array/Array<i32>>#__get (; 4 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<i32>>#__get (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   local.get $0
@@ -68,7 +68,7 @@
   end
   local.get $2
  )
- (func $~lib/array/Array<i32>#__unchecked_get (; 5 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#__unchecked_get (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -77,7 +77,7 @@
   i32.add
   i32.load
  )
- (func $~lib/array/Array<i32>#__get (; 6 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#__get (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   local.get $0
@@ -97,7 +97,7 @@
   local.set $2
   local.get $2
  )
- (func $std/array-access/i32ArrayArrayElementAccess (; 7 ;) (param $0 i32) (result i32)
+ (func $std/array-access/i32ArrayArrayElementAccess (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -116,7 +116,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $~lib/array/Array<~lib/string/String>#__unchecked_get (; 8 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/string/String>#__unchecked_get (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -126,7 +126,7 @@
   i32.load
   call $~lib/rt/stub/__retain
  )
- (func $~lib/array/Array<~lib/string/String>#__get (; 9 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/string/String>#__get (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   local.get $0
@@ -158,7 +158,7 @@
   end
   local.get $2
  )
- (func $~lib/string/String#get:length (; 10 ;) (param $0 i32) (result i32)
+ (func $~lib/string/String#get:length (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub
@@ -166,7 +166,7 @@
   i32.const 1
   i32.shr_u
  )
- (func $std/array-access/stringArrayPropertyAccess (; 11 ;) (param $0 i32) (result i32)
+ (func $std/array-access/stringArrayPropertyAccess (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -184,7 +184,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $~lib/util/string/compareImpl (; 12 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
+ (func $~lib/util/string/compareImpl (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
@@ -306,7 +306,7 @@
   call $~lib/rt/stub/__release
   local.get $7
  )
- (func $~lib/string/String#startsWith (; 13 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/string/String#startsWith (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -381,7 +381,7 @@
   call $~lib/rt/stub/__release
   local.get $3
  )
- (func $std/array-access/stringArrayMethodCall (; 14 ;) (param $0 i32) (result i32)
+ (func $std/array-access/stringArrayMethodCall (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -401,7 +401,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $~lib/array/Array<~lib/array/Array<~lib/string/String>>#__unchecked_get (; 15 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<~lib/string/String>>#__unchecked_get (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -411,7 +411,7 @@
   i32.load
   call $~lib/rt/stub/__retain
  )
- (func $~lib/array/Array<~lib/array/Array<~lib/string/String>>#__get (; 16 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<~lib/string/String>>#__get (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   local.get $0
@@ -443,7 +443,7 @@
   end
   local.get $2
  )
- (func $std/array-access/stringArrayArrayPropertyAccess (; 17 ;) (param $0 i32) (result i32)
+ (func $std/array-access/stringArrayArrayPropertyAccess (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -467,7 +467,7 @@
   call $~lib/rt/stub/__release
   local.get $3
  )
- (func $std/array-access/stringArrayArrayMethodCall (; 18 ;) (param $0 i32) (result i32)
+ (func $std/array-access/stringArrayArrayMethodCall (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)

--- a/tests/compiler/std/array-literal.optimized.wat
+++ b/tests/compiler/std/array-literal.optimized.wat
@@ -35,7 +35,7 @@
  (global $std/array-literal/dynamicArrayRefWithCtor (mut i32) (i32.const 0))
  (export "memory" (memory $0))
  (start $~start)
- (func $~lib/array/Array<i8>#__get (; 5 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i8>#__get (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -54,7 +54,7 @@
   i32.add
   i32.load8_s
  )
- (func $~lib/array/Array<i32>#__get (; 6 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#__get (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -75,7 +75,7 @@
   i32.add
   i32.load
  )
- (func $~lib/rt/tlsf/removeBlock (; 7 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/removeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -237,7 +237,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/insertBlock (; 8 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/insertBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -516,7 +516,7 @@
   i32.or
   i32.store offset=4
  )
- (func $~lib/rt/tlsf/addMemory (; 9 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $2
@@ -630,7 +630,7 @@
   local.get $1
   call $~lib/rt/tlsf/insertBlock
  )
- (func $~lib/rt/tlsf/maybeInitialize (; 10 ;) (result i32)
+ (func $~lib/rt/tlsf/maybeInitialize (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -717,7 +717,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/tlsf/searchBlock (; 11 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/searchBlock (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   i32.const 256
@@ -846,7 +846,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/prepareBlock (; 12 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/rt/tlsf/prepareBlock (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $1
@@ -921,7 +921,7 @@
    i32.store
   end
  )
- (func $~lib/rt/tlsf/allocateBlock (; 13 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/allocateBlock (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1081,7 +1081,7 @@
   call $~lib/rt/rtrace/onalloc
   local.get $3
  )
- (func $~lib/rt/tlsf/__alloc (; 14 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/__alloc (param $0 i32) (param $1 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
   local.get $0
   local.get $1
@@ -1089,7 +1089,7 @@
   i32.const 16
   i32.add
  )
- (func $~lib/rt/pure/__retain (; 15 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/pure/__retain (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -1140,7 +1140,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/__allocArray (; 16 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/__allocArray (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   i32.const 16
   local.get $2
@@ -1166,7 +1166,7 @@
   i32.store offset=12
   local.get $2
  )
- (func $~lib/rt/pure/__release (; 17 ;) (param $0 i32)
+ (func $~lib/rt/pure/__release (param $0 i32)
   local.get $0
   i32.const 1536
   i32.gt_u
@@ -1177,7 +1177,7 @@
    call $~lib/rt/pure/decrement
   end
  )
- (func $start:std/array-literal (; 18 ;)
+ (func $start:std/array-literal
   (local $0 i32)
   (local $1 i32)
   i32.const 1084
@@ -1541,10 +1541,10 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~start (; 19 ;)
+ (func $~start
   call $start:std/array-literal
  )
- (func $~lib/rt/pure/decrement (; 20 ;) (param $0 i32)
+ (func $~lib/rt/pure/decrement (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -1661,7 +1661,7 @@
    i32.store offset=4
   end
  )
- (func $~lib/rt/pure/__visit (; 21 ;) (param $0 i32)
+ (func $~lib/rt/pure/__visit (param $0 i32)
   local.get $0
   i32.const 1536
   i32.lt_u
@@ -1673,7 +1673,7 @@
   i32.sub
   call $~lib/rt/pure/decrement
  )
- (func $~lib/array/Array<std/array-literal/Ref>#__visit_impl (; 22 ;) (param $0 i32)
+ (func $~lib/array/Array<std/array-literal/Ref>#__visit_impl (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)

--- a/tests/compiler/std/array-literal.untouched.wat
+++ b/tests/compiler/std/array-literal.untouched.wat
@@ -44,11 +44,11 @@
  (global $~lib/heap/__heap_base i32 (i32.const 528))
  (export "memory" (memory $0))
  (start $~start)
- (func $~lib/array/Array<i8>#get:length (; 5 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<i8>#get:length (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<i8>#__unchecked_get (; 6 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i8>#__unchecked_get (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -57,7 +57,7 @@
   i32.add
   i32.load8_s
  )
- (func $~lib/array/Array<i8>#__get (; 7 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i8>#__get (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   local.get $0
@@ -77,11 +77,11 @@
   local.set $2
   local.get $2
  )
- (func $~lib/array/Array<i32>#get:length (; 8 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<i32>#get:length (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<i32>#__unchecked_get (; 9 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#__unchecked_get (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -90,7 +90,7 @@
   i32.add
   i32.load
  )
- (func $~lib/array/Array<i32>#__get (; 10 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#__get (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   local.get $0
@@ -110,7 +110,7 @@
   local.set $2
   local.get $2
  )
- (func $~lib/rt/tlsf/removeBlock (; 11 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/removeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -320,7 +320,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/insertBlock (; 12 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/insertBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -670,7 +670,7 @@
   local.get $7
   i32.store offset=4
  )
- (func $~lib/rt/tlsf/addMemory (; 13 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -818,7 +818,7 @@
   call $~lib/rt/tlsf/insertBlock
   i32.const 1
  )
- (func $~lib/rt/tlsf/maybeInitialize (; 14 ;) (result i32)
+ (func $~lib/rt/tlsf/maybeInitialize (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -972,7 +972,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/tlsf/prepareSize (; 15 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/tlsf/prepareSize (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -1001,7 +1001,7 @@
   i32.gt_u
   select
  )
- (func $~lib/rt/tlsf/searchBlock (; 16 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/searchBlock (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1184,7 +1184,7 @@
   end
   local.get $7
  )
- (func $~lib/rt/tlsf/growMemory (; 17 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/growMemory (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1268,7 +1268,7 @@
   call $~lib/rt/tlsf/addMemory
   drop
  )
- (func $~lib/rt/tlsf/prepareBlock (; 18 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/rt/tlsf/prepareBlock (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1363,7 +1363,7 @@
    i32.store
   end
  )
- (func $~lib/rt/tlsf/allocateBlock (; 19 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/allocateBlock (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   global.get $~lib/rt/tlsf/collectLock
@@ -1474,7 +1474,7 @@
   call $~lib/rt/rtrace/onalloc
   local.get $4
  )
- (func $~lib/rt/tlsf/__alloc (; 20 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/__alloc (param $0 i32) (param $1 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
   local.get $0
   local.get $1
@@ -1482,7 +1482,7 @@
   i32.const 16
   i32.add
  )
- (func $~lib/util/memory/memcpy (; 21 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/memory/memcpy (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2506,7 +2506,7 @@
    i32.store8
   end
  )
- (func $~lib/memory/memory.copy (; 22 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/memory/memory.copy (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2726,7 +2726,7 @@
    end
   end
  )
- (func $~lib/rt/__allocBuffer (; 23 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/__allocBuffer (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $0
   local.get $1
@@ -2741,7 +2741,7 @@
   end
   local.get $3
  )
- (func $~lib/rt/pure/increment (; 24 ;) (param $0 i32)
+ (func $~lib/rt/pure/increment (param $0 i32)
   (local $1 i32)
   local.get $0
   i32.load offset=4
@@ -2786,7 +2786,7 @@
    unreachable
   end
  )
- (func $~lib/rt/pure/__retain (; 25 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/pure/__retain (param $0 i32) (result i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.gt_u
@@ -2798,7 +2798,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/__allocArray (; 26 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $~lib/rt/__allocArray (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -2830,7 +2830,7 @@
   i32.store offset=12
   local.get $4
  )
- (func $std/array-literal/Ref#constructor (; 27 ;) (param $0 i32) (result i32)
+ (func $std/array-literal/Ref#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -2842,11 +2842,11 @@
   end
   local.get $0
  )
- (func $~lib/array/Array<std/array-literal/Ref>#get:length (; 28 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<std/array-literal/Ref>#get:length (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $std/array-literal/RefWithCtor#constructor (; 29 ;) (param $0 i32) (result i32)
+ (func $std/array-literal/RefWithCtor#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -2858,11 +2858,11 @@
   end
   local.get $0
  )
- (func $~lib/array/Array<std/array-literal/RefWithCtor>#get:length (; 30 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<std/array-literal/RefWithCtor>#get:length (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/rt/pure/__release (; 31 ;) (param $0 i32)
+ (func $~lib/rt/pure/__release (param $0 i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.gt_u
@@ -2873,14 +2873,14 @@
    call $~lib/rt/pure/decrement
   end
  )
- (func $std/array-literal/doesntLeak (; 32 ;) (param $0 i32)
+ (func $std/array-literal/doesntLeak (param $0 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $0
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $start:std/array-literal (; 33 ;)
+ (func $start:std/array-literal
   (local $0 i32)
   (local $1 i32)
   i32.const 64
@@ -3280,13 +3280,13 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~start (; 34 ;)
+ (func $~start
   call $start:std/array-literal
  )
- (func $~lib/rt/pure/__collect (; 35 ;)
+ (func $~lib/rt/pure/__collect
   return
  )
- (func $~lib/rt/tlsf/freeBlock (; 36 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/freeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $1
   i32.load
@@ -3302,7 +3302,7 @@
   local.get $1
   call $~lib/rt/rtrace/onfree
  )
- (func $~lib/rt/pure/decrement (; 37 ;) (param $0 i32)
+ (func $~lib/rt/pure/decrement (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -3379,7 +3379,7 @@
    i32.store offset=4
   end
  )
- (func $~lib/rt/pure/__visit (; 38 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/pure/__visit (param $0 i32) (param $1 i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.lt_u
@@ -3403,19 +3403,19 @@
   i32.sub
   call $~lib/rt/pure/decrement
  )
- (func $~lib/array/Array<i8>#__visit_impl (; 39 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i8>#__visit_impl (param $0 i32) (param $1 i32)
   local.get $0
   i32.load
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/array/Array<i32>#__visit_impl (; 40 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i32>#__visit_impl (param $0 i32) (param $1 i32)
   local.get $0
   i32.load
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/array/Array<std/array-literal/Ref>#__visit_impl (; 41 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<std/array-literal/Ref>#__visit_impl (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3458,7 +3458,7 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/array/Array<std/array-literal/RefWithCtor>#__visit_impl (; 42 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<std/array-literal/RefWithCtor>#__visit_impl (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3501,7 +3501,7 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/rt/__visit_members (; 43 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/__visit_members (param $0 i32) (param $1 i32)
   (local $2 i32)
   block $switch$1$default
    block $switch$1$case$10

--- a/tests/compiler/std/array.optimized.wat
+++ b/tests/compiler/std/array.optimized.wat
@@ -254,7 +254,7 @@
  (export "__setArgumentsLength" (func $~setArgumentsLength))
  (export "_start" (func $~start))
  (export "memory" (memory $0))
- (func $~lib/rt/tlsf/removeBlock (; 8 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/removeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -416,7 +416,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/insertBlock (; 9 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/insertBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -695,7 +695,7 @@
   i32.or
   i32.store offset=4
  )
- (func $~lib/rt/tlsf/addMemory (; 10 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $2
@@ -809,7 +809,7 @@
   local.get $1
   call $~lib/rt/tlsf/insertBlock
  )
- (func $~lib/rt/tlsf/maybeInitialize (; 11 ;) (result i32)
+ (func $~lib/rt/tlsf/maybeInitialize (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -896,7 +896,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/tlsf/prepareSize (; 12 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/tlsf/prepareSize (param $0 i32) (result i32)
   local.get $0
   i32.const 1073741808
   i32.ge_u
@@ -920,7 +920,7 @@
   i32.gt_u
   select
  )
- (func $~lib/rt/tlsf/searchBlock (; 13 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/searchBlock (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   i32.const 256
@@ -1049,7 +1049,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/prepareBlock (; 14 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/rt/tlsf/prepareBlock (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $1
@@ -1124,7 +1124,7 @@
    i32.store
   end
  )
- (func $~lib/rt/tlsf/allocateBlock (; 15 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/allocateBlock (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1264,7 +1264,7 @@
   call $~lib/rt/rtrace/onalloc
   local.get $3
  )
- (func $~lib/rt/tlsf/__alloc (; 16 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/__alloc (param $0 i32) (param $1 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
   local.get $0
   local.get $1
@@ -1272,7 +1272,7 @@
   i32.const 16
   i32.add
  )
- (func $~lib/memory/memory.fill (; 17 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/memory/memory.fill (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i64)
   (local $5 i32)
@@ -1445,7 +1445,7 @@
    end
   end
  )
- (func $~lib/rt/pure/__retain (; 18 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/pure/__retain (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -1496,7 +1496,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/pure/__release (; 19 ;) (param $0 i32)
+ (func $~lib/rt/pure/__release (param $0 i32)
   local.get $0
   i32.const 9808
   i32.gt_u
@@ -1507,7 +1507,7 @@
    call $~lib/rt/pure/decrement
   end
  )
- (func $~lib/array/Array<i32>#constructor (; 20 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<i32>#constructor (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -1578,7 +1578,7 @@
   i32.store offset=12
   local.get $3
  )
- (func $std/array/Ref#constructor (; 21 ;) (param $0 i32) (result i32)
+ (func $std/array/Ref#constructor (param $0 i32) (result i32)
   (local $1 i32)
   i32.const 4
   i32.const 4
@@ -1589,7 +1589,7 @@
   i32.store
   local.get $1
  )
- (func $~lib/memory/memory.copy (; 22 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/memory/memory.copy (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   block $~lib/util/memory/memmove|inlined.0
@@ -1762,7 +1762,7 @@
    end
   end
  )
- (func $~lib/rt/__allocArray (; 23 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $~lib/rt/__allocArray (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -1800,7 +1800,7 @@
   i32.store offset=12
   local.get $2
  )
- (func $~lib/array/Array<u8>#fill (; 24 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $~lib/array/Array<u8>#fill (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   (local $5 i32)
   local.get $0
@@ -1867,7 +1867,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/array/Array<u8>#__get (; 25 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u8>#__get (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -1886,7 +1886,7 @@
   i32.add
   i32.load8_u
  )
- (func $std/array/isArraysEqual<u8> (; 26 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/array/isArraysEqual<u8> (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -1931,7 +1931,7 @@
   end
   i32.const 1
  )
- (func $~lib/array/Array<u32>#fill (; 27 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $~lib/array/Array<u32>#fill (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   (local $5 i32)
   local.get $0
@@ -2006,7 +2006,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/array/Array<u32>#__get (; 28 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u32>#__get (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -2027,7 +2027,7 @@
   i32.add
   i32.load
  )
- (func $std/array/isArraysEqual<u32> (; 29 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/array/isArraysEqual<u32> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   i32.eqz
@@ -2075,7 +2075,7 @@
   end
   i32.const 1
  )
- (func $std/array/internalCapacity<i32> (; 30 ;) (param $0 i32) (result i32)
+ (func $std/array/internalCapacity<i32> (param $0 i32) (result i32)
   local.get $0
   i32.load
   i32.const 16
@@ -2084,7 +2084,7 @@
   i32.const 2
   i32.shr_s
  )
- (func $~lib/rt/tlsf/checkUsedBlock (; 31 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/tlsf/checkUsedBlock (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   i32.const 16
@@ -2126,7 +2126,7 @@
   end
   local.get $1
  )
- (func $~lib/rt/tlsf/freeBlock (; 32 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/freeBlock (param $0 i32) (param $1 i32)
   local.get $1
   local.get $1
   i32.load
@@ -2139,7 +2139,7 @@
   local.get $1
   call $~lib/rt/rtrace/onfree
  )
- (func $~lib/rt/tlsf/reallocateBlock (; 33 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/reallocateBlock (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2242,7 +2242,7 @@
   end
   local.get $3
  )
- (func $~lib/array/ensureSize (; 34 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/ensureSize (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2302,7 +2302,7 @@
    i32.store offset=8
   end
  )
- (func $~lib/array/Array<i32>#push (; 35 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i32>#push (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -2325,7 +2325,7 @@
   local.get $3
   i32.store offset=12
  )
- (func $~lib/array/Array<i32>#pop (; 36 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<i32>#pop (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -2355,7 +2355,7 @@
   local.get $1
   i32.store offset=12
  )
- (func $~lib/array/Array<i32>#concat (; 37 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#concat (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2408,7 +2408,7 @@
   call $~lib/memory/memory.copy
   local.get $2
  )
- (func $~lib/array/Array<i32>#copyWithin (; 38 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $~lib/array/Array<i32>#copyWithin (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -2513,7 +2513,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/array/Array<i32>#unshift (; 39 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i32>#unshift (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -2542,7 +2542,7 @@
   local.get $2
   i32.store offset=12
  )
- (func $~lib/array/Array<i32>#indexOf (; 40 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/array/Array<i32>#indexOf (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $0
   i32.load offset=12
@@ -2602,7 +2602,7 @@
   end
   i32.const -1
  )
- (func $~lib/array/Array<i32>#includes (; 41 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/array/Array<i32>#includes (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   local.get $1
   local.get $2
@@ -2610,7 +2610,7 @@
   i32.const 0
   i32.ge_s
  )
- (func $~lib/array/Array<i32>#splice (; 42 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/array/Array<i32>#splice (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2701,7 +2701,7 @@
   i32.store offset=12
   local.get $3
  )
- (func $~lib/array/Array<std/array/Ref>#splice (; 43 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<std/array/Ref>#splice (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2792,7 +2792,7 @@
   i32.store offset=12
   local.get $4
  )
- (func $~lib/array/Array<std/array/Ref>#__unchecked_get (; 44 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<std/array/Ref>#__unchecked_get (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -2802,7 +2802,7 @@
   i32.load
   call $~lib/rt/pure/__retain
  )
- (func $~lib/array/Array<std/array/Ref>#__get (; 45 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<std/array/Ref>#__get (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -2832,7 +2832,7 @@
   end
   local.get $0
  )
- (func $~lib/array/Array<std/array/Ref | null>#splice (; 46 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<std/array/Ref | null>#splice (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -2910,7 +2910,7 @@
   i32.store offset=12
   local.get $4
  )
- (func $~lib/array/Array<std/array/Ref | null>#__get (; 47 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<std/array/Ref | null>#__get (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -2927,7 +2927,7 @@
   local.get $1
   call $~lib/array/Array<std/array/Ref>#__unchecked_get
  )
- (func $~lib/array/Array<i32>#__set (; 48 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<i32>#__set (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $1
   local.get $0
@@ -2964,15 +2964,15 @@
   local.get $2
   i32.store
  )
- (func $start:std/array~anonymous|0 (; 49 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.eqz
  )
- (func $~setArgumentsLength (; 50 ;) (param $0 i32)
+ (func $~setArgumentsLength (param $0 i32)
   local.get $0
   global.set $~argumentsLength
  )
- (func $~lib/array/Array<i32>#findIndex (; 51 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#findIndex (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3017,17 +3017,17 @@
   end
   i32.const -1
  )
- (func $start:std/array~anonymous|1 (; 52 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|1 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 1
   i32.eq
  )
- (func $start:std/array~anonymous|2 (; 53 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|2 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 100
   i32.eq
  )
- (func $start:std/array~anonymous|3 (; 54 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|3 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $2
   i32.const 100
   call $~lib/array/Array<i32>#push
@@ -3035,7 +3035,7 @@
   i32.const 100
   i32.eq
  )
- (func $start:std/array~anonymous|5 (; 55 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|5 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $2
   call $~lib/array/Array<i32>#pop
   drop
@@ -3043,12 +3043,12 @@
   i32.const 100
   i32.eq
  )
- (func $start:std/array~anonymous|6 (; 56 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|6 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 0
   i32.ge_s
  )
- (func $~lib/array/Array<i32>#every (; 57 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#every (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3094,12 +3094,12 @@
   end
   i32.const 1
  )
- (func $start:std/array~anonymous|7 (; 58 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|7 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 0
   i32.le_s
  )
- (func $start:std/array~anonymous|8 (; 59 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|8 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $2
   i32.const 100
   call $~lib/array/Array<i32>#push
@@ -3107,12 +3107,12 @@
   i32.const 10
   i32.lt_s
  )
- (func $start:std/array~anonymous|9 (; 60 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|9 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 10
   i32.lt_s
  )
- (func $start:std/array~anonymous|10 (; 61 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|10 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $2
   call $~lib/array/Array<i32>#pop
   drop
@@ -3120,12 +3120,12 @@
   i32.const 3
   i32.lt_s
  )
- (func $start:std/array~anonymous|11 (; 62 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|11 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 3
   i32.ge_s
  )
- (func $~lib/array/Array<i32>#some (; 63 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#some (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3170,12 +3170,12 @@
   end
   i32.const 0
  )
- (func $start:std/array~anonymous|12 (; 64 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|12 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const -1
   i32.le_s
  )
- (func $start:std/array~anonymous|13 (; 65 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|13 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $2
   i32.const 100
   call $~lib/array/Array<i32>#push
@@ -3183,12 +3183,12 @@
   i32.const 10
   i32.gt_s
  )
- (func $start:std/array~anonymous|14 (; 66 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|14 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 10
   i32.gt_s
  )
- (func $start:std/array~anonymous|15 (; 67 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|15 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $2
   call $~lib/array/Array<i32>#pop
   drop
@@ -3196,13 +3196,13 @@
   i32.const 3
   i32.gt_s
  )
- (func $start:std/array~anonymous|16 (; 68 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $start:std/array~anonymous|16 (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $0
   global.get $std/array/i
   i32.add
   global.set $std/array/i
  )
- (func $~lib/array/Array<i32>#forEach (; 69 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i32>#forEach (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3242,7 +3242,7 @@
    end
   end
  )
- (func $start:std/array~anonymous|17 (; 70 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $start:std/array~anonymous|17 (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $2
   i32.const 100
   call $~lib/array/Array<i32>#push
@@ -3251,7 +3251,7 @@
   i32.add
   global.set $std/array/i
  )
- (func $start:std/array~anonymous|19 (; 71 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $start:std/array~anonymous|19 (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $2
   call $~lib/array/Array<i32>#pop
   drop
@@ -3260,7 +3260,7 @@
   i32.add
   global.set $std/array/i
  )
- (func $start:std/array~anonymous|20 (; 72 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $start:std/array~anonymous|20 (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $1
   i32.eqz
@@ -3353,11 +3353,11 @@
    end
   end
  )
- (func $start:std/array~anonymous|21 (; 73 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result f32)
+ (func $start:std/array~anonymous|21 (param $0 i32) (param $1 i32) (param $2 i32) (result f32)
   local.get $0
   f32.convert_i32_s
  )
- (func $~lib/array/Array<f32>#__get (; 74 ;) (param $0 i32) (param $1 i32) (result f32)
+ (func $~lib/array/Array<f32>#__get (param $0 i32) (param $1 i32) (result f32)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -3378,7 +3378,7 @@
   i32.add
   f32.load
  )
- (func $start:std/array~anonymous|22 (; 75 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|22 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $2
   i32.const 100
   call $~lib/array/Array<i32>#push
@@ -3388,7 +3388,7 @@
   global.set $std/array/i
   local.get $0
  )
- (func $~lib/array/Array<i32>#map<i32> (; 76 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#map<i32> (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3447,14 +3447,14 @@
   end
   local.get $5
  )
- (func $start:std/array~anonymous|23 (; 77 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|23 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   global.get $std/array/i
   i32.add
   global.set $std/array/i
   local.get $0
  )
- (func $start:std/array~anonymous|24 (; 78 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|24 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $2
   call $~lib/array/Array<i32>#pop
   drop
@@ -3464,12 +3464,12 @@
   global.set $std/array/i
   local.get $0
  )
- (func $start:std/array~anonymous|25 (; 79 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|25 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 2
   i32.ge_s
  )
- (func $~lib/array/Array<i32>#filter (; 80 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#filter (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3525,7 +3525,7 @@
   end
   local.get $4
  )
- (func $start:std/array~anonymous|26 (; 81 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|26 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $2
   i32.const 100
   call $~lib/array/Array<i32>#push
@@ -3537,7 +3537,7 @@
   i32.const 2
   i32.ge_s
  )
- (func $start:std/array~anonymous|27 (; 82 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|27 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   global.get $std/array/i
   i32.add
@@ -3546,7 +3546,7 @@
   i32.const 2
   i32.ge_s
  )
- (func $start:std/array~anonymous|28 (; 83 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|28 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $2
   call $~lib/array/Array<i32>#pop
   drop
@@ -3558,12 +3558,12 @@
   i32.const 2
   i32.ge_s
  )
- (func $start:std/array~anonymous|29 (; 84 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|29 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   local.get $0
   local.get $1
   i32.add
  )
- (func $~lib/array/Array<i32>#reduce<i32> (; 85 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/array/Array<i32>#reduce<i32> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3606,7 +3606,7 @@
   end
   local.get $2
  )
- (func $start:std/array~anonymous|31 (; 86 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|31 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   i32.const 1
   local.get $1
   i32.const 2
@@ -3614,7 +3614,7 @@
   local.get $0
   select
  )
- (func $start:std/array~anonymous|32 (; 87 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|32 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   i32.const 1
   local.get $1
   i32.const 100
@@ -3622,7 +3622,7 @@
   local.get $0
   select
  )
- (func $start:std/array~anonymous|33 (; 88 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|33 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   local.get $3
   i32.const 1
   call $~lib/array/Array<i32>#push
@@ -3630,7 +3630,7 @@
   local.get $1
   i32.add
  )
- (func $start:std/array~anonymous|35 (; 89 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|35 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   local.get $3
   call $~lib/array/Array<i32>#pop
   drop
@@ -3638,7 +3638,7 @@
   local.get $1
   i32.add
  )
- (func $~lib/array/Array<i32>#reduceRight<i32> (; 90 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/array/Array<i32>#reduceRight<i32> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $0
   i32.load offset=12
@@ -3674,7 +3674,7 @@
   end
   local.get $2
  )
- (func $~lib/math/murmurHash3 (; 91 ;) (param $0 i64) (result i64)
+ (func $~lib/math/murmurHash3 (param $0 i64) (result i64)
   local.get $0
   local.get $0
   i64.const 33
@@ -3695,7 +3695,7 @@
   i64.shr_u
   i64.xor
  )
- (func $~lib/math/splitMix32 (; 92 ;) (param $0 i32) (result i32)
+ (func $~lib/math/splitMix32 (param $0 i32) (result i32)
   local.get $0
   i32.const 1831565813
   i32.add
@@ -3727,7 +3727,7 @@
   i32.shr_u
   i32.xor
  )
- (func $~lib/math/NativeMath.seedRandom (; 93 ;) (param $0 i64)
+ (func $~lib/math/NativeMath.seedRandom (param $0 i64)
   (local $1 i32)
   i32.const 1
   global.set $~lib/math/random_seeded
@@ -3772,7 +3772,7 @@
    unreachable
   end
  )
- (func $~lib/util/sort/insertionSort<f32> (; 94 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/sort/insertionSort<f32> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 f32)
@@ -3851,7 +3851,7 @@
    end
   end
  )
- (func $~lib/util/sort/weakHeapSort<f32> (; 95 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/sort/weakHeapSort<f32> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 f32)
@@ -4112,7 +4112,7 @@
   local.get $5
   f32.store
  )
- (func $~lib/util/sort/COMPARATOR<f32>~anonymous|0 (; 96 ;) (param $0 f32) (param $1 f32) (result i32)
+ (func $~lib/util/sort/COMPARATOR<f32>~anonymous|0 (param $0 f32) (param $1 f32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -4141,7 +4141,7 @@
   i32.lt_s
   i32.sub
  )
- (func $~lib/array/Array<f32>#sort|trampoline (; 97 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<f32>#sort|trampoline (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -4220,7 +4220,7 @@
    call $~lib/rt/pure/__retain
   end
  )
- (func $~lib/util/sort/insertionSort<f64> (; 98 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/sort/insertionSort<f64> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 f64)
@@ -4299,7 +4299,7 @@
    end
   end
  )
- (func $~lib/util/sort/weakHeapSort<f64> (; 99 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/sort/weakHeapSort<f64> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 f64)
@@ -4560,7 +4560,7 @@
   local.get $5
   f64.store
  )
- (func $~lib/util/sort/COMPARATOR<f64>~anonymous|0 (; 100 ;) (param $0 f64) (param $1 f64) (result i32)
+ (func $~lib/util/sort/COMPARATOR<f64>~anonymous|0 (param $0 f64) (param $1 f64) (result i32)
   (local $2 i64)
   (local $3 i64)
   local.get $0
@@ -4589,7 +4589,7 @@
   i64.lt_s
   i32.sub
  )
- (func $~lib/array/Array<f64>#sort|trampoline (; 101 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<f64>#sort|trampoline (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -4668,7 +4668,7 @@
    call $~lib/rt/pure/__retain
   end
  )
- (func $~lib/array/Array<f64>#__get (; 102 ;) (param $0 i32) (param $1 i32) (result f64)
+ (func $~lib/array/Array<f64>#__get (param $0 i32) (param $1 i32) (result f64)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -4689,7 +4689,7 @@
   i32.add
   f64.load
  )
- (func $~lib/util/sort/insertionSort<i32> (; 103 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/sort/insertionSort<i32> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -4768,7 +4768,7 @@
    end
   end
  )
- (func $~lib/util/sort/weakHeapSort<i32> (; 104 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/sort/weakHeapSort<i32> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -5029,7 +5029,7 @@
   local.get $1
   i32.store
  )
- (func $~lib/array/Array<i32>#sort (; 105 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#sort (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5094,12 +5094,12 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/sort/COMPARATOR<i32>~anonymous|0 (; 106 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/sort/COMPARATOR<i32>~anonymous|0 (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.sub
  )
- (func $~lib/util/sort/COMPARATOR<u32>~anonymous|0 (; 107 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/sort/COMPARATOR<u32>~anonymous|0 (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.gt_u
@@ -5108,7 +5108,7 @@
   i32.lt_u
   i32.sub
  )
- (func $std/array/createReverseOrderedArray (; 108 ;) (param $0 i32) (result i32)
+ (func $std/array/createReverseOrderedArray (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -5136,7 +5136,7 @@
   end
   local.get $2
  )
- (func $~lib/math/NativeMath.random (; 109 ;) (result f64)
+ (func $~lib/math/NativeMath.random (result f64)
   (local $0 i64)
   (local $1 i64)
   global.get $~lib/math/random_seeded
@@ -5177,7 +5177,7 @@
   f64.const 1
   f64.sub
  )
- (func $std/array/createRandomOrderedArray (; 110 ;) (param $0 i32) (result i32)
+ (func $std/array/createRandomOrderedArray (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -5205,7 +5205,7 @@
   end
   local.get $2
  )
- (func $std/array/assertSorted<i32> (; 111 ;) (param $0 i32) (param $1 i32)
+ (func $std/array/assertSorted<i32> (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5262,12 +5262,12 @@
   local.get $3
   call $~lib/rt/pure/__release
  )
- (func $start:std/array~anonymous|44 (; 112 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $start:std/array~anonymous|44 (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.sub
  )
- (func $~lib/array/Array<~lib/array/Array<i32>>#__set (; 113 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<~lib/array/Array<i32>>#__set (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $1
   local.get $0
@@ -5315,7 +5315,7 @@
    call $~lib/rt/pure/__release
   end
  )
- (func $std/array/createReverseOrderedNestedArray (; 114 ;) (result i32)
+ (func $std/array/createReverseOrderedNestedArray (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -5398,7 +5398,7 @@
   end
   local.get $2
  )
- (func $start:std/array~anonymous|47 (; 115 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $start:std/array~anonymous|47 (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.const 0
   call $~lib/array/Array<u32>#__get
@@ -5407,7 +5407,7 @@
   call $~lib/array/Array<u32>#__get
   i32.sub
  )
- (func $~lib/array/Array<~lib/array/Array<i32>>#sort (; 116 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<i32>>#sort (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5461,7 +5461,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $std/array/assertSorted<~lib/array/Array<i32>> (; 117 ;) (param $0 i32) (param $1 i32)
+ (func $std/array/assertSorted<~lib/array/Array<i32>> (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5531,7 +5531,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $std/array/createReverseOrderedElementsArray (; 118 ;) (result i32)
+ (func $std/array/createReverseOrderedElementsArray (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -5615,14 +5615,14 @@
   end
   local.get $2
  )
- (func $start:std/array~anonymous|48 (; 119 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $start:std/array~anonymous|48 (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load
   local.get $1
   i32.load
   i32.sub
  )
- (func $~lib/string/String#get:length (; 120 ;) (param $0 i32) (result i32)
+ (func $~lib/string/String#get:length (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub
@@ -5630,7 +5630,7 @@
   i32.const 1
   i32.shr_u
  )
- (func $~lib/util/string/compareImpl (; 121 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/compareImpl (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -5706,7 +5706,7 @@
   end
   i32.const 0
  )
- (func $~lib/util/sort/COMPARATOR<~lib/string/String | null>~anonymous|0 (; 122 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/sort/COMPARATOR<~lib/string/String | null>~anonymous|0 (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   i32.const 1
@@ -5760,7 +5760,7 @@
   select
   call $~lib/util/string/compareImpl
  )
- (func $std/array/assertSorted<~lib/string/String | null>|trampoline (; 123 ;) (param $0 i32)
+ (func $std/array/assertSorted<~lib/string/String | null>|trampoline (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -5844,7 +5844,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/string/String.__eq (; 124 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__eq (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -5878,7 +5878,7 @@
   call $~lib/util/string/compareImpl
   i32.eqz
  )
- (func $~lib/string/String.__concat (; 125 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__concat (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5941,7 +5941,7 @@
    local.get $1
   end
  )
- (func $std/array/createRandomStringArray (; 126 ;) (result i32)
+ (func $std/array/createRandomStringArray (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -6087,7 +6087,7 @@
   end
   local.get $7
  )
- (func $~lib/string/String#substring (; 127 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String#substring (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6161,7 +6161,7 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/string/joinBooleanArray (; 128 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/joinBooleanArray (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6299,7 +6299,7 @@
   end
   local.get $1
  )
- (func $~lib/util/number/decimalCount32 (; 129 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/decimalCount32 (param $0 i32) (result i32)
   local.get $0
   i32.const 10
   i32.ge_u
@@ -6341,7 +6341,7 @@
   i32.lt_u
   select
  )
- (func $~lib/util/number/utoa_simple<u32> (; 130 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/number/utoa_simple<u32> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   loop $do-continue|0
    local.get $1
@@ -6368,7 +6368,7 @@
    br_if $do-continue|0
   end
  )
- (func $~lib/util/number/itoa32 (; 131 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/itoa32 (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -6410,7 +6410,7 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/itoa_stream<i32> (; 132 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_stream<i32> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   local.get $1
   i32.const 1
@@ -6458,7 +6458,7 @@
   call $~lib/util/number/utoa_simple<u32>
   local.get $0
  )
- (func $~lib/util/string/joinIntegerArray<i32> (; 133 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<i32> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -6563,7 +6563,7 @@
   end
   local.get $1
  )
- (func $~lib/array/Array<i32>#join (; 134 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#join (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $0
@@ -6571,7 +6571,7 @@
   local.get $1
   call $~lib/util/string/joinIntegerArray<i32>
  )
- (func $~lib/util/number/utoa32 (; 135 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/utoa32 (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -6594,7 +6594,7 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/itoa_stream<u32> (; 136 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_stream<u32> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   local.get $1
   i32.const 1
@@ -6621,7 +6621,7 @@
   call $~lib/util/number/utoa_simple<u32>
   local.get $0
  )
- (func $~lib/util/string/joinIntegerArray<u32> (; 137 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<u32> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -6726,7 +6726,7 @@
   end
   local.get $1
  )
- (func $~lib/array/Array<u32>#join (; 138 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u32>#join (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $0
@@ -6734,7 +6734,7 @@
   local.get $1
   call $~lib/util/string/joinIntegerArray<u32>
  )
- (func $~lib/util/number/genDigits (; 139 ;) (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (param $6 i32) (result i32)
+ (func $~lib/util/number/genDigits (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (param $6 i32) (result i32)
   (local $7 i32)
   (local $8 i64)
   (local $9 i64)
@@ -7125,7 +7125,7 @@
    local.get $6
   end
  )
- (func $~lib/util/number/prettify (; 140 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/prettify (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   i32.eqz
@@ -7370,7 +7370,7 @@
    end
   end
  )
- (func $~lib/util/number/dtoa_core (; 141 ;) (param $0 i32) (param $1 f64) (result i32)
+ (func $~lib/util/number/dtoa_core (param $0 i32) (param $1 f64) (result i32)
   (local $2 i64)
   (local $3 i64)
   (local $4 i32)
@@ -7662,7 +7662,7 @@
   local.get $7
   i32.add
  )
- (func $~lib/util/number/dtoa_stream (; 142 ;) (param $0 i32) (param $1 i32) (param $2 f64) (result i32)
+ (func $~lib/util/number/dtoa_stream (param $0 i32) (param $1 i32) (param $2 f64) (result i32)
   local.get $0
   local.get $1
   i32.const 1
@@ -7737,7 +7737,7 @@
   local.get $2
   call $~lib/util/number/dtoa_core
  )
- (func $~lib/util/string/joinFloatArray<f64> (; 143 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/joinFloatArray<f64> (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 f64)
   (local $4 i32)
@@ -7900,7 +7900,7 @@
   end
   local.get $1
  )
- (func $~lib/util/string/joinReferenceArray<~lib/string/String | null> (; 144 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinReferenceArray<~lib/string/String | null> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -8066,7 +8066,7 @@
   call $~lib/rt/pure/__release
   local.get $1
  )
- (func $~lib/array/Array<~lib/string/String | null>#join (; 145 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/string/String | null>#join (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $0
@@ -8074,7 +8074,7 @@
   local.get $1
   call $~lib/util/string/joinReferenceArray<~lib/string/String | null>
  )
- (func $~lib/util/string/joinReferenceArray<std/array/Ref | null> (; 146 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/joinReferenceArray<std/array/Ref | null> (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -8227,14 +8227,14 @@
   call $~lib/rt/pure/__release
   local.get $1
  )
- (func $~lib/array/Array<std/array/Ref | null>#join (; 147 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<std/array/Ref | null>#join (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $0
   i32.load offset=12
   call $~lib/util/string/joinReferenceArray<std/array/Ref | null>
  )
- (func $~lib/util/number/itoa_stream<i8> (; 148 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_stream<i8> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   local.get $1
   i32.const 1
@@ -8300,7 +8300,7 @@
   call $~lib/util/number/utoa_simple<u32>
   local.get $1
  )
- (func $~lib/util/string/joinIntegerArray<i8> (; 149 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<i8> (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -8401,7 +8401,7 @@
   end
   local.get $1
  )
- (func $~lib/util/number/itoa_stream<u16> (; 150 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_stream<u16> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   local.get $1
   i32.const 1
@@ -8436,7 +8436,7 @@
   call $~lib/util/number/utoa_simple<u32>
   local.get $1
  )
- (func $~lib/util/string/joinIntegerArray<u16> (; 151 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<u16> (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -8541,7 +8541,7 @@
   end
   local.get $1
  )
- (func $~lib/util/number/decimalCount64High (; 152 ;) (param $0 i64) (result i32)
+ (func $~lib/util/number/decimalCount64High (param $0 i64) (result i32)
   local.get $0
   i64.const 100000000000
   i64.ge_u
@@ -8587,7 +8587,7 @@
   i64.lt_u
   select
  )
- (func $~lib/util/number/utoa_simple<u64> (; 153 ;) (param $0 i32) (param $1 i64) (param $2 i32)
+ (func $~lib/util/number/utoa_simple<u64> (param $0 i32) (param $1 i64) (param $2 i32)
   (local $3 i32)
   loop $do-continue|0
    local.get $1
@@ -8617,7 +8617,7 @@
    br_if $do-continue|0
   end
  )
- (func $~lib/util/number/itoa_stream<u64> (; 154 ;) (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
+ (func $~lib/util/number/itoa_stream<u64> (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
   (local $3 i32)
   local.get $0
   local.get $1
@@ -8660,7 +8660,7 @@
   end
   local.get $1
  )
- (func $~lib/util/string/joinIntegerArray<u64> (; 155 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<u64> (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i64)
@@ -8803,7 +8803,7 @@
   end
   local.get $1
  )
- (func $~lib/util/number/itoa_stream<i64> (; 156 ;) (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
+ (func $~lib/util/number/itoa_stream<i64> (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
   (local $3 i32)
   local.get $0
   local.get $1
@@ -8869,7 +8869,7 @@
   end
   local.get $0
  )
- (func $~lib/util/string/joinIntegerArray<i64> (; 157 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<i64> (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i64)
   (local $4 i32)
@@ -9033,7 +9033,7 @@
   end
   local.get $1
  )
- (func $~lib/util/string/joinReferenceArray<~lib/array/Array<i32>> (; 158 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/joinReferenceArray<~lib/array/Array<i32>> (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9201,7 +9201,7 @@
   call $~lib/rt/pure/__release
   local.get $1
  )
- (func $~lib/util/number/itoa_stream<u8> (; 159 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_stream<u8> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   local.get $1
   i32.const 1
@@ -9236,7 +9236,7 @@
   call $~lib/util/number/utoa_simple<u32>
   local.get $1
  )
- (func $~lib/util/string/joinIntegerArray<u8> (; 160 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<u8> (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9337,14 +9337,14 @@
   end
   local.get $1
  )
- (func $~lib/array/Array<u8>#toString (; 161 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<u8>#toString (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $0
   i32.load offset=12
   call $~lib/util/string/joinIntegerArray<u8>
  )
- (func $~lib/util/string/joinReferenceArray<~lib/array/Array<u8>> (; 162 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/joinReferenceArray<~lib/array/Array<u8>> (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9509,7 +9509,7 @@
   call $~lib/rt/pure/__release
   local.get $1
  )
- (func $~lib/util/string/joinReferenceArray<~lib/array/Array<u32>> (; 163 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/joinReferenceArray<~lib/array/Array<u32>> (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9677,14 +9677,14 @@
   call $~lib/rt/pure/__release
   local.get $1
  )
- (func $~lib/array/Array<~lib/array/Array<u32>>#toString (; 164 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<u32>>#toString (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $0
   i32.load offset=12
   call $~lib/util/string/joinReferenceArray<~lib/array/Array<u32>>
  )
- (func $~lib/util/string/joinReferenceArray<~lib/array/Array<~lib/array/Array<u32>>> (; 165 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/joinReferenceArray<~lib/array/Array<~lib/array/Array<u32>>> (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9849,7 +9849,7 @@
   call $~lib/rt/pure/__release
   local.get $1
  )
- (func $~lib/array/Array<~lib/array/Array<i32>>#flat (; 166 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<i32>>#flat (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -9952,7 +9952,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/array/Array<~lib/array/Array<~lib/string/String | null>>#flat (; 167 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<~lib/string/String | null>>#flat (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -10078,7 +10078,7 @@
   local.get $3
   call $~lib/rt/pure/__retain
  )
- (func $start:std/array (; 168 ;)
+ (func $start:std/array
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -16272,7 +16272,7 @@
   local.get $55
   call $~lib/rt/pure/__release
  )
- (func $~start (; 169 ;)
+ (func $~start
   global.get $~started
   if
    return
@@ -16282,7 +16282,7 @@
   end
   call $start:std/array
  )
- (func $~lib/rt/pure/decrement (; 170 ;) (param $0 i32)
+ (func $~lib/rt/pure/decrement (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -16411,7 +16411,7 @@
    i32.store offset=4
   end
  )
- (func $~lib/rt/pure/__visit (; 171 ;) (param $0 i32)
+ (func $~lib/rt/pure/__visit (param $0 i32)
   local.get $0
   i32.const 9808
   i32.lt_u

--- a/tests/compiler/std/array.untouched.wat
+++ b/tests/compiler/std/array.untouched.wat
@@ -261,7 +261,7 @@
  (export "__setArgumentsLength" (func $~setArgumentsLength))
  (export "_start" (func $~start))
  (export "memory" (memory $0))
- (func $~lib/rt/tlsf/removeBlock (; 8 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/removeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -471,7 +471,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/insertBlock (; 9 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/insertBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -821,7 +821,7 @@
   local.get $7
   i32.store offset=4
  )
- (func $~lib/rt/tlsf/addMemory (; 10 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -969,7 +969,7 @@
   call $~lib/rt/tlsf/insertBlock
   i32.const 1
  )
- (func $~lib/rt/tlsf/maybeInitialize (; 11 ;) (result i32)
+ (func $~lib/rt/tlsf/maybeInitialize (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -1123,7 +1123,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/tlsf/prepareSize (; 12 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/tlsf/prepareSize (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -1152,7 +1152,7 @@
   i32.gt_u
   select
  )
- (func $~lib/rt/tlsf/searchBlock (; 13 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/searchBlock (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1335,7 +1335,7 @@
   end
   local.get $7
  )
- (func $~lib/rt/tlsf/growMemory (; 14 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/growMemory (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1419,7 +1419,7 @@
   call $~lib/rt/tlsf/addMemory
   drop
  )
- (func $~lib/rt/tlsf/prepareBlock (; 15 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/rt/tlsf/prepareBlock (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1514,7 +1514,7 @@
    i32.store
   end
  )
- (func $~lib/rt/tlsf/allocateBlock (; 16 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/allocateBlock (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   global.get $~lib/rt/tlsf/collectLock
@@ -1625,7 +1625,7 @@
   call $~lib/rt/rtrace/onalloc
   local.get $4
  )
- (func $~lib/rt/tlsf/__alloc (; 17 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/__alloc (param $0 i32) (param $1 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
   local.get $0
   local.get $1
@@ -1633,7 +1633,7 @@
   i32.const 16
   i32.add
  )
- (func $~lib/memory/memory.fill (; 18 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/memory/memory.fill (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1842,7 +1842,7 @@
    end
   end
  )
- (func $~lib/rt/pure/increment (; 19 ;) (param $0 i32)
+ (func $~lib/rt/pure/increment (param $0 i32)
   (local $1 i32)
   local.get $0
   i32.load offset=4
@@ -1887,7 +1887,7 @@
    unreachable
   end
  )
- (func $~lib/rt/pure/__retain (; 20 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/pure/__retain (param $0 i32) (result i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.gt_u
@@ -1899,7 +1899,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/pure/__release (; 21 ;) (param $0 i32)
+ (func $~lib/rt/pure/__release (param $0 i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.gt_u
@@ -1910,7 +1910,7 @@
    call $~lib/rt/pure/decrement
   end
  )
- (func $~lib/array/Array<i32>#constructor (; 22 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#constructor (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1988,7 +1988,7 @@
   i32.store offset=12
   local.get $0
  )
- (func $~lib/array/Array.isArray<~lib/array/Array<i32> | null> (; 23 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array.isArray<~lib/array/Array<i32> | null> (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -2006,7 +2006,7 @@
   call $~lib/rt/pure/__release
   local.get $1
  )
- (func $std/array/Ref#constructor (; 24 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/array/Ref#constructor (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -2021,7 +2021,7 @@
   i32.store
   local.get $0
  )
- (func $~lib/array/Array.isArray<std/array/Ref> (; 25 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array.isArray<std/array/Ref> (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -2039,7 +2039,7 @@
   call $~lib/rt/pure/__release
   local.get $1
  )
- (func $~lib/arraybuffer/ArrayBufferView#constructor (; 26 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBufferView#constructor (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2111,7 +2111,7 @@
   i32.store offset=8
   local.get $0
  )
- (func $~lib/typedarray/Uint8Array#constructor (; 27 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#constructor (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   if (result i32)
    local.get $0
@@ -2127,7 +2127,7 @@
   local.set $0
   local.get $0
  )
- (func $~lib/array/Array.isArray<~lib/typedarray/Uint8Array> (; 28 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array.isArray<~lib/typedarray/Uint8Array> (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -2145,10 +2145,10 @@
   call $~lib/rt/pure/__release
   local.get $1
  )
- (func $~lib/array/Array.isArray<i32> (; 29 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array.isArray<i32> (param $0 i32) (result i32)
   i32.const 0
  )
- (func $~lib/array/Array.isArray<~lib/string/String> (; 30 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array.isArray<~lib/string/String> (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -2166,7 +2166,7 @@
   call $~lib/rt/pure/__release
   local.get $1
  )
- (func $~lib/array/Array.isArray<~lib/array/Array<i32>> (; 31 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array.isArray<~lib/array/Array<i32>> (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -2184,7 +2184,7 @@
   call $~lib/rt/pure/__release
   local.get $1
  )
- (func $~lib/util/memory/memcpy (; 32 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/memory/memcpy (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3208,7 +3208,7 @@
    i32.store8
   end
  )
- (func $~lib/memory/memory.copy (; 33 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/memory/memory.copy (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3428,7 +3428,7 @@
    end
   end
  )
- (func $~lib/rt/__allocBuffer (; 34 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/__allocBuffer (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $0
   local.get $1
@@ -3443,7 +3443,7 @@
   end
   local.get $3
  )
- (func $~lib/rt/__allocArray (; 35 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $~lib/rt/__allocArray (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -3475,7 +3475,7 @@
   i32.store offset=12
   local.get $4
  )
- (func $~lib/array/Array<u8>#fill (; 36 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $~lib/array/Array<u8>#fill (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -3552,11 +3552,11 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/array/Array<u8>#get:length (; 37 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<u8>#get:length (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<u8>#__unchecked_get (; 38 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u8>#__unchecked_get (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -3565,7 +3565,7 @@
   i32.add
   i32.load8_u
  )
- (func $~lib/array/Array<u8>#__get (; 39 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u8>#__get (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   local.get $0
@@ -3585,7 +3585,7 @@
   local.set $2
   local.get $2
  )
- (func $std/array/isArraysEqual<u8> (; 40 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/array/isArraysEqual<u8> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3670,7 +3670,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/array/Array<u32>#fill (; 41 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $~lib/array/Array<u32>#fill (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -3755,11 +3755,11 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/array/Array<u32>#get:length (; 42 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<u32>#get:length (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<u32>#__unchecked_get (; 43 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u32>#__unchecked_get (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -3768,7 +3768,7 @@
   i32.add
   i32.load
  )
- (func $~lib/array/Array<u32>#__get (; 44 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u32>#__get (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   local.get $0
@@ -3788,7 +3788,7 @@
   local.set $2
   local.get $2
  )
- (func $std/array/isArraysEqual<u32> (; 45 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/array/isArraysEqual<u32> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3873,17 +3873,17 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/array/Array<i32>#get:length (; 46 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<i32>#get:length (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/arraybuffer/ArrayBuffer#get:byteLength (; 47 ;) (param $0 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBuffer#get:byteLength (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub
   i32.load offset=12
  )
- (func $std/array/internalCapacity<i32> (; 48 ;) (param $0 i32) (result i32)
+ (func $std/array/internalCapacity<i32> (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -3904,7 +3904,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/rt/tlsf/checkUsedBlock (; 49 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/tlsf/checkUsedBlock (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   i32.const 16
@@ -3950,7 +3950,7 @@
   end
   local.get $1
  )
- (func $~lib/rt/tlsf/freeBlock (; 50 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/freeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $1
   i32.load
@@ -3966,7 +3966,7 @@
   local.get $1
   call $~lib/rt/rtrace/onfree
  )
- (func $~lib/rt/tlsf/reallocateBlock (; 51 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/reallocateBlock (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -4085,7 +4085,7 @@
   end
   local.get $8
  )
- (func $~lib/rt/tlsf/__realloc (; 52 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/__realloc (param $0 i32) (param $1 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
   local.get $0
   call $~lib/rt/tlsf/checkUsedBlock
@@ -4094,7 +4094,7 @@
   i32.const 16
   i32.add
  )
- (func $~lib/array/ensureSize (; 53 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/ensureSize (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -4156,7 +4156,7 @@
    i32.store offset=8
   end
  )
- (func $~lib/array/Array<i32>#push (; 54 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#push (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -4183,7 +4183,7 @@
   i32.store offset=12
   local.get $3
  )
- (func $~lib/array/Array<i32>#__unchecked_get (; 55 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#__unchecked_get (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -4192,7 +4192,7 @@
   i32.add
   i32.load
  )
- (func $~lib/array/Array<i32>#__get (; 56 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#__get (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   local.get $0
@@ -4212,7 +4212,7 @@
   local.set $2
   local.get $2
  )
- (func $~lib/array/Array<i32>#pop (; 57 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<i32>#pop (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -4245,7 +4245,7 @@
   i32.store offset=12
   local.get $2
  )
- (func $~lib/array/Array<std/array/Ref>#set:length (; 58 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<std/array/Ref>#set:length (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4297,11 +4297,11 @@
   local.get $1
   i32.store offset=12
  )
- (func $~lib/array/Array<std/array/Ref>#get:length (; 59 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<std/array/Ref>#get:length (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<i32>#concat (; 60 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#concat (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4374,7 +4374,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $~lib/array/Array<i32>#copyWithin (; 61 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $~lib/array/Array<i32>#copyWithin (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -4503,7 +4503,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $std/array/isArraysEqual<i32> (; 62 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/array/isArraysEqual<i32> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -4588,7 +4588,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/array/Array<i32>#unshift (; 63 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#unshift (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -4621,7 +4621,7 @@
   i32.store offset=12
   local.get $2
  )
- (func $~lib/array/Array<i32>#shift (; 64 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<i32>#shift (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -4670,7 +4670,7 @@
   i32.store offset=12
   local.get $3
  )
- (func $~lib/array/Array<i32>#reverse (; 65 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<i32>#reverse (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -4725,7 +4725,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/array/Array<i32>#indexOf (; 66 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/array/Array<i32>#indexOf (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -4794,7 +4794,7 @@
   end
   i32.const -1
  )
- (func $~lib/array/Array<f32>#indexOf (; 67 ;) (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
+ (func $~lib/array/Array<f32>#indexOf (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -4863,7 +4863,7 @@
   end
   i32.const -1
  )
- (func $~lib/array/Array<f64>#indexOf (; 68 ;) (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
+ (func $~lib/array/Array<f64>#indexOf (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -4932,7 +4932,7 @@
   end
   i32.const -1
  )
- (func $~lib/array/Array<i32>#includes (; 69 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/array/Array<i32>#includes (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   local.get $1
   local.get $2
@@ -4941,7 +4941,7 @@
   i32.ge_s
   return
  )
- (func $~lib/array/Array<f32>#includes (; 70 ;) (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
+ (func $~lib/array/Array<f32>#includes (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -5024,7 +5024,7 @@
   i32.const 0
   return
  )
- (func $~lib/array/Array<f64>#includes (; 71 ;) (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
+ (func $~lib/array/Array<f64>#includes (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -5107,7 +5107,7 @@
   i32.const 0
   return
  )
- (func $~lib/array/Array<i32>#splice (; 72 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/array/Array<i32>#splice (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -5215,7 +5215,7 @@
   i32.store offset=12
   local.get $6
  )
- (func $~lib/array/Array<std/array/Ref>#splice (; 73 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/array/Array<std/array/Ref>#splice (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -5323,7 +5323,7 @@
   i32.store offset=12
   local.get $6
  )
- (func $~lib/array/Array<std/array/Ref>#__unchecked_get (; 74 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<std/array/Ref>#__unchecked_get (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -5333,7 +5333,7 @@
   i32.load
   call $~lib/rt/pure/__retain
  )
- (func $~lib/array/Array<std/array/Ref>#__get (; 75 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<std/array/Ref>#__get (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   local.get $0
@@ -5365,7 +5365,7 @@
   end
   local.get $2
  )
- (func $~lib/array/Array<std/array/Ref | null>#splice (; 76 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/array/Array<std/array/Ref | null>#splice (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -5473,11 +5473,11 @@
   i32.store offset=12
   local.get $6
  )
- (func $~lib/array/Array<std/array/Ref | null>#get:length (; 77 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<std/array/Ref | null>#get:length (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<std/array/Ref | null>#__unchecked_get (; 78 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<std/array/Ref | null>#__unchecked_get (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -5487,7 +5487,7 @@
   i32.load
   call $~lib/rt/pure/__retain
  )
- (func $~lib/array/Array<std/array/Ref | null>#__get (; 79 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<std/array/Ref | null>#__get (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   local.get $0
@@ -5507,7 +5507,7 @@
   local.set $2
   local.get $2
  )
- (func $~lib/array/Array<i32>#__unchecked_set (; 80 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<i32>#__unchecked_set (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -5517,7 +5517,7 @@
   local.get $2
   i32.store
  )
- (func $~lib/array/Array<i32>#__set (; 81 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<i32>#__set (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -5551,7 +5551,7 @@
   local.get $2
   call $~lib/array/Array<i32>#__unchecked_set
  )
- (func $start:std/array~anonymous|0 (; 82 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -5564,11 +5564,11 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~setArgumentsLength (; 83 ;) (param $0 i32)
+ (func $~setArgumentsLength (param $0 i32)
   local.get $0
   global.set $~argumentsLength
  )
- (func $~lib/array/Array<i32>#findIndex (; 84 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#findIndex (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5619,7 +5619,7 @@
   end
   i32.const -1
  )
- (func $start:std/array~anonymous|1 (; 85 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|1 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -5632,7 +5632,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $start:std/array~anonymous|2 (; 86 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|2 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -5645,7 +5645,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $start:std/array~anonymous|3 (; 87 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|3 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -5662,7 +5662,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $start:std/array~anonymous|4 (; 88 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|4 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -5675,7 +5675,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $start:std/array~anonymous|5 (; 89 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|5 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -5691,7 +5691,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $start:std/array~anonymous|6 (; 90 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|6 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -5704,7 +5704,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/array/Array<i32>#every (; 91 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#every (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5756,7 +5756,7 @@
   end
   i32.const 1
  )
- (func $start:std/array~anonymous|7 (; 92 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|7 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -5769,7 +5769,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $start:std/array~anonymous|8 (; 93 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|8 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -5786,7 +5786,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $start:std/array~anonymous|9 (; 94 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|9 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -5799,7 +5799,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $start:std/array~anonymous|10 (; 95 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|10 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -5815,7 +5815,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $start:std/array~anonymous|11 (; 96 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|11 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -5828,7 +5828,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/array/Array<i32>#some (; 97 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#some (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5879,7 +5879,7 @@
   end
   i32.const 0
  )
- (func $start:std/array~anonymous|12 (; 98 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|12 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -5892,7 +5892,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $start:std/array~anonymous|13 (; 99 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|13 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -5909,7 +5909,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $start:std/array~anonymous|14 (; 100 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|14 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -5922,7 +5922,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $start:std/array~anonymous|15 (; 101 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|15 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -5938,7 +5938,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $start:std/array~anonymous|16 (; 102 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $start:std/array~anonymous|16 (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $2
   call $~lib/rt/pure/__retain
   local.set $2
@@ -5949,7 +5949,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $~lib/array/Array<i32>#forEach (; 103 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i32>#forEach (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5995,7 +5995,7 @@
    end
   end
  )
- (func $start:std/array~anonymous|17 (; 104 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $start:std/array~anonymous|17 (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $2
   call $~lib/rt/pure/__retain
   local.set $2
@@ -6010,7 +6010,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $start:std/array~anonymous|18 (; 105 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $start:std/array~anonymous|18 (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $2
   call $~lib/rt/pure/__retain
   local.set $2
@@ -6021,7 +6021,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $start:std/array~anonymous|19 (; 106 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $start:std/array~anonymous|19 (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $2
   call $~lib/rt/pure/__retain
   local.set $2
@@ -6035,7 +6035,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $start:std/array~anonymous|20 (; 107 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $start:std/array~anonymous|20 (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $2
@@ -6148,7 +6148,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $start:std/array~anonymous|21 (; 108 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result f32)
+ (func $start:std/array~anonymous|21 (param $0 i32) (param $1 i32) (param $2 i32) (result f32)
   (local $3 f32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -6160,7 +6160,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/array/Array<i32>#map<f32> (; 109 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#map<f32> (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6228,11 +6228,11 @@
   end
   local.get $3
  )
- (func $~lib/array/Array<f32>#get:length (; 110 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<f32>#get:length (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<f32>#__unchecked_get (; 111 ;) (param $0 i32) (param $1 i32) (result f32)
+ (func $~lib/array/Array<f32>#__unchecked_get (param $0 i32) (param $1 i32) (result f32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -6241,7 +6241,7 @@
   i32.add
   f32.load
  )
- (func $~lib/array/Array<f32>#__get (; 112 ;) (param $0 i32) (param $1 i32) (result f32)
+ (func $~lib/array/Array<f32>#__get (param $0 i32) (param $1 i32) (result f32)
   (local $2 f32)
   local.get $1
   local.get $0
@@ -6261,7 +6261,7 @@
   local.set $2
   local.get $2
  )
- (func $start:std/array~anonymous|22 (; 113 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|22 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -6280,7 +6280,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/array/Array<i32>#map<i32> (; 114 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#map<i32> (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6347,7 +6347,7 @@
   end
   local.get $3
  )
- (func $start:std/array~anonymous|23 (; 115 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|23 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -6362,7 +6362,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $start:std/array~anonymous|24 (; 116 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|24 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -6380,7 +6380,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $start:std/array~anonymous|25 (; 117 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|25 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -6393,7 +6393,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/array/Array<i32>#filter (; 118 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#filter (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6456,7 +6456,7 @@
   end
   local.get $2
  )
- (func $start:std/array~anonymous|26 (; 119 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|26 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -6477,7 +6477,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $start:std/array~anonymous|27 (; 120 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|27 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -6494,7 +6494,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $start:std/array~anonymous|28 (; 121 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|28 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -6514,7 +6514,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $start:std/array~anonymous|29 (; 122 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|29 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -6527,7 +6527,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/array/Array<i32>#reduce<i32> (; 123 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/array/Array<i32>#reduce<i32> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -6579,7 +6579,7 @@
   end
   local.get $3
  )
- (func $start:std/array~anonymous|30 (; 124 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|30 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -6592,7 +6592,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $start:std/array~anonymous|31 (; 125 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|31 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -6610,7 +6610,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/array/Array<i32>#reduce<bool> (; 126 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/array/Array<i32>#reduce<bool> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -6662,7 +6662,7 @@
   end
   local.get $3
  )
- (func $start:std/array~anonymous|32 (; 127 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|32 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -6680,7 +6680,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $start:std/array~anonymous|33 (; 128 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|33 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -6697,7 +6697,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $start:std/array~anonymous|34 (; 129 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|34 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -6710,7 +6710,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $start:std/array~anonymous|35 (; 130 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|35 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -6726,7 +6726,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $start:std/array~anonymous|36 (; 131 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|36 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -6739,7 +6739,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/array/Array<i32>#reduceRight<i32> (; 132 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/array/Array<i32>#reduceRight<i32> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -6781,7 +6781,7 @@
   end
   local.get $3
  )
- (func $start:std/array~anonymous|37 (; 133 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|37 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -6794,7 +6794,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $start:std/array~anonymous|38 (; 134 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|38 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -6812,7 +6812,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/array/Array<i32>#reduceRight<bool> (; 135 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/array/Array<i32>#reduceRight<bool> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -6854,7 +6854,7 @@
   end
   local.get $3
  )
- (func $start:std/array~anonymous|39 (; 136 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|39 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -6872,7 +6872,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $start:std/array~anonymous|40 (; 137 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|40 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -6889,7 +6889,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $start:std/array~anonymous|41 (; 138 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|41 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -6902,7 +6902,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $start:std/array~anonymous|42 (; 139 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|42 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -6918,7 +6918,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/math/murmurHash3 (; 140 ;) (param $0 i64) (result i64)
+ (func $~lib/math/murmurHash3 (param $0 i64) (result i64)
   local.get $0
   local.get $0
   i64.const 33
@@ -6947,7 +6947,7 @@
   local.set $0
   local.get $0
  )
- (func $~lib/math/splitMix32 (; 141 ;) (param $0 i32) (result i32)
+ (func $~lib/math/splitMix32 (param $0 i32) (result i32)
   local.get $0
   i32.const 1831565813
   i32.add
@@ -6982,7 +6982,7 @@
   i32.shr_u
   i32.xor
  )
- (func $~lib/math/NativeMath.seedRandom (; 142 ;) (param $0 i64)
+ (func $~lib/math/NativeMath.seedRandom (param $0 i64)
   i32.const 1
   global.set $~lib/math/random_seeded
   local.get $0
@@ -7034,7 +7034,7 @@
    unreachable
   end
  )
- (func $~lib/util/sort/insertionSort<f32> (; 143 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/sort/insertionSort<f32> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 f32)
@@ -7124,13 +7124,13 @@
    end
   end
  )
- (func $~lib/rt/tlsf/__free (; 144 ;) (param $0 i32)
+ (func $~lib/rt/tlsf/__free (param $0 i32)
   call $~lib/rt/tlsf/maybeInitialize
   local.get $0
   call $~lib/rt/tlsf/checkUsedBlock
   call $~lib/rt/tlsf/freeBlock
  )
- (func $~lib/util/sort/weakHeapSort<f32> (; 145 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/sort/weakHeapSort<f32> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -7419,7 +7419,7 @@
   local.get $12
   f32.store
  )
- (func $~lib/array/Array<f32>#sort (; 146 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<f32>#sort (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 f32)
@@ -7494,7 +7494,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/sort/COMPARATOR<f32>~anonymous|0 (; 147 ;) (param $0 f32) (param $1 f32) (result i32)
+ (func $~lib/util/sort/COMPARATOR<f32>~anonymous|0 (param $0 f32) (param $1 f32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -7527,7 +7527,7 @@
   i32.lt_s
   i32.sub
  )
- (func $~lib/array/Array<f32>#sort|trampoline (; 148 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<f32>#sort|trampoline (param $0 i32) (param $1 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -7546,7 +7546,7 @@
   local.get $1
   call $~lib/array/Array<f32>#sort
  )
- (func $std/array/isArraysEqual<f32> (; 149 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/array/isArraysEqual<f32> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 f32)
@@ -7653,7 +7653,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/util/sort/insertionSort<f64> (; 150 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/sort/insertionSort<f64> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 f64)
@@ -7743,7 +7743,7 @@
    end
   end
  )
- (func $~lib/util/sort/weakHeapSort<f64> (; 151 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/sort/weakHeapSort<f64> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -8032,7 +8032,7 @@
   local.get $12
   f64.store
  )
- (func $~lib/array/Array<f64>#sort (; 152 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<f64>#sort (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 f64)
@@ -8107,7 +8107,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/sort/COMPARATOR<f64>~anonymous|0 (; 153 ;) (param $0 f64) (param $1 f64) (result i32)
+ (func $~lib/util/sort/COMPARATOR<f64>~anonymous|0 (param $0 f64) (param $1 f64) (result i32)
   (local $2 i64)
   (local $3 i64)
   local.get $0
@@ -8140,7 +8140,7 @@
   i64.lt_s
   i32.sub
  )
- (func $~lib/array/Array<f64>#sort|trampoline (; 154 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<f64>#sort|trampoline (param $0 i32) (param $1 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -8159,11 +8159,11 @@
   local.get $1
   call $~lib/array/Array<f64>#sort
  )
- (func $~lib/array/Array<f64>#get:length (; 155 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<f64>#get:length (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<f64>#__unchecked_get (; 156 ;) (param $0 i32) (param $1 i32) (result f64)
+ (func $~lib/array/Array<f64>#__unchecked_get (param $0 i32) (param $1 i32) (result f64)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -8172,7 +8172,7 @@
   i32.add
   f64.load
  )
- (func $~lib/array/Array<f64>#__get (; 157 ;) (param $0 i32) (param $1 i32) (result f64)
+ (func $~lib/array/Array<f64>#__get (param $0 i32) (param $1 i32) (result f64)
   (local $2 f64)
   local.get $1
   local.get $0
@@ -8192,7 +8192,7 @@
   local.set $2
   local.get $2
  )
- (func $std/array/isArraysEqual<f64> (; 158 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/array/isArraysEqual<f64> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 f64)
@@ -8299,7 +8299,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/util/sort/insertionSort<i32> (; 159 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/sort/insertionSort<i32> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -8389,7 +8389,7 @@
    end
   end
  )
- (func $~lib/util/sort/weakHeapSort<i32> (; 160 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/sort/weakHeapSort<i32> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -8678,7 +8678,7 @@
   local.get $12
   i32.store
  )
- (func $~lib/array/Array<i32>#sort (; 161 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#sort (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -8751,12 +8751,12 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/sort/COMPARATOR<i32>~anonymous|0 (; 162 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/sort/COMPARATOR<i32>~anonymous|0 (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.sub
  )
- (func $~lib/array/Array<i32>#sort|trampoline (; 163 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#sort|trampoline (param $0 i32) (param $1 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -8775,7 +8775,7 @@
   local.get $1
   call $~lib/array/Array<i32>#sort
  )
- (func $~lib/util/sort/insertionSort<u32> (; 164 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/sort/insertionSort<u32> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -8865,7 +8865,7 @@
    end
   end
  )
- (func $~lib/util/sort/weakHeapSort<u32> (; 165 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/sort/weakHeapSort<u32> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -9154,7 +9154,7 @@
   local.get $12
   i32.store
  )
- (func $~lib/array/Array<u32>#sort (; 166 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u32>#sort (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9227,7 +9227,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/sort/COMPARATOR<u32>~anonymous|0 (; 167 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/sort/COMPARATOR<u32>~anonymous|0 (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.gt_u
@@ -9236,7 +9236,7 @@
   i32.lt_u
   i32.sub
  )
- (func $~lib/array/Array<u32>#sort|trampoline (; 168 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u32>#sort|trampoline (param $0 i32) (param $1 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -9255,7 +9255,7 @@
   local.get $1
   call $~lib/array/Array<u32>#sort
  )
- (func $std/array/createReverseOrderedArray (; 169 ;) (param $0 i32) (result i32)
+ (func $std/array/createReverseOrderedArray (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -9289,7 +9289,7 @@
   end
   local.get $1
  )
- (func $~lib/math/NativeMath.random (; 170 ;) (result f64)
+ (func $~lib/math/NativeMath.random (result f64)
   (local $0 i64)
   (local $1 i64)
   (local $2 i64)
@@ -9341,7 +9341,7 @@
   f64.const 1
   f64.sub
  )
- (func $std/array/createRandomOrderedArray (; 171 ;) (param $0 i32) (result i32)
+ (func $std/array/createRandomOrderedArray (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -9375,12 +9375,12 @@
   end
   local.get $1
  )
- (func $~lib/util/sort/COMPARATOR<i32>~anonymous|1 (; 172 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/sort/COMPARATOR<i32>~anonymous|1 (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.sub
  )
- (func $std/array/isSorted<i32> (; 173 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/array/isSorted<i32> (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9435,7 +9435,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $std/array/assertSorted<i32> (; 174 ;) (param $0 i32) (param $1 i32)
+ (func $std/array/assertSorted<i32> (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -9460,7 +9460,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $std/array/assertSortedDefault<i32> (; 175 ;) (param $0 i32)
+ (func $std/array/assertSortedDefault<i32> (param $0 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $0
@@ -9473,27 +9473,27 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $start:std/array~anonymous|43 (; 176 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $start:std/array~anonymous|43 (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.sub
  )
- (func $start:std/array~anonymous|44 (; 177 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $start:std/array~anonymous|44 (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.sub
  )
- (func $start:std/array~anonymous|45 (; 178 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $start:std/array~anonymous|45 (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.sub
  )
- (func $start:std/array~anonymous|46 (; 179 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $start:std/array~anonymous|46 (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.sub
  )
- (func $~lib/array/Array<~lib/array/Array<i32>>#constructor (; 180 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<i32>>#constructor (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9571,7 +9571,7 @@
   i32.store offset=12
   local.get $0
  )
- (func $~lib/array/Array<~lib/array/Array<i32>>#__unchecked_set (; 181 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<~lib/array/Array<i32>>#__unchecked_set (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $2
@@ -9601,7 +9601,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $~lib/array/Array<~lib/array/Array<i32>>#__set (; 182 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<~lib/array/Array<i32>>#__set (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $2
   call $~lib/rt/pure/__retain
   local.set $2
@@ -9642,7 +9642,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/array/createReverseOrderedNestedArray (; 183 ;) (param $0 i32) (result i32)
+ (func $std/array/createReverseOrderedNestedArray (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -9687,7 +9687,7 @@
   end
   local.get $1
  )
- (func $start:std/array~anonymous|47 (; 184 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $start:std/array~anonymous|47 (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -9709,7 +9709,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/util/sort/insertionSort<~lib/array/Array<i32>> (; 185 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/sort/insertionSort<~lib/array/Array<i32>> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -9807,7 +9807,7 @@
    end
   end
  )
- (func $~lib/array/Array<~lib/array/Array<i32>>#sort (; 186 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<i32>>#sort (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9878,11 +9878,11 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/array/Array<~lib/array/Array<i32>>#get:length (; 187 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<i32>>#get:length (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<~lib/array/Array<i32>>#__unchecked_get (; 188 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<i32>>#__unchecked_get (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -9892,7 +9892,7 @@
   i32.load
   call $~lib/rt/pure/__retain
  )
- (func $~lib/array/Array<~lib/array/Array<i32>>#__get (; 189 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<i32>>#__get (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   local.get $0
@@ -9924,7 +9924,7 @@
   end
   local.get $2
  )
- (func $std/array/isSorted<~lib/array/Array<i32>> (; 190 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/array/isSorted<~lib/array/Array<i32>> (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9991,7 +9991,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $std/array/assertSorted<~lib/array/Array<i32>> (; 191 ;) (param $0 i32) (param $1 i32)
+ (func $std/array/assertSorted<~lib/array/Array<i32>> (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -10016,7 +10016,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/array/Array<std/array/Proxy<i32>>#constructor (; 192 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<std/array/Proxy<i32>>#constructor (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10094,7 +10094,7 @@
   i32.store offset=12
   local.get $0
  )
- (func $std/array/Proxy<i32>#constructor (; 193 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/array/Proxy<i32>#constructor (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -10109,7 +10109,7 @@
   i32.store
   local.get $0
  )
- (func $~lib/array/Array<std/array/Proxy<i32>>#__unchecked_set (; 194 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<std/array/Proxy<i32>>#__unchecked_set (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $2
@@ -10139,7 +10139,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $~lib/array/Array<std/array/Proxy<i32>>#__set (; 195 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<std/array/Proxy<i32>>#__set (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $2
   call $~lib/rt/pure/__retain
   local.set $2
@@ -10180,7 +10180,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/array/createReverseOrderedElementsArray (; 196 ;) (param $0 i32) (result i32)
+ (func $std/array/createReverseOrderedElementsArray (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -10220,7 +10220,7 @@
   end
   local.get $1
  )
- (func $start:std/array~anonymous|48 (; 197 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $start:std/array~anonymous|48 (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -10240,7 +10240,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/util/sort/insertionSort<std/array/Proxy<i32>> (; 198 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/sort/insertionSort<std/array/Proxy<i32>> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -10338,7 +10338,7 @@
    end
   end
  )
- (func $~lib/array/Array<std/array/Proxy<i32>>#sort (; 199 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<std/array/Proxy<i32>>#sort (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10409,11 +10409,11 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/array/Array<std/array/Proxy<i32>>#get:length (; 200 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<std/array/Proxy<i32>>#get:length (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<std/array/Proxy<i32>>#__unchecked_get (; 201 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<std/array/Proxy<i32>>#__unchecked_get (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -10423,7 +10423,7 @@
   i32.load
   call $~lib/rt/pure/__retain
  )
- (func $~lib/array/Array<std/array/Proxy<i32>>#__get (; 202 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<std/array/Proxy<i32>>#__get (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   local.get $0
@@ -10455,7 +10455,7 @@
   end
   local.get $2
  )
- (func $std/array/isSorted<std/array/Proxy<i32>> (; 203 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/array/isSorted<std/array/Proxy<i32>> (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10522,7 +10522,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $std/array/assertSorted<std/array/Proxy<i32>> (; 204 ;) (param $0 i32) (param $1 i32)
+ (func $std/array/assertSorted<std/array/Proxy<i32>> (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -10547,7 +10547,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/util/sort/insertionSort<~lib/string/String | null> (; 205 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/sort/insertionSort<~lib/string/String | null> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -10645,7 +10645,7 @@
    end
   end
  )
- (func $~lib/array/Array<~lib/string/String | null>#sort (; 206 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/string/String | null>#sort (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10716,11 +10716,11 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/array/Array<~lib/string/String | null>#get:length (; 207 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<~lib/string/String | null>#get:length (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<~lib/string/String | null>#__unchecked_get (; 208 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/string/String | null>#__unchecked_get (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -10730,7 +10730,7 @@
   i32.load
   call $~lib/rt/pure/__retain
  )
- (func $~lib/array/Array<~lib/string/String | null>#__get (; 209 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/string/String | null>#__get (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   local.get $0
@@ -10750,7 +10750,7 @@
   local.set $2
   local.get $2
  )
- (func $std/array/isSorted<~lib/string/String | null> (; 210 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/array/isSorted<~lib/string/String | null> (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10817,7 +10817,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $std/array/assertSorted<~lib/string/String | null> (; 211 ;) (param $0 i32) (param $1 i32)
+ (func $std/array/assertSorted<~lib/string/String | null> (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -10842,7 +10842,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/string/String#get:length (; 212 ;) (param $0 i32) (result i32)
+ (func $~lib/string/String#get:length (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub
@@ -10850,7 +10850,7 @@
   i32.const 1
   i32.shr_u
  )
- (func $~lib/util/string/compareImpl (; 213 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
+ (func $~lib/util/string/compareImpl (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
@@ -10972,7 +10972,7 @@
   call $~lib/rt/pure/__release
   local.get $7
  )
- (func $~lib/util/sort/COMPARATOR<~lib/string/String | null>~anonymous|0 (; 214 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/sort/COMPARATOR<~lib/string/String | null>~anonymous|0 (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -11078,7 +11078,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $std/array/assertSorted<~lib/string/String | null>|trampoline (; 215 ;) (param $0 i32) (param $1 i32)
+ (func $std/array/assertSorted<~lib/string/String | null>|trampoline (param $0 i32) (param $1 i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -11099,7 +11099,7 @@
   local.get $1
   call $std/array/assertSorted<~lib/string/String | null>
  )
- (func $~lib/string/String.__eq (; 216 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__eq (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -11172,7 +11172,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/string/String.__ne (; 217 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__ne (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -11191,7 +11191,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $std/array/isArraysEqual<~lib/string/String | null> (; 218 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/array/isArraysEqual<~lib/string/String | null> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -11288,7 +11288,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/array/Array<~lib/string/String>#constructor (; 219 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/string/String>#constructor (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -11366,7 +11366,7 @@
   i32.store offset=12
   local.get $0
  )
- (func $~lib/string/String#charAt (; 220 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String#charAt (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   local.get $0
@@ -11392,7 +11392,7 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~lib/string/String#concat (; 221 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String#concat (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -11468,7 +11468,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/string/String.__concat (; 222 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__concat (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -11491,7 +11491,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $std/array/createRandomString (; 223 ;) (param $0 i32) (result i32)
+ (func $std/array/createRandomString (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -11552,7 +11552,7 @@
   end
   local.get $1
  )
- (func $~lib/array/Array<~lib/string/String>#__unchecked_set (; 224 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<~lib/string/String>#__unchecked_set (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $2
@@ -11582,7 +11582,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $~lib/array/Array<~lib/string/String>#__set (; 225 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<~lib/string/String>#__set (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $2
   call $~lib/rt/pure/__retain
   local.set $2
@@ -11623,7 +11623,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/array/createRandomStringArray (; 226 ;) (param $0 i32) (result i32)
+ (func $std/array/createRandomStringArray (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -11661,7 +11661,7 @@
   end
   local.get $1
  )
- (func $~lib/util/sort/insertionSort<~lib/string/String> (; 227 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/sort/insertionSort<~lib/string/String> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -11759,7 +11759,7 @@
    end
   end
  )
- (func $~lib/array/Array<~lib/string/String>#sort (; 228 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/string/String>#sort (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -11830,11 +11830,11 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/array/Array<~lib/string/String>#get:length (; 229 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<~lib/string/String>#get:length (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<~lib/string/String>#__unchecked_get (; 230 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/string/String>#__unchecked_get (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -11844,7 +11844,7 @@
   i32.load
   call $~lib/rt/pure/__retain
  )
- (func $~lib/array/Array<~lib/string/String>#__get (; 231 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/string/String>#__get (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   local.get $0
@@ -11876,7 +11876,7 @@
   end
   local.get $2
  )
- (func $std/array/isSorted<~lib/string/String> (; 232 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/array/isSorted<~lib/string/String> (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -11943,7 +11943,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $std/array/assertSorted<~lib/string/String> (; 233 ;) (param $0 i32) (param $1 i32)
+ (func $std/array/assertSorted<~lib/string/String> (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -11968,7 +11968,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/util/sort/COMPARATOR<~lib/string/String>~anonymous|0 (; 234 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/sort/COMPARATOR<~lib/string/String>~anonymous|0 (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -12074,7 +12074,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $std/array/assertSorted<~lib/string/String>|trampoline (; 235 ;) (param $0 i32) (param $1 i32)
+ (func $std/array/assertSorted<~lib/string/String>|trampoline (param $0 i32) (param $1 i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -12095,7 +12095,7 @@
   local.get $1
   call $std/array/assertSorted<~lib/string/String>
  )
- (func $~lib/string/String#substring (; 236 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/string/String#substring (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -12202,7 +12202,7 @@
   local.get $11
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/string/joinBooleanArray (; 237 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinBooleanArray (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -12377,7 +12377,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/array/Array<bool>#join (; 238 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<bool>#join (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -12400,7 +12400,7 @@
   local.get $4
   return
  )
- (func $~lib/util/number/decimalCount32 (; 239 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/decimalCount32 (param $0 i32) (result i32)
   local.get $0
   i32.const 100000
   i32.lt_u
@@ -12455,7 +12455,7 @@
   end
   unreachable
  )
- (func $~lib/util/number/utoa32_lut (; 240 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/number/utoa32_lut (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -12595,7 +12595,7 @@
    i32.store16
   end
  )
- (func $~lib/util/number/itoa32 (; 241 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/itoa32 (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -12649,12 +12649,12 @@
   local.get $3
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/itoa<i32> (; 242 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/itoa<i32> (param $0 i32) (result i32)
   local.get $0
   call $~lib/util/number/itoa32
   return
  )
- (func $~lib/util/number/itoa_stream<i32> (; 243 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_stream<i32> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -12719,7 +12719,7 @@
   call $~lib/util/number/utoa32_lut
   local.get $4
  )
- (func $~lib/util/string/joinIntegerArray<i32> (; 244 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<i32> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -12862,7 +12862,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/array/Array<i32>#join (; 245 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#join (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -12885,7 +12885,7 @@
   local.get $4
   return
  )
- (func $~lib/util/number/utoa32 (; 246 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/utoa32 (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -12919,12 +12919,12 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/itoa<u32> (; 247 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/itoa<u32> (param $0 i32) (result i32)
   local.get $0
   call $~lib/util/number/utoa32
   return
  )
- (func $~lib/util/number/itoa_stream<u32> (; 248 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_stream<u32> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -12969,7 +12969,7 @@
   call $~lib/util/number/utoa32_lut
   local.get $4
  )
- (func $~lib/util/string/joinIntegerArray<u32> (; 249 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<u32> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -13112,7 +13112,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/array/Array<u32>#join (; 250 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u32>#join (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -13135,7 +13135,7 @@
   local.get $4
   return
  )
- (func $~lib/util/number/genDigits (; 251 ;) (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (param $6 i32) (result i32)
+ (func $~lib/util/number/genDigits (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (param $6 i32) (result i32)
   (local $7 i32)
   (local $8 i64)
   (local $9 i64)
@@ -13638,7 +13638,7 @@
   end
   unreachable
  )
- (func $~lib/util/number/prettify (; 252 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/prettify (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -13955,7 +13955,7 @@
   end
   unreachable
  )
- (func $~lib/util/number/dtoa_core (; 253 ;) (param $0 i32) (param $1 f64) (result i32)
+ (func $~lib/util/number/dtoa_core (param $0 i32) (param $1 f64) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -14381,7 +14381,7 @@
   local.get $2
   i32.add
  )
- (func $~lib/util/number/dtoa (; 254 ;) (param $0 f64) (result i32)
+ (func $~lib/util/number/dtoa (param $0 f64) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -14442,7 +14442,7 @@
   call $~lib/rt/tlsf/__free
   local.get $3
  )
- (func $~lib/util/number/dtoa_stream (; 255 ;) (param $0 i32) (param $1 i32) (param $2 f64) (result i32)
+ (func $~lib/util/number/dtoa_stream (param $0 i32) (param $1 i32) (param $2 f64) (result i32)
   (local $3 i32)
   local.get $0
   local.get $1
@@ -14520,7 +14520,7 @@
   local.get $2
   call $~lib/util/number/dtoa_core
  )
- (func $~lib/util/string/joinFloatArray<f64> (; 256 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinFloatArray<f64> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -14663,7 +14663,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/array/Array<f64>#join (; 257 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<f64>#join (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -14686,7 +14686,7 @@
   local.get $4
   return
  )
- (func $~lib/util/string/joinStringArray (; 258 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinStringArray (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -14915,7 +14915,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $~lib/array/Array<~lib/string/String | null>#join (; 259 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/string/String | null>#join (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -14938,10 +14938,10 @@
   local.get $4
   return
  )
- (func $std/array/Ref#toString (; 260 ;) (param $0 i32) (result i32)
+ (func $std/array/Ref#toString (param $0 i32) (result i32)
   i32.const 7456
  )
- (func $~lib/util/string/joinReferenceArray<std/array/Ref | null> (; 261 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinReferenceArray<std/array/Ref | null> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -15152,7 +15152,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/array/Array<std/array/Ref | null>#join (; 262 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<std/array/Ref | null>#join (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -15175,7 +15175,7 @@
   local.get $4
   return
  )
- (func $~lib/util/string/joinReferenceArray<std/array/Ref> (; 263 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinReferenceArray<std/array/Ref> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -15386,7 +15386,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/array/Array<std/array/Ref>#join (; 264 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<std/array/Ref>#join (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -15409,12 +15409,12 @@
   local.get $4
   return
  )
- (func $~lib/array/Array<i32>#toString (; 265 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<i32>#toString (param $0 i32) (result i32)
   local.get $0
   i32.const 5296
   call $~lib/array/Array<i32>#join
  )
- (func $~lib/util/number/itoa<i8> (; 266 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/itoa<i8> (param $0 i32) (result i32)
   local.get $0
   i32.const 24
   i32.shl
@@ -15423,7 +15423,7 @@
   call $~lib/util/number/itoa32
   return
  )
- (func $~lib/util/number/itoa_stream<i8> (; 267 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_stream<i8> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -15508,7 +15508,7 @@
   call $~lib/util/number/utoa32_lut
   local.get $4
  )
- (func $~lib/util/string/joinIntegerArray<i8> (; 268 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<i8> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -15651,7 +15651,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/array/Array<i8>#join (; 269 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i8>#join (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -15674,19 +15674,19 @@
   local.get $4
   return
  )
- (func $~lib/array/Array<i8>#toString (; 270 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<i8>#toString (param $0 i32) (result i32)
   local.get $0
   i32.const 5296
   call $~lib/array/Array<i8>#join
  )
- (func $~lib/util/number/itoa<u16> (; 271 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/itoa<u16> (param $0 i32) (result i32)
   local.get $0
   i32.const 65535
   i32.and
   call $~lib/util/number/utoa32
   return
  )
- (func $~lib/util/number/itoa_stream<u16> (; 272 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_stream<u16> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -15739,7 +15739,7 @@
   call $~lib/util/number/utoa32_lut
   local.get $4
  )
- (func $~lib/util/string/joinIntegerArray<u16> (; 273 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<u16> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -15882,7 +15882,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/array/Array<u16>#join (; 274 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u16>#join (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -15905,12 +15905,12 @@
   local.get $4
   return
  )
- (func $~lib/array/Array<u16>#toString (; 275 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<u16>#toString (param $0 i32) (result i32)
   local.get $0
   i32.const 5296
   call $~lib/array/Array<u16>#join
  )
- (func $~lib/util/number/decimalCount64High (; 276 ;) (param $0 i64) (result i32)
+ (func $~lib/util/number/decimalCount64High (param $0 i64) (result i32)
   local.get $0
   i64.const 1000000000000000
   i64.lt_u
@@ -15969,7 +15969,7 @@
   end
   unreachable
  )
- (func $~lib/util/number/utoa64_lut (; 277 ;) (param $0 i32) (param $1 i64) (param $2 i32)
+ (func $~lib/util/number/utoa64_lut (param $0 i32) (param $1 i64) (param $2 i32)
   (local $3 i32)
   (local $4 i64)
   (local $5 i32)
@@ -16092,7 +16092,7 @@
   local.get $2
   call $~lib/util/number/utoa32_lut
  )
- (func $~lib/util/number/utoa64 (; 278 ;) (param $0 i64) (result i32)
+ (func $~lib/util/number/utoa64 (param $0 i64) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -16158,12 +16158,12 @@
   local.get $1
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/itoa<u64> (; 279 ;) (param $0 i64) (result i32)
+ (func $~lib/util/number/itoa<u64> (param $0 i64) (result i32)
   local.get $0
   call $~lib/util/number/utoa64
   return
  )
- (func $~lib/util/number/itoa_stream<u64> (; 280 ;) (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
+ (func $~lib/util/number/itoa_stream<u64> (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -16234,7 +16234,7 @@
   end
   local.get $4
  )
- (func $~lib/util/string/joinIntegerArray<u64> (; 281 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<u64> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -16377,7 +16377,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/array/Array<u64>#join (; 282 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u64>#join (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -16400,12 +16400,12 @@
   local.get $4
   return
  )
- (func $~lib/array/Array<u64>#toString (; 283 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<u64>#toString (param $0 i32) (result i32)
   local.get $0
   i32.const 5296
   call $~lib/array/Array<u64>#join
  )
- (func $~lib/util/number/itoa64 (; 284 ;) (param $0 i64) (result i32)
+ (func $~lib/util/number/itoa64 (param $0 i64) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -16494,12 +16494,12 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/itoa<i64> (; 285 ;) (param $0 i64) (result i32)
+ (func $~lib/util/number/itoa<i64> (param $0 i64) (result i32)
   local.get $0
   call $~lib/util/number/itoa64
   return
  )
- (func $~lib/util/number/itoa_stream<i64> (; 286 ;) (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
+ (func $~lib/util/number/itoa_stream<i64> (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -16590,7 +16590,7 @@
   end
   local.get $4
  )
- (func $~lib/util/string/joinIntegerArray<i64> (; 287 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<i64> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -16733,7 +16733,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/array/Array<i64>#join (; 288 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i64>#join (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -16756,17 +16756,17 @@
   local.get $4
   return
  )
- (func $~lib/array/Array<i64>#toString (; 289 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<i64>#toString (param $0 i32) (result i32)
   local.get $0
   i32.const 5296
   call $~lib/array/Array<i64>#join
  )
- (func $~lib/array/Array<~lib/string/String | null>#toString (; 290 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<~lib/string/String | null>#toString (param $0 i32) (result i32)
   local.get $0
   i32.const 5296
   call $~lib/array/Array<~lib/string/String | null>#join
  )
- (func $~lib/util/string/joinReferenceArray<~lib/array/Array<i32>> (; 291 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinReferenceArray<~lib/array/Array<i32>> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -16977,7 +16977,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/array/Array<~lib/array/Array<i32>>#join (; 292 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<i32>>#join (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -17000,19 +17000,19 @@
   local.get $4
   return
  )
- (func $~lib/array/Array<~lib/array/Array<i32>>#toString (; 293 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<i32>>#toString (param $0 i32) (result i32)
   local.get $0
   i32.const 5296
   call $~lib/array/Array<~lib/array/Array<i32>>#join
  )
- (func $~lib/util/number/itoa<u8> (; 294 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/itoa<u8> (param $0 i32) (result i32)
   local.get $0
   i32.const 255
   i32.and
   call $~lib/util/number/utoa32
   return
  )
- (func $~lib/util/number/itoa_stream<u8> (; 295 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_stream<u8> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -17065,7 +17065,7 @@
   call $~lib/util/number/utoa32_lut
   local.get $4
  )
- (func $~lib/util/string/joinIntegerArray<u8> (; 296 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<u8> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -17208,7 +17208,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/array/Array<u8>#join (; 297 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u8>#join (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -17231,12 +17231,12 @@
   local.get $4
   return
  )
- (func $~lib/array/Array<u8>#toString (; 298 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<u8>#toString (param $0 i32) (result i32)
   local.get $0
   i32.const 5296
   call $~lib/array/Array<u8>#join
  )
- (func $~lib/util/string/joinReferenceArray<~lib/array/Array<u8>> (; 299 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinReferenceArray<~lib/array/Array<u8>> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -17447,7 +17447,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/array/Array<~lib/array/Array<u8>>#join (; 300 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<u8>>#join (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -17470,17 +17470,17 @@
   local.get $4
   return
  )
- (func $~lib/array/Array<~lib/array/Array<u8>>#toString (; 301 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<u8>>#toString (param $0 i32) (result i32)
   local.get $0
   i32.const 5296
   call $~lib/array/Array<~lib/array/Array<u8>>#join
  )
- (func $~lib/array/Array<u32>#toString (; 302 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<u32>#toString (param $0 i32) (result i32)
   local.get $0
   i32.const 5296
   call $~lib/array/Array<u32>#join
  )
- (func $~lib/util/string/joinReferenceArray<~lib/array/Array<u32>> (; 303 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinReferenceArray<~lib/array/Array<u32>> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -17691,7 +17691,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/array/Array<~lib/array/Array<u32>>#join (; 304 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<u32>>#join (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -17714,12 +17714,12 @@
   local.get $4
   return
  )
- (func $~lib/array/Array<~lib/array/Array<u32>>#toString (; 305 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<u32>>#toString (param $0 i32) (result i32)
   local.get $0
   i32.const 5296
   call $~lib/array/Array<~lib/array/Array<u32>>#join
  )
- (func $~lib/util/string/joinReferenceArray<~lib/array/Array<~lib/array/Array<u32>>> (; 306 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinReferenceArray<~lib/array/Array<~lib/array/Array<u32>>> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -17930,7 +17930,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/array/Array<~lib/array/Array<~lib/array/Array<u32>>>#join (; 307 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<~lib/array/Array<u32>>>#join (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -17953,12 +17953,12 @@
   local.get $4
   return
  )
- (func $~lib/array/Array<~lib/array/Array<~lib/array/Array<u32>>>#toString (; 308 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<~lib/array/Array<u32>>>#toString (param $0 i32) (result i32)
   local.get $0
   i32.const 5296
   call $~lib/array/Array<~lib/array/Array<~lib/array/Array<u32>>>#join
  )
- (func $~lib/array/Array<~lib/array/Array<i32>>#flat (; 309 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<i32>>#flat (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -18088,7 +18088,7 @@
   local.get $9
   call $~lib/rt/pure/__retain
  )
- (func $~lib/array/Array<~lib/array/Array<~lib/string/String | null>>#flat (; 310 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<~lib/string/String | null>>#flat (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -18242,7 +18242,7 @@
   local.get $9
   call $~lib/rt/pure/__retain
  )
- (func $start:std/array (; 311 ;)
+ (func $start:std/array
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -24368,7 +24368,7 @@
   local.get $63
   call $~lib/rt/pure/__release
  )
- (func $~start (; 312 ;)
+ (func $~start
   global.get $~started
   if
    return
@@ -24378,10 +24378,10 @@
   end
   call $start:std/array
  )
- (func $~lib/rt/pure/__collect (; 313 ;)
+ (func $~lib/rt/pure/__collect
   return
  )
- (func $~lib/rt/pure/decrement (; 314 ;) (param $0 i32)
+ (func $~lib/rt/pure/decrement (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -24458,7 +24458,7 @@
    i32.store offset=4
   end
  )
- (func $~lib/rt/pure/__visit (; 315 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/pure/__visit (param $0 i32) (param $1 i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.lt_u
@@ -24482,25 +24482,25 @@
   i32.sub
   call $~lib/rt/pure/decrement
  )
- (func $~lib/array/Array<i32>#__visit_impl (; 316 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i32>#__visit_impl (param $0 i32) (param $1 i32)
   local.get $0
   i32.load
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/array/Array<u8>#__visit_impl (; 317 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<u8>#__visit_impl (param $0 i32) (param $1 i32)
   local.get $0
   i32.load
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/array/Array<u32>#__visit_impl (; 318 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<u32>#__visit_impl (param $0 i32) (param $1 i32)
   local.get $0
   i32.load
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/array/Array<std/array/Ref>#__visit_impl (; 319 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<std/array/Ref>#__visit_impl (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -24543,19 +24543,19 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/array/Array<f32>#__visit_impl (; 320 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<f32>#__visit_impl (param $0 i32) (param $1 i32)
   local.get $0
   i32.load
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/array/Array<f64>#__visit_impl (; 321 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<f64>#__visit_impl (param $0 i32) (param $1 i32)
   local.get $0
   i32.load
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/array/Array<std/array/Ref | null>#__visit_impl (; 322 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<std/array/Ref | null>#__visit_impl (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -24598,7 +24598,7 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/array/Array<~lib/array/Array<i32>>#__visit_impl (; 323 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<~lib/array/Array<i32>>#__visit_impl (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -24641,7 +24641,7 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/array/Array<std/array/Proxy<i32>>#__visit_impl (; 324 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<std/array/Proxy<i32>>#__visit_impl (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -24684,7 +24684,7 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/array/Array<~lib/string/String | null>#__visit_impl (; 325 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<~lib/string/String | null>#__visit_impl (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -24727,7 +24727,7 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/array/Array<~lib/string/String>#__visit_impl (; 326 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<~lib/string/String>#__visit_impl (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -24770,46 +24770,46 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/array/Array<bool>#__visit_impl (; 327 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<bool>#__visit_impl (param $0 i32) (param $1 i32)
   local.get $0
   i32.load
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/staticarray/StaticArray<u32>#__visit_impl (; 328 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/staticarray/StaticArray<u32>#__visit_impl (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/staticarray/StaticArray<u64>#__visit_impl (; 329 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/staticarray/StaticArray<u64>#__visit_impl (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/staticarray/StaticArray<i16>#__visit_impl (; 330 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/staticarray/StaticArray<i16>#__visit_impl (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/array/Array<i8>#__visit_impl (; 331 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i8>#__visit_impl (param $0 i32) (param $1 i32)
   local.get $0
   i32.load
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/array/Array<u16>#__visit_impl (; 332 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<u16>#__visit_impl (param $0 i32) (param $1 i32)
   local.get $0
   i32.load
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/array/Array<u64>#__visit_impl (; 333 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<u64>#__visit_impl (param $0 i32) (param $1 i32)
   local.get $0
   i32.load
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/array/Array<i64>#__visit_impl (; 334 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i64>#__visit_impl (param $0 i32) (param $1 i32)
   local.get $0
   i32.load
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/array/Array<~lib/array/Array<u8>>#__visit_impl (; 335 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<~lib/array/Array<u8>>#__visit_impl (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -24852,7 +24852,7 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/array/Array<~lib/array/Array<u32>>#__visit_impl (; 336 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<~lib/array/Array<u32>>#__visit_impl (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -24895,7 +24895,7 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/array/Array<~lib/array/Array<~lib/array/Array<u32>>>#__visit_impl (; 337 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<~lib/array/Array<~lib/array/Array<u32>>>#__visit_impl (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -24938,7 +24938,7 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/array/Array<~lib/array/Array<~lib/string/String | null>>#__visit_impl (; 338 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<~lib/array/Array<~lib/string/String | null>>#__visit_impl (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -24981,7 +24981,7 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/rt/__visit_members (; 339 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/__visit_members (param $0 i32) (param $1 i32)
   (local $2 i32)
   block $switch$1$default
    block $switch$1$case$30

--- a/tests/compiler/std/arraybuffer.optimized.wat
+++ b/tests/compiler/std/arraybuffer.optimized.wat
@@ -28,7 +28,7 @@
  (export "__setArgumentsLength" (func $~setArgumentsLength))
  (export "memory" (memory $0))
  (start $~start)
- (func $~lib/rt/tlsf/removeBlock (; 5 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/removeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -190,7 +190,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/insertBlock (; 6 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/insertBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -469,7 +469,7 @@
   i32.or
   i32.store offset=4
  )
- (func $~lib/rt/tlsf/addMemory (; 7 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $2
@@ -583,7 +583,7 @@
   local.get $1
   call $~lib/rt/tlsf/insertBlock
  )
- (func $~lib/rt/tlsf/maybeInitialize (; 8 ;) (result i32)
+ (func $~lib/rt/tlsf/maybeInitialize (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -670,7 +670,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/tlsf/searchBlock (; 9 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/searchBlock (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   i32.const 256
@@ -799,7 +799,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/prepareBlock (; 10 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/rt/tlsf/prepareBlock (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $1
@@ -874,7 +874,7 @@
    i32.store
   end
  )
- (func $~lib/rt/tlsf/allocateBlock (; 11 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/allocateBlock (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1034,7 +1034,7 @@
   call $~lib/rt/rtrace/onalloc
   local.get $3
  )
- (func $~lib/rt/tlsf/__alloc (; 12 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/__alloc (param $0 i32) (param $1 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
   local.get $0
   local.get $1
@@ -1042,7 +1042,7 @@
   i32.const 16
   i32.add
  )
- (func $~lib/memory/memory.fill (; 13 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/memory/memory.fill (param $0 i32) (param $1 i32)
   (local $2 i32)
   block $~lib/util/memory/memset|inlined.0
    local.get $1
@@ -1200,7 +1200,7 @@
    end
   end
  )
- (func $~lib/rt/pure/__retain (; 14 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/pure/__retain (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -1251,7 +1251,7 @@
   end
   local.get $0
  )
- (func $~lib/memory/memory.copy (; 15 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/memory/memory.copy (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   block $~lib/util/memory/memmove|inlined.0
@@ -1424,7 +1424,7 @@
    end
   end
  )
- (func $~lib/arraybuffer/ArrayBuffer#slice (; 16 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBuffer#slice (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $0
   i32.const 16
@@ -1494,7 +1494,7 @@
   local.get $3
   call $~lib/rt/pure/__retain
  )
- (func $~lib/rt/pure/__release (; 17 ;) (param $0 i32)
+ (func $~lib/rt/pure/__release (param $0 i32)
   local.get $0
   i32.const 1440
   i32.gt_u
@@ -1505,7 +1505,7 @@
    call $~lib/rt/pure/decrement
   end
  )
- (func $~lib/arraybuffer/ArrayBufferView#constructor (; 18 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBufferView#constructor (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1574,7 +1574,7 @@
   i32.store offset=8
   local.get $0
  )
- (func $~lib/dataview/DataView#constructor|trampoline (; 19 ;) (param $0 i32) (result i32)
+ (func $~lib/dataview/DataView#constructor|trampoline (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -1652,11 +1652,11 @@
   i32.store offset=8
   local.get $3
  )
- (func $~setArgumentsLength (; 20 ;) (param $0 i32)
+ (func $~setArgumentsLength (param $0 i32)
   local.get $0
   global.set $~argumentsLength
  )
- (func $start:std/arraybuffer (; 21 ;)
+ (func $start:std/arraybuffer
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -1923,10 +1923,10 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $~start (; 22 ;)
+ (func $~start
   call $start:std/arraybuffer
  )
- (func $~lib/rt/pure/decrement (; 23 ;) (param $0 i32)
+ (func $~lib/rt/pure/decrement (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -2027,7 +2027,7 @@
    i32.store offset=4
   end
  )
- (func $~lib/rt/pure/__visit (; 24 ;) (param $0 i32)
+ (func $~lib/rt/pure/__visit (param $0 i32)
   local.get $0
   i32.const 1440
   i32.lt_u

--- a/tests/compiler/std/arraybuffer.untouched.wat
+++ b/tests/compiler/std/arraybuffer.untouched.wat
@@ -34,7 +34,7 @@
  (export "__setArgumentsLength" (func $~setArgumentsLength))
  (export "memory" (memory $0))
  (start $~start)
- (func $~lib/rt/tlsf/removeBlock (; 5 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/removeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -244,7 +244,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/insertBlock (; 6 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/insertBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -594,7 +594,7 @@
   local.get $7
   i32.store offset=4
  )
- (func $~lib/rt/tlsf/addMemory (; 7 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -742,7 +742,7 @@
   call $~lib/rt/tlsf/insertBlock
   i32.const 1
  )
- (func $~lib/rt/tlsf/maybeInitialize (; 8 ;) (result i32)
+ (func $~lib/rt/tlsf/maybeInitialize (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -896,7 +896,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/tlsf/prepareSize (; 9 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/tlsf/prepareSize (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -925,7 +925,7 @@
   i32.gt_u
   select
  )
- (func $~lib/rt/tlsf/searchBlock (; 10 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/searchBlock (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1108,7 +1108,7 @@
   end
   local.get $7
  )
- (func $~lib/rt/tlsf/growMemory (; 11 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/growMemory (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1192,7 +1192,7 @@
   call $~lib/rt/tlsf/addMemory
   drop
  )
- (func $~lib/rt/tlsf/prepareBlock (; 12 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/rt/tlsf/prepareBlock (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1287,7 +1287,7 @@
    i32.store
   end
  )
- (func $~lib/rt/tlsf/allocateBlock (; 13 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/allocateBlock (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   global.get $~lib/rt/tlsf/collectLock
@@ -1398,7 +1398,7 @@
   call $~lib/rt/rtrace/onalloc
   local.get $4
  )
- (func $~lib/rt/tlsf/__alloc (; 14 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/__alloc (param $0 i32) (param $1 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
   local.get $0
   local.get $1
@@ -1406,7 +1406,7 @@
   i32.const 16
   i32.add
  )
- (func $~lib/memory/memory.fill (; 15 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/memory/memory.fill (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1615,7 +1615,7 @@
    end
   end
  )
- (func $~lib/rt/pure/increment (; 16 ;) (param $0 i32)
+ (func $~lib/rt/pure/increment (param $0 i32)
   (local $1 i32)
   local.get $0
   i32.load offset=4
@@ -1660,7 +1660,7 @@
    unreachable
   end
  )
- (func $~lib/rt/pure/__retain (; 17 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/pure/__retain (param $0 i32) (result i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.gt_u
@@ -1672,7 +1672,7 @@
   end
   local.get $0
  )
- (func $~lib/arraybuffer/ArrayBuffer#constructor (; 18 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBuffer#constructor (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   i32.const 1073741808
@@ -1696,13 +1696,13 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~lib/arraybuffer/ArrayBuffer#get:byteLength (; 19 ;) (param $0 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBuffer#get:byteLength (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub
   i32.load offset=12
  )
- (func $~lib/util/memory/memcpy (; 20 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/memory/memcpy (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2726,7 +2726,7 @@
    i32.store8
   end
  )
- (func $~lib/memory/memory.copy (; 21 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/memory/memory.copy (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2946,7 +2946,7 @@
    end
   end
  )
- (func $~lib/arraybuffer/ArrayBuffer#slice (; 22 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBuffer#slice (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3029,7 +3029,7 @@
   local.get $7
   call $~lib/rt/pure/__retain
  )
- (func $~lib/rt/pure/__release (; 23 ;) (param $0 i32)
+ (func $~lib/rt/pure/__release (param $0 i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.gt_u
@@ -3040,7 +3040,7 @@
    call $~lib/rt/pure/decrement
   end
  )
- (func $~lib/arraybuffer/ArrayBuffer.isView<~lib/array/Array<i32> | null> (; 24 ;) (param $0 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBuffer.isView<~lib/array/Array<i32> | null> (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -3062,33 +3062,10 @@
   call $~lib/rt/pure/__release
   local.get $1
  )
- (func $~lib/arraybuffer/ArrayBuffer.isView<usize> (; 25 ;) (param $0 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBuffer.isView<usize> (param $0 i32) (result i32)
   i32.const 0
  )
- (func $~lib/arraybuffer/ArrayBuffer.isView<~lib/typedarray/Uint8Array | null> (; 26 ;) (param $0 i32) (result i32)
-  (local $1 i32)
-  local.get $0
-  call $~lib/rt/pure/__retain
-  local.set $0
-  local.get $0
-  i32.const 0
-  i32.eq
-  if
-   i32.const 0
-   local.set $1
-   local.get $0
-   call $~lib/rt/pure/__release
-   local.get $1
-   return
-  end
-  i32.const 1
-  local.set $1
-  local.get $0
-  call $~lib/rt/pure/__release
-  local.get $1
-  return
- )
- (func $~lib/arraybuffer/ArrayBuffer.isView<~lib/typedarray/Int32Array | null> (; 27 ;) (param $0 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBuffer.isView<~lib/typedarray/Uint8Array | null> (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -3111,7 +3088,7 @@
   local.get $1
   return
  )
- (func $~lib/arraybuffer/ArrayBuffer.isView<~lib/dataview/DataView | null> (; 28 ;) (param $0 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBuffer.isView<~lib/typedarray/Int32Array | null> (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -3134,7 +3111,30 @@
   local.get $1
   return
  )
- (func $~lib/arraybuffer/ArrayBufferView#constructor (; 29 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBuffer.isView<~lib/dataview/DataView | null> (param $0 i32) (result i32)
+  (local $1 i32)
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $0
+  local.get $0
+  i32.const 0
+  i32.eq
+  if
+   i32.const 0
+   local.set $1
+   local.get $0
+   call $~lib/rt/pure/__release
+   local.get $1
+   return
+  end
+  i32.const 1
+  local.set $1
+  local.get $0
+  call $~lib/rt/pure/__release
+  local.get $1
+  return
+ )
+ (func $~lib/arraybuffer/ArrayBufferView#constructor (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3206,7 +3206,7 @@
   i32.store offset=8
   local.get $0
  )
- (func $~lib/typedarray/Uint8Array#constructor (; 30 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#constructor (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   if (result i32)
    local.get $0
@@ -3222,7 +3222,7 @@
   local.set $0
   local.get $0
  )
- (func $~lib/rt/__allocBuffer (; 31 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/__allocBuffer (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $0
   local.get $1
@@ -3237,7 +3237,7 @@
   end
   local.get $3
  )
- (func $~lib/rt/__allocArray (; 32 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $~lib/rt/__allocArray (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -3269,7 +3269,7 @@
   i32.store offset=12
   local.get $4
  )
- (func $~lib/arraybuffer/ArrayBuffer.isView<~lib/array/Array<i32>> (; 33 ;) (param $0 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBuffer.isView<~lib/array/Array<i32>> (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -3280,7 +3280,7 @@
   call $~lib/rt/pure/__release
   local.get $1
  )
- (func $~lib/arraybuffer/ArrayBuffer.isView<~lib/typedarray/Uint8Array> (; 34 ;) (param $0 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBuffer.isView<~lib/typedarray/Uint8Array> (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -3292,7 +3292,7 @@
   local.get $1
   return
  )
- (func $~lib/typedarray/Int32Array#constructor (; 35 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#constructor (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   if (result i32)
    local.get $0
@@ -3308,7 +3308,7 @@
   local.set $0
   local.get $0
  )
- (func $~lib/arraybuffer/ArrayBuffer.isView<~lib/typedarray/Int32Array> (; 36 ;) (param $0 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBuffer.isView<~lib/typedarray/Int32Array> (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -3320,7 +3320,7 @@
   local.get $1
   return
  )
- (func $~lib/dataview/DataView#constructor (; 37 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $~lib/dataview/DataView#constructor (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -3397,7 +3397,7 @@
   call $~lib/rt/pure/__release
   local.get $0
  )
- (func $~lib/dataview/DataView#constructor|trampoline (; 38 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $~lib/dataview/DataView#constructor|trampoline (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   block $2of2
    block $1of2
     block $0of2
@@ -3422,11 +3422,11 @@
   local.get $3
   call $~lib/dataview/DataView#constructor
  )
- (func $~setArgumentsLength (; 39 ;) (param $0 i32)
+ (func $~setArgumentsLength (param $0 i32)
   local.get $0
   global.set $~argumentsLength
  )
- (func $~lib/arraybuffer/ArrayBuffer.isView<~lib/dataview/DataView> (; 40 ;) (param $0 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBuffer.isView<~lib/dataview/DataView> (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -3438,7 +3438,7 @@
   local.get $1
   return
  )
- (func $start:std/arraybuffer (; 41 ;)
+ (func $start:std/arraybuffer
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -3809,13 +3809,13 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~start (; 42 ;)
+ (func $~start
   call $start:std/arraybuffer
  )
- (func $~lib/rt/pure/__collect (; 43 ;)
+ (func $~lib/rt/pure/__collect
   return
  )
- (func $~lib/rt/tlsf/freeBlock (; 44 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/freeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $1
   i32.load
@@ -3831,7 +3831,7 @@
   local.get $1
   call $~lib/rt/rtrace/onfree
  )
- (func $~lib/rt/pure/decrement (; 45 ;) (param $0 i32)
+ (func $~lib/rt/pure/decrement (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -3908,7 +3908,7 @@
    i32.store offset=4
   end
  )
- (func $~lib/rt/pure/__visit (; 46 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/pure/__visit (param $0 i32) (param $1 i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.lt_u
@@ -3932,13 +3932,13 @@
   i32.sub
   call $~lib/rt/pure/decrement
  )
- (func $~lib/array/Array<i32>#__visit_impl (; 47 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i32>#__visit_impl (param $0 i32) (param $1 i32)
   local.get $0
   i32.load
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/rt/__visit_members (; 48 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/__visit_members (param $0 i32) (param $1 i32)
   (local $2 i32)
   block $switch$1$default
    block $switch$1$case$5

--- a/tests/compiler/std/dataview.optimized.wat
+++ b/tests/compiler/std/dataview.optimized.wat
@@ -32,11 +32,10 @@
  (data (i32.const 1472) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00s\00t\00d\00/\00d\00a\00t\00a\00v\00i\00e\00w\00.\00t\00s")
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/collectLock (mut i32) (i32.const 0))
- (global $~argumentsLength (mut i32) (i32.const 0))
  (export "__setArgumentsLength" (func $~setArgumentsLength))
  (export "memory" (memory $0))
  (start $~start)
- (func $~lib/rt/tlsf/removeBlock (; 5 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/removeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -198,7 +197,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/insertBlock (; 6 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/insertBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -477,7 +476,7 @@
   i32.or
   i32.store offset=4
  )
- (func $~lib/rt/tlsf/addMemory (; 7 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $2
@@ -591,7 +590,7 @@
   local.get $1
   call $~lib/rt/tlsf/insertBlock
  )
- (func $~lib/rt/tlsf/maybeInitialize (; 8 ;) (result i32)
+ (func $~lib/rt/tlsf/maybeInitialize (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -678,7 +677,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/tlsf/searchBlock (; 9 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/searchBlock (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   i32.const 256
@@ -807,7 +806,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/prepareBlock (; 10 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/rt/tlsf/prepareBlock (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $1
@@ -882,7 +881,7 @@
    i32.store
   end
  )
- (func $~lib/rt/tlsf/allocateBlock (; 11 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/allocateBlock (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1042,7 +1041,7 @@
   call $~lib/rt/rtrace/onalloc
   local.get $3
  )
- (func $~lib/rt/tlsf/__alloc (; 12 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/__alloc (param $0 i32) (param $1 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
   local.get $0
   local.get $1
@@ -1050,7 +1049,7 @@
   i32.const 16
   i32.add
  )
- (func $~lib/rt/pure/__retain (; 13 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/pure/__retain (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -1101,7 +1100,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/pure/__release (; 14 ;) (param $0 i32)
+ (func $~lib/rt/pure/__release (param $0 i32)
   local.get $0
   i32.const 1520
   i32.gt_u
@@ -1112,7 +1111,7 @@
    call $~lib/rt/pure/decrement
   end
  )
- (func $~lib/arraybuffer/ArrayBufferView#constructor (; 15 ;) (param $0 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBufferView#constructor (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -1189,7 +1188,7 @@
   i32.store offset=8
   local.get $0
  )
- (func $~lib/typedarray/Uint8Array#__set (; 16 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint8Array#__set (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -1209,7 +1208,7 @@
   local.get $2
   i32.store8
  )
- (func $~lib/dataview/DataView#constructor (; 17 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/dataview/DataView#constructor (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1273,14 +1272,14 @@
   i32.store offset=8
   local.get $4
  )
- (func $~lib/arraybuffer/ArrayBufferView#get:byteOffset (; 18 ;) (param $0 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBufferView#get:byteOffset (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $0
   i32.load
   i32.sub
  )
- (func $~lib/polyfills/bswap<u32> (; 19 ;) (param $0 i32) (result i32)
+ (func $~lib/polyfills/bswap<u32> (param $0 i32) (result i32)
   local.get $0
   i32.const -16711936
   i32.and
@@ -1293,7 +1292,7 @@
   i32.rotr
   i32.or
  )
- (func $~lib/dataview/DataView#getFloat32 (; 20 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result f32)
+ (func $~lib/dataview/DataView#getFloat32 (param $0 i32) (param $1 i32) (param $2 i32) (result f32)
   local.get $1
   i32.const 31
   i32.shr_u
@@ -1329,7 +1328,7 @@
    f32.reinterpret_i32
   end
  )
- (func $~lib/polyfills/bswap<u64> (; 21 ;) (param $0 i64) (result i64)
+ (func $~lib/polyfills/bswap<u64> (param $0 i64) (result i64)
   local.get $0
   i64.const 8
   i64.shr_u
@@ -1355,7 +1354,7 @@
   i64.const 32
   i64.rotr
  )
- (func $~lib/dataview/DataView#getFloat64 (; 22 ;) (param $0 i32) (param $1 i32) (result f64)
+ (func $~lib/dataview/DataView#getFloat64 (param $0 i32) (param $1 i32) (result f64)
   i32.const 8
   local.get $0
   i32.load offset=8
@@ -1381,7 +1380,7 @@
    f64.reinterpret_i64
   end
  )
- (func $~lib/dataview/DataView#getInt8 (; 23 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/dataview/DataView#getInt8 (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -1400,7 +1399,7 @@
   i32.add
   i32.load8_s
  )
- (func $~lib/polyfills/bswap<i16> (; 24 ;) (param $0 i32) (result i32)
+ (func $~lib/polyfills/bswap<i16> (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.shl
@@ -1413,7 +1412,7 @@
   i32.shl
   i32.or
  )
- (func $~lib/dataview/DataView#getInt16 (; 25 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/dataview/DataView#getInt16 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $1
   i32.const 31
   i32.shr_u
@@ -1447,7 +1446,7 @@
   end
   local.get $0
  )
- (func $~lib/dataview/DataView#getInt32 (; 26 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/dataview/DataView#getInt32 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $1
   i32.const 31
   i32.shr_u
@@ -1481,7 +1480,7 @@
   end
   local.get $0
  )
- (func $~lib/dataview/DataView#getInt64 (; 27 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $~lib/dataview/DataView#getInt64 (param $0 i32) (param $1 i32) (result i64)
   (local $2 i64)
   i32.const 8
   local.get $0
@@ -1507,7 +1506,7 @@
    call $~lib/polyfills/bswap<u64>
   end
  )
- (func $~lib/dataview/DataView#getUint8 (; 28 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/dataview/DataView#getUint8 (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -1526,7 +1525,7 @@
   i32.add
   i32.load8_u
  )
- (func $~lib/polyfills/bswap<u16> (; 29 ;) (param $0 i32) (result i32)
+ (func $~lib/polyfills/bswap<u16> (param $0 i32) (result i32)
   local.get $0
   i32.const 8
   i32.shl
@@ -1537,7 +1536,7 @@
   i32.shr_u
   i32.or
  )
- (func $~lib/dataview/DataView#getUint16 (; 30 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/dataview/DataView#getUint16 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $1
   i32.const 31
   i32.shr_u
@@ -1571,7 +1570,7 @@
   end
   local.get $0
  )
- (func $~lib/dataview/DataView#getUint32 (; 31 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/dataview/DataView#getUint32 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $1
   i32.const 31
   i32.shr_u
@@ -1605,7 +1604,7 @@
   end
   local.get $0
  )
- (func $~lib/dataview/DataView#getUint64 (; 32 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $~lib/dataview/DataView#getUint64 (param $0 i32) (param $1 i32) (result i64)
   (local $2 i64)
   i32.const 8
   local.get $0
@@ -1631,7 +1630,7 @@
    call $~lib/polyfills/bswap<u64>
   end
  )
- (func $~lib/dataview/DataView#setFloat32 (; 33 ;) (param $0 i32) (param $1 f32) (param $2 i32)
+ (func $~lib/dataview/DataView#setFloat32 (param $0 i32) (param $1 f32) (param $2 i32)
   i32.const 4
   local.get $0
   i32.load offset=8
@@ -1659,7 +1658,7 @@
    i32.store
   end
  )
- (func $~lib/dataview/DataView#setFloat64 (; 34 ;) (param $0 i32) (param $1 f64) (param $2 i32)
+ (func $~lib/dataview/DataView#setFloat64 (param $0 i32) (param $1 f64) (param $2 i32)
   i32.const 8
   local.get $0
   i32.load offset=8
@@ -1687,7 +1686,7 @@
    i64.store
   end
  )
- (func $~lib/dataview/DataView#setInt16 (; 35 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/dataview/DataView#setInt16 (param $0 i32) (param $1 i32) (param $2 i32)
   i32.const 2
   local.get $0
   i32.load offset=8
@@ -1711,7 +1710,7 @@
   end
   i32.store16
  )
- (func $~lib/dataview/DataView#setInt32 (; 36 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/dataview/DataView#setInt32 (param $0 i32) (param $1 i32) (param $2 i32)
   i32.const 4
   local.get $0
   i32.load offset=8
@@ -1735,7 +1734,7 @@
   end
   i32.store
  )
- (func $~lib/dataview/DataView#setInt64 (; 37 ;) (param $0 i32) (param $1 i64) (param $2 i32)
+ (func $~lib/dataview/DataView#setInt64 (param $0 i32) (param $1 i64) (param $2 i32)
   i32.const 8
   local.get $0
   i32.load offset=8
@@ -1759,7 +1758,7 @@
   end
   i64.store
  )
- (func $~lib/dataview/DataView#setUint16 (; 38 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/dataview/DataView#setUint16 (param $0 i32) (param $1 i32) (param $2 i32)
   i32.const 2
   local.get $0
   i32.load offset=8
@@ -1783,7 +1782,7 @@
   end
   i32.store16
  )
- (func $~lib/dataview/DataView#setUint32 (; 39 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/dataview/DataView#setUint32 (param $0 i32) (param $1 i32) (param $2 i32)
   i32.const 4
   local.get $0
   i32.load offset=8
@@ -1807,7 +1806,7 @@
   end
   i32.store
  )
- (func $~lib/dataview/DataView#setUint64 (; 40 ;) (param $0 i32) (param $1 i64) (param $2 i32)
+ (func $~lib/dataview/DataView#setUint64 (param $0 i32) (param $1 i64) (param $2 i32)
   i32.const 8
   local.get $0
   i32.load offset=8
@@ -1831,11 +1830,10 @@
   end
   i64.store
  )
- (func $~setArgumentsLength (; 41 ;) (param $0 i32)
-  local.get $0
-  global.set $~argumentsLength
+ (func $~setArgumentsLength (param $0 i32)
+  nop
  )
- (func $start:std/dataview (; 42 ;)
+ (func $start:std/dataview
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -3385,8 +3383,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1
-  global.set $~argumentsLength
   local.get $1
   i32.load
   local.tee $2
@@ -3426,10 +3422,10 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $~start (; 43 ;)
+ (func $~start
   call $start:std/dataview
  )
- (func $~lib/rt/pure/decrement (; 44 ;) (param $0 i32)
+ (func $~lib/rt/pure/decrement (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0

--- a/tests/compiler/std/dataview.untouched.wat
+++ b/tests/compiler/std/dataview.untouched.wat
@@ -42,7 +42,7 @@
  (export "__setArgumentsLength" (func $~setArgumentsLength))
  (export "memory" (memory $0))
  (start $~start)
- (func $~lib/rt/tlsf/removeBlock (; 5 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/removeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -252,7 +252,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/insertBlock (; 6 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/insertBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -602,7 +602,7 @@
   local.get $7
   i32.store offset=4
  )
- (func $~lib/rt/tlsf/addMemory (; 7 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -750,7 +750,7 @@
   call $~lib/rt/tlsf/insertBlock
   i32.const 1
  )
- (func $~lib/rt/tlsf/maybeInitialize (; 8 ;) (result i32)
+ (func $~lib/rt/tlsf/maybeInitialize (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -904,7 +904,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/tlsf/prepareSize (; 9 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/tlsf/prepareSize (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -933,7 +933,7 @@
   i32.gt_u
   select
  )
- (func $~lib/rt/tlsf/searchBlock (; 10 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/searchBlock (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1116,7 +1116,7 @@
   end
   local.get $7
  )
- (func $~lib/rt/tlsf/growMemory (; 11 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/growMemory (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1200,7 +1200,7 @@
   call $~lib/rt/tlsf/addMemory
   drop
  )
- (func $~lib/rt/tlsf/prepareBlock (; 12 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/rt/tlsf/prepareBlock (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1295,7 +1295,7 @@
    i32.store
   end
  )
- (func $~lib/rt/tlsf/allocateBlock (; 13 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/allocateBlock (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   global.get $~lib/rt/tlsf/collectLock
@@ -1406,7 +1406,7 @@
   call $~lib/rt/rtrace/onalloc
   local.get $4
  )
- (func $~lib/rt/tlsf/__alloc (; 14 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/__alloc (param $0 i32) (param $1 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
   local.get $0
   local.get $1
@@ -1414,7 +1414,7 @@
   i32.const 16
   i32.add
  )
- (func $~lib/memory/memory.fill (; 15 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/memory/memory.fill (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1623,7 +1623,7 @@
    end
   end
  )
- (func $~lib/rt/pure/increment (; 16 ;) (param $0 i32)
+ (func $~lib/rt/pure/increment (param $0 i32)
   (local $1 i32)
   local.get $0
   i32.load offset=4
@@ -1668,7 +1668,7 @@
    unreachable
   end
  )
- (func $~lib/rt/pure/__retain (; 17 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/pure/__retain (param $0 i32) (result i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.gt_u
@@ -1680,7 +1680,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/pure/__release (; 18 ;) (param $0 i32)
+ (func $~lib/rt/pure/__release (param $0 i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.gt_u
@@ -1691,7 +1691,7 @@
    call $~lib/rt/pure/decrement
   end
  )
- (func $~lib/arraybuffer/ArrayBufferView#constructor (; 19 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBufferView#constructor (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1763,7 +1763,7 @@
   i32.store offset=8
   local.get $0
  )
- (func $~lib/typedarray/Uint8Array#constructor (; 20 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#constructor (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   if (result i32)
    local.get $0
@@ -1779,7 +1779,7 @@
   local.set $0
   local.get $0
  )
- (func $~lib/typedarray/Uint8Array#__set (; 21 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint8Array#__set (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -1799,13 +1799,13 @@
   local.get $2
   i32.store8
  )
- (func $~lib/arraybuffer/ArrayBuffer#get:byteLength (; 22 ;) (param $0 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBuffer#get:byteLength (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub
   i32.load offset=12
  )
- (func $~lib/dataview/DataView#constructor (; 23 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $~lib/dataview/DataView#constructor (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -1882,14 +1882,14 @@
   call $~lib/rt/pure/__release
   local.get $0
  )
- (func $~lib/arraybuffer/ArrayBufferView#get:byteOffset (; 24 ;) (param $0 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBufferView#get:byteOffset (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $0
   i32.load
   i32.sub
  )
- (func $~lib/polyfills/bswap<u32> (; 25 ;) (param $0 i32) (result i32)
+ (func $~lib/polyfills/bswap<u32> (param $0 i32) (result i32)
   local.get $0
   i32.const -16711936
   i32.and
@@ -1903,7 +1903,7 @@
   i32.or
   return
  )
- (func $~lib/dataview/DataView#getFloat32 (; 26 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result f32)
+ (func $~lib/dataview/DataView#getFloat32 (param $0 i32) (param $1 i32) (param $2 i32) (result f32)
   local.get $1
   i32.const 31
   i32.shr_u
@@ -1939,7 +1939,7 @@
    f32.reinterpret_i32
   end
  )
- (func $~lib/polyfills/bswap<u64> (; 27 ;) (param $0 i64) (result i64)
+ (func $~lib/polyfills/bswap<u64> (param $0 i64) (result i64)
   (local $1 i64)
   (local $2 i64)
   (local $3 i64)
@@ -1978,7 +1978,7 @@
   i64.rotr
   return
  )
- (func $~lib/dataview/DataView#getFloat64 (; 28 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result f64)
+ (func $~lib/dataview/DataView#getFloat64 (param $0 i32) (param $1 i32) (param $2 i32) (result f64)
   local.get $1
   i32.const 31
   i32.shr_u
@@ -2014,7 +2014,7 @@
    f64.reinterpret_i64
   end
  )
- (func $~lib/dataview/DataView#getInt8 (; 29 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/dataview/DataView#getInt8 (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -2033,7 +2033,7 @@
   i32.add
   i32.load8_s
  )
- (func $~lib/polyfills/bswap<i16> (; 30 ;) (param $0 i32) (result i32)
+ (func $~lib/polyfills/bswap<i16> (param $0 i32) (result i32)
   local.get $0
   i32.const 8
   i32.shl
@@ -2049,7 +2049,7 @@
   i32.or
   return
  )
- (func $~lib/dataview/DataView#getInt16 (; 31 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/dataview/DataView#getInt16 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $1
   i32.const 31
@@ -2083,7 +2083,7 @@
    call $~lib/polyfills/bswap<i16>
   end
  )
- (func $~lib/polyfills/bswap<i32> (; 32 ;) (param $0 i32) (result i32)
+ (func $~lib/polyfills/bswap<i32> (param $0 i32) (result i32)
   local.get $0
   i32.const -16711936
   i32.and
@@ -2097,7 +2097,7 @@
   i32.or
   return
  )
- (func $~lib/dataview/DataView#getInt32 (; 33 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/dataview/DataView#getInt32 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $1
   i32.const 31
@@ -2131,7 +2131,7 @@
    call $~lib/polyfills/bswap<i32>
   end
  )
- (func $~lib/polyfills/bswap<i64> (; 34 ;) (param $0 i64) (result i64)
+ (func $~lib/polyfills/bswap<i64> (param $0 i64) (result i64)
   (local $1 i64)
   (local $2 i64)
   (local $3 i64)
@@ -2170,7 +2170,7 @@
   i64.rotr
   return
  )
- (func $~lib/dataview/DataView#getInt64 (; 35 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i64)
+ (func $~lib/dataview/DataView#getInt64 (param $0 i32) (param $1 i32) (param $2 i32) (result i64)
   (local $3 i64)
   local.get $1
   i32.const 31
@@ -2204,7 +2204,7 @@
    call $~lib/polyfills/bswap<i64>
   end
  )
- (func $~lib/dataview/DataView#getUint8 (; 36 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/dataview/DataView#getUint8 (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -2223,7 +2223,7 @@
   i32.add
   i32.load8_u
  )
- (func $~lib/polyfills/bswap<u16> (; 37 ;) (param $0 i32) (result i32)
+ (func $~lib/polyfills/bswap<u16> (param $0 i32) (result i32)
   local.get $0
   i32.const 8
   i32.shl
@@ -2237,7 +2237,7 @@
   i32.or
   return
  )
- (func $~lib/dataview/DataView#getUint16 (; 38 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/dataview/DataView#getUint16 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $1
   i32.const 31
@@ -2271,7 +2271,7 @@
    call $~lib/polyfills/bswap<u16>
   end
  )
- (func $~lib/dataview/DataView#getUint32 (; 39 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/dataview/DataView#getUint32 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $1
   i32.const 31
@@ -2305,7 +2305,7 @@
    call $~lib/polyfills/bswap<u32>
   end
  )
- (func $~lib/dataview/DataView#getUint64 (; 40 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i64)
+ (func $~lib/dataview/DataView#getUint64 (param $0 i32) (param $1 i32) (param $2 i32) (result i64)
   (local $3 i64)
   local.get $1
   i32.const 31
@@ -2339,7 +2339,7 @@
    call $~lib/polyfills/bswap<u64>
   end
  )
- (func $~lib/dataview/DataView#setFloat32 (; 41 ;) (param $0 i32) (param $1 i32) (param $2 f32) (param $3 i32)
+ (func $~lib/dataview/DataView#setFloat32 (param $0 i32) (param $1 i32) (param $2 f32) (param $3 i32)
   local.get $1
   i32.const 31
   i32.shr_u
@@ -2377,7 +2377,7 @@
    i32.store
   end
  )
- (func $~lib/dataview/DataView#setFloat64 (; 42 ;) (param $0 i32) (param $1 i32) (param $2 f64) (param $3 i32)
+ (func $~lib/dataview/DataView#setFloat64 (param $0 i32) (param $1 i32) (param $2 f64) (param $3 i32)
   local.get $1
   i32.const 31
   i32.shr_u
@@ -2415,7 +2415,7 @@
    i64.store
   end
  )
- (func $~lib/dataview/DataView#setInt8 (; 43 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/dataview/DataView#setInt8 (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -2435,7 +2435,7 @@
   local.get $2
   i32.store8
  )
- (func $~lib/dataview/DataView#setInt16 (; 44 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/dataview/DataView#setInt16 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   local.get $1
   i32.const 31
   i32.shr_u
@@ -2467,7 +2467,7 @@
   end
   i32.store16
  )
- (func $~lib/dataview/DataView#setInt32 (; 45 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/dataview/DataView#setInt32 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   local.get $1
   i32.const 31
   i32.shr_u
@@ -2499,7 +2499,7 @@
   end
   i32.store
  )
- (func $~lib/dataview/DataView#setInt64 (; 46 ;) (param $0 i32) (param $1 i32) (param $2 i64) (param $3 i32)
+ (func $~lib/dataview/DataView#setInt64 (param $0 i32) (param $1 i32) (param $2 i64) (param $3 i32)
   local.get $1
   i32.const 31
   i32.shr_u
@@ -2531,7 +2531,7 @@
   end
   i64.store
  )
- (func $~lib/dataview/DataView#setUint8 (; 47 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/dataview/DataView#setUint8 (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -2551,7 +2551,7 @@
   local.get $2
   i32.store8
  )
- (func $~lib/dataview/DataView#setUint16 (; 48 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/dataview/DataView#setUint16 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   local.get $1
   i32.const 31
   i32.shr_u
@@ -2583,7 +2583,7 @@
   end
   i32.store16
  )
- (func $~lib/dataview/DataView#setUint32 (; 49 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/dataview/DataView#setUint32 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   local.get $1
   i32.const 31
   i32.shr_u
@@ -2615,7 +2615,7 @@
   end
   i32.store
  )
- (func $~lib/dataview/DataView#setUint64 (; 50 ;) (param $0 i32) (param $1 i32) (param $2 i64) (param $3 i32)
+ (func $~lib/dataview/DataView#setUint64 (param $0 i32) (param $1 i32) (param $2 i64) (param $3 i32)
   local.get $1
   i32.const 31
   i32.shr_u
@@ -2647,7 +2647,7 @@
   end
   i64.store
  )
- (func $~lib/dataview/DataView#constructor|trampoline (; 51 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $~lib/dataview/DataView#constructor|trampoline (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   block $2of2
    block $1of2
     block $0of2
@@ -2672,18 +2672,18 @@
   local.get $3
   call $~lib/dataview/DataView#constructor
  )
- (func $~setArgumentsLength (; 52 ;) (param $0 i32)
+ (func $~setArgumentsLength (param $0 i32)
   local.get $0
   global.set $~argumentsLength
  )
- (func $~lib/dataview/DataView#get:byteOffset (; 53 ;) (param $0 i32) (result i32)
+ (func $~lib/dataview/DataView#get:byteOffset (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $0
   i32.load
   i32.sub
  )
- (func $start:std/dataview (; 54 ;)
+ (func $start:std/dataview
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -4412,13 +4412,13 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~start (; 55 ;)
+ (func $~start
   call $start:std/dataview
  )
- (func $~lib/rt/pure/__collect (; 56 ;)
+ (func $~lib/rt/pure/__collect
   return
  )
- (func $~lib/rt/tlsf/freeBlock (; 57 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/freeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $1
   i32.load
@@ -4434,7 +4434,7 @@
   local.get $1
   call $~lib/rt/rtrace/onfree
  )
- (func $~lib/rt/pure/decrement (; 58 ;) (param $0 i32)
+ (func $~lib/rt/pure/decrement (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -4511,7 +4511,7 @@
    i32.store offset=4
   end
  )
- (func $~lib/rt/pure/__visit (; 59 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/pure/__visit (param $0 i32) (param $1 i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.lt_u
@@ -4535,7 +4535,7 @@
   i32.sub
   call $~lib/rt/pure/decrement
  )
- (func $~lib/rt/__visit_members (; 60 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/__visit_members (param $0 i32) (param $1 i32)
   (local $2 i32)
   block $switch$1$default
    block $switch$1$case$4

--- a/tests/compiler/std/date.optimized.wat
+++ b/tests/compiler/std/date.optimized.wat
@@ -9,12 +9,10 @@
  (memory $0 1)
  (data (i32.const 1024) "\16\00\00\00\01\00\00\00\01\00\00\00\16\00\00\00s\00t\00d\00/\00d\00a\00t\00e\00.\00t\00s")
  (global $std/date/creationTime (mut i64) (i64.const 0))
- (global $~lib/rt/stub/startOffset (mut i32) (i32.const 0))
- (global $~lib/rt/stub/offset (mut i32) (i32.const 0))
  (global $std/date/date (mut i32) (i32.const 0))
  (export "memory" (memory $0))
  (start $~start)
- (func $start:std/date (; 3 ;)
+ (func $start:std/date
   (local $0 i32)
   (local $1 i32)
   (local $2 i64)
@@ -89,10 +87,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1072
-  global.set $~lib/rt/stub/startOffset
-  i32.const 1072
-  global.set $~lib/rt/stub/offset
   global.get $std/date/creationTime
   local.set $2
   i32.const 1104
@@ -129,8 +123,6 @@
     end
    end
   end
-  i32.const 1104
-  global.set $~lib/rt/stub/offset
   i32.const 1072
   i32.const 16
   i32.store
@@ -183,7 +175,7 @@
    unreachable
   end
  )
- (func $~start (; 4 ;)
+ (func $~start
   call $start:std/date
  )
 )

--- a/tests/compiler/std/date.untouched.wat
+++ b/tests/compiler/std/date.untouched.wat
@@ -22,7 +22,7 @@
  (global $~lib/heap/__heap_base i32 (i32.const 56))
  (export "memory" (memory $0))
  (start $~start)
- (func $~lib/rt/stub/maybeGrowMemory (; 3 ;) (param $0 i32)
+ (func $~lib/rt/stub/maybeGrowMemory (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -76,7 +76,7 @@
   local.get $0
   global.set $~lib/rt/stub/offset
  )
- (func $~lib/rt/stub/__alloc (; 4 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/stub/__alloc (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -129,10 +129,10 @@
   i32.store offset=12
   local.get $2
  )
- (func $~lib/rt/stub/__retain (; 5 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/stub/__retain (param $0 i32) (result i32)
   local.get $0
  )
- (func $~lib/date/Date#constructor (; 6 ;) (param $0 i32) (param $1 i64) (result i32)
+ (func $~lib/date/Date#constructor (param $0 i32) (param $1 i64) (result i32)
   local.get $0
   i32.eqz
   if
@@ -150,17 +150,17 @@
   i64.store
   local.get $0
  )
- (func $~lib/date/Date#getTime (; 7 ;) (param $0 i32) (result i64)
+ (func $~lib/date/Date#getTime (param $0 i32) (result i64)
   local.get $0
   i64.load
  )
- (func $~lib/date/Date#setTime (; 8 ;) (param $0 i32) (param $1 i64) (result i64)
+ (func $~lib/date/Date#setTime (param $0 i32) (param $1 i64) (result i64)
   local.get $0
   local.get $1
   i64.store
   local.get $1
  )
- (func $start:std/date (; 9 ;)
+ (func $start:std/date
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -337,7 +337,7 @@
    unreachable
   end
  )
- (func $~start (; 10 ;)
+ (func $~start
   call $start:std/date
  )
 )

--- a/tests/compiler/std/hash.optimized.wat
+++ b/tests/compiler/std/hash.optimized.wat
@@ -8,7 +8,7 @@
  (data (i32.const 1104) "\06\00\00\00\01\00\00\00\01\00\00\00\06\00\00\00a\00b\00c")
  (export "memory" (memory $0))
  (start $~start)
- (func $~lib/util/hash/hashStr (; 0 ;) (param $0 i32)
+ (func $~lib/util/hash/hashStr (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -48,7 +48,7 @@
    end
   end
  )
- (func $~start (; 1 ;)
+ (func $~start
   i32.const 0
   call $~lib/util/hash/hashStr
   i32.const 1040

--- a/tests/compiler/std/hash.untouched.wat
+++ b/tests/compiler/std/hash.untouched.wat
@@ -11,10 +11,10 @@
  (table $0 1 funcref)
  (export "memory" (memory $0))
  (start $~start)
- (func $~lib/rt/stub/__retain (; 0 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/stub/__retain (param $0 i32) (result i32)
   local.get $0
  )
- (func $~lib/string/String#get:length (; 1 ;) (param $0 i32) (result i32)
+ (func $~lib/string/String#get:length (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub
@@ -22,10 +22,10 @@
   i32.const 1
   i32.shr_u
  )
- (func $~lib/rt/stub/__release (; 2 ;) (param $0 i32)
+ (func $~lib/rt/stub/__release (param $0 i32)
   nop
  )
- (func $~lib/util/hash/hashStr (; 3 ;) (param $0 i32) (result i32)
+ (func $~lib/util/hash/hashStr (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -76,10 +76,10 @@
   call $~lib/rt/stub/__release
   local.get $3
  )
- (func $std/hash/check (; 4 ;) (param $0 i32) (result i32)
+ (func $std/hash/check (param $0 i32) (result i32)
   i32.const 1
  )
- (func $~lib/util/hash/hash32 (; 5 ;) (param $0 i32) (result i32)
+ (func $~lib/util/hash/hash32 (param $0 i32) (result i32)
   (local $1 i32)
   i32.const -2128831035
   local.set $1
@@ -121,7 +121,7 @@
   local.set $1
   local.get $1
  )
- (func $~lib/util/hash/hash64 (; 6 ;) (param $0 i64) (result i32)
+ (func $~lib/util/hash/hash64 (param $0 i64) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -209,7 +209,7 @@
   local.set $3
   local.get $3
  )
- (func $start:std/hash (; 7 ;)
+ (func $start:std/hash
   (local $0 i32)
   (local $1 i32)
   (local $2 f32)
@@ -401,7 +401,7 @@
   call $std/hash/check
   drop
  )
- (func $~start (; 8 ;)
+ (func $~start
   call $start:std/hash
  )
 )

--- a/tests/compiler/std/libm.optimized.wat
+++ b/tests/compiler/std/libm.optimized.wat
@@ -116,11 +116,11 @@
  (export "libmf.tan" (func $../../lib/libm/assembly/libmf/tan))
  (export "libmf.tanh" (func $../../lib/libm/assembly/libmf/tanh))
  (export "libmf.trunc" (func $../../lib/libm/assembly/libmf/trunc))
- (func $../../lib/libm/assembly/libm/abs (; 0 ;) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/abs (param $0 f64) (result f64)
   local.get $0
   f64.abs
  )
- (func $~lib/math/R (; 1 ;) (param $0 f64) (result f64)
+ (func $~lib/math/R (param $0 f64) (result f64)
   local.get $0
   f64.const 0.16666666666666666
   local.get $0
@@ -163,7 +163,7 @@
   f64.add
   f64.div
  )
- (func $~lib/math/NativeMath.acos (; 2 ;) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.acos (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 i32)
   (local $3 i32)
@@ -287,11 +287,11 @@
   f64.add
   f64.mul
  )
- (func $../../lib/libm/assembly/libm/acos (; 3 ;) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/acos (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.acos
  )
- (func $~lib/math/NativeMath.log1p (; 4 ;) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.log1p (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 i32)
   (local $3 i32)
@@ -487,7 +487,7 @@
   f64.mul
   f64.add
  )
- (func $~lib/math/NativeMath.log (; 5 ;) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.log (param $0 f64) (result f64)
   (local $1 i32)
   (local $2 i64)
   (local $3 f64)
@@ -654,7 +654,7 @@
   f64.mul
   f64.add
  )
- (func $../../lib/libm/assembly/libm/acosh (; 6 ;) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/acosh (param $0 f64) (result f64)
   (local $1 i64)
   block $__inlined_func$~lib/math/NativeMath.acosh (result f64)
    local.get $0
@@ -710,7 +710,7 @@
    f64.add
   end
  )
- (func $~lib/math/NativeMath.asin (; 7 ;) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.asin (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 i32)
   (local $3 f64)
@@ -848,11 +848,11 @@
   end
   local.get $0
  )
- (func $../../lib/libm/assembly/libm/asin (; 8 ;) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/asin (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.asin
  )
- (func $../../lib/libm/assembly/libm/asinh (; 9 ;) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/asinh (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 i64)
   local.get $0
@@ -925,7 +925,7 @@
   local.get $1
   f64.copysign
  )
- (func $~lib/math/NativeMath.atan (; 10 ;) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.atan (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 f64)
   (local $3 i32)
@@ -1147,11 +1147,11 @@
   local.get $1
   f64.copysign
  )
- (func $../../lib/libm/assembly/libm/atan (; 11 ;) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/atan (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.atan
  )
- (func $../../lib/libm/assembly/libm/atanh (; 12 ;) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/atanh (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 i64)
   (local $3 f64)
@@ -1207,7 +1207,7 @@
   local.get $1
   f64.copysign
  )
- (func $~lib/math/NativeMath.atan2 (; 13 ;) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.atan2 (param $0 f64) (param $1 f64) (result f64)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1417,12 +1417,12 @@
   i32.and
   select
  )
- (func $../../lib/libm/assembly/libm/atan2 (; 14 ;) (param $0 f64) (param $1 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/atan2 (param $0 f64) (param $1 f64) (result f64)
   local.get $0
   local.get $1
   call $~lib/math/NativeMath.atan2
  )
- (func $~lib/math/NativeMath.cbrt (; 15 ;) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.cbrt (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 i32)
   (local $3 f64)
@@ -1543,15 +1543,15 @@
   f64.mul
   f64.add
  )
- (func $../../lib/libm/assembly/libm/cbrt (; 16 ;) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/cbrt (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.cbrt
  )
- (func $../../lib/libm/assembly/libm/ceil (; 17 ;) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/ceil (param $0 f64) (result f64)
   local.get $0
   f64.ceil
  )
- (func $~lib/math/dtoi32 (; 18 ;) (param $0 f64) (result i32)
+ (func $~lib/math/dtoi32 (param $0 f64) (result i32)
   local.get $0
   f64.const 4294967296
   local.get $0
@@ -1563,7 +1563,7 @@
   i64.trunc_f64_s
   i32.wrap_i64
  )
- (func $../../lib/libm/assembly/libm/clz32 (; 19 ;) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/clz32 (param $0 f64) (result f64)
   local.get $0
   local.get $0
   f64.sub
@@ -1578,7 +1578,7 @@
    f64.convert_i32_s
   end
  )
- (func $~lib/math/pio2_large_quot (; 20 ;) (param $0 i64) (result i32)
+ (func $~lib/math/pio2_large_quot (param $0 i64) (result i32)
   (local $1 i64)
   (local $2 i64)
   (local $3 i64)
@@ -1864,7 +1864,7 @@
   i64.sub
   i32.wrap_i64
  )
- (func $~lib/math/NativeMath.cos (; 21 ;) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.cos (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 f64)
   (local $3 f64)
@@ -2197,11 +2197,11 @@
   end
   local.get $0
  )
- (func $../../lib/libm/assembly/libm/cos (; 22 ;) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/cos (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.cos
  )
- (func $~lib/math/NativeMath.expm1 (; 23 ;) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.expm1 (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 i32)
   (local $3 f64)
@@ -2472,7 +2472,7 @@
   local.get $4
   f64.mul
  )
- (func $~lib/math/NativeMath.scalbn (; 24 ;) (param $0 f64) (param $1 i32) (result f64)
+ (func $~lib/math/NativeMath.scalbn (param $0 f64) (param $1 i32) (result f64)
   local.get $1
   i32.const 1023
   i32.gt_s
@@ -2549,7 +2549,7 @@
   f64.reinterpret_i64
   f64.mul
  )
- (func $~lib/math/NativeMath.exp (; 25 ;) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.exp (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 i32)
   (local $3 f64)
@@ -2699,7 +2699,7 @@
   end
   local.get $0
  )
- (func $../../lib/libm/assembly/libm/cosh (; 26 ;) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/cosh (param $0 f64) (result f64)
   (local $1 i32)
   (local $2 i64)
   block $__inlined_func$~lib/math/NativeMath.cosh (result f64)
@@ -2764,24 +2764,24 @@
    f64.mul
   end
  )
- (func $../../lib/libm/assembly/libm/exp (; 27 ;) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/exp (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.exp
  )
- (func $../../lib/libm/assembly/libm/expm1 (; 28 ;) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/expm1 (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.expm1
  )
- (func $../../lib/libm/assembly/libm/floor (; 29 ;) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/floor (param $0 f64) (result f64)
   local.get $0
   f64.floor
  )
- (func $../../lib/libm/assembly/libm/fround (; 30 ;) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/fround (param $0 f64) (result f64)
   local.get $0
   f32.demote_f64
   f64.promote_f32
  )
- (func $~lib/math/NativeMath.hypot (; 31 ;) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.hypot (param $0 f64) (param $1 f64) (result f64)
   (local $2 i64)
   (local $3 i64)
   (local $4 i64)
@@ -2951,12 +2951,12 @@
   f64.sqrt
   f64.mul
  )
- (func $../../lib/libm/assembly/libm/hypot (; 32 ;) (param $0 f64) (param $1 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/hypot (param $0 f64) (param $1 f64) (result f64)
   local.get $0
   local.get $1
   call $~lib/math/NativeMath.hypot
  )
- (func $../../lib/libm/assembly/libm/imul (; 33 ;) (param $0 f64) (param $1 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/imul (param $0 f64) (param $1 f64) (result f64)
   (local $2 f64)
   block $__inlined_func$~lib/math/NativeMath.imul (result f64)
    f64.const 0
@@ -2978,11 +2978,11 @@
    f64.convert_i32_s
   end
  )
- (func $../../lib/libm/assembly/libm/log (; 34 ;) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/log (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.log
  )
- (func $~lib/math/NativeMath.log10 (; 35 ;) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.log10 (param $0 f64) (result f64)
   (local $1 i32)
   (local $2 i64)
   (local $3 f64)
@@ -3187,15 +3187,15 @@
   local.get $7
   f64.add
  )
- (func $../../lib/libm/assembly/libm/log10 (; 36 ;) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/log10 (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.log10
  )
- (func $../../lib/libm/assembly/libm/log1p (; 37 ;) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/log1p (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.log1p
  )
- (func $~lib/math/NativeMath.log2 (; 38 ;) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.log2 (param $0 f64) (result f64)
   (local $1 i32)
   (local $2 i64)
   (local $3 f64)
@@ -3392,21 +3392,21 @@
   local.get $7
   f64.add
  )
- (func $../../lib/libm/assembly/libm/log2 (; 39 ;) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/log2 (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.log2
  )
- (func $../../lib/libm/assembly/libm/max (; 40 ;) (param $0 f64) (param $1 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/max (param $0 f64) (param $1 f64) (result f64)
   local.get $0
   local.get $1
   f64.max
  )
- (func $../../lib/libm/assembly/libm/min (; 41 ;) (param $0 f64) (param $1 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/min (param $0 f64) (param $1 f64) (result f64)
   local.get $0
   local.get $1
   f64.min
  )
- (func $~lib/math/NativeMath.pow (; 42 ;) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.pow (param $0 f64) (param $1 f64) (result f64)
   (local $2 f64)
   (local $3 f64)
   (local $4 i32)
@@ -4351,12 +4351,12 @@
   f64.const 1e-300
   f64.mul
  )
- (func $../../lib/libm/assembly/libm/pow (; 43 ;) (param $0 f64) (param $1 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/pow (param $0 f64) (param $1 f64) (result f64)
   local.get $0
   local.get $1
   call $~lib/math/NativeMath.pow
  )
- (func $../../lib/libm/assembly/libm/round (; 44 ;) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/round (param $0 f64) (result f64)
   local.get $0
   f64.const 0.5
   f64.add
@@ -4364,7 +4364,7 @@
   local.get $0
   f64.copysign
  )
- (func $../../lib/libm/assembly/libm/sign (; 45 ;) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/sign (param $0 f64) (result f64)
   local.get $0
   f64.abs
   f64.const 0
@@ -4377,7 +4377,7 @@
   end
   local.get $0
  )
- (func $~lib/math/NativeMath.sin (; 46 ;) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.sin (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 f64)
   (local $3 f64)
@@ -4693,11 +4693,11 @@
   end
   local.get $0
  )
- (func $../../lib/libm/assembly/libm/sin (; 47 ;) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/sin (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.sin
  )
- (func $~lib/math/NativeMath.sinh (; 48 ;) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.sinh (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 f64)
   (local $3 i32)
@@ -4774,15 +4774,15 @@
   f64.mul
   f64.mul
  )
- (func $../../lib/libm/assembly/libm/sinh (; 49 ;) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/sinh (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.sinh
  )
- (func $../../lib/libm/assembly/libm/sqrt (; 50 ;) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/sqrt (param $0 f64) (result f64)
   local.get $0
   f64.sqrt
  )
- (func $~lib/math/tan_kern (; 51 ;) (param $0 f64) (param $1 f64) (param $2 i32) (result f64)
+ (func $~lib/math/tan_kern (param $0 f64) (param $1 f64) (param $2 i32) (result f64)
   (local $3 f64)
   (local $4 f64)
   (local $5 f64)
@@ -4961,7 +4961,7 @@
   f64.mul
   f64.add
  )
- (func $~lib/math/NativeMath.tan (; 52 ;) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.tan (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 f64)
   (local $3 i32)
@@ -5138,11 +5138,11 @@
   i32.sub
   call $~lib/math/tan_kern
  )
- (func $../../lib/libm/assembly/libm/tan (; 53 ;) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/tan (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.tan
  )
- (func $~lib/math/NativeMath.tanh (; 54 ;) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.tanh (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 i32)
   (local $3 i64)
@@ -5221,19 +5221,19 @@
   local.get $0
   f64.copysign
  )
- (func $../../lib/libm/assembly/libm/tanh (; 55 ;) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/tanh (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.tanh
  )
- (func $../../lib/libm/assembly/libm/trunc (; 56 ;) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/trunc (param $0 f64) (result f64)
   local.get $0
   f64.trunc
  )
- (func $../../lib/libm/assembly/libmf/abs (; 57 ;) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/abs (param $0 f32) (result f32)
   local.get $0
   f32.abs
  )
- (func $~lib/math/Rf (; 58 ;) (param $0 f32) (result f32)
+ (func $~lib/math/Rf (param $0 f32) (result f32)
   local.get $0
   f32.const 0.16666586697101593
   local.get $0
@@ -5252,7 +5252,7 @@
   f32.add
   f32.div
  )
- (func $~lib/math/NativeMathf.acos (; 59 ;) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.acos (param $0 f32) (result f32)
   (local $1 f32)
   (local $2 i32)
   (local $3 i32)
@@ -5368,11 +5368,11 @@
   f32.add
   f32.mul
  )
- (func $../../lib/libm/assembly/libmf/acos (; 60 ;) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/acos (param $0 f32) (result f32)
   local.get $0
   call $~lib/math/NativeMathf.acos
  )
- (func $~lib/math/NativeMathf.log1p (; 61 ;) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.log1p (param $0 f32) (result f32)
   (local $1 f32)
   (local $2 i32)
   (local $3 i32)
@@ -5540,7 +5540,7 @@
   f32.mul
   f32.add
  )
- (func $~lib/math/NativeMathf.log (; 62 ;) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.log (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 f32)
   (local $3 f32)
@@ -5673,7 +5673,7 @@
   f32.mul
   f32.add
  )
- (func $../../lib/libm/assembly/libmf/acosh (; 63 ;) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/acosh (param $0 f32) (result f32)
   (local $1 i32)
   block $__inlined_func$~lib/math/NativeMathf.acosh (result f32)
    local.get $0
@@ -5725,7 +5725,7 @@
    f32.add
   end
  )
- (func $~lib/math/NativeMathf.asin (; 64 ;) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.asin (param $0 f32) (result f32)
   (local $1 f32)
   (local $2 i32)
   (local $3 f64)
@@ -5806,11 +5806,11 @@
   local.get $1
   f32.copysign
  )
- (func $../../lib/libm/assembly/libmf/asin (; 65 ;) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/asin (param $0 f32) (result f32)
   local.get $0
   call $~lib/math/NativeMathf.asin
  )
- (func $../../lib/libm/assembly/libmf/asinh (; 66 ;) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/asinh (param $0 f32) (result f32)
   (local $1 f32)
   (local $2 i32)
   local.get $0
@@ -5878,7 +5878,7 @@
   local.get $1
   f32.copysign
  )
- (func $~lib/math/NativeMathf.atan (; 67 ;) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.atan (param $0 f32) (result f32)
   (local $1 f32)
   (local $2 f32)
   (local $3 i32)
@@ -6073,11 +6073,11 @@
   local.get $1
   f32.copysign
  )
- (func $../../lib/libm/assembly/libmf/atan (; 68 ;) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/atan (param $0 f32) (result f32)
   local.get $0
   call $~lib/math/NativeMathf.atan
  )
- (func $../../lib/libm/assembly/libmf/atanh (; 69 ;) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/atanh (param $0 f32) (result f32)
   (local $1 f32)
   (local $2 i32)
   local.get $0
@@ -6127,7 +6127,7 @@
   local.get $1
   f32.copysign
  )
- (func $~lib/math/NativeMathf.atan2 (; 70 ;) (param $0 f32) (param $1 f32) (result f32)
+ (func $~lib/math/NativeMathf.atan2 (param $0 f32) (param $1 f32) (result f32)
   (local $2 i32)
   (local $3 i32)
   (local $4 f32)
@@ -6321,12 +6321,12 @@
   i32.and
   select
  )
- (func $../../lib/libm/assembly/libmf/atan2 (; 71 ;) (param $0 f32) (param $1 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/atan2 (param $0 f32) (param $1 f32) (result f32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMathf.atan2
  )
- (func $~lib/math/NativeMathf.cbrt (; 72 ;) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.cbrt (param $0 f32) (result f32)
   (local $1 f64)
   (local $2 f64)
   (local $3 i32)
@@ -6425,15 +6425,15 @@
   f64.div
   f32.demote_f64
  )
- (func $../../lib/libm/assembly/libmf/cbrt (; 73 ;) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/cbrt (param $0 f32) (result f32)
   local.get $0
   call $~lib/math/NativeMathf.cbrt
  )
- (func $../../lib/libm/assembly/libmf/ceil (; 74 ;) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/ceil (param $0 f32) (result f32)
   local.get $0
   f32.ceil
  )
- (func $../../lib/libm/assembly/libmf/clz32 (; 75 ;) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/clz32 (param $0 f32) (result f32)
   local.get $0
   local.get $0
   f32.sub
@@ -6449,7 +6449,7 @@
    f32.convert_i32_s
   end
  )
- (func $~lib/math/NativeMathf.cos (; 76 ;) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.cos (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 i32)
   (local $3 f64)
@@ -6718,11 +6718,11 @@
   end
   local.get $0
  )
- (func $../../lib/libm/assembly/libmf/cos (; 77 ;) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/cos (param $0 f32) (result f32)
   local.get $0
   call $~lib/math/NativeMathf.cos
  )
- (func $~lib/math/NativeMathf.expm1 (; 78 ;) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.expm1 (param $0 f32) (result f32)
   (local $1 f32)
   (local $2 f32)
   (local $3 i32)
@@ -6970,7 +6970,7 @@
   local.get $5
   f32.mul
  )
- (func $~lib/math/NativeMathf.scalbn (; 79 ;) (param $0 f32) (param $1 i32) (result f32)
+ (func $~lib/math/NativeMathf.scalbn (param $0 f32) (param $1 i32) (result f32)
   local.get $1
   i32.const 127
   i32.gt_s
@@ -7046,7 +7046,7 @@
   f32.reinterpret_i32
   f32.mul
  )
- (func $~lib/math/NativeMathf.exp (; 80 ;) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.exp (param $0 f32) (result f32)
   (local $1 f32)
   (local $2 i32)
   (local $3 i32)
@@ -7179,7 +7179,7 @@
   end
   local.get $0
  )
- (func $../../lib/libm/assembly/libmf/cosh (; 81 ;) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/cosh (param $0 f32) (result f32)
   (local $1 i32)
   block $__inlined_func$~lib/math/NativeMathf.cosh (result f32)
    local.get $0
@@ -7239,22 +7239,22 @@
    f32.mul
   end
  )
- (func $../../lib/libm/assembly/libmf/exp (; 82 ;) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/exp (param $0 f32) (result f32)
   local.get $0
   call $~lib/math/NativeMathf.exp
  )
- (func $../../lib/libm/assembly/libmf/expm1 (; 83 ;) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/expm1 (param $0 f32) (result f32)
   local.get $0
   call $~lib/math/NativeMathf.expm1
  )
- (func $../../lib/libm/assembly/libmf/floor (; 84 ;) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/floor (param $0 f32) (result f32)
   local.get $0
   f32.floor
  )
- (func $../../lib/libm/assembly/libmf/fround (; 85 ;) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/fround (param $0 f32) (result f32)
   local.get $0
  )
- (func $~lib/math/NativeMathf.hypot (; 86 ;) (param $0 f32) (param $1 f32) (result f32)
+ (func $~lib/math/NativeMathf.hypot (param $0 f32) (param $1 f32) (result f32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7359,12 +7359,12 @@
   f32.sqrt
   f32.mul
  )
- (func $../../lib/libm/assembly/libmf/hypot (; 87 ;) (param $0 f32) (param $1 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/hypot (param $0 f32) (param $1 f32) (result f32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMathf.hypot
  )
- (func $../../lib/libm/assembly/libmf/imul (; 88 ;) (param $0 f32) (param $1 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/imul (param $0 f32) (param $1 f32) (result f32)
   (local $2 f32)
   (local $3 f32)
   local.get $0
@@ -7389,11 +7389,11 @@
   end
   local.get $3
  )
- (func $../../lib/libm/assembly/libmf/log (; 89 ;) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/log (param $0 f32) (result f32)
   local.get $0
   call $~lib/math/NativeMathf.log
  )
- (func $~lib/math/NativeMathf.log10 (; 90 ;) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.log10 (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 f32)
   (local $3 f32)
@@ -7550,15 +7550,15 @@
   f32.mul
   f32.add
  )
- (func $../../lib/libm/assembly/libmf/log10 (; 91 ;) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/log10 (param $0 f32) (result f32)
   local.get $0
   call $~lib/math/NativeMathf.log10
  )
- (func $../../lib/libm/assembly/libmf/log1p (; 92 ;) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/log1p (param $0 f32) (result f32)
   local.get $0
   call $~lib/math/NativeMathf.log1p
  )
- (func $~lib/math/NativeMathf.log2 (; 93 ;) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.log2 (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 f32)
   (local $3 f32)
@@ -7707,21 +7707,21 @@
   f32.convert_i32_s
   f32.add
  )
- (func $../../lib/libm/assembly/libmf/log2 (; 94 ;) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/log2 (param $0 f32) (result f32)
   local.get $0
   call $~lib/math/NativeMathf.log2
  )
- (func $../../lib/libm/assembly/libmf/max (; 95 ;) (param $0 f32) (param $1 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/max (param $0 f32) (param $1 f32) (result f32)
   local.get $0
   local.get $1
   f32.max
  )
- (func $../../lib/libm/assembly/libmf/min (; 96 ;) (param $0 f32) (param $1 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/min (param $0 f32) (param $1 f32) (result f32)
   local.get $0
   local.get $1
   f32.min
  )
- (func $~lib/math/NativeMathf.pow (; 97 ;) (param $0 f32) (param $1 f32) (result f32)
+ (func $~lib/math/NativeMathf.pow (param $0 f32) (param $1 f32) (result f32)
   (local $2 f64)
   (local $3 f64)
   (local $4 i32)
@@ -8003,12 +8003,12 @@
   i32.or
   f32.reinterpret_i32
  )
- (func $../../lib/libm/assembly/libmf/pow (; 98 ;) (param $0 f32) (param $1 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/pow (param $0 f32) (param $1 f32) (result f32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMathf.pow
  )
- (func $../../lib/libm/assembly/libmf/round (; 99 ;) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/round (param $0 f32) (result f32)
   local.get $0
   f32.const 0.5
   f32.add
@@ -8016,7 +8016,7 @@
   local.get $0
   f32.copysign
  )
- (func $../../lib/libm/assembly/libmf/sign (; 100 ;) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/sign (param $0 f32) (result f32)
   local.get $0
   f32.abs
   f32.const 0
@@ -8029,7 +8029,7 @@
   end
   local.get $0
  )
- (func $~lib/math/NativeMathf.sin (; 101 ;) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.sin (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 i32)
   (local $3 f64)
@@ -8299,11 +8299,11 @@
   end
   local.get $0
  )
- (func $../../lib/libm/assembly/libmf/sin (; 102 ;) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/sin (param $0 f32) (result f32)
   local.get $0
   call $~lib/math/NativeMathf.sin
  )
- (func $~lib/math/NativeMathf.sinh (; 103 ;) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.sinh (param $0 f32) (result f32)
   (local $1 f32)
   (local $2 i32)
   (local $3 f32)
@@ -8375,15 +8375,15 @@
   f32.mul
   f32.mul
  )
- (func $../../lib/libm/assembly/libmf/sinh (; 104 ;) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/sinh (param $0 f32) (result f32)
   local.get $0
   call $~lib/math/NativeMathf.sinh
  )
- (func $../../lib/libm/assembly/libmf/sqrt (; 105 ;) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/sqrt (param $0 f32) (result f32)
   local.get $0
   f32.sqrt
  )
- (func $~lib/math/NativeMathf.tan (; 106 ;) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.tan (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 i32)
   (local $3 f64)
@@ -8637,11 +8637,11 @@
   local.get $3
   f32.demote_f64
  )
- (func $../../lib/libm/assembly/libmf/tan (; 107 ;) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/tan (param $0 f32) (result f32)
   local.get $0
   call $~lib/math/NativeMathf.tan
  )
- (func $../../lib/libm/assembly/libmf/tanh (; 108 ;) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/tanh (param $0 f32) (result f32)
   (local $1 f32)
   (local $2 i32)
   local.get $0
@@ -8713,7 +8713,7 @@
   local.get $0
   f32.copysign
  )
- (func $../../lib/libm/assembly/libmf/trunc (; 109 ;) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/trunc (param $0 f32) (result f32)
   local.get $0
   f32.trunc
  )

--- a/tests/compiler/std/libm.untouched.wat
+++ b/tests/compiler/std/libm.untouched.wat
@@ -142,14 +142,14 @@
  (export "libmf.tan" (func $../../lib/libm/assembly/libmf/tan))
  (export "libmf.tanh" (func $../../lib/libm/assembly/libmf/tanh))
  (export "libmf.trunc" (func $../../lib/libm/assembly/libmf/trunc))
- (func $../../lib/libm/assembly/libm/abs (; 0 ;) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/abs (param $0 f64) (result f64)
   (local $1 f64)
   local.get $0
   local.set $1
   local.get $1
   f64.abs
  )
- (func $~lib/math/R (; 1 ;) (param $0 f64) (result f64)
+ (func $~lib/math/R (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 f64)
   local.get $0
@@ -198,7 +198,7 @@
   local.get $2
   f64.div
  )
- (func $~lib/math/NativeMath.acos (; 2 ;) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.acos (param $0 f64) (result f64)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -350,11 +350,11 @@
   f64.add
   f64.mul
  )
- (func $../../lib/libm/assembly/libm/acos (; 3 ;) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/acos (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.acos
  )
- (func $~lib/math/NativeMath.log1p (; 4 ;) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.log1p (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i32)
   (local $3 i32)
@@ -596,7 +596,7 @@
   f64.mul
   f64.add
  )
- (func $~lib/math/NativeMath.log (; 5 ;) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.log (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 i64)
   (local $3 f64)
@@ -914,7 +914,7 @@
   end
   return
  )
- (func $~lib/math/NativeMath.acosh (; 6 ;) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.acosh (param $0 f64) (result f64)
   (local $1 i64)
   local.get $0
   i64.reinterpret_f64
@@ -974,11 +974,11 @@
   f64.const 0.6931471805599453
   f64.add
  )
- (func $../../lib/libm/assembly/libm/acosh (; 7 ;) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/acosh (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.acosh
  )
- (func $~lib/math/NativeMath.asin (; 8 ;) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.asin (param $0 f64) (result f64)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -1137,11 +1137,11 @@
   end
   local.get $0
  )
- (func $../../lib/libm/assembly/libm/asin (; 9 ;) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/asin (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.asin
  )
- (func $~lib/math/NativeMath.asinh (; 10 ;) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.asinh (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i64)
   (local $3 f64)
@@ -1217,11 +1217,11 @@
   local.get $0
   f64.copysign
  )
- (func $../../lib/libm/assembly/libm/asinh (; 11 ;) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/asinh (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.asinh
  )
- (func $~lib/math/NativeMath.atan (; 12 ;) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.atan (param $0 f64) (result f64)
   (local $1 i32)
   (local $2 f64)
   (local $3 f64)
@@ -1479,11 +1479,11 @@
   local.get $2
   f64.copysign
  )
- (func $../../lib/libm/assembly/libm/atan (; 13 ;) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/atan (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.atan
  )
- (func $~lib/math/NativeMath.atanh (; 14 ;) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.atanh (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i64)
   (local $3 f64)
@@ -1542,11 +1542,11 @@
   local.get $0
   f64.copysign
  )
- (func $../../lib/libm/assembly/libm/atanh (; 15 ;) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/atanh (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.atanh
  )
- (func $~lib/math/NativeMath.atan2 (; 16 ;) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.atan2 (param $0 f64) (param $1 f64) (result f64)
   (local $2 i64)
   (local $3 i32)
   (local $4 i32)
@@ -1846,12 +1846,12 @@
   end
   unreachable
  )
- (func $../../lib/libm/assembly/libm/atan2 (; 17 ;) (param $0 f64) (param $1 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/atan2 (param $0 f64) (param $1 f64) (result f64)
   local.get $0
   local.get $1
   call $~lib/math/NativeMath.atan2
  )
- (func $~lib/math/NativeMath.cbrt (; 18 ;) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.cbrt (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i32)
   (local $3 f64)
@@ -1995,18 +1995,18 @@
   local.set $3
   local.get $3
  )
- (func $../../lib/libm/assembly/libm/cbrt (; 19 ;) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/cbrt (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.cbrt
  )
- (func $../../lib/libm/assembly/libm/ceil (; 20 ;) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/ceil (param $0 f64) (result f64)
   (local $1 f64)
   local.get $0
   local.set $1
   local.get $1
   f64.ceil
  )
- (func $~lib/math/dtoi32 (; 21 ;) (param $0 f64) (result i32)
+ (func $~lib/math/dtoi32 (param $0 f64) (result i32)
   (local $1 i32)
   (local $2 i64)
   (local $3 i64)
@@ -2077,7 +2077,7 @@
   local.get $1
   return
  )
- (func $~lib/math/NativeMath.clz32 (; 22 ;) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.clz32 (param $0 f64) (result f64)
   local.get $0
   local.get $0
   f64.sub
@@ -2093,11 +2093,11 @@
   i32.clz
   f64.convert_i32_s
  )
- (func $../../lib/libm/assembly/libm/clz32 (; 23 ;) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/clz32 (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.clz32
  )
- (func $~lib/math/pio2_large_quot (; 24 ;) (param $0 f64) (param $1 i64) (result i32)
+ (func $~lib/math/pio2_large_quot (param $0 f64) (param $1 i64) (result i32)
   (local $2 i64)
   (local $3 i64)
   (local $4 i64)
@@ -2495,7 +2495,7 @@
   local.get $30
   i32.wrap_i64
  )
- (func $~lib/math/NativeMath.cos (; 25 ;) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.cos (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i32)
   (local $3 i32)
@@ -3013,11 +3013,11 @@
    local.get $0
   end
  )
- (func $../../lib/libm/assembly/libm/cos (; 26 ;) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/cos (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.cos
  )
- (func $~lib/math/NativeMath.expm1 (; 27 ;) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.expm1 (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i32)
   (local $3 i32)
@@ -3330,7 +3330,7 @@
   local.get $14
   f64.mul
  )
- (func $~lib/math/NativeMath.exp (; 28 ;) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.exp (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 i64)
   (local $3 i32)
@@ -3608,7 +3608,7 @@
   end
   return
  )
- (func $~lib/math/NativeMath.cosh (; 29 ;) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.cosh (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i32)
   (local $3 f64)
@@ -3697,26 +3697,26 @@
   local.set $3
   local.get $3
  )
- (func $../../lib/libm/assembly/libm/cosh (; 30 ;) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/cosh (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.cosh
  )
- (func $../../lib/libm/assembly/libm/exp (; 31 ;) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/exp (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.exp
  )
- (func $../../lib/libm/assembly/libm/expm1 (; 32 ;) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/expm1 (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.expm1
  )
- (func $../../lib/libm/assembly/libm/floor (; 33 ;) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/floor (param $0 f64) (result f64)
   (local $1 f64)
   local.get $0
   local.set $1
   local.get $1
   f64.floor
  )
- (func $../../lib/libm/assembly/libm/fround (; 34 ;) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/fround (param $0 f64) (result f64)
   (local $1 f64)
   local.get $0
   local.set $1
@@ -3724,7 +3724,7 @@
   f32.demote_f64
   f64.promote_f32
  )
- (func $~lib/math/NativeMath.hypot (; 35 ;) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.hypot (param $0 f64) (param $1 f64) (result f64)
   (local $2 i64)
   (local $3 i64)
   (local $4 i64)
@@ -3919,12 +3919,12 @@
   f64.sqrt
   f64.mul
  )
- (func $../../lib/libm/assembly/libm/hypot (; 36 ;) (param $0 f64) (param $1 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/hypot (param $0 f64) (param $1 f64) (result f64)
   local.get $0
   local.get $1
   call $~lib/math/NativeMath.hypot
  )
- (func $~lib/math/NativeMath.imul (; 37 ;) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.imul (param $0 f64) (param $1 f64) (result f64)
   (local $2 f64)
   local.get $0
   local.get $1
@@ -3946,16 +3946,16 @@
   i32.mul
   f64.convert_i32_s
  )
- (func $../../lib/libm/assembly/libm/imul (; 38 ;) (param $0 f64) (param $1 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/imul (param $0 f64) (param $1 f64) (result f64)
   local.get $0
   local.get $1
   call $~lib/math/NativeMath.imul
  )
- (func $../../lib/libm/assembly/libm/log (; 39 ;) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/log (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.log
  )
- (func $~lib/math/NativeMath.log10 (; 40 ;) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.log10 (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i32)
   (local $3 i32)
@@ -4215,15 +4215,15 @@
   local.get $8
   f64.add
  )
- (func $../../lib/libm/assembly/libm/log10 (; 41 ;) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/log10 (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.log10
  )
- (func $../../lib/libm/assembly/libm/log1p (; 42 ;) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/log1p (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.log1p
  )
- (func $~lib/math/NativeMath.log2 (; 43 ;) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.log2 (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 i64)
   (local $3 f64)
@@ -4566,11 +4566,11 @@
   end
   return
  )
- (func $../../lib/libm/assembly/libm/log2 (; 44 ;) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/log2 (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.log2
  )
- (func $../../lib/libm/assembly/libm/max (; 45 ;) (param $0 f64) (param $1 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/max (param $0 f64) (param $1 f64) (result f64)
   (local $2 f64)
   (local $3 f64)
   local.get $0
@@ -4581,7 +4581,7 @@
   local.get $2
   f64.max
  )
- (func $../../lib/libm/assembly/libm/min (; 46 ;) (param $0 f64) (param $1 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/min (param $0 f64) (param $1 f64) (result f64)
   (local $2 f64)
   (local $3 f64)
   local.get $0
@@ -4592,7 +4592,7 @@
   local.get $2
   f64.min
  )
- (func $~lib/math/NativeMath.pow (; 47 ;) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.pow (param $0 f64) (param $1 f64) (result f64)
   (local $2 f64)
   (local $3 f64)
   (local $4 i32)
@@ -5552,12 +5552,12 @@
   end
   return
  )
- (func $../../lib/libm/assembly/libm/pow (; 48 ;) (param $0 f64) (param $1 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/pow (param $0 f64) (param $1 f64) (result f64)
   local.get $0
   local.get $1
   call $~lib/math/NativeMath.pow
  )
- (func $../../lib/libm/assembly/libm/round (; 49 ;) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/round (param $0 f64) (result f64)
   (local $1 f64)
   local.get $0
   local.set $1
@@ -5568,7 +5568,7 @@
   local.get $1
   f64.copysign
  )
- (func $../../lib/libm/assembly/libm/sign (; 50 ;) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/sign (param $0 f64) (result f64)
   (local $1 f64)
   block $~lib/math/NativeMath.sign|inlined.0 (result f64)
    local.get $0
@@ -5591,7 +5591,7 @@
    br $~lib/math/NativeMath.sign|inlined.0
   end
  )
- (func $~lib/math/NativeMath.sin (; 51 ;) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.sin (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i32)
   (local $3 i32)
@@ -6120,11 +6120,11 @@
    local.get $0
   end
  )
- (func $../../lib/libm/assembly/libm/sin (; 52 ;) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/sin (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.sin
  )
- (func $~lib/math/NativeMath.sinh (; 53 ;) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.sinh (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 f64)
   (local $3 i32)
@@ -6222,18 +6222,18 @@
   local.set $4
   local.get $4
  )
- (func $../../lib/libm/assembly/libm/sinh (; 54 ;) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/sinh (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.sinh
  )
- (func $../../lib/libm/assembly/libm/sqrt (; 55 ;) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/sqrt (param $0 f64) (result f64)
   (local $1 f64)
   local.get $0
   local.set $1
   local.get $1
   f64.sqrt
  )
- (func $~lib/math/tan_kern (; 56 ;) (param $0 f64) (param $1 f64) (param $2 i32) (result f64)
+ (func $~lib/math/tan_kern (param $0 f64) (param $1 f64) (param $2 i32) (result f64)
   (local $3 f64)
   (local $4 f64)
   (local $5 f64)
@@ -6446,7 +6446,7 @@
   f64.mul
   f64.add
  )
- (func $~lib/math/NativeMath.tan (; 57 ;) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.tan (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i32)
   (local $3 i32)
@@ -6758,11 +6758,11 @@
   i32.sub
   call $~lib/math/tan_kern
  )
- (func $../../lib/libm/assembly/libm/tan (; 58 ;) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/tan (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.tan
  )
- (func $~lib/math/NativeMath.tanh (; 59 ;) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.tanh (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 f64)
   (local $3 i32)
@@ -6854,25 +6854,25 @@
   local.get $0
   f64.copysign
  )
- (func $../../lib/libm/assembly/libm/tanh (; 60 ;) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/tanh (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.tanh
  )
- (func $../../lib/libm/assembly/libm/trunc (; 61 ;) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/trunc (param $0 f64) (result f64)
   (local $1 f64)
   local.get $0
   local.set $1
   local.get $1
   f64.trunc
  )
- (func $../../lib/libm/assembly/libmf/abs (; 62 ;) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/abs (param $0 f32) (result f32)
   (local $1 f32)
   local.get $0
   local.set $1
   local.get $1
   f32.abs
  )
- (func $~lib/math/Rf (; 63 ;) (param $0 f32) (result f32)
+ (func $~lib/math/Rf (param $0 f32) (result f32)
   (local $1 f32)
   (local $2 f32)
   local.get $0
@@ -6897,7 +6897,7 @@
   local.get $2
   f32.div
  )
- (func $~lib/math/NativeMathf.acos (; 64 ;) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.acos (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 i32)
   (local $3 f32)
@@ -7037,11 +7037,11 @@
   f32.add
   f32.mul
  )
- (func $../../lib/libm/assembly/libmf/acos (; 65 ;) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/acos (param $0 f32) (result f32)
   local.get $0
   call $~lib/math/NativeMathf.acos
  )
- (func $~lib/math/NativeMathf.log1p (; 66 ;) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.log1p (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 f32)
   (local $3 f32)
@@ -7250,7 +7250,7 @@
   f32.mul
   f32.add
  )
- (func $~lib/math/NativeMathf.log (; 67 ;) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.log (param $0 f32) (result f32)
   (local $1 f32)
   (local $2 i32)
   (local $3 i32)
@@ -7415,7 +7415,7 @@
   end
   return
  )
- (func $~lib/math/NativeMathf.acosh (; 68 ;) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.acosh (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 i32)
   (local $3 f32)
@@ -7471,11 +7471,11 @@
   f32.const 0.6931471824645996
   f32.add
  )
- (func $../../lib/libm/assembly/libmf/acosh (; 69 ;) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/acosh (param $0 f32) (result f32)
   local.get $0
   call $~lib/math/NativeMathf.acosh
  )
- (func $~lib/math/NativeMathf.asin (; 70 ;) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.asin (param $0 f32) (result f32)
   (local $1 f32)
   (local $2 i32)
   (local $3 f32)
@@ -7567,11 +7567,11 @@
   local.get $1
   f32.copysign
  )
- (func $../../lib/libm/assembly/libmf/asin (; 71 ;) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/asin (param $0 f32) (result f32)
   local.get $0
   call $~lib/math/NativeMathf.asin
  )
- (func $~lib/math/NativeMathf.asinh (; 72 ;) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.asinh (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 f32)
   local.get $0
@@ -7640,11 +7640,11 @@
   local.get $0
   f32.copysign
  )
- (func $../../lib/libm/assembly/libmf/asinh (; 73 ;) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/asinh (param $0 f32) (result f32)
   local.get $0
   call $~lib/math/NativeMathf.asinh
  )
- (func $~lib/math/NativeMathf.atan (; 74 ;) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.atan (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 f32)
   (local $3 f32)
@@ -7874,11 +7874,11 @@
   local.get $2
   f32.copysign
  )
- (func $../../lib/libm/assembly/libmf/atan (; 75 ;) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/atan (param $0 f32) (result f32)
   local.get $0
   call $~lib/math/NativeMathf.atan
  )
- (func $~lib/math/NativeMathf.atanh (; 76 ;) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.atanh (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 f32)
   local.get $0
@@ -7928,11 +7928,11 @@
   local.get $0
   f32.copysign
  )
- (func $../../lib/libm/assembly/libmf/atanh (; 77 ;) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/atanh (param $0 f32) (result f32)
   local.get $0
   call $~lib/math/NativeMathf.atanh
  )
- (func $~lib/math/NativeMathf.atan2 (; 78 ;) (param $0 f32) (param $1 f32) (result f32)
+ (func $~lib/math/NativeMathf.atan2 (param $0 f32) (param $1 f32) (result f32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -8204,12 +8204,12 @@
   end
   unreachable
  )
- (func $../../lib/libm/assembly/libmf/atan2 (; 79 ;) (param $0 f32) (param $1 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/atan2 (param $0 f32) (param $1 f32) (result f32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMathf.atan2
  )
- (func $~lib/math/NativeMathf.cbrt (; 80 ;) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.cbrt (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 i32)
   (local $3 f64)
@@ -8325,18 +8325,18 @@
   local.get $3
   f32.demote_f64
  )
- (func $../../lib/libm/assembly/libmf/cbrt (; 81 ;) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/cbrt (param $0 f32) (result f32)
   local.get $0
   call $~lib/math/NativeMathf.cbrt
  )
- (func $../../lib/libm/assembly/libmf/ceil (; 82 ;) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/ceil (param $0 f32) (result f32)
   (local $1 f32)
   local.get $0
   local.set $1
   local.get $1
   f32.ceil
  )
- (func $~lib/math/NativeMathf.clz32 (; 83 ;) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.clz32 (param $0 f32) (result f32)
   local.get $0
   local.get $0
   f32.sub
@@ -8353,11 +8353,11 @@
   i32.clz
   f32.convert_i32_s
  )
- (func $../../lib/libm/assembly/libmf/clz32 (; 84 ;) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/clz32 (param $0 f32) (result f32)
   local.get $0
   call $~lib/math/NativeMathf.clz32
  )
- (func $~lib/math/NativeMathf.cos (; 85 ;) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.cos (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 i32)
   (local $3 f64)
@@ -8971,11 +8971,11 @@
    local.get $26
   end
  )
- (func $../../lib/libm/assembly/libmf/cos (; 86 ;) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/cos (param $0 f32) (result f32)
   local.get $0
   call $~lib/math/NativeMathf.cos
  )
- (func $~lib/math/NativeMathf.expm1 (; 87 ;) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.expm1 (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -9268,7 +9268,7 @@
   local.get $13
   f32.mul
  )
- (func $~lib/math/NativeMathf.exp (; 88 ;) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.exp (param $0 f32) (result f32)
   (local $1 f32)
   (local $2 f64)
   (local $3 i32)
@@ -9399,7 +9399,7 @@
   end
   return
  )
- (func $~lib/math/NativeMathf.cosh (; 89 ;) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.cosh (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 f32)
   (local $3 f32)
@@ -9476,32 +9476,32 @@
   local.get $3
   f32.mul
  )
- (func $../../lib/libm/assembly/libmf/cosh (; 90 ;) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/cosh (param $0 f32) (result f32)
   local.get $0
   call $~lib/math/NativeMathf.cosh
  )
- (func $../../lib/libm/assembly/libmf/exp (; 91 ;) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/exp (param $0 f32) (result f32)
   local.get $0
   call $~lib/math/NativeMathf.exp
  )
- (func $../../lib/libm/assembly/libmf/expm1 (; 92 ;) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/expm1 (param $0 f32) (result f32)
   local.get $0
   call $~lib/math/NativeMathf.expm1
  )
- (func $../../lib/libm/assembly/libmf/floor (; 93 ;) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/floor (param $0 f32) (result f32)
   (local $1 f32)
   local.get $0
   local.set $1
   local.get $1
   f32.floor
  )
- (func $../../lib/libm/assembly/libmf/fround (; 94 ;) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/fround (param $0 f32) (result f32)
   (local $1 f32)
   local.get $0
   local.set $1
   local.get $1
  )
- (func $~lib/math/NativeMathf.hypot (; 95 ;) (param $0 f32) (param $1 f32) (result f32)
+ (func $~lib/math/NativeMathf.hypot (param $0 f32) (param $1 f32) (result f32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9618,12 +9618,12 @@
   f32.sqrt
   f32.mul
  )
- (func $../../lib/libm/assembly/libmf/hypot (; 96 ;) (param $0 f32) (param $1 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/hypot (param $0 f32) (param $1 f32) (result f32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMathf.hypot
  )
- (func $../../lib/libm/assembly/libmf/imul (; 97 ;) (param $0 f32) (param $1 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/imul (param $0 f32) (param $1 f32) (result f32)
   (local $2 f32)
   (local $3 f32)
   (local $4 f32)
@@ -9655,11 +9655,11 @@
    f32.convert_i32_s
   end
  )
- (func $../../lib/libm/assembly/libmf/log (; 98 ;) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/log (param $0 f32) (result f32)
   local.get $0
   call $~lib/math/NativeMathf.log
  )
- (func $~lib/math/NativeMathf.log10 (; 99 ;) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.log10 (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 i32)
   (local $3 f32)
@@ -9859,15 +9859,15 @@
   f32.mul
   f32.add
  )
- (func $../../lib/libm/assembly/libmf/log10 (; 100 ;) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/log10 (param $0 f32) (result f32)
   local.get $0
   call $~lib/math/NativeMathf.log10
  )
- (func $../../lib/libm/assembly/libmf/log1p (; 101 ;) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/log1p (param $0 f32) (result f32)
   local.get $0
   call $~lib/math/NativeMathf.log1p
  )
- (func $~lib/math/NativeMathf.log2 (; 102 ;) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.log2 (param $0 f32) (result f32)
   (local $1 f32)
   (local $2 i32)
   (local $3 i32)
@@ -10036,11 +10036,11 @@
   end
   return
  )
- (func $../../lib/libm/assembly/libmf/log2 (; 103 ;) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/log2 (param $0 f32) (result f32)
   local.get $0
   call $~lib/math/NativeMathf.log2
  )
- (func $../../lib/libm/assembly/libmf/max (; 104 ;) (param $0 f32) (param $1 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/max (param $0 f32) (param $1 f32) (result f32)
   (local $2 f32)
   (local $3 f32)
   local.get $0
@@ -10051,7 +10051,7 @@
   local.get $2
   f32.max
  )
- (func $../../lib/libm/assembly/libmf/min (; 105 ;) (param $0 f32) (param $1 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/min (param $0 f32) (param $1 f32) (result f32)
   (local $2 f32)
   (local $3 f32)
   local.get $0
@@ -10062,7 +10062,7 @@
   local.get $2
   f32.min
  )
- (func $~lib/math/NativeMathf.pow (; 106 ;) (param $0 f32) (param $1 f32) (result f32)
+ (func $~lib/math/NativeMathf.pow (param $0 f32) (param $1 f32) (result f32)
   (local $2 f32)
   (local $3 f32)
   (local $4 i32)
@@ -10648,12 +10648,12 @@
   end
   return
  )
- (func $../../lib/libm/assembly/libmf/pow (; 107 ;) (param $0 f32) (param $1 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/pow (param $0 f32) (param $1 f32) (result f32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMathf.pow
  )
- (func $../../lib/libm/assembly/libmf/round (; 108 ;) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/round (param $0 f32) (result f32)
   (local $1 f32)
   local.get $0
   local.set $1
@@ -10664,7 +10664,7 @@
   local.get $1
   f32.copysign
  )
- (func $../../lib/libm/assembly/libmf/sign (; 109 ;) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/sign (param $0 f32) (result f32)
   (local $1 f32)
   block $~lib/math/NativeMathf.sign|inlined.0 (result f32)
    local.get $0
@@ -10687,7 +10687,7 @@
    br $~lib/math/NativeMathf.sign|inlined.0
   end
  )
- (func $~lib/math/NativeMathf.sin (; 110 ;) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.sin (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 i32)
   (local $3 f64)
@@ -11293,11 +11293,11 @@
    local.get $26
   end
  )
- (func $../../lib/libm/assembly/libmf/sin (; 111 ;) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/sin (param $0 f32) (result f32)
   local.get $0
   call $~lib/math/NativeMathf.sin
  )
- (func $~lib/math/NativeMathf.sinh (; 112 ;) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.sinh (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 f32)
   (local $3 f32)
@@ -11386,18 +11386,18 @@
   local.set $3
   local.get $3
  )
- (func $../../lib/libm/assembly/libmf/sinh (; 113 ;) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/sinh (param $0 f32) (result f32)
   local.get $0
   call $~lib/math/NativeMathf.sinh
  )
- (func $../../lib/libm/assembly/libmf/sqrt (; 114 ;) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/sqrt (param $0 f32) (result f32)
   (local $1 f32)
   local.get $0
   local.set $1
   local.get $1
   f32.sqrt
  )
- (func $~lib/math/NativeMathf.tan (; 115 ;) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.tan (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -12044,11 +12044,11 @@
   end
   f32.demote_f64
  )
- (func $../../lib/libm/assembly/libmf/tan (; 116 ;) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/tan (param $0 f32) (result f32)
   local.get $0
   call $~lib/math/NativeMathf.tan
  )
- (func $~lib/math/NativeMathf.tanh (; 117 ;) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.tanh (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 f32)
   (local $3 f32)
@@ -12134,11 +12134,11 @@
   local.get $0
   f32.copysign
  )
- (func $../../lib/libm/assembly/libmf/tanh (; 118 ;) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/tanh (param $0 f32) (result f32)
   local.get $0
   call $~lib/math/NativeMathf.tanh
  )
- (func $../../lib/libm/assembly/libmf/trunc (; 119 ;) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/trunc (param $0 f32) (result f32)
   (local $1 f32)
   local.get $0
   local.set $1

--- a/tests/compiler/std/map.optimized.wat
+++ b/tests/compiler/std/map.optimized.wat
@@ -44,7 +44,7 @@
  (global $~lib/rt/tlsf/collectLock (mut i32) (i32.const 0))
  (export "memory" (memory $0))
  (start $~start)
- (func $~lib/rt/tlsf/removeBlock (; 6 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/removeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -206,7 +206,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/insertBlock (; 7 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/insertBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -485,7 +485,7 @@
   i32.or
   i32.store offset=4
  )
- (func $~lib/rt/tlsf/addMemory (; 8 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $2
@@ -599,7 +599,7 @@
   local.get $1
   call $~lib/rt/tlsf/insertBlock
  )
- (func $~lib/rt/tlsf/maybeInitialize (; 9 ;) (result i32)
+ (func $~lib/rt/tlsf/maybeInitialize (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -686,7 +686,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/tlsf/prepareSize (; 10 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/tlsf/prepareSize (param $0 i32) (result i32)
   local.get $0
   i32.const 1073741808
   i32.ge_u
@@ -710,7 +710,7 @@
   i32.gt_u
   select
  )
- (func $~lib/rt/tlsf/searchBlock (; 11 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/searchBlock (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   i32.const 256
@@ -839,7 +839,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/prepareBlock (; 12 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/rt/tlsf/prepareBlock (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $1
@@ -914,7 +914,7 @@
    i32.store
   end
  )
- (func $~lib/rt/tlsf/allocateBlock (; 13 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/allocateBlock (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1054,7 +1054,7 @@
   call $~lib/rt/rtrace/onalloc
   local.get $3
  )
- (func $~lib/rt/tlsf/__alloc (; 14 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/__alloc (param $0 i32) (param $1 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
   local.get $0
   local.get $1
@@ -1062,7 +1062,7 @@
   i32.const 16
   i32.add
  )
- (func $~lib/rt/pure/__retain (; 15 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/pure/__retain (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -1113,7 +1113,7 @@
   end
   local.get $0
  )
- (func $~lib/memory/memory.fill (; 16 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/memory/memory.fill (param $0 i32) (param $1 i32)
   (local $2 i32)
   block $~lib/util/memory/memset|inlined.0
    local.get $1
@@ -1271,7 +1271,7 @@
    end
   end
  )
- (func $~lib/arraybuffer/ArrayBuffer#constructor (; 17 ;) (param $0 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBuffer#constructor (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   i32.const 1073741808
@@ -1293,7 +1293,7 @@
   local.get $1
   call $~lib/rt/pure/__retain
  )
- (func $~lib/rt/pure/__release (; 18 ;) (param $0 i32)
+ (func $~lib/rt/pure/__release (param $0 i32)
   local.get $0
   i32.const 1556
   i32.gt_u
@@ -1304,7 +1304,7 @@
    call $~lib/rt/pure/decrement
   end
  )
- (func $~lib/map/Map<i8,i32>#clear (; 19 ;) (param $0 i32)
+ (func $~lib/map/Map<i8,i32>#clear (param $0 i32)
   (local $1 i32)
   i32.const 16
   call $~lib/arraybuffer/ArrayBuffer#constructor
@@ -1337,14 +1337,14 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/util/hash/hash8 (; 20 ;) (param $0 i32) (result i32)
+ (func $~lib/util/hash/hash8 (param $0 i32) (result i32)
   local.get $0
   i32.const -2128831035
   i32.xor
   i32.const 16777619
   i32.mul
  )
- (func $~lib/map/Map<i8,i32>#find (; 21 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<i8,i32>#find (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.load
   local.get $2
@@ -1387,7 +1387,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<i8,i32>#has (; 22 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<i8,i32>#has (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -1400,7 +1400,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<i8,i32>#rehash (; 23 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<i8,i32>#rehash (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1535,7 +1535,7 @@
   local.get $4
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<i8,i32>#set (; 24 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<i8,i32>#set (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1629,7 +1629,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/map/Map<i8,i32>#get (; 25 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<i8,i32>#get (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -1652,7 +1652,7 @@
   local.get $0
   i32.load offset=4
  )
- (func $~lib/memory/memory.copy (; 26 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/memory/memory.copy (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   block $~lib/util/memory/memmove|inlined.0
@@ -1825,7 +1825,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/freeBlock (; 27 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/freeBlock (param $0 i32) (param $1 i32)
   local.get $1
   local.get $1
   i32.load
@@ -1838,7 +1838,7 @@
   local.get $1
   call $~lib/rt/rtrace/onfree
  )
- (func $~lib/rt/tlsf/reallocateBlock (; 28 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/reallocateBlock (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1941,7 +1941,7 @@
   end
   local.get $3
  )
- (func $~lib/array/ensureSize (; 29 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/ensureSize (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2042,7 +2042,7 @@
    i32.store offset=8
   end
  )
- (func $~lib/array/Array<i8>#__set (; 30 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<i8>#__set (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $1
   local.get $0
@@ -2078,7 +2078,7 @@
   local.get $2
   i32.store8
  )
- (func $~lib/array/Array<i8>#set:length (; 31 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i8>#set:length (param $0 i32) (param $1 i32)
   local.get $0
   i32.load offset=12
   drop
@@ -2090,7 +2090,7 @@
   local.get $1
   i32.store offset=12
  )
- (func $~lib/map/Map<i8,i32>#keys (; 32 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<i8,i32>#keys (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -2202,7 +2202,7 @@
   call $~lib/array/Array<i8>#set:length
   local.get $0
  )
- (func $~lib/array/Array<i32>#constructor (; 33 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<i32>#constructor (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -2272,7 +2272,7 @@
   i32.store offset=12
   local.get $3
  )
- (func $~lib/array/Array<i32>#__set (; 34 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<i32>#__set (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $1
   local.get $0
@@ -2310,7 +2310,7 @@
   local.get $2
   i32.store
  )
- (func $~lib/array/Array<i32>#set:length (; 35 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i32>#set:length (param $0 i32) (param $1 i32)
   local.get $0
   i32.load offset=12
   drop
@@ -2322,7 +2322,7 @@
   local.get $1
   i32.store offset=12
  )
- (func $~lib/map/Map<i8,i32>#values (; 36 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<i8,i32>#values (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -2374,7 +2374,7 @@
   call $~lib/array/Array<i32>#set:length
   local.get $0
  )
- (func $~lib/map/Map<i8,i8>#clear (; 37 ;) (param $0 i32)
+ (func $~lib/map/Map<i8,i8>#clear (param $0 i32)
   (local $1 i32)
   i32.const 16
   call $~lib/arraybuffer/ArrayBuffer#constructor
@@ -2407,7 +2407,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<i32,i32>#constructor (; 38 ;) (result i32)
+ (func $~lib/map/Map<i32,i32>#constructor (result i32)
   (local $0 i32)
   i32.const 24
   i32.const 7
@@ -2435,7 +2435,7 @@
   call $~lib/map/Map<i8,i32>#clear
   local.get $0
  )
- (func $~lib/array/Array<i32>#__get (; 39 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#__get (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -2456,7 +2456,7 @@
   i32.add
   i32.load
  )
- (func $~lib/map/Map<i8,i8>#rehash (; 40 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<i8,i8>#rehash (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2591,7 +2591,7 @@
   local.get $4
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<i8,i8>#set (; 41 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<i8,i8>#set (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2724,7 +2724,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/hash/hash32 (; 42 ;) (param $0 i32) (result i32)
+ (func $~lib/util/hash/hash32 (param $0 i32) (result i32)
   local.get $0
   i32.const 255
   i32.and
@@ -2755,7 +2755,7 @@
   i32.const 16777619
   i32.mul
  )
- (func $~lib/map/Map<i32,i32>#find (; 43 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<i32,i32>#find (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.load
   local.get $2
@@ -2796,7 +2796,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<i32,i32>#rehash (; 44 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<i32,i32>#rehash (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2931,7 +2931,7 @@
   local.get $4
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<i32,i32>#set (; 45 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<i32,i32>#set (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3021,7 +3021,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/map/Map<i8,i32>#delete (; 46 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<i8,i32>#delete (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -3084,7 +3084,7 @@
    call $~lib/map/Map<i8,i32>#rehash
   end
  )
- (func $std/map/testNumeric<i8,i32> (; 47 ;)
+ (func $std/map/testNumeric<i8,i32>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -3607,7 +3607,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<u8,i32>#has (; 48 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<u8,i32>#has (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -3618,7 +3618,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<u8,i32>#rehash (; 49 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<u8,i32>#rehash (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3753,7 +3753,7 @@
   local.get $4
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<u8,i32>#set (; 50 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<u8,i32>#set (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3845,7 +3845,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/map/Map<u8,i32>#get (; 51 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<u8,i32>#get (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -3866,7 +3866,7 @@
   local.get $0
   i32.load offset=4
  )
- (func $~lib/map/Map<u8,i32>#keys (; 52 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u8,i32>#keys (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -3978,7 +3978,7 @@
   call $~lib/array/Array<i8>#set:length
   local.get $0
  )
- (func $~lib/map/Map<u8,u8>#rehash (; 53 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<u8,u8>#rehash (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4113,7 +4113,7 @@
   local.get $4
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<u8,u8>#set (; 54 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<u8,u8>#set (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -4244,7 +4244,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/map/Map<u8,i32>#delete (; 55 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<u8,i32>#delete (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -4305,7 +4305,7 @@
    call $~lib/map/Map<u8,i32>#rehash
   end
  )
- (func $std/map/testNumeric<u8,i32> (; 56 ;)
+ (func $std/map/testNumeric<u8,i32>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -4806,7 +4806,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/util/hash/hash16 (; 57 ;) (param $0 i32) (result i32)
+ (func $~lib/util/hash/hash16 (param $0 i32) (result i32)
   local.get $0
   i32.const 255
   i32.and
@@ -4821,7 +4821,7 @@
   i32.const 16777619
   i32.mul
  )
- (func $~lib/map/Map<i16,i32>#find (; 58 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<i16,i32>#find (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.load
   local.get $2
@@ -4864,7 +4864,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<i16,i32>#has (; 59 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<i16,i32>#has (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -4877,7 +4877,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<i16,i32>#rehash (; 60 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<i16,i32>#rehash (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5012,7 +5012,7 @@
   local.get $4
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<i16,i32>#set (; 61 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<i16,i32>#set (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -5106,7 +5106,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/map/Map<i16,i32>#get (; 62 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<i16,i32>#get (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -5129,7 +5129,7 @@
   local.get $0
   i32.load offset=4
  )
- (func $~lib/array/Array<i16>#__set (; 63 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<i16>#__set (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $1
   local.get $0
@@ -5167,7 +5167,7 @@
   local.get $2
   i32.store16
  )
- (func $~lib/array/Array<i16>#set:length (; 64 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i16>#set:length (param $0 i32) (param $1 i32)
   local.get $0
   i32.load offset=12
   drop
@@ -5179,7 +5179,7 @@
   local.get $1
   i32.store offset=12
  )
- (func $~lib/map/Map<i16,i32>#keys (; 65 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<i16,i32>#keys (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -5296,7 +5296,7 @@
   call $~lib/array/Array<i16>#set:length
   local.get $0
  )
- (func $~lib/map/Map<i16,i16>#rehash (; 66 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<i16,i16>#rehash (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5431,7 +5431,7 @@
   local.get $4
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<i16,i16>#set (; 67 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<i16,i16>#set (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -5564,7 +5564,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/map/Map<i16,i32>#delete (; 68 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<i16,i32>#delete (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -5627,7 +5627,7 @@
    call $~lib/map/Map<i16,i32>#rehash
   end
  )
- (func $std/map/testNumeric<i16,i32> (; 69 ;)
+ (func $std/map/testNumeric<i16,i32>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -6152,7 +6152,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<u16,i32>#has (; 70 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<u16,i32>#has (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -6163,7 +6163,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<u16,i32>#rehash (; 71 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<u16,i32>#rehash (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6298,7 +6298,7 @@
   local.get $4
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<u16,i32>#set (; 72 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<u16,i32>#set (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -6390,7 +6390,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/map/Map<u16,i32>#get (; 73 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<u16,i32>#get (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -6411,7 +6411,7 @@
   local.get $0
   i32.load offset=4
  )
- (func $~lib/map/Map<u16,i32>#keys (; 74 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u16,i32>#keys (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -6528,7 +6528,7 @@
   call $~lib/array/Array<i16>#set:length
   local.get $0
  )
- (func $~lib/map/Map<u16,u16>#rehash (; 75 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<u16,u16>#rehash (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6663,7 +6663,7 @@
   local.get $4
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<u16,u16>#set (; 76 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<u16,u16>#set (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -6794,7 +6794,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/map/Map<u16,i32>#delete (; 77 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<u16,i32>#delete (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -6855,7 +6855,7 @@
    call $~lib/map/Map<u16,i32>#rehash
   end
  )
- (func $std/map/testNumeric<u16,i32> (; 78 ;)
+ (func $std/map/testNumeric<u16,i32>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -7358,7 +7358,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<i32,i32>#has (; 79 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<i32,i32>#has (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -7367,7 +7367,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<i32,i32>#get (; 80 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<i32,i32>#get (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -7386,7 +7386,7 @@
   local.get $0
   i32.load offset=4
  )
- (func $~lib/map/Map<i32,i32>#delete (; 81 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<i32,i32>#delete (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -7445,7 +7445,7 @@
    call $~lib/map/Map<i32,i32>#rehash
   end
  )
- (func $std/map/testNumeric<i32,i32> (; 82 ;)
+ (func $std/map/testNumeric<i32,i32>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -7907,7 +7907,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<u32,i32>#keys (; 83 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u32,i32>#keys (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -8024,7 +8024,7 @@
   call $~lib/array/Array<i32>#set:length
   local.get $0
  )
- (func $std/map/testNumeric<u32,i32> (; 84 ;)
+ (func $std/map/testNumeric<u32,i32>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -8489,7 +8489,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<i64,i32>#clear (; 85 ;) (param $0 i32)
+ (func $~lib/map/Map<i64,i32>#clear (param $0 i32)
   (local $1 i32)
   i32.const 16
   call $~lib/arraybuffer/ArrayBuffer#constructor
@@ -8522,7 +8522,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/util/hash/hash64 (; 86 ;) (param $0 i64) (result i32)
+ (func $~lib/util/hash/hash64 (param $0 i64) (result i32)
   (local $1 i32)
   local.get $0
   i32.wrap_i64
@@ -8588,7 +8588,7 @@
   i32.const 16777619
   i32.mul
  )
- (func $~lib/map/Map<i64,i32>#find (; 87 ;) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
+ (func $~lib/map/Map<i64,i32>#find (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
   local.get $0
   i32.load
   local.get $2
@@ -8629,7 +8629,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<i64,i32>#has (; 88 ;) (param $0 i32) (param $1 i64) (result i32)
+ (func $~lib/map/Map<i64,i32>#has (param $0 i32) (param $1 i64) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -8638,7 +8638,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<i64,i32>#rehash (; 89 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<i64,i32>#rehash (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -8773,7 +8773,7 @@
   local.get $4
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<i64,i32>#set (; 90 ;) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
+ (func $~lib/map/Map<i64,i32>#set (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -8863,7 +8863,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/map/Map<i64,i32>#get (; 91 ;) (param $0 i32) (param $1 i64) (result i32)
+ (func $~lib/map/Map<i64,i32>#get (param $0 i32) (param $1 i64) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -8882,7 +8882,7 @@
   local.get $0
   i32.load offset=8
  )
- (func $~lib/array/Array<i64>#__set (; 92 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $~lib/array/Array<i64>#__set (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   local.get $1
   local.get $0
@@ -8920,7 +8920,7 @@
   local.get $2
   i64.store
  )
- (func $~lib/array/Array<i64>#set:length (; 93 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i64>#set:length (param $0 i32) (param $1 i32)
   local.get $0
   i32.load offset=12
   drop
@@ -8932,7 +8932,7 @@
   local.get $1
   i32.store offset=12
  )
- (func $~lib/map/Map<i64,i32>#keys (; 94 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<i64,i32>#keys (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -9049,7 +9049,7 @@
   call $~lib/array/Array<i64>#set:length
   local.get $0
  )
- (func $~lib/map/Map<i64,i32>#values (; 95 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<i64,i32>#values (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -9101,7 +9101,7 @@
   call $~lib/array/Array<i32>#set:length
   local.get $0
  )
- (func $~lib/map/Map<i64,i64>#clear (; 96 ;) (param $0 i32)
+ (func $~lib/map/Map<i64,i64>#clear (param $0 i32)
   (local $1 i32)
   i32.const 16
   call $~lib/arraybuffer/ArrayBuffer#constructor
@@ -9134,7 +9134,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/array/Array<i64>#__get (; 97 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $~lib/array/Array<i64>#__get (param $0 i32) (param $1 i32) (result i64)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -9155,7 +9155,7 @@
   i32.add
   i64.load
  )
- (func $~lib/map/Map<i64,i64>#rehash (; 98 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<i64,i64>#rehash (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9290,7 +9290,7 @@
   local.get $4
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<i64,i64>#set (; 99 ;) (param $0 i32) (param $1 i64) (param $2 i64) (result i32)
+ (func $~lib/map/Map<i64,i64>#set (param $0 i32) (param $1 i64) (param $2 i64) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -9416,7 +9416,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/map/Map<i64,i32>#delete (; 100 ;) (param $0 i32) (param $1 i64)
+ (func $~lib/map/Map<i64,i32>#delete (param $0 i32) (param $1 i64)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -9476,7 +9476,7 @@
    call $~lib/map/Map<i64,i32>#rehash
   end
  )
- (func $std/map/testNumeric<i64,i32> (; 101 ;)
+ (func $std/map/testNumeric<i64,i32>
   (local $0 i64)
   (local $1 i32)
   (local $2 i32)
@@ -9949,7 +9949,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<u64,i32>#keys (; 102 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u64,i32>#keys (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -10066,7 +10066,7 @@
   call $~lib/array/Array<i64>#set:length
   local.get $0
  )
- (func $std/map/testNumeric<u64,i32> (; 103 ;)
+ (func $std/map/testNumeric<u64,i32>
   (local $0 i64)
   (local $1 i32)
   (local $2 i32)
@@ -10539,7 +10539,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<f32,i32>#find (; 104 ;) (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<f32,i32>#find (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
   local.get $0
   i32.load
   local.get $2
@@ -10580,7 +10580,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<f32,i32>#has (; 105 ;) (param $0 i32) (param $1 f32) (result i32)
+ (func $~lib/map/Map<f32,i32>#has (param $0 i32) (param $1 f32) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -10590,7 +10590,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<f32,i32>#rehash (; 106 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<f32,i32>#rehash (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10726,7 +10726,7 @@
   local.get $4
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<f32,i32>#set (; 107 ;) (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<f32,i32>#set (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -10817,7 +10817,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/map/Map<f32,i32>#get (; 108 ;) (param $0 i32) (param $1 f32) (result i32)
+ (func $~lib/map/Map<f32,i32>#get (param $0 i32) (param $1 f32) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -10837,7 +10837,7 @@
   local.get $0
   i32.load offset=4
  )
- (func $~lib/map/Map<f32,i32>#keys (; 109 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<f32,i32>#keys (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 f32)
@@ -10988,7 +10988,7 @@
   call $~lib/array/Array<i32>#set:length
   local.get $0
  )
- (func $~lib/map/Map<f32,f32>#rehash (; 110 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<f32,f32>#rehash (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -11124,7 +11124,7 @@
   local.get $4
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<f32,f32>#set (; 111 ;) (param $0 i32) (param $1 f32) (param $2 f32) (result i32)
+ (func $~lib/map/Map<f32,f32>#set (param $0 i32) (param $1 f32) (param $2 f32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -11215,7 +11215,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/map/Map<f32,i32>#delete (; 112 ;) (param $0 i32) (param $1 f32)
+ (func $~lib/map/Map<f32,i32>#delete (param $0 i32) (param $1 f32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -11276,7 +11276,7 @@
    call $~lib/map/Map<f32,i32>#rehash
   end
  )
- (func $std/map/testNumeric<f32,i32> (; 113 ;)
+ (func $std/map/testNumeric<f32,i32>
   (local $0 f32)
   (local $1 i32)
   (local $2 i32)
@@ -11765,7 +11765,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<f64,i32>#find (; 114 ;) (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
+ (func $~lib/map/Map<f64,i32>#find (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
   local.get $0
   i32.load
   local.get $2
@@ -11806,7 +11806,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<f64,i32>#has (; 115 ;) (param $0 i32) (param $1 f64) (result i32)
+ (func $~lib/map/Map<f64,i32>#has (param $0 i32) (param $1 f64) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -11816,7 +11816,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<f64,i32>#rehash (; 116 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<f64,i32>#rehash (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -11952,7 +11952,7 @@
   local.get $4
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<f64,i32>#set (; 117 ;) (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
+ (func $~lib/map/Map<f64,i32>#set (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -12043,7 +12043,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/map/Map<f64,i32>#get (; 118 ;) (param $0 i32) (param $1 f64) (result i32)
+ (func $~lib/map/Map<f64,i32>#get (param $0 i32) (param $1 f64) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -12063,7 +12063,7 @@
   local.get $0
   i32.load offset=8
  )
- (func $~lib/map/Map<f64,i32>#keys (; 119 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<f64,i32>#keys (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 f64)
@@ -12214,7 +12214,7 @@
   call $~lib/array/Array<i64>#set:length
   local.get $0
  )
- (func $~lib/map/Map<f64,f64>#rehash (; 120 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<f64,f64>#rehash (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -12350,7 +12350,7 @@
   local.get $4
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<f64,f64>#set (; 121 ;) (param $0 i32) (param $1 f64) (param $2 f64) (result i32)
+ (func $~lib/map/Map<f64,f64>#set (param $0 i32) (param $1 f64) (param $2 f64) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -12477,7 +12477,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/map/Map<f64,i32>#delete (; 122 ;) (param $0 i32) (param $1 f64)
+ (func $~lib/map/Map<f64,i32>#delete (param $0 i32) (param $1 f64)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -12538,7 +12538,7 @@
    call $~lib/map/Map<f64,i32>#rehash
   end
  )
- (func $std/map/testNumeric<f64,i32> (; 123 ;)
+ (func $std/map/testNumeric<f64,i32>
   (local $0 f64)
   (local $1 i32)
   (local $2 i32)
@@ -13027,7 +13027,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~start (; 124 ;)
+ (func $~start
   call $std/map/testNumeric<i8,i32>
   call $std/map/testNumeric<u8,i32>
   call $std/map/testNumeric<i16,i32>
@@ -13039,7 +13039,7 @@
   call $std/map/testNumeric<f32,i32>
   call $std/map/testNumeric<f64,i32>
  )
- (func $~lib/rt/pure/decrement (; 125 ;) (param $0 i32)
+ (func $~lib/rt/pure/decrement (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -13140,7 +13140,7 @@
    i32.store offset=4
   end
  )
- (func $~lib/rt/pure/__visit (; 126 ;) (param $0 i32)
+ (func $~lib/rt/pure/__visit (param $0 i32)
   local.get $0
   i32.const 1556
   i32.lt_u

--- a/tests/compiler/std/map.untouched.wat
+++ b/tests/compiler/std/map.untouched.wat
@@ -50,7 +50,7 @@
  (global $~lib/heap/__heap_base i32 (i32.const 548))
  (export "memory" (memory $0))
  (start $~start)
- (func $~lib/rt/tlsf/removeBlock (; 6 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/removeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -260,7 +260,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/insertBlock (; 7 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/insertBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -610,7 +610,7 @@
   local.get $7
   i32.store offset=4
  )
- (func $~lib/rt/tlsf/addMemory (; 8 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -758,7 +758,7 @@
   call $~lib/rt/tlsf/insertBlock
   i32.const 1
  )
- (func $~lib/rt/tlsf/maybeInitialize (; 9 ;) (result i32)
+ (func $~lib/rt/tlsf/maybeInitialize (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -912,7 +912,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/tlsf/prepareSize (; 10 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/tlsf/prepareSize (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -941,7 +941,7 @@
   i32.gt_u
   select
  )
- (func $~lib/rt/tlsf/searchBlock (; 11 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/searchBlock (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1124,7 +1124,7 @@
   end
   local.get $7
  )
- (func $~lib/rt/tlsf/growMemory (; 12 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/growMemory (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1208,7 +1208,7 @@
   call $~lib/rt/tlsf/addMemory
   drop
  )
- (func $~lib/rt/tlsf/prepareBlock (; 13 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/rt/tlsf/prepareBlock (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1303,7 +1303,7 @@
    i32.store
   end
  )
- (func $~lib/rt/tlsf/allocateBlock (; 14 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/allocateBlock (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   global.get $~lib/rt/tlsf/collectLock
@@ -1414,7 +1414,7 @@
   call $~lib/rt/rtrace/onalloc
   local.get $4
  )
- (func $~lib/rt/tlsf/__alloc (; 15 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/__alloc (param $0 i32) (param $1 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
   local.get $0
   local.get $1
@@ -1422,7 +1422,7 @@
   i32.const 16
   i32.add
  )
- (func $~lib/rt/pure/increment (; 16 ;) (param $0 i32)
+ (func $~lib/rt/pure/increment (param $0 i32)
   (local $1 i32)
   local.get $0
   i32.load offset=4
@@ -1467,7 +1467,7 @@
    unreachable
   end
  )
- (func $~lib/rt/pure/__retain (; 17 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/pure/__retain (param $0 i32) (result i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.gt_u
@@ -1479,7 +1479,7 @@
   end
   local.get $0
  )
- (func $~lib/memory/memory.fill (; 18 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/memory/memory.fill (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1688,7 +1688,7 @@
    end
   end
  )
- (func $~lib/arraybuffer/ArrayBuffer#constructor (; 19 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBuffer#constructor (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   i32.const 1073741808
@@ -1712,7 +1712,7 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~lib/rt/pure/__release (; 20 ;) (param $0 i32)
+ (func $~lib/rt/pure/__release (param $0 i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.gt_u
@@ -1723,7 +1723,7 @@
    call $~lib/rt/pure/decrement
   end
  )
- (func $~lib/map/Map<i8,i32>#clear (; 21 ;) (param $0 i32)
+ (func $~lib/map/Map<i8,i32>#clear (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -1763,7 +1763,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<i8,i32>#constructor (; 22 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<i8,i32>#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -1795,14 +1795,14 @@
   call $~lib/map/Map<i8,i32>#clear
   local.get $0
  )
- (func $~lib/util/hash/hash8 (; 23 ;) (param $0 i32) (result i32)
+ (func $~lib/util/hash/hash8 (param $0 i32) (result i32)
   i32.const -2128831035
   local.get $0
   i32.xor
   i32.const 16777619
   i32.mul
  )
- (func $~lib/map/Map<i8,i32>#find (; 24 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<i8,i32>#find (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -1854,7 +1854,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<i8,i32>#has (; 25 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<i8,i32>#has (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -1873,7 +1873,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<i8,i32>#rehash (; 26 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<i8,i32>#rehash (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2030,7 +2030,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<i8,i32>#set (; 27 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<i8,i32>#set (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2139,7 +2139,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/map/Map<i8,i32>#get (; 28 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<i8,i32>#get (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -2170,11 +2170,11 @@
   local.get $3
   i32.load offset=4
  )
- (func $~lib/map/Map<i8,i32>#get:size (; 29 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<i8,i32>#get:size (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/array/Array<i8>#constructor (; 30 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i8>#constructor (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2252,7 +2252,7 @@
   i32.store offset=12
   local.get $0
  )
- (func $~lib/rt/tlsf/checkUsedBlock (; 31 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/tlsf/checkUsedBlock (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   i32.const 16
@@ -2298,7 +2298,7 @@
   end
   local.get $1
  )
- (func $~lib/util/memory/memcpy (; 32 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/memory/memcpy (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3322,7 +3322,7 @@
    i32.store8
   end
  )
- (func $~lib/memory/memory.copy (; 33 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/memory/memory.copy (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3542,7 +3542,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/freeBlock (; 34 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/freeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $1
   i32.load
@@ -3558,7 +3558,7 @@
   local.get $1
   call $~lib/rt/rtrace/onfree
  )
- (func $~lib/rt/tlsf/reallocateBlock (; 35 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/reallocateBlock (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3677,7 +3677,7 @@
   end
   local.get $8
  )
- (func $~lib/rt/tlsf/__realloc (; 36 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/__realloc (param $0 i32) (param $1 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
   local.get $0
   call $~lib/rt/tlsf/checkUsedBlock
@@ -3686,7 +3686,7 @@
   i32.const 16
   i32.add
  )
- (func $~lib/array/ensureSize (; 37 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/ensureSize (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3748,7 +3748,7 @@
    i32.store offset=8
   end
  )
- (func $~lib/array/Array<i8>#__unchecked_set (; 38 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<i8>#__unchecked_set (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -3758,7 +3758,7 @@
   local.get $2
   i32.store8
  )
- (func $~lib/array/Array<i8>#__set (; 39 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<i8>#__set (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -3792,7 +3792,7 @@
   local.get $2
   call $~lib/array/Array<i8>#__unchecked_set
  )
- (func $~lib/array/Array<i8>#set:length (; 40 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i8>#set:length (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load offset=12
@@ -3805,7 +3805,7 @@
   local.get $1
   i32.store offset=12
  )
- (func $~lib/map/Map<i8,i32>#keys (; 41 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<i8,i32>#keys (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -3870,7 +3870,7 @@
   call $~lib/array/Array<i8>#set:length
   local.get $3
  )
- (func $~lib/array/Array<i32>#constructor (; 42 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#constructor (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3948,7 +3948,7 @@
   i32.store offset=12
   local.get $0
  )
- (func $~lib/array/Array<i32>#__unchecked_set (; 43 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<i32>#__unchecked_set (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -3958,7 +3958,7 @@
   local.get $2
   i32.store
  )
- (func $~lib/array/Array<i32>#__set (; 44 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<i32>#__set (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -3992,7 +3992,7 @@
   local.get $2
   call $~lib/array/Array<i32>#__unchecked_set
  )
- (func $~lib/array/Array<i32>#set:length (; 45 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i32>#set:length (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load offset=12
@@ -4005,7 +4005,7 @@
   local.get $1
   i32.store offset=12
  )
- (func $~lib/map/Map<i8,i32>#values (; 46 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<i8,i32>#values (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -4070,7 +4070,7 @@
   call $~lib/array/Array<i32>#set:length
   local.get $3
  )
- (func $~lib/map/Map<i8,i8>#clear (; 47 ;) (param $0 i32)
+ (func $~lib/map/Map<i8,i8>#clear (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -4110,7 +4110,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<i8,i8>#constructor (; 48 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<i8,i8>#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -4142,7 +4142,7 @@
   call $~lib/map/Map<i8,i8>#clear
   local.get $0
  )
- (func $~lib/map/Map<i32,i32>#clear (; 49 ;) (param $0 i32)
+ (func $~lib/map/Map<i32,i32>#clear (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -4182,7 +4182,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<i32,i32>#constructor (; 50 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<i32,i32>#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -4214,11 +4214,11 @@
   call $~lib/map/Map<i32,i32>#clear
   local.get $0
  )
- (func $~lib/array/Array<i8>#get:length (; 51 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<i8>#get:length (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<i8>#__unchecked_get (; 52 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i8>#__unchecked_get (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -4227,7 +4227,7 @@
   i32.add
   i32.load8_s
  )
- (func $~lib/array/Array<i8>#__get (; 53 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i8>#__get (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   local.get $0
@@ -4247,7 +4247,7 @@
   local.set $2
   local.get $2
  )
- (func $~lib/array/Array<i32>#__unchecked_get (; 54 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#__unchecked_get (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -4256,7 +4256,7 @@
   i32.add
   i32.load
  )
- (func $~lib/array/Array<i32>#__get (; 55 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#__get (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   local.get $0
@@ -4276,7 +4276,7 @@
   local.set $2
   local.get $2
  )
- (func $~lib/map/Map<i8,i8>#find (; 56 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<i8,i8>#find (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -4328,7 +4328,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<i8,i8>#rehash (; 57 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<i8,i8>#rehash (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4485,7 +4485,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<i8,i8>#set (; 58 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<i8,i8>#set (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -4594,7 +4594,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/hash/hash32 (; 59 ;) (param $0 i32) (result i32)
+ (func $~lib/util/hash/hash32 (param $0 i32) (result i32)
   (local $1 i32)
   i32.const -2128831035
   local.set $1
@@ -4636,7 +4636,7 @@
   local.set $1
   local.get $1
  )
- (func $~lib/map/Map<i32,i32>#find (; 60 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<i32,i32>#find (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -4684,7 +4684,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<i32,i32>#rehash (; 61 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<i32,i32>#rehash (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4841,7 +4841,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<i32,i32>#set (; 62 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<i32,i32>#set (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -4946,15 +4946,15 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/map/Map<i8,i8>#get:size (; 63 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<i8,i8>#get:size (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/map/Map<i32,i32>#get:size (; 64 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<i32,i32>#get:size (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/map/Map<i8,i32>#delete (; 65 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<i8,i32>#delete (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5030,7 +5030,7 @@
   end
   i32.const 1
  )
- (func $std/map/testNumeric<i8,i32> (; 66 ;)
+ (func $std/map/testNumeric<i8,i32>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -5539,7 +5539,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<u8,i32>#clear (; 67 ;) (param $0 i32)
+ (func $~lib/map/Map<u8,i32>#clear (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -5579,7 +5579,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<u8,i32>#constructor (; 68 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u8,i32>#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -5611,7 +5611,7 @@
   call $~lib/map/Map<u8,i32>#clear
   local.get $0
  )
- (func $~lib/map/Map<u8,i32>#find (; 69 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<u8,i32>#find (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -5661,7 +5661,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<u8,i32>#has (; 70 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<u8,i32>#has (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -5678,7 +5678,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<u8,i32>#rehash (; 71 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<u8,i32>#rehash (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5835,7 +5835,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<u8,i32>#set (; 72 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<u8,i32>#set (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -5942,7 +5942,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/map/Map<u8,i32>#get (; 73 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<u8,i32>#get (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -5971,11 +5971,11 @@
   local.get $3
   i32.load offset=4
  )
- (func $~lib/map/Map<u8,i32>#get:size (; 74 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u8,i32>#get:size (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/array/Array<u8>#constructor (; 75 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u8>#constructor (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6053,7 +6053,7 @@
   i32.store offset=12
   local.get $0
  )
- (func $~lib/array/Array<u8>#__unchecked_set (; 76 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<u8>#__unchecked_set (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -6063,7 +6063,7 @@
   local.get $2
   i32.store8
  )
- (func $~lib/array/Array<u8>#__set (; 77 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<u8>#__set (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -6097,7 +6097,7 @@
   local.get $2
   call $~lib/array/Array<u8>#__unchecked_set
  )
- (func $~lib/array/Array<u8>#set:length (; 78 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<u8>#set:length (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load offset=12
@@ -6110,7 +6110,7 @@
   local.get $1
   i32.store offset=12
  )
- (func $~lib/map/Map<u8,i32>#keys (; 79 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u8,i32>#keys (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -6175,7 +6175,7 @@
   call $~lib/array/Array<u8>#set:length
   local.get $3
  )
- (func $~lib/map/Map<u8,i32>#values (; 80 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u8,i32>#values (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -6240,7 +6240,7 @@
   call $~lib/array/Array<i32>#set:length
   local.get $3
  )
- (func $~lib/map/Map<u8,u8>#clear (; 81 ;) (param $0 i32)
+ (func $~lib/map/Map<u8,u8>#clear (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -6280,7 +6280,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<u8,u8>#constructor (; 82 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u8,u8>#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -6312,11 +6312,11 @@
   call $~lib/map/Map<u8,u8>#clear
   local.get $0
  )
- (func $~lib/array/Array<u8>#get:length (; 83 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<u8>#get:length (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<u8>#__unchecked_get (; 84 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u8>#__unchecked_get (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -6325,7 +6325,7 @@
   i32.add
   i32.load8_u
  )
- (func $~lib/array/Array<u8>#__get (; 85 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u8>#__get (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   local.get $0
@@ -6345,7 +6345,7 @@
   local.set $2
   local.get $2
  )
- (func $~lib/map/Map<u8,u8>#find (; 86 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<u8,u8>#find (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -6395,7 +6395,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<u8,u8>#rehash (; 87 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<u8,u8>#rehash (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6552,7 +6552,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<u8,u8>#set (; 88 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<u8,u8>#set (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -6659,11 +6659,11 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/map/Map<u8,u8>#get:size (; 89 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u8,u8>#get:size (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/map/Map<u8,i32>#delete (; 90 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<u8,i32>#delete (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6737,7 +6737,7 @@
   end
   i32.const 1
  )
- (func $std/map/testNumeric<u8,i32> (; 91 ;)
+ (func $std/map/testNumeric<u8,i32>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -7224,7 +7224,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<i16,i32>#clear (; 92 ;) (param $0 i32)
+ (func $~lib/map/Map<i16,i32>#clear (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -7264,7 +7264,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<i16,i32>#constructor (; 93 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<i16,i32>#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -7296,7 +7296,7 @@
   call $~lib/map/Map<i16,i32>#clear
   local.get $0
  )
- (func $~lib/util/hash/hash16 (; 94 ;) (param $0 i32) (result i32)
+ (func $~lib/util/hash/hash16 (param $0 i32) (result i32)
   (local $1 i32)
   i32.const -2128831035
   local.set $1
@@ -7318,7 +7318,7 @@
   local.set $1
   local.get $1
  )
- (func $~lib/map/Map<i16,i32>#find (; 95 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<i16,i32>#find (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -7370,7 +7370,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<i16,i32>#has (; 96 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<i16,i32>#has (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -7389,7 +7389,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<i16,i32>#rehash (; 97 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<i16,i32>#rehash (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7546,7 +7546,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<i16,i32>#set (; 98 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<i16,i32>#set (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -7655,7 +7655,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/map/Map<i16,i32>#get (; 99 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<i16,i32>#get (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -7686,11 +7686,11 @@
   local.get $3
   i32.load offset=4
  )
- (func $~lib/map/Map<i16,i32>#get:size (; 100 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<i16,i32>#get:size (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/array/Array<i16>#constructor (; 101 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i16>#constructor (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7768,7 +7768,7 @@
   i32.store offset=12
   local.get $0
  )
- (func $~lib/array/Array<i16>#__unchecked_set (; 102 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<i16>#__unchecked_set (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -7778,7 +7778,7 @@
   local.get $2
   i32.store16
  )
- (func $~lib/array/Array<i16>#__set (; 103 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<i16>#__set (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -7812,7 +7812,7 @@
   local.get $2
   call $~lib/array/Array<i16>#__unchecked_set
  )
- (func $~lib/array/Array<i16>#set:length (; 104 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i16>#set:length (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load offset=12
@@ -7825,7 +7825,7 @@
   local.get $1
   i32.store offset=12
  )
- (func $~lib/map/Map<i16,i32>#keys (; 105 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<i16,i32>#keys (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -7890,7 +7890,7 @@
   call $~lib/array/Array<i16>#set:length
   local.get $3
  )
- (func $~lib/map/Map<i16,i32>#values (; 106 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<i16,i32>#values (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -7955,7 +7955,7 @@
   call $~lib/array/Array<i32>#set:length
   local.get $3
  )
- (func $~lib/map/Map<i16,i16>#clear (; 107 ;) (param $0 i32)
+ (func $~lib/map/Map<i16,i16>#clear (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -7995,7 +7995,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<i16,i16>#constructor (; 108 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<i16,i16>#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -8027,11 +8027,11 @@
   call $~lib/map/Map<i16,i16>#clear
   local.get $0
  )
- (func $~lib/array/Array<i16>#get:length (; 109 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<i16>#get:length (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<i16>#__unchecked_get (; 110 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i16>#__unchecked_get (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -8040,7 +8040,7 @@
   i32.add
   i32.load16_s
  )
- (func $~lib/array/Array<i16>#__get (; 111 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i16>#__get (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   local.get $0
@@ -8060,7 +8060,7 @@
   local.set $2
   local.get $2
  )
- (func $~lib/map/Map<i16,i16>#find (; 112 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<i16,i16>#find (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -8112,7 +8112,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<i16,i16>#rehash (; 113 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<i16,i16>#rehash (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -8269,7 +8269,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<i16,i16>#set (; 114 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<i16,i16>#set (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -8378,11 +8378,11 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/map/Map<i16,i16>#get:size (; 115 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<i16,i16>#get:size (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/map/Map<i16,i32>#delete (; 116 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<i16,i32>#delete (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -8458,7 +8458,7 @@
   end
   i32.const 1
  )
- (func $std/map/testNumeric<i16,i32> (; 117 ;)
+ (func $std/map/testNumeric<i16,i32>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -8967,7 +8967,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<u16,i32>#clear (; 118 ;) (param $0 i32)
+ (func $~lib/map/Map<u16,i32>#clear (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -9007,7 +9007,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<u16,i32>#constructor (; 119 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u16,i32>#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -9039,7 +9039,7 @@
   call $~lib/map/Map<u16,i32>#clear
   local.get $0
  )
- (func $~lib/map/Map<u16,i32>#find (; 120 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<u16,i32>#find (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -9089,7 +9089,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<u16,i32>#has (; 121 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<u16,i32>#has (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -9106,7 +9106,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<u16,i32>#rehash (; 122 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<u16,i32>#rehash (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9263,7 +9263,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<u16,i32>#set (; 123 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<u16,i32>#set (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -9370,7 +9370,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/map/Map<u16,i32>#get (; 124 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<u16,i32>#get (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -9399,11 +9399,11 @@
   local.get $3
   i32.load offset=4
  )
- (func $~lib/map/Map<u16,i32>#get:size (; 125 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u16,i32>#get:size (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/array/Array<u16>#constructor (; 126 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u16>#constructor (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9481,7 +9481,7 @@
   i32.store offset=12
   local.get $0
  )
- (func $~lib/array/Array<u16>#__unchecked_set (; 127 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<u16>#__unchecked_set (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -9491,7 +9491,7 @@
   local.get $2
   i32.store16
  )
- (func $~lib/array/Array<u16>#__set (; 128 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<u16>#__set (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -9525,7 +9525,7 @@
   local.get $2
   call $~lib/array/Array<u16>#__unchecked_set
  )
- (func $~lib/array/Array<u16>#set:length (; 129 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<u16>#set:length (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load offset=12
@@ -9538,7 +9538,7 @@
   local.get $1
   i32.store offset=12
  )
- (func $~lib/map/Map<u16,i32>#keys (; 130 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u16,i32>#keys (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -9603,7 +9603,7 @@
   call $~lib/array/Array<u16>#set:length
   local.get $3
  )
- (func $~lib/map/Map<u16,i32>#values (; 131 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u16,i32>#values (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -9668,7 +9668,7 @@
   call $~lib/array/Array<i32>#set:length
   local.get $3
  )
- (func $~lib/map/Map<u16,u16>#clear (; 132 ;) (param $0 i32)
+ (func $~lib/map/Map<u16,u16>#clear (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -9708,7 +9708,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<u16,u16>#constructor (; 133 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u16,u16>#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -9740,11 +9740,11 @@
   call $~lib/map/Map<u16,u16>#clear
   local.get $0
  )
- (func $~lib/array/Array<u16>#get:length (; 134 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<u16>#get:length (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<u16>#__unchecked_get (; 135 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u16>#__unchecked_get (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -9753,7 +9753,7 @@
   i32.add
   i32.load16_u
  )
- (func $~lib/array/Array<u16>#__get (; 136 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u16>#__get (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   local.get $0
@@ -9773,7 +9773,7 @@
   local.set $2
   local.get $2
  )
- (func $~lib/map/Map<u16,u16>#find (; 137 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<u16,u16>#find (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -9823,7 +9823,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<u16,u16>#rehash (; 138 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<u16,u16>#rehash (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9980,7 +9980,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<u16,u16>#set (; 139 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<u16,u16>#set (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -10087,11 +10087,11 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/map/Map<u16,u16>#get:size (; 140 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u16,u16>#get:size (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/map/Map<u16,i32>#delete (; 141 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<u16,i32>#delete (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10165,7 +10165,7 @@
   end
   i32.const 1
  )
- (func $std/map/testNumeric<u16,i32> (; 142 ;)
+ (func $std/map/testNumeric<u16,i32>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -10652,7 +10652,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<i32,i32>#has (; 143 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<i32,i32>#has (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -10667,7 +10667,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<i32,i32>#get (; 144 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<i32,i32>#get (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -10694,7 +10694,7 @@
   local.get $3
   i32.load offset=4
  )
- (func $~lib/map/Map<i32,i32>#keys (; 145 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<i32,i32>#keys (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -10759,7 +10759,7 @@
   call $~lib/array/Array<i32>#set:length
   local.get $3
  )
- (func $~lib/map/Map<i32,i32>#values (; 146 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<i32,i32>#values (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -10824,11 +10824,11 @@
   call $~lib/array/Array<i32>#set:length
   local.get $3
  )
- (func $~lib/array/Array<i32>#get:length (; 147 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<i32>#get:length (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/map/Map<i32,i32>#delete (; 148 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<i32,i32>#delete (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10900,7 +10900,7 @@
   end
   i32.const 1
  )
- (func $std/map/testNumeric<i32,i32> (; 149 ;)
+ (func $std/map/testNumeric<i32,i32>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -11363,7 +11363,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<u32,i32>#clear (; 150 ;) (param $0 i32)
+ (func $~lib/map/Map<u32,i32>#clear (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -11403,7 +11403,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<u32,i32>#constructor (; 151 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u32,i32>#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -11435,7 +11435,7 @@
   call $~lib/map/Map<u32,i32>#clear
   local.get $0
  )
- (func $~lib/map/Map<u32,i32>#find (; 152 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<u32,i32>#find (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -11483,7 +11483,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<u32,i32>#has (; 153 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<u32,i32>#has (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -11498,7 +11498,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<u32,i32>#rehash (; 154 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<u32,i32>#rehash (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -11655,7 +11655,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<u32,i32>#set (; 155 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<u32,i32>#set (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -11760,7 +11760,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/map/Map<u32,i32>#get (; 156 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<u32,i32>#get (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -11787,11 +11787,11 @@
   local.get $3
   i32.load offset=4
  )
- (func $~lib/map/Map<u32,i32>#get:size (; 157 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u32,i32>#get:size (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/array/Array<u32>#constructor (; 158 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u32>#constructor (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -11869,7 +11869,7 @@
   i32.store offset=12
   local.get $0
  )
- (func $~lib/array/Array<u32>#__unchecked_set (; 159 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<u32>#__unchecked_set (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -11879,7 +11879,7 @@
   local.get $2
   i32.store
  )
- (func $~lib/array/Array<u32>#__set (; 160 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<u32>#__set (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -11913,7 +11913,7 @@
   local.get $2
   call $~lib/array/Array<u32>#__unchecked_set
  )
- (func $~lib/array/Array<u32>#set:length (; 161 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<u32>#set:length (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load offset=12
@@ -11926,7 +11926,7 @@
   local.get $1
   i32.store offset=12
  )
- (func $~lib/map/Map<u32,i32>#keys (; 162 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u32,i32>#keys (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -11991,7 +11991,7 @@
   call $~lib/array/Array<u32>#set:length
   local.get $3
  )
- (func $~lib/map/Map<u32,i32>#values (; 163 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u32,i32>#values (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -12056,7 +12056,7 @@
   call $~lib/array/Array<i32>#set:length
   local.get $3
  )
- (func $~lib/map/Map<u32,u32>#clear (; 164 ;) (param $0 i32)
+ (func $~lib/map/Map<u32,u32>#clear (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -12096,7 +12096,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<u32,u32>#constructor (; 165 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u32,u32>#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -12128,11 +12128,11 @@
   call $~lib/map/Map<u32,u32>#clear
   local.get $0
  )
- (func $~lib/array/Array<u32>#get:length (; 166 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<u32>#get:length (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<u32>#__unchecked_get (; 167 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u32>#__unchecked_get (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -12141,7 +12141,7 @@
   i32.add
   i32.load
  )
- (func $~lib/array/Array<u32>#__get (; 168 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u32>#__get (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   local.get $0
@@ -12161,7 +12161,7 @@
   local.set $2
   local.get $2
  )
- (func $~lib/map/Map<u32,u32>#find (; 169 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<u32,u32>#find (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -12209,7 +12209,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<u32,u32>#rehash (; 170 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<u32,u32>#rehash (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -12366,7 +12366,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<u32,u32>#set (; 171 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<u32,u32>#set (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -12471,11 +12471,11 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/map/Map<u32,u32>#get:size (; 172 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u32,u32>#get:size (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/map/Map<u32,i32>#delete (; 173 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<u32,i32>#delete (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -12547,7 +12547,7 @@
   end
   i32.const 1
  )
- (func $std/map/testNumeric<u32,i32> (; 174 ;)
+ (func $std/map/testNumeric<u32,i32>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -13010,7 +13010,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<i64,i32>#clear (; 175 ;) (param $0 i32)
+ (func $~lib/map/Map<i64,i32>#clear (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -13050,7 +13050,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<i64,i32>#constructor (; 176 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<i64,i32>#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -13082,7 +13082,7 @@
   call $~lib/map/Map<i64,i32>#clear
   local.get $0
  )
- (func $~lib/util/hash/hash64 (; 177 ;) (param $0 i64) (result i32)
+ (func $~lib/util/hash/hash64 (param $0 i64) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -13170,7 +13170,7 @@
   local.set $3
   local.get $3
  )
- (func $~lib/map/Map<i64,i32>#find (; 178 ;) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
+ (func $~lib/map/Map<i64,i32>#find (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -13218,7 +13218,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<i64,i32>#has (; 179 ;) (param $0 i32) (param $1 i64) (result i32)
+ (func $~lib/map/Map<i64,i32>#has (param $0 i32) (param $1 i64) (result i32)
   (local $2 i64)
   local.get $0
   local.get $1
@@ -13233,7 +13233,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<i64,i32>#rehash (; 180 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<i64,i32>#rehash (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -13391,7 +13391,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<i64,i32>#set (; 181 ;) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
+ (func $~lib/map/Map<i64,i32>#set (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
   (local $3 i64)
   (local $4 i32)
   (local $5 i32)
@@ -13497,7 +13497,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/map/Map<i64,i32>#get (; 182 ;) (param $0 i32) (param $1 i64) (result i32)
+ (func $~lib/map/Map<i64,i32>#get (param $0 i32) (param $1 i64) (result i32)
   (local $2 i64)
   (local $3 i32)
   local.get $0
@@ -13524,11 +13524,11 @@
   local.get $3
   i32.load offset=8
  )
- (func $~lib/map/Map<i64,i32>#get:size (; 183 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<i64,i32>#get:size (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/array/Array<i64>#constructor (; 184 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i64>#constructor (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -13606,7 +13606,7 @@
   i32.store offset=12
   local.get $0
  )
- (func $~lib/array/Array<i64>#__unchecked_set (; 185 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $~lib/array/Array<i64>#__unchecked_set (param $0 i32) (param $1 i32) (param $2 i64)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -13616,7 +13616,7 @@
   local.get $2
   i64.store
  )
- (func $~lib/array/Array<i64>#__set (; 186 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $~lib/array/Array<i64>#__set (param $0 i32) (param $1 i32) (param $2 i64)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -13650,7 +13650,7 @@
   local.get $2
   call $~lib/array/Array<i64>#__unchecked_set
  )
- (func $~lib/array/Array<i64>#set:length (; 187 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i64>#set:length (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load offset=12
@@ -13663,7 +13663,7 @@
   local.get $1
   i32.store offset=12
  )
- (func $~lib/map/Map<i64,i32>#keys (; 188 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<i64,i32>#keys (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -13728,7 +13728,7 @@
   call $~lib/array/Array<i64>#set:length
   local.get $3
  )
- (func $~lib/map/Map<i64,i32>#values (; 189 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<i64,i32>#values (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -13793,7 +13793,7 @@
   call $~lib/array/Array<i32>#set:length
   local.get $3
  )
- (func $~lib/map/Map<i64,i64>#clear (; 190 ;) (param $0 i32)
+ (func $~lib/map/Map<i64,i64>#clear (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -13833,7 +13833,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<i64,i64>#constructor (; 191 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<i64,i64>#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -13865,11 +13865,11 @@
   call $~lib/map/Map<i64,i64>#clear
   local.get $0
  )
- (func $~lib/array/Array<i64>#get:length (; 192 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<i64>#get:length (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<i64>#__unchecked_get (; 193 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $~lib/array/Array<i64>#__unchecked_get (param $0 i32) (param $1 i32) (result i64)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -13878,7 +13878,7 @@
   i32.add
   i64.load
  )
- (func $~lib/array/Array<i64>#__get (; 194 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $~lib/array/Array<i64>#__get (param $0 i32) (param $1 i32) (result i64)
   (local $2 i64)
   local.get $1
   local.get $0
@@ -13898,7 +13898,7 @@
   local.set $2
   local.get $2
  )
- (func $~lib/map/Map<i64,i64>#find (; 195 ;) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
+ (func $~lib/map/Map<i64,i64>#find (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -13946,7 +13946,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<i64,i64>#rehash (; 196 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<i64,i64>#rehash (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -14104,7 +14104,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<i64,i64>#set (; 197 ;) (param $0 i32) (param $1 i64) (param $2 i64) (result i32)
+ (func $~lib/map/Map<i64,i64>#set (param $0 i32) (param $1 i64) (param $2 i64) (result i32)
   (local $3 i64)
   (local $4 i32)
   (local $5 i32)
@@ -14210,11 +14210,11 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/map/Map<i64,i64>#get:size (; 198 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<i64,i64>#get:size (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/map/Map<i64,i32>#delete (; 199 ;) (param $0 i32) (param $1 i64) (result i32)
+ (func $~lib/map/Map<i64,i32>#delete (param $0 i32) (param $1 i64) (result i32)
   (local $2 i64)
   (local $3 i32)
   (local $4 i32)
@@ -14287,7 +14287,7 @@
   end
   i32.const 1
  )
- (func $std/map/testNumeric<i64,i32> (; 200 ;)
+ (func $std/map/testNumeric<i64,i32>
   (local $0 i32)
   (local $1 i64)
   (local $2 i32)
@@ -14758,7 +14758,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<u64,i32>#clear (; 201 ;) (param $0 i32)
+ (func $~lib/map/Map<u64,i32>#clear (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -14798,7 +14798,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<u64,i32>#constructor (; 202 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u64,i32>#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -14830,7 +14830,7 @@
   call $~lib/map/Map<u64,i32>#clear
   local.get $0
  )
- (func $~lib/map/Map<u64,i32>#find (; 203 ;) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
+ (func $~lib/map/Map<u64,i32>#find (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -14878,7 +14878,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<u64,i32>#has (; 204 ;) (param $0 i32) (param $1 i64) (result i32)
+ (func $~lib/map/Map<u64,i32>#has (param $0 i32) (param $1 i64) (result i32)
   (local $2 i64)
   local.get $0
   local.get $1
@@ -14893,7 +14893,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<u64,i32>#rehash (; 205 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<u64,i32>#rehash (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -15051,7 +15051,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<u64,i32>#set (; 206 ;) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
+ (func $~lib/map/Map<u64,i32>#set (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
   (local $3 i64)
   (local $4 i32)
   (local $5 i32)
@@ -15157,7 +15157,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/map/Map<u64,i32>#get (; 207 ;) (param $0 i32) (param $1 i64) (result i32)
+ (func $~lib/map/Map<u64,i32>#get (param $0 i32) (param $1 i64) (result i32)
   (local $2 i64)
   (local $3 i32)
   local.get $0
@@ -15184,11 +15184,11 @@
   local.get $3
   i32.load offset=8
  )
- (func $~lib/map/Map<u64,i32>#get:size (; 208 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u64,i32>#get:size (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/array/Array<u64>#constructor (; 209 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u64>#constructor (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -15266,7 +15266,7 @@
   i32.store offset=12
   local.get $0
  )
- (func $~lib/array/Array<u64>#__unchecked_set (; 210 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $~lib/array/Array<u64>#__unchecked_set (param $0 i32) (param $1 i32) (param $2 i64)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -15276,7 +15276,7 @@
   local.get $2
   i64.store
  )
- (func $~lib/array/Array<u64>#__set (; 211 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $~lib/array/Array<u64>#__set (param $0 i32) (param $1 i32) (param $2 i64)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -15310,7 +15310,7 @@
   local.get $2
   call $~lib/array/Array<u64>#__unchecked_set
  )
- (func $~lib/array/Array<u64>#set:length (; 212 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<u64>#set:length (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load offset=12
@@ -15323,7 +15323,7 @@
   local.get $1
   i32.store offset=12
  )
- (func $~lib/map/Map<u64,i32>#keys (; 213 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u64,i32>#keys (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -15388,7 +15388,7 @@
   call $~lib/array/Array<u64>#set:length
   local.get $3
  )
- (func $~lib/map/Map<u64,i32>#values (; 214 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u64,i32>#values (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -15453,7 +15453,7 @@
   call $~lib/array/Array<i32>#set:length
   local.get $3
  )
- (func $~lib/map/Map<u64,u64>#clear (; 215 ;) (param $0 i32)
+ (func $~lib/map/Map<u64,u64>#clear (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -15493,7 +15493,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<u64,u64>#constructor (; 216 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u64,u64>#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -15525,11 +15525,11 @@
   call $~lib/map/Map<u64,u64>#clear
   local.get $0
  )
- (func $~lib/array/Array<u64>#get:length (; 217 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<u64>#get:length (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<u64>#__unchecked_get (; 218 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $~lib/array/Array<u64>#__unchecked_get (param $0 i32) (param $1 i32) (result i64)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -15538,7 +15538,7 @@
   i32.add
   i64.load
  )
- (func $~lib/array/Array<u64>#__get (; 219 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $~lib/array/Array<u64>#__get (param $0 i32) (param $1 i32) (result i64)
   (local $2 i64)
   local.get $1
   local.get $0
@@ -15558,7 +15558,7 @@
   local.set $2
   local.get $2
  )
- (func $~lib/map/Map<u64,u64>#find (; 220 ;) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
+ (func $~lib/map/Map<u64,u64>#find (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -15606,7 +15606,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<u64,u64>#rehash (; 221 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<u64,u64>#rehash (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -15764,7 +15764,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<u64,u64>#set (; 222 ;) (param $0 i32) (param $1 i64) (param $2 i64) (result i32)
+ (func $~lib/map/Map<u64,u64>#set (param $0 i32) (param $1 i64) (param $2 i64) (result i32)
   (local $3 i64)
   (local $4 i32)
   (local $5 i32)
@@ -15870,11 +15870,11 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/map/Map<u64,u64>#get:size (; 223 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u64,u64>#get:size (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/map/Map<u64,i32>#delete (; 224 ;) (param $0 i32) (param $1 i64) (result i32)
+ (func $~lib/map/Map<u64,i32>#delete (param $0 i32) (param $1 i64) (result i32)
   (local $2 i64)
   (local $3 i32)
   (local $4 i32)
@@ -15947,7 +15947,7 @@
   end
   i32.const 1
  )
- (func $std/map/testNumeric<u64,i32> (; 225 ;)
+ (func $std/map/testNumeric<u64,i32>
   (local $0 i32)
   (local $1 i64)
   (local $2 i32)
@@ -16418,7 +16418,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<f32,i32>#clear (; 226 ;) (param $0 i32)
+ (func $~lib/map/Map<f32,i32>#clear (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -16458,7 +16458,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<f32,i32>#constructor (; 227 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<f32,i32>#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -16490,7 +16490,7 @@
   call $~lib/map/Map<f32,i32>#clear
   local.get $0
  )
- (func $~lib/map/Map<f32,i32>#find (; 228 ;) (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<f32,i32>#find (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -16538,7 +16538,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<f32,i32>#has (; 229 ;) (param $0 i32) (param $1 f32) (result i32)
+ (func $~lib/map/Map<f32,i32>#has (param $0 i32) (param $1 f32) (result i32)
   (local $2 f32)
   local.get $0
   local.get $1
@@ -16554,7 +16554,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<f32,i32>#rehash (; 230 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<f32,i32>#rehash (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -16713,7 +16713,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<f32,i32>#set (; 231 ;) (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<f32,i32>#set (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
   (local $3 f32)
   (local $4 i32)
   (local $5 i32)
@@ -16820,7 +16820,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/map/Map<f32,i32>#get (; 232 ;) (param $0 i32) (param $1 f32) (result i32)
+ (func $~lib/map/Map<f32,i32>#get (param $0 i32) (param $1 f32) (result i32)
   (local $2 f32)
   (local $3 i32)
   local.get $0
@@ -16848,11 +16848,11 @@
   local.get $3
   i32.load offset=4
  )
- (func $~lib/map/Map<f32,i32>#get:size (; 233 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<f32,i32>#get:size (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/array/Array<f32>#constructor (; 234 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<f32>#constructor (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -16930,7 +16930,7 @@
   i32.store offset=12
   local.get $0
  )
- (func $~lib/array/Array<f32>#__unchecked_set (; 235 ;) (param $0 i32) (param $1 i32) (param $2 f32)
+ (func $~lib/array/Array<f32>#__unchecked_set (param $0 i32) (param $1 i32) (param $2 f32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -16940,7 +16940,7 @@
   local.get $2
   f32.store
  )
- (func $~lib/array/Array<f32>#__set (; 236 ;) (param $0 i32) (param $1 i32) (param $2 f32)
+ (func $~lib/array/Array<f32>#__set (param $0 i32) (param $1 i32) (param $2 f32)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -16974,7 +16974,7 @@
   local.get $2
   call $~lib/array/Array<f32>#__unchecked_set
  )
- (func $~lib/array/Array<f32>#set:length (; 237 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<f32>#set:length (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load offset=12
@@ -16987,7 +16987,7 @@
   local.get $1
   i32.store offset=12
  )
- (func $~lib/map/Map<f32,i32>#keys (; 238 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<f32,i32>#keys (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -17052,7 +17052,7 @@
   call $~lib/array/Array<f32>#set:length
   local.get $3
  )
- (func $~lib/map/Map<f32,i32>#values (; 239 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<f32,i32>#values (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -17117,7 +17117,7 @@
   call $~lib/array/Array<i32>#set:length
   local.get $3
  )
- (func $~lib/map/Map<f32,f32>#clear (; 240 ;) (param $0 i32)
+ (func $~lib/map/Map<f32,f32>#clear (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -17157,7 +17157,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<f32,f32>#constructor (; 241 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<f32,f32>#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -17189,11 +17189,11 @@
   call $~lib/map/Map<f32,f32>#clear
   local.get $0
  )
- (func $~lib/array/Array<f32>#get:length (; 242 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<f32>#get:length (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<f32>#__unchecked_get (; 243 ;) (param $0 i32) (param $1 i32) (result f32)
+ (func $~lib/array/Array<f32>#__unchecked_get (param $0 i32) (param $1 i32) (result f32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -17202,7 +17202,7 @@
   i32.add
   f32.load
  )
- (func $~lib/array/Array<f32>#__get (; 244 ;) (param $0 i32) (param $1 i32) (result f32)
+ (func $~lib/array/Array<f32>#__get (param $0 i32) (param $1 i32) (result f32)
   (local $2 f32)
   local.get $1
   local.get $0
@@ -17222,7 +17222,7 @@
   local.set $2
   local.get $2
  )
- (func $~lib/map/Map<f32,f32>#find (; 245 ;) (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<f32,f32>#find (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -17270,7 +17270,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<f32,f32>#rehash (; 246 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<f32,f32>#rehash (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -17429,7 +17429,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<f32,f32>#set (; 247 ;) (param $0 i32) (param $1 f32) (param $2 f32) (result i32)
+ (func $~lib/map/Map<f32,f32>#set (param $0 i32) (param $1 f32) (param $2 f32) (result i32)
   (local $3 f32)
   (local $4 i32)
   (local $5 i32)
@@ -17536,11 +17536,11 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/map/Map<f32,f32>#get:size (; 248 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<f32,f32>#get:size (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/map/Map<f32,i32>#delete (; 249 ;) (param $0 i32) (param $1 f32) (result i32)
+ (func $~lib/map/Map<f32,i32>#delete (param $0 i32) (param $1 f32) (result i32)
   (local $2 f32)
   (local $3 i32)
   (local $4 i32)
@@ -17614,7 +17614,7 @@
   end
   i32.const 1
  )
- (func $std/map/testNumeric<f32,i32> (; 250 ;)
+ (func $std/map/testNumeric<f32,i32>
   (local $0 i32)
   (local $1 f32)
   (local $2 i32)
@@ -18085,7 +18085,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<f64,i32>#clear (; 251 ;) (param $0 i32)
+ (func $~lib/map/Map<f64,i32>#clear (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -18125,7 +18125,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<f64,i32>#constructor (; 252 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<f64,i32>#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -18157,7 +18157,7 @@
   call $~lib/map/Map<f64,i32>#clear
   local.get $0
  )
- (func $~lib/map/Map<f64,i32>#find (; 253 ;) (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
+ (func $~lib/map/Map<f64,i32>#find (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -18205,7 +18205,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<f64,i32>#has (; 254 ;) (param $0 i32) (param $1 f64) (result i32)
+ (func $~lib/map/Map<f64,i32>#has (param $0 i32) (param $1 f64) (result i32)
   (local $2 f64)
   local.get $0
   local.get $1
@@ -18221,7 +18221,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<f64,i32>#rehash (; 255 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<f64,i32>#rehash (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -18380,7 +18380,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<f64,i32>#set (; 256 ;) (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
+ (func $~lib/map/Map<f64,i32>#set (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
   (local $3 f64)
   (local $4 i32)
   (local $5 i32)
@@ -18487,7 +18487,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/map/Map<f64,i32>#get (; 257 ;) (param $0 i32) (param $1 f64) (result i32)
+ (func $~lib/map/Map<f64,i32>#get (param $0 i32) (param $1 f64) (result i32)
   (local $2 f64)
   (local $3 i32)
   local.get $0
@@ -18515,11 +18515,11 @@
   local.get $3
   i32.load offset=8
  )
- (func $~lib/map/Map<f64,i32>#get:size (; 258 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<f64,i32>#get:size (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/array/Array<f64>#constructor (; 259 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<f64>#constructor (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -18597,7 +18597,7 @@
   i32.store offset=12
   local.get $0
  )
- (func $~lib/array/Array<f64>#__unchecked_set (; 260 ;) (param $0 i32) (param $1 i32) (param $2 f64)
+ (func $~lib/array/Array<f64>#__unchecked_set (param $0 i32) (param $1 i32) (param $2 f64)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -18607,7 +18607,7 @@
   local.get $2
   f64.store
  )
- (func $~lib/array/Array<f64>#__set (; 261 ;) (param $0 i32) (param $1 i32) (param $2 f64)
+ (func $~lib/array/Array<f64>#__set (param $0 i32) (param $1 i32) (param $2 f64)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -18641,7 +18641,7 @@
   local.get $2
   call $~lib/array/Array<f64>#__unchecked_set
  )
- (func $~lib/array/Array<f64>#set:length (; 262 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<f64>#set:length (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load offset=12
@@ -18654,7 +18654,7 @@
   local.get $1
   i32.store offset=12
  )
- (func $~lib/map/Map<f64,i32>#keys (; 263 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<f64,i32>#keys (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -18719,7 +18719,7 @@
   call $~lib/array/Array<f64>#set:length
   local.get $3
  )
- (func $~lib/map/Map<f64,i32>#values (; 264 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<f64,i32>#values (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -18784,7 +18784,7 @@
   call $~lib/array/Array<i32>#set:length
   local.get $3
  )
- (func $~lib/map/Map<f64,f64>#clear (; 265 ;) (param $0 i32)
+ (func $~lib/map/Map<f64,f64>#clear (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -18824,7 +18824,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<f64,f64>#constructor (; 266 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<f64,f64>#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -18856,11 +18856,11 @@
   call $~lib/map/Map<f64,f64>#clear
   local.get $0
  )
- (func $~lib/array/Array<f64>#get:length (; 267 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<f64>#get:length (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<f64>#__unchecked_get (; 268 ;) (param $0 i32) (param $1 i32) (result f64)
+ (func $~lib/array/Array<f64>#__unchecked_get (param $0 i32) (param $1 i32) (result f64)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -18869,7 +18869,7 @@
   i32.add
   f64.load
  )
- (func $~lib/array/Array<f64>#__get (; 269 ;) (param $0 i32) (param $1 i32) (result f64)
+ (func $~lib/array/Array<f64>#__get (param $0 i32) (param $1 i32) (result f64)
   (local $2 f64)
   local.get $1
   local.get $0
@@ -18889,7 +18889,7 @@
   local.set $2
   local.get $2
  )
- (func $~lib/map/Map<f64,f64>#find (; 270 ;) (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
+ (func $~lib/map/Map<f64,f64>#find (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -18937,7 +18937,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<f64,f64>#rehash (; 271 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<f64,f64>#rehash (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -19096,7 +19096,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<f64,f64>#set (; 272 ;) (param $0 i32) (param $1 f64) (param $2 f64) (result i32)
+ (func $~lib/map/Map<f64,f64>#set (param $0 i32) (param $1 f64) (param $2 f64) (result i32)
   (local $3 f64)
   (local $4 i32)
   (local $5 i32)
@@ -19203,11 +19203,11 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/map/Map<f64,f64>#get:size (; 273 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<f64,f64>#get:size (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/map/Map<f64,i32>#delete (; 274 ;) (param $0 i32) (param $1 f64) (result i32)
+ (func $~lib/map/Map<f64,i32>#delete (param $0 i32) (param $1 f64) (result i32)
   (local $2 f64)
   (local $3 i32)
   (local $4 i32)
@@ -19281,7 +19281,7 @@
   end
   i32.const 1
  )
- (func $std/map/testNumeric<f64,i32> (; 275 ;)
+ (func $std/map/testNumeric<f64,i32>
   (local $0 i32)
   (local $1 f64)
   (local $2 i32)
@@ -19752,7 +19752,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $start:std/map (; 276 ;)
+ (func $start:std/map
   call $std/map/testNumeric<i8,i32>
   call $std/map/testNumeric<u8,i32>
   call $std/map/testNumeric<i16,i32>
@@ -19764,13 +19764,13 @@
   call $std/map/testNumeric<f32,i32>
   call $std/map/testNumeric<f64,i32>
  )
- (func $~start (; 277 ;)
+ (func $~start
   call $start:std/map
  )
- (func $~lib/rt/pure/__collect (; 278 ;)
+ (func $~lib/rt/pure/__collect
   return
  )
- (func $~lib/rt/pure/decrement (; 279 ;) (param $0 i32)
+ (func $~lib/rt/pure/decrement (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -19847,7 +19847,7 @@
    i32.store offset=4
   end
  )
- (func $~lib/rt/pure/__visit (; 280 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/pure/__visit (param $0 i32) (param $1 i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.lt_u
@@ -19871,7 +19871,7 @@
   i32.sub
   call $~lib/rt/pure/decrement
  )
- (func $~lib/map/Map<i8,i32>#__visit_impl (; 281 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<i8,i32>#__visit_impl (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -19884,19 +19884,19 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/array/Array<i8>#__visit_impl (; 282 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i8>#__visit_impl (param $0 i32) (param $1 i32)
   local.get $0
   i32.load
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/array/Array<i32>#__visit_impl (; 283 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i32>#__visit_impl (param $0 i32) (param $1 i32)
   local.get $0
   i32.load
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/map/Map<i8,i8>#__visit_impl (; 284 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<i8,i8>#__visit_impl (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -19909,7 +19909,7 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/map/Map<i32,i32>#__visit_impl (; 285 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<i32,i32>#__visit_impl (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -19922,7 +19922,7 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/map/Map<u8,i32>#__visit_impl (; 286 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<u8,i32>#__visit_impl (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -19935,13 +19935,13 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/array/Array<u8>#__visit_impl (; 287 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<u8>#__visit_impl (param $0 i32) (param $1 i32)
   local.get $0
   i32.load
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/map/Map<u8,u8>#__visit_impl (; 288 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<u8,u8>#__visit_impl (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -19954,7 +19954,7 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/map/Map<i16,i32>#__visit_impl (; 289 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<i16,i32>#__visit_impl (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -19967,13 +19967,13 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/array/Array<i16>#__visit_impl (; 290 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i16>#__visit_impl (param $0 i32) (param $1 i32)
   local.get $0
   i32.load
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/map/Map<i16,i16>#__visit_impl (; 291 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<i16,i16>#__visit_impl (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -19986,7 +19986,7 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/map/Map<u16,i32>#__visit_impl (; 292 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<u16,i32>#__visit_impl (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -19999,13 +19999,13 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/array/Array<u16>#__visit_impl (; 293 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<u16>#__visit_impl (param $0 i32) (param $1 i32)
   local.get $0
   i32.load
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/map/Map<u16,u16>#__visit_impl (; 294 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<u16,u16>#__visit_impl (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -20018,7 +20018,7 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/map/Map<u32,i32>#__visit_impl (; 295 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<u32,i32>#__visit_impl (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -20031,13 +20031,13 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/array/Array<u32>#__visit_impl (; 296 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<u32>#__visit_impl (param $0 i32) (param $1 i32)
   local.get $0
   i32.load
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/map/Map<u32,u32>#__visit_impl (; 297 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<u32,u32>#__visit_impl (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -20050,7 +20050,7 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/map/Map<i64,i32>#__visit_impl (; 298 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<i64,i32>#__visit_impl (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -20063,13 +20063,13 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/array/Array<i64>#__visit_impl (; 299 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i64>#__visit_impl (param $0 i32) (param $1 i32)
   local.get $0
   i32.load
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/map/Map<i64,i64>#__visit_impl (; 300 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<i64,i64>#__visit_impl (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -20082,7 +20082,7 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/map/Map<u64,i32>#__visit_impl (; 301 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<u64,i32>#__visit_impl (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -20095,13 +20095,13 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/array/Array<u64>#__visit_impl (; 302 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<u64>#__visit_impl (param $0 i32) (param $1 i32)
   local.get $0
   i32.load
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/map/Map<u64,u64>#__visit_impl (; 303 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<u64,u64>#__visit_impl (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -20114,7 +20114,7 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/map/Map<f32,i32>#__visit_impl (; 304 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<f32,i32>#__visit_impl (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -20127,13 +20127,13 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/array/Array<f32>#__visit_impl (; 305 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<f32>#__visit_impl (param $0 i32) (param $1 i32)
   local.get $0
   i32.load
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/map/Map<f32,f32>#__visit_impl (; 306 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<f32,f32>#__visit_impl (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -20146,7 +20146,7 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/map/Map<f64,i32>#__visit_impl (; 307 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<f64,i32>#__visit_impl (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -20159,13 +20159,13 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/array/Array<f64>#__visit_impl (; 308 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<f64>#__visit_impl (param $0 i32) (param $1 i32)
   local.get $0
   i32.load
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/map/Map<f64,f64>#__visit_impl (; 309 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<f64,f64>#__visit_impl (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -20178,7 +20178,7 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/rt/__visit_members (; 310 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/__visit_members (param $0 i32) (param $1 i32)
   (local $2 i32)
   block $switch$1$default
    block $switch$1$case$33

--- a/tests/compiler/std/math.optimized.wat
+++ b/tests/compiler/std/math.optimized.wat
@@ -88,7 +88,7 @@
  (global $~lib/math/NativeMath.sincos_cos (mut f64) (f64.const 0))
  (export "memory" (memory $0))
  (start $~start)
- (func $~lib/math/NativeMath.scalbn (; 33 ;) (param $0 f64) (param $1 i32) (result f64)
+ (func $~lib/math/NativeMath.scalbn (param $0 f64) (param $1 i32) (result f64)
   local.get $1
   i32.const 1023
   i32.gt_s
@@ -165,7 +165,7 @@
   f64.reinterpret_i64
   f64.mul
  )
- (func $std/math/ulperr (; 34 ;) (param $0 f64) (param $1 f64) (param $2 f64) (result f64)
+ (func $std/math/ulperr (param $0 f64) (param $1 f64) (param $2 f64) (result f64)
   (local $3 i32)
   local.get $1
   local.get $1
@@ -255,7 +255,7 @@
   local.get $2
   f64.add
  )
- (func $std/math/check<f64> (; 35 ;) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
+ (func $std/math/check<f64> (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   local.get $0
   local.get $1
   f64.eq
@@ -285,7 +285,7 @@
   end
   i32.const 1
  )
- (func $~lib/math/NativeMathf.scalbn (; 36 ;) (param $0 f32) (param $1 i32) (result f32)
+ (func $~lib/math/NativeMathf.scalbn (param $0 f32) (param $1 i32) (result f32)
   local.get $1
   i32.const 127
   i32.gt_s
@@ -361,7 +361,7 @@
   f32.reinterpret_i32
   f32.mul
  )
- (func $std/math/ulperrf (; 37 ;) (param $0 f32) (param $1 f32) (param $2 f32) (result f32)
+ (func $std/math/ulperrf (param $0 f32) (param $1 f32) (param $2 f32) (result f32)
   (local $3 i32)
   local.get $1
   local.get $1
@@ -448,7 +448,7 @@
   local.get $2
   f32.add
  )
- (func $std/math/check<f32> (; 38 ;) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
+ (func $std/math/check<f32> (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
   local.get $0
   local.get $1
   f32.eq
@@ -478,7 +478,7 @@
   end
   i32.const 1
  )
- (func $std/math/test_scalbn (; 39 ;) (param $0 f64) (param $1 i32) (param $2 f64) (result i32)
+ (func $std/math/test_scalbn (param $0 f64) (param $1 i32) (param $2 f64) (result i32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMath.scalbn
@@ -486,7 +486,7 @@
   f64.const 0
   call $std/math/check<f64>
  )
- (func $std/math/test_scalbnf (; 40 ;) (param $0 f32) (param $1 i32) (param $2 f32) (result i32)
+ (func $std/math/test_scalbnf (param $0 f32) (param $1 i32) (param $2 f32) (result i32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMathf.scalbn
@@ -494,7 +494,7 @@
   f32.const 0
   call $std/math/check<f32>
  )
- (func $std/math/test_abs (; 41 ;) (param $0 f64) (param $1 f64) (result i32)
+ (func $std/math/test_abs (param $0 f64) (param $1 f64) (result i32)
   local.get $0
   f64.abs
   local.get $1
@@ -510,14 +510,14 @@
    i32.const 0
   end
  )
- (func $std/math/test_absf (; 42 ;) (param $0 f32) (param $1 f32) (result i32)
+ (func $std/math/test_absf (param $0 f32) (param $1 f32) (result i32)
   local.get $0
   f32.abs
   local.get $1
   f32.const 0
   call $std/math/check<f32>
  )
- (func $~lib/math/R (; 43 ;) (param $0 f64) (result f64)
+ (func $~lib/math/R (param $0 f64) (result f64)
   local.get $0
   f64.const 0.16666666666666666
   local.get $0
@@ -560,7 +560,7 @@
   f64.add
   f64.div
  )
- (func $~lib/math/NativeMath.acos (; 44 ;) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.acos (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 i32)
   (local $3 i32)
@@ -684,7 +684,7 @@
   f64.add
   f64.mul
  )
- (func $std/math/test_acos (; 45 ;) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
+ (func $std/math/test_acos (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   local.get $0
   call $~lib/math/NativeMath.acos
   local.get $1
@@ -700,7 +700,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/Rf (; 46 ;) (param $0 f32) (result f32)
+ (func $~lib/math/Rf (param $0 f32) (result f32)
   local.get $0
   f32.const 0.16666586697101593
   local.get $0
@@ -719,7 +719,7 @@
   f32.add
   f32.div
  )
- (func $~lib/math/NativeMathf.acos (; 47 ;) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.acos (param $0 f32) (result f32)
   (local $1 f32)
   (local $2 i32)
   (local $3 i32)
@@ -835,14 +835,14 @@
   f32.add
   f32.mul
  )
- (func $std/math/test_acosf (; 48 ;) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
+ (func $std/math/test_acosf (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.acos
   local.get $1
   local.get $2
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.log1p (; 49 ;) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.log1p (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 i32)
   (local $3 i32)
@@ -1038,7 +1038,7 @@
   f64.mul
   f64.add
  )
- (func $~lib/math/NativeMath.log (; 50 ;) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.log (param $0 f64) (result f64)
   (local $1 i32)
   (local $2 i64)
   (local $3 f64)
@@ -1205,7 +1205,7 @@
   f64.mul
   f64.add
  )
- (func $std/math/test_acosh (; 51 ;) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
+ (func $std/math/test_acosh (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   (local $3 f64)
   (local $4 i64)
   block $__inlined_func$~lib/math/NativeMath.acosh (result f64)
@@ -1274,7 +1274,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.log1p (; 52 ;) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.log1p (param $0 f32) (result f32)
   (local $1 f32)
   (local $2 i32)
   (local $3 i32)
@@ -1442,7 +1442,7 @@
   f32.mul
   f32.add
  )
- (func $~lib/math/NativeMathf.log (; 53 ;) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.log (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 f32)
   (local $3 f32)
@@ -1575,7 +1575,7 @@
   f32.mul
   f32.add
  )
- (func $std/math/test_acoshf (; 54 ;) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
+ (func $std/math/test_acoshf (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
   (local $3 i32)
   block $__inlined_func$~lib/math/NativeMathf.acosh (result f32)
    local.get $0
@@ -1630,7 +1630,7 @@
   local.get $2
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.asin (; 55 ;) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.asin (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 i32)
   (local $3 f64)
@@ -1768,7 +1768,7 @@
   end
   local.get $0
  )
- (func $std/math/test_asin (; 56 ;) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
+ (func $std/math/test_asin (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   local.get $0
   call $~lib/math/NativeMath.asin
   local.get $1
@@ -1784,7 +1784,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.asin (; 57 ;) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.asin (param $0 f32) (result f32)
   (local $1 f32)
   (local $2 i32)
   (local $3 f64)
@@ -1865,14 +1865,14 @@
   local.get $1
   f32.copysign
  )
- (func $std/math/test_asinf (; 58 ;) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
+ (func $std/math/test_asinf (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.asin
   local.get $1
   local.get $2
   call $std/math/check<f32>
  )
- (func $std/math/test_asinh (; 59 ;) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
+ (func $std/math/test_asinh (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   (local $3 f64)
   (local $4 i64)
   local.get $0
@@ -1957,7 +1957,7 @@
    i32.const 0
   end
  )
- (func $std/math/test_asinhf (; 60 ;) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
+ (func $std/math/test_asinhf (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
   (local $3 f32)
   (local $4 i32)
   local.get $0
@@ -2028,7 +2028,7 @@
   local.get $2
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.atan (; 61 ;) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.atan (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 f64)
   (local $3 i32)
@@ -2250,7 +2250,7 @@
   local.get $1
   f64.copysign
  )
- (func $std/math/test_atan (; 62 ;) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
+ (func $std/math/test_atan (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   local.get $0
   call $~lib/math/NativeMath.atan
   local.get $1
@@ -2266,7 +2266,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.atan (; 63 ;) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.atan (param $0 f32) (result f32)
   (local $1 f32)
   (local $2 f32)
   (local $3 i32)
@@ -2461,14 +2461,14 @@
   local.get $1
   f32.copysign
  )
- (func $std/math/test_atanf (; 64 ;) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
+ (func $std/math/test_atanf (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.atan
   local.get $1
   local.get $2
   call $std/math/check<f32>
  )
- (func $std/math/test_atanh (; 65 ;) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
+ (func $std/math/test_atanh (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   (local $3 f64)
   (local $4 i64)
   (local $5 f64)
@@ -2536,7 +2536,7 @@
    i32.const 0
   end
  )
- (func $std/math/test_atanhf (; 66 ;) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
+ (func $std/math/test_atanhf (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
   (local $3 f32)
   (local $4 i32)
   local.get $0
@@ -2589,7 +2589,7 @@
   local.get $2
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.atan2 (; 67 ;) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.atan2 (param $0 f64) (param $1 f64) (result f64)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2799,7 +2799,7 @@
   i32.and
   select
  )
- (func $std/math/test_atan2 (; 68 ;) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 f64) (result i32)
+ (func $std/math/test_atan2 (param $0 f64) (param $1 f64) (param $2 f64) (param $3 f64) (result i32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMath.atan2
@@ -2817,7 +2817,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.atan2 (; 69 ;) (param $0 f32) (param $1 f32) (result f32)
+ (func $~lib/math/NativeMathf.atan2 (param $0 f32) (param $1 f32) (result f32)
   (local $2 i32)
   (local $3 i32)
   (local $4 f32)
@@ -3011,7 +3011,7 @@
   i32.and
   select
  )
- (func $std/math/test_atan2f (; 70 ;) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 f32) (result i32)
+ (func $std/math/test_atan2f (param $0 f32) (param $1 f32) (param $2 f32) (param $3 f32) (result i32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMathf.atan2
@@ -3019,7 +3019,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.cbrt (; 71 ;) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.cbrt (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 i32)
   (local $3 f64)
@@ -3140,7 +3140,7 @@
   f64.mul
   f64.add
  )
- (func $std/math/test_cbrt (; 72 ;) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
+ (func $std/math/test_cbrt (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   local.get $0
   call $~lib/math/NativeMath.cbrt
   local.get $1
@@ -3156,7 +3156,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.cbrt (; 73 ;) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.cbrt (param $0 f32) (result f32)
   (local $1 f64)
   (local $2 f64)
   (local $3 i32)
@@ -3255,14 +3255,14 @@
   f64.div
   f32.demote_f64
  )
- (func $std/math/test_cbrtf (; 74 ;) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
+ (func $std/math/test_cbrtf (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.cbrt
   local.get $1
   local.get $2
   call $std/math/check<f32>
  )
- (func $std/math/test_ceil (; 75 ;) (param $0 f64) (param $1 f64) (result i32)
+ (func $std/math/test_ceil (param $0 f64) (param $1 f64) (result i32)
   local.get $0
   f64.ceil
   local.get $1
@@ -3278,14 +3278,14 @@
    i32.const 0
   end
  )
- (func $std/math/test_ceilf (; 76 ;) (param $0 f32) (param $1 f32) (result i32)
+ (func $std/math/test_ceilf (param $0 f32) (param $1 f32) (result i32)
   local.get $0
   f32.ceil
   local.get $1
   f32.const 0
   call $std/math/check<f32>
  )
- (func $~lib/math/pio2_large_quot (; 77 ;) (param $0 i64) (result i32)
+ (func $~lib/math/pio2_large_quot (param $0 i64) (result i32)
   (local $1 i64)
   (local $2 i64)
   (local $3 i64)
@@ -3571,7 +3571,7 @@
   i64.sub
   i32.wrap_i64
  )
- (func $~lib/math/NativeMath.cos (; 78 ;) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.cos (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 f64)
   (local $3 f64)
@@ -3904,7 +3904,7 @@
   end
   local.get $0
  )
- (func $std/math/test_cos (; 79 ;) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
+ (func $std/math/test_cos (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   local.get $0
   call $~lib/math/NativeMath.cos
   local.get $1
@@ -3920,7 +3920,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.cos (; 80 ;) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.cos (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 i32)
   (local $3 f64)
@@ -4189,14 +4189,14 @@
   end
   local.get $0
  )
- (func $std/math/test_cosf (; 81 ;) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
+ (func $std/math/test_cosf (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.cos
   local.get $1
   local.get $2
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.expm1 (; 82 ;) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.expm1 (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 i32)
   (local $3 f64)
@@ -4467,7 +4467,7 @@
   local.get $4
   f64.mul
  )
- (func $~lib/math/NativeMath.exp (; 83 ;) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.exp (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 i32)
   (local $3 f64)
@@ -4617,7 +4617,7 @@
   end
   local.get $0
  )
- (func $std/math/test_cosh (; 84 ;) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
+ (func $std/math/test_cosh (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   (local $3 f64)
   (local $4 i32)
   (local $5 i64)
@@ -4695,7 +4695,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.expm1 (; 85 ;) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.expm1 (param $0 f32) (result f32)
   (local $1 f32)
   (local $2 f32)
   (local $3 i32)
@@ -4943,7 +4943,7 @@
   local.get $5
   f32.mul
  )
- (func $~lib/math/NativeMathf.exp (; 86 ;) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.exp (param $0 f32) (result f32)
   (local $1 f32)
   (local $2 i32)
   (local $3 i32)
@@ -5076,7 +5076,7 @@
   end
   local.get $0
  )
- (func $std/math/test_coshf (; 87 ;) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
+ (func $std/math/test_coshf (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
   (local $3 i32)
   block $__inlined_func$~lib/math/NativeMathf.cosh (result f32)
    local.get $0
@@ -5139,7 +5139,7 @@
   local.get $2
   call $std/math/check<f32>
  )
- (func $std/math/test_exp (; 88 ;) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
+ (func $std/math/test_exp (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   local.get $0
   call $~lib/math/NativeMath.exp
   local.get $1
@@ -5155,14 +5155,14 @@
    i32.const 0
   end
  )
- (func $std/math/test_expf (; 89 ;) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
+ (func $std/math/test_expf (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.exp
   local.get $1
   local.get $2
   call $std/math/check<f32>
  )
- (func $std/math/test_expm1 (; 90 ;) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
+ (func $std/math/test_expm1 (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   local.get $0
   call $~lib/math/NativeMath.expm1
   local.get $1
@@ -5178,14 +5178,14 @@
    i32.const 0
   end
  )
- (func $std/math/test_expm1f (; 91 ;) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
+ (func $std/math/test_expm1f (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.expm1
   local.get $1
   local.get $2
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.exp2 (; 92 ;) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.exp2 (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 i64)
   (local $3 i32)
@@ -5393,7 +5393,7 @@
   end
   local.get $1
  )
- (func $std/math/test_exp2 (; 93 ;) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
+ (func $std/math/test_exp2 (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   local.get $0
   call $~lib/math/NativeMath.exp2
   local.get $1
@@ -5410,7 +5410,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.exp2 (; 94 ;) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.exp2 (param $0 f32) (result f32)
   (local $1 f64)
   (local $2 f32)
   (local $3 i32)
@@ -5506,14 +5506,14 @@
   end
   local.get $2
  )
- (func $std/math/test_exp2f (; 95 ;) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
+ (func $std/math/test_exp2f (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.exp2
   local.get $1
   local.get $2
   call $std/math/check<f32>
  )
- (func $std/math/test_floor (; 96 ;) (param $0 f64) (param $1 f64) (result i32)
+ (func $std/math/test_floor (param $0 f64) (param $1 f64) (result i32)
   local.get $0
   f64.floor
   local.get $1
@@ -5529,14 +5529,14 @@
    i32.const 0
   end
  )
- (func $std/math/test_floorf (; 97 ;) (param $0 f32) (param $1 f32) (result i32)
+ (func $std/math/test_floorf (param $0 f32) (param $1 f32) (result i32)
   local.get $0
   f32.floor
   local.get $1
   f32.const 0
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.hypot (; 98 ;) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.hypot (param $0 f64) (param $1 f64) (result f64)
   (local $2 i64)
   (local $3 i64)
   (local $4 i64)
@@ -5706,7 +5706,7 @@
   f64.sqrt
   f64.mul
  )
- (func $std/math/test_hypot (; 99 ;) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 f64) (result i32)
+ (func $std/math/test_hypot (param $0 f64) (param $1 f64) (param $2 f64) (param $3 f64) (result i32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMath.hypot
@@ -5714,7 +5714,7 @@
   local.get $3
   call $std/math/check<f64>
  )
- (func $~lib/math/NativeMathf.hypot (; 100 ;) (param $0 f32) (param $1 f32) (result f32)
+ (func $~lib/math/NativeMathf.hypot (param $0 f32) (param $1 f32) (result f32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5819,7 +5819,7 @@
   f32.sqrt
   f32.mul
  )
- (func $std/math/test_hypotf (; 101 ;) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 f32) (result i32)
+ (func $std/math/test_hypotf (param $0 f32) (param $1 f32) (param $2 f32) (param $3 f32) (result i32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMathf.hypot
@@ -5827,7 +5827,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $std/math/test_log (; 102 ;) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
+ (func $std/math/test_log (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   local.get $0
   call $~lib/math/NativeMath.log
   local.get $1
@@ -5843,14 +5843,14 @@
    i32.const 0
   end
  )
- (func $std/math/test_logf (; 103 ;) (param $0 f32) (param $1 f32) (result i32)
+ (func $std/math/test_logf (param $0 f32) (param $1 f32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.log
   local.get $1
   f32.const 0
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.log10 (; 104 ;) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.log10 (param $0 f64) (result f64)
   (local $1 i32)
   (local $2 i64)
   (local $3 f64)
@@ -6055,7 +6055,7 @@
   local.get $7
   f64.add
  )
- (func $std/math/test_log10 (; 105 ;) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
+ (func $std/math/test_log10 (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   local.get $0
   call $~lib/math/NativeMath.log10
   local.get $1
@@ -6071,7 +6071,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.log10 (; 106 ;) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.log10 (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 f32)
   (local $3 f32)
@@ -6228,14 +6228,14 @@
   f32.mul
   f32.add
  )
- (func $std/math/test_log10f (; 107 ;) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
+ (func $std/math/test_log10f (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.log10
   local.get $1
   local.get $2
   call $std/math/check<f32>
  )
- (func $std/math/test_log1p (; 108 ;) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
+ (func $std/math/test_log1p (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   local.get $0
   call $~lib/math/NativeMath.log1p
   local.get $1
@@ -6251,14 +6251,14 @@
    i32.const 0
   end
  )
- (func $std/math/test_log1pf (; 109 ;) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
+ (func $std/math/test_log1pf (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.log1p
   local.get $1
   local.get $2
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.log2 (; 110 ;) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.log2 (param $0 f64) (result f64)
   (local $1 i32)
   (local $2 i64)
   (local $3 f64)
@@ -6455,7 +6455,7 @@
   local.get $7
   f64.add
  )
- (func $std/math/test_log2 (; 111 ;) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
+ (func $std/math/test_log2 (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   local.get $0
   call $~lib/math/NativeMath.log2
   local.get $1
@@ -6471,7 +6471,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.log2 (; 112 ;) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.log2 (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 f32)
   (local $3 f32)
@@ -6620,14 +6620,14 @@
   f32.convert_i32_s
   f32.add
  )
- (func $std/math/test_log2f (; 113 ;) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
+ (func $std/math/test_log2f (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.log2
   local.get $1
   local.get $2
   call $std/math/check<f32>
  )
- (func $std/math/test_max (; 114 ;) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
+ (func $std/math/test_max (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   local.get $0
   local.get $1
   f64.max
@@ -6645,7 +6645,7 @@
    i32.const 0
   end
  )
- (func $std/math/test_maxf (; 115 ;) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
+ (func $std/math/test_maxf (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
   local.get $0
   local.get $1
   f32.max
@@ -6653,7 +6653,7 @@
   f32.const 0
   call $std/math/check<f32>
  )
- (func $std/math/test_min (; 116 ;) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
+ (func $std/math/test_min (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   local.get $0
   local.get $1
   f64.min
@@ -6671,7 +6671,7 @@
    i32.const 0
   end
  )
- (func $std/math/test_minf (; 117 ;) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
+ (func $std/math/test_minf (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
   local.get $0
   local.get $1
   f32.min
@@ -6679,7 +6679,7 @@
   f32.const 0
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.mod (; 118 ;) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.mod (param $0 f64) (param $1 f64) (result f64)
   (local $2 i64)
   (local $3 i64)
   (local $4 i64)
@@ -6882,7 +6882,7 @@
   local.get $0
   f64.mul
  )
- (func $std/math/test_mod (; 119 ;) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
+ (func $std/math/test_mod (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMath.mod
@@ -6900,7 +6900,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.mod (; 120 ;) (param $0 f32) (param $1 f32) (result f32)
+ (func $~lib/math/NativeMathf.mod (param $0 f32) (param $1 f32) (result f32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7092,7 +7092,7 @@
   local.get $0
   f32.mul
  )
- (func $std/math/test_modf (; 121 ;) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
+ (func $std/math/test_modf (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMathf.mod
@@ -7100,7 +7100,7 @@
   f32.const 0
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.pow (; 122 ;) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.pow (param $0 f64) (param $1 f64) (result f64)
   (local $2 f64)
   (local $3 f64)
   (local $4 i32)
@@ -8045,7 +8045,7 @@
   f64.const 1e-300
   f64.mul
  )
- (func $std/math/test_pow (; 123 ;) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 f64) (result i32)
+ (func $std/math/test_pow (param $0 f64) (param $1 f64) (param $2 f64) (param $3 f64) (result i32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMath.pow
@@ -8063,7 +8063,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.pow (; 124 ;) (param $0 f32) (param $1 f32) (result f32)
+ (func $~lib/math/NativeMathf.pow (param $0 f32) (param $1 f32) (result f32)
   (local $2 f64)
   (local $3 f64)
   (local $4 i32)
@@ -8345,7 +8345,7 @@
   i32.or
   f32.reinterpret_i32
  )
- (func $std/math/test_powf (; 125 ;) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 f32) (result i32)
+ (func $std/math/test_powf (param $0 f32) (param $1 f32) (param $2 f32) (param $3 f32) (result i32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMathf.pow
@@ -8353,7 +8353,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/murmurHash3 (; 126 ;) (param $0 i64) (result i64)
+ (func $~lib/math/murmurHash3 (param $0 i64) (result i64)
   local.get $0
   local.get $0
   i64.const 33
@@ -8374,7 +8374,7 @@
   i64.shr_u
   i64.xor
  )
- (func $~lib/math/splitMix32 (; 127 ;) (param $0 i32) (result i32)
+ (func $~lib/math/splitMix32 (param $0 i32) (result i32)
   local.get $0
   i32.const 1831565813
   i32.add
@@ -8406,7 +8406,7 @@
   i32.shr_u
   i32.xor
  )
- (func $~lib/math/NativeMath.seedRandom (; 128 ;) (param $0 i64)
+ (func $~lib/math/NativeMath.seedRandom (param $0 i64)
   (local $1 i32)
   i32.const 1
   global.set $~lib/math/random_seeded
@@ -8451,7 +8451,7 @@
    unreachable
   end
  )
- (func $std/math/test_round (; 129 ;) (param $0 f64) (param $1 f64) (result i32)
+ (func $std/math/test_round (param $0 f64) (param $1 f64) (result i32)
   local.get $0
   f64.const 0.5
   f64.add
@@ -8462,7 +8462,7 @@
   f64.const 0
   call $std/math/check<f64>
  )
- (func $std/math/test_roundf (; 130 ;) (param $0 f32) (param $1 f32) (result i32)
+ (func $std/math/test_roundf (param $0 f32) (param $1 f32) (result i32)
   local.get $0
   f32.const 0.5
   f32.add
@@ -8473,7 +8473,7 @@
   f32.const 0
   call $std/math/check<f32>
  )
- (func $std/math/test_sign (; 131 ;) (param $0 f64) (param $1 f64) (result i32)
+ (func $std/math/test_sign (param $0 f64) (param $1 f64) (result i32)
   f64.const 1
   local.get $0
   f64.copysign
@@ -8496,7 +8496,7 @@
    i32.const 0
   end
  )
- (func $std/math/test_signf (; 132 ;) (param $0 f32) (param $1 f32) (result i32)
+ (func $std/math/test_signf (param $0 f32) (param $1 f32) (result i32)
   f32.const 1
   local.get $0
   f32.copysign
@@ -8510,7 +8510,7 @@
   f32.const 0
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.rem (; 133 ;) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.rem (param $0 f64) (param $1 f64) (result f64)
   (local $2 i64)
   (local $3 i64)
   (local $4 i64)
@@ -8759,7 +8759,7 @@
   end
   local.get $0
  )
- (func $std/math/test_rem (; 134 ;) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
+ (func $std/math/test_rem (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMath.rem
@@ -8767,7 +8767,7 @@
   f64.const 0
   call $std/math/check<f64>
  )
- (func $~lib/math/NativeMathf.rem (; 135 ;) (param $0 f32) (param $1 f32) (result f32)
+ (func $~lib/math/NativeMathf.rem (param $0 f32) (param $1 f32) (result f32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9010,7 +9010,7 @@
   end
   local.get $0
  )
- (func $std/math/test_remf (; 136 ;) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
+ (func $std/math/test_remf (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMathf.rem
@@ -9018,7 +9018,7 @@
   f32.const 0
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.sin (; 137 ;) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.sin (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 f64)
   (local $3 f64)
@@ -9334,7 +9334,7 @@
   end
   local.get $0
  )
- (func $std/math/test_sin (; 138 ;) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
+ (func $std/math/test_sin (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   local.get $0
   call $~lib/math/NativeMath.sin
   local.get $1
@@ -9350,7 +9350,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.sin (; 139 ;) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.sin (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 i32)
   (local $3 f64)
@@ -9620,14 +9620,14 @@
   end
   local.get $0
  )
- (func $std/math/test_sinf (; 140 ;) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
+ (func $std/math/test_sinf (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.sin
   local.get $1
   local.get $2
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.sinh (; 141 ;) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.sinh (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 f64)
   (local $3 i32)
@@ -9704,7 +9704,7 @@
   f64.mul
   f64.mul
  )
- (func $std/math/test_sinh (; 142 ;) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
+ (func $std/math/test_sinh (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   local.get $0
   call $~lib/math/NativeMath.sinh
   local.get $1
@@ -9720,7 +9720,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.sinh (; 143 ;) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.sinh (param $0 f32) (result f32)
   (local $1 f32)
   (local $2 i32)
   (local $3 f32)
@@ -9792,14 +9792,14 @@
   f32.mul
   f32.mul
  )
- (func $std/math/test_sinhf (; 144 ;) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
+ (func $std/math/test_sinhf (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.sinh
   local.get $1
   local.get $2
   call $std/math/check<f32>
  )
- (func $std/math/test_sqrt (; 145 ;) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
+ (func $std/math/test_sqrt (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   local.get $0
   f64.sqrt
   local.get $1
@@ -9815,14 +9815,14 @@
    i32.const 0
   end
  )
- (func $std/math/test_sqrtf (; 146 ;) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
+ (func $std/math/test_sqrtf (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
   local.get $0
   f32.sqrt
   local.get $1
   local.get $2
   call $std/math/check<f32>
  )
- (func $~lib/math/tan_kern (; 147 ;) (param $0 f64) (param $1 f64) (param $2 i32) (result f64)
+ (func $~lib/math/tan_kern (param $0 f64) (param $1 f64) (param $2 i32) (result f64)
   (local $3 f64)
   (local $4 f64)
   (local $5 f64)
@@ -10001,7 +10001,7 @@
   f64.mul
   f64.add
  )
- (func $~lib/math/NativeMath.tan (; 148 ;) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.tan (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 f64)
   (local $3 i32)
@@ -10178,7 +10178,7 @@
   i32.sub
   call $~lib/math/tan_kern
  )
- (func $std/math/test_tan (; 149 ;) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
+ (func $std/math/test_tan (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   local.get $0
   call $~lib/math/NativeMath.tan
   local.get $1
@@ -10194,7 +10194,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.tan (; 150 ;) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.tan (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 i32)
   (local $3 f64)
@@ -10448,14 +10448,14 @@
   local.get $3
   f32.demote_f64
  )
- (func $std/math/test_tanf (; 151 ;) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
+ (func $std/math/test_tanf (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.tan
   local.get $1
   local.get $2
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.tanh (; 152 ;) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.tanh (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 i32)
   (local $3 i64)
@@ -10534,7 +10534,7 @@
   local.get $0
   f64.copysign
  )
- (func $std/math/test_tanh (; 153 ;) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
+ (func $std/math/test_tanh (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   local.get $0
   call $~lib/math/NativeMath.tanh
   local.get $1
@@ -10550,7 +10550,7 @@
    i32.const 0
   end
  )
- (func $std/math/test_tanhf (; 154 ;) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
+ (func $std/math/test_tanhf (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
   (local $3 f32)
   (local $4 i32)
   local.get $0
@@ -10625,7 +10625,7 @@
   local.get $2
   call $std/math/check<f32>
  )
- (func $std/math/test_trunc (; 155 ;) (param $0 f64) (param $1 f64) (result i32)
+ (func $std/math/test_trunc (param $0 f64) (param $1 f64) (result i32)
   local.get $0
   f64.trunc
   local.get $1
@@ -10641,14 +10641,14 @@
    i32.const 0
   end
  )
- (func $std/math/test_truncf (; 156 ;) (param $0 f32) (param $1 f32) (result i32)
+ (func $std/math/test_truncf (param $0 f32) (param $1 f32) (result i32)
   local.get $0
   f32.trunc
   local.get $1
   f32.const 0
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.sincos (; 157 ;) (param $0 f64)
+ (func $~lib/math/NativeMath.sincos (param $0 f64)
   (local $1 f64)
   (local $2 i64)
   (local $3 f64)
@@ -11039,7 +11039,7 @@
   local.get $3
   global.set $~lib/math/NativeMath.sincos_cos
  )
- (func $std/math/test_sincos (; 158 ;) (param $0 i64) (param $1 i64) (param $2 i64) (param $3 i64) (param $4 i64)
+ (func $std/math/test_sincos (param $0 i64) (param $1 i64) (param $2 i64) (param $3 i64) (param $4 i64)
   (local $5 f64)
   (local $6 f64)
   local.get $3
@@ -11065,7 +11065,7 @@
    drop
   end
  )
- (func $~lib/math/dtoi32 (; 159 ;) (param $0 f64) (result i32)
+ (func $~lib/math/dtoi32 (param $0 f64) (result i32)
   local.get $0
   f64.const 4294967296
   local.get $0
@@ -11077,7 +11077,7 @@
   i64.trunc_f64_s
   i32.wrap_i64
  )
- (func $~lib/math/NativeMath.imul (; 160 ;) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.imul (param $0 f64) (param $1 f64) (result f64)
   (local $2 f64)
   local.get $0
   local.get $1
@@ -11098,7 +11098,7 @@
   i32.mul
   f64.convert_i32_s
  )
- (func $~lib/math/NativeMath.clz32 (; 161 ;) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.clz32 (param $0 f64) (result f64)
   local.get $0
   local.get $0
   f64.sub
@@ -11113,7 +11113,7 @@
   i32.clz
   f64.convert_i32_s
  )
- (func $~lib/math/ipow64 (; 162 ;) (param $0 i64) (param $1 i32) (result i64)
+ (func $~lib/math/ipow64 (param $0 i64) (param $1 i32) (result i64)
   (local $2 i64)
   i64.const 1
   local.set $2
@@ -11144,7 +11144,7 @@
   end
   local.get $2
  )
- (func $~lib/math/ipow32f (; 163 ;) (param $0 f32) (param $1 i32) (result f32)
+ (func $~lib/math/ipow32f (param $0 f32) (param $1 i32) (result f32)
   (local $2 f32)
   (local $3 i32)
   local.get $1
@@ -11190,7 +11190,7 @@
   end
   local.get $2
  )
- (func $~lib/math/ipow64f (; 164 ;) (param $0 f64) (param $1 i32) (result f64)
+ (func $~lib/math/ipow64f (param $0 f64) (param $1 i32) (result f64)
   (local $2 f64)
   (local $3 i32)
   local.get $1
@@ -11236,7 +11236,7 @@
   end
   local.get $2
  )
- (func $start:std/math (; 165 ;)
+ (func $start:std/math
   (local $0 f64)
   (local $1 f32)
   (local $2 i32)
@@ -48777,7 +48777,7 @@
    unreachable
   end
  )
- (func $~start (; 166 ;)
+ (func $~start
   call $start:std/math
  )
 )

--- a/tests/compiler/std/math.untouched.wat
+++ b/tests/compiler/std/math.untouched.wat
@@ -125,7 +125,7 @@
  (global $~lib/builtins/f32.MIN_VALUE f32 (f32.const 1.401298464324817e-45))
  (export "memory" (memory $0))
  (start $~start)
- (func $std/math/eulp (; 33 ;) (param $0 f64) (result i32)
+ (func $std/math/eulp (param $0 f64) (result i32)
   (local $1 i64)
   (local $2 i32)
   local.get $0
@@ -152,7 +152,7 @@
   i32.const 52
   i32.sub
  )
- (func $~lib/math/NativeMath.scalbn (; 34 ;) (param $0 f64) (param $1 i32) (result f64)
+ (func $~lib/math/NativeMath.scalbn (param $0 f64) (param $1 i32) (result f64)
   (local $2 f64)
   (local $3 i32)
   (local $4 i32)
@@ -243,7 +243,7 @@
   f64.reinterpret_i64
   f64.mul
  )
- (func $std/math/ulperr (; 35 ;) (param $0 f64) (param $1 f64) (param $2 f64) (result f64)
+ (func $std/math/ulperr (param $0 f64) (param $1 f64) (param $2 f64) (result f64)
   (local $3 f64)
   local.get $0
   local.get $0
@@ -324,7 +324,7 @@
   local.get $2
   f64.add
  )
- (func $std/math/check<f64> (; 36 ;) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/check<f64> (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   (local $4 f64)
   local.get $0
   local.get $1
@@ -357,7 +357,7 @@
   end
   i32.const 1
  )
- (func $std/math/eulpf (; 37 ;) (param $0 f32) (result i32)
+ (func $std/math/eulpf (param $0 f32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -383,7 +383,7 @@
   i32.const 23
   i32.sub
  )
- (func $~lib/math/NativeMathf.scalbn (; 38 ;) (param $0 f32) (param $1 i32) (result f32)
+ (func $~lib/math/NativeMathf.scalbn (param $0 f32) (param $1 i32) (result f32)
   (local $2 f32)
   (local $3 i32)
   (local $4 i32)
@@ -473,7 +473,7 @@
   f32.reinterpret_i32
   f32.mul
  )
- (func $std/math/ulperrf (; 39 ;) (param $0 f32) (param $1 f32) (param $2 f32) (result f32)
+ (func $std/math/ulperrf (param $0 f32) (param $1 f32) (param $2 f32) (result f32)
   (local $3 f32)
   local.get $0
   local.get $0
@@ -552,7 +552,7 @@
   local.get $2
   f32.add
  )
- (func $std/math/check<f32> (; 40 ;) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/check<f32> (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   (local $4 f32)
   local.get $0
   local.get $1
@@ -585,7 +585,7 @@
   end
   i32.const 1
  )
- (func $std/math/test_scalbn (; 41 ;) (param $0 f64) (param $1 i32) (param $2 f64) (param $3 f64) (param $4 i32) (result i32)
+ (func $std/math/test_scalbn (param $0 f64) (param $1 i32) (param $2 f64) (param $3 f64) (param $4 i32) (result i32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMath.scalbn
@@ -594,7 +594,7 @@
   local.get $4
   call $std/math/check<f64>
  )
- (func $std/math/test_scalbnf (; 42 ;) (param $0 f32) (param $1 i32) (param $2 f32) (param $3 f32) (param $4 i32) (result i32)
+ (func $std/math/test_scalbnf (param $0 f32) (param $1 i32) (param $2 f32) (param $3 f32) (param $4 i32) (result i32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMathf.scalbn
@@ -603,7 +603,7 @@
   local.get $4
   call $std/math/check<f32>
  )
- (func $std/math/test_abs (; 43 ;) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_abs (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   (local $4 f64)
   local.get $0
   local.set $4
@@ -630,7 +630,7 @@
    i32.const 0
   end
  )
- (func $std/math/test_absf (; 44 ;) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_absf (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   (local $4 f32)
   local.get $0
   local.set $4
@@ -641,7 +641,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/R (; 45 ;) (param $0 f64) (result f64)
+ (func $~lib/math/R (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 f64)
   local.get $0
@@ -690,7 +690,7 @@
   local.get $2
   f64.div
  )
- (func $~lib/math/NativeMath.acos (; 46 ;) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.acos (param $0 f64) (result f64)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -842,7 +842,7 @@
   f64.add
   f64.mul
  )
- (func $std/math/test_acos (; 47 ;) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_acos (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMath.acos
   local.get $1
@@ -866,7 +866,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/Rf (; 48 ;) (param $0 f32) (result f32)
+ (func $~lib/math/Rf (param $0 f32) (result f32)
   (local $1 f32)
   (local $2 f32)
   local.get $0
@@ -891,7 +891,7 @@
   local.get $2
   f32.div
  )
- (func $~lib/math/NativeMathf.acos (; 49 ;) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.acos (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 i32)
   (local $3 f32)
@@ -1031,7 +1031,7 @@
   f32.add
   f32.mul
  )
- (func $std/math/test_acosf (; 50 ;) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_acosf (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.acos
   local.get $1
@@ -1039,7 +1039,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.log1p (; 51 ;) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.log1p (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i32)
   (local $3 i32)
@@ -1281,7 +1281,7 @@
   f64.mul
   f64.add
  )
- (func $~lib/math/NativeMath.log (; 52 ;) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.log (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 i64)
   (local $3 f64)
@@ -1599,7 +1599,7 @@
   end
   return
  )
- (func $~lib/math/NativeMath.acosh (; 53 ;) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.acosh (param $0 f64) (result f64)
   (local $1 i64)
   local.get $0
   i64.reinterpret_f64
@@ -1659,7 +1659,7 @@
   f64.const 0.6931471805599453
   f64.add
  )
- (func $std/math/test_acosh (; 54 ;) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_acosh (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMath.acosh
   local.get $1
@@ -1683,7 +1683,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.log1p (; 55 ;) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.log1p (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 f32)
   (local $3 f32)
@@ -1892,7 +1892,7 @@
   f32.mul
   f32.add
  )
- (func $~lib/math/NativeMathf.log (; 56 ;) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.log (param $0 f32) (result f32)
   (local $1 f32)
   (local $2 i32)
   (local $3 i32)
@@ -2057,7 +2057,7 @@
   end
   return
  )
- (func $~lib/math/NativeMathf.acosh (; 57 ;) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.acosh (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 i32)
   (local $3 f32)
@@ -2113,7 +2113,7 @@
   f32.const 0.6931471824645996
   f32.add
  )
- (func $std/math/test_acoshf (; 58 ;) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_acoshf (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.acosh
   local.get $1
@@ -2121,7 +2121,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.asin (; 59 ;) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.asin (param $0 f64) (result f64)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -2280,7 +2280,7 @@
   end
   local.get $0
  )
- (func $std/math/test_asin (; 60 ;) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_asin (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMath.asin
   local.get $1
@@ -2304,7 +2304,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.asin (; 61 ;) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.asin (param $0 f32) (result f32)
   (local $1 f32)
   (local $2 i32)
   (local $3 f32)
@@ -2396,7 +2396,7 @@
   local.get $1
   f32.copysign
  )
- (func $std/math/test_asinf (; 62 ;) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_asinf (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.asin
   local.get $1
@@ -2404,7 +2404,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.asinh (; 63 ;) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.asinh (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i64)
   (local $3 f64)
@@ -2480,7 +2480,7 @@
   local.get $0
   f64.copysign
  )
- (func $std/math/test_asinh (; 64 ;) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_asinh (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMath.asinh
   local.get $1
@@ -2504,7 +2504,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.asinh (; 65 ;) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.asinh (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 f32)
   local.get $0
@@ -2573,7 +2573,7 @@
   local.get $0
   f32.copysign
  )
- (func $std/math/test_asinhf (; 66 ;) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_asinhf (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.asinh
   local.get $1
@@ -2581,7 +2581,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.atan (; 67 ;) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.atan (param $0 f64) (result f64)
   (local $1 i32)
   (local $2 f64)
   (local $3 f64)
@@ -2839,7 +2839,7 @@
   local.get $2
   f64.copysign
  )
- (func $std/math/test_atan (; 68 ;) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_atan (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMath.atan
   local.get $1
@@ -2863,7 +2863,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.atan (; 69 ;) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.atan (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 f32)
   (local $3 f32)
@@ -3093,7 +3093,7 @@
   local.get $2
   f32.copysign
  )
- (func $std/math/test_atanf (; 70 ;) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_atanf (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.atan
   local.get $1
@@ -3101,7 +3101,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.atanh (; 71 ;) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.atanh (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i64)
   (local $3 f64)
@@ -3160,7 +3160,7 @@
   local.get $0
   f64.copysign
  )
- (func $std/math/test_atanh (; 72 ;) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_atanh (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMath.atanh
   local.get $1
@@ -3184,7 +3184,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.atanh (; 73 ;) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.atanh (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 f32)
   local.get $0
@@ -3234,7 +3234,7 @@
   local.get $0
   f32.copysign
  )
- (func $std/math/test_atanhf (; 74 ;) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_atanhf (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.atanh
   local.get $1
@@ -3242,7 +3242,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.atan2 (; 75 ;) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.atan2 (param $0 f64) (param $1 f64) (result f64)
   (local $2 i64)
   (local $3 i32)
   (local $4 i32)
@@ -3542,7 +3542,7 @@
   end
   unreachable
  )
- (func $std/math/test_atan2 (; 76 ;) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 f64) (param $4 i32) (result i32)
+ (func $std/math/test_atan2 (param $0 f64) (param $1 f64) (param $2 f64) (param $3 f64) (param $4 i32) (result i32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMath.atan2
@@ -3568,7 +3568,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.atan2 (; 77 ;) (param $0 f32) (param $1 f32) (result f32)
+ (func $~lib/math/NativeMathf.atan2 (param $0 f32) (param $1 f32) (result f32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3840,7 +3840,7 @@
   end
   unreachable
  )
- (func $std/math/test_atan2f (; 78 ;) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 f32) (param $4 i32) (result i32)
+ (func $std/math/test_atan2f (param $0 f32) (param $1 f32) (param $2 f32) (param $3 f32) (param $4 i32) (result i32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMathf.atan2
@@ -3849,7 +3849,7 @@
   local.get $4
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.cbrt (; 79 ;) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.cbrt (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i32)
   (local $3 f64)
@@ -3993,7 +3993,7 @@
   local.set $3
   local.get $3
  )
- (func $std/math/test_cbrt (; 80 ;) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_cbrt (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMath.cbrt
   local.get $1
@@ -4017,7 +4017,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.cbrt (; 81 ;) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.cbrt (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 i32)
   (local $3 f64)
@@ -4133,7 +4133,7 @@
   local.get $3
   f32.demote_f64
  )
- (func $std/math/test_cbrtf (; 82 ;) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_cbrtf (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.cbrt
   local.get $1
@@ -4141,7 +4141,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $std/math/test_ceil (; 83 ;) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_ceil (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   (local $4 f64)
   local.get $0
   local.set $4
@@ -4168,7 +4168,7 @@
    i32.const 0
   end
  )
- (func $std/math/test_ceilf (; 84 ;) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_ceilf (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   (local $4 f32)
   local.get $0
   local.set $4
@@ -4179,7 +4179,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/pio2_large_quot (; 85 ;) (param $0 f64) (param $1 i64) (result i32)
+ (func $~lib/math/pio2_large_quot (param $0 f64) (param $1 i64) (result i32)
   (local $2 i64)
   (local $3 i64)
   (local $4 i64)
@@ -4577,7 +4577,7 @@
   local.get $30
   i32.wrap_i64
  )
- (func $~lib/math/NativeMath.cos (; 86 ;) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.cos (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i32)
   (local $3 i32)
@@ -5095,7 +5095,7 @@
    local.get $0
   end
  )
- (func $std/math/test_cos (; 87 ;) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_cos (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMath.cos
   local.get $1
@@ -5119,7 +5119,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.cos (; 88 ;) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.cos (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 i32)
   (local $3 f64)
@@ -5733,7 +5733,7 @@
    local.get $26
   end
  )
- (func $std/math/test_cosf (; 89 ;) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_cosf (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.cos
   local.get $1
@@ -5741,7 +5741,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.expm1 (; 90 ;) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.expm1 (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i32)
   (local $3 i32)
@@ -6054,7 +6054,7 @@
   local.get $14
   f64.mul
  )
- (func $~lib/math/NativeMath.exp (; 91 ;) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.exp (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 i64)
   (local $3 i32)
@@ -6332,7 +6332,7 @@
   end
   return
  )
- (func $~lib/math/NativeMath.cosh (; 92 ;) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.cosh (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i32)
   (local $3 f64)
@@ -6421,7 +6421,7 @@
   local.set $3
   local.get $3
  )
- (func $std/math/test_cosh (; 93 ;) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_cosh (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMath.cosh
   local.get $1
@@ -6445,7 +6445,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.expm1 (; 94 ;) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.expm1 (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -6738,7 +6738,7 @@
   local.get $13
   f32.mul
  )
- (func $~lib/math/NativeMathf.exp (; 95 ;) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.exp (param $0 f32) (result f32)
   (local $1 f32)
   (local $2 f64)
   (local $3 i32)
@@ -6869,7 +6869,7 @@
   end
   return
  )
- (func $~lib/math/NativeMathf.cosh (; 96 ;) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.cosh (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 f32)
   (local $3 f32)
@@ -6946,7 +6946,7 @@
   local.get $3
   f32.mul
  )
- (func $std/math/test_coshf (; 97 ;) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_coshf (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.cosh
   local.get $1
@@ -6954,7 +6954,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $std/math/test_exp (; 98 ;) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_exp (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMath.exp
   local.get $1
@@ -6978,7 +6978,7 @@
    i32.const 0
   end
  )
- (func $std/math/test_expf (; 99 ;) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_expf (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.exp
   local.get $1
@@ -6986,7 +6986,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $std/math/test_expm1 (; 100 ;) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_expm1 (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMath.expm1
   local.get $1
@@ -7010,7 +7010,7 @@
    i32.const 0
   end
  )
- (func $std/math/test_expm1f (; 101 ;) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_expm1f (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.expm1
   local.get $1
@@ -7018,7 +7018,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.exp2 (; 102 ;) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.exp2 (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 i64)
   (local $3 i32)
@@ -7285,7 +7285,7 @@
    f64.add
   end
  )
- (func $std/math/test_exp2 (; 103 ;) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_exp2 (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMath.exp2
   local.get $1
@@ -7310,7 +7310,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.exp2 (; 104 ;) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.exp2 (param $0 f32) (result f32)
   (local $1 f32)
   (local $2 f64)
   (local $3 i32)
@@ -7433,7 +7433,7 @@
    f32.demote_f64
   end
  )
- (func $std/math/test_exp2f (; 105 ;) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_exp2f (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.exp2
   local.get $1
@@ -7441,7 +7441,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $std/math/test_floor (; 106 ;) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_floor (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   (local $4 f64)
   local.get $0
   local.set $4
@@ -7468,7 +7468,7 @@
    i32.const 0
   end
  )
- (func $std/math/test_floorf (; 107 ;) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_floorf (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   (local $4 f32)
   local.get $0
   local.set $4
@@ -7479,7 +7479,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.hypot (; 108 ;) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.hypot (param $0 f64) (param $1 f64) (result f64)
   (local $2 i64)
   (local $3 i64)
   (local $4 i64)
@@ -7674,7 +7674,7 @@
   f64.sqrt
   f64.mul
  )
- (func $std/math/test_hypot (; 109 ;) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 f64) (param $4 i32) (result i32)
+ (func $std/math/test_hypot (param $0 f64) (param $1 f64) (param $2 f64) (param $3 f64) (param $4 i32) (result i32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMath.hypot
@@ -7683,7 +7683,7 @@
   local.get $4
   call $std/math/check<f64>
  )
- (func $~lib/math/NativeMathf.hypot (; 110 ;) (param $0 f32) (param $1 f32) (result f32)
+ (func $~lib/math/NativeMathf.hypot (param $0 f32) (param $1 f32) (result f32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7800,7 +7800,7 @@
   f32.sqrt
   f32.mul
  )
- (func $std/math/test_hypotf (; 111 ;) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 f32) (param $4 i32) (result i32)
+ (func $std/math/test_hypotf (param $0 f32) (param $1 f32) (param $2 f32) (param $3 f32) (param $4 i32) (result i32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMathf.hypot
@@ -7809,7 +7809,7 @@
   local.get $4
   call $std/math/check<f32>
  )
- (func $std/math/test_log (; 112 ;) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_log (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMath.log
   local.get $1
@@ -7833,7 +7833,7 @@
    i32.const 0
   end
  )
- (func $std/math/test_logf (; 113 ;) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_logf (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.log
   local.get $1
@@ -7841,7 +7841,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.log10 (; 114 ;) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.log10 (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i32)
   (local $3 i32)
@@ -8101,7 +8101,7 @@
   local.get $8
   f64.add
  )
- (func $std/math/test_log10 (; 115 ;) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_log10 (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMath.log10
   local.get $1
@@ -8125,7 +8125,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.log10 (; 116 ;) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.log10 (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 i32)
   (local $3 f32)
@@ -8325,7 +8325,7 @@
   f32.mul
   f32.add
  )
- (func $std/math/test_log10f (; 117 ;) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_log10f (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.log10
   local.get $1
@@ -8333,7 +8333,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $std/math/test_log1p (; 118 ;) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_log1p (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMath.log1p
   local.get $1
@@ -8357,7 +8357,7 @@
    i32.const 0
   end
  )
- (func $std/math/test_log1pf (; 119 ;) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_log1pf (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.log1p
   local.get $1
@@ -8365,7 +8365,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.log2 (; 120 ;) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.log2 (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 i64)
   (local $3 f64)
@@ -8708,7 +8708,7 @@
   end
   return
  )
- (func $std/math/test_log2 (; 121 ;) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_log2 (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMath.log2
   local.get $1
@@ -8732,7 +8732,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.log2 (; 122 ;) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.log2 (param $0 f32) (result f32)
   (local $1 f32)
   (local $2 i32)
   (local $3 i32)
@@ -8901,7 +8901,7 @@
   end
   return
  )
- (func $std/math/test_log2f (; 123 ;) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_log2f (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.log2
   local.get $1
@@ -8909,7 +8909,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $std/math/test_max (; 124 ;) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 f64) (param $4 i32) (result i32)
+ (func $std/math/test_max (param $0 f64) (param $1 f64) (param $2 f64) (param $3 f64) (param $4 i32) (result i32)
   (local $5 f64)
   (local $6 f64)
   local.get $0
@@ -8941,7 +8941,7 @@
    i32.const 0
   end
  )
- (func $std/math/test_maxf (; 125 ;) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 f32) (param $4 i32) (result i32)
+ (func $std/math/test_maxf (param $0 f32) (param $1 f32) (param $2 f32) (param $3 f32) (param $4 i32) (result i32)
   (local $5 f32)
   (local $6 f32)
   local.get $0
@@ -8956,7 +8956,7 @@
   local.get $4
   call $std/math/check<f32>
  )
- (func $std/math/test_min (; 126 ;) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 f64) (param $4 i32) (result i32)
+ (func $std/math/test_min (param $0 f64) (param $1 f64) (param $2 f64) (param $3 f64) (param $4 i32) (result i32)
   (local $5 f64)
   (local $6 f64)
   local.get $0
@@ -8988,7 +8988,7 @@
    i32.const 0
   end
  )
- (func $std/math/test_minf (; 127 ;) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 f32) (param $4 i32) (result i32)
+ (func $std/math/test_minf (param $0 f32) (param $1 f32) (param $2 f32) (param $3 f32) (param $4 i32) (result i32)
   (local $5 f32)
   (local $6 f32)
   local.get $0
@@ -9003,7 +9003,7 @@
   local.get $4
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.mod (; 128 ;) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.mod (param $0 f64) (param $1 f64) (result f64)
   (local $2 i64)
   (local $3 i64)
   (local $4 i64)
@@ -9257,7 +9257,7 @@
   local.get $2
   f64.reinterpret_i64
  )
- (func $std/math/test_mod (; 129 ;) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 f64) (param $4 i32) (result i32)
+ (func $std/math/test_mod (param $0 f64) (param $1 f64) (param $2 f64) (param $3 f64) (param $4 i32) (result i32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMath.mod
@@ -9283,7 +9283,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.mod (; 130 ;) (param $0 f32) (param $1 f32) (result f32)
+ (func $~lib/math/NativeMathf.mod (param $0 f32) (param $1 f32) (result f32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9531,7 +9531,7 @@
   local.get $2
   f32.reinterpret_i32
  )
- (func $std/math/test_modf (; 131 ;) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 f32) (param $4 i32) (result i32)
+ (func $std/math/test_modf (param $0 f32) (param $1 f32) (param $2 f32) (param $3 f32) (param $4 i32) (result i32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMathf.mod
@@ -9540,7 +9540,7 @@
   local.get $4
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.pow (; 132 ;) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.pow (param $0 f64) (param $1 f64) (result f64)
   (local $2 f64)
   (local $3 f64)
   (local $4 i32)
@@ -10500,7 +10500,7 @@
   end
   return
  )
- (func $std/math/test_pow (; 133 ;) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 f64) (param $4 i32) (result i32)
+ (func $std/math/test_pow (param $0 f64) (param $1 f64) (param $2 f64) (param $3 f64) (param $4 i32) (result i32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMath.pow
@@ -10526,7 +10526,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.pow (; 134 ;) (param $0 f32) (param $1 f32) (result f32)
+ (func $~lib/math/NativeMathf.pow (param $0 f32) (param $1 f32) (result f32)
   (local $2 f32)
   (local $3 f32)
   (local $4 i32)
@@ -11112,7 +11112,7 @@
   end
   return
  )
- (func $std/math/test_powf (; 135 ;) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 f32) (param $4 i32) (result i32)
+ (func $std/math/test_powf (param $0 f32) (param $1 f32) (param $2 f32) (param $3 f32) (param $4 i32) (result i32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMathf.pow
@@ -11121,7 +11121,7 @@
   local.get $4
   call $std/math/check<f32>
  )
- (func $~lib/math/murmurHash3 (; 136 ;) (param $0 i64) (result i64)
+ (func $~lib/math/murmurHash3 (param $0 i64) (result i64)
   local.get $0
   local.get $0
   i64.const 33
@@ -11150,7 +11150,7 @@
   local.set $0
   local.get $0
  )
- (func $~lib/math/splitMix32 (; 137 ;) (param $0 i32) (result i32)
+ (func $~lib/math/splitMix32 (param $0 i32) (result i32)
   local.get $0
   i32.const 1831565813
   i32.add
@@ -11185,7 +11185,7 @@
   i32.shr_u
   i32.xor
  )
- (func $~lib/math/NativeMath.seedRandom (; 138 ;) (param $0 i64)
+ (func $~lib/math/NativeMath.seedRandom (param $0 i64)
   i32.const 1
   global.set $~lib/math/random_seeded
   local.get $0
@@ -11237,7 +11237,7 @@
    unreachable
   end
  )
- (func $~lib/math/NativeMath.random (; 139 ;) (result f64)
+ (func $~lib/math/NativeMath.random (result f64)
   (local $0 i64)
   (local $1 i64)
   (local $2 i64)
@@ -11289,7 +11289,7 @@
   f64.const 1
   f64.sub
  )
- (func $~lib/math/NativeMathf.random (; 140 ;) (result f32)
+ (func $~lib/math/NativeMathf.random (result f32)
   (local $0 i64)
   (local $1 i32)
   (local $2 i32)
@@ -11344,7 +11344,7 @@
   f32.const 1
   f32.sub
  )
- (func $std/math/test_round (; 141 ;) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_round (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   (local $4 f64)
   local.get $0
   local.set $4
@@ -11359,7 +11359,7 @@
   local.get $3
   call $std/math/check<f64>
  )
- (func $std/math/test_roundf (; 142 ;) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_roundf (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   (local $4 f32)
   local.get $0
   local.set $4
@@ -11374,7 +11374,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $std/math/test_sign (; 143 ;) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_sign (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   (local $4 f64)
   block $~lib/math/NativeMath.sign|inlined.0 (result f64)
    local.get $0
@@ -11417,7 +11417,7 @@
    i32.const 0
   end
  )
- (func $std/math/test_signf (; 144 ;) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_signf (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   (local $4 f32)
   block $~lib/math/NativeMathf.sign|inlined.0 (result f32)
    local.get $0
@@ -11444,7 +11444,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.rem (; 145 ;) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.rem (param $0 f64) (param $1 f64) (result f64)
   (local $2 i64)
   (local $3 i64)
   (local $4 i64)
@@ -11762,7 +11762,7 @@
    local.get $0
   end
  )
- (func $std/math/test_rem (; 146 ;) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 f64) (param $4 i32) (result i32)
+ (func $std/math/test_rem (param $0 f64) (param $1 f64) (param $2 f64) (param $3 f64) (param $4 i32) (result i32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMath.rem
@@ -11771,7 +11771,7 @@
   local.get $4
   call $std/math/check<f64>
  )
- (func $~lib/math/NativeMathf.rem (; 147 ;) (param $0 f32) (param $1 f32) (result f32)
+ (func $~lib/math/NativeMathf.rem (param $0 f32) (param $1 f32) (result f32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -12082,7 +12082,7 @@
    local.get $0
   end
  )
- (func $std/math/test_remf (; 148 ;) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 f32) (param $4 i32) (result i32)
+ (func $std/math/test_remf (param $0 f32) (param $1 f32) (param $2 f32) (param $3 f32) (param $4 i32) (result i32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMathf.rem
@@ -12091,7 +12091,7 @@
   local.get $4
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.sin (; 149 ;) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.sin (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i32)
   (local $3 i32)
@@ -12620,7 +12620,7 @@
    local.get $0
   end
  )
- (func $std/math/test_sin (; 150 ;) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_sin (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMath.sin
   local.get $1
@@ -12644,7 +12644,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.sin (; 151 ;) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.sin (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 i32)
   (local $3 f64)
@@ -13250,7 +13250,7 @@
    local.get $26
   end
  )
- (func $std/math/test_sinf (; 152 ;) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_sinf (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.sin
   local.get $1
@@ -13258,7 +13258,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.sinh (; 153 ;) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.sinh (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 f64)
   (local $3 i32)
@@ -13356,7 +13356,7 @@
   local.set $4
   local.get $4
  )
- (func $std/math/test_sinh (; 154 ;) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_sinh (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMath.sinh
   local.get $1
@@ -13380,7 +13380,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.sinh (; 155 ;) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.sinh (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 f32)
   (local $3 f32)
@@ -13469,7 +13469,7 @@
   local.set $3
   local.get $3
  )
- (func $std/math/test_sinhf (; 156 ;) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_sinhf (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.sinh
   local.get $1
@@ -13477,7 +13477,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $std/math/test_sqrt (; 157 ;) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_sqrt (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   (local $4 f64)
   local.get $0
   local.set $4
@@ -13504,7 +13504,7 @@
    i32.const 0
   end
  )
- (func $std/math/test_sqrtf (; 158 ;) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_sqrtf (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   (local $4 f32)
   local.get $0
   local.set $4
@@ -13515,7 +13515,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/tan_kern (; 159 ;) (param $0 f64) (param $1 f64) (param $2 i32) (result f64)
+ (func $~lib/math/tan_kern (param $0 f64) (param $1 f64) (param $2 i32) (result f64)
   (local $3 f64)
   (local $4 f64)
   (local $5 f64)
@@ -13728,7 +13728,7 @@
   f64.mul
   f64.add
  )
- (func $~lib/math/NativeMath.tan (; 160 ;) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.tan (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i32)
   (local $3 i32)
@@ -14040,7 +14040,7 @@
   i32.sub
   call $~lib/math/tan_kern
  )
- (func $std/math/test_tan (; 161 ;) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_tan (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMath.tan
   local.get $1
@@ -14064,7 +14064,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.tan (; 162 ;) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.tan (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -14711,7 +14711,7 @@
   end
   f32.demote_f64
  )
- (func $std/math/test_tanf (; 163 ;) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_tanf (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.tan
   local.get $1
@@ -14719,7 +14719,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.tanh (; 164 ;) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.tanh (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 f64)
   (local $3 i32)
@@ -14811,7 +14811,7 @@
   local.get $0
   f64.copysign
  )
- (func $std/math/test_tanh (; 165 ;) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_tanh (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMath.tanh
   local.get $1
@@ -14835,7 +14835,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.tanh (; 166 ;) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.tanh (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 f32)
   (local $3 f32)
@@ -14921,7 +14921,7 @@
   local.get $0
   f32.copysign
  )
- (func $std/math/test_tanhf (; 167 ;) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_tanhf (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.tanh
   local.get $1
@@ -14929,7 +14929,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $std/math/test_trunc (; 168 ;) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_trunc (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   (local $4 f64)
   local.get $0
   local.set $4
@@ -14956,7 +14956,7 @@
    i32.const 0
   end
  )
- (func $std/math/test_truncf (; 169 ;) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_truncf (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   (local $4 f32)
   local.get $0
   local.set $4
@@ -14967,7 +14967,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.sincos (; 170 ;) (param $0 f64)
+ (func $~lib/math/NativeMath.sincos (param $0 f64)
   (local $1 i64)
   (local $2 i32)
   (local $3 i32)
@@ -15586,7 +15586,7 @@
   local.get $23
   global.set $~lib/math/NativeMath.sincos_cos
  )
- (func $std/math/test_sincos (; 171 ;) (param $0 i64) (param $1 i64) (param $2 i64) (param $3 i64) (param $4 i64) (param $5 i32) (result i32)
+ (func $std/math/test_sincos (param $0 i64) (param $1 i64) (param $2 i64) (param $3 i64) (param $4 i64) (param $5 i32) (result i32)
   (local $6 f64)
   (local $7 f64)
   (local $8 f64)
@@ -15624,7 +15624,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/dtoi32 (; 172 ;) (param $0 f64) (result i32)
+ (func $~lib/math/dtoi32 (param $0 f64) (result i32)
   (local $1 i32)
   (local $2 i64)
   (local $3 i64)
@@ -15695,7 +15695,7 @@
   local.get $1
   return
  )
- (func $~lib/math/NativeMath.imul (; 173 ;) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.imul (param $0 f64) (param $1 f64) (result f64)
   (local $2 f64)
   local.get $0
   local.get $1
@@ -15717,7 +15717,7 @@
   i32.mul
   f64.convert_i32_s
  )
- (func $~lib/math/NativeMath.clz32 (; 174 ;) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.clz32 (param $0 f64) (result f64)
   local.get $0
   local.get $0
   f64.sub
@@ -15733,7 +15733,7 @@
   i32.clz
   f64.convert_i32_s
  )
- (func $~lib/math/ipow64 (; 175 ;) (param $0 i64) (param $1 i32) (result i64)
+ (func $~lib/math/ipow64 (param $0 i64) (param $1 i32) (result i64)
   (local $2 i64)
   (local $3 i32)
   (local $4 i32)
@@ -15953,7 +15953,7 @@
   end
   local.get $2
  )
- (func $~lib/math/ipow32f (; 176 ;) (param $0 f32) (param $1 i32) (result f32)
+ (func $~lib/math/ipow32f (param $0 f32) (param $1 i32) (result f32)
   (local $2 i32)
   (local $3 f32)
   (local $4 i32)
@@ -16003,7 +16003,7 @@
    local.get $3
   end
  )
- (func $~lib/math/ipow64f (; 177 ;) (param $0 f64) (param $1 i32) (result f64)
+ (func $~lib/math/ipow64f (param $0 f64) (param $1 i32) (result f64)
   (local $2 i32)
   (local $3 f64)
   (local $4 i32)
@@ -16053,7 +16053,7 @@
    local.get $3
   end
  )
- (func $start:std/math (; 178 ;)
+ (func $start:std/math
   (local $0 f64)
   (local $1 i32)
   (local $2 i32)
@@ -57819,7 +57819,7 @@
    unreachable
   end
  )
- (func $~start (; 179 ;)
+ (func $~start
   call $start:std/math
  )
 )

--- a/tests/compiler/std/mod.optimized.wat
+++ b/tests/compiler/std/mod.optimized.wat
@@ -13,7 +13,7 @@
  (export "memory" (memory $0))
  (export "mod" (func $std/mod/mod))
  (start $~start)
- (func $~lib/math/NativeMath.mod (; 2 ;) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.mod (param $0 f64) (param $1 f64) (result f64)
   (local $2 i64)
   (local $3 i64)
   (local $4 i64)
@@ -216,7 +216,7 @@
   local.get $0
   f64.mul
  )
- (func $std/mod/check<f64> (; 3 ;) (param $0 f64) (param $1 f64) (result i32)
+ (func $std/mod/check<f64> (param $0 f64) (param $1 f64) (result i32)
   local.get $1
   local.get $1
   f64.ne
@@ -243,7 +243,7 @@
   local.get $1
   f64.eq
  )
- (func $std/mod/test_fmod (; 4 ;) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
+ (func $std/mod/test_fmod (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMath.mod
@@ -259,7 +259,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.mod (; 5 ;) (param $0 f32) (param $1 f32) (result f32)
+ (func $~lib/math/NativeMathf.mod (param $0 f32) (param $1 f32) (result f32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -451,7 +451,7 @@
   local.get $0
   f32.mul
  )
- (func $std/mod/test_fmodf (; 6 ;) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
+ (func $std/mod/test_fmodf (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
   block $__inlined_func$std/mod/check<f32> (result i32)
    local.get $0
    local.get $1
@@ -481,7 +481,7 @@
    f32.eq
   end
  )
- (func $start:std/mod (; 7 ;)
+ (func $start:std/mod
   f64.const 3
   f64.const 2
   f64.const 1
@@ -2238,7 +2238,7 @@
    unreachable
   end
  )
- (func $~start (; 8 ;)
+ (func $~start
   call $start:std/mod
  )
 )

--- a/tests/compiler/std/mod.untouched.wat
+++ b/tests/compiler/std/mod.untouched.wat
@@ -16,7 +16,7 @@
  (export "memory" (memory $0))
  (export "mod" (func $std/mod/mod))
  (start $~start)
- (func $~lib/math/NativeMath.mod (; 2 ;) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.mod (param $0 f64) (param $1 f64) (result f64)
   (local $2 i64)
   (local $3 i64)
   (local $4 i64)
@@ -270,7 +270,7 @@
   local.get $2
   f64.reinterpret_i64
  )
- (func $std/mod/check<f64> (; 3 ;) (param $0 f64) (param $1 f64) (result i32)
+ (func $std/mod/check<f64> (param $0 f64) (param $1 f64) (result i32)
   local.get $1
   local.get $1
   f64.ne
@@ -298,7 +298,7 @@
   local.get $1
   f64.eq
  )
- (func $std/mod/test_fmod (; 4 ;) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
+ (func $std/mod/test_fmod (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMath.mod
@@ -320,7 +320,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.mod (; 5 ;) (param $0 f32) (param $1 f32) (result f32)
+ (func $~lib/math/NativeMathf.mod (param $0 f32) (param $1 f32) (result f32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -568,7 +568,7 @@
   local.get $2
   f32.reinterpret_i32
  )
- (func $std/mod/check<f32> (; 6 ;) (param $0 f32) (param $1 f32) (result i32)
+ (func $std/mod/check<f32> (param $0 f32) (param $1 f32) (result i32)
   local.get $1
   local.get $1
   f32.ne
@@ -596,14 +596,14 @@
   local.get $1
   f32.eq
  )
- (func $std/mod/test_fmodf (; 7 ;) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
+ (func $std/mod/test_fmodf (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMathf.mod
   local.get $2
   call $std/mod/check<f32>
  )
- (func $start:std/mod (; 8 ;)
+ (func $start:std/mod
   f64.const 3
   f64.const 2
   f64.const 1
@@ -2360,7 +2360,7 @@
    unreachable
   end
  )
- (func $~start (; 9 ;)
+ (func $~start
   call $start:std/mod
  )
 )

--- a/tests/compiler/std/new.optimized.wat
+++ b/tests/compiler/std/new.optimized.wat
@@ -1,13 +1,10 @@
 (module
  (type $none_=>_none (func))
- (type $none_=>_i32 (func (result i32)))
  (memory $0 0)
- (global $~lib/rt/stub/startOffset (mut i32) (i32.const 0))
  (global $~lib/rt/stub/offset (mut i32) (i32.const 0))
- (global $std/new/aClass (mut i32) (i32.const 0))
  (export "memory" (memory $0))
  (start $~start)
- (func $std/new/AClass#constructor (; 0 ;) (result i32)
+ (func $std/new/AClass#constructor
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -18,17 +15,17 @@
   local.tee $1
   i32.const 16
   i32.add
-  local.tee $2
+  local.tee $0
   memory.size
   local.tee $3
   i32.const 16
   i32.shl
-  local.tee $0
+  local.tee $2
   i32.gt_u
   if
    local.get $3
-   local.get $2
    local.get $0
+   local.get $2
    i32.sub
    i32.const 65535
    i32.add
@@ -36,16 +33,16 @@
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $0
+   local.tee $2
    local.get $3
-   local.get $0
+   local.get $2
    i32.gt_s
    select
    memory.grow
    i32.const 0
    i32.lt_s
    if
-    local.get $0
+    local.get $2
     memory.grow
     i32.const 0
     i32.lt_s
@@ -54,7 +51,7 @@
     end
    end
   end
-  local.get $2
+  local.get $0
   global.set $~lib/rt/stub/offset
   local.get $1
   i32.const 16
@@ -86,14 +83,10 @@
   local.get $1
   f32.const 3
   f32.store offset=4
-  local.get $1
  )
- (func $~start (; 1 ;)
-  i32.const 1024
-  global.set $~lib/rt/stub/startOffset
+ (func $~start
   i32.const 1024
   global.set $~lib/rt/stub/offset
   call $std/new/AClass#constructor
-  global.set $std/new/aClass
  )
 )

--- a/tests/compiler/std/new.untouched.wat
+++ b/tests/compiler/std/new.untouched.wat
@@ -13,7 +13,7 @@
  (global $~lib/heap/__heap_base i32 (i32.const 8))
  (export "memory" (memory $0))
  (start $~start)
- (func $~lib/rt/stub/maybeGrowMemory (; 0 ;) (param $0 i32)
+ (func $~lib/rt/stub/maybeGrowMemory (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -67,7 +67,7 @@
   local.get $0
   global.set $~lib/rt/stub/offset
  )
- (func $~lib/rt/stub/__alloc (; 1 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/stub/__alloc (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -120,10 +120,10 @@
   i32.store offset=12
   local.get $2
  )
- (func $~lib/rt/stub/__retain (; 2 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/stub/__retain (param $0 i32) (result i32)
   local.get $0
  )
- (func $std/new/AClass#constructor (; 3 ;) (param $0 i32) (param $1 f32) (result i32)
+ (func $std/new/AClass#constructor (param $0 i32) (param $1 f32) (result i32)
   local.get $0
   local.get $0
   i32.eqz
@@ -150,7 +150,7 @@
   f32.store offset=4
   local.get $0
  )
- (func $start:std/new (; 4 ;)
+ (func $start:std/new
   global.get $~lib/heap/__heap_base
   i32.const 15
   i32.add
@@ -166,7 +166,7 @@
   call $std/new/AClass#constructor
   global.set $std/new/aClass
  )
- (func $~start (; 5 ;)
+ (func $~start
   call $start:std/new
  )
 )

--- a/tests/compiler/std/object-literal-unmanaged.optimized.wat
+++ b/tests/compiler/std/object-literal-unmanaged.optimized.wat
@@ -18,7 +18,7 @@
  (global $~lib/rt/tlsf/collectLock (mut i32) (i32.const 0))
  (export "memory" (memory $0))
  (start $~start)
- (func $~lib/rt/tlsf/removeBlock (; 3 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/removeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -180,7 +180,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/insertBlock (; 4 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/insertBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -459,7 +459,7 @@
   i32.or
   i32.store offset=4
  )
- (func $~lib/rt/tlsf/addMemory (; 5 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $2
@@ -573,7 +573,7 @@
   local.get $1
   call $~lib/rt/tlsf/insertBlock
  )
- (func $~lib/rt/tlsf/maybeInitialize (; 6 ;) (result i32)
+ (func $~lib/rt/tlsf/maybeInitialize (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -660,7 +660,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/tlsf/searchBlock (; 7 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/tlsf/searchBlock (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   nop
@@ -718,7 +718,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/allocateBlock (; 8 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/tlsf/allocateBlock (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -890,7 +890,7 @@
   call $~lib/rt/rtrace/onalloc
   local.get $1
  )
- (func $~start (; 9 ;)
+ (func $~start
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)

--- a/tests/compiler/std/object-literal-unmanaged.untouched.wat
+++ b/tests/compiler/std/object-literal-unmanaged.untouched.wat
@@ -24,7 +24,7 @@
  (global $~lib/heap/__heap_base i32 (i32.const 208))
  (export "memory" (memory $0))
  (start $~start)
- (func $~lib/rt/tlsf/removeBlock (; 3 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/removeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -234,7 +234,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/insertBlock (; 4 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/insertBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -584,7 +584,7 @@
   local.get $7
   i32.store offset=4
  )
- (func $~lib/rt/tlsf/addMemory (; 5 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -732,7 +732,7 @@
   call $~lib/rt/tlsf/insertBlock
   i32.const 1
  )
- (func $~lib/rt/tlsf/maybeInitialize (; 6 ;) (result i32)
+ (func $~lib/rt/tlsf/maybeInitialize (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -886,7 +886,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/tlsf/prepareSize (; 7 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/tlsf/prepareSize (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -915,7 +915,7 @@
   i32.gt_u
   select
  )
- (func $~lib/rt/tlsf/searchBlock (; 8 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/searchBlock (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1098,7 +1098,7 @@
   end
   local.get $7
  )
- (func $~lib/rt/tlsf/growMemory (; 9 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/growMemory (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1182,7 +1182,7 @@
   call $~lib/rt/tlsf/addMemory
   drop
  )
- (func $~lib/rt/tlsf/prepareBlock (; 10 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/rt/tlsf/prepareBlock (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1277,7 +1277,7 @@
    i32.store
   end
  )
- (func $~lib/rt/tlsf/allocateBlock (; 11 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/allocateBlock (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   global.get $~lib/rt/tlsf/collectLock
@@ -1388,7 +1388,7 @@
   call $~lib/rt/rtrace/onalloc
   local.get $4
  )
- (func $~lib/rt/tlsf/__alloc (; 12 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/__alloc (param $0 i32) (param $1 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
   local.get $0
   local.get $1
@@ -1396,7 +1396,7 @@
   i32.const 16
   i32.add
  )
- (func $std/object-literal-unmanaged/test (; 13 ;) (param $0 i32) (result i32)
+ (func $std/object-literal-unmanaged/test (param $0 i32) (result i32)
   (local $1 i32)
   i32.const 4
   i32.const 0
@@ -1410,7 +1410,7 @@
   global.get $std/object-literal-unmanaged/foo
   i32.load
  )
- (func $~lib/rt/tlsf/checkUsedBlock (; 14 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/tlsf/checkUsedBlock (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   i32.const 16
@@ -1456,7 +1456,7 @@
   end
   local.get $1
  )
- (func $~lib/rt/tlsf/freeBlock (; 15 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/freeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $1
   i32.load
@@ -1472,13 +1472,13 @@
   local.get $1
   call $~lib/rt/rtrace/onfree
  )
- (func $~lib/rt/tlsf/__free (; 16 ;) (param $0 i32)
+ (func $~lib/rt/tlsf/__free (param $0 i32)
   call $~lib/rt/tlsf/maybeInitialize
   local.get $0
   call $~lib/rt/tlsf/checkUsedBlock
   call $~lib/rt/tlsf/freeBlock
  )
- (func $start:std/object-literal-unmanaged (; 17 ;)
+ (func $start:std/object-literal-unmanaged
   i32.const 123
   call $std/object-literal-unmanaged/test
   i32.const 123
@@ -1495,10 +1495,10 @@
   global.get $std/object-literal-unmanaged/foo
   call $~lib/rt/tlsf/__free
  )
- (func $~start (; 18 ;)
+ (func $~start
   call $start:std/object-literal-unmanaged
  )
- (func $~lib/rt/pure/__collect (; 19 ;)
+ (func $~lib/rt/pure/__collect
   return
  )
 )

--- a/tests/compiler/std/object-literal.optimized.wat
+++ b/tests/compiler/std/object-literal.optimized.wat
@@ -7,11 +7,10 @@
  (memory $0 1)
  (data (i32.const 1024) "\16\00\00\00\01\00\00\00\01\00\00\00\16\00\00\00h\00e\00l\00l\00o\00 \00w\00o\00r\00l\00d")
  (data (i32.const 1072) "*\00\00\00\01\00\00\00\01\00\00\00*\00\00\00s\00t\00d\00/\00o\00b\00j\00e\00c\00t\00-\00l\00i\00t\00e\00r\00a\00l\00.\00t\00s")
- (global $~lib/rt/stub/startOffset (mut i32) (i32.const 0))
  (global $~lib/rt/stub/offset (mut i32) (i32.const 0))
  (export "memory" (memory $0))
  (start $~start)
- (func $~lib/rt/stub/__alloc (; 1 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/stub/__alloc (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -95,7 +94,7 @@
   i32.store offset=12
   local.get $4
  )
- (func $~lib/string/String#get:length (; 2 ;) (param $0 i32) (result i32)
+ (func $~lib/string/String#get:length (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub
@@ -103,7 +102,7 @@
   i32.const 1
   i32.shr_u
  )
- (func $~lib/util/string/compareImpl (; 3 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/compareImpl (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -178,11 +177,9 @@
   end
   i32.const 0
  )
- (func $start:std/object-literal (; 4 ;)
+ (func $start:std/object-literal
   (local $0 i32)
   (local $1 i32)
-  i32.const 1136
-  global.set $~lib/rt/stub/startOffset
   i32.const 1136
   global.set $~lib/rt/stub/offset
   i32.const 8
@@ -282,7 +279,7 @@
    unreachable
   end
  )
- (func $~start (; 5 ;)
+ (func $~start
   call $start:std/object-literal
  )
 )

--- a/tests/compiler/std/object-literal.untouched.wat
+++ b/tests/compiler/std/object-literal.untouched.wat
@@ -16,7 +16,7 @@
  (global $~lib/heap/__heap_base i32 (i32.const 124))
  (export "memory" (memory $0))
  (start $~start)
- (func $~lib/rt/stub/maybeGrowMemory (; 1 ;) (param $0 i32)
+ (func $~lib/rt/stub/maybeGrowMemory (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -70,7 +70,7 @@
   local.get $0
   global.set $~lib/rt/stub/offset
  )
- (func $~lib/rt/stub/__alloc (; 2 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/stub/__alloc (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -123,13 +123,13 @@
   i32.store offset=12
   local.get $2
  )
- (func $~lib/rt/stub/__retain (; 3 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/stub/__retain (param $0 i32) (result i32)
   local.get $0
  )
- (func $~lib/rt/stub/__release (; 4 ;) (param $0 i32)
+ (func $~lib/rt/stub/__release (param $0 i32)
   nop
  )
- (func $~lib/string/String#get:length (; 5 ;) (param $0 i32) (result i32)
+ (func $~lib/string/String#get:length (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub
@@ -137,7 +137,7 @@
   i32.const 1
   i32.shr_u
  )
- (func $~lib/util/string/compareImpl (; 6 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
+ (func $~lib/util/string/compareImpl (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
@@ -259,7 +259,7 @@
   call $~lib/rt/stub/__release
   local.get $7
  )
- (func $~lib/string/String.__eq (; 7 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__eq (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -332,7 +332,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $std/object-literal/bar (; 8 ;) (param $0 i32)
+ (func $std/object-literal/bar (param $0 i32)
   local.get $0
   call $~lib/rt/stub/__retain
   local.set $0
@@ -365,7 +365,7 @@
   local.get $0
   call $~lib/rt/stub/__release
  )
- (func $std/object-literal/bar2 (; 9 ;) (param $0 i32)
+ (func $std/object-literal/bar2 (param $0 i32)
   local.get $0
   call $~lib/rt/stub/__retain
   local.set $0
@@ -385,7 +385,7 @@
   local.get $0
   call $~lib/rt/stub/__release
  )
- (func $std/object-literal/Foo2#test (; 10 ;) (param $0 i32)
+ (func $std/object-literal/Foo2#test (param $0 i32)
   local.get $0
   i32.load
   i32.const 3
@@ -400,7 +400,7 @@
    unreachable
   end
  )
- (func $start:std/object-literal (; 11 ;)
+ (func $start:std/object-literal
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -454,7 +454,7 @@
   local.get $2
   call $~lib/rt/stub/__release
  )
- (func $~start (; 12 ;)
+ (func $~start
   call $start:std/object-literal
  )
 )

--- a/tests/compiler/std/object.optimized.wat
+++ b/tests/compiler/std/object.optimized.wat
@@ -15,7 +15,7 @@
  (data (i32.const 1172) "\01\00\00\00\01")
  (export "memory" (memory $0))
  (start $~start)
- (func $~lib/object/Object.is<f64> (; 1 ;) (param $0 f64) (param $1 f64) (result i32)
+ (func $~lib/object/Object.is<f64> (param $0 f64) (param $1 f64) (result i32)
   local.get $0
   local.get $1
   f64.eq
@@ -35,7 +35,7 @@
   f64.ne
   i32.and
  )
- (func $~lib/object/Object.is<f32> (; 2 ;) (param $0 f32) (param $1 f32) (result i32)
+ (func $~lib/object/Object.is<f32> (param $0 f32) (param $1 f32) (result i32)
   local.get $0
   local.get $1
   f32.eq
@@ -55,7 +55,7 @@
   f32.ne
   i32.and
  )
- (func $~lib/object/Object.is<bool> (; 3 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/object/Object.is<bool> (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.const 0
   i32.ne
@@ -64,7 +64,7 @@
   i32.ne
   i32.eq
  )
- (func $~lib/string/String#get:length (; 4 ;) (param $0 i32) (result i32)
+ (func $~lib/string/String#get:length (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub
@@ -72,7 +72,7 @@
   i32.const 1
   i32.shr_u
  )
- (func $~lib/util/string/compareImpl (; 5 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/compareImpl (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -148,7 +148,7 @@
   end
   i32.const 0
  )
- (func $~lib/object/Object.is<~lib/string/String> (; 6 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/object/Object.is<~lib/string/String> (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   block $__inlined_func$~lib/string/String.__eq (result i32)
    i32.const 1
@@ -181,7 +181,7 @@
    i32.const 0
   end
  )
- (func $start:std/object (; 7 ;)
+ (func $start:std/object
   f64.const 0
   f64.const 0
   call $~lib/object/Object.is<f64>
@@ -631,7 +631,7 @@
    unreachable
   end
  )
- (func $~start (; 8 ;)
+ (func $~start
   call $start:std/object
  )
 )

--- a/tests/compiler/std/object.untouched.wat
+++ b/tests/compiler/std/object.untouched.wat
@@ -18,7 +18,7 @@
  (global $~lib/ASC_SHRINK_LEVEL i32 (i32.const 0))
  (export "memory" (memory $0))
  (start $~start)
- (func $~lib/object/Object.is<f64> (; 1 ;) (param $0 f64) (param $1 f64) (result i32)
+ (func $~lib/object/Object.is<f64> (param $0 f64) (param $1 f64) (result i32)
   local.get $0
   local.get $1
   f64.eq
@@ -39,7 +39,7 @@
   i32.and
   return
  )
- (func $~lib/object/Object.is<f32> (; 2 ;) (param $0 f32) (param $1 f32) (result i32)
+ (func $~lib/object/Object.is<f32> (param $0 f32) (param $1 f32) (result i32)
   local.get $0
   local.get $1
   f32.eq
@@ -60,12 +60,12 @@
   i32.and
   return
  )
- (func $~lib/object/Object.is<i32> (; 3 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/object/Object.is<i32> (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.eq
  )
- (func $~lib/object/Object.is<bool> (; 4 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/object/Object.is<bool> (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.const 0
   i32.ne
@@ -74,13 +74,13 @@
   i32.ne
   i32.eq
  )
- (func $~lib/rt/stub/__retain (; 5 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/stub/__retain (param $0 i32) (result i32)
   local.get $0
  )
- (func $~lib/rt/stub/__release (; 6 ;) (param $0 i32)
+ (func $~lib/rt/stub/__release (param $0 i32)
   nop
  )
- (func $~lib/string/String#get:length (; 7 ;) (param $0 i32) (result i32)
+ (func $~lib/string/String#get:length (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub
@@ -88,7 +88,7 @@
   i32.const 1
   i32.shr_u
  )
- (func $~lib/util/string/compareImpl (; 8 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
+ (func $~lib/util/string/compareImpl (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
@@ -210,7 +210,7 @@
   call $~lib/rt/stub/__release
   local.get $7
  )
- (func $~lib/string/String.__eq (; 9 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__eq (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -283,7 +283,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $~lib/object/Object.is<~lib/string/String> (; 10 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/object/Object.is<~lib/string/String> (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/stub/__retain
@@ -301,7 +301,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $~lib/object/Object.is<~lib/string/String | null> (; 11 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/object/Object.is<~lib/string/String | null> (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/stub/__retain
@@ -319,7 +319,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $start:std/object (; 12 ;)
+ (func $start:std/object
   f64.const 0
   f64.const 0
   call $~lib/object/Object.is<f64>
@@ -881,7 +881,7 @@
    unreachable
   end
  )
- (func $~start (; 13 ;)
+ (func $~start
   call $start:std/object
  )
 )

--- a/tests/compiler/std/operator-overloading.optimized.wat
+++ b/tests/compiler/std/operator-overloading.optimized.wat
@@ -8,7 +8,6 @@
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 1024) "6\00\00\00\01\00\00\00\01\00\00\006\00\00\00s\00t\00d\00/\00o\00p\00e\00r\00a\00t\00o\00r\00-\00o\00v\00e\00r\00l\00o\00a\00d\00i\00n\00g\00.\00t\00s")
- (global $~lib/rt/stub/startOffset (mut i32) (i32.const 0))
  (global $~lib/rt/stub/offset (mut i32) (i32.const 0))
  (global $std/operator-overloading/a1 (mut i32) (i32.const 0))
  (global $std/operator-overloading/a2 (mut i32) (i32.const 0))
@@ -78,7 +77,7 @@
  (global $std/operator-overloading/aii (mut i32) (i32.const 0))
  (export "memory" (memory $0))
  (start $~start)
- (func $~lib/rt/stub/__alloc (; 1 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/stub/__alloc (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -144,7 +143,7 @@
   i32.store offset=12
   local.get $3
  )
- (func $std/operator-overloading/Tester#constructor (; 2 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/operator-overloading/Tester#constructor (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   i32.const 3
   call $~lib/rt/stub/__alloc
@@ -156,7 +155,7 @@
   i32.store offset=4
   local.get $2
  )
- (func $~lib/math/NativeMath.scalbn (; 3 ;) (param $0 f64) (param $1 i32) (result f64)
+ (func $~lib/math/NativeMath.scalbn (param $0 f64) (param $1 i32) (result f64)
   local.get $1
   i32.const 1023
   i32.gt_s
@@ -233,7 +232,7 @@
   f64.reinterpret_i64
   f64.mul
  )
- (func $~lib/math/NativeMath.pow (; 4 ;) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.pow (param $0 f64) (param $1 f64) (result f64)
   (local $2 f64)
   (local $3 f64)
   (local $4 i32)
@@ -1178,7 +1177,7 @@
   f64.const 1e-300
   f64.mul
  )
- (func $std/operator-overloading/Tester.equals (; 5 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/operator-overloading/Tester.equals (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load
   local.get $1
@@ -1194,7 +1193,7 @@
    i32.const 0
   end
  )
- (func $std/operator-overloading/Tester.notEquals (; 6 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/operator-overloading/Tester.notEquals (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load
   local.get $1
@@ -1210,7 +1209,7 @@
    i32.const 0
   end
  )
- (func $std/operator-overloading/TesterInlineStatic#constructor (; 7 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/operator-overloading/TesterInlineStatic#constructor (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   i32.const 4
   call $~lib/rt/stub/__alloc
@@ -1222,7 +1221,7 @@
   i32.store offset=4
   local.get $2
  )
- (func $std/operator-overloading/TesterInlineInstance#constructor (; 8 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/operator-overloading/TesterInlineInstance#constructor (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   i32.const 5
   call $~lib/rt/stub/__alloc
@@ -1234,11 +1233,9 @@
   i32.store offset=4
   local.get $2
  )
- (func $start:std/operator-overloading (; 9 ;)
+ (func $start:std/operator-overloading
   (local $0 i32)
   (local $1 i32)
-  i32.const 1104
-  global.set $~lib/rt/stub/startOffset
   i32.const 1104
   global.set $~lib/rt/stub/offset
   i32.const 1
@@ -2411,7 +2408,7 @@
    unreachable
   end
  )
- (func $~start (; 10 ;)
+ (func $~start
   call $start:std/operator-overloading
  )
 )

--- a/tests/compiler/std/operator-overloading.untouched.wat
+++ b/tests/compiler/std/operator-overloading.untouched.wat
@@ -86,7 +86,7 @@
  (global $~lib/heap/__heap_base i32 (i32.const 6272))
  (export "memory" (memory $0))
  (start $~start)
- (func $~lib/rt/stub/maybeGrowMemory (; 1 ;) (param $0 i32)
+ (func $~lib/rt/stub/maybeGrowMemory (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -140,7 +140,7 @@
   local.get $0
   global.set $~lib/rt/stub/offset
  )
- (func $~lib/rt/stub/__alloc (; 2 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/stub/__alloc (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -193,10 +193,10 @@
   i32.store offset=12
   local.get $2
  )
- (func $~lib/rt/stub/__retain (; 3 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/stub/__retain (param $0 i32) (result i32)
   local.get $0
  )
- (func $std/operator-overloading/Tester#constructor (; 4 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/operator-overloading/Tester#constructor (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -214,10 +214,10 @@
   i32.store offset=4
   local.get $0
  )
- (func $~lib/rt/stub/__release (; 5 ;) (param $0 i32)
+ (func $~lib/rt/stub/__release (param $0 i32)
   nop
  )
- (func $std/operator-overloading/Tester.add (; 6 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/operator-overloading/Tester.add (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/stub/__retain
@@ -244,7 +244,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $std/operator-overloading/Tester.sub (; 7 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/operator-overloading/Tester.sub (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/stub/__retain
@@ -271,7 +271,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $std/operator-overloading/Tester.mul (; 8 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/operator-overloading/Tester.mul (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/stub/__retain
@@ -298,7 +298,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $std/operator-overloading/Tester.div (; 9 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/operator-overloading/Tester.div (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/stub/__retain
@@ -325,7 +325,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $std/operator-overloading/Tester.mod (; 10 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/operator-overloading/Tester.mod (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/stub/__retain
@@ -352,7 +352,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $~lib/math/NativeMath.pow (; 11 ;) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.pow (param $0 f64) (param $1 f64) (result f64)
   (local $2 f64)
   (local $3 f64)
   (local $4 i32)
@@ -1312,7 +1312,7 @@
   end
   return
  )
- (func $std/operator-overloading/Tester.pow (; 12 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/operator-overloading/Tester.pow (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/stub/__retain
@@ -1345,7 +1345,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $std/operator-overloading/Tester.and (; 13 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/operator-overloading/Tester.and (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/stub/__retain
@@ -1372,7 +1372,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $std/operator-overloading/Tester.or (; 14 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/operator-overloading/Tester.or (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/stub/__retain
@@ -1399,7 +1399,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $std/operator-overloading/Tester.xor (; 15 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/operator-overloading/Tester.xor (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/stub/__retain
@@ -1426,7 +1426,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $std/operator-overloading/Tester.equals (; 16 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/operator-overloading/Tester.equals (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/stub/__retain
@@ -1455,7 +1455,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $std/operator-overloading/Tester.notEquals (; 17 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/operator-overloading/Tester.notEquals (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/stub/__retain
@@ -1484,7 +1484,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $std/operator-overloading/Tester.greater (; 18 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/operator-overloading/Tester.greater (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/stub/__retain
@@ -1513,7 +1513,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $std/operator-overloading/Tester.greaterEquals (; 19 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/operator-overloading/Tester.greaterEquals (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/stub/__retain
@@ -1542,7 +1542,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $std/operator-overloading/Tester.less (; 20 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/operator-overloading/Tester.less (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/stub/__retain
@@ -1571,7 +1571,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $std/operator-overloading/Tester.lessEquals (; 21 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/operator-overloading/Tester.lessEquals (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/stub/__retain
@@ -1600,7 +1600,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $std/operator-overloading/Tester.shr (; 22 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/operator-overloading/Tester.shr (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/stub/__retain
@@ -1620,7 +1620,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $std/operator-overloading/Tester.shu (; 23 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/operator-overloading/Tester.shu (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/stub/__retain
@@ -1640,7 +1640,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $std/operator-overloading/Tester.shl (; 24 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/operator-overloading/Tester.shl (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/stub/__retain
@@ -1660,7 +1660,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $std/operator-overloading/Tester.pos (; 25 ;) (param $0 i32) (result i32)
+ (func $std/operator-overloading/Tester.pos (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   call $~lib/rt/stub/__retain
@@ -1676,7 +1676,7 @@
   call $~lib/rt/stub/__release
   local.get $1
  )
- (func $std/operator-overloading/Tester.neg (; 26 ;) (param $0 i32) (result i32)
+ (func $std/operator-overloading/Tester.neg (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   call $~lib/rt/stub/__retain
@@ -1696,7 +1696,7 @@
   call $~lib/rt/stub/__release
   local.get $1
  )
- (func $std/operator-overloading/Tester.not (; 27 ;) (param $0 i32) (result i32)
+ (func $std/operator-overloading/Tester.not (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   call $~lib/rt/stub/__retain
@@ -1716,7 +1716,7 @@
   call $~lib/rt/stub/__release
   local.get $1
  )
- (func $std/operator-overloading/Tester.excl (; 28 ;) (param $0 i32) (result i32)
+ (func $std/operator-overloading/Tester.excl (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   call $~lib/rt/stub/__retain
@@ -1736,7 +1736,7 @@
   call $~lib/rt/stub/__release
   local.get $1
  )
- (func $std/operator-overloading/Tester#inc (; 29 ;) (param $0 i32) (result i32)
+ (func $std/operator-overloading/Tester#inc (param $0 i32) (result i32)
   local.get $0
   local.get $0
   i32.load
@@ -1752,7 +1752,7 @@
   local.get $0
   call $~lib/rt/stub/__retain
  )
- (func $std/operator-overloading/Tester#dec (; 30 ;) (param $0 i32) (result i32)
+ (func $std/operator-overloading/Tester#dec (param $0 i32) (result i32)
   local.get $0
   local.get $0
   i32.load
@@ -1768,7 +1768,7 @@
   local.get $0
   call $~lib/rt/stub/__retain
  )
- (func $std/operator-overloading/Tester#postInc (; 31 ;) (param $0 i32) (result i32)
+ (func $std/operator-overloading/Tester#postInc (param $0 i32) (result i32)
   i32.const 0
   local.get $0
   i32.load
@@ -1780,7 +1780,7 @@
   i32.add
   call $std/operator-overloading/Tester#constructor
  )
- (func $std/operator-overloading/Tester#postDec (; 32 ;) (param $0 i32) (result i32)
+ (func $std/operator-overloading/Tester#postDec (param $0 i32) (result i32)
   i32.const 0
   local.get $0
   i32.load
@@ -1792,7 +1792,7 @@
   i32.sub
   call $std/operator-overloading/Tester#constructor
  )
- (func $std/operator-overloading/TesterInlineStatic#constructor (; 33 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/operator-overloading/TesterInlineStatic#constructor (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -1810,7 +1810,7 @@
   i32.store offset=4
   local.get $0
  )
- (func $std/operator-overloading/TesterInlineInstance#constructor (; 34 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/operator-overloading/TesterInlineInstance#constructor (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -1828,7 +1828,7 @@
   i32.store offset=4
   local.get $0
  )
- (func $start:std/operator-overloading (; 35 ;)
+ (func $start:std/operator-overloading
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -3080,7 +3080,7 @@
   local.get $22
   call $~lib/rt/stub/__release
  )
- (func $~start (; 36 ;)
+ (func $~start
   call $start:std/operator-overloading
  )
 )

--- a/tests/compiler/std/pointer.optimized.wat
+++ b/tests/compiler/std/pointer.optimized.wat
@@ -13,7 +13,7 @@
  (global $std/pointer/buf (mut i32) (i32.const 0))
  (export "memory" (memory $0))
  (start $~start)
- (func $~lib/memory/memory.copy (; 1 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/memory/memory.copy (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -187,7 +187,7 @@
    end
   end
  )
- (func $start:std/pointer (; 2 ;)
+ (func $start:std/pointer
   (local $0 i32)
   (local $1 i32)
   i32.const 8
@@ -566,7 +566,7 @@
    unreachable
   end
  )
- (func $~start (; 3 ;)
+ (func $~start
   call $start:std/pointer
  )
 )

--- a/tests/compiler/std/pointer.untouched.wat
+++ b/tests/compiler/std/pointer.untouched.wat
@@ -17,13 +17,13 @@
  (global $std/pointer/buf (mut i32) (i32.const 0))
  (export "memory" (memory $0))
  (start $~start)
- (func $~lib/rt/stub/__retain (; 1 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/stub/__retain (param $0 i32) (result i32)
   local.get $0
  )
- (func $~lib/rt/stub/__release (; 2 ;) (param $0 i32)
+ (func $~lib/rt/stub/__release (param $0 i32)
   nop
  )
- (func $~lib/memory/memory.fill (; 3 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/memory/memory.fill (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -232,7 +232,7 @@
    end
   end
  )
- (func $~lib/util/memory/memcpy (; 4 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/memory/memcpy (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1256,7 +1256,7 @@
    i32.store8
   end
  )
- (func $~lib/memory/memory.copy (; 5 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/memory/memory.copy (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1476,7 +1476,7 @@
    end
   end
  )
- (func $start:std/pointer (; 6 ;)
+ (func $start:std/pointer
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -2142,7 +2142,7 @@
   local.get $5
   call $~lib/rt/stub/__release
  )
- (func $~start (; 7 ;)
+ (func $~start
   call $start:std/pointer
  )
 )

--- a/tests/compiler/std/polyfills.untouched.wat
+++ b/tests/compiler/std/polyfills.untouched.wat
@@ -9,15 +9,15 @@
  (table $0 1 funcref)
  (export "memory" (memory $0))
  (start $~start)
- (func $~lib/polyfills/bswap<u8> (; 1 ;) (param $0 i32) (result i32)
+ (func $~lib/polyfills/bswap<u8> (param $0 i32) (result i32)
   local.get $0
   return
  )
- (func $~lib/polyfills/bswap<i8> (; 2 ;) (param $0 i32) (result i32)
+ (func $~lib/polyfills/bswap<i8> (param $0 i32) (result i32)
   local.get $0
   return
  )
- (func $~lib/polyfills/bswap<u16> (; 3 ;) (param $0 i32) (result i32)
+ (func $~lib/polyfills/bswap<u16> (param $0 i32) (result i32)
   local.get $0
   i32.const 8
   i32.shl
@@ -31,7 +31,7 @@
   i32.or
   return
  )
- (func $~lib/polyfills/bswap<i16> (; 4 ;) (param $0 i32) (result i32)
+ (func $~lib/polyfills/bswap<i16> (param $0 i32) (result i32)
   local.get $0
   i32.const 8
   i32.shl
@@ -47,7 +47,7 @@
   i32.or
   return
  )
- (func $~lib/polyfills/bswap<u32> (; 5 ;) (param $0 i32) (result i32)
+ (func $~lib/polyfills/bswap<u32> (param $0 i32) (result i32)
   local.get $0
   i32.const -16711936
   i32.and
@@ -61,7 +61,7 @@
   i32.or
   return
  )
- (func $~lib/polyfills/bswap<i32> (; 6 ;) (param $0 i32) (result i32)
+ (func $~lib/polyfills/bswap<i32> (param $0 i32) (result i32)
   local.get $0
   i32.const -16711936
   i32.and
@@ -75,7 +75,7 @@
   i32.or
   return
  )
- (func $~lib/polyfills/bswap<u64> (; 7 ;) (param $0 i64) (result i64)
+ (func $~lib/polyfills/bswap<u64> (param $0 i64) (result i64)
   (local $1 i64)
   (local $2 i64)
   (local $3 i64)
@@ -114,7 +114,7 @@
   i64.rotr
   return
  )
- (func $~lib/polyfills/bswap<i64> (; 8 ;) (param $0 i64) (result i64)
+ (func $~lib/polyfills/bswap<i64> (param $0 i64) (result i64)
   (local $1 i64)
   (local $2 i64)
   (local $3 i64)
@@ -153,7 +153,7 @@
   i64.rotr
   return
  )
- (func $~lib/polyfills/bswap<usize> (; 9 ;) (param $0 i32) (result i32)
+ (func $~lib/polyfills/bswap<usize> (param $0 i32) (result i32)
   local.get $0
   i32.const -16711936
   i32.and
@@ -167,7 +167,7 @@
   i32.or
   return
  )
- (func $~lib/polyfills/bswap<isize> (; 10 ;) (param $0 i32) (result i32)
+ (func $~lib/polyfills/bswap<isize> (param $0 i32) (result i32)
   local.get $0
   i32.const -16711936
   i32.and
@@ -181,15 +181,15 @@
   i32.or
   return
  )
- (func $~lib/polyfills/bswap16<u8> (; 11 ;) (param $0 i32) (result i32)
+ (func $~lib/polyfills/bswap16<u8> (param $0 i32) (result i32)
   local.get $0
   return
  )
- (func $~lib/polyfills/bswap16<i8> (; 12 ;) (param $0 i32) (result i32)
+ (func $~lib/polyfills/bswap16<i8> (param $0 i32) (result i32)
   local.get $0
   return
  )
- (func $~lib/polyfills/bswap16<u16> (; 13 ;) (param $0 i32) (result i32)
+ (func $~lib/polyfills/bswap16<u16> (param $0 i32) (result i32)
   local.get $0
   i32.const 8
   i32.shl
@@ -203,7 +203,7 @@
   i32.or
   return
  )
- (func $~lib/polyfills/bswap16<i16> (; 14 ;) (param $0 i32) (result i32)
+ (func $~lib/polyfills/bswap16<i16> (param $0 i32) (result i32)
   local.get $0
   i32.const 8
   i32.shl
@@ -219,7 +219,7 @@
   i32.or
   return
  )
- (func $~lib/polyfills/bswap16<u32> (; 15 ;) (param $0 i32) (result i32)
+ (func $~lib/polyfills/bswap16<u32> (param $0 i32) (result i32)
   local.get $0
   i32.const 8
   i32.shl
@@ -237,7 +237,7 @@
   i32.or
   return
  )
- (func $~lib/polyfills/bswap16<i32> (; 16 ;) (param $0 i32) (result i32)
+ (func $~lib/polyfills/bswap16<i32> (param $0 i32) (result i32)
   local.get $0
   i32.const 8
   i32.shl
@@ -255,7 +255,7 @@
   i32.or
   return
  )
- (func $start:std/polyfills (; 17 ;)
+ (func $start:std/polyfills
   i32.const 170
   call $~lib/polyfills/bswap<u8>
   i32.const 255
@@ -489,7 +489,7 @@
    unreachable
   end
  )
- (func $~start (; 18 ;)
+ (func $~start
   call $start:std/polyfills
  )
 )

--- a/tests/compiler/std/set.optimized.wat
+++ b/tests/compiler/std/set.optimized.wat
@@ -41,7 +41,7 @@
  (global $~lib/rt/tlsf/collectLock (mut i32) (i32.const 0))
  (export "memory" (memory $0))
  (start $~start)
- (func $~lib/rt/tlsf/removeBlock (; 6 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/removeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -203,7 +203,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/insertBlock (; 7 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/insertBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -482,7 +482,7 @@
   i32.or
   i32.store offset=4
  )
- (func $~lib/rt/tlsf/addMemory (; 8 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $2
@@ -596,7 +596,7 @@
   local.get $1
   call $~lib/rt/tlsf/insertBlock
  )
- (func $~lib/rt/tlsf/maybeInitialize (; 9 ;) (result i32)
+ (func $~lib/rt/tlsf/maybeInitialize (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -683,7 +683,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/tlsf/prepareSize (; 10 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/tlsf/prepareSize (param $0 i32) (result i32)
   local.get $0
   i32.const 1073741808
   i32.ge_u
@@ -707,7 +707,7 @@
   i32.gt_u
   select
  )
- (func $~lib/rt/tlsf/searchBlock (; 11 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/searchBlock (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   i32.const 256
@@ -836,7 +836,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/prepareBlock (; 12 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/rt/tlsf/prepareBlock (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $1
@@ -911,7 +911,7 @@
    i32.store
   end
  )
- (func $~lib/rt/tlsf/allocateBlock (; 13 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/allocateBlock (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1051,7 +1051,7 @@
   call $~lib/rt/rtrace/onalloc
   local.get $3
  )
- (func $~lib/rt/tlsf/__alloc (; 14 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/__alloc (param $0 i32) (param $1 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
   local.get $0
   local.get $1
@@ -1059,7 +1059,7 @@
   i32.const 16
   i32.add
  )
- (func $~lib/rt/pure/__retain (; 15 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/pure/__retain (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -1110,7 +1110,7 @@
   end
   local.get $0
  )
- (func $~lib/memory/memory.fill (; 16 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/memory/memory.fill (param $0 i32) (param $1 i32)
   (local $2 i32)
   block $~lib/util/memory/memset|inlined.0
    local.get $1
@@ -1268,7 +1268,7 @@
    end
   end
  )
- (func $~lib/arraybuffer/ArrayBuffer#constructor (; 17 ;) (param $0 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBuffer#constructor (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   i32.const 1073741808
@@ -1290,7 +1290,7 @@
   local.get $1
   call $~lib/rt/pure/__retain
  )
- (func $~lib/rt/pure/__release (; 18 ;) (param $0 i32)
+ (func $~lib/rt/pure/__release (param $0 i32)
   local.get $0
   i32.const 1444
   i32.gt_u
@@ -1301,7 +1301,7 @@
    call $~lib/rt/pure/decrement
   end
  )
- (func $~lib/set/Set<i8>#clear (; 19 ;) (param $0 i32)
+ (func $~lib/set/Set<i8>#clear (param $0 i32)
   (local $1 i32)
   i32.const 16
   call $~lib/arraybuffer/ArrayBuffer#constructor
@@ -1334,7 +1334,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/set/Set<i8>#constructor (; 20 ;) (result i32)
+ (func $~lib/set/Set<i8>#constructor (result i32)
   (local $0 i32)
   i32.const 24
   i32.const 3
@@ -1362,14 +1362,14 @@
   call $~lib/set/Set<i8>#clear
   local.get $0
  )
- (func $~lib/util/hash/hash8 (; 21 ;) (param $0 i32) (result i32)
+ (func $~lib/util/hash/hash8 (param $0 i32) (result i32)
   local.get $0
   i32.const -2128831035
   i32.xor
   i32.const 16777619
   i32.mul
  )
- (func $~lib/set/Set<i8>#find (; 22 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/set/Set<i8>#find (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.load
   local.get $2
@@ -1412,7 +1412,7 @@
   end
   i32.const 0
  )
- (func $~lib/set/Set<i8>#has (; 23 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/set/Set<i8>#has (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -1425,7 +1425,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/set/Set<i8>#rehash (; 24 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<i8>#rehash (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1556,7 +1556,7 @@
   local.get $3
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<i8>#add (; 25 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/set/Set<i8>#add (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1643,7 +1643,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/memory/memory.copy (; 26 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/memory/memory.copy (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   block $~lib/util/memory/memmove|inlined.0
@@ -1816,7 +1816,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/freeBlock (; 27 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/freeBlock (param $0 i32) (param $1 i32)
   local.get $1
   local.get $1
   i32.load
@@ -1829,7 +1829,7 @@
   local.get $1
   call $~lib/rt/rtrace/onfree
  )
- (func $~lib/rt/tlsf/reallocateBlock (; 28 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/reallocateBlock (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1932,7 +1932,7 @@
   end
   local.get $3
  )
- (func $~lib/array/ensureSize (; 29 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/ensureSize (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2033,7 +2033,7 @@
    i32.store offset=8
   end
  )
- (func $~lib/array/Array<i8>#__set (; 30 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<i8>#__set (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $1
   local.get $0
@@ -2069,7 +2069,7 @@
   local.get $2
   i32.store8
  )
- (func $~lib/set/Set<i8>#values (; 31 ;) (param $0 i32) (result i32)
+ (func $~lib/set/Set<i8>#values (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -2179,7 +2179,7 @@
   end
   local.get $0
  )
- (func $~lib/array/Array<i8>#__get (; 32 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i8>#__get (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -2198,7 +2198,7 @@
   i32.add
   i32.load8_s
  )
- (func $~lib/set/Set<i8>#delete (; 33 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<i8>#delete (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -2261,7 +2261,7 @@
    call $~lib/set/Set<i8>#rehash
   end
  )
- (func $std/set/testNumeric<i8> (; 34 ;)
+ (func $std/set/testNumeric<i8>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -2578,7 +2578,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<u8>#constructor (; 35 ;) (result i32)
+ (func $~lib/set/Set<u8>#constructor (result i32)
   (local $0 i32)
   i32.const 24
   i32.const 5
@@ -2606,7 +2606,7 @@
   call $~lib/set/Set<i8>#clear
   local.get $0
  )
- (func $~lib/set/Set<u8>#has (; 36 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/set/Set<u8>#has (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -2617,7 +2617,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/set/Set<u8>#rehash (; 37 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<u8>#rehash (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2748,7 +2748,7 @@
   local.get $3
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<u8>#add (; 38 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/set/Set<u8>#add (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2833,7 +2833,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/set/Set<u8>#values (; 39 ;) (param $0 i32) (result i32)
+ (func $~lib/set/Set<u8>#values (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -2943,7 +2943,7 @@
   end
   local.get $0
  )
- (func $~lib/array/Array<u8>#__get (; 40 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u8>#__get (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -2962,7 +2962,7 @@
   i32.add
   i32.load8_u
  )
- (func $~lib/set/Set<u8>#delete (; 41 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<u8>#delete (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -3023,7 +3023,7 @@
    call $~lib/set/Set<u8>#rehash
   end
  )
- (func $std/set/testNumeric<u8> (; 42 ;)
+ (func $std/set/testNumeric<u8>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -3332,7 +3332,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<i16>#constructor (; 43 ;) (result i32)
+ (func $~lib/set/Set<i16>#constructor (result i32)
   (local $0 i32)
   i32.const 24
   i32.const 7
@@ -3360,7 +3360,7 @@
   call $~lib/set/Set<i8>#clear
   local.get $0
  )
- (func $~lib/util/hash/hash16 (; 44 ;) (param $0 i32) (result i32)
+ (func $~lib/util/hash/hash16 (param $0 i32) (result i32)
   local.get $0
   i32.const 255
   i32.and
@@ -3375,7 +3375,7 @@
   i32.const 16777619
   i32.mul
  )
- (func $~lib/set/Set<i16>#find (; 45 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/set/Set<i16>#find (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.load
   local.get $2
@@ -3418,7 +3418,7 @@
   end
   i32.const 0
  )
- (func $~lib/set/Set<i16>#has (; 46 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/set/Set<i16>#has (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -3431,7 +3431,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/set/Set<i16>#rehash (; 47 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<i16>#rehash (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3562,7 +3562,7 @@
   local.get $3
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<i16>#add (; 48 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/set/Set<i16>#add (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3649,7 +3649,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/array/Array<i16>#__set (; 49 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<i16>#__set (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $1
   local.get $0
@@ -3687,7 +3687,7 @@
   local.get $2
   i32.store16
  )
- (func $~lib/set/Set<i16>#values (; 50 ;) (param $0 i32) (result i32)
+ (func $~lib/set/Set<i16>#values (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -3802,7 +3802,7 @@
   end
   local.get $0
  )
- (func $~lib/array/Array<i16>#__get (; 51 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i16>#__get (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -3823,7 +3823,7 @@
   i32.add
   i32.load16_s
  )
- (func $~lib/set/Set<i16>#delete (; 52 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<i16>#delete (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -3886,7 +3886,7 @@
    call $~lib/set/Set<i16>#rehash
   end
  )
- (func $std/set/testNumeric<i16> (; 53 ;)
+ (func $std/set/testNumeric<i16>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -4203,7 +4203,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<u16>#constructor (; 54 ;) (result i32)
+ (func $~lib/set/Set<u16>#constructor (result i32)
   (local $0 i32)
   i32.const 24
   i32.const 9
@@ -4231,7 +4231,7 @@
   call $~lib/set/Set<i8>#clear
   local.get $0
  )
- (func $~lib/set/Set<u16>#has (; 55 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/set/Set<u16>#has (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -4242,7 +4242,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/set/Set<u16>#rehash (; 56 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<u16>#rehash (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4373,7 +4373,7 @@
   local.get $3
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<u16>#add (; 57 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/set/Set<u16>#add (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4458,7 +4458,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/set/Set<u16>#values (; 58 ;) (param $0 i32) (result i32)
+ (func $~lib/set/Set<u16>#values (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -4573,7 +4573,7 @@
   end
   local.get $0
  )
- (func $~lib/array/Array<u16>#__get (; 59 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u16>#__get (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -4594,7 +4594,7 @@
   i32.add
   i32.load16_u
  )
- (func $~lib/set/Set<u16>#delete (; 60 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<u16>#delete (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -4655,7 +4655,7 @@
    call $~lib/set/Set<u16>#rehash
   end
  )
- (func $std/set/testNumeric<u16> (; 61 ;)
+ (func $std/set/testNumeric<u16>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -4964,7 +4964,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<i32>#constructor (; 62 ;) (result i32)
+ (func $~lib/set/Set<i32>#constructor (result i32)
   (local $0 i32)
   i32.const 24
   i32.const 11
@@ -4992,7 +4992,7 @@
   call $~lib/set/Set<i8>#clear
   local.get $0
  )
- (func $~lib/util/hash/hash32 (; 63 ;) (param $0 i32) (result i32)
+ (func $~lib/util/hash/hash32 (param $0 i32) (result i32)
   local.get $0
   i32.const 255
   i32.and
@@ -5023,7 +5023,7 @@
   i32.const 16777619
   i32.mul
  )
- (func $~lib/set/Set<i32>#find (; 64 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/set/Set<i32>#find (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.load
   local.get $2
@@ -5064,7 +5064,7 @@
   end
   i32.const 0
  )
- (func $~lib/set/Set<i32>#has (; 65 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/set/Set<i32>#has (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -5073,7 +5073,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/set/Set<i32>#rehash (; 66 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<i32>#rehash (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5204,7 +5204,7 @@
   local.get $3
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<i32>#add (; 67 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/set/Set<i32>#add (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5287,7 +5287,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/array/Array<i32>#__set (; 68 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<i32>#__set (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $1
   local.get $0
@@ -5325,7 +5325,7 @@
   local.get $2
   i32.store
  )
- (func $~lib/set/Set<i32>#values (; 69 ;) (param $0 i32) (result i32)
+ (func $~lib/set/Set<i32>#values (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -5440,7 +5440,7 @@
   end
   local.get $0
  )
- (func $~lib/array/Array<i32>#__get (; 70 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#__get (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -5461,7 +5461,7 @@
   i32.add
   i32.load
  )
- (func $~lib/set/Set<i32>#delete (; 71 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<i32>#delete (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -5520,7 +5520,7 @@
    call $~lib/set/Set<i32>#rehash
   end
  )
- (func $std/set/testNumeric<i32> (; 72 ;)
+ (func $std/set/testNumeric<i32>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -5821,7 +5821,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<u32>#constructor (; 73 ;) (result i32)
+ (func $~lib/set/Set<u32>#constructor (result i32)
   (local $0 i32)
   i32.const 24
   i32.const 13
@@ -5849,7 +5849,7 @@
   call $~lib/set/Set<i8>#clear
   local.get $0
  )
- (func $~lib/set/Set<u32>#values (; 74 ;) (param $0 i32) (result i32)
+ (func $~lib/set/Set<u32>#values (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -5964,7 +5964,7 @@
   end
   local.get $0
  )
- (func $std/set/testNumeric<u32> (; 75 ;)
+ (func $std/set/testNumeric<u32>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -6265,7 +6265,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<i64>#clear (; 76 ;) (param $0 i32)
+ (func $~lib/set/Set<i64>#clear (param $0 i32)
   (local $1 i32)
   i32.const 16
   call $~lib/arraybuffer/ArrayBuffer#constructor
@@ -6298,7 +6298,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/set/Set<i64>#constructor (; 77 ;) (result i32)
+ (func $~lib/set/Set<i64>#constructor (result i32)
   (local $0 i32)
   i32.const 24
   i32.const 15
@@ -6326,7 +6326,7 @@
   call $~lib/set/Set<i64>#clear
   local.get $0
  )
- (func $~lib/util/hash/hash64 (; 78 ;) (param $0 i64) (result i32)
+ (func $~lib/util/hash/hash64 (param $0 i64) (result i32)
   (local $1 i32)
   local.get $0
   i32.wrap_i64
@@ -6392,7 +6392,7 @@
   i32.const 16777619
   i32.mul
  )
- (func $~lib/set/Set<i64>#find (; 79 ;) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
+ (func $~lib/set/Set<i64>#find (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
   local.get $0
   i32.load
   local.get $2
@@ -6433,7 +6433,7 @@
   end
   i32.const 0
  )
- (func $~lib/set/Set<i64>#has (; 80 ;) (param $0 i32) (param $1 i64) (result i32)
+ (func $~lib/set/Set<i64>#has (param $0 i32) (param $1 i64) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -6442,7 +6442,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/set/Set<i64>#rehash (; 81 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<i64>#rehash (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6573,7 +6573,7 @@
   local.get $3
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<i64>#add (; 82 ;) (param $0 i32) (param $1 i64) (result i32)
+ (func $~lib/set/Set<i64>#add (param $0 i32) (param $1 i64) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6656,7 +6656,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/array/Array<i64>#__set (; 83 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $~lib/array/Array<i64>#__set (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   local.get $1
   local.get $0
@@ -6694,7 +6694,7 @@
   local.get $2
   i64.store
  )
- (func $~lib/set/Set<i64>#values (; 84 ;) (param $0 i32) (result i32)
+ (func $~lib/set/Set<i64>#values (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -6809,7 +6809,7 @@
   end
   local.get $0
  )
- (func $~lib/array/Array<i64>#__get (; 85 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $~lib/array/Array<i64>#__get (param $0 i32) (param $1 i32) (result i64)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -6830,7 +6830,7 @@
   i32.add
   i64.load
  )
- (func $~lib/set/Set<i64>#delete (; 86 ;) (param $0 i32) (param $1 i64)
+ (func $~lib/set/Set<i64>#delete (param $0 i32) (param $1 i64)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -6890,7 +6890,7 @@
    call $~lib/set/Set<i64>#rehash
   end
  )
- (func $std/set/testNumeric<i64> (; 87 ;)
+ (func $std/set/testNumeric<i64>
   (local $0 i64)
   (local $1 i32)
   (local $2 i32)
@@ -7192,7 +7192,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<u64>#constructor (; 88 ;) (result i32)
+ (func $~lib/set/Set<u64>#constructor (result i32)
   (local $0 i32)
   i32.const 24
   i32.const 17
@@ -7220,7 +7220,7 @@
   call $~lib/set/Set<i64>#clear
   local.get $0
  )
- (func $~lib/set/Set<u64>#values (; 89 ;) (param $0 i32) (result i32)
+ (func $~lib/set/Set<u64>#values (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -7335,7 +7335,7 @@
   end
   local.get $0
  )
- (func $std/set/testNumeric<u64> (; 90 ;)
+ (func $std/set/testNumeric<u64>
   (local $0 i64)
   (local $1 i32)
   (local $2 i32)
@@ -7637,7 +7637,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<f32>#constructor (; 91 ;) (result i32)
+ (func $~lib/set/Set<f32>#constructor (result i32)
   (local $0 i32)
   i32.const 24
   i32.const 19
@@ -7665,7 +7665,7 @@
   call $~lib/set/Set<i8>#clear
   local.get $0
  )
- (func $~lib/set/Set<f32>#find (; 92 ;) (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
+ (func $~lib/set/Set<f32>#find (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
   local.get $0
   i32.load
   local.get $2
@@ -7706,7 +7706,7 @@
   end
   i32.const 0
  )
- (func $~lib/set/Set<f32>#has (; 93 ;) (param $0 i32) (param $1 f32) (result i32)
+ (func $~lib/set/Set<f32>#has (param $0 i32) (param $1 f32) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -7716,7 +7716,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/set/Set<f32>#rehash (; 94 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<f32>#rehash (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7848,7 +7848,7 @@
   local.get $3
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<f32>#add (; 95 ;) (param $0 i32) (param $1 f32) (result i32)
+ (func $~lib/set/Set<f32>#add (param $0 i32) (param $1 f32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7932,7 +7932,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/set/Set<f32>#values (; 96 ;) (param $0 i32) (result i32)
+ (func $~lib/set/Set<f32>#values (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -8081,7 +8081,7 @@
   end
   local.get $3
  )
- (func $~lib/array/Array<f32>#__get (; 97 ;) (param $0 i32) (param $1 i32) (result f32)
+ (func $~lib/array/Array<f32>#__get (param $0 i32) (param $1 i32) (result f32)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -8102,7 +8102,7 @@
   i32.add
   f32.load
  )
- (func $~lib/set/Set<f32>#delete (; 98 ;) (param $0 i32) (param $1 f32)
+ (func $~lib/set/Set<f32>#delete (param $0 i32) (param $1 f32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -8163,7 +8163,7 @@
    call $~lib/set/Set<f32>#rehash
   end
  )
- (func $std/set/testNumeric<f32> (; 99 ;)
+ (func $std/set/testNumeric<f32>
   (local $0 f32)
   (local $1 i32)
   (local $2 i32)
@@ -8465,7 +8465,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<f64>#constructor (; 100 ;) (result i32)
+ (func $~lib/set/Set<f64>#constructor (result i32)
   (local $0 i32)
   i32.const 24
   i32.const 21
@@ -8493,7 +8493,7 @@
   call $~lib/set/Set<i64>#clear
   local.get $0
  )
- (func $~lib/set/Set<f64>#find (; 101 ;) (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
+ (func $~lib/set/Set<f64>#find (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
   local.get $0
   i32.load
   local.get $2
@@ -8534,7 +8534,7 @@
   end
   i32.const 0
  )
- (func $~lib/set/Set<f64>#has (; 102 ;) (param $0 i32) (param $1 f64) (result i32)
+ (func $~lib/set/Set<f64>#has (param $0 i32) (param $1 f64) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -8544,7 +8544,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/set/Set<f64>#rehash (; 103 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<f64>#rehash (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -8676,7 +8676,7 @@
   local.get $3
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<f64>#add (; 104 ;) (param $0 i32) (param $1 f64) (result i32)
+ (func $~lib/set/Set<f64>#add (param $0 i32) (param $1 f64) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -8760,7 +8760,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/set/Set<f64>#values (; 105 ;) (param $0 i32) (result i32)
+ (func $~lib/set/Set<f64>#values (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -8909,7 +8909,7 @@
   end
   local.get $3
  )
- (func $~lib/array/Array<f64>#__get (; 106 ;) (param $0 i32) (param $1 i32) (result f64)
+ (func $~lib/array/Array<f64>#__get (param $0 i32) (param $1 i32) (result f64)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -8930,7 +8930,7 @@
   i32.add
   f64.load
  )
- (func $~lib/set/Set<f64>#delete (; 107 ;) (param $0 i32) (param $1 f64)
+ (func $~lib/set/Set<f64>#delete (param $0 i32) (param $1 f64)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -8991,7 +8991,7 @@
    call $~lib/set/Set<f64>#rehash
   end
  )
- (func $std/set/testNumeric<f64> (; 108 ;)
+ (func $std/set/testNumeric<f64>
   (local $0 f64)
   (local $1 i32)
   (local $2 i32)
@@ -9293,7 +9293,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~start (; 109 ;)
+ (func $~start
   call $std/set/testNumeric<i8>
   call $std/set/testNumeric<u8>
   call $std/set/testNumeric<i16>
@@ -9305,7 +9305,7 @@
   call $std/set/testNumeric<f32>
   call $std/set/testNumeric<f64>
  )
- (func $~lib/rt/pure/decrement (; 110 ;) (param $0 i32)
+ (func $~lib/rt/pure/decrement (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -9406,7 +9406,7 @@
    i32.store offset=4
   end
  )
- (func $~lib/rt/pure/__visit (; 111 ;) (param $0 i32)
+ (func $~lib/rt/pure/__visit (param $0 i32)
   local.get $0
   i32.const 1444
   i32.lt_u

--- a/tests/compiler/std/set.untouched.wat
+++ b/tests/compiler/std/set.untouched.wat
@@ -45,7 +45,7 @@
  (global $~lib/heap/__heap_base i32 (i32.const 436))
  (export "memory" (memory $0))
  (start $~start)
- (func $~lib/rt/tlsf/removeBlock (; 6 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/removeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -255,7 +255,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/insertBlock (; 7 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/insertBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -605,7 +605,7 @@
   local.get $7
   i32.store offset=4
  )
- (func $~lib/rt/tlsf/addMemory (; 8 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -753,7 +753,7 @@
   call $~lib/rt/tlsf/insertBlock
   i32.const 1
  )
- (func $~lib/rt/tlsf/maybeInitialize (; 9 ;) (result i32)
+ (func $~lib/rt/tlsf/maybeInitialize (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -907,7 +907,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/tlsf/prepareSize (; 10 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/tlsf/prepareSize (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -936,7 +936,7 @@
   i32.gt_u
   select
  )
- (func $~lib/rt/tlsf/searchBlock (; 11 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/searchBlock (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1119,7 +1119,7 @@
   end
   local.get $7
  )
- (func $~lib/rt/tlsf/growMemory (; 12 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/growMemory (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1203,7 +1203,7 @@
   call $~lib/rt/tlsf/addMemory
   drop
  )
- (func $~lib/rt/tlsf/prepareBlock (; 13 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/rt/tlsf/prepareBlock (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1298,7 +1298,7 @@
    i32.store
   end
  )
- (func $~lib/rt/tlsf/allocateBlock (; 14 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/allocateBlock (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   global.get $~lib/rt/tlsf/collectLock
@@ -1409,7 +1409,7 @@
   call $~lib/rt/rtrace/onalloc
   local.get $4
  )
- (func $~lib/rt/tlsf/__alloc (; 15 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/__alloc (param $0 i32) (param $1 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
   local.get $0
   local.get $1
@@ -1417,7 +1417,7 @@
   i32.const 16
   i32.add
  )
- (func $~lib/rt/pure/increment (; 16 ;) (param $0 i32)
+ (func $~lib/rt/pure/increment (param $0 i32)
   (local $1 i32)
   local.get $0
   i32.load offset=4
@@ -1462,7 +1462,7 @@
    unreachable
   end
  )
- (func $~lib/rt/pure/__retain (; 17 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/pure/__retain (param $0 i32) (result i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.gt_u
@@ -1474,7 +1474,7 @@
   end
   local.get $0
  )
- (func $~lib/memory/memory.fill (; 18 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/memory/memory.fill (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1683,7 +1683,7 @@
    end
   end
  )
- (func $~lib/arraybuffer/ArrayBuffer#constructor (; 19 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBuffer#constructor (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   i32.const 1073741808
@@ -1707,7 +1707,7 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~lib/rt/pure/__release (; 20 ;) (param $0 i32)
+ (func $~lib/rt/pure/__release (param $0 i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.gt_u
@@ -1718,7 +1718,7 @@
    call $~lib/rt/pure/decrement
   end
  )
- (func $~lib/set/Set<i8>#clear (; 21 ;) (param $0 i32)
+ (func $~lib/set/Set<i8>#clear (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -1758,7 +1758,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/set/Set<i8>#constructor (; 22 ;) (param $0 i32) (result i32)
+ (func $~lib/set/Set<i8>#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -1790,14 +1790,14 @@
   call $~lib/set/Set<i8>#clear
   local.get $0
  )
- (func $~lib/util/hash/hash8 (; 23 ;) (param $0 i32) (result i32)
+ (func $~lib/util/hash/hash8 (param $0 i32) (result i32)
   i32.const -2128831035
   local.get $0
   i32.xor
   i32.const 16777619
   i32.mul
  )
- (func $~lib/set/Set<i8>#find (; 24 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/set/Set<i8>#find (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -1849,7 +1849,7 @@
   end
   i32.const 0
  )
- (func $~lib/set/Set<i8>#has (; 25 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/set/Set<i8>#has (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -1868,7 +1868,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/set/Set<i8>#rehash (; 26 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<i8>#rehash (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2021,7 +2021,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<i8>#add (; 27 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/set/Set<i8>#add (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2118,11 +2118,11 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/set/Set<i8>#get:size (; 28 ;) (param $0 i32) (result i32)
+ (func $~lib/set/Set<i8>#get:size (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/array/Array<i8>#constructor (; 29 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i8>#constructor (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2200,7 +2200,7 @@
   i32.store offset=12
   local.get $0
  )
- (func $~lib/rt/tlsf/checkUsedBlock (; 30 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/tlsf/checkUsedBlock (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   i32.const 16
@@ -2246,7 +2246,7 @@
   end
   local.get $1
  )
- (func $~lib/util/memory/memcpy (; 31 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/memory/memcpy (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3270,7 +3270,7 @@
    i32.store8
   end
  )
- (func $~lib/memory/memory.copy (; 32 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/memory/memory.copy (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3490,7 +3490,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/freeBlock (; 33 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/freeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $1
   i32.load
@@ -3506,7 +3506,7 @@
   local.get $1
   call $~lib/rt/rtrace/onfree
  )
- (func $~lib/rt/tlsf/reallocateBlock (; 34 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/reallocateBlock (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3625,7 +3625,7 @@
   end
   local.get $8
  )
- (func $~lib/rt/tlsf/__realloc (; 35 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/__realloc (param $0 i32) (param $1 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
   local.get $0
   call $~lib/rt/tlsf/checkUsedBlock
@@ -3634,7 +3634,7 @@
   i32.const 16
   i32.add
  )
- (func $~lib/array/ensureSize (; 36 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/ensureSize (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3696,7 +3696,7 @@
    i32.store offset=8
   end
  )
- (func $~lib/array/Array<i8>#__unchecked_set (; 37 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<i8>#__unchecked_set (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -3706,7 +3706,7 @@
   local.get $2
   i32.store8
  )
- (func $~lib/array/Array<i8>#__set (; 38 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<i8>#__set (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -3740,7 +3740,7 @@
   local.get $2
   call $~lib/array/Array<i8>#__unchecked_set
  )
- (func $~lib/set/Set<i8>#values (; 39 ;) (param $0 i32) (result i32)
+ (func $~lib/set/Set<i8>#values (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -3802,11 +3802,11 @@
   end
   local.get $3
  )
- (func $~lib/array/Array<i8>#get:length (; 40 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<i8>#get:length (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<i8>#__unchecked_get (; 41 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i8>#__unchecked_get (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -3815,7 +3815,7 @@
   i32.add
   i32.load8_s
  )
- (func $~lib/array/Array<i8>#__get (; 42 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i8>#__get (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   local.get $0
@@ -3835,7 +3835,7 @@
   local.set $2
   local.get $2
  )
- (func $~lib/set/Set<i8>#delete (; 43 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/set/Set<i8>#delete (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3911,7 +3911,7 @@
   end
   i32.const 1
  )
- (func $std/set/testNumeric<i8> (; 44 ;)
+ (func $std/set/testNumeric<i8>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -4267,7 +4267,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<u8>#clear (; 45 ;) (param $0 i32)
+ (func $~lib/set/Set<u8>#clear (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -4307,7 +4307,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/set/Set<u8>#constructor (; 46 ;) (param $0 i32) (result i32)
+ (func $~lib/set/Set<u8>#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -4339,7 +4339,7 @@
   call $~lib/set/Set<u8>#clear
   local.get $0
  )
- (func $~lib/set/Set<u8>#find (; 47 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/set/Set<u8>#find (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -4389,7 +4389,7 @@
   end
   i32.const 0
  )
- (func $~lib/set/Set<u8>#has (; 48 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/set/Set<u8>#has (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -4406,7 +4406,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/set/Set<u8>#rehash (; 49 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<u8>#rehash (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4559,7 +4559,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<u8>#add (; 50 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/set/Set<u8>#add (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4654,11 +4654,11 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/set/Set<u8>#get:size (; 51 ;) (param $0 i32) (result i32)
+ (func $~lib/set/Set<u8>#get:size (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/array/Array<u8>#constructor (; 52 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u8>#constructor (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4736,7 +4736,7 @@
   i32.store offset=12
   local.get $0
  )
- (func $~lib/array/Array<u8>#__unchecked_set (; 53 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<u8>#__unchecked_set (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -4746,7 +4746,7 @@
   local.get $2
   i32.store8
  )
- (func $~lib/array/Array<u8>#__set (; 54 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<u8>#__set (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -4780,7 +4780,7 @@
   local.get $2
   call $~lib/array/Array<u8>#__unchecked_set
  )
- (func $~lib/set/Set<u8>#values (; 55 ;) (param $0 i32) (result i32)
+ (func $~lib/set/Set<u8>#values (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -4842,11 +4842,11 @@
   end
   local.get $3
  )
- (func $~lib/array/Array<u8>#get:length (; 56 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<u8>#get:length (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<u8>#__unchecked_get (; 57 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u8>#__unchecked_get (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -4855,7 +4855,7 @@
   i32.add
   i32.load8_u
  )
- (func $~lib/array/Array<u8>#__get (; 58 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u8>#__get (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   local.get $0
@@ -4875,7 +4875,7 @@
   local.set $2
   local.get $2
  )
- (func $~lib/set/Set<u8>#delete (; 59 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/set/Set<u8>#delete (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4949,7 +4949,7 @@
   end
   i32.const 1
  )
- (func $std/set/testNumeric<u8> (; 60 ;)
+ (func $std/set/testNumeric<u8>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -5297,7 +5297,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<i16>#clear (; 61 ;) (param $0 i32)
+ (func $~lib/set/Set<i16>#clear (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -5337,7 +5337,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/set/Set<i16>#constructor (; 62 ;) (param $0 i32) (result i32)
+ (func $~lib/set/Set<i16>#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -5369,7 +5369,7 @@
   call $~lib/set/Set<i16>#clear
   local.get $0
  )
- (func $~lib/util/hash/hash16 (; 63 ;) (param $0 i32) (result i32)
+ (func $~lib/util/hash/hash16 (param $0 i32) (result i32)
   (local $1 i32)
   i32.const -2128831035
   local.set $1
@@ -5391,7 +5391,7 @@
   local.set $1
   local.get $1
  )
- (func $~lib/set/Set<i16>#find (; 64 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/set/Set<i16>#find (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -5443,7 +5443,7 @@
   end
   i32.const 0
  )
- (func $~lib/set/Set<i16>#has (; 65 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/set/Set<i16>#has (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -5462,7 +5462,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/set/Set<i16>#rehash (; 66 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<i16>#rehash (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5615,7 +5615,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<i16>#add (; 67 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/set/Set<i16>#add (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5712,11 +5712,11 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/set/Set<i16>#get:size (; 68 ;) (param $0 i32) (result i32)
+ (func $~lib/set/Set<i16>#get:size (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/array/Array<i16>#constructor (; 69 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i16>#constructor (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5794,7 +5794,7 @@
   i32.store offset=12
   local.get $0
  )
- (func $~lib/array/Array<i16>#__unchecked_set (; 70 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<i16>#__unchecked_set (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -5804,7 +5804,7 @@
   local.get $2
   i32.store16
  )
- (func $~lib/array/Array<i16>#__set (; 71 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<i16>#__set (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -5838,7 +5838,7 @@
   local.get $2
   call $~lib/array/Array<i16>#__unchecked_set
  )
- (func $~lib/set/Set<i16>#values (; 72 ;) (param $0 i32) (result i32)
+ (func $~lib/set/Set<i16>#values (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -5900,11 +5900,11 @@
   end
   local.get $3
  )
- (func $~lib/array/Array<i16>#get:length (; 73 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<i16>#get:length (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<i16>#__unchecked_get (; 74 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i16>#__unchecked_get (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -5913,7 +5913,7 @@
   i32.add
   i32.load16_s
  )
- (func $~lib/array/Array<i16>#__get (; 75 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i16>#__get (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   local.get $0
@@ -5933,7 +5933,7 @@
   local.set $2
   local.get $2
  )
- (func $~lib/set/Set<i16>#delete (; 76 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/set/Set<i16>#delete (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6009,7 +6009,7 @@
   end
   i32.const 1
  )
- (func $std/set/testNumeric<i16> (; 77 ;)
+ (func $std/set/testNumeric<i16>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -6365,7 +6365,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<u16>#clear (; 78 ;) (param $0 i32)
+ (func $~lib/set/Set<u16>#clear (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -6405,7 +6405,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/set/Set<u16>#constructor (; 79 ;) (param $0 i32) (result i32)
+ (func $~lib/set/Set<u16>#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -6437,7 +6437,7 @@
   call $~lib/set/Set<u16>#clear
   local.get $0
  )
- (func $~lib/set/Set<u16>#find (; 80 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/set/Set<u16>#find (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -6487,7 +6487,7 @@
   end
   i32.const 0
  )
- (func $~lib/set/Set<u16>#has (; 81 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/set/Set<u16>#has (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -6504,7 +6504,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/set/Set<u16>#rehash (; 82 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<u16>#rehash (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6657,7 +6657,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<u16>#add (; 83 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/set/Set<u16>#add (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6752,11 +6752,11 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/set/Set<u16>#get:size (; 84 ;) (param $0 i32) (result i32)
+ (func $~lib/set/Set<u16>#get:size (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/array/Array<u16>#constructor (; 85 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u16>#constructor (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6834,7 +6834,7 @@
   i32.store offset=12
   local.get $0
  )
- (func $~lib/array/Array<u16>#__unchecked_set (; 86 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<u16>#__unchecked_set (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -6844,7 +6844,7 @@
   local.get $2
   i32.store16
  )
- (func $~lib/array/Array<u16>#__set (; 87 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<u16>#__set (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -6878,7 +6878,7 @@
   local.get $2
   call $~lib/array/Array<u16>#__unchecked_set
  )
- (func $~lib/set/Set<u16>#values (; 88 ;) (param $0 i32) (result i32)
+ (func $~lib/set/Set<u16>#values (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -6940,11 +6940,11 @@
   end
   local.get $3
  )
- (func $~lib/array/Array<u16>#get:length (; 89 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<u16>#get:length (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<u16>#__unchecked_get (; 90 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u16>#__unchecked_get (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -6953,7 +6953,7 @@
   i32.add
   i32.load16_u
  )
- (func $~lib/array/Array<u16>#__get (; 91 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u16>#__get (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   local.get $0
@@ -6973,7 +6973,7 @@
   local.set $2
   local.get $2
  )
- (func $~lib/set/Set<u16>#delete (; 92 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/set/Set<u16>#delete (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7047,7 +7047,7 @@
   end
   i32.const 1
  )
- (func $std/set/testNumeric<u16> (; 93 ;)
+ (func $std/set/testNumeric<u16>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -7395,7 +7395,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<i32>#clear (; 94 ;) (param $0 i32)
+ (func $~lib/set/Set<i32>#clear (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -7435,7 +7435,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/set/Set<i32>#constructor (; 95 ;) (param $0 i32) (result i32)
+ (func $~lib/set/Set<i32>#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -7467,7 +7467,7 @@
   call $~lib/set/Set<i32>#clear
   local.get $0
  )
- (func $~lib/util/hash/hash32 (; 96 ;) (param $0 i32) (result i32)
+ (func $~lib/util/hash/hash32 (param $0 i32) (result i32)
   (local $1 i32)
   i32.const -2128831035
   local.set $1
@@ -7509,7 +7509,7 @@
   local.set $1
   local.get $1
  )
- (func $~lib/set/Set<i32>#find (; 97 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/set/Set<i32>#find (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -7557,7 +7557,7 @@
   end
   i32.const 0
  )
- (func $~lib/set/Set<i32>#has (; 98 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/set/Set<i32>#has (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -7572,7 +7572,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/set/Set<i32>#rehash (; 99 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<i32>#rehash (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7725,7 +7725,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<i32>#add (; 100 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/set/Set<i32>#add (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7818,11 +7818,11 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/set/Set<i32>#get:size (; 101 ;) (param $0 i32) (result i32)
+ (func $~lib/set/Set<i32>#get:size (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/array/Array<i32>#constructor (; 102 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#constructor (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7900,7 +7900,7 @@
   i32.store offset=12
   local.get $0
  )
- (func $~lib/array/Array<i32>#__unchecked_set (; 103 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<i32>#__unchecked_set (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -7910,7 +7910,7 @@
   local.get $2
   i32.store
  )
- (func $~lib/array/Array<i32>#__set (; 104 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<i32>#__set (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -7944,7 +7944,7 @@
   local.get $2
   call $~lib/array/Array<i32>#__unchecked_set
  )
- (func $~lib/set/Set<i32>#values (; 105 ;) (param $0 i32) (result i32)
+ (func $~lib/set/Set<i32>#values (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -8006,11 +8006,11 @@
   end
   local.get $3
  )
- (func $~lib/array/Array<i32>#get:length (; 106 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<i32>#get:length (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<i32>#__unchecked_get (; 107 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#__unchecked_get (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -8019,7 +8019,7 @@
   i32.add
   i32.load
  )
- (func $~lib/array/Array<i32>#__get (; 108 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#__get (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   local.get $0
@@ -8039,7 +8039,7 @@
   local.set $2
   local.get $2
  )
- (func $~lib/set/Set<i32>#delete (; 109 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/set/Set<i32>#delete (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -8111,7 +8111,7 @@
   end
   i32.const 1
  )
- (func $std/set/testNumeric<i32> (; 110 ;)
+ (func $std/set/testNumeric<i32>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -8447,7 +8447,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<u32>#clear (; 111 ;) (param $0 i32)
+ (func $~lib/set/Set<u32>#clear (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -8487,7 +8487,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/set/Set<u32>#constructor (; 112 ;) (param $0 i32) (result i32)
+ (func $~lib/set/Set<u32>#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -8519,7 +8519,7 @@
   call $~lib/set/Set<u32>#clear
   local.get $0
  )
- (func $~lib/set/Set<u32>#find (; 113 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/set/Set<u32>#find (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -8567,7 +8567,7 @@
   end
   i32.const 0
  )
- (func $~lib/set/Set<u32>#has (; 114 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/set/Set<u32>#has (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -8582,7 +8582,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/set/Set<u32>#rehash (; 115 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<u32>#rehash (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -8735,7 +8735,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<u32>#add (; 116 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/set/Set<u32>#add (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -8828,11 +8828,11 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/set/Set<u32>#get:size (; 117 ;) (param $0 i32) (result i32)
+ (func $~lib/set/Set<u32>#get:size (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/array/Array<u32>#constructor (; 118 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u32>#constructor (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -8910,7 +8910,7 @@
   i32.store offset=12
   local.get $0
  )
- (func $~lib/array/Array<u32>#__unchecked_set (; 119 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<u32>#__unchecked_set (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -8920,7 +8920,7 @@
   local.get $2
   i32.store
  )
- (func $~lib/array/Array<u32>#__set (; 120 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<u32>#__set (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -8954,7 +8954,7 @@
   local.get $2
   call $~lib/array/Array<u32>#__unchecked_set
  )
- (func $~lib/set/Set<u32>#values (; 121 ;) (param $0 i32) (result i32)
+ (func $~lib/set/Set<u32>#values (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -9016,11 +9016,11 @@
   end
   local.get $3
  )
- (func $~lib/array/Array<u32>#get:length (; 122 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<u32>#get:length (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<u32>#__unchecked_get (; 123 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u32>#__unchecked_get (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -9029,7 +9029,7 @@
   i32.add
   i32.load
  )
- (func $~lib/array/Array<u32>#__get (; 124 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u32>#__get (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   local.get $0
@@ -9049,7 +9049,7 @@
   local.set $2
   local.get $2
  )
- (func $~lib/set/Set<u32>#delete (; 125 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/set/Set<u32>#delete (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9121,7 +9121,7 @@
   end
   i32.const 1
  )
- (func $std/set/testNumeric<u32> (; 126 ;)
+ (func $std/set/testNumeric<u32>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -9457,7 +9457,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<i64>#clear (; 127 ;) (param $0 i32)
+ (func $~lib/set/Set<i64>#clear (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -9497,7 +9497,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/set/Set<i64>#constructor (; 128 ;) (param $0 i32) (result i32)
+ (func $~lib/set/Set<i64>#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -9529,7 +9529,7 @@
   call $~lib/set/Set<i64>#clear
   local.get $0
  )
- (func $~lib/util/hash/hash64 (; 129 ;) (param $0 i64) (result i32)
+ (func $~lib/util/hash/hash64 (param $0 i64) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -9617,7 +9617,7 @@
   local.set $3
   local.get $3
  )
- (func $~lib/set/Set<i64>#find (; 130 ;) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
+ (func $~lib/set/Set<i64>#find (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -9665,7 +9665,7 @@
   end
   i32.const 0
  )
- (func $~lib/set/Set<i64>#has (; 131 ;) (param $0 i32) (param $1 i64) (result i32)
+ (func $~lib/set/Set<i64>#has (param $0 i32) (param $1 i64) (result i32)
   (local $2 i64)
   local.get $0
   local.get $1
@@ -9680,7 +9680,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/set/Set<i64>#rehash (; 132 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<i64>#rehash (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9834,7 +9834,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<i64>#add (; 133 ;) (param $0 i32) (param $1 i64) (result i32)
+ (func $~lib/set/Set<i64>#add (param $0 i32) (param $1 i64) (result i32)
   (local $2 i64)
   (local $3 i32)
   (local $4 i32)
@@ -9928,11 +9928,11 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/set/Set<i64>#get:size (; 134 ;) (param $0 i32) (result i32)
+ (func $~lib/set/Set<i64>#get:size (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/array/Array<i64>#constructor (; 135 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i64>#constructor (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10010,7 +10010,7 @@
   i32.store offset=12
   local.get $0
  )
- (func $~lib/array/Array<i64>#__unchecked_set (; 136 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $~lib/array/Array<i64>#__unchecked_set (param $0 i32) (param $1 i32) (param $2 i64)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -10020,7 +10020,7 @@
   local.get $2
   i64.store
  )
- (func $~lib/array/Array<i64>#__set (; 137 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $~lib/array/Array<i64>#__set (param $0 i32) (param $1 i32) (param $2 i64)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -10054,7 +10054,7 @@
   local.get $2
   call $~lib/array/Array<i64>#__unchecked_set
  )
- (func $~lib/set/Set<i64>#values (; 138 ;) (param $0 i32) (result i32)
+ (func $~lib/set/Set<i64>#values (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -10116,11 +10116,11 @@
   end
   local.get $3
  )
- (func $~lib/array/Array<i64>#get:length (; 139 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<i64>#get:length (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<i64>#__unchecked_get (; 140 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $~lib/array/Array<i64>#__unchecked_get (param $0 i32) (param $1 i32) (result i64)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -10129,7 +10129,7 @@
   i32.add
   i64.load
  )
- (func $~lib/array/Array<i64>#__get (; 141 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $~lib/array/Array<i64>#__get (param $0 i32) (param $1 i32) (result i64)
   (local $2 i64)
   local.get $1
   local.get $0
@@ -10149,7 +10149,7 @@
   local.set $2
   local.get $2
  )
- (func $~lib/set/Set<i64>#delete (; 142 ;) (param $0 i32) (param $1 i64) (result i32)
+ (func $~lib/set/Set<i64>#delete (param $0 i32) (param $1 i64) (result i32)
   (local $2 i64)
   (local $3 i32)
   (local $4 i32)
@@ -10222,7 +10222,7 @@
   end
   i32.const 1
  )
- (func $std/set/testNumeric<i64> (; 143 ;)
+ (func $std/set/testNumeric<i64>
   (local $0 i32)
   (local $1 i64)
   (local $2 i32)
@@ -10559,7 +10559,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<u64>#clear (; 144 ;) (param $0 i32)
+ (func $~lib/set/Set<u64>#clear (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -10599,7 +10599,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/set/Set<u64>#constructor (; 145 ;) (param $0 i32) (result i32)
+ (func $~lib/set/Set<u64>#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -10631,7 +10631,7 @@
   call $~lib/set/Set<u64>#clear
   local.get $0
  )
- (func $~lib/set/Set<u64>#find (; 146 ;) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
+ (func $~lib/set/Set<u64>#find (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -10679,7 +10679,7 @@
   end
   i32.const 0
  )
- (func $~lib/set/Set<u64>#has (; 147 ;) (param $0 i32) (param $1 i64) (result i32)
+ (func $~lib/set/Set<u64>#has (param $0 i32) (param $1 i64) (result i32)
   (local $2 i64)
   local.get $0
   local.get $1
@@ -10694,7 +10694,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/set/Set<u64>#rehash (; 148 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<u64>#rehash (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10848,7 +10848,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<u64>#add (; 149 ;) (param $0 i32) (param $1 i64) (result i32)
+ (func $~lib/set/Set<u64>#add (param $0 i32) (param $1 i64) (result i32)
   (local $2 i64)
   (local $3 i32)
   (local $4 i32)
@@ -10942,11 +10942,11 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/set/Set<u64>#get:size (; 150 ;) (param $0 i32) (result i32)
+ (func $~lib/set/Set<u64>#get:size (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/array/Array<u64>#constructor (; 151 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u64>#constructor (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -11024,7 +11024,7 @@
   i32.store offset=12
   local.get $0
  )
- (func $~lib/array/Array<u64>#__unchecked_set (; 152 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $~lib/array/Array<u64>#__unchecked_set (param $0 i32) (param $1 i32) (param $2 i64)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -11034,7 +11034,7 @@
   local.get $2
   i64.store
  )
- (func $~lib/array/Array<u64>#__set (; 153 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $~lib/array/Array<u64>#__set (param $0 i32) (param $1 i32) (param $2 i64)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -11068,7 +11068,7 @@
   local.get $2
   call $~lib/array/Array<u64>#__unchecked_set
  )
- (func $~lib/set/Set<u64>#values (; 154 ;) (param $0 i32) (result i32)
+ (func $~lib/set/Set<u64>#values (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -11130,11 +11130,11 @@
   end
   local.get $3
  )
- (func $~lib/array/Array<u64>#get:length (; 155 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<u64>#get:length (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<u64>#__unchecked_get (; 156 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $~lib/array/Array<u64>#__unchecked_get (param $0 i32) (param $1 i32) (result i64)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -11143,7 +11143,7 @@
   i32.add
   i64.load
  )
- (func $~lib/array/Array<u64>#__get (; 157 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $~lib/array/Array<u64>#__get (param $0 i32) (param $1 i32) (result i64)
   (local $2 i64)
   local.get $1
   local.get $0
@@ -11163,7 +11163,7 @@
   local.set $2
   local.get $2
  )
- (func $~lib/set/Set<u64>#delete (; 158 ;) (param $0 i32) (param $1 i64) (result i32)
+ (func $~lib/set/Set<u64>#delete (param $0 i32) (param $1 i64) (result i32)
   (local $2 i64)
   (local $3 i32)
   (local $4 i32)
@@ -11236,7 +11236,7 @@
   end
   i32.const 1
  )
- (func $std/set/testNumeric<u64> (; 159 ;)
+ (func $std/set/testNumeric<u64>
   (local $0 i32)
   (local $1 i64)
   (local $2 i32)
@@ -11573,7 +11573,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<f32>#clear (; 160 ;) (param $0 i32)
+ (func $~lib/set/Set<f32>#clear (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -11613,7 +11613,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/set/Set<f32>#constructor (; 161 ;) (param $0 i32) (result i32)
+ (func $~lib/set/Set<f32>#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -11645,7 +11645,7 @@
   call $~lib/set/Set<f32>#clear
   local.get $0
  )
- (func $~lib/set/Set<f32>#find (; 162 ;) (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
+ (func $~lib/set/Set<f32>#find (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -11693,7 +11693,7 @@
   end
   i32.const 0
  )
- (func $~lib/set/Set<f32>#has (; 163 ;) (param $0 i32) (param $1 f32) (result i32)
+ (func $~lib/set/Set<f32>#has (param $0 i32) (param $1 f32) (result i32)
   (local $2 f32)
   local.get $0
   local.get $1
@@ -11709,7 +11709,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/set/Set<f32>#rehash (; 164 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<f32>#rehash (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -11864,7 +11864,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<f32>#add (; 165 ;) (param $0 i32) (param $1 f32) (result i32)
+ (func $~lib/set/Set<f32>#add (param $0 i32) (param $1 f32) (result i32)
   (local $2 f32)
   (local $3 i32)
   (local $4 i32)
@@ -11959,11 +11959,11 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/set/Set<f32>#get:size (; 166 ;) (param $0 i32) (result i32)
+ (func $~lib/set/Set<f32>#get:size (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/array/Array<f32>#constructor (; 167 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<f32>#constructor (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -12041,7 +12041,7 @@
   i32.store offset=12
   local.get $0
  )
- (func $~lib/array/Array<f32>#__unchecked_set (; 168 ;) (param $0 i32) (param $1 i32) (param $2 f32)
+ (func $~lib/array/Array<f32>#__unchecked_set (param $0 i32) (param $1 i32) (param $2 f32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -12051,7 +12051,7 @@
   local.get $2
   f32.store
  )
- (func $~lib/array/Array<f32>#__set (; 169 ;) (param $0 i32) (param $1 i32) (param $2 f32)
+ (func $~lib/array/Array<f32>#__set (param $0 i32) (param $1 i32) (param $2 f32)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -12085,7 +12085,7 @@
   local.get $2
   call $~lib/array/Array<f32>#__unchecked_set
  )
- (func $~lib/set/Set<f32>#values (; 170 ;) (param $0 i32) (result i32)
+ (func $~lib/set/Set<f32>#values (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -12147,11 +12147,11 @@
   end
   local.get $3
  )
- (func $~lib/array/Array<f32>#get:length (; 171 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<f32>#get:length (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<f32>#__unchecked_get (; 172 ;) (param $0 i32) (param $1 i32) (result f32)
+ (func $~lib/array/Array<f32>#__unchecked_get (param $0 i32) (param $1 i32) (result f32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -12160,7 +12160,7 @@
   i32.add
   f32.load
  )
- (func $~lib/array/Array<f32>#__get (; 173 ;) (param $0 i32) (param $1 i32) (result f32)
+ (func $~lib/array/Array<f32>#__get (param $0 i32) (param $1 i32) (result f32)
   (local $2 f32)
   local.get $1
   local.get $0
@@ -12180,7 +12180,7 @@
   local.set $2
   local.get $2
  )
- (func $~lib/set/Set<f32>#delete (; 174 ;) (param $0 i32) (param $1 f32) (result i32)
+ (func $~lib/set/Set<f32>#delete (param $0 i32) (param $1 f32) (result i32)
   (local $2 f32)
   (local $3 i32)
   (local $4 i32)
@@ -12254,7 +12254,7 @@
   end
   i32.const 1
  )
- (func $std/set/testNumeric<f32> (; 175 ;)
+ (func $std/set/testNumeric<f32>
   (local $0 i32)
   (local $1 f32)
   (local $2 i32)
@@ -12591,7 +12591,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<f64>#clear (; 176 ;) (param $0 i32)
+ (func $~lib/set/Set<f64>#clear (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -12631,7 +12631,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/set/Set<f64>#constructor (; 177 ;) (param $0 i32) (result i32)
+ (func $~lib/set/Set<f64>#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -12663,7 +12663,7 @@
   call $~lib/set/Set<f64>#clear
   local.get $0
  )
- (func $~lib/set/Set<f64>#find (; 178 ;) (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
+ (func $~lib/set/Set<f64>#find (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -12711,7 +12711,7 @@
   end
   i32.const 0
  )
- (func $~lib/set/Set<f64>#has (; 179 ;) (param $0 i32) (param $1 f64) (result i32)
+ (func $~lib/set/Set<f64>#has (param $0 i32) (param $1 f64) (result i32)
   (local $2 f64)
   local.get $0
   local.get $1
@@ -12727,7 +12727,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/set/Set<f64>#rehash (; 180 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<f64>#rehash (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -12882,7 +12882,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<f64>#add (; 181 ;) (param $0 i32) (param $1 f64) (result i32)
+ (func $~lib/set/Set<f64>#add (param $0 i32) (param $1 f64) (result i32)
   (local $2 f64)
   (local $3 i32)
   (local $4 i32)
@@ -12977,11 +12977,11 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/set/Set<f64>#get:size (; 182 ;) (param $0 i32) (result i32)
+ (func $~lib/set/Set<f64>#get:size (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/array/Array<f64>#constructor (; 183 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<f64>#constructor (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -13059,7 +13059,7 @@
   i32.store offset=12
   local.get $0
  )
- (func $~lib/array/Array<f64>#__unchecked_set (; 184 ;) (param $0 i32) (param $1 i32) (param $2 f64)
+ (func $~lib/array/Array<f64>#__unchecked_set (param $0 i32) (param $1 i32) (param $2 f64)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -13069,7 +13069,7 @@
   local.get $2
   f64.store
  )
- (func $~lib/array/Array<f64>#__set (; 185 ;) (param $0 i32) (param $1 i32) (param $2 f64)
+ (func $~lib/array/Array<f64>#__set (param $0 i32) (param $1 i32) (param $2 f64)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -13103,7 +13103,7 @@
   local.get $2
   call $~lib/array/Array<f64>#__unchecked_set
  )
- (func $~lib/set/Set<f64>#values (; 186 ;) (param $0 i32) (result i32)
+ (func $~lib/set/Set<f64>#values (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -13165,11 +13165,11 @@
   end
   local.get $3
  )
- (func $~lib/array/Array<f64>#get:length (; 187 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<f64>#get:length (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<f64>#__unchecked_get (; 188 ;) (param $0 i32) (param $1 i32) (result f64)
+ (func $~lib/array/Array<f64>#__unchecked_get (param $0 i32) (param $1 i32) (result f64)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -13178,7 +13178,7 @@
   i32.add
   f64.load
  )
- (func $~lib/array/Array<f64>#__get (; 189 ;) (param $0 i32) (param $1 i32) (result f64)
+ (func $~lib/array/Array<f64>#__get (param $0 i32) (param $1 i32) (result f64)
   (local $2 f64)
   local.get $1
   local.get $0
@@ -13198,7 +13198,7 @@
   local.set $2
   local.get $2
  )
- (func $~lib/set/Set<f64>#delete (; 190 ;) (param $0 i32) (param $1 f64) (result i32)
+ (func $~lib/set/Set<f64>#delete (param $0 i32) (param $1 f64) (result i32)
   (local $2 f64)
   (local $3 i32)
   (local $4 i32)
@@ -13272,7 +13272,7 @@
   end
   i32.const 1
  )
- (func $std/set/testNumeric<f64> (; 191 ;)
+ (func $std/set/testNumeric<f64>
   (local $0 i32)
   (local $1 f64)
   (local $2 i32)
@@ -13609,7 +13609,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $start:std/set (; 192 ;)
+ (func $start:std/set
   call $std/set/testNumeric<i8>
   call $std/set/testNumeric<u8>
   call $std/set/testNumeric<i16>
@@ -13621,13 +13621,13 @@
   call $std/set/testNumeric<f32>
   call $std/set/testNumeric<f64>
  )
- (func $~start (; 193 ;)
+ (func $~start
   call $start:std/set
  )
- (func $~lib/rt/pure/__collect (; 194 ;)
+ (func $~lib/rt/pure/__collect
   return
  )
- (func $~lib/rt/pure/decrement (; 195 ;) (param $0 i32)
+ (func $~lib/rt/pure/decrement (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -13704,7 +13704,7 @@
    i32.store offset=4
   end
  )
- (func $~lib/rt/pure/__visit (; 196 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/pure/__visit (param $0 i32) (param $1 i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.lt_u
@@ -13728,7 +13728,7 @@
   i32.sub
   call $~lib/rt/pure/decrement
  )
- (func $~lib/set/Set<i8>#__visit_impl (; 197 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<i8>#__visit_impl (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -13741,13 +13741,13 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/array/Array<i8>#__visit_impl (; 198 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i8>#__visit_impl (param $0 i32) (param $1 i32)
   local.get $0
   i32.load
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/set/Set<u8>#__visit_impl (; 199 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<u8>#__visit_impl (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -13760,13 +13760,13 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/array/Array<u8>#__visit_impl (; 200 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<u8>#__visit_impl (param $0 i32) (param $1 i32)
   local.get $0
   i32.load
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/set/Set<i16>#__visit_impl (; 201 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<i16>#__visit_impl (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -13779,13 +13779,13 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/array/Array<i16>#__visit_impl (; 202 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i16>#__visit_impl (param $0 i32) (param $1 i32)
   local.get $0
   i32.load
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/set/Set<u16>#__visit_impl (; 203 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<u16>#__visit_impl (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -13798,13 +13798,13 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/array/Array<u16>#__visit_impl (; 204 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<u16>#__visit_impl (param $0 i32) (param $1 i32)
   local.get $0
   i32.load
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/set/Set<i32>#__visit_impl (; 205 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<i32>#__visit_impl (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -13817,13 +13817,13 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/array/Array<i32>#__visit_impl (; 206 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i32>#__visit_impl (param $0 i32) (param $1 i32)
   local.get $0
   i32.load
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/set/Set<u32>#__visit_impl (; 207 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<u32>#__visit_impl (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -13836,13 +13836,13 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/array/Array<u32>#__visit_impl (; 208 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<u32>#__visit_impl (param $0 i32) (param $1 i32)
   local.get $0
   i32.load
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/set/Set<i64>#__visit_impl (; 209 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<i64>#__visit_impl (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -13855,13 +13855,13 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/array/Array<i64>#__visit_impl (; 210 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i64>#__visit_impl (param $0 i32) (param $1 i32)
   local.get $0
   i32.load
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/set/Set<u64>#__visit_impl (; 211 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<u64>#__visit_impl (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -13874,13 +13874,13 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/array/Array<u64>#__visit_impl (; 212 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<u64>#__visit_impl (param $0 i32) (param $1 i32)
   local.get $0
   i32.load
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/set/Set<f32>#__visit_impl (; 213 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<f32>#__visit_impl (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -13893,13 +13893,13 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/array/Array<f32>#__visit_impl (; 214 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<f32>#__visit_impl (param $0 i32) (param $1 i32)
   local.get $0
   i32.load
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/set/Set<f64>#__visit_impl (; 215 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<f64>#__visit_impl (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -13912,13 +13912,13 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/array/Array<f64>#__visit_impl (; 216 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<f64>#__visit_impl (param $0 i32) (param $1 i32)
   local.get $0
   i32.load
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/rt/__visit_members (; 217 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/__visit_members (param $0 i32) (param $1 i32)
   (local $2 i32)
   block $switch$1$default
    block $switch$1$case$24

--- a/tests/compiler/std/static-array.optimized.wat
+++ b/tests/compiler/std/static-array.optimized.wat
@@ -25,11 +25,10 @@
  (data (i32.const 1408) "\1a\00\00\00\01\00\00\00\01\00\00\00\1a\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00.\00t\00s")
  (data (i32.const 1456) "\1c\00\00\00\01\00\00\00\01\00\00\00\1c\00\00\00I\00n\00v\00a\00l\00i\00d\00 \00l\00e\00n\00g\00t\00h")
  (data (i32.const 1504) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00s\00t\00u\00b\00.\00t\00s")
- (global $~lib/rt/stub/startOffset (mut i32) (i32.const 0))
  (global $~lib/rt/stub/offset (mut i32) (i32.const 0))
  (export "memory" (memory $0))
  (start $~start)
- (func $~lib/array/Array<i32>#__get (; 1 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<i32>#__get (param $0 i32) (result i32)
   local.get $0
   i32.const 1084
   i32.load
@@ -50,7 +49,7 @@
   i32.add
   i32.load
  )
- (func $~lib/rt/stub/maybeGrowMemory (; 2 ;) (param $0 i32)
+ (func $~lib/rt/stub/maybeGrowMemory (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -92,7 +91,7 @@
   local.get $0
   global.set $~lib/rt/stub/offset
  )
- (func $~lib/memory/memory.copy (; 3 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/memory/memory.copy (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   block $~lib/util/memory/memmove|inlined.0
@@ -265,7 +264,7 @@
    end
   end
  )
- (func $~lib/rt/stub/__realloc (; 4 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/stub/__realloc (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -417,7 +416,7 @@
   i32.store offset=12
   local.get $0
  )
- (func $~lib/memory/memory.fill (; 5 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/memory/memory.fill (param $0 i32) (param $1 i32)
   (local $2 i32)
   block $~lib/util/memory/memset|inlined.0
    local.get $1
@@ -575,7 +574,7 @@
    end
   end
  )
- (func $~lib/array/ensureSize (; 6 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/ensureSize (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -631,7 +630,7 @@
    i32.store offset=8
   end
  )
- (func $~lib/array/Array<i64>#__get (; 7 ;) (param $0 i32) (result i64)
+ (func $~lib/array/Array<i64>#__get (param $0 i32) (result i64)
   local.get $0
   i32.const 1148
   i32.load
@@ -652,7 +651,7 @@
   i32.add
   i64.load
  )
- (func $~lib/array/Array<f32>#__get (; 8 ;) (param $0 i32) (result f32)
+ (func $~lib/array/Array<f32>#__get (param $0 i32) (result f32)
   local.get $0
   i32.const 1212
   i32.load
@@ -673,7 +672,7 @@
   i32.add
   f32.load
  )
- (func $~lib/array/Array<f64>#__get (; 9 ;) (param $0 i32) (result f64)
+ (func $~lib/array/Array<f64>#__get (param $0 i32) (result f64)
   local.get $0
   i32.const 1276
   i32.load
@@ -694,7 +693,7 @@
   i32.add
   f64.load
  )
- (func $start:std/static-array (; 10 ;)
+ (func $start:std/static-array
   i32.const 1084
   i32.load
   i32.const 2
@@ -731,8 +730,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1552
-  global.set $~lib/rt/stub/startOffset
   i32.const 1552
   global.set $~lib/rt/stub/offset
   i32.const 0
@@ -956,7 +953,7 @@
    unreachable
   end
  )
- (func $~start (; 11 ;)
+ (func $~start
   call $start:std/static-array
  )
 )

--- a/tests/compiler/std/static-array.untouched.wat
+++ b/tests/compiler/std/static-array.untouched.wat
@@ -37,11 +37,11 @@
  (global $~lib/heap/__heap_base i32 (i32.const 544))
  (export "memory" (memory $0))
  (start $~start)
- (func $~lib/array/Array<i32>#get:length (; 1 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<i32>#get:length (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<i32>#__unchecked_get (; 2 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#__unchecked_get (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -50,7 +50,7 @@
   i32.add
   i32.load
  )
- (func $~lib/array/Array<i32>#__get (; 3 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#__get (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   local.get $0
@@ -70,7 +70,7 @@
   local.set $2
   local.get $2
  )
- (func $~lib/rt/stub/maybeGrowMemory (; 4 ;) (param $0 i32)
+ (func $~lib/rt/stub/maybeGrowMemory (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -124,7 +124,7 @@
   local.get $0
   global.set $~lib/rt/stub/offset
  )
- (func $~lib/rt/stub/__alloc (; 5 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/stub/__alloc (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -177,7 +177,7 @@
   i32.store offset=12
   local.get $2
  )
- (func $~lib/util/memory/memcpy (; 6 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/memory/memcpy (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1201,7 +1201,7 @@
    i32.store8
   end
  )
- (func $~lib/memory/memory.copy (; 7 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/memory/memory.copy (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1421,7 +1421,7 @@
    end
   end
  )
- (func $~lib/rt/stub/__realloc (; 8 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/stub/__realloc (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1544,7 +1544,7 @@
   i32.store offset=12
   local.get $0
  )
- (func $~lib/memory/memory.fill (; 9 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/memory/memory.fill (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1753,7 +1753,7 @@
    end
   end
  )
- (func $~lib/array/ensureSize (; 10 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/ensureSize (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1815,7 +1815,7 @@
    i32.store offset=8
   end
  )
- (func $~lib/array/Array<i32>#__unchecked_set (; 11 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<i32>#__unchecked_set (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -1825,7 +1825,7 @@
   local.get $2
   i32.store
  )
- (func $~lib/array/Array<i32>#__set (; 12 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<i32>#__set (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -1859,11 +1859,11 @@
   local.get $2
   call $~lib/array/Array<i32>#__unchecked_set
  )
- (func $~lib/array/Array<i64>#get:length (; 13 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<i64>#get:length (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<i64>#__unchecked_get (; 14 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $~lib/array/Array<i64>#__unchecked_get (param $0 i32) (param $1 i32) (result i64)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -1872,7 +1872,7 @@
   i32.add
   i64.load
  )
- (func $~lib/array/Array<i64>#__get (; 15 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $~lib/array/Array<i64>#__get (param $0 i32) (param $1 i32) (result i64)
   (local $2 i64)
   local.get $1
   local.get $0
@@ -1892,7 +1892,7 @@
   local.set $2
   local.get $2
  )
- (func $~lib/array/Array<i64>#__unchecked_set (; 16 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $~lib/array/Array<i64>#__unchecked_set (param $0 i32) (param $1 i32) (param $2 i64)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -1902,7 +1902,7 @@
   local.get $2
   i64.store
  )
- (func $~lib/array/Array<i64>#__set (; 17 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $~lib/array/Array<i64>#__set (param $0 i32) (param $1 i32) (param $2 i64)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -1936,11 +1936,11 @@
   local.get $2
   call $~lib/array/Array<i64>#__unchecked_set
  )
- (func $~lib/array/Array<f32>#get:length (; 18 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<f32>#get:length (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<f32>#__unchecked_get (; 19 ;) (param $0 i32) (param $1 i32) (result f32)
+ (func $~lib/array/Array<f32>#__unchecked_get (param $0 i32) (param $1 i32) (result f32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -1949,7 +1949,7 @@
   i32.add
   f32.load
  )
- (func $~lib/array/Array<f32>#__get (; 20 ;) (param $0 i32) (param $1 i32) (result f32)
+ (func $~lib/array/Array<f32>#__get (param $0 i32) (param $1 i32) (result f32)
   (local $2 f32)
   local.get $1
   local.get $0
@@ -1969,7 +1969,7 @@
   local.set $2
   local.get $2
  )
- (func $~lib/array/Array<f32>#__unchecked_set (; 21 ;) (param $0 i32) (param $1 i32) (param $2 f32)
+ (func $~lib/array/Array<f32>#__unchecked_set (param $0 i32) (param $1 i32) (param $2 f32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -1979,7 +1979,7 @@
   local.get $2
   f32.store
  )
- (func $~lib/array/Array<f32>#__set (; 22 ;) (param $0 i32) (param $1 i32) (param $2 f32)
+ (func $~lib/array/Array<f32>#__set (param $0 i32) (param $1 i32) (param $2 f32)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -2013,11 +2013,11 @@
   local.get $2
   call $~lib/array/Array<f32>#__unchecked_set
  )
- (func $~lib/array/Array<f64>#get:length (; 23 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<f64>#get:length (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<f64>#__unchecked_get (; 24 ;) (param $0 i32) (param $1 i32) (result f64)
+ (func $~lib/array/Array<f64>#__unchecked_get (param $0 i32) (param $1 i32) (result f64)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -2026,7 +2026,7 @@
   i32.add
   f64.load
  )
- (func $~lib/array/Array<f64>#__get (; 25 ;) (param $0 i32) (param $1 i32) (result f64)
+ (func $~lib/array/Array<f64>#__get (param $0 i32) (param $1 i32) (result f64)
   (local $2 f64)
   local.get $1
   local.get $0
@@ -2046,7 +2046,7 @@
   local.set $2
   local.get $2
  )
- (func $~lib/array/Array<f64>#__unchecked_set (; 26 ;) (param $0 i32) (param $1 i32) (param $2 f64)
+ (func $~lib/array/Array<f64>#__unchecked_set (param $0 i32) (param $1 i32) (param $2 f64)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -2056,7 +2056,7 @@
   local.get $2
   f64.store
  )
- (func $~lib/array/Array<f64>#__set (; 27 ;) (param $0 i32) (param $1 i32) (param $2 f64)
+ (func $~lib/array/Array<f64>#__set (param $0 i32) (param $1 i32) (param $2 f64)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -2090,7 +2090,7 @@
   local.get $2
   call $~lib/array/Array<f64>#__unchecked_set
  )
- (func $start:std/static-array (; 28 ;)
+ (func $start:std/static-array
   (local $0 i32)
   (local $1 i32)
   i32.const 64
@@ -2340,7 +2340,7 @@
    unreachable
   end
  )
- (func $~start (; 29 ;)
+ (func $~start
   call $start:std/static-array
  )
 )

--- a/tests/compiler/std/staticarray.optimized.wat
+++ b/tests/compiler/std/staticarray.optimized.wat
@@ -30,7 +30,7 @@
  (global $~started (mut i32) (i32.const 0))
  (export "_start" (func $~start))
  (export "memory" (memory $0))
- (func $~lib/staticarray/StaticArray<i32>#get:length (; 5 ;) (param $0 i32) (result i32)
+ (func $~lib/staticarray/StaticArray<i32>#get:length (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub
@@ -38,7 +38,7 @@
   i32.const 2
   i32.shr_u
  )
- (func $~lib/staticarray/StaticArray<i32>#__get (; 6 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/staticarray/StaticArray<i32>#__get (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   call $~lib/staticarray/StaticArray<i32>#get:length
@@ -58,7 +58,7 @@
   i32.add
   i32.load
  )
- (func $~lib/staticarray/StaticArray<i32>#__set (; 7 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/staticarray/StaticArray<i32>#__set (param $0 i32) (param $1 i32)
   i32.const 1
   local.get $0
   call $~lib/staticarray/StaticArray<i32>#get:length
@@ -75,7 +75,7 @@
   local.get $1
   i32.store offset=4
  )
- (func $~lib/rt/tlsf/removeBlock (; 8 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/removeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -237,7 +237,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/insertBlock (; 9 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/insertBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -516,7 +516,7 @@
   i32.or
   i32.store offset=4
  )
- (func $~lib/rt/tlsf/addMemory (; 10 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $2
@@ -630,7 +630,7 @@
   local.get $1
   call $~lib/rt/tlsf/insertBlock
  )
- (func $~lib/rt/tlsf/maybeInitialize (; 11 ;) (result i32)
+ (func $~lib/rt/tlsf/maybeInitialize (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -717,7 +717,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/tlsf/searchBlock (; 12 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/searchBlock (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   i32.const 256
@@ -846,7 +846,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/prepareBlock (; 13 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/rt/tlsf/prepareBlock (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $1
@@ -921,7 +921,7 @@
    i32.store
   end
  )
- (func $~lib/rt/tlsf/allocateBlock (; 14 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/allocateBlock (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1081,7 +1081,7 @@
   call $~lib/rt/rtrace/onalloc
   local.get $3
  )
- (func $~lib/rt/tlsf/__alloc (; 15 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/__alloc (param $0 i32) (param $1 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
   local.get $0
   local.get $1
@@ -1089,7 +1089,7 @@
   i32.const 16
   i32.add
  )
- (func $~lib/memory/memory.copy (; 16 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/memory/memory.copy (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   block $~lib/util/memory/memmove|inlined.0
@@ -1262,7 +1262,7 @@
    end
   end
  )
- (func $~lib/rt/__allocBuffer (; 17 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/__allocBuffer (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   local.get $1
   call $~lib/rt/tlsf/__alloc
@@ -1276,7 +1276,7 @@
   end
   local.get $1
  )
- (func $~lib/rt/pure/__retain (; 18 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/pure/__retain (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -1327,14 +1327,14 @@
   end
   local.get $0
  )
- (func $std/staticarray/test (; 19 ;) (result i32)
+ (func $std/staticarray/test (result i32)
   i32.const 12
   i32.const 3
   i32.const 1296
   call $~lib/rt/__allocBuffer
   call $~lib/rt/pure/__retain
  )
- (func $~lib/rt/pure/__release (; 20 ;) (param $0 i32)
+ (func $~lib/rt/pure/__release (param $0 i32)
   local.get $0
   i32.const 1472
   i32.gt_u
@@ -1345,7 +1345,7 @@
    call $~lib/rt/pure/decrement
   end
  )
- (func $start:std/staticarray (; 21 ;)
+ (func $start:std/staticarray
   (local $0 i32)
   i32.const 1040
   i32.const 1
@@ -1551,7 +1551,7 @@
   i32.const 0
   global.set $std/staticarray/arr4
  )
- (func $~start (; 22 ;)
+ (func $~start
   global.get $~started
   if
    return
@@ -1561,7 +1561,7 @@
   end
   call $start:std/staticarray
  )
- (func $~lib/rt/pure/decrement (; 23 ;) (param $0 i32)
+ (func $~lib/rt/pure/decrement (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -1687,7 +1687,7 @@
    i32.store offset=4
   end
  )
- (func $~lib/rt/pure/__visit (; 24 ;) (param $0 i32)
+ (func $~lib/rt/pure/__visit (param $0 i32)
   local.get $0
   i32.const 1472
   i32.lt_u

--- a/tests/compiler/std/staticarray.untouched.wat
+++ b/tests/compiler/std/staticarray.untouched.wat
@@ -37,7 +37,7 @@
  (global $~lib/heap/__heap_base i32 (i32.const 464))
  (export "_start" (func $~start))
  (export "memory" (memory $0))
- (func $~lib/staticarray/StaticArray<i32>#get:length (; 5 ;) (param $0 i32) (result i32)
+ (func $~lib/staticarray/StaticArray<i32>#get:length (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub
@@ -45,7 +45,7 @@
   i32.const 2
   i32.shr_u
  )
- (func $~lib/staticarray/StaticArray<i32>#__unchecked_get (; 6 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/staticarray/StaticArray<i32>#__unchecked_get (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.const 2
@@ -53,7 +53,7 @@
   i32.add
   i32.load
  )
- (func $~lib/staticarray/StaticArray<i32>#__get (; 7 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/staticarray/StaticArray<i32>#__get (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   local.get $0
@@ -73,7 +73,7 @@
   local.set $2
   local.get $2
  )
- (func $~lib/staticarray/StaticArray<i32>#__unchecked_set (; 8 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/staticarray/StaticArray<i32>#__unchecked_set (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $0
   local.get $1
   i32.const 2
@@ -82,7 +82,7 @@
   local.get $2
   i32.store
  )
- (func $~lib/staticarray/StaticArray<i32>#__set (; 9 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/staticarray/StaticArray<i32>#__set (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $1
   local.get $0
   call $~lib/staticarray/StaticArray<i32>#get:length
@@ -100,7 +100,7 @@
   local.get $2
   call $~lib/staticarray/StaticArray<i32>#__unchecked_set
  )
- (func $~lib/rt/tlsf/removeBlock (; 10 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/removeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -310,7 +310,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/insertBlock (; 11 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/insertBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -660,7 +660,7 @@
   local.get $7
   i32.store offset=4
  )
- (func $~lib/rt/tlsf/addMemory (; 12 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -808,7 +808,7 @@
   call $~lib/rt/tlsf/insertBlock
   i32.const 1
  )
- (func $~lib/rt/tlsf/maybeInitialize (; 13 ;) (result i32)
+ (func $~lib/rt/tlsf/maybeInitialize (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -962,7 +962,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/tlsf/prepareSize (; 14 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/tlsf/prepareSize (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -991,7 +991,7 @@
   i32.gt_u
   select
  )
- (func $~lib/rt/tlsf/searchBlock (; 15 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/searchBlock (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1174,7 +1174,7 @@
   end
   local.get $7
  )
- (func $~lib/rt/tlsf/growMemory (; 16 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/growMemory (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1258,7 +1258,7 @@
   call $~lib/rt/tlsf/addMemory
   drop
  )
- (func $~lib/rt/tlsf/prepareBlock (; 17 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/rt/tlsf/prepareBlock (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1353,7 +1353,7 @@
    i32.store
   end
  )
- (func $~lib/rt/tlsf/allocateBlock (; 18 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/allocateBlock (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   global.get $~lib/rt/tlsf/collectLock
@@ -1464,7 +1464,7 @@
   call $~lib/rt/rtrace/onalloc
   local.get $4
  )
- (func $~lib/rt/tlsf/__alloc (; 19 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/__alloc (param $0 i32) (param $1 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
   local.get $0
   local.get $1
@@ -1472,7 +1472,7 @@
   i32.const 16
   i32.add
  )
- (func $~lib/util/memory/memcpy (; 20 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/memory/memcpy (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2496,7 +2496,7 @@
    i32.store8
   end
  )
- (func $~lib/memory/memory.copy (; 21 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/memory/memory.copy (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2716,7 +2716,7 @@
    end
   end
  )
- (func $~lib/rt/__allocBuffer (; 22 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/__allocBuffer (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $0
   local.get $1
@@ -2731,7 +2731,7 @@
   end
   local.get $3
  )
- (func $~lib/rt/pure/increment (; 23 ;) (param $0 i32)
+ (func $~lib/rt/pure/increment (param $0 i32)
   (local $1 i32)
   local.get $0
   i32.load offset=4
@@ -2776,7 +2776,7 @@
    unreachable
   end
  )
- (func $~lib/rt/pure/__retain (; 24 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/pure/__retain (param $0 i32) (result i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.gt_u
@@ -2788,7 +2788,7 @@
   end
   local.get $0
  )
- (func $std/staticarray/test (; 25 ;) (result i32)
+ (func $std/staticarray/test (result i32)
   (local $0 i32)
   i32.const 12
   i32.const 3
@@ -2796,7 +2796,7 @@
   call $~lib/rt/__allocBuffer
   call $~lib/rt/pure/__retain
  )
- (func $~lib/rt/pure/__release (; 26 ;) (param $0 i32)
+ (func $~lib/rt/pure/__release (param $0 i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.gt_u
@@ -2807,7 +2807,7 @@
    call $~lib/rt/pure/decrement
   end
  )
- (func $std/staticarray/Ref#constructor (; 27 ;) (param $0 i32) (result i32)
+ (func $std/staticarray/Ref#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -2819,7 +2819,7 @@
   end
   local.get $0
  )
- (func $start:std/staticarray (; 28 ;)
+ (func $start:std/staticarray
   (local $0 i32)
   (local $1 i32)
   i32.const 32
@@ -3052,7 +3052,7 @@
   local.get $1
   global.set $std/staticarray/arr4
  )
- (func $~start (; 29 ;)
+ (func $~start
   global.get $~started
   if
    return
@@ -3062,10 +3062,10 @@
   end
   call $start:std/staticarray
  )
- (func $~lib/rt/pure/__collect (; 30 ;)
+ (func $~lib/rt/pure/__collect
   return
  )
- (func $~lib/rt/tlsf/freeBlock (; 31 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/freeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $1
   i32.load
@@ -3081,7 +3081,7 @@
   local.get $1
   call $~lib/rt/rtrace/onfree
  )
- (func $~lib/rt/pure/decrement (; 32 ;) (param $0 i32)
+ (func $~lib/rt/pure/decrement (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -3158,7 +3158,7 @@
    i32.store offset=4
   end
  )
- (func $~lib/rt/pure/__visit (; 33 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/pure/__visit (param $0 i32) (param $1 i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.lt_u
@@ -3182,10 +3182,10 @@
   i32.sub
   call $~lib/rt/pure/decrement
  )
- (func $~lib/staticarray/StaticArray<i32>#__visit_impl (; 34 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/staticarray/StaticArray<i32>#__visit_impl (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/staticarray/StaticArray<std/staticarray/Ref>#__visit_impl (; 35 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/staticarray/StaticArray<std/staticarray/Ref>#__visit_impl (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3223,7 +3223,7 @@
    end
   end
  )
- (func $~lib/rt/__visit_members (; 36 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/__visit_members (param $0 i32) (param $1 i32)
   (local $2 i32)
   block $switch$1$default
    block $switch$1$case$7

--- a/tests/compiler/std/string-casemapping.optimized.wat
+++ b/tests/compiler/std/string-casemapping.optimized.wat
@@ -305,7 +305,7 @@
  (global $~started (mut i32) (i32.const 0))
  (export "_start" (func $~start))
  (export "memory" (memory $0))
- (func $~lib/string/String#get:length (; 9 ;) (param $0 i32) (result i32)
+ (func $~lib/string/String#get:length (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub
@@ -313,7 +313,7 @@
   i32.const 1
   i32.shr_u
  )
- (func $~lib/rt/pure/__retain (; 10 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/pure/__retain (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -364,7 +364,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/tlsf/removeBlock (; 11 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/removeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -526,7 +526,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/insertBlock (; 12 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/insertBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -805,7 +805,7 @@
   i32.or
   i32.store offset=4
  )
- (func $~lib/rt/tlsf/addMemory (; 13 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $2
@@ -919,7 +919,7 @@
   local.get $1
   call $~lib/rt/tlsf/insertBlock
  )
- (func $~lib/rt/tlsf/maybeInitialize (; 14 ;) (result i32)
+ (func $~lib/rt/tlsf/maybeInitialize (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -1006,7 +1006,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/tlsf/prepareSize (; 15 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/tlsf/prepareSize (param $0 i32) (result i32)
   local.get $0
   i32.const 1073741808
   i32.ge_u
@@ -1030,7 +1030,7 @@
   i32.gt_u
   select
  )
- (func $~lib/rt/tlsf/searchBlock (; 16 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/searchBlock (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   i32.const 256
@@ -1159,7 +1159,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/prepareBlock (; 17 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/rt/tlsf/prepareBlock (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $1
@@ -1234,7 +1234,7 @@
    i32.store
   end
  )
- (func $~lib/rt/tlsf/allocateBlock (; 18 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/allocateBlock (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1374,7 +1374,7 @@
   call $~lib/rt/rtrace/onalloc
   local.get $3
  )
- (func $~lib/rt/tlsf/__alloc (; 19 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/tlsf/__alloc (param $0 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
   local.get $0
   i32.const 1
@@ -1382,7 +1382,7 @@
   i32.const 16
   i32.add
  )
- (func $~lib/util/casemap/casemap (; 20 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/casemap/casemap (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1533,7 +1533,7 @@
   i32.and
   i32.add
  )
- (func $~lib/memory/memory.copy (; 21 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/memory/memory.copy (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   block $~lib/util/memory/memmove|inlined.0
@@ -1706,7 +1706,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/freeBlock (; 22 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/freeBlock (param $0 i32) (param $1 i32)
   local.get $1
   local.get $1
   i32.load
@@ -1719,7 +1719,7 @@
   local.get $1
   call $~lib/rt/rtrace/onfree
  )
- (func $~lib/rt/tlsf/reallocateBlock (; 23 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/reallocateBlock (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1822,7 +1822,7 @@
   end
   local.get $3
  )
- (func $~lib/rt/tlsf/__realloc (; 24 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/__realloc (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   call $~lib/rt/tlsf/maybeInitialize
@@ -1870,7 +1870,7 @@
   i32.const 16
   i32.add
  )
- (func $~lib/string/String#toUpperCase (; 25 ;) (param $0 i32) (result i32)
+ (func $~lib/string/String#toUpperCase (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -2175,7 +2175,7 @@
   call $~lib/rt/tlsf/__realloc
   call $~lib/rt/pure/__retain
  )
- (func $~lib/rt/pure/__release (; 26 ;) (param $0 i32)
+ (func $~lib/rt/pure/__release (param $0 i32)
   local.get $0
   i32.const 18728
   i32.gt_u
@@ -2186,7 +2186,7 @@
    call $~lib/rt/pure/decrement
   end
  )
- (func $~lib/util/string/compareImpl (; 27 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/compareImpl (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -2262,7 +2262,7 @@
   end
   i32.const 0
  )
- (func $~lib/string/String.__eq (; 28 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__eq (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -2296,7 +2296,7 @@
   call $~lib/util/string/compareImpl
   i32.eqz
  )
- (func $~lib/util/string/stagedBinaryLookup (; 29 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/stagedBinaryLookup (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $0
   local.get $1
@@ -2321,7 +2321,7 @@
   i32.const 1
   i32.and
  )
- (func $~lib/string/String#toLowerCase (; 30 ;) (param $0 i32) (result i32)
+ (func $~lib/string/String#toLowerCase (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -2799,7 +2799,7 @@
   call $~lib/rt/tlsf/__realloc
   call $~lib/rt/pure/__retain
  )
- (func $~lib/string/String.fromCodePoint (; 31 ;) (param $0 i32) (result i32)
+ (func $~lib/string/String.fromCodePoint (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -2849,7 +2849,7 @@
   local.get $1
   call $~lib/rt/pure/__retain
  )
- (func $~lib/string/String#codePointAt (; 32 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String#codePointAt (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $1
@@ -2908,7 +2908,7 @@
   i32.const -56613888
   i32.add
  )
- (func $~lib/util/number/utoa64 (; 33 ;) (param $0 i64) (result i32)
+ (func $~lib/util/number/utoa64 (param $0 i64) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -3078,7 +3078,7 @@
   local.get $4
   call $~lib/rt/pure/__retain
  )
- (func $~lib/string/String.__concat (; 34 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__concat (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3140,7 +3140,7 @@
    local.get $1
   end
  )
- (func $start:std/string-casemapping (; 35 ;)
+ (func $start:std/string-casemapping
   (local $0 i64)
   (local $1 i64)
   (local $2 i64)
@@ -4819,7 +4819,7 @@
   local.get $98
   call $~lib/rt/pure/__release
  )
- (func $~start (; 36 ;)
+ (func $~start
   global.get $~started
   if
    return
@@ -4829,7 +4829,7 @@
   end
   call $start:std/string-casemapping
  )
- (func $~lib/rt/pure/decrement (; 37 ;) (param $0 i32)
+ (func $~lib/rt/pure/decrement (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0

--- a/tests/compiler/std/string-casemapping.untouched.wat
+++ b/tests/compiler/std/string-casemapping.untouched.wat
@@ -204,7 +204,7 @@
  (global $~lib/heap/__heap_base i32 (i32.const 18424))
  (export "_start" (func $~start))
  (export "memory" (memory $0))
- (func $~lib/string/String#get:length (; 9 ;) (param $0 i32) (result i32)
+ (func $~lib/string/String#get:length (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub
@@ -212,7 +212,7 @@
   i32.const 1
   i32.shr_u
  )
- (func $~lib/rt/pure/increment (; 10 ;) (param $0 i32)
+ (func $~lib/rt/pure/increment (param $0 i32)
   (local $1 i32)
   local.get $0
   i32.load offset=4
@@ -257,7 +257,7 @@
    unreachable
   end
  )
- (func $~lib/rt/pure/__retain (; 11 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/pure/__retain (param $0 i32) (result i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.gt_u
@@ -269,7 +269,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/tlsf/removeBlock (; 12 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/removeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -479,7 +479,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/insertBlock (; 13 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/insertBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -829,7 +829,7 @@
   local.get $7
   i32.store offset=4
  )
- (func $~lib/rt/tlsf/addMemory (; 14 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -977,7 +977,7 @@
   call $~lib/rt/tlsf/insertBlock
   i32.const 1
  )
- (func $~lib/rt/tlsf/maybeInitialize (; 15 ;) (result i32)
+ (func $~lib/rt/tlsf/maybeInitialize (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -1131,7 +1131,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/tlsf/prepareSize (; 16 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/tlsf/prepareSize (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -1160,7 +1160,7 @@
   i32.gt_u
   select
  )
- (func $~lib/rt/tlsf/searchBlock (; 17 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/searchBlock (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1343,7 +1343,7 @@
   end
   local.get $7
  )
- (func $~lib/rt/tlsf/growMemory (; 18 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/growMemory (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1427,7 +1427,7 @@
   call $~lib/rt/tlsf/addMemory
   drop
  )
- (func $~lib/rt/tlsf/prepareBlock (; 19 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/rt/tlsf/prepareBlock (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1522,7 +1522,7 @@
    i32.store
   end
  )
- (func $~lib/rt/tlsf/allocateBlock (; 20 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/allocateBlock (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   global.get $~lib/rt/tlsf/collectLock
@@ -1633,7 +1633,7 @@
   call $~lib/rt/rtrace/onalloc
   local.get $4
  )
- (func $~lib/rt/tlsf/__alloc (; 21 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/__alloc (param $0 i32) (param $1 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
   local.get $0
   local.get $1
@@ -1641,7 +1641,7 @@
   i32.const 16
   i32.add
  )
- (func $~lib/staticarray/StaticArray<u16>#get:length (; 22 ;) (param $0 i32) (result i32)
+ (func $~lib/staticarray/StaticArray<u16>#get:length (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub
@@ -1649,7 +1649,7 @@
   i32.const 1
   i32.shr_u
  )
- (func $~lib/util/casemap/casemap (; 23 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/casemap/casemap (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1839,7 +1839,7 @@
   end
   local.get $2
  )
- (func $~lib/rt/tlsf/checkUsedBlock (; 24 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/tlsf/checkUsedBlock (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   i32.const 16
@@ -1885,7 +1885,7 @@
   end
   local.get $1
  )
- (func $~lib/util/memory/memcpy (; 25 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/memory/memcpy (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2909,7 +2909,7 @@
    i32.store8
   end
  )
- (func $~lib/memory/memory.copy (; 26 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/memory/memory.copy (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3129,7 +3129,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/freeBlock (; 27 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/freeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $1
   i32.load
@@ -3145,7 +3145,7 @@
   local.get $1
   call $~lib/rt/rtrace/onfree
  )
- (func $~lib/rt/tlsf/reallocateBlock (; 28 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/reallocateBlock (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3264,7 +3264,7 @@
   end
   local.get $8
  )
- (func $~lib/rt/tlsf/__realloc (; 29 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/__realloc (param $0 i32) (param $1 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
   local.get $0
   call $~lib/rt/tlsf/checkUsedBlock
@@ -3273,7 +3273,7 @@
   i32.const 16
   i32.add
  )
- (func $~lib/string/String#toUpperCase (; 30 ;) (param $0 i32) (result i32)
+ (func $~lib/string/String#toUpperCase (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -3625,7 +3625,7 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~lib/rt/pure/__release (; 31 ;) (param $0 i32)
+ (func $~lib/rt/pure/__release (param $0 i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.gt_u
@@ -3636,7 +3636,7 @@
    call $~lib/rt/pure/decrement
   end
  )
- (func $~lib/util/string/compareImpl (; 32 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
+ (func $~lib/util/string/compareImpl (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
@@ -3758,7 +3758,7 @@
   call $~lib/rt/pure/__release
   local.get $7
  )
- (func $~lib/string/String.__eq (; 33 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__eq (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -3831,7 +3831,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/util/string/stagedBinaryLookup (; 34 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/stagedBinaryLookup (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $0
   local.get $1
@@ -3856,7 +3856,7 @@
   i32.const 1
   i32.and
  )
- (func $~lib/string/String#toLowerCase (; 35 ;) (param $0 i32) (result i32)
+ (func $~lib/string/String#toLowerCase (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -4404,7 +4404,7 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~lib/string/String.fromCodePoint (; 36 ;) (param $0 i32) (result i32)
+ (func $~lib/string/String.fromCodePoint (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -4465,7 +4465,7 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~lib/string/String#codePointAt (; 37 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String#codePointAt (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4532,7 +4532,7 @@
   i32.const 65536
   i32.add
  )
- (func $~lib/util/number/decimalCount32 (; 38 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/decimalCount32 (param $0 i32) (result i32)
   local.get $0
   i32.const 100000
   i32.lt_u
@@ -4587,7 +4587,7 @@
   end
   unreachable
  )
- (func $~lib/util/number/utoa32_lut (; 39 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/number/utoa32_lut (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -4727,7 +4727,7 @@
    i32.store16
   end
  )
- (func $~lib/util/number/decimalCount64High (; 40 ;) (param $0 i64) (result i32)
+ (func $~lib/util/number/decimalCount64High (param $0 i64) (result i32)
   local.get $0
   i64.const 1000000000000000
   i64.lt_u
@@ -4786,7 +4786,7 @@
   end
   unreachable
  )
- (func $~lib/util/number/utoa64_lut (; 41 ;) (param $0 i32) (param $1 i64) (param $2 i32)
+ (func $~lib/util/number/utoa64_lut (param $0 i32) (param $1 i64) (param $2 i32)
   (local $3 i32)
   (local $4 i64)
   (local $5 i32)
@@ -4909,7 +4909,7 @@
   local.get $2
   call $~lib/util/number/utoa32_lut
  )
- (func $~lib/util/number/utoa64 (; 42 ;) (param $0 i64) (result i32)
+ (func $~lib/util/number/utoa64 (param $0 i64) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -4975,16 +4975,16 @@
   local.get $1
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/itoa<u64> (; 43 ;) (param $0 i64) (result i32)
+ (func $~lib/util/number/itoa<u64> (param $0 i64) (result i32)
   local.get $0
   call $~lib/util/number/utoa64
   return
  )
- (func $~lib/number/U64#toString (; 44 ;) (param $0 i64) (result i32)
+ (func $~lib/number/U64#toString (param $0 i64) (result i32)
   local.get $0
   call $~lib/util/number/itoa<u64>
  )
- (func $~lib/string/String#concat (; 45 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String#concat (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5060,7 +5060,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/string/String.__concat (; 46 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__concat (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -5083,7 +5083,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $start:std/string-casemapping (; 47 ;)
+ (func $start:std/string-casemapping
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -6769,7 +6769,7 @@
   local.get $85
   call $~lib/rt/pure/__release
  )
- (func $~start (; 48 ;)
+ (func $~start
   global.get $~started
   if
    return
@@ -6779,10 +6779,10 @@
   end
   call $start:std/string-casemapping
  )
- (func $~lib/rt/pure/__collect (; 49 ;)
+ (func $~lib/rt/pure/__collect
   return
  )
- (func $~lib/rt/pure/decrement (; 50 ;) (param $0 i32)
+ (func $~lib/rt/pure/decrement (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -6859,7 +6859,7 @@
    i32.store offset=4
   end
  )
- (func $~lib/rt/pure/__visit (; 51 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/pure/__visit (param $0 i32) (param $1 i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.lt_u
@@ -6883,19 +6883,19 @@
   i32.sub
   call $~lib/rt/pure/decrement
  )
- (func $~lib/staticarray/StaticArray<u16>#__visit_impl (; 52 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/staticarray/StaticArray<u16>#__visit_impl (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/staticarray/StaticArray<u8>#__visit_impl (; 53 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/staticarray/StaticArray<u8>#__visit_impl (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/staticarray/StaticArray<i32>#__visit_impl (; 54 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/staticarray/StaticArray<i32>#__visit_impl (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/staticarray/StaticArray<u32>#__visit_impl (; 55 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/staticarray/StaticArray<u32>#__visit_impl (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/rt/__visit_members (; 56 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/__visit_members (param $0 i32) (param $1 i32)
   (local $2 i32)
   block $switch$1$default
    block $switch$1$case$8

--- a/tests/compiler/std/string-encoding.optimized.wat
+++ b/tests/compiler/std/string-encoding.optimized.wat
@@ -35,7 +35,7 @@
  (global $~lib/rt/tlsf/collectLock (mut i32) (i32.const 0))
  (export "memory" (memory $0))
  (start $~start)
- (func $~lib/rt/pure/__retain (; 6 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/pure/__retain (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -86,7 +86,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/pure/__release (; 7 ;) (param $0 i32)
+ (func $~lib/rt/pure/__release (param $0 i32)
   local.get $0
   i32.const 22060
   i32.gt_u
@@ -97,7 +97,7 @@
    call $~lib/rt/pure/decrement
   end
  )
- (func $~lib/rt/tlsf/removeBlock (; 8 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/removeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -259,7 +259,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/insertBlock (; 9 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/insertBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -538,7 +538,7 @@
   i32.or
   i32.store offset=4
  )
- (func $~lib/rt/tlsf/addMemory (; 10 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $2
@@ -652,7 +652,7 @@
   local.get $1
   call $~lib/rt/tlsf/insertBlock
  )
- (func $~lib/rt/tlsf/maybeInitialize (; 11 ;) (result i32)
+ (func $~lib/rt/tlsf/maybeInitialize (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -739,7 +739,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/tlsf/prepareSize (; 12 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/tlsf/prepareSize (param $0 i32) (result i32)
   local.get $0
   i32.const 1073741808
   i32.ge_u
@@ -763,7 +763,7 @@
   i32.gt_u
   select
  )
- (func $~lib/rt/tlsf/searchBlock (; 13 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/searchBlock (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   i32.const 256
@@ -892,7 +892,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/prepareBlock (; 14 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/rt/tlsf/prepareBlock (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $1
@@ -967,7 +967,7 @@
    i32.store
   end
  )
- (func $~lib/rt/tlsf/allocateBlock (; 15 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/allocateBlock (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1107,7 +1107,7 @@
   call $~lib/rt/rtrace/onalloc
   local.get $3
  )
- (func $~lib/rt/tlsf/__alloc (; 16 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/__alloc (param $0 i32) (param $1 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
   local.get $0
   local.get $1
@@ -1115,7 +1115,7 @@
   i32.const 16
   i32.add
  )
- (func $~lib/string/String#get:length (; 17 ;) (param $0 i32) (result i32)
+ (func $~lib/string/String#get:length (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub
@@ -1123,7 +1123,7 @@
   i32.const 1
   i32.shr_u
  )
- (func $~lib/memory/memory.copy (; 18 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/memory/memory.copy (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   block $~lib/util/memory/memmove|inlined.0
@@ -1296,7 +1296,7 @@
    end
   end
  )
- (func $~lib/string/String.UTF16.encode (; 19 ;) (param $0 i32) (result i32)
+ (func $~lib/string/String.UTF16.encode (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   i32.const 16
@@ -1314,7 +1314,7 @@
   local.get $1
   call $~lib/rt/pure/__retain
  )
- (func $std/string-encoding/testUTF16Encode (; 20 ;)
+ (func $std/string-encoding/testUTF16Encode
   (local $0 i32)
   (local $1 i32)
   i32.const 1040
@@ -1477,7 +1477,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/string/String.UTF16.decodeUnsafe (; 21 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.UTF16.decodeUnsafe (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   i32.const -2
@@ -1492,7 +1492,7 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~lib/string/String.UTF16.decode (; 22 ;) (param $0 i32) (result i32)
+ (func $~lib/string/String.UTF16.decode (param $0 i32) (result i32)
   local.get $0
   local.get $0
   i32.const 16
@@ -1500,7 +1500,7 @@
   i32.load offset=12
   call $~lib/string/String.UTF16.decodeUnsafe
  )
- (func $~lib/util/string/compareImpl (; 23 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/compareImpl (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -1576,7 +1576,7 @@
   end
   i32.const 0
  )
- (func $~lib/string/String.__eq (; 24 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__eq (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -1610,7 +1610,7 @@
   call $~lib/util/string/compareImpl
   i32.eqz
  )
- (func $std/string-encoding/testUTF16DecodeUnsafe (; 25 ;)
+ (func $std/string-encoding/testUTF16DecodeUnsafe
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -1755,7 +1755,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/string/String.UTF8.byteLength (; 26 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.UTF8.byteLength (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1846,7 +1846,7 @@
   end
   local.get $2
  )
- (func $~lib/string/String.UTF8.encodeUnsafe (; 27 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/string/String.UTF8.encodeUnsafe (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   local.get $0
@@ -2020,7 +2020,7 @@
    i32.store8
   end
  )
- (func $~lib/string/String.UTF8.encode (; 28 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.UTF8.encode (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -2037,7 +2037,7 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $std/string-encoding/testUTF8Encode (; 29 ;)
+ (func $std/string-encoding/testUTF8Encode
   (local $0 i32)
   (local $1 i32)
   i32.const 1040
@@ -2181,7 +2181,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/string-encoding/testUTF8EncodeNullTerminated (; 30 ;)
+ (func $std/string-encoding/testUTF8EncodeNullTerminated
   (local $0 i32)
   (local $1 i32)
   i32.const 1040
@@ -2335,7 +2335,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/rt/tlsf/freeBlock (; 31 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/freeBlock (param $0 i32) (param $1 i32)
   local.get $1
   local.get $1
   i32.load
@@ -2348,7 +2348,7 @@
   local.get $1
   call $~lib/rt/rtrace/onfree
  )
- (func $~lib/rt/tlsf/reallocateBlock (; 32 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/reallocateBlock (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2451,7 +2451,7 @@
   end
   local.get $3
  )
- (func $~lib/string/String.UTF8.decodeUnsafe (; 33 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/string/String.UTF8.decodeUnsafe (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2684,7 +2684,7 @@
   i32.add
   call $~lib/rt/pure/__retain
  )
- (func $~lib/string/String.UTF8.decode (; 34 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.UTF8.decode (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $0
   i32.const 16
@@ -2693,7 +2693,7 @@
   local.get $1
   call $~lib/string/String.UTF8.decodeUnsafe
  )
- (func $std/string-encoding/testUTF8DecodeNullTerminated (; 35 ;)
+ (func $std/string-encoding/testUTF8DecodeNullTerminated
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -2807,7 +2807,7 @@
   local.get $4
   call $~lib/rt/pure/__release
  )
- (func $std/string-encoding/testUTF8DecodeUnsafe (; 36 ;)
+ (func $std/string-encoding/testUTF8DecodeUnsafe
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -3004,7 +3004,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $std/string-encoding/testLarge (; 37 ;) (param $0 i32)
+ (func $std/string-encoding/testLarge (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -3052,7 +3052,7 @@
   local.get $3
   call $~lib/rt/pure/__release
  )
- (func $start:std/string-encoding (; 38 ;)
+ (func $start:std/string-encoding
   (local $0 i32)
   (local $1 i32)
   i32.const 1036
@@ -3146,10 +3146,10 @@
   i32.const 14704
   call $std/string-encoding/testLarge
  )
- (func $~start (; 39 ;)
+ (func $~start
   call $start:std/string-encoding
  )
- (func $~lib/rt/pure/decrement (; 40 ;) (param $0 i32)
+ (func $~lib/rt/pure/decrement (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0

--- a/tests/compiler/std/string-encoding.untouched.wat
+++ b/tests/compiler/std/string-encoding.untouched.wat
@@ -43,7 +43,7 @@
  (global $~lib/heap/__heap_base i32 (i32.const 21052))
  (export "memory" (memory $0))
  (start $~start)
- (func $~lib/rt/pure/increment (; 6 ;) (param $0 i32)
+ (func $~lib/rt/pure/increment (param $0 i32)
   (local $1 i32)
   local.get $0
   i32.load offset=4
@@ -88,7 +88,7 @@
    unreachable
   end
  )
- (func $~lib/rt/pure/__retain (; 7 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/pure/__retain (param $0 i32) (result i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.gt_u
@@ -100,7 +100,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/pure/__release (; 8 ;) (param $0 i32)
+ (func $~lib/rt/pure/__release (param $0 i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.gt_u
@@ -111,7 +111,7 @@
    call $~lib/rt/pure/decrement
   end
  )
- (func $~lib/string/String.UTF16.byteLength (; 9 ;) (param $0 i32) (result i32)
+ (func $~lib/string/String.UTF16.byteLength (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -125,7 +125,7 @@
   call $~lib/rt/pure/__release
   local.get $1
  )
- (func $std/string-encoding/testUTF16Length (; 10 ;)
+ (func $std/string-encoding/testUTF16Length
   global.get $std/string-encoding/str
   call $~lib/string/String.UTF16.byteLength
   i32.const 12
@@ -140,7 +140,7 @@
    unreachable
   end
  )
- (func $~lib/rt/tlsf/removeBlock (; 11 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/removeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -350,7 +350,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/insertBlock (; 12 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/insertBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -700,7 +700,7 @@
   local.get $7
   i32.store offset=4
  )
- (func $~lib/rt/tlsf/addMemory (; 13 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -848,7 +848,7 @@
   call $~lib/rt/tlsf/insertBlock
   i32.const 1
  )
- (func $~lib/rt/tlsf/maybeInitialize (; 14 ;) (result i32)
+ (func $~lib/rt/tlsf/maybeInitialize (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -1002,7 +1002,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/tlsf/prepareSize (; 15 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/tlsf/prepareSize (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -1031,7 +1031,7 @@
   i32.gt_u
   select
  )
- (func $~lib/rt/tlsf/searchBlock (; 16 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/searchBlock (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1214,7 +1214,7 @@
   end
   local.get $7
  )
- (func $~lib/rt/tlsf/growMemory (; 17 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/growMemory (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1298,7 +1298,7 @@
   call $~lib/rt/tlsf/addMemory
   drop
  )
- (func $~lib/rt/tlsf/prepareBlock (; 18 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/rt/tlsf/prepareBlock (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1393,7 +1393,7 @@
    i32.store
   end
  )
- (func $~lib/rt/tlsf/allocateBlock (; 19 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/allocateBlock (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   global.get $~lib/rt/tlsf/collectLock
@@ -1504,7 +1504,7 @@
   call $~lib/rt/rtrace/onalloc
   local.get $4
  )
- (func $~lib/rt/tlsf/__alloc (; 20 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/__alloc (param $0 i32) (param $1 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
   local.get $0
   local.get $1
@@ -1512,7 +1512,7 @@
   i32.const 16
   i32.add
  )
- (func $~lib/string/String#get:length (; 21 ;) (param $0 i32) (result i32)
+ (func $~lib/string/String#get:length (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub
@@ -1520,7 +1520,7 @@
   i32.const 1
   i32.shr_u
  )
- (func $~lib/util/memory/memcpy (; 22 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/memory/memcpy (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2544,7 +2544,7 @@
    i32.store8
   end
  )
- (func $~lib/memory/memory.copy (; 23 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/memory/memory.copy (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2764,7 +2764,7 @@
    end
   end
  )
- (func $~lib/string/String.UTF16.encodeUnsafe (; 24 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/string/String.UTF16.encodeUnsafe (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $1
   i32.const 1
@@ -2776,7 +2776,7 @@
   call $~lib/memory/memory.copy
   local.get $3
  )
- (func $~lib/string/String.UTF16.encode (; 25 ;) (param $0 i32) (result i32)
+ (func $~lib/string/String.UTF16.encode (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -2800,13 +2800,13 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/arraybuffer/ArrayBuffer#get:byteLength (; 26 ;) (param $0 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBuffer#get:byteLength (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub
   i32.load offset=12
  )
- (func $std/string-encoding/testUTF16Encode (; 27 ;)
+ (func $std/string-encoding/testUTF16Encode
   (local $0 i32)
   (local $1 i32)
   global.get $std/string-encoding/str
@@ -2986,7 +2986,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/string/String.UTF16.decodeUnsafe (; 28 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.UTF16.decodeUnsafe (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   i32.const 1
@@ -3004,7 +3004,7 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~lib/string/String.UTF16.decode (; 29 ;) (param $0 i32) (result i32)
+ (func $~lib/string/String.UTF16.decode (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -3018,7 +3018,7 @@
   call $~lib/rt/pure/__release
   local.get $1
  )
- (func $~lib/util/string/compareImpl (; 30 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
+ (func $~lib/util/string/compareImpl (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
@@ -3140,7 +3140,7 @@
   call $~lib/rt/pure/__release
   local.get $7
  )
- (func $~lib/string/String.__eq (; 31 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__eq (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -3213,7 +3213,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $std/string-encoding/testUTF16Decode (; 32 ;)
+ (func $std/string-encoding/testUTF16Decode
   (local $0 i32)
   (local $1 i32)
   global.get $std/string-encoding/str
@@ -3238,7 +3238,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $std/string-encoding/testUTF16DecodeUnsafe (; 33 ;)
+ (func $std/string-encoding/testUTF16DecodeUnsafe
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -3387,7 +3387,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/string/String.UTF8.byteLength (; 34 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.UTF8.byteLength (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3498,7 +3498,7 @@
   call $~lib/rt/pure/__release
   local.get $5
  )
- (func $std/string-encoding/testUTF8Length (; 35 ;)
+ (func $std/string-encoding/testUTF8Length
   global.get $std/string-encoding/str
   i32.const 0
   call $~lib/string/String.UTF8.byteLength
@@ -3528,7 +3528,7 @@
    unreachable
   end
  )
- (func $~lib/string/String.UTF8.encodeUnsafe (; 36 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $~lib/string/String.UTF8.encodeUnsafe (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -3744,7 +3744,7 @@
   local.get $2
   i32.sub
  )
- (func $~lib/string/String.UTF8.encode (; 37 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.UTF8.encode (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -3770,7 +3770,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $std/string-encoding/testUTF8Encode (; 38 ;)
+ (func $std/string-encoding/testUTF8Encode
   (local $0 i32)
   (local $1 i32)
   global.get $std/string-encoding/str
@@ -3925,7 +3925,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $std/string-encoding/testUTF8EncodeNullTerminated (; 39 ;)
+ (func $std/string-encoding/testUTF8EncodeNullTerminated
   (local $0 i32)
   (local $1 i32)
   global.get $std/string-encoding/str
@@ -4093,7 +4093,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/rt/tlsf/checkUsedBlock (; 40 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/tlsf/checkUsedBlock (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   i32.const 16
@@ -4139,7 +4139,7 @@
   end
   local.get $1
  )
- (func $~lib/rt/tlsf/freeBlock (; 41 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/freeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $1
   i32.load
@@ -4155,7 +4155,7 @@
   local.get $1
   call $~lib/rt/rtrace/onfree
  )
- (func $~lib/rt/tlsf/reallocateBlock (; 42 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/reallocateBlock (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -4274,7 +4274,7 @@
   end
   local.get $8
  )
- (func $~lib/rt/tlsf/__realloc (; 43 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/__realloc (param $0 i32) (param $1 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
   local.get $0
   call $~lib/rt/tlsf/checkUsedBlock
@@ -4283,7 +4283,7 @@
   i32.const 16
   i32.add
  )
- (func $~lib/string/String.UTF8.decodeUnsafe (; 44 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/string/String.UTF8.decodeUnsafe (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -4499,7 +4499,7 @@
   call $~lib/rt/tlsf/__realloc
   call $~lib/rt/pure/__retain
  )
- (func $~lib/string/String.UTF8.decode (; 45 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.UTF8.decode (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -4514,7 +4514,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $std/string-encoding/testUTF8Decode (; 46 ;)
+ (func $std/string-encoding/testUTF8Decode
   (local $0 i32)
   (local $1 i32)
   global.get $std/string-encoding/str
@@ -4541,7 +4541,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $std/string-encoding/testUTF8DecodeNullTerminated (; 47 ;)
+ (func $std/string-encoding/testUTF8DecodeNullTerminated
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -4669,7 +4669,7 @@
   local.get $6
   call $~lib/rt/pure/__release
  )
- (func $std/string-encoding/testUTF8DecodeUnsafe (; 48 ;)
+ (func $std/string-encoding/testUTF8DecodeUnsafe
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -4869,7 +4869,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $std/string-encoding/testLarge (; 49 ;) (param $0 i32)
+ (func $std/string-encoding/testLarge (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -4924,7 +4924,7 @@
   local.get $3
   call $~lib/rt/pure/__release
  )
- (func $start:std/string-encoding (; 50 ;)
+ (func $start:std/string-encoding
   call $std/string-encoding/testUTF16Length
   call $std/string-encoding/testUTF16Encode
   call $std/string-encoding/testUTF16Decode
@@ -4940,10 +4940,10 @@
   i32.const 13696
   call $std/string-encoding/testLarge
  )
- (func $~start (; 51 ;)
+ (func $~start
   call $start:std/string-encoding
  )
- (func $~lib/rt/pure/decrement (; 52 ;) (param $0 i32)
+ (func $~lib/rt/pure/decrement (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -5020,10 +5020,10 @@
    i32.store offset=4
   end
  )
- (func $~lib/rt/pure/__collect (; 53 ;)
+ (func $~lib/rt/pure/__collect
   return
  )
- (func $~lib/rt/pure/__visit (; 54 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/pure/__visit (param $0 i32) (param $1 i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.lt_u
@@ -5047,7 +5047,7 @@
   i32.sub
   call $~lib/rt/pure/decrement
  )
- (func $~lib/rt/__visit_members (; 55 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/__visit_members (param $0 i32) (param $1 i32)
   (local $2 i32)
   block $switch$1$default
    block $switch$1$case$4

--- a/tests/compiler/std/string.optimized.wat
+++ b/tests/compiler/std/string.optimized.wat
@@ -386,7 +386,7 @@
  (export "_start" (func $~start))
  (export "memory" (memory $0))
  (export "getString" (func $std/string/getString))
- (func $~lib/rt/pure/__retain (; 6 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/pure/__retain (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -437,7 +437,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/pure/__release (; 7 ;) (param $0 i32)
+ (func $~lib/rt/pure/__release (param $0 i32)
   local.get $0
   i32.const 18008
   i32.gt_u
@@ -448,7 +448,7 @@
    call $~lib/rt/pure/decrement
   end
  )
- (func $~lib/string/String#get:length (; 8 ;) (param $0 i32) (result i32)
+ (func $~lib/string/String#get:length (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub
@@ -456,7 +456,7 @@
   i32.const 1
   i32.shr_u
  )
- (func $~lib/util/string/compareImpl (; 9 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $~lib/util/string/compareImpl (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $0
   local.get $1
@@ -536,7 +536,7 @@
   end
   i32.const 0
  )
- (func $~lib/string/String.__eq (; 10 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__eq (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -571,7 +571,7 @@
   call $~lib/util/string/compareImpl
   i32.eqz
  )
- (func $~lib/string/String.__not (; 11 ;) (param $0 i32) (result i32)
+ (func $~lib/string/String.__not (param $0 i32) (result i32)
   local.get $0
   if (result i32)
    local.get $0
@@ -581,7 +581,7 @@
    i32.const 1
   end
  )
- (func $~lib/rt/tlsf/removeBlock (; 12 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/removeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -743,7 +743,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/insertBlock (; 13 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/insertBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1022,7 +1022,7 @@
   i32.or
   i32.store offset=4
  )
- (func $~lib/rt/tlsf/addMemory (; 14 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $2
@@ -1136,7 +1136,7 @@
   local.get $1
   call $~lib/rt/tlsf/insertBlock
  )
- (func $~lib/rt/tlsf/maybeInitialize (; 15 ;) (result i32)
+ (func $~lib/rt/tlsf/maybeInitialize (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -1223,7 +1223,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/tlsf/prepareSize (; 16 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/tlsf/prepareSize (param $0 i32) (result i32)
   local.get $0
   i32.const 1073741808
   i32.ge_u
@@ -1247,7 +1247,7 @@
   i32.gt_u
   select
  )
- (func $~lib/rt/tlsf/searchBlock (; 17 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/searchBlock (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   i32.const 256
@@ -1376,7 +1376,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/prepareBlock (; 18 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/rt/tlsf/prepareBlock (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $1
@@ -1451,7 +1451,7 @@
    i32.store
   end
  )
- (func $~lib/rt/tlsf/allocateBlock (; 19 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/allocateBlock (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1591,7 +1591,7 @@
   call $~lib/rt/rtrace/onalloc
   local.get $3
  )
- (func $~lib/rt/tlsf/__alloc (; 20 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/__alloc (param $0 i32) (param $1 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
   local.get $0
   local.get $1
@@ -1599,7 +1599,7 @@
   i32.const 16
   i32.add
  )
- (func $~lib/string/String.fromCharCode (; 21 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.fromCharCode (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   i32.const 2
@@ -1622,7 +1622,7 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~lib/string/String.fromCharCode|trampoline (; 22 ;) (param $0 i32) (result i32)
+ (func $~lib/string/String.fromCharCode|trampoline (param $0 i32) (result i32)
   (local $1 i32)
   block $1of1
    block $0of1
@@ -1641,11 +1641,11 @@
   local.get $1
   call $~lib/string/String.fromCharCode
  )
- (func $~setArgumentsLength (; 23 ;) (param $0 i32)
+ (func $~setArgumentsLength (param $0 i32)
   local.get $0
   global.set $~argumentsLength
  )
- (func $~lib/string/String.fromCodePoint (; 24 ;) (param $0 i32) (result i32)
+ (func $~lib/string/String.fromCodePoint (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -1696,7 +1696,7 @@
   local.get $1
   call $~lib/rt/pure/__retain
  )
- (func $~lib/string/String#indexOf (; 25 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/string/String#indexOf (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $1
@@ -1756,7 +1756,7 @@
   end
   i32.const -1
  )
- (func $~lib/memory/memory.copy (; 26 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/memory/memory.copy (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   block $~lib/util/memory/memmove|inlined.0
@@ -1929,7 +1929,7 @@
    end
   end
  )
- (func $~lib/memory/memory.repeat (; 27 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/memory/memory.repeat (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   local.get $2
   local.get $3
@@ -1954,7 +1954,7 @@
    end
   end
  )
- (func $~lib/string/String#padStart (; 28 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/string/String#padStart (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2033,7 +2033,7 @@
   local.get $1
   call $~lib/rt/pure/__retain
  )
- (func $~lib/string/String#padEnd (; 29 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/string/String#padEnd (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2113,7 +2113,7 @@
   local.get $1
   call $~lib/rt/pure/__retain
  )
- (func $~lib/string/String#lastIndexOf (; 30 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/string/String#lastIndexOf (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $1
@@ -2173,7 +2173,7 @@
   end
   i32.const -1
  )
- (func $~lib/string/String#localeCompare (; 31 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String#localeCompare (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -2211,7 +2211,7 @@
   local.get $2
   call $~lib/util/string/compareImpl
  )
- (func $~lib/util/string/isSpace (; 32 ;) (param $0 i32) (result i32)
+ (func $~lib/util/string/isSpace (param $0 i32) (result i32)
   local.get $0
   i32.const 5760
   i32.lt_u
@@ -2275,7 +2275,7 @@
   end
   i32.const 0
  )
- (func $~lib/string/String#trimStart (; 33 ;) (param $0 i32) (result i32)
+ (func $~lib/string/String#trimStart (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -2333,7 +2333,7 @@
   local.get $3
   call $~lib/rt/pure/__retain
  )
- (func $~lib/string/String#trimEnd (; 34 ;) (param $0 i32) (result i32)
+ (func $~lib/string/String#trimEnd (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -2387,7 +2387,7 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~lib/string/String#trim (; 35 ;) (param $0 i32) (result i32)
+ (func $~lib/string/String#trim (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -2474,7 +2474,7 @@
   local.get $3
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/string/strtol<f64> (; 36 ;) (param $0 i32) (result f64)
+ (func $~lib/util/string/strtol<f64> (param $0 i32) (result f64)
   (local $1 i32)
   (local $2 i32)
   (local $3 f64)
@@ -2689,7 +2689,7 @@
   local.get $3
   f64.mul
  )
- (func $~lib/util/string/strtol<i32> (; 37 ;) (result i32)
+ (func $~lib/util/string/strtol<i32> (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -2905,7 +2905,7 @@
   local.get $4
   i32.mul
  )
- (func $~lib/util/string/strtol<i64> (; 38 ;) (result i64)
+ (func $~lib/util/string/strtol<i64> (result i64)
   (local $0 i32)
   (local $1 i32)
   (local $2 i64)
@@ -3123,7 +3123,7 @@
   local.get $4
   i64.mul
  )
- (func $~lib/math/ipow32 (; 39 ;) (param $0 i32) (result i32)
+ (func $~lib/math/ipow32 (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   i32.const 5
@@ -3157,7 +3157,7 @@
   end
   local.get $2
  )
- (func $~lib/math/NativeMath.scalbn (; 40 ;) (param $0 f64) (param $1 i32) (result f64)
+ (func $~lib/math/NativeMath.scalbn (param $0 f64) (param $1 i32) (result f64)
   local.get $1
   i32.const 1023
   i32.gt_s
@@ -3234,7 +3234,7 @@
   f64.reinterpret_i64
   f64.mul
  )
- (func $~lib/util/string/strtod (; 41 ;) (param $0 i32) (result f64)
+ (func $~lib/util/string/strtod (param $0 i32) (result f64)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -3979,7 +3979,7 @@
   end
   f64.const nan:0x8000000000000
  )
- (func $~lib/string/String.__concat (; 42 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__concat (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4042,7 +4042,7 @@
    local.get $1
   end
  )
- (func $~lib/string/String.__gt (; 43 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__gt (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   i32.const 1
@@ -4089,7 +4089,7 @@
   i32.const 0
   i32.gt_s
  )
- (func $~lib/string/String.__lt (; 44 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__lt (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   i32.const 1
@@ -4136,7 +4136,7 @@
   i32.const 0
   i32.lt_s
  )
- (func $~lib/string/String#repeat (; 45 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String#repeat (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   i32.const 1
@@ -4195,7 +4195,7 @@
   local.get $3
   call $~lib/rt/pure/__retain
  )
- (func $~lib/string/String#replace (; 46 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/string/String#replace (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -4292,7 +4292,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/rt/tlsf/checkUsedBlock (; 47 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/tlsf/checkUsedBlock (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   i32.const 16
@@ -4334,7 +4334,7 @@
   end
   local.get $1
  )
- (func $~lib/rt/tlsf/freeBlock (; 48 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/freeBlock (param $0 i32) (param $1 i32)
   local.get $1
   local.get $1
   i32.load
@@ -4347,7 +4347,7 @@
   local.get $1
   call $~lib/rt/rtrace/onfree
  )
- (func $~lib/rt/tlsf/reallocateBlock (; 49 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/reallocateBlock (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -4450,7 +4450,7 @@
   end
   local.get $3
  )
- (func $~lib/rt/tlsf/__realloc (; 50 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/__realloc (param $0 i32) (param $1 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
   local.get $0
   call $~lib/rt/tlsf/checkUsedBlock
@@ -4459,7 +4459,7 @@
   i32.const 16
   i32.add
  )
- (func $~lib/string/String#replaceAll (; 51 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/string/String#replaceAll (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -4750,7 +4750,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/string/String#slice (; 52 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/string/String#slice (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $0
   call $~lib/string/String#get:length
@@ -4824,7 +4824,7 @@
   local.get $3
   call $~lib/rt/pure/__retain
  )
- (func $~lib/string/String#substr (; 53 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/string/String#substr (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   i32.const 0
@@ -4881,7 +4881,7 @@
   local.get $3
   call $~lib/rt/pure/__retain
  )
- (func $~lib/string/String#substring (; 54 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/string/String#substring (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $1
@@ -4960,7 +4960,7 @@
   local.get $1
   call $~lib/rt/pure/__retain
  )
- (func $~lib/rt/__allocArray (; 55 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/__allocArray (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -4988,7 +4988,7 @@
   i32.store offset=12
   local.get $1
  )
- (func $~lib/memory/memory.fill (; 56 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/memory/memory.fill (param $0 i32) (param $1 i32)
   (local $2 i32)
   block $~lib/util/memory/memset|inlined.0
    local.get $1
@@ -5146,7 +5146,7 @@
    end
   end
  )
- (func $~lib/array/Array<~lib/string/String>#push (; 57 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<~lib/string/String>#push (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5222,7 +5222,7 @@
   local.get $3
   i32.store offset=12
  )
- (func $~lib/string/String#split (; 58 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/string/String#split (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -5432,7 +5432,7 @@
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
  )
- (func $~lib/array/Array<~lib/string/String>#__get (; 59 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/string/String>#__get (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -5467,7 +5467,7 @@
   end
   local.get $0
  )
- (func $~lib/util/number/decimalCount32 (; 60 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/decimalCount32 (param $0 i32) (result i32)
   local.get $0
   i32.const 10
   i32.ge_u
@@ -5509,7 +5509,7 @@
   i32.lt_u
   select
  )
- (func $~lib/util/number/utoa_simple<u32> (; 61 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/number/utoa_simple<u32> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   loop $do-continue|0
    local.get $1
@@ -5536,7 +5536,7 @@
    br_if $do-continue|0
   end
  )
- (func $~lib/util/number/itoa32 (; 62 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/itoa32 (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -5578,7 +5578,7 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/utoa32 (; 63 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/utoa32 (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -5601,7 +5601,7 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/decimalCount64High (; 64 ;) (param $0 i64) (result i32)
+ (func $~lib/util/number/decimalCount64High (param $0 i64) (result i32)
   local.get $0
   i64.const 100000000000
   i64.ge_u
@@ -5647,7 +5647,7 @@
   i64.lt_u
   select
  )
- (func $~lib/util/number/utoa_simple<u64> (; 65 ;) (param $0 i32) (param $1 i64) (param $2 i32)
+ (func $~lib/util/number/utoa_simple<u64> (param $0 i32) (param $1 i64) (param $2 i32)
   (local $3 i32)
   loop $do-continue|0
    local.get $1
@@ -5677,7 +5677,7 @@
    br_if $do-continue|0
   end
  )
- (func $~lib/util/number/utoa64 (; 66 ;) (param $0 i64) (result i32)
+ (func $~lib/util/number/utoa64 (param $0 i64) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -5720,7 +5720,7 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/itoa64 (; 67 ;) (param $0 i64) (result i32)
+ (func $~lib/util/number/itoa64 (param $0 i64) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -5785,7 +5785,7 @@
   local.get $3
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/genDigits (; 68 ;) (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (param $6 i32) (result i32)
+ (func $~lib/util/number/genDigits (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (param $6 i32) (result i32)
   (local $7 i32)
   (local $8 i64)
   (local $9 i64)
@@ -6176,7 +6176,7 @@
    local.get $6
   end
  )
- (func $~lib/util/number/prettify (; 69 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/prettify (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   i32.eqz
@@ -6421,7 +6421,7 @@
    end
   end
  )
- (func $~lib/util/number/dtoa_core (; 70 ;) (param $0 i32) (param $1 f64) (result i32)
+ (func $~lib/util/number/dtoa_core (param $0 i32) (param $1 f64) (result i32)
   (local $2 i64)
   (local $3 i64)
   (local $4 i32)
@@ -6713,7 +6713,7 @@
   local.get $7
   i32.add
  )
- (func $~lib/util/number/dtoa (; 71 ;) (param $0 f64) (result i32)
+ (func $~lib/util/number/dtoa (param $0 f64) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -6768,7 +6768,7 @@
   call $~lib/rt/tlsf/checkUsedBlock
   call $~lib/rt/tlsf/freeBlock
  )
- (func $start:std/string (; 72 ;)
+ (func $start:std/string
   (local $0 i32)
   (local $1 i32)
   (local $2 f64)
@@ -14238,11 +14238,11 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $std/string/getString (; 73 ;) (result i32)
+ (func $std/string/getString (result i32)
   global.get $std/string/str
   call $~lib/rt/pure/__retain
  )
- (func $~start (; 74 ;)
+ (func $~start
   global.get $~started
   if
    return
@@ -14252,7 +14252,7 @@
   end
   call $start:std/string
  )
- (func $~lib/rt/pure/decrement (; 75 ;) (param $0 i32)
+ (func $~lib/rt/pure/decrement (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -14382,7 +14382,7 @@
    i32.store offset=4
   end
  )
- (func $~lib/rt/pure/__visit (; 76 ;) (param $0 i32)
+ (func $~lib/rt/pure/__visit (param $0 i32)
   local.get $0
   i32.const 18008
   i32.lt_u

--- a/tests/compiler/std/string.untouched.wat
+++ b/tests/compiler/std/string.untouched.wat
@@ -407,7 +407,7 @@
  (export "_start" (func $~start))
  (export "memory" (memory $0))
  (export "getString" (func $std/string/getString))
- (func $~lib/rt/pure/increment (; 6 ;) (param $0 i32)
+ (func $~lib/rt/pure/increment (param $0 i32)
   (local $1 i32)
   local.get $0
   i32.load offset=4
@@ -452,7 +452,7 @@
    unreachable
   end
  )
- (func $~lib/rt/pure/__retain (; 7 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/pure/__retain (param $0 i32) (result i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.gt_u
@@ -464,7 +464,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/pure/__release (; 8 ;) (param $0 i32)
+ (func $~lib/rt/pure/__release (param $0 i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.gt_u
@@ -475,7 +475,7 @@
    call $~lib/rt/pure/decrement
   end
  )
- (func $~lib/string/String#get:length (; 9 ;) (param $0 i32) (result i32)
+ (func $~lib/string/String#get:length (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub
@@ -483,7 +483,7 @@
   i32.const 1
   i32.shr_u
  )
- (func $~lib/util/string/compareImpl (; 10 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
+ (func $~lib/util/string/compareImpl (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
@@ -605,7 +605,7 @@
   call $~lib/rt/pure/__release
   local.get $7
  )
- (func $~lib/string/String.__eq (; 11 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__eq (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -678,7 +678,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/string/String#charCodeAt (; 12 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String#charCodeAt (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   call $~lib/string/String#get:length
@@ -694,7 +694,7 @@
   i32.add
   i32.load16_u
  )
- (func $~lib/string/String.__not (; 13 ;) (param $0 i32) (result i32)
+ (func $~lib/string/String.__not (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -714,7 +714,7 @@
   call $~lib/rt/pure/__release
   local.get $1
  )
- (func $~lib/rt/tlsf/removeBlock (; 14 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/removeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -924,7 +924,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/insertBlock (; 15 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/insertBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1274,7 +1274,7 @@
   local.get $7
   i32.store offset=4
  )
- (func $~lib/rt/tlsf/addMemory (; 16 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1422,7 +1422,7 @@
   call $~lib/rt/tlsf/insertBlock
   i32.const 1
  )
- (func $~lib/rt/tlsf/maybeInitialize (; 17 ;) (result i32)
+ (func $~lib/rt/tlsf/maybeInitialize (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -1576,7 +1576,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/tlsf/prepareSize (; 18 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/tlsf/prepareSize (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -1605,7 +1605,7 @@
   i32.gt_u
   select
  )
- (func $~lib/rt/tlsf/searchBlock (; 19 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/searchBlock (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1788,7 +1788,7 @@
   end
   local.get $7
  )
- (func $~lib/rt/tlsf/growMemory (; 20 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/growMemory (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1872,7 +1872,7 @@
   call $~lib/rt/tlsf/addMemory
   drop
  )
- (func $~lib/rt/tlsf/prepareBlock (; 21 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/rt/tlsf/prepareBlock (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1967,7 +1967,7 @@
    i32.store
   end
  )
- (func $~lib/rt/tlsf/allocateBlock (; 22 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/allocateBlock (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   global.get $~lib/rt/tlsf/collectLock
@@ -2078,7 +2078,7 @@
   call $~lib/rt/rtrace/onalloc
   local.get $4
  )
- (func $~lib/rt/tlsf/__alloc (; 23 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/__alloc (param $0 i32) (param $1 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
   local.get $0
   local.get $1
@@ -2086,7 +2086,7 @@
   i32.const 16
   i32.add
  )
- (func $~lib/string/String.fromCharCode (; 24 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.fromCharCode (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $1
@@ -2111,7 +2111,7 @@
   local.get $3
   call $~lib/rt/pure/__retain
  )
- (func $~lib/string/String.fromCharCode|trampoline (; 25 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.fromCharCode|trampoline (param $0 i32) (param $1 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -2129,11 +2129,11 @@
   local.get $1
   call $~lib/string/String.fromCharCode
  )
- (func $~setArgumentsLength (; 26 ;) (param $0 i32)
+ (func $~setArgumentsLength (param $0 i32)
   local.get $0
   global.set $~argumentsLength
  )
- (func $~lib/string/String.fromCodePoint (; 27 ;) (param $0 i32) (result i32)
+ (func $~lib/string/String.fromCodePoint (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -2194,7 +2194,7 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~lib/string/String#startsWith (; 28 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/string/String#startsWith (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2269,7 +2269,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/string/String#endsWith (; 29 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/string/String#endsWith (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2335,7 +2335,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/string/String#indexOf (; 30 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/string/String#indexOf (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2425,7 +2425,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/string/String#includes (; 31 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/string/String#includes (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $1
   call $~lib/rt/pure/__retain
@@ -2441,7 +2441,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/util/memory/memcpy (; 32 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/memory/memcpy (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3465,7 +3465,7 @@
    i32.store8
   end
  )
- (func $~lib/memory/memory.copy (; 33 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/memory/memory.copy (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3685,7 +3685,7 @@
    end
   end
  )
- (func $~lib/memory/memory.repeat (; 34 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/memory/memory.repeat (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -3716,7 +3716,7 @@
    end
   end
  )
- (func $~lib/string/String#padStart (; 35 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/string/String#padStart (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3816,7 +3816,7 @@
   call $~lib/rt/pure/__release
   local.get $10
  )
- (func $~lib/string/String#padEnd (; 36 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/string/String#padEnd (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3920,7 +3920,7 @@
   call $~lib/rt/pure/__release
   local.get $10
  )
- (func $~lib/string/String#lastIndexOf (; 37 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/string/String#lastIndexOf (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -4009,7 +4009,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/string/String#localeCompare (; 38 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String#localeCompare (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4070,7 +4070,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/util/string/isSpace (; 39 ;) (param $0 i32) (result i32)
+ (func $~lib/util/string/isSpace (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   i32.const 5760
@@ -4151,7 +4151,7 @@
   end
   i32.const 0
  )
- (func $~lib/string/String#trimStart (; 40 ;) (param $0 i32) (result i32)
+ (func $~lib/string/String#trimStart (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -4217,7 +4217,7 @@
   local.get $4
   call $~lib/rt/pure/__retain
  )
- (func $~lib/string/String#trimEnd (; 41 ;) (param $0 i32) (result i32)
+ (func $~lib/string/String#trimEnd (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -4278,7 +4278,7 @@
   local.get $4
   call $~lib/rt/pure/__retain
  )
- (func $~lib/string/String#trim (; 42 ;) (param $0 i32) (result i32)
+ (func $~lib/string/String#trim (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -4379,7 +4379,7 @@
   local.get $5
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/string/strtol<f64> (; 43 ;) (param $0 i32) (param $1 i32) (result f64)
+ (func $~lib/util/string/strtol<f64> (param $0 i32) (param $1 i32) (result f64)
   (local $2 i32)
   (local $3 f64)
   (local $4 i32)
@@ -4670,7 +4670,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/string/parseInt (; 44 ;) (param $0 i32) (param $1 i32) (result f64)
+ (func $~lib/string/parseInt (param $0 i32) (param $1 i32) (result f64)
   (local $2 f64)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -4683,7 +4683,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/util/string/strtol<i32> (; 45 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/strtol<i32> (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4971,7 +4971,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/number/I32.parseInt (; 46 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/number/I32.parseInt (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -4984,7 +4984,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/util/string/strtol<i64> (; 47 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $~lib/util/string/strtol<i64> (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local $3 i64)
   (local $4 i32)
@@ -5275,7 +5275,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/number/I64.parseInt (; 48 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $~lib/number/I64.parseInt (param $0 i32) (param $1 i32) (result i64)
   (local $2 i64)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -5288,7 +5288,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/math/ipow32 (; 49 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/math/ipow32 (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5485,7 +5485,7 @@
   end
   local.get $2
  )
- (func $~lib/math/NativeMath.scalbn (; 50 ;) (param $0 f64) (param $1 i32) (result f64)
+ (func $~lib/math/NativeMath.scalbn (param $0 f64) (param $1 i32) (result f64)
   (local $2 f64)
   (local $3 i32)
   (local $4 i32)
@@ -5576,7 +5576,7 @@
   f64.reinterpret_i64
   f64.mul
  )
- (func $~lib/util/string/strtod (; 51 ;) (param $0 i32) (result f64)
+ (func $~lib/util/string/strtod (param $0 i32) (result f64)
   (local $1 i32)
   (local $2 f64)
   (local $3 i32)
@@ -6541,7 +6541,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/string/parseFloat (; 52 ;) (param $0 i32) (result f64)
+ (func $~lib/string/parseFloat (param $0 i32) (result f64)
   (local $1 f64)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -6553,7 +6553,7 @@
   call $~lib/rt/pure/__release
   local.get $1
  )
- (func $~lib/string/String#concat (; 53 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String#concat (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6629,7 +6629,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/string/String.__concat (; 54 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__concat (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -6652,7 +6652,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/string/String.__ne (; 55 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__ne (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -6671,7 +6671,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/string/String.__gt (; 56 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__gt (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6761,7 +6761,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/string/String.__lt (; 57 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__lt (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6851,7 +6851,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/string/String.__gte (; 58 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__gte (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -6870,7 +6870,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/string/String.__lte (; 59 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__lte (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -6889,7 +6889,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/string/String#repeat (; 60 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String#repeat (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -6957,7 +6957,7 @@
   local.get $3
   call $~lib/rt/pure/__retain
  )
- (func $~lib/string/String#replace (; 61 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/string/String#replace (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -7088,7 +7088,7 @@
   call $~lib/rt/pure/__release
   local.get $7
  )
- (func $~lib/rt/tlsf/checkUsedBlock (; 62 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/tlsf/checkUsedBlock (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   i32.const 16
@@ -7134,7 +7134,7 @@
   end
   local.get $1
  )
- (func $~lib/rt/tlsf/freeBlock (; 63 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/freeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $1
   i32.load
@@ -7150,7 +7150,7 @@
   local.get $1
   call $~lib/rt/rtrace/onfree
  )
- (func $~lib/rt/tlsf/reallocateBlock (; 64 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/reallocateBlock (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -7269,7 +7269,7 @@
   end
   local.get $8
  )
- (func $~lib/rt/tlsf/__realloc (; 65 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/__realloc (param $0 i32) (param $1 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
   local.get $0
   call $~lib/rt/tlsf/checkUsedBlock
@@ -7278,7 +7278,7 @@
   i32.const 16
   i32.add
  )
- (func $~lib/string/String#replaceAll (; 66 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/string/String#replaceAll (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -7646,7 +7646,7 @@
   call $~lib/rt/pure/__release
   local.get $5
  )
- (func $~lib/string/String#slice (; 67 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/string/String#slice (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -7735,7 +7735,7 @@
   local.get $6
   call $~lib/rt/pure/__retain
  )
- (func $~lib/string/String#substr (; 68 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/string/String#substr (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -7809,7 +7809,7 @@
   local.get $9
   call $~lib/rt/pure/__retain
  )
- (func $~lib/string/String#substring (; 69 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/string/String#substring (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -7916,7 +7916,7 @@
   local.get $11
   call $~lib/rt/pure/__retain
  )
- (func $~lib/rt/__allocBuffer (; 70 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/__allocBuffer (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $0
   local.get $1
@@ -7931,7 +7931,7 @@
   end
   local.get $3
  )
- (func $~lib/rt/__allocArray (; 71 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $~lib/rt/__allocArray (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -7963,7 +7963,7 @@
   i32.store offset=12
   local.get $4
  )
- (func $~lib/memory/memory.fill (; 72 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/memory/memory.fill (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -8172,7 +8172,7 @@
    end
   end
  )
- (func $~lib/array/ensureSize (; 73 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/ensureSize (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -8234,7 +8234,7 @@
    i32.store offset=8
   end
  )
- (func $~lib/array/Array<~lib/string/String>#push (; 74 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/string/String>#push (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -8270,7 +8270,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/string/String#split (; 75 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/string/String#split (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -8576,11 +8576,11 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/array/Array<~lib/string/String>#get:length (; 76 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<~lib/string/String>#get:length (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<~lib/string/String>#__unchecked_get (; 77 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/string/String>#__unchecked_get (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -8590,7 +8590,7 @@
   i32.load
   call $~lib/rt/pure/__retain
  )
- (func $~lib/array/Array<~lib/string/String>#__get (; 78 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/string/String>#__get (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   local.get $0
@@ -8622,7 +8622,7 @@
   end
   local.get $2
  )
- (func $~lib/util/number/decimalCount32 (; 79 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/decimalCount32 (param $0 i32) (result i32)
   local.get $0
   i32.const 100000
   i32.lt_u
@@ -8677,7 +8677,7 @@
   end
   unreachable
  )
- (func $~lib/util/number/utoa32_lut (; 80 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/number/utoa32_lut (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -8817,7 +8817,7 @@
    i32.store16
   end
  )
- (func $~lib/util/number/itoa32 (; 81 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/itoa32 (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -8871,7 +8871,7 @@
   local.get $3
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/utoa32 (; 82 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/utoa32 (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -8905,7 +8905,7 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/decimalCount64High (; 83 ;) (param $0 i64) (result i32)
+ (func $~lib/util/number/decimalCount64High (param $0 i64) (result i32)
   local.get $0
   i64.const 1000000000000000
   i64.lt_u
@@ -8964,7 +8964,7 @@
   end
   unreachable
  )
- (func $~lib/util/number/utoa64_lut (; 84 ;) (param $0 i32) (param $1 i64) (param $2 i32)
+ (func $~lib/util/number/utoa64_lut (param $0 i32) (param $1 i64) (param $2 i32)
   (local $3 i32)
   (local $4 i64)
   (local $5 i32)
@@ -9087,7 +9087,7 @@
   local.get $2
   call $~lib/util/number/utoa32_lut
  )
- (func $~lib/util/number/utoa64 (; 85 ;) (param $0 i64) (result i32)
+ (func $~lib/util/number/utoa64 (param $0 i64) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -9153,7 +9153,7 @@
   local.get $1
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/itoa64 (; 86 ;) (param $0 i64) (result i32)
+ (func $~lib/util/number/itoa64 (param $0 i64) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -9242,7 +9242,7 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/genDigits (; 87 ;) (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (param $6 i32) (result i32)
+ (func $~lib/util/number/genDigits (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (param $6 i32) (result i32)
   (local $7 i32)
   (local $8 i64)
   (local $9 i64)
@@ -9745,7 +9745,7 @@
   end
   unreachable
  )
- (func $~lib/util/number/prettify (; 88 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/prettify (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -10062,7 +10062,7 @@
   end
   unreachable
  )
- (func $~lib/util/number/dtoa_core (; 89 ;) (param $0 i32) (param $1 f64) (result i32)
+ (func $~lib/util/number/dtoa_core (param $0 i32) (param $1 f64) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10488,13 +10488,13 @@
   local.get $2
   i32.add
  )
- (func $~lib/rt/tlsf/__free (; 90 ;) (param $0 i32)
+ (func $~lib/rt/tlsf/__free (param $0 i32)
   call $~lib/rt/tlsf/maybeInitialize
   local.get $0
   call $~lib/rt/tlsf/checkUsedBlock
   call $~lib/rt/tlsf/freeBlock
  )
- (func $~lib/util/number/dtoa (; 91 ;) (param $0 f64) (result i32)
+ (func $~lib/util/number/dtoa (param $0 f64) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -10555,7 +10555,7 @@
   call $~lib/rt/tlsf/__free
   local.get $3
  )
- (func $start:std/string (; 92 ;)
+ (func $start:std/string
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -18417,11 +18417,11 @@
   local.get $211
   call $~lib/rt/pure/__release
  )
- (func $std/string/getString (; 93 ;) (result i32)
+ (func $std/string/getString (result i32)
   global.get $std/string/str
   call $~lib/rt/pure/__retain
  )
- (func $~start (; 94 ;)
+ (func $~start
   global.get $~started
   if
    return
@@ -18431,7 +18431,7 @@
   end
   call $start:std/string
  )
- (func $~lib/rt/pure/decrement (; 95 ;) (param $0 i32)
+ (func $~lib/rt/pure/decrement (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -18508,10 +18508,10 @@
    i32.store offset=4
   end
  )
- (func $~lib/rt/pure/__collect (; 96 ;)
+ (func $~lib/rt/pure/__collect
   return
  )
- (func $~lib/rt/pure/__visit (; 97 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/pure/__visit (param $0 i32) (param $1 i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.lt_u
@@ -18535,10 +18535,10 @@
   i32.sub
   call $~lib/rt/pure/decrement
  )
- (func $~lib/staticarray/StaticArray<f64>#__visit_impl (; 98 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/staticarray/StaticArray<f64>#__visit_impl (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/array/Array<~lib/string/String>#__visit_impl (; 99 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<~lib/string/String>#__visit_impl (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -18581,22 +18581,22 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/array/Array<i32>#__visit_impl (; 100 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i32>#__visit_impl (param $0 i32) (param $1 i32)
   local.get $0
   i32.load
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/staticarray/StaticArray<u32>#__visit_impl (; 101 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/staticarray/StaticArray<u32>#__visit_impl (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/staticarray/StaticArray<u64>#__visit_impl (; 102 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/staticarray/StaticArray<u64>#__visit_impl (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/staticarray/StaticArray<i16>#__visit_impl (; 103 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/staticarray/StaticArray<i16>#__visit_impl (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/rt/__visit_members (; 104 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/__visit_members (param $0 i32) (param $1 i32)
   (local $2 i32)
   block $switch$1$default
    block $switch$1$case$10

--- a/tests/compiler/std/symbol.optimized.wat
+++ b/tests/compiler/std/symbol.optimized.wat
@@ -39,7 +39,6 @@
  (global $std/symbol/sym1 (mut i32) (i32.const 0))
  (global $std/symbol/sym2 (mut i32) (i32.const 0))
  (global $~lib/symbol/stringToId (mut i32) (i32.const 0))
- (global $~lib/rt/stub/startOffset (mut i32) (i32.const 0))
  (global $~lib/rt/stub/offset (mut i32) (i32.const 0))
  (global $~lib/symbol/idToString (mut i32) (i32.const 0))
  (global $std/symbol/sym3 (mut i32) (i32.const 0))
@@ -48,11 +47,10 @@
  (global $std/symbol/key2 (mut i32) (i32.const 0))
  (global $std/symbol/key3 (mut i32) (i32.const 0))
  (global $std/symbol/key4 (mut i32) (i32.const 0))
- (global $std/symbol/hasInstance (mut i32) (i32.const 0))
  (global $std/symbol/isConcatSpreadable (mut i32) (i32.const 0))
  (export "memory" (memory $0))
  (start $~start)
- (func $~lib/symbol/Symbol (; 1 ;) (result i32)
+ (func $~lib/symbol/Symbol (result i32)
   (local $0 i32)
   global.get $~lib/symbol/nextId
   local.tee $0
@@ -66,7 +64,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/stub/__alloc (; 2 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/stub/__alloc (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -150,7 +148,7 @@
   i32.store offset=12
   local.get $4
  )
- (func $~lib/memory/memory.fill (; 3 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/memory/memory.fill (param $0 i32) (param $1 i32)
   (local $2 i32)
   block $~lib/util/memory/memset|inlined.0
    local.get $1
@@ -308,7 +306,7 @@
    end
   end
  )
- (func $~lib/arraybuffer/ArrayBuffer#constructor (; 4 ;) (param $0 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBuffer#constructor (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   i32.const 1073741808
@@ -329,7 +327,7 @@
   call $~lib/memory/memory.fill
   local.get $1
  )
- (func $~lib/map/Map<~lib/string/String,usize>#clear (; 5 ;) (param $0 i32)
+ (func $~lib/map/Map<~lib/string/String,usize>#clear (param $0 i32)
   (local $1 i32)
   i32.const 16
   call $~lib/arraybuffer/ArrayBuffer#constructor
@@ -362,7 +360,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/string/String#get:length (; 6 ;) (param $0 i32) (result i32)
+ (func $~lib/string/String#get:length (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub
@@ -370,7 +368,7 @@
   i32.const 1
   i32.shr_u
  )
- (func $~lib/util/hash/hashStr (; 7 ;) (param $0 i32) (result i32)
+ (func $~lib/util/hash/hashStr (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -407,7 +405,7 @@
   end
   local.get $1
  )
- (func $~lib/util/string/compareImpl (; 8 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/compareImpl (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -483,7 +481,7 @@
   end
   i32.const 0
  )
- (func $~lib/string/String.__eq (; 9 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__eq (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -515,7 +513,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<~lib/string/String,usize>#find (; 10 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<~lib/string/String,usize>#find (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load
   local.get $1
@@ -556,7 +554,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<~lib/string/String,usize>#rehash (; 11 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<~lib/string/String,usize>#rehash (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -666,7 +664,7 @@
   i32.load offset=20
   i32.store offset=16
  )
- (func $~lib/map/Map<~lib/string/String,usize>#set (; 12 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<~lib/string/String,usize>#set (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -753,7 +751,7 @@
    i32.store
   end
  )
- (func $~lib/util/hash/hash32 (; 13 ;) (param $0 i32) (result i32)
+ (func $~lib/util/hash/hash32 (param $0 i32) (result i32)
   local.get $0
   i32.const 255
   i32.and
@@ -784,7 +782,7 @@
   i32.const 16777619
   i32.mul
  )
- (func $~lib/map/Map<usize,~lib/string/String>#find (; 14 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<usize,~lib/string/String>#find (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.load
   local.get $2
@@ -825,7 +823,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<usize,~lib/string/String>#rehash (; 15 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<usize,~lib/string/String>#rehash (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -935,7 +933,7 @@
   i32.load offset=20
   i32.store offset=16
  )
- (func $~lib/map/Map<usize,~lib/string/String>#set (; 16 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<usize,~lib/string/String>#set (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1029,7 +1027,7 @@
    i32.store
   end
  )
- (func $~lib/symbol/_Symbol.for (; 17 ;) (result i32)
+ (func $~lib/symbol/_Symbol.for (result i32)
   (local $0 i32)
   global.get $~lib/symbol/stringToId
   if
@@ -1126,7 +1124,7 @@
   call $~lib/map/Map<usize,~lib/string/String>#set
   local.get $0
  )
- (func $~lib/map/Map<usize,~lib/string/String>#has (; 18 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<usize,~lib/string/String>#has (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -1135,7 +1133,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<usize,~lib/string/String>#get (; 19 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<usize,~lib/string/String>#get (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -1154,7 +1152,7 @@
   local.get $0
   i32.load offset=4
  )
- (func $~lib/symbol/_Symbol.keyFor (; 20 ;) (param $0 i32) (result i32)
+ (func $~lib/symbol/_Symbol.keyFor (param $0 i32) (result i32)
   global.get $~lib/symbol/idToString
   if (result i32)
    global.get $~lib/symbol/idToString
@@ -1171,7 +1169,7 @@
    i32.const 0
   end
  )
- (func $~lib/memory/memory.copy (; 21 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/memory/memory.copy (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   block $~lib/util/memory/memmove|inlined.0
@@ -1344,7 +1342,7 @@
    end
   end
  )
- (func $~lib/string/String.__concat (; 22 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__concat (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1391,7 +1389,7 @@
   end
   local.get $0
  )
- (func $~lib/symbol/_Symbol#toString (; 23 ;) (param $0 i32) (result i32)
+ (func $~lib/symbol/_Symbol#toString (param $0 i32) (result i32)
   i32.const 1808
   block $break|0 (result i32)
    block $case11|0
@@ -1467,7 +1465,7 @@
   i32.const 1872
   call $~lib/string/String.__concat
  )
- (func $start:std/symbol (; 24 ;)
+ (func $start:std/symbol
   (local $0 i32)
   call $~lib/symbol/Symbol
   global.set $std/symbol/sym1
@@ -1484,8 +1482,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 2112
-  global.set $~lib/rt/stub/startOffset
   i32.const 2112
   global.set $~lib/rt/stub/offset
   call $~lib/symbol/_Symbol.for
@@ -1605,8 +1601,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1
-  global.set $std/symbol/hasInstance
   i32.const 2
   global.set $std/symbol/isConcatSpreadable
   i32.const 1
@@ -1636,7 +1630,7 @@
    unreachable
   end
  )
- (func $~start (; 25 ;)
+ (func $~start
   call $start:std/symbol
  )
 )

--- a/tests/compiler/std/symbol.untouched.wat
+++ b/tests/compiler/std/symbol.untouched.wat
@@ -57,13 +57,13 @@
  (global $~lib/heap/__heap_base i32 (i32.const 1092))
  (export "memory" (memory $0))
  (start $~start)
- (func $~lib/rt/stub/__retain (; 1 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/stub/__retain (param $0 i32) (result i32)
   local.get $0
  )
- (func $~lib/rt/stub/__release (; 2 ;) (param $0 i32)
+ (func $~lib/rt/stub/__release (param $0 i32)
   nop
  )
- (func $~lib/symbol/Symbol (; 3 ;) (param $0 i32) (result i32)
+ (func $~lib/symbol/Symbol (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -87,7 +87,7 @@
   call $~lib/rt/stub/__release
   local.get $1
  )
- (func $~lib/rt/stub/maybeGrowMemory (; 4 ;) (param $0 i32)
+ (func $~lib/rt/stub/maybeGrowMemory (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -141,7 +141,7 @@
   local.get $0
   global.set $~lib/rt/stub/offset
  )
- (func $~lib/rt/stub/__alloc (; 5 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/stub/__alloc (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -194,7 +194,7 @@
   i32.store offset=12
   local.get $2
  )
- (func $~lib/memory/memory.fill (; 6 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/memory/memory.fill (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -403,7 +403,7 @@
    end
   end
  )
- (func $~lib/arraybuffer/ArrayBuffer#constructor (; 7 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBuffer#constructor (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   i32.const 1073741808
@@ -427,7 +427,7 @@
   local.get $2
   call $~lib/rt/stub/__retain
  )
- (func $~lib/map/Map<~lib/string/String,usize>#clear (; 8 ;) (param $0 i32)
+ (func $~lib/map/Map<~lib/string/String,usize>#clear (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -467,7 +467,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<~lib/string/String,usize>#constructor (; 9 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<~lib/string/String,usize>#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -499,7 +499,7 @@
   call $~lib/map/Map<~lib/string/String,usize>#clear
   local.get $0
  )
- (func $~lib/map/Map<usize,~lib/string/String>#clear (; 10 ;) (param $0 i32)
+ (func $~lib/map/Map<usize,~lib/string/String>#clear (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -539,7 +539,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<usize,~lib/string/String>#constructor (; 11 ;) (param $0 i32) (result i32)
+ (func $~lib/map/Map<usize,~lib/string/String>#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -571,7 +571,7 @@
   call $~lib/map/Map<usize,~lib/string/String>#clear
   local.get $0
  )
- (func $~lib/string/String#get:length (; 12 ;) (param $0 i32) (result i32)
+ (func $~lib/string/String#get:length (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub
@@ -579,7 +579,7 @@
   i32.const 1
   i32.shr_u
  )
- (func $~lib/util/hash/hashStr (; 13 ;) (param $0 i32) (result i32)
+ (func $~lib/util/hash/hashStr (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -630,7 +630,7 @@
   call $~lib/rt/stub/__release
   local.get $3
  )
- (func $~lib/util/string/compareImpl (; 14 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
+ (func $~lib/util/string/compareImpl (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
@@ -752,7 +752,7 @@
   call $~lib/rt/stub/__release
   local.get $7
  )
- (func $~lib/string/String.__eq (; 15 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__eq (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -825,7 +825,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $~lib/map/Map<~lib/string/String,usize>#find (; 16 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<~lib/string/String,usize>#find (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -885,7 +885,7 @@
   call $~lib/rt/stub/__release
   local.get $4
  )
- (func $~lib/map/Map<~lib/string/String,usize>#has (; 17 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<~lib/string/String,usize>#has (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $1
@@ -913,7 +913,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $~lib/map/Map<~lib/string/String,usize>#get (; 18 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<~lib/string/String,usize>#get (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -955,7 +955,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $~lib/map/Map<~lib/string/String,usize>#rehash (; 19 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<~lib/string/String,usize>#rehash (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1117,7 +1117,7 @@
   local.get $5
   call $~lib/rt/stub/__release
  )
- (func $~lib/map/Map<~lib/string/String,usize>#set (; 20 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<~lib/string/String,usize>#set (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1235,7 +1235,7 @@
   call $~lib/rt/stub/__release
   local.get $4
  )
- (func $~lib/util/hash/hash32 (; 21 ;) (param $0 i32) (result i32)
+ (func $~lib/util/hash/hash32 (param $0 i32) (result i32)
   (local $1 i32)
   i32.const -2128831035
   local.set $1
@@ -1277,7 +1277,7 @@
   local.set $1
   local.get $1
  )
- (func $~lib/map/Map<usize,~lib/string/String>#find (; 22 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<usize,~lib/string/String>#find (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -1325,7 +1325,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<usize,~lib/string/String>#rehash (; 23 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<usize,~lib/string/String>#rehash (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1482,7 +1482,7 @@
   local.get $5
   call $~lib/rt/stub/__release
  )
- (func $~lib/map/Map<usize,~lib/string/String>#set (; 24 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<usize,~lib/string/String>#set (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1606,7 +1606,7 @@
   call $~lib/rt/stub/__release
   local.get $6
  )
- (func $~lib/symbol/_Symbol.for (; 25 ;) (param $0 i32) (result i32)
+ (func $~lib/symbol/_Symbol.for (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -1672,7 +1672,7 @@
   call $~lib/rt/stub/__release
   local.get $1
  )
- (func $~lib/map/Map<usize,~lib/string/String>#has (; 26 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<usize,~lib/string/String>#has (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -1687,7 +1687,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<usize,~lib/string/String>#get (; 27 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<usize,~lib/string/String>#get (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -1715,7 +1715,7 @@
   i32.load offset=4
   call $~lib/rt/stub/__retain
  )
- (func $~lib/symbol/_Symbol.keyFor (; 28 ;) (param $0 i32) (result i32)
+ (func $~lib/symbol/_Symbol.keyFor (param $0 i32) (result i32)
   global.get $~lib/symbol/idToString
   i32.const 0
   i32.ne
@@ -1735,7 +1735,7 @@
    call $~lib/rt/stub/__retain
   end
  )
- (func $~lib/util/memory/memcpy (; 29 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/memory/memcpy (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2759,7 +2759,7 @@
    i32.store8
   end
  )
- (func $~lib/memory/memory.copy (; 30 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/memory/memory.copy (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2979,7 +2979,7 @@
    end
   end
  )
- (func $~lib/string/String#concat (; 31 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String#concat (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3055,7 +3055,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $~lib/string/String.__concat (; 32 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__concat (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/stub/__retain
@@ -3078,7 +3078,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $~lib/symbol/_Symbol#toString (; 33 ;) (param $0 i32) (result i32)
+ (func $~lib/symbol/_Symbol#toString (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -3273,7 +3273,7 @@
   call $~lib/rt/stub/__release
   local.get $5
  )
- (func $start:std/symbol (; 34 ;)
+ (func $start:std/symbol
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -3482,7 +3482,7 @@
   local.get $3
   call $~lib/rt/stub/__release
  )
- (func $~start (; 35 ;)
+ (func $~start
   call $start:std/symbol
  )
 )

--- a/tests/compiler/std/trace.optimized.wat
+++ b/tests/compiler/std/trace.optimized.wat
@@ -14,7 +14,7 @@
  (global $~started (mut i32) (i32.const 0))
  (export "_start" (func $~start))
  (export "memory" (memory $0))
- (func $~start (; 1 ;)
+ (func $~start
   global.get $~started
   if
    return

--- a/tests/compiler/std/trace.untouched.wat
+++ b/tests/compiler/std/trace.untouched.wat
@@ -15,7 +15,7 @@
  (global $~started (mut i32) (i32.const 0))
  (export "_start" (func $~start))
  (export "memory" (memory $0))
- (func $start:std/trace (; 1 ;)
+ (func $start:std/trace
   i32.const 32
   i32.const 0
   f64.const 0
@@ -81,7 +81,7 @@
   f64.const 5.5
   call $~lib/builtins/trace
  )
- (func $~start (; 2 ;)
+ (func $~start
   global.get $~started
   if
    return

--- a/tests/compiler/std/typedarray.optimized.wat
+++ b/tests/compiler/std/typedarray.optimized.wat
@@ -207,7 +207,7 @@
  (export "__setArgumentsLength" (func $~setArgumentsLength))
  (export "_start" (func $~start))
  (export "memory" (memory $0))
- (func $~lib/rt/tlsf/removeBlock (; 7 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/removeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -369,7 +369,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/insertBlock (; 8 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/insertBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -648,7 +648,7 @@
   i32.or
   i32.store offset=4
  )
- (func $~lib/rt/tlsf/addMemory (; 9 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $2
@@ -762,7 +762,7 @@
   local.get $1
   call $~lib/rt/tlsf/insertBlock
  )
- (func $~lib/rt/tlsf/maybeInitialize (; 10 ;) (result i32)
+ (func $~lib/rt/tlsf/maybeInitialize (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -849,7 +849,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/tlsf/prepareSize (; 11 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/tlsf/prepareSize (param $0 i32) (result i32)
   local.get $0
   i32.const 1073741808
   i32.ge_u
@@ -873,7 +873,7 @@
   i32.gt_u
   select
  )
- (func $~lib/rt/tlsf/searchBlock (; 12 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/searchBlock (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   i32.const 256
@@ -1002,7 +1002,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/prepareBlock (; 13 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/rt/tlsf/prepareBlock (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $1
@@ -1077,7 +1077,7 @@
    i32.store
   end
  )
- (func $~lib/rt/tlsf/allocateBlock (; 14 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/allocateBlock (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1217,7 +1217,7 @@
   call $~lib/rt/rtrace/onalloc
   local.get $3
  )
- (func $~lib/rt/tlsf/__alloc (; 15 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/__alloc (param $0 i32) (param $1 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
   local.get $0
   local.get $1
@@ -1225,7 +1225,7 @@
   i32.const 16
   i32.add
  )
- (func $~lib/memory/memory.fill (; 16 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/memory/memory.fill (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i64)
   (local $5 i32)
@@ -1398,7 +1398,7 @@
    end
   end
  )
- (func $~lib/rt/pure/__retain (; 17 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/pure/__retain (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -1449,7 +1449,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/pure/__release (; 18 ;) (param $0 i32)
+ (func $~lib/rt/pure/__release (param $0 i32)
   local.get $0
   i32.const 8396
   i32.gt_u
@@ -1460,7 +1460,7 @@
    call $~lib/rt/pure/decrement
   end
  )
- (func $~lib/arraybuffer/ArrayBufferView#constructor (; 19 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBufferView#constructor (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $1
@@ -1528,7 +1528,7 @@
   i32.store offset=8
   local.get $0
  )
- (func $~lib/typedarray/Int8Array#constructor (; 20 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#constructor (param $0 i32) (result i32)
   i32.const 12
   i32.const 3
   call $~lib/rt/tlsf/__alloc
@@ -1537,14 +1537,14 @@
   i32.const 0
   call $~lib/arraybuffer/ArrayBufferView#constructor
  )
- (func $~lib/arraybuffer/ArrayBufferView#get:byteOffset (; 21 ;) (param $0 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBufferView#get:byteOffset (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $0
   i32.load
   i32.sub
  )
- (func $~lib/typedarray/Uint8Array#constructor (; 22 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#constructor (param $0 i32) (result i32)
   i32.const 12
   i32.const 4
   call $~lib/rt/tlsf/__alloc
@@ -1553,7 +1553,7 @@
   i32.const 0
   call $~lib/arraybuffer/ArrayBufferView#constructor
  )
- (func $~lib/typedarray/Uint8ClampedArray#constructor (; 23 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint8ClampedArray#constructor (param $0 i32) (result i32)
   i32.const 12
   i32.const 5
   call $~lib/rt/tlsf/__alloc
@@ -1562,7 +1562,7 @@
   i32.const 0
   call $~lib/arraybuffer/ArrayBufferView#constructor
  )
- (func $~lib/typedarray/Int16Array#constructor (; 24 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#constructor (param $0 i32) (result i32)
   i32.const 12
   i32.const 6
   call $~lib/rt/tlsf/__alloc
@@ -1571,7 +1571,7 @@
   i32.const 1
   call $~lib/arraybuffer/ArrayBufferView#constructor
  )
- (func $~lib/typedarray/Uint16Array#constructor (; 25 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#constructor (param $0 i32) (result i32)
   i32.const 12
   i32.const 7
   call $~lib/rt/tlsf/__alloc
@@ -1580,7 +1580,7 @@
   i32.const 1
   call $~lib/arraybuffer/ArrayBufferView#constructor
  )
- (func $~lib/typedarray/Int32Array#constructor (; 26 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#constructor (param $0 i32) (result i32)
   i32.const 12
   i32.const 8
   call $~lib/rt/tlsf/__alloc
@@ -1589,7 +1589,7 @@
   i32.const 2
   call $~lib/arraybuffer/ArrayBufferView#constructor
  )
- (func $~lib/typedarray/Uint32Array#constructor (; 27 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint32Array#constructor (param $0 i32) (result i32)
   i32.const 12
   i32.const 9
   call $~lib/rt/tlsf/__alloc
@@ -1598,7 +1598,7 @@
   i32.const 2
   call $~lib/arraybuffer/ArrayBufferView#constructor
  )
- (func $~lib/typedarray/Int64Array#constructor (; 28 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int64Array#constructor (param $0 i32) (result i32)
   i32.const 12
   i32.const 10
   call $~lib/rt/tlsf/__alloc
@@ -1607,7 +1607,7 @@
   i32.const 3
   call $~lib/arraybuffer/ArrayBufferView#constructor
  )
- (func $~lib/typedarray/Uint64Array#constructor (; 29 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint64Array#constructor (param $0 i32) (result i32)
   i32.const 12
   i32.const 11
   call $~lib/rt/tlsf/__alloc
@@ -1616,7 +1616,7 @@
   i32.const 3
   call $~lib/arraybuffer/ArrayBufferView#constructor
  )
- (func $~lib/typedarray/Float32Array#constructor (; 30 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#constructor (param $0 i32) (result i32)
   i32.const 12
   i32.const 12
   call $~lib/rt/tlsf/__alloc
@@ -1625,7 +1625,7 @@
   i32.const 2
   call $~lib/arraybuffer/ArrayBufferView#constructor
  )
- (func $~lib/typedarray/Float64Array#constructor (; 31 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#constructor (param $0 i32) (result i32)
   i32.const 12
   i32.const 13
   call $~lib/rt/tlsf/__alloc
@@ -1634,7 +1634,7 @@
   i32.const 3
   call $~lib/arraybuffer/ArrayBufferView#constructor
  )
- (func $std/typedarray/testInstantiate (; 32 ;) (param $0 i32)
+ (func $std/typedarray/testInstantiate (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -2097,7 +2097,7 @@
   local.get $11
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int32Array#__set (; 33 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int32Array#__set (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -2121,7 +2121,7 @@
   local.get $2
   i32.store
  )
- (func $~lib/typedarray/Int32Array#__get (; 34 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#__get (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -2144,7 +2144,7 @@
   i32.add
   i32.load
  )
- (func $~lib/typedarray/Int32Array#subarray (; 35 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#subarray (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -2225,7 +2225,7 @@
   local.get $4
   call $~lib/rt/pure/__retain
  )
- (func $~lib/typedarray/Float64Array#__set (; 36 ;) (param $0 i32) (param $1 i32) (param $2 f64)
+ (func $~lib/typedarray/Float64Array#__set (param $0 i32) (param $1 i32) (param $2 f64)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -2249,7 +2249,7 @@
   local.get $2
   f64.store
  )
- (func $~lib/typedarray/Float64Array#subarray (; 37 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#subarray (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -2330,11 +2330,11 @@
   local.get $4
   call $~lib/rt/pure/__retain
  )
- (func $~setArgumentsLength (; 38 ;) (param $0 i32)
+ (func $~setArgumentsLength (param $0 i32)
   local.get $0
   global.set $~argumentsLength
  )
- (func $~lib/util/sort/insertionSort<f64> (; 39 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/util/sort/insertionSort<f64> (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 f64)
@@ -2412,7 +2412,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/checkUsedBlock (; 40 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/tlsf/checkUsedBlock (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   i32.const 16
@@ -2454,7 +2454,7 @@
   end
   local.get $1
  )
- (func $~lib/rt/tlsf/freeBlock (; 41 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/freeBlock (param $0 i32) (param $1 i32)
   local.get $1
   local.get $1
   i32.load
@@ -2467,7 +2467,7 @@
   local.get $1
   call $~lib/rt/rtrace/onfree
  )
- (func $~lib/util/sort/weakHeapSort<f64> (; 42 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/util/sort/weakHeapSort<f64> (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 f64)
@@ -2726,7 +2726,7 @@
   local.get $4
   f64.store
  )
- (func $~lib/util/sort/COMPARATOR<f64>~anonymous|0 (; 43 ;) (param $0 f64) (param $1 f64) (result i32)
+ (func $~lib/util/sort/COMPARATOR<f64>~anonymous|0 (param $0 f64) (param $1 f64) (result i32)
   (local $2 i64)
   (local $3 i64)
   local.get $0
@@ -2755,7 +2755,7 @@
   i64.lt_s
   i32.sub
  )
- (func $~lib/typedarray/Float64Array#__get (; 44 ;) (param $0 i32) (param $1 i32) (result f64)
+ (func $~lib/typedarray/Float64Array#__get (param $0 i32) (param $1 i32) (result f64)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -2778,7 +2778,7 @@
   i32.add
   f64.load
  )
- (func $~lib/typedarray/Uint8ClampedArray#__set (; 45 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint8ClampedArray#__set (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -2810,7 +2810,7 @@
   i32.and
   i32.store8
  )
- (func $~lib/typedarray/Uint8ClampedArray#__get (; 46 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8ClampedArray#__get (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -2829,7 +2829,7 @@
   i32.add
   i32.load8_u
  )
- (func $~lib/typedarray/Int8Array#__set (; 47 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int8Array#__set (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -2849,7 +2849,7 @@
   local.get $2
   i32.store8
  )
- (func $~lib/typedarray/Int8Array#fill (; 48 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#fill (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -2918,7 +2918,7 @@
   end
   local.get $5
  )
- (func $~lib/memory/memory.copy (; 49 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/memory/memory.copy (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   block $~lib/util/memory/memmove|inlined.0
@@ -3091,7 +3091,7 @@
    end
   end
  )
- (func $~lib/rt/__allocArray (; 50 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $~lib/rt/__allocArray (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -3129,7 +3129,7 @@
   i32.store offset=12
   local.get $2
  )
- (func $~lib/typedarray/Int8Array#__get (; 51 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#__get (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -3148,14 +3148,14 @@
   i32.add
   i32.load8_s
  )
- (func $~lib/array/Array<i8>#__unchecked_get (; 52 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i8>#__unchecked_get (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
   i32.add
   i32.load8_s
  )
- (func $std/typedarray/isInt8ArrayEqual (; 53 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/typedarray/isInt8ArrayEqual (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3210,7 +3210,7 @@
   end
   i32.const 1
  )
- (func $~lib/typedarray/Int8Array#subarray (; 54 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#subarray (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -3287,7 +3287,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/typedarray/Int32Array#fill (; 55 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#fill (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -3368,7 +3368,7 @@
   end
   local.get $5
  )
- (func $~lib/array/Array<i32>#__unchecked_get (; 56 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#__unchecked_get (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -3377,7 +3377,7 @@
   i32.add
   i32.load
  )
- (func $~lib/array/Array<i32>#__get (; 57 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#__get (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -3394,7 +3394,7 @@
   local.get $1
   call $~lib/array/Array<i32>#__unchecked_get
  )
- (func $std/typedarray/isInt32ArrayEqual (; 58 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/typedarray/isInt32ArrayEqual (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $1
@@ -3438,7 +3438,7 @@
   end
   i32.const 1
  )
- (func $~lib/typedarray/Int32Array#slice (; 59 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#slice (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -3517,7 +3517,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/typedarray/Int32Array#copyWithin (; 60 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#copyWithin (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -3625,12 +3625,12 @@
   call $~lib/memory/memory.copy
   local.get $5
  )
- (func $std/typedarray/testReduce<~lib/typedarray/Int8Array,i8>~anonymous|0 (; 61 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduce<~lib/typedarray/Int8Array,i8>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   local.get $0
   local.get $1
   i32.add
  )
- (func $~lib/typedarray/Uint8Array#__set (; 62 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint8Array#__set (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -3650,7 +3650,7 @@
   local.get $2
   i32.store8
  )
- (func $~lib/typedarray/Uint8Array#reduce<u8> (; 63 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#reduce<u8> (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3687,7 +3687,7 @@
   end
   local.get $3
  )
- (func $~lib/typedarray/Int16Array#__set (; 64 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int16Array#__set (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -3711,7 +3711,7 @@
   local.get $2
   i32.store16
  )
- (func $~lib/typedarray/Uint16Array#__set (; 65 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint16Array#__set (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -3735,7 +3735,7 @@
   local.get $2
   i32.store16
  )
- (func $~lib/typedarray/Int32Array#reduce<i32> (; 66 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#reduce<i32> (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3776,7 +3776,7 @@
   end
   local.get $3
  )
- (func $~lib/typedarray/Uint32Array#__set (; 67 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint32Array#__set (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -3800,7 +3800,7 @@
   local.get $2
   i32.store
  )
- (func $~lib/typedarray/Int64Array#__set (; 68 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $~lib/typedarray/Int64Array#__set (param $0 i32) (param $1 i32) (param $2 i64)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -3824,12 +3824,12 @@
   local.get $2
   i64.store
  )
- (func $std/typedarray/testReduce<~lib/typedarray/Int64Array,i64>~anonymous|0 (; 69 ;) (param $0 i64) (param $1 i64) (param $2 i32) (param $3 i32) (result i64)
+ (func $std/typedarray/testReduce<~lib/typedarray/Int64Array,i64>~anonymous|0 (param $0 i64) (param $1 i64) (param $2 i32) (param $3 i32) (result i64)
   local.get $0
   local.get $1
   i64.add
  )
- (func $~lib/typedarray/Int64Array#reduce<i64> (; 70 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $~lib/typedarray/Int64Array#reduce<i64> (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local $3 i64)
   (local $4 i32)
@@ -3870,7 +3870,7 @@
   end
   local.get $3
  )
- (func $~lib/typedarray/Uint64Array#__set (; 71 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $~lib/typedarray/Uint64Array#__set (param $0 i32) (param $1 i32) (param $2 i64)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -3894,7 +3894,7 @@
   local.get $2
   i64.store
  )
- (func $~lib/typedarray/Float32Array#__set (; 72 ;) (param $0 i32) (param $1 i32) (param $2 f32)
+ (func $~lib/typedarray/Float32Array#__set (param $0 i32) (param $1 i32) (param $2 f32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -3918,17 +3918,17 @@
   local.get $2
   f32.store
  )
- (func $std/typedarray/testReduce<~lib/typedarray/Float32Array,f32>~anonymous|0 (; 73 ;) (param $0 f32) (param $1 f32) (param $2 i32) (param $3 i32) (result f32)
+ (func $std/typedarray/testReduce<~lib/typedarray/Float32Array,f32>~anonymous|0 (param $0 f32) (param $1 f32) (param $2 i32) (param $3 i32) (result f32)
   local.get $0
   local.get $1
   f32.add
  )
- (func $std/typedarray/testReduce<~lib/typedarray/Float64Array,f64>~anonymous|0 (; 74 ;) (param $0 f64) (param $1 f64) (param $2 i32) (param $3 i32) (result f64)
+ (func $std/typedarray/testReduce<~lib/typedarray/Float64Array,f64>~anonymous|0 (param $0 f64) (param $1 f64) (param $2 i32) (param $3 i32) (result f64)
   local.get $0
   local.get $1
   f64.add
  )
- (func $~lib/typedarray/Uint8Array#reduceRight<u8> (; 75 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#reduceRight<u8> (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3966,7 +3966,7 @@
   end
   local.get $3
  )
- (func $~lib/typedarray/Int32Array#reduceRight<i32> (; 76 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#reduceRight<i32> (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4008,7 +4008,7 @@
   end
   local.get $3
  )
- (func $~lib/typedarray/Int64Array#reduceRight<i64> (; 77 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $~lib/typedarray/Int64Array#reduceRight<i64> (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local $3 i64)
   (local $4 i32)
@@ -4050,12 +4050,12 @@
   end
   local.get $3
  )
- (func $std/typedarray/testArrayMap<~lib/typedarray/Int8Array,i8>~anonymous|0 (; 78 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Int8Array,i8>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   local.get $0
   i32.mul
  )
- (func $~lib/typedarray/Uint8Array#__get (; 79 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#__get (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -4074,7 +4074,7 @@
   i32.add
   i32.load8_u
  )
- (func $~lib/typedarray/Int16Array#__get (; 80 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#__get (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -4097,7 +4097,7 @@
   i32.add
   i32.load16_s
  )
- (func $~lib/typedarray/Uint16Array#__get (; 81 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#__get (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -4120,7 +4120,7 @@
   i32.add
   i32.load16_u
  )
- (func $~lib/typedarray/Uint32Array#__get (; 82 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint32Array#__get (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -4143,12 +4143,12 @@
   i32.add
   i32.load
  )
- (func $std/typedarray/testArrayMap<~lib/typedarray/Int64Array,i64>~anonymous|0 (; 83 ;) (param $0 i64) (param $1 i32) (param $2 i32) (result i64)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Int64Array,i64>~anonymous|0 (param $0 i64) (param $1 i32) (param $2 i32) (result i64)
   local.get $0
   local.get $0
   i64.mul
  )
- (func $~lib/typedarray/Int64Array#__get (; 84 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $~lib/typedarray/Int64Array#__get (param $0 i32) (param $1 i32) (result i64)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -4171,7 +4171,7 @@
   i32.add
   i64.load
  )
- (func $~lib/typedarray/Uint64Array#__get (; 85 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $~lib/typedarray/Uint64Array#__get (param $0 i32) (param $1 i32) (result i64)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -4194,12 +4194,12 @@
   i32.add
   i64.load
  )
- (func $std/typedarray/testArrayMap<~lib/typedarray/Float32Array,f32>~anonymous|0 (; 86 ;) (param $0 f32) (param $1 i32) (param $2 i32) (result f32)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Float32Array,f32>~anonymous|0 (param $0 f32) (param $1 i32) (param $2 i32) (result f32)
   local.get $0
   local.get $0
   f32.mul
  )
- (func $~lib/typedarray/Float32Array#__get (; 87 ;) (param $0 i32) (param $1 i32) (result f32)
+ (func $~lib/typedarray/Float32Array#__get (param $0 i32) (param $1 i32) (result f32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -4222,12 +4222,12 @@
   i32.add
   f32.load
  )
- (func $std/typedarray/testArrayMap<~lib/typedarray/Float64Array,f64>~anonymous|0 (; 88 ;) (param $0 f64) (param $1 i32) (param $2 i32) (result f64)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Float64Array,f64>~anonymous|0 (param $0 f64) (param $1 i32) (param $2 i32) (result f64)
   local.get $0
   local.get $0
   f64.mul
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Int8Array,i8>~anonymous|0 (; 89 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Int8Array,i8>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 24
   i32.shl
@@ -4236,7 +4236,7 @@
   i32.const 2
   i32.gt_s
  )
- (func $~lib/rt/tlsf/reallocateBlock (; 90 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/reallocateBlock (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -4339,7 +4339,7 @@
   end
   local.get $3
  )
- (func $~lib/rt/tlsf/__realloc (; 91 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/__realloc (param $0 i32) (param $1 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
   local.get $0
   call $~lib/rt/tlsf/checkUsedBlock
@@ -4348,7 +4348,7 @@
   i32.const 16
   i32.add
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Int8Array,i8> (; 92 ;)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Int8Array,i8>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -4508,14 +4508,14 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint8Array,u8>~anonymous|0 (; 93 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint8Array,u8>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 255
   i32.and
   i32.const 2
   i32.gt_u
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint8Array,u8> (; 94 ;)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint8Array,u8>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -4675,7 +4675,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint8ClampedArray,u8> (; 95 ;)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint8ClampedArray,u8>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -4835,7 +4835,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Int16Array,i16>~anonymous|0 (; 96 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Int16Array,i16>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 16
   i32.shl
@@ -4844,7 +4844,7 @@
   i32.const 2
   i32.gt_s
  )
- (func $~lib/typedarray/Int16Array#filter (; 97 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#filter (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -4927,7 +4927,7 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Int16Array,i16> (; 98 ;)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Int16Array,i16>
   (local $0 i32)
   (local $1 i32)
   i32.const 6
@@ -5022,14 +5022,14 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint16Array,u16>~anonymous|0 (; 99 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint16Array,u16>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 65535
   i32.and
   i32.const 2
   i32.gt_u
  )
- (func $~lib/typedarray/Uint16Array#filter (; 100 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#filter (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -5112,7 +5112,7 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint16Array,u16> (; 101 ;)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint16Array,u16>
   (local $0 i32)
   (local $1 i32)
   i32.const 6
@@ -5207,12 +5207,12 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Int32Array,i32>~anonymous|0 (; 102 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Int32Array,i32>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 2
   i32.gt_s
  )
- (func $~lib/typedarray/Int32Array#filter (; 103 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#filter (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -5293,7 +5293,7 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Int32Array,i32> (; 104 ;)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Int32Array,i32>
   (local $0 i32)
   (local $1 i32)
   i32.const 6
@@ -5388,12 +5388,12 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint32Array,u32>~anonymous|0 (; 105 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint32Array,u32>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 2
   i32.gt_u
  )
- (func $~lib/typedarray/Uint32Array#filter (; 106 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint32Array#filter (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -5474,7 +5474,7 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint32Array,u32> (; 107 ;)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint32Array,u32>
   (local $0 i32)
   (local $1 i32)
   i32.const 6
@@ -5569,12 +5569,12 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Int64Array,i64>~anonymous|0 (; 108 ;) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Int64Array,i64>~anonymous|0 (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i64.const 2
   i64.gt_s
  )
- (func $~lib/typedarray/Int64Array#filter (; 109 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int64Array#filter (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -5655,7 +5655,7 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Int64Array,i64> (; 110 ;)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Int64Array,i64>
   (local $0 i32)
   (local $1 i32)
   i32.const 6
@@ -5750,12 +5750,12 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint64Array,u64>~anonymous|0 (; 111 ;) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint64Array,u64>~anonymous|0 (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i64.const 2
   i64.gt_u
  )
- (func $~lib/typedarray/Uint64Array#filter (; 112 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint64Array#filter (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -5836,7 +5836,7 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint64Array,u64> (; 113 ;)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint64Array,u64>
   (local $0 i32)
   (local $1 i32)
   i32.const 6
@@ -5931,12 +5931,12 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Float32Array,f32>~anonymous|0 (; 114 ;) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Float32Array,f32>~anonymous|0 (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   f32.const 2
   f32.gt
  )
- (func $~lib/typedarray/Float32Array#filter (; 115 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#filter (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -6017,7 +6017,7 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Float32Array,f32> (; 116 ;)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Float32Array,f32>
   (local $0 i32)
   (local $1 i32)
   i32.const 6
@@ -6112,12 +6112,12 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Float64Array,f64>~anonymous|0 (; 117 ;) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Float64Array,f64>~anonymous|0 (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   f64.const 2
   f64.gt
  )
- (func $~lib/typedarray/Float64Array#filter (; 118 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#filter (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -6198,7 +6198,7 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Float64Array,f64> (; 119 ;)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Float64Array,f64>
   (local $0 i32)
   (local $1 i32)
   i32.const 6
@@ -6293,14 +6293,14 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Int8Array,i8>~anonymous|0 (; 120 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Int8Array,i8>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 255
   i32.and
   i32.const 2
   i32.eq
  )
- (func $~lib/typedarray/Int8Array#some (; 121 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#some (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6342,13 +6342,13 @@
   end
   local.get $5
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Int8Array,i8>~anonymous|1 (; 122 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Int8Array,i8>~anonymous|1 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 255
   i32.and
   i32.eqz
  )
- (func $~lib/typedarray/Uint8Array#some (; 123 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#some (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6390,14 +6390,14 @@
   end
   local.get $5
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Int16Array,i16>~anonymous|0 (; 124 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Int16Array,i16>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 65535
   i32.and
   i32.const 2
   i32.eq
  )
- (func $~lib/typedarray/Int16Array#some (; 125 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#some (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6443,13 +6443,13 @@
   end
   local.get $5
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Int16Array,i16>~anonymous|1 (; 126 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Int16Array,i16>~anonymous|1 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 65535
   i32.and
   i32.eqz
  )
- (func $~lib/typedarray/Uint16Array#some (; 127 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#some (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6495,12 +6495,12 @@
   end
   local.get $5
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Int32Array,i32>~anonymous|0 (; 128 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Int32Array,i32>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 2
   i32.eq
  )
- (func $~lib/typedarray/Int32Array#some (; 129 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#some (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6546,16 +6546,16 @@
   end
   local.get $5
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Int32Array,i32>~anonymous|1 (; 130 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Int32Array,i32>~anonymous|1 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.eqz
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Int64Array,i64>~anonymous|0 (; 131 ;) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Int64Array,i64>~anonymous|0 (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i64.const 2
   i64.eq
  )
- (func $~lib/typedarray/Int64Array#some (; 132 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int64Array#some (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6601,16 +6601,16 @@
   end
   local.get $5
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Int64Array,i64>~anonymous|1 (; 133 ;) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Int64Array,i64>~anonymous|1 (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i64.eqz
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Float32Array,f32>~anonymous|0 (; 134 ;) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Float32Array,f32>~anonymous|0 (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   f32.const 2
   f32.eq
  )
- (func $~lib/typedarray/Float32Array#some (; 135 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#some (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6656,17 +6656,17 @@
   end
   local.get $5
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Float32Array,f32>~anonymous|1 (; 136 ;) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Float32Array,f32>~anonymous|1 (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   f32.const 0
   f32.eq
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Float64Array,f64>~anonymous|0 (; 137 ;) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Float64Array,f64>~anonymous|0 (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   f64.const 2
   f64.eq
  )
- (func $~lib/typedarray/Float64Array#some (; 138 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#some (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6712,12 +6712,12 @@
   end
   local.get $5
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Float64Array,f64>~anonymous|1 (; 139 ;) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Float64Array,f64>~anonymous|1 (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   f64.const 0
   f64.eq
  )
- (func $~lib/typedarray/Int8Array#findIndex (; 140 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#findIndex (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6756,14 +6756,14 @@
   end
   local.get $2
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int8Array,i8>~anonymous|1 (; 141 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int8Array,i8>~anonymous|1 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 255
   i32.and
   i32.const 4
   i32.eq
  )
- (func $~lib/typedarray/Uint8Array#findIndex (; 142 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#findIndex (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6802,7 +6802,7 @@
   end
   local.get $2
  )
- (func $~lib/typedarray/Int16Array#findIndex (; 143 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#findIndex (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6845,14 +6845,14 @@
   end
   local.get $2
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int16Array,i16>~anonymous|1 (; 144 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int16Array,i16>~anonymous|1 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 65535
   i32.and
   i32.const 4
   i32.eq
  )
- (func $~lib/typedarray/Uint16Array#findIndex (; 145 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#findIndex (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6895,7 +6895,7 @@
   end
   local.get $2
  )
- (func $~lib/typedarray/Int32Array#findIndex (; 146 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#findIndex (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6938,12 +6938,12 @@
   end
   local.get $2
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int32Array,i32>~anonymous|1 (; 147 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int32Array,i32>~anonymous|1 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 4
   i32.eq
  )
- (func $~lib/typedarray/Int64Array#findIndex (; 148 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int64Array#findIndex (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6986,12 +6986,12 @@
   end
   local.get $2
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int64Array,i64>~anonymous|1 (; 149 ;) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int64Array,i64>~anonymous|1 (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i64.const 4
   i64.eq
  )
- (func $~lib/typedarray/Float32Array#findIndex (; 150 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#findIndex (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7034,12 +7034,12 @@
   end
   local.get $2
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Float32Array,f32>~anonymous|1 (; 151 ;) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Float32Array,f32>~anonymous|1 (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   f32.const 4
   f32.eq
  )
- (func $~lib/typedarray/Float64Array#findIndex (; 152 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#findIndex (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7082,12 +7082,12 @@
   end
   local.get $2
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Float64Array,f64>~anonymous|1 (; 153 ;) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Float64Array,f64>~anonymous|1 (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   f64.const 4
   f64.eq
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Int8Array,i8>~anonymous|0 (; 154 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Int8Array,i8>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 24
   i32.shl
@@ -7097,7 +7097,7 @@
   i32.rem_s
   i32.eqz
  )
- (func $~lib/typedarray/Int8Array#every (; 155 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#every (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7138,13 +7138,13 @@
   end
   local.get $5
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint8Array,u8>~anonymous|0 (; 156 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint8Array,u8>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 1
   i32.and
   i32.eqz
  )
- (func $~lib/typedarray/Uint8Array#every (; 157 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#every (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7185,7 +7185,7 @@
   end
   local.get $5
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Int16Array,i16>~anonymous|0 (; 158 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Int16Array,i16>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 16
   i32.shl
@@ -7195,7 +7195,7 @@
   i32.rem_s
   i32.eqz
  )
- (func $~lib/typedarray/Int16Array#every (; 159 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#every (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7240,7 +7240,7 @@
   end
   local.get $5
  )
- (func $~lib/typedarray/Uint16Array#every (; 160 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#every (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7285,13 +7285,13 @@
   end
   local.get $5
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Int32Array,i32>~anonymous|0 (; 161 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Int32Array,i32>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 2
   i32.rem_s
   i32.eqz
  )
- (func $~lib/typedarray/Int32Array#every (; 162 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#every (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7336,13 +7336,13 @@
   end
   local.get $5
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Int64Array,i64>~anonymous|0 (; 163 ;) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Int64Array,i64>~anonymous|0 (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i64.const 2
   i64.rem_s
   i64.eqz
  )
- (func $~lib/typedarray/Int64Array#every (; 164 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int64Array#every (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7387,13 +7387,13 @@
   end
   local.get $5
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint64Array,u64>~anonymous|0 (; 165 ;) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint64Array,u64>~anonymous|0 (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i64.const 2
   i64.rem_u
   i64.eqz
  )
- (func $~lib/math/NativeMathf.mod (; 166 ;) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.mod (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -7540,13 +7540,13 @@
   local.get $0
   f32.mul
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Float32Array,f32>~anonymous|0 (; 167 ;) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Float32Array,f32>~anonymous|0 (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.mod
   f32.const 0
   f32.eq
  )
- (func $~lib/typedarray/Float32Array#every (; 168 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#every (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7591,7 +7591,7 @@
   end
   local.get $5
  )
- (func $~lib/math/NativeMath.mod (; 169 ;) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.mod (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i64)
   (local $3 i64)
@@ -7745,13 +7745,13 @@
   local.get $0
   f64.mul
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Float64Array,f64>~anonymous|0 (; 170 ;) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Float64Array,f64>~anonymous|0 (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMath.mod
   f64.const 0
   f64.eq
  )
- (func $~lib/typedarray/Float64Array#every (; 171 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#every (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7796,7 +7796,7 @@
   end
   local.get $5
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Int8Array,i8>~anonymous|0 (; 172 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Int8Array,i8>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $0
   i32.const 255
   i32.and
@@ -7841,7 +7841,7 @@
   i32.add
   global.set $std/typedarray/forEachCallCount
  )
- (func $~lib/typedarray/Uint8Array#forEach (; 173 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Uint8Array#forEach (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7874,7 +7874,7 @@
    end
   end
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Int16Array,i16>~anonymous|0 (; 174 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Int16Array,i16>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $0
   i32.const 65535
   i32.and
@@ -7919,7 +7919,7 @@
   i32.add
   global.set $std/typedarray/forEachCallCount
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Int32Array,i32>~anonymous|0 (; 175 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Int32Array,i32>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32)
   i32.const 2704
   local.get $1
   call $~lib/array/Array<i32>#__get
@@ -7960,7 +7960,7 @@
   i32.add
   global.set $std/typedarray/forEachCallCount
  )
- (func $~lib/typedarray/Int32Array#forEach (; 176 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Int32Array#forEach (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7997,7 +7997,7 @@
    end
   end
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Int64Array,i64>~anonymous|0 (; 177 ;) (param $0 i64) (param $1 i32) (param $2 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Int64Array,i64>~anonymous|0 (param $0 i64) (param $1 i32) (param $2 i32)
   i32.const 2704
   local.get $1
   call $~lib/array/Array<i32>#__get
@@ -8039,7 +8039,7 @@
   i32.add
   global.set $std/typedarray/forEachCallCount
  )
- (func $~lib/typedarray/Int64Array#forEach (; 178 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Int64Array#forEach (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -8076,7 +8076,7 @@
    end
   end
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Float32Array,f32>~anonymous|0 (; 179 ;) (param $0 f32) (param $1 i32) (param $2 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Float32Array,f32>~anonymous|0 (param $0 f32) (param $1 i32) (param $2 i32)
   local.get $0
   i32.const 2704
   local.get $1
@@ -8118,7 +8118,7 @@
   i32.add
   global.set $std/typedarray/forEachCallCount
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Float64Array,f64>~anonymous|0 (; 180 ;) (param $0 f64) (param $1 i32) (param $2 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Float64Array,f64>~anonymous|0 (param $0 f64) (param $1 i32) (param $2 i32)
   local.get $0
   i32.const 2704
   local.get $1
@@ -8160,7 +8160,7 @@
   i32.add
   global.set $std/typedarray/forEachCallCount
  )
- (func $~lib/typedarray/Int8Array#reverse (; 181 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#reverse (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -8210,7 +8210,7 @@
   end
   local.get $3
  )
- (func $std/typedarray/testArrayReverse<~lib/typedarray/Int8Array,i8> (; 182 ;)
+ (func $std/typedarray/testArrayReverse<~lib/typedarray/Int8Array,i8>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -8366,7 +8366,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8Array#reverse (; 183 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#reverse (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -8416,7 +8416,7 @@
   end
   local.get $3
  )
- (func $~lib/typedarray/Uint8Array#subarray (; 184 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#subarray (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -8477,7 +8477,7 @@
   local.get $3
   call $~lib/rt/pure/__retain
  )
- (func $std/typedarray/testArrayReverse<~lib/typedarray/Uint8Array,u8> (; 185 ;)
+ (func $std/typedarray/testArrayReverse<~lib/typedarray/Uint8Array,u8>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -8626,7 +8626,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8ClampedArray#subarray (; 186 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8ClampedArray#subarray (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -8687,7 +8687,7 @@
   local.get $3
   call $~lib/rt/pure/__retain
  )
- (func $std/typedarray/testArrayReverse<~lib/typedarray/Uint8ClampedArray,u8> (; 187 ;)
+ (func $std/typedarray/testArrayReverse<~lib/typedarray/Uint8ClampedArray,u8>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -8836,7 +8836,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int16Array#reverse (; 188 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#reverse (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -8892,7 +8892,7 @@
   end
   local.get $3
  )
- (func $~lib/typedarray/Int16Array#subarray (; 189 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#subarray (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -8960,7 +8960,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $std/typedarray/testArrayReverse<~lib/typedarray/Int16Array,i16> (; 190 ;)
+ (func $std/typedarray/testArrayReverse<~lib/typedarray/Int16Array,i16>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -9115,7 +9115,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint16Array#reverse (; 191 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#reverse (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -9171,7 +9171,7 @@
   end
   local.get $3
  )
- (func $~lib/typedarray/Uint16Array#subarray (; 192 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#subarray (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9239,7 +9239,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $std/typedarray/testArrayReverse<~lib/typedarray/Uint16Array,u16> (; 193 ;)
+ (func $std/typedarray/testArrayReverse<~lib/typedarray/Uint16Array,u16>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -9388,7 +9388,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int32Array#reverse (; 194 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#reverse (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -9444,7 +9444,7 @@
   end
   local.get $3
  )
- (func $std/typedarray/testArrayReverse<~lib/typedarray/Int32Array,i32> (; 195 ;)
+ (func $std/typedarray/testArrayReverse<~lib/typedarray/Int32Array,i32>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -9588,7 +9588,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint32Array#subarray (; 196 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint32Array#subarray (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9656,7 +9656,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $std/typedarray/testArrayReverse<~lib/typedarray/Uint32Array,u32> (; 197 ;)
+ (func $std/typedarray/testArrayReverse<~lib/typedarray/Uint32Array,u32>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -9799,7 +9799,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int64Array#reverse (; 198 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int64Array#reverse (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -9855,7 +9855,7 @@
   end
   local.get $3
  )
- (func $~lib/typedarray/Int64Array#subarray (; 199 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int64Array#subarray (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9923,7 +9923,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $std/typedarray/testArrayReverse<~lib/typedarray/Int64Array,i64> (; 200 ;)
+ (func $std/typedarray/testArrayReverse<~lib/typedarray/Int64Array,i64>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -10069,7 +10069,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint64Array#subarray (; 201 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint64Array#subarray (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10137,7 +10137,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $std/typedarray/testArrayReverse<~lib/typedarray/Uint64Array,u64> (; 202 ;)
+ (func $std/typedarray/testArrayReverse<~lib/typedarray/Uint64Array,u64>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -10283,7 +10283,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float32Array#reverse (; 203 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#reverse (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -10339,7 +10339,7 @@
   end
   local.get $3
  )
- (func $~lib/typedarray/Float32Array#subarray (; 204 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#subarray (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10407,7 +10407,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $std/typedarray/testArrayReverse<~lib/typedarray/Float32Array,f32> (; 205 ;)
+ (func $std/typedarray/testArrayReverse<~lib/typedarray/Float32Array,f32>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -10553,7 +10553,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float64Array#reverse (; 206 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#reverse (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -10609,7 +10609,7 @@
   end
   local.get $3
  )
- (func $std/typedarray/testArrayReverse<~lib/typedarray/Float64Array,f64> (; 207 ;)
+ (func $std/typedarray/testArrayReverse<~lib/typedarray/Float64Array,f64>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -10756,7 +10756,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int8Array#indexOf (; 208 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#indexOf (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   block $~lib/typedarray/INDEX_OF<~lib/typedarray/Int8Array,i8>|inlined.0
    local.get $0
@@ -10818,7 +10818,7 @@
   end
   local.get $2
  )
- (func $~lib/typedarray/Int8Array#lastIndexOf (; 209 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#lastIndexOf (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   block $~lib/typedarray/LAST_INDEX_OF<~lib/typedarray/Int8Array,i8>|inlined.0
    local.get $0
@@ -10875,7 +10875,7 @@
   end
   local.get $2
  )
- (func $~lib/typedarray/Int8Array#lastIndexOf|trampoline (; 210 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#lastIndexOf|trampoline (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   block $1of1
    block $0of1
@@ -10896,7 +10896,7 @@
   local.get $2
   call $~lib/typedarray/Int8Array#lastIndexOf
  )
- (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Int8Array,i8> (; 211 ;)
+ (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Int8Array,i8>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -11316,7 +11316,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Uint8Array,u8> (; 212 ;)
+ (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Uint8Array,u8>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -11733,7 +11733,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Uint8ClampedArray,u8> (; 213 ;)
+ (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Uint8ClampedArray,u8>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -12150,7 +12150,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int16Array#indexOf (; 214 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#indexOf (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   block $~lib/typedarray/INDEX_OF<~lib/typedarray/Int16Array,i16>|inlined.0
    local.get $0
@@ -12216,7 +12216,7 @@
   end
   local.get $2
  )
- (func $~lib/typedarray/Int16Array#lastIndexOf (; 215 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#lastIndexOf (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   block $~lib/typedarray/LAST_INDEX_OF<~lib/typedarray/Int16Array,i16>|inlined.0
    local.get $0
@@ -12277,7 +12277,7 @@
   end
   local.get $2
  )
- (func $~lib/typedarray/Int16Array#lastIndexOf|trampoline (; 216 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#lastIndexOf|trampoline (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   block $1of1
    block $0of1
@@ -12300,7 +12300,7 @@
   local.get $2
   call $~lib/typedarray/Int16Array#lastIndexOf
  )
- (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Int16Array,i16> (; 217 ;)
+ (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Int16Array,i16>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -12719,7 +12719,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Uint16Array,u16> (; 218 ;)
+ (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Uint16Array,u16>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -13136,7 +13136,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int32Array#indexOf (; 219 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#indexOf (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   block $~lib/typedarray/INDEX_OF<~lib/typedarray/Int32Array,i32>|inlined.0
    local.get $0
@@ -13200,7 +13200,7 @@
   end
   local.get $2
  )
- (func $~lib/typedarray/Int32Array#lastIndexOf (; 220 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#lastIndexOf (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   block $~lib/typedarray/LAST_INDEX_OF<~lib/typedarray/Int32Array,i32>|inlined.0
    local.get $0
@@ -13259,7 +13259,7 @@
   end
   local.get $2
  )
- (func $~lib/typedarray/Int32Array#lastIndexOf|trampoline (; 221 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#lastIndexOf|trampoline (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   block $1of1
    block $0of1
@@ -13282,7 +13282,7 @@
   local.get $2
   call $~lib/typedarray/Int32Array#lastIndexOf
  )
- (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Int32Array,i32> (; 222 ;)
+ (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Int32Array,i32>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -13698,7 +13698,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Uint32Array,u32> (; 223 ;)
+ (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Uint32Array,u32>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -14113,7 +14113,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int64Array#indexOf (; 224 ;) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int64Array#indexOf (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
   (local $3 i32)
   block $~lib/typedarray/INDEX_OF<~lib/typedarray/Int64Array,i64>|inlined.0
    local.get $0
@@ -14177,7 +14177,7 @@
   end
   local.get $2
  )
- (func $~lib/typedarray/Int64Array#lastIndexOf (; 225 ;) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int64Array#lastIndexOf (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
   (local $3 i32)
   block $~lib/typedarray/LAST_INDEX_OF<~lib/typedarray/Int64Array,i64>|inlined.0
    local.get $0
@@ -14236,7 +14236,7 @@
   end
   local.get $2
  )
- (func $~lib/typedarray/Int64Array#lastIndexOf|trampoline (; 226 ;) (param $0 i32) (param $1 i64) (result i32)
+ (func $~lib/typedarray/Int64Array#lastIndexOf|trampoline (param $0 i32) (param $1 i64) (result i32)
   (local $2 i32)
   block $1of1
    block $0of1
@@ -14259,7 +14259,7 @@
   local.get $2
   call $~lib/typedarray/Int64Array#lastIndexOf
  )
- (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Int64Array,i64> (; 227 ;)
+ (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Int64Array,i64>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -14675,7 +14675,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Uint64Array,u64> (; 228 ;)
+ (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Uint64Array,u64>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -15091,7 +15091,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float32Array#indexOf (; 229 ;) (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#indexOf (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
   (local $3 i32)
   block $~lib/typedarray/INDEX_OF<~lib/typedarray/Float32Array,f32>|inlined.0
    local.get $0
@@ -15155,7 +15155,7 @@
   end
   local.get $2
  )
- (func $~lib/typedarray/Float32Array#lastIndexOf (; 230 ;) (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#lastIndexOf (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
   (local $3 i32)
   block $~lib/typedarray/LAST_INDEX_OF<~lib/typedarray/Float32Array,f32>|inlined.0
    local.get $0
@@ -15214,7 +15214,7 @@
   end
   local.get $2
  )
- (func $~lib/typedarray/Float32Array#lastIndexOf|trampoline (; 231 ;) (param $0 i32) (param $1 f32) (result i32)
+ (func $~lib/typedarray/Float32Array#lastIndexOf|trampoline (param $0 i32) (param $1 f32) (result i32)
   (local $2 i32)
   block $1of1
    block $0of1
@@ -15237,7 +15237,7 @@
   local.get $2
   call $~lib/typedarray/Float32Array#lastIndexOf
  )
- (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Float32Array,f32> (; 232 ;)
+ (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Float32Array,f32>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -15653,7 +15653,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float64Array#indexOf (; 233 ;) (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#indexOf (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
   (local $3 i32)
   block $~lib/typedarray/INDEX_OF<~lib/typedarray/Float64Array,f64>|inlined.0
    local.get $0
@@ -15717,7 +15717,7 @@
   end
   local.get $2
  )
- (func $~lib/typedarray/Float64Array#lastIndexOf (; 234 ;) (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#lastIndexOf (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
   (local $3 i32)
   block $~lib/typedarray/LAST_INDEX_OF<~lib/typedarray/Float64Array,f64>|inlined.0
    local.get $0
@@ -15776,7 +15776,7 @@
   end
   local.get $2
  )
- (func $~lib/typedarray/Float64Array#lastIndexOf|trampoline (; 235 ;) (param $0 i32) (param $1 f64) (result i32)
+ (func $~lib/typedarray/Float64Array#lastIndexOf|trampoline (param $0 i32) (param $1 f64) (result i32)
   (local $2 i32)
   block $1of1
    block $0of1
@@ -15799,7 +15799,7 @@
   local.get $2
   call $~lib/typedarray/Float64Array#lastIndexOf
  )
- (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Float64Array,f64> (; 236 ;)
+ (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Float64Array,f64>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -16216,7 +16216,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/util/number/decimalCount32 (; 237 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/decimalCount32 (param $0 i32) (result i32)
   local.get $0
   i32.const 10
   i32.ge_u
@@ -16258,7 +16258,7 @@
   i32.lt_u
   select
  )
- (func $~lib/util/number/utoa_simple<u32> (; 238 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/number/utoa_simple<u32> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   loop $do-continue|0
    local.get $1
@@ -16285,7 +16285,7 @@
    br_if $do-continue|0
   end
  )
- (func $~lib/util/number/itoa32 (; 239 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/itoa32 (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -16327,7 +16327,7 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~lib/string/String#get:length (; 240 ;) (param $0 i32) (result i32)
+ (func $~lib/string/String#get:length (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub
@@ -16335,7 +16335,7 @@
   i32.const 1
   i32.shr_u
  )
- (func $~lib/util/number/itoa_stream<i8> (; 241 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_stream<i8> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   local.get $1
   i32.const 1
@@ -16401,7 +16401,7 @@
   call $~lib/util/number/utoa_simple<u32>
   local.get $1
  )
- (func $~lib/string/String#substring (; 242 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String#substring (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -16475,7 +16475,7 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/string/joinIntegerArray<i8> (; 243 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<i8> (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -16576,14 +16576,14 @@
   end
   local.get $1
  )
- (func $~lib/typedarray/Int8Array#join (; 244 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#join (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $0
   i32.load offset=8
   call $~lib/util/string/joinIntegerArray<i8>
  )
- (func $~lib/util/string/compareImpl (; 245 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/compareImpl (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -16659,7 +16659,7 @@
   end
   i32.const 0
  )
- (func $~lib/string/String.__eq (; 246 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__eq (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -16693,7 +16693,7 @@
   call $~lib/util/string/compareImpl
   i32.eqz
  )
- (func $~lib/util/number/utoa32 (; 247 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/utoa32 (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -16716,7 +16716,7 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/itoa_stream<u8> (; 248 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_stream<u8> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   local.get $1
   i32.const 1
@@ -16751,7 +16751,7 @@
   call $~lib/util/number/utoa_simple<u32>
   local.get $1
  )
- (func $~lib/util/string/joinIntegerArray<u8> (; 249 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<u8> (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -16852,14 +16852,14 @@
   end
   local.get $1
  )
- (func $~lib/typedarray/Uint8Array#join (; 250 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#join (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $0
   i32.load offset=8
   call $~lib/util/string/joinIntegerArray<u8>
  )
- (func $~lib/util/number/itoa_stream<i16> (; 251 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_stream<i16> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   local.get $1
   i32.const 1
@@ -16925,7 +16925,7 @@
   call $~lib/util/number/utoa_simple<u32>
   local.get $1
  )
- (func $~lib/util/string/joinIntegerArray<i16> (; 252 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<i16> (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -17030,7 +17030,7 @@
   end
   local.get $1
  )
- (func $~lib/typedarray/Int16Array#join (; 253 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#join (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $0
@@ -17039,7 +17039,7 @@
   i32.shr_u
   call $~lib/util/string/joinIntegerArray<i16>
  )
- (func $~lib/util/number/itoa_stream<u16> (; 254 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_stream<u16> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   local.get $1
   i32.const 1
@@ -17074,7 +17074,7 @@
   call $~lib/util/number/utoa_simple<u32>
   local.get $1
  )
- (func $~lib/util/string/joinIntegerArray<u16> (; 255 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<u16> (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -17179,7 +17179,7 @@
   end
   local.get $1
  )
- (func $~lib/typedarray/Uint16Array#join (; 256 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#join (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $0
@@ -17188,7 +17188,7 @@
   i32.shr_u
   call $~lib/util/string/joinIntegerArray<u16>
  )
- (func $~lib/util/number/itoa_stream<i32> (; 257 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_stream<i32> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   local.get $1
   i32.const 1
@@ -17236,7 +17236,7 @@
   call $~lib/util/number/utoa_simple<u32>
   local.get $0
  )
- (func $~lib/util/string/joinIntegerArray<i32> (; 258 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<i32> (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -17341,7 +17341,7 @@
   end
   local.get $1
  )
- (func $~lib/typedarray/Int32Array#join (; 259 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#join (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $0
@@ -17350,7 +17350,7 @@
   i32.shr_u
   call $~lib/util/string/joinIntegerArray<i32>
  )
- (func $~lib/util/number/itoa_stream<u32> (; 260 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_stream<u32> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   local.get $1
   i32.const 1
@@ -17377,7 +17377,7 @@
   call $~lib/util/number/utoa_simple<u32>
   local.get $0
  )
- (func $~lib/util/string/joinIntegerArray<u32> (; 261 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<u32> (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -17482,7 +17482,7 @@
   end
   local.get $1
  )
- (func $~lib/typedarray/Uint32Array#join (; 262 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint32Array#join (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $0
@@ -17491,7 +17491,7 @@
   i32.shr_u
   call $~lib/util/string/joinIntegerArray<u32>
  )
- (func $~lib/util/number/decimalCount64High (; 263 ;) (param $0 i64) (result i32)
+ (func $~lib/util/number/decimalCount64High (param $0 i64) (result i32)
   local.get $0
   i64.const 100000000000
   i64.ge_u
@@ -17537,7 +17537,7 @@
   i64.lt_u
   select
  )
- (func $~lib/util/number/utoa_simple<u64> (; 264 ;) (param $0 i32) (param $1 i64) (param $2 i32)
+ (func $~lib/util/number/utoa_simple<u64> (param $0 i32) (param $1 i64) (param $2 i32)
   (local $3 i32)
   loop $do-continue|0
    local.get $1
@@ -17567,7 +17567,7 @@
    br_if $do-continue|0
   end
  )
- (func $~lib/util/number/itoa_stream<i64> (; 265 ;) (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
+ (func $~lib/util/number/itoa_stream<i64> (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
   (local $3 i32)
   local.get $0
   local.get $1
@@ -17633,7 +17633,7 @@
   end
   local.get $0
  )
- (func $~lib/util/string/joinIntegerArray<i64> (; 266 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<i64> (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i64)
   (local $4 i32)
@@ -17797,7 +17797,7 @@
   end
   local.get $1
  )
- (func $~lib/typedarray/Int64Array#join (; 267 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int64Array#join (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $0
@@ -17806,7 +17806,7 @@
   i32.shr_u
   call $~lib/util/string/joinIntegerArray<i64>
  )
- (func $~lib/util/number/itoa_stream<u64> (; 268 ;) (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
+ (func $~lib/util/number/itoa_stream<u64> (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
   (local $3 i32)
   local.get $0
   local.get $1
@@ -17849,7 +17849,7 @@
   end
   local.get $1
  )
- (func $~lib/util/string/joinIntegerArray<u64> (; 269 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<u64> (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i64)
@@ -17992,7 +17992,7 @@
   end
   local.get $1
  )
- (func $~lib/typedarray/Uint64Array#join (; 270 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint64Array#join (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $0
@@ -18001,7 +18001,7 @@
   i32.shr_u
   call $~lib/util/string/joinIntegerArray<u64>
  )
- (func $~lib/util/number/genDigits (; 271 ;) (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (param $6 i32) (result i32)
+ (func $~lib/util/number/genDigits (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (param $6 i32) (result i32)
   (local $7 i32)
   (local $8 i64)
   (local $9 i64)
@@ -18392,7 +18392,7 @@
    local.get $6
   end
  )
- (func $~lib/util/number/prettify (; 272 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/prettify (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   i32.eqz
@@ -18637,7 +18637,7 @@
    end
   end
  )
- (func $~lib/util/number/dtoa_core (; 273 ;) (param $0 i32) (param $1 f64) (result i32)
+ (func $~lib/util/number/dtoa_core (param $0 i32) (param $1 f64) (result i32)
   (local $2 i64)
   (local $3 i64)
   (local $4 i32)
@@ -18929,7 +18929,7 @@
   local.get $7
   i32.add
  )
- (func $~lib/util/number/dtoa (; 274 ;) (param $0 f64) (result i32)
+ (func $~lib/util/number/dtoa (param $0 f64) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -18983,7 +18983,7 @@
   call $~lib/rt/tlsf/checkUsedBlock
   call $~lib/rt/tlsf/freeBlock
  )
- (func $~lib/util/number/dtoa_stream (; 275 ;) (param $0 i32) (param $1 i32) (param $2 f64) (result i32)
+ (func $~lib/util/number/dtoa_stream (param $0 i32) (param $1 i32) (param $2 f64) (result i32)
   local.get $0
   local.get $1
   i32.const 1
@@ -19058,7 +19058,7 @@
   local.get $2
   call $~lib/util/number/dtoa_core
  )
- (func $~lib/util/string/joinFloatArray<f32> (; 276 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/joinFloatArray<f32> (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -19166,7 +19166,7 @@
   end
   local.get $1
  )
- (func $~lib/typedarray/Float32Array#join (; 277 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#join (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $0
@@ -19175,7 +19175,7 @@
   i32.shr_u
   call $~lib/util/string/joinFloatArray<f32>
  )
- (func $~lib/util/string/joinFloatArray<f64> (; 278 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/joinFloatArray<f64> (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -19280,7 +19280,7 @@
   end
   local.get $1
  )
- (func $~lib/typedarray/Float64Array#join (; 279 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#join (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $0
@@ -19289,7 +19289,7 @@
   i32.shr_u
   call $~lib/util/string/joinFloatArray<f64>
  )
- (func $~lib/arraybuffer/ArrayBuffer#constructor (; 280 ;) (param $0 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBuffer#constructor (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   i32.const 1073741808
@@ -19312,7 +19312,7 @@
   local.get $1
   call $~lib/rt/pure/__retain
  )
- (func $~lib/typedarray/Uint8Array.wrap|trampoline (; 281 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array.wrap|trampoline (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   block $2of2
@@ -19400,7 +19400,7 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~lib/arraybuffer/ArrayBuffer#slice (; 282 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBuffer#slice (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $0
   i32.const 16
@@ -19470,7 +19470,7 @@
   local.get $3
   call $~lib/rt/pure/__retain
  )
- (func $std/typedarray/testArrayWrap<~lib/typedarray/Int8Array,i8> (; 283 ;)
+ (func $std/typedarray/testArrayWrap<~lib/typedarray/Int8Array,i8>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -19586,7 +19586,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayWrap<~lib/typedarray/Uint8Array,u8> (; 284 ;)
+ (func $std/typedarray/testArrayWrap<~lib/typedarray/Uint8Array,u8>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -19670,7 +19670,7 @@
   local.get $4
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayWrap<~lib/typedarray/Uint8ClampedArray,u8> (; 285 ;)
+ (func $std/typedarray/testArrayWrap<~lib/typedarray/Uint8ClampedArray,u8>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -19784,7 +19784,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayWrap<~lib/typedarray/Int16Array,i16> (; 286 ;)
+ (func $std/typedarray/testArrayWrap<~lib/typedarray/Int16Array,i16>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -19909,7 +19909,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayWrap<~lib/typedarray/Uint16Array,u16> (; 287 ;)
+ (func $std/typedarray/testArrayWrap<~lib/typedarray/Uint16Array,u16>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -20032,7 +20032,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayWrap<~lib/typedarray/Int32Array,i32> (; 288 ;)
+ (func $std/typedarray/testArrayWrap<~lib/typedarray/Int32Array,i32>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -20153,7 +20153,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayWrap<~lib/typedarray/Uint32Array,u32> (; 289 ;)
+ (func $std/typedarray/testArrayWrap<~lib/typedarray/Uint32Array,u32>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -20274,7 +20274,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayWrap<~lib/typedarray/Int64Array,i64> (; 290 ;)
+ (func $std/typedarray/testArrayWrap<~lib/typedarray/Int64Array,i64>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -20396,7 +20396,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayWrap<~lib/typedarray/Uint64Array,u64> (; 291 ;)
+ (func $std/typedarray/testArrayWrap<~lib/typedarray/Uint64Array,u64>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -20518,7 +20518,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayWrap<~lib/typedarray/Float32Array,f32> (; 292 ;)
+ (func $std/typedarray/testArrayWrap<~lib/typedarray/Float32Array,f32>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -20640,7 +20640,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayWrap<~lib/typedarray/Float64Array,f64> (; 293 ;)
+ (func $std/typedarray/testArrayWrap<~lib/typedarray/Float64Array,f64>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -20762,7 +20762,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int8Array#set<~lib/array/Array<i32>> (; 294 ;) (param $0 i32)
+ (func $~lib/typedarray/Int8Array#set<~lib/array/Array<i32>> (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -20811,7 +20811,7 @@
    end
   end
  )
- (func $std/typedarray/valuesEqual<~lib/typedarray/Int8Array> (; 295 ;) (param $0 i32) (param $1 i32)
+ (func $std/typedarray/valuesEqual<~lib/typedarray/Int8Array> (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -20871,7 +20871,7 @@
    end
   end
  )
- (func $~lib/typedarray/Int8Array#set<~lib/typedarray/Int64Array> (; 296 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Int8Array#set<~lib/typedarray/Int64Array> (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   local.get $1
@@ -20927,7 +20927,7 @@
    end
   end
  )
- (func $~lib/typedarray/Int8Array#set<~lib/typedarray/Uint8Array> (; 297 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Int8Array#set<~lib/typedarray/Uint8Array> (param $0 i32) (param $1 i32)
   local.get $1
   i32.load offset=8
   local.get $0
@@ -20949,7 +20949,7 @@
   i32.load offset=8
   call $~lib/memory/memory.copy
  )
- (func $~lib/typedarray/Int8Array#set<~lib/typedarray/Int16Array> (; 298 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Int8Array#set<~lib/typedarray/Int16Array> (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   local.get $1
@@ -21005,7 +21005,7 @@
    end
   end
  )
- (func $~lib/typedarray/Int8Array#set<~lib/array/Array<i8>> (; 299 ;) (param $0 i32)
+ (func $~lib/typedarray/Int8Array#set<~lib/array/Array<i8>> (param $0 i32)
   i32.const 4588
   i32.load
   i32.const 7
@@ -21031,7 +21031,7 @@
   i32.load
   call $~lib/memory/memory.copy
  )
- (func $std/typedarray/testTypedArraySet<~lib/typedarray/Int8Array> (; 300 ;)
+ (func $std/typedarray/testTypedArraySet<~lib/typedarray/Int8Array>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -21285,14 +21285,14 @@
   call $~lib/builtins/abort
   unreachable
  )
- (func $~lib/array/Array<u8>#__unchecked_get (; 301 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u8>#__unchecked_get (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
   i32.add
   i32.load8_u
  )
- (func $std/typedarray/valuesEqual<~lib/typedarray/Uint8Array> (; 302 ;) (param $0 i32) (param $1 i32)
+ (func $std/typedarray/valuesEqual<~lib/typedarray/Uint8Array> (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -21352,7 +21352,7 @@
    end
   end
  )
- (func $std/typedarray/testTypedArraySet<~lib/typedarray/Uint8Array> (; 303 ;)
+ (func $std/typedarray/testTypedArraySet<~lib/typedarray/Uint8Array>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -21606,7 +21606,7 @@
   call $~lib/builtins/abort
   unreachable
  )
- (func $std/typedarray/valuesEqual<~lib/typedarray/Uint8ClampedArray> (; 304 ;) (param $0 i32) (param $1 i32)
+ (func $std/typedarray/valuesEqual<~lib/typedarray/Uint8ClampedArray> (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -21666,7 +21666,7 @@
    end
   end
  )
- (func $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Int64Array> (; 305 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Int64Array> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i64)
   local.get $2
@@ -21750,7 +21750,7 @@
    end
   end
  )
- (func $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Int16Array> (; 306 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Int16Array> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $2
@@ -21830,7 +21830,7 @@
    end
   end
  )
- (func $std/typedarray/testTypedArraySet<~lib/typedarray/Uint8ClampedArray> (; 307 ;)
+ (func $std/typedarray/testTypedArraySet<~lib/typedarray/Uint8ClampedArray>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -22199,7 +22199,7 @@
   call $~lib/builtins/abort
   unreachable
  )
- (func $~lib/typedarray/Int16Array#set<~lib/array/Array<i32>> (; 308 ;) (param $0 i32)
+ (func $~lib/typedarray/Int16Array#set<~lib/array/Array<i32>> (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -22252,7 +22252,7 @@
    end
   end
  )
- (func $std/typedarray/valuesEqual<~lib/typedarray/Int16Array> (; 309 ;) (param $0 i32) (param $1 i32)
+ (func $std/typedarray/valuesEqual<~lib/typedarray/Int16Array> (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -22322,7 +22322,7 @@
    end
   end
  )
- (func $~lib/typedarray/Int16Array#set<~lib/typedarray/Int64Array> (; 310 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Int16Array#set<~lib/typedarray/Int64Array> (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   local.get $1
@@ -22382,7 +22382,7 @@
    end
   end
  )
- (func $~lib/typedarray/Int16Array#set<~lib/typedarray/Uint8Array> (; 311 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Int16Array#set<~lib/typedarray/Uint8Array> (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   local.get $1
@@ -22432,7 +22432,7 @@
    end
   end
  )
- (func $~lib/typedarray/Int16Array#set<~lib/typedarray/Int16Array> (; 312 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Int16Array#set<~lib/typedarray/Int16Array> (param $0 i32) (param $1 i32)
   local.get $1
   i32.load offset=8
   i32.const 1
@@ -22462,7 +22462,7 @@
   i32.load offset=8
   call $~lib/memory/memory.copy
  )
- (func $~lib/typedarray/Int16Array#set<~lib/array/Array<i8>> (; 313 ;) (param $0 i32)
+ (func $~lib/typedarray/Int16Array#set<~lib/array/Array<i8>> (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -22517,7 +22517,7 @@
    end
   end
  )
- (func $std/typedarray/testTypedArraySet<~lib/typedarray/Int16Array> (; 314 ;)
+ (func $std/typedarray/testTypedArraySet<~lib/typedarray/Int16Array>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -22779,7 +22779,7 @@
   call $~lib/builtins/abort
   unreachable
  )
- (func $std/typedarray/valuesEqual<~lib/typedarray/Uint16Array> (; 315 ;) (param $0 i32) (param $1 i32)
+ (func $std/typedarray/valuesEqual<~lib/typedarray/Uint16Array> (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -22849,7 +22849,7 @@
    end
   end
  )
- (func $std/typedarray/testTypedArraySet<~lib/typedarray/Uint16Array> (; 316 ;)
+ (func $std/typedarray/testTypedArraySet<~lib/typedarray/Uint16Array>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -23111,7 +23111,7 @@
   call $~lib/builtins/abort
   unreachable
  )
- (func $~lib/typedarray/Int32Array#set<~lib/array/Array<i32>> (; 317 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int32Array#set<~lib/array/Array<i32>> (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $2
   i32.const 0
   i32.lt_s
@@ -23152,7 +23152,7 @@
   i32.load offset=8
   call $~lib/memory/memory.copy
  )
- (func $std/typedarray/valuesEqual<~lib/typedarray/Int32Array> (; 318 ;) (param $0 i32) (param $1 i32)
+ (func $std/typedarray/valuesEqual<~lib/typedarray/Int32Array> (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -23214,7 +23214,7 @@
    end
   end
  )
- (func $~lib/typedarray/Int32Array#set<~lib/typedarray/Int64Array> (; 319 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Int32Array#set<~lib/typedarray/Int64Array> (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   local.get $1
@@ -23274,7 +23274,7 @@
    end
   end
  )
- (func $~lib/typedarray/Int32Array#set<~lib/typedarray/Uint8Array> (; 320 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Int32Array#set<~lib/typedarray/Uint8Array> (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   local.get $1
@@ -23324,7 +23324,7 @@
    end
   end
  )
- (func $~lib/typedarray/Int32Array#set<~lib/typedarray/Int16Array> (; 321 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Int32Array#set<~lib/typedarray/Int16Array> (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   local.get $1
@@ -23384,7 +23384,7 @@
    end
   end
  )
- (func $~lib/typedarray/Int32Array#set<~lib/array/Array<i8>> (; 322 ;) (param $0 i32)
+ (func $~lib/typedarray/Int32Array#set<~lib/array/Array<i8>> (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -23439,7 +23439,7 @@
    end
   end
  )
- (func $std/typedarray/testTypedArraySet<~lib/typedarray/Int32Array> (; 323 ;)
+ (func $std/typedarray/testTypedArraySet<~lib/typedarray/Int32Array>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -23702,7 +23702,7 @@
   call $~lib/builtins/abort
   unreachable
  )
- (func $std/typedarray/valuesEqual<~lib/typedarray/Uint32Array> (; 324 ;) (param $0 i32) (param $1 i32)
+ (func $std/typedarray/valuesEqual<~lib/typedarray/Uint32Array> (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -23764,7 +23764,7 @@
    end
   end
  )
- (func $std/typedarray/testTypedArraySet<~lib/typedarray/Uint32Array> (; 325 ;)
+ (func $std/typedarray/testTypedArraySet<~lib/typedarray/Uint32Array>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -24027,7 +24027,7 @@
   call $~lib/builtins/abort
   unreachable
  )
- (func $~lib/typedarray/Int64Array#set<~lib/array/Array<i32>> (; 326 ;) (param $0 i32)
+ (func $~lib/typedarray/Int64Array#set<~lib/array/Array<i32>> (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -24080,7 +24080,7 @@
    end
   end
  )
- (func $~lib/array/Array<i64>#__unchecked_get (; 327 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $~lib/array/Array<i64>#__unchecked_get (param $0 i32) (param $1 i32) (result i64)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -24089,7 +24089,7 @@
   i32.add
   i64.load
  )
- (func $std/typedarray/valuesEqual<~lib/typedarray/Int64Array> (; 328 ;) (param $0 i32) (param $1 i32)
+ (func $std/typedarray/valuesEqual<~lib/typedarray/Int64Array> (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i64)
@@ -24151,7 +24151,7 @@
    end
   end
  )
- (func $~lib/typedarray/Int64Array#set<~lib/typedarray/Int64Array> (; 329 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Int64Array#set<~lib/typedarray/Int64Array> (param $0 i32) (param $1 i32)
   local.get $1
   i32.load offset=8
   i32.const 3
@@ -24181,7 +24181,7 @@
   i32.load offset=8
   call $~lib/memory/memory.copy
  )
- (func $~lib/typedarray/Int64Array#set<~lib/typedarray/Uint8Array> (; 330 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Int64Array#set<~lib/typedarray/Uint8Array> (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   local.get $1
@@ -24231,7 +24231,7 @@
    end
   end
  )
- (func $~lib/typedarray/Int64Array#set<~lib/typedarray/Int16Array> (; 331 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Int64Array#set<~lib/typedarray/Int16Array> (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   local.get $1
@@ -24291,7 +24291,7 @@
    end
   end
  )
- (func $~lib/typedarray/Int64Array#set<~lib/array/Array<i8>> (; 332 ;) (param $0 i32)
+ (func $~lib/typedarray/Int64Array#set<~lib/array/Array<i8>> (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -24346,7 +24346,7 @@
    end
   end
  )
- (func $std/typedarray/testTypedArraySet<~lib/typedarray/Int64Array> (; 333 ;)
+ (func $std/typedarray/testTypedArraySet<~lib/typedarray/Int64Array>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -24608,7 +24608,7 @@
   call $~lib/builtins/abort
   unreachable
  )
- (func $std/typedarray/valuesEqual<~lib/typedarray/Uint64Array> (; 334 ;) (param $0 i32) (param $1 i32)
+ (func $std/typedarray/valuesEqual<~lib/typedarray/Uint64Array> (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i64)
@@ -24670,7 +24670,7 @@
    end
   end
  )
- (func $std/typedarray/testTypedArraySet<~lib/typedarray/Uint64Array> (; 335 ;)
+ (func $std/typedarray/testTypedArraySet<~lib/typedarray/Uint64Array>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -24932,7 +24932,7 @@
   call $~lib/builtins/abort
   unreachable
  )
- (func $std/typedarray/valuesEqual<~lib/typedarray/Float32Array> (; 336 ;) (param $0 i32) (param $1 i32)
+ (func $std/typedarray/valuesEqual<~lib/typedarray/Float32Array> (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 f32)
   (local $4 i32)
@@ -25002,7 +25002,7 @@
    end
   end
  )
- (func $std/typedarray/testTypedArraySet<~lib/typedarray/Float32Array> (; 337 ;)
+ (func $std/typedarray/testTypedArraySet<~lib/typedarray/Float32Array>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -25363,7 +25363,7 @@
   call $~lib/builtins/abort
   unreachable
  )
- (func $std/typedarray/valuesEqual<~lib/typedarray/Float64Array> (; 338 ;) (param $0 i32) (param $1 i32)
+ (func $std/typedarray/valuesEqual<~lib/typedarray/Float64Array> (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 f64)
   (local $4 i32)
@@ -25431,7 +25431,7 @@
    end
   end
  )
- (func $std/typedarray/testTypedArraySet<~lib/typedarray/Float64Array> (; 339 ;)
+ (func $std/typedarray/testTypedArraySet<~lib/typedarray/Float64Array>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -25836,7 +25836,7 @@
   call $~lib/builtins/abort
   unreachable
  )
- (func $start:std/typedarray (; 340 ;)
+ (func $start:std/typedarray
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -32085,7 +32085,7 @@
   call $~lib/builtins/abort
   unreachable
  )
- (func $~start (; 341 ;)
+ (func $~start
   global.get $~started
   if
    return
@@ -32095,7 +32095,7 @@
   end
   call $start:std/typedarray
  )
- (func $~lib/rt/pure/decrement (; 342 ;) (param $0 i32)
+ (func $~lib/rt/pure/decrement (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -32187,7 +32187,7 @@
    i32.store offset=4
   end
  )
- (func $~lib/rt/pure/__visit (; 343 ;) (param $0 i32)
+ (func $~lib/rt/pure/__visit (param $0 i32)
   local.get $0
   i32.const 8396
   i32.lt_u

--- a/tests/compiler/std/typedarray.untouched.wat
+++ b/tests/compiler/std/typedarray.untouched.wat
@@ -225,7 +225,7 @@
  (export "__setArgumentsLength" (func $~setArgumentsLength))
  (export "_start" (func $~start))
  (export "memory" (memory $0))
- (func $~lib/rt/tlsf/removeBlock (; 7 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/removeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -435,7 +435,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/insertBlock (; 8 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/insertBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -785,7 +785,7 @@
   local.get $7
   i32.store offset=4
  )
- (func $~lib/rt/tlsf/addMemory (; 9 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -933,7 +933,7 @@
   call $~lib/rt/tlsf/insertBlock
   i32.const 1
  )
- (func $~lib/rt/tlsf/maybeInitialize (; 10 ;) (result i32)
+ (func $~lib/rt/tlsf/maybeInitialize (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -1087,7 +1087,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/tlsf/prepareSize (; 11 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/tlsf/prepareSize (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -1116,7 +1116,7 @@
   i32.gt_u
   select
  )
- (func $~lib/rt/tlsf/searchBlock (; 12 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/searchBlock (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1299,7 +1299,7 @@
   end
   local.get $7
  )
- (func $~lib/rt/tlsf/growMemory (; 13 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/growMemory (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1383,7 +1383,7 @@
   call $~lib/rt/tlsf/addMemory
   drop
  )
- (func $~lib/rt/tlsf/prepareBlock (; 14 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/rt/tlsf/prepareBlock (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1478,7 +1478,7 @@
    i32.store
   end
  )
- (func $~lib/rt/tlsf/allocateBlock (; 15 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/allocateBlock (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   global.get $~lib/rt/tlsf/collectLock
@@ -1589,7 +1589,7 @@
   call $~lib/rt/rtrace/onalloc
   local.get $4
  )
- (func $~lib/rt/tlsf/__alloc (; 16 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/__alloc (param $0 i32) (param $1 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
   local.get $0
   local.get $1
@@ -1597,7 +1597,7 @@
   i32.const 16
   i32.add
  )
- (func $~lib/memory/memory.fill (; 17 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/memory/memory.fill (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1806,7 +1806,7 @@
    end
   end
  )
- (func $~lib/rt/pure/increment (; 18 ;) (param $0 i32)
+ (func $~lib/rt/pure/increment (param $0 i32)
   (local $1 i32)
   local.get $0
   i32.load offset=4
@@ -1851,7 +1851,7 @@
    unreachable
   end
  )
- (func $~lib/rt/pure/__retain (; 19 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/pure/__retain (param $0 i32) (result i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.gt_u
@@ -1863,7 +1863,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/pure/__release (; 20 ;) (param $0 i32)
+ (func $~lib/rt/pure/__release (param $0 i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.gt_u
@@ -1874,7 +1874,7 @@
    call $~lib/rt/pure/decrement
   end
  )
- (func $~lib/arraybuffer/ArrayBufferView#constructor (; 21 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBufferView#constructor (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1946,7 +1946,7 @@
   i32.store offset=8
   local.get $0
  )
- (func $~lib/typedarray/Int8Array#constructor (; 22 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#constructor (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   if (result i32)
    local.get $0
@@ -1962,18 +1962,18 @@
   local.set $0
   local.get $0
  )
- (func $~lib/arraybuffer/ArrayBufferView#get:byteOffset (; 23 ;) (param $0 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBufferView#get:byteOffset (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $0
   i32.load
   i32.sub
  )
- (func $~lib/typedarray/Int8Array#get:length (; 24 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#get:length (param $0 i32) (result i32)
   local.get $0
   i32.load offset=8
  )
- (func $~lib/typedarray/Uint8Array#constructor (; 25 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#constructor (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   if (result i32)
    local.get $0
@@ -1989,11 +1989,11 @@
   local.set $0
   local.get $0
  )
- (func $~lib/typedarray/Uint8Array#get:length (; 26 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#get:length (param $0 i32) (result i32)
   local.get $0
   i32.load offset=8
  )
- (func $~lib/typedarray/Uint8ClampedArray#constructor (; 27 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8ClampedArray#constructor (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   if (result i32)
    local.get $0
@@ -2009,11 +2009,11 @@
   local.set $0
   local.get $0
  )
- (func $~lib/typedarray/Uint8ClampedArray#get:length (; 28 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint8ClampedArray#get:length (param $0 i32) (result i32)
   local.get $0
   i32.load offset=8
  )
- (func $~lib/typedarray/Int16Array#constructor (; 29 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#constructor (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   if (result i32)
    local.get $0
@@ -2029,13 +2029,13 @@
   local.set $0
   local.get $0
  )
- (func $~lib/typedarray/Int16Array#get:length (; 30 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#get:length (param $0 i32) (result i32)
   local.get $0
   i32.load offset=8
   i32.const 1
   i32.shr_u
  )
- (func $~lib/typedarray/Uint16Array#constructor (; 31 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#constructor (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   if (result i32)
    local.get $0
@@ -2051,13 +2051,13 @@
   local.set $0
   local.get $0
  )
- (func $~lib/typedarray/Uint16Array#get:length (; 32 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#get:length (param $0 i32) (result i32)
   local.get $0
   i32.load offset=8
   i32.const 1
   i32.shr_u
  )
- (func $~lib/typedarray/Int32Array#constructor (; 33 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#constructor (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   if (result i32)
    local.get $0
@@ -2073,13 +2073,13 @@
   local.set $0
   local.get $0
  )
- (func $~lib/typedarray/Int32Array#get:length (; 34 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#get:length (param $0 i32) (result i32)
   local.get $0
   i32.load offset=8
   i32.const 2
   i32.shr_u
  )
- (func $~lib/typedarray/Uint32Array#constructor (; 35 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint32Array#constructor (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   if (result i32)
    local.get $0
@@ -2095,13 +2095,13 @@
   local.set $0
   local.get $0
  )
- (func $~lib/typedarray/Uint32Array#get:length (; 36 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint32Array#get:length (param $0 i32) (result i32)
   local.get $0
   i32.load offset=8
   i32.const 2
   i32.shr_u
  )
- (func $~lib/typedarray/Int64Array#constructor (; 37 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int64Array#constructor (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   if (result i32)
    local.get $0
@@ -2117,13 +2117,13 @@
   local.set $0
   local.get $0
  )
- (func $~lib/typedarray/Int64Array#get:length (; 38 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int64Array#get:length (param $0 i32) (result i32)
   local.get $0
   i32.load offset=8
   i32.const 3
   i32.shr_u
  )
- (func $~lib/typedarray/Uint64Array#constructor (; 39 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint64Array#constructor (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   if (result i32)
    local.get $0
@@ -2139,13 +2139,13 @@
   local.set $0
   local.get $0
  )
- (func $~lib/typedarray/Uint64Array#get:length (; 40 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint64Array#get:length (param $0 i32) (result i32)
   local.get $0
   i32.load offset=8
   i32.const 3
   i32.shr_u
  )
- (func $~lib/typedarray/Float32Array#constructor (; 41 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#constructor (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   if (result i32)
    local.get $0
@@ -2161,13 +2161,13 @@
   local.set $0
   local.get $0
  )
- (func $~lib/typedarray/Float32Array#get:length (; 42 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#get:length (param $0 i32) (result i32)
   local.get $0
   i32.load offset=8
   i32.const 2
   i32.shr_u
  )
- (func $~lib/typedarray/Float64Array#constructor (; 43 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#constructor (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   if (result i32)
    local.get $0
@@ -2183,13 +2183,13 @@
   local.set $0
   local.get $0
  )
- (func $~lib/typedarray/Float64Array#get:length (; 44 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#get:length (param $0 i32) (result i32)
   local.get $0
   i32.load offset=8
   i32.const 3
   i32.shr_u
  )
- (func $std/typedarray/testInstantiate (; 45 ;) (param $0 i32)
+ (func $std/typedarray/testInstantiate (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -2719,7 +2719,7 @@
   local.get $11
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int32Array#__set (; 46 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int32Array#__set (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -2743,7 +2743,7 @@
   local.get $2
   i32.store
  )
- (func $~lib/typedarray/Int32Array#__get (; 47 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#__get (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -2766,7 +2766,7 @@
   i32.add
   i32.load
  )
- (func $~lib/typedarray/Int32Array#subarray (; 48 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#subarray (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2873,7 +2873,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $~lib/typedarray/Float64Array#__set (; 49 ;) (param $0 i32) (param $1 i32) (param $2 f64)
+ (func $~lib/typedarray/Float64Array#__set (param $0 i32) (param $1 i32) (param $2 f64)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -2897,7 +2897,7 @@
   local.get $2
   f64.store
  )
- (func $~lib/typedarray/Float64Array#subarray (; 50 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#subarray (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3004,11 +3004,11 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $~setArgumentsLength (; 51 ;) (param $0 i32)
+ (func $~setArgumentsLength (param $0 i32)
   local.get $0
   global.set $~argumentsLength
  )
- (func $~lib/util/sort/insertionSort<f64> (; 52 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/sort/insertionSort<f64> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 f64)
@@ -3098,7 +3098,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/checkUsedBlock (; 53 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/tlsf/checkUsedBlock (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   i32.const 16
@@ -3144,7 +3144,7 @@
   end
   local.get $1
  )
- (func $~lib/rt/tlsf/freeBlock (; 54 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/freeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $1
   i32.load
@@ -3160,13 +3160,13 @@
   local.get $1
   call $~lib/rt/rtrace/onfree
  )
- (func $~lib/rt/tlsf/__free (; 55 ;) (param $0 i32)
+ (func $~lib/rt/tlsf/__free (param $0 i32)
   call $~lib/rt/tlsf/maybeInitialize
   local.get $0
   call $~lib/rt/tlsf/checkUsedBlock
   call $~lib/rt/tlsf/freeBlock
  )
- (func $~lib/util/sort/weakHeapSort<f64> (; 56 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/sort/weakHeapSort<f64> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3455,7 +3455,7 @@
   local.get $12
   f64.store
  )
- (func $~lib/typedarray/Float64Array#sort (; 57 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#sort (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3536,7 +3536,7 @@
    local.get $3
   end
  )
- (func $~lib/util/sort/COMPARATOR<f64>~anonymous|0 (; 58 ;) (param $0 f64) (param $1 f64) (result i32)
+ (func $~lib/util/sort/COMPARATOR<f64>~anonymous|0 (param $0 f64) (param $1 f64) (result i32)
   (local $2 i64)
   (local $3 i64)
   local.get $0
@@ -3569,7 +3569,7 @@
   i64.lt_s
   i32.sub
  )
- (func $~lib/typedarray/Float64Array#sort|trampoline (; 59 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#sort|trampoline (param $0 i32) (param $1 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -3588,7 +3588,7 @@
   local.get $1
   call $~lib/typedarray/Float64Array#sort
  )
- (func $~lib/typedarray/Float64Array#__get (; 60 ;) (param $0 i32) (param $1 i32) (result f64)
+ (func $~lib/typedarray/Float64Array#__get (param $0 i32) (param $1 i32) (result f64)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -3611,7 +3611,7 @@
   i32.add
   f64.load
  )
- (func $~lib/typedarray/Uint8ClampedArray#__set (; 61 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint8ClampedArray#__set (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -3643,7 +3643,7 @@
   i32.and
   i32.store8
  )
- (func $~lib/typedarray/Uint8ClampedArray#__get (; 62 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8ClampedArray#__get (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -3662,7 +3662,7 @@
   i32.add
   i32.load8_u
  )
- (func $~lib/typedarray/Int8Array#__set (; 63 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int8Array#__set (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -3682,7 +3682,7 @@
   local.get $2
   i32.store8
  )
- (func $~lib/typedarray/Int8Array#fill (; 64 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#fill (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -3771,7 +3771,7 @@
   end
   local.get $7
  )
- (func $~lib/util/memory/memcpy (; 65 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/memory/memcpy (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -4795,7 +4795,7 @@
    i32.store8
   end
  )
- (func $~lib/memory/memory.copy (; 66 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/memory/memory.copy (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -5015,7 +5015,7 @@
    end
   end
  )
- (func $~lib/rt/__allocBuffer (; 67 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/__allocBuffer (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $0
   local.get $1
@@ -5030,7 +5030,7 @@
   end
   local.get $3
  )
- (func $~lib/rt/__allocArray (; 68 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $~lib/rt/__allocArray (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -5062,11 +5062,11 @@
   i32.store offset=12
   local.get $4
  )
- (func $~lib/array/Array<i8>#get:length (; 69 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<i8>#get:length (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/typedarray/Int8Array#__get (; 70 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#__get (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -5085,7 +5085,7 @@
   i32.add
   i32.load8_s
  )
- (func $~lib/array/Array<i8>#__unchecked_get (; 71 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i8>#__unchecked_get (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -5094,7 +5094,7 @@
   i32.add
   i32.load8_s
  )
- (func $~lib/array/Array<i8>#__get (; 72 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i8>#__get (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   local.get $0
@@ -5114,7 +5114,7 @@
   local.set $2
   local.get $2
  )
- (func $std/typedarray/isInt8ArrayEqual (; 73 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/typedarray/isInt8ArrayEqual (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5184,7 +5184,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Int8Array#subarray (; 74 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#subarray (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -5291,7 +5291,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $~lib/typedarray/Int32Array#fill (; 75 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#fill (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -5388,11 +5388,11 @@
   end
   local.get $7
  )
- (func $~lib/array/Array<i32>#get:length (; 76 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<i32>#get:length (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<i32>#__unchecked_get (; 77 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#__unchecked_get (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -5401,7 +5401,7 @@
   i32.add
   i32.load
  )
- (func $~lib/array/Array<i32>#__get (; 78 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#__get (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   local.get $0
@@ -5421,7 +5421,7 @@
   local.set $2
   local.get $2
  )
- (func $std/typedarray/isInt32ArrayEqual (; 79 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/typedarray/isInt32ArrayEqual (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5491,7 +5491,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Int32Array#slice (; 80 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#slice (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -5596,7 +5596,7 @@
   call $~lib/rt/pure/__release
   local.get $9
  )
- (func $~lib/typedarray/Int32Array#copyWithin (; 81 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#copyWithin (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -5736,7 +5736,7 @@
   call $~lib/memory/memory.copy
   local.get $7
  )
- (func $std/typedarray/testReduce<~lib/typedarray/Int8Array,i8>~anonymous|0 (; 82 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduce<~lib/typedarray/Int8Array,i8>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -5749,7 +5749,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/typedarray/Int8Array#reduce<i8> (; 83 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#reduce<i8> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -5806,7 +5806,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $std/typedarray/testReduce<~lib/typedarray/Int8Array,i8> (; 84 ;)
+ (func $std/typedarray/testReduce<~lib/typedarray/Int8Array,i8>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -5854,7 +5854,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8Array#__set (; 85 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint8Array#__set (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -5874,7 +5874,7 @@
   local.get $2
   i32.store8
  )
- (func $std/typedarray/testReduce<~lib/typedarray/Uint8Array,u8>~anonymous|0 (; 86 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduce<~lib/typedarray/Uint8Array,u8>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -5887,7 +5887,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/typedarray/Uint8Array#reduce<u8> (; 87 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#reduce<u8> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -5944,7 +5944,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $std/typedarray/testReduce<~lib/typedarray/Uint8Array,u8> (; 88 ;)
+ (func $std/typedarray/testReduce<~lib/typedarray/Uint8Array,u8>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -5990,7 +5990,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testReduce<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|0 (; 89 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduce<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -6003,7 +6003,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/typedarray/Uint8ClampedArray#reduce<u8> (; 90 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint8ClampedArray#reduce<u8> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -6060,7 +6060,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $std/typedarray/testReduce<~lib/typedarray/Uint8ClampedArray,u8> (; 91 ;)
+ (func $std/typedarray/testReduce<~lib/typedarray/Uint8ClampedArray,u8>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -6106,7 +6106,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int16Array#__set (; 92 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int16Array#__set (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -6130,7 +6130,7 @@
   local.get $2
   i32.store16
  )
- (func $std/typedarray/testReduce<~lib/typedarray/Int16Array,i16>~anonymous|0 (; 93 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduce<~lib/typedarray/Int16Array,i16>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -6143,7 +6143,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/typedarray/Int16Array#reduce<i16> (; 94 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#reduce<i16> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -6200,7 +6200,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $std/typedarray/testReduce<~lib/typedarray/Int16Array,i16> (; 95 ;)
+ (func $std/typedarray/testReduce<~lib/typedarray/Int16Array,i16>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -6248,7 +6248,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint16Array#__set (; 96 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint16Array#__set (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -6272,7 +6272,7 @@
   local.get $2
   i32.store16
  )
- (func $std/typedarray/testReduce<~lib/typedarray/Uint16Array,u16>~anonymous|0 (; 97 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduce<~lib/typedarray/Uint16Array,u16>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -6285,7 +6285,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/typedarray/Uint16Array#reduce<u16> (; 98 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#reduce<u16> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -6342,7 +6342,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $std/typedarray/testReduce<~lib/typedarray/Uint16Array,u16> (; 99 ;)
+ (func $std/typedarray/testReduce<~lib/typedarray/Uint16Array,u16>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -6388,7 +6388,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testReduce<~lib/typedarray/Int32Array,i32>~anonymous|0 (; 100 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduce<~lib/typedarray/Int32Array,i32>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -6401,7 +6401,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/typedarray/Int32Array#reduce<i32> (; 101 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#reduce<i32> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -6458,7 +6458,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $std/typedarray/testReduce<~lib/typedarray/Int32Array,i32> (; 102 ;)
+ (func $std/typedarray/testReduce<~lib/typedarray/Int32Array,i32>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -6502,7 +6502,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint32Array#__set (; 103 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint32Array#__set (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -6526,7 +6526,7 @@
   local.get $2
   i32.store
  )
- (func $std/typedarray/testReduce<~lib/typedarray/Uint32Array,u32>~anonymous|0 (; 104 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduce<~lib/typedarray/Uint32Array,u32>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -6539,7 +6539,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/typedarray/Uint32Array#reduce<u32> (; 105 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint32Array#reduce<u32> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -6596,7 +6596,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $std/typedarray/testReduce<~lib/typedarray/Uint32Array,u32> (; 106 ;)
+ (func $std/typedarray/testReduce<~lib/typedarray/Uint32Array,u32>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -6640,7 +6640,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int64Array#__set (; 107 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $~lib/typedarray/Int64Array#__set (param $0 i32) (param $1 i32) (param $2 i64)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -6664,7 +6664,7 @@
   local.get $2
   i64.store
  )
- (func $std/typedarray/testReduce<~lib/typedarray/Int64Array,i64>~anonymous|0 (; 108 ;) (param $0 i64) (param $1 i64) (param $2 i32) (param $3 i32) (result i64)
+ (func $std/typedarray/testReduce<~lib/typedarray/Int64Array,i64>~anonymous|0 (param $0 i64) (param $1 i64) (param $2 i32) (param $3 i32) (result i64)
   (local $4 i64)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -6677,7 +6677,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/typedarray/Int64Array#reduce<i64> (; 109 ;) (param $0 i32) (param $1 i32) (param $2 i64) (result i64)
+ (func $~lib/typedarray/Int64Array#reduce<i64> (param $0 i32) (param $1 i32) (param $2 i64) (result i64)
   (local $3 i64)
   (local $4 i32)
   (local $5 i32)
@@ -6735,7 +6735,7 @@
   call $~lib/rt/pure/__release
   local.get $10
  )
- (func $std/typedarray/testReduce<~lib/typedarray/Int64Array,i64> (; 110 ;)
+ (func $std/typedarray/testReduce<~lib/typedarray/Int64Array,i64>
   (local $0 i32)
   (local $1 i32)
   (local $2 i64)
@@ -6779,7 +6779,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint64Array#__set (; 111 ;) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $~lib/typedarray/Uint64Array#__set (param $0 i32) (param $1 i32) (param $2 i64)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -6803,7 +6803,7 @@
   local.get $2
   i64.store
  )
- (func $std/typedarray/testReduce<~lib/typedarray/Uint64Array,u64>~anonymous|0 (; 112 ;) (param $0 i64) (param $1 i64) (param $2 i32) (param $3 i32) (result i64)
+ (func $std/typedarray/testReduce<~lib/typedarray/Uint64Array,u64>~anonymous|0 (param $0 i64) (param $1 i64) (param $2 i32) (param $3 i32) (result i64)
   (local $4 i64)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -6816,7 +6816,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/typedarray/Uint64Array#reduce<u64> (; 113 ;) (param $0 i32) (param $1 i32) (param $2 i64) (result i64)
+ (func $~lib/typedarray/Uint64Array#reduce<u64> (param $0 i32) (param $1 i32) (param $2 i64) (result i64)
   (local $3 i64)
   (local $4 i32)
   (local $5 i32)
@@ -6874,7 +6874,7 @@
   call $~lib/rt/pure/__release
   local.get $10
  )
- (func $std/typedarray/testReduce<~lib/typedarray/Uint64Array,u64> (; 114 ;)
+ (func $std/typedarray/testReduce<~lib/typedarray/Uint64Array,u64>
   (local $0 i32)
   (local $1 i32)
   (local $2 i64)
@@ -6918,7 +6918,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float32Array#__set (; 115 ;) (param $0 i32) (param $1 i32) (param $2 f32)
+ (func $~lib/typedarray/Float32Array#__set (param $0 i32) (param $1 i32) (param $2 f32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -6942,7 +6942,7 @@
   local.get $2
   f32.store
  )
- (func $std/typedarray/testReduce<~lib/typedarray/Float32Array,f32>~anonymous|0 (; 116 ;) (param $0 f32) (param $1 f32) (param $2 i32) (param $3 i32) (result f32)
+ (func $std/typedarray/testReduce<~lib/typedarray/Float32Array,f32>~anonymous|0 (param $0 f32) (param $1 f32) (param $2 i32) (param $3 i32) (result f32)
   (local $4 f32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -6955,7 +6955,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/typedarray/Float32Array#reduce<f32> (; 117 ;) (param $0 i32) (param $1 i32) (param $2 f32) (result f32)
+ (func $~lib/typedarray/Float32Array#reduce<f32> (param $0 i32) (param $1 i32) (param $2 f32) (result f32)
   (local $3 f32)
   (local $4 i32)
   (local $5 i32)
@@ -7013,7 +7013,7 @@
   call $~lib/rt/pure/__release
   local.get $10
  )
- (func $std/typedarray/testReduce<~lib/typedarray/Float32Array,f32> (; 118 ;)
+ (func $std/typedarray/testReduce<~lib/typedarray/Float32Array,f32>
   (local $0 i32)
   (local $1 i32)
   (local $2 f32)
@@ -7057,7 +7057,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testReduce<~lib/typedarray/Float64Array,f64>~anonymous|0 (; 119 ;) (param $0 f64) (param $1 f64) (param $2 i32) (param $3 i32) (result f64)
+ (func $std/typedarray/testReduce<~lib/typedarray/Float64Array,f64>~anonymous|0 (param $0 f64) (param $1 f64) (param $2 i32) (param $3 i32) (result f64)
   (local $4 f64)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -7070,7 +7070,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/typedarray/Float64Array#reduce<f64> (; 120 ;) (param $0 i32) (param $1 i32) (param $2 f64) (result f64)
+ (func $~lib/typedarray/Float64Array#reduce<f64> (param $0 i32) (param $1 i32) (param $2 f64) (result f64)
   (local $3 f64)
   (local $4 i32)
   (local $5 i32)
@@ -7128,7 +7128,7 @@
   call $~lib/rt/pure/__release
   local.get $10
  )
- (func $std/typedarray/testReduce<~lib/typedarray/Float64Array,f64> (; 121 ;)
+ (func $std/typedarray/testReduce<~lib/typedarray/Float64Array,f64>
   (local $0 i32)
   (local $1 i32)
   (local $2 f64)
@@ -7172,7 +7172,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testReduceRight<~lib/typedarray/Int8Array,i8>~anonymous|0 (; 122 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Int8Array,i8>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -7185,7 +7185,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/typedarray/Int8Array#reduceRight<i8> (; 123 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#reduceRight<i8> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -7241,7 +7241,7 @@
   call $~lib/rt/pure/__release
   local.get $7
  )
- (func $std/typedarray/testReduceRight<~lib/typedarray/Int8Array,i8> (; 124 ;)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Int8Array,i8>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -7289,7 +7289,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testReduceRight<~lib/typedarray/Uint8Array,u8>~anonymous|0 (; 125 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Uint8Array,u8>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -7302,7 +7302,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/typedarray/Uint8Array#reduceRight<u8> (; 126 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#reduceRight<u8> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -7358,7 +7358,7 @@
   call $~lib/rt/pure/__release
   local.get $7
  )
- (func $std/typedarray/testReduceRight<~lib/typedarray/Uint8Array,u8> (; 127 ;)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Uint8Array,u8>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -7404,7 +7404,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testReduceRight<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|0 (; 128 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -7417,7 +7417,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/typedarray/Uint8ClampedArray#reduceRight<u8> (; 129 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint8ClampedArray#reduceRight<u8> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -7473,7 +7473,7 @@
   call $~lib/rt/pure/__release
   local.get $7
  )
- (func $std/typedarray/testReduceRight<~lib/typedarray/Uint8ClampedArray,u8> (; 130 ;)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Uint8ClampedArray,u8>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -7519,7 +7519,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testReduceRight<~lib/typedarray/Int16Array,i16>~anonymous|0 (; 131 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Int16Array,i16>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -7532,7 +7532,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/typedarray/Int16Array#reduceRight<i16> (; 132 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#reduceRight<i16> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -7588,7 +7588,7 @@
   call $~lib/rt/pure/__release
   local.get $7
  )
- (func $std/typedarray/testReduceRight<~lib/typedarray/Int16Array,i16> (; 133 ;)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Int16Array,i16>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -7636,7 +7636,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testReduceRight<~lib/typedarray/Uint16Array,u16>~anonymous|0 (; 134 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Uint16Array,u16>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -7649,7 +7649,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/typedarray/Uint16Array#reduceRight<u16> (; 135 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#reduceRight<u16> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -7705,7 +7705,7 @@
   call $~lib/rt/pure/__release
   local.get $7
  )
- (func $std/typedarray/testReduceRight<~lib/typedarray/Uint16Array,u16> (; 136 ;)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Uint16Array,u16>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -7751,7 +7751,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testReduceRight<~lib/typedarray/Int32Array,i32>~anonymous|0 (; 137 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Int32Array,i32>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -7764,7 +7764,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/typedarray/Int32Array#reduceRight<i32> (; 138 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#reduceRight<i32> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -7820,7 +7820,7 @@
   call $~lib/rt/pure/__release
   local.get $7
  )
- (func $std/typedarray/testReduceRight<~lib/typedarray/Int32Array,i32> (; 139 ;)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Int32Array,i32>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -7864,7 +7864,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testReduceRight<~lib/typedarray/Uint32Array,u32>~anonymous|0 (; 140 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Uint32Array,u32>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -7877,7 +7877,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/typedarray/Uint32Array#reduceRight<u32> (; 141 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint32Array#reduceRight<u32> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -7933,7 +7933,7 @@
   call $~lib/rt/pure/__release
   local.get $7
  )
- (func $std/typedarray/testReduceRight<~lib/typedarray/Uint32Array,u32> (; 142 ;)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Uint32Array,u32>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -7977,7 +7977,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testReduceRight<~lib/typedarray/Int64Array,i64>~anonymous|0 (; 143 ;) (param $0 i64) (param $1 i64) (param $2 i32) (param $3 i32) (result i64)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Int64Array,i64>~anonymous|0 (param $0 i64) (param $1 i64) (param $2 i32) (param $3 i32) (result i64)
   (local $4 i64)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -7990,7 +7990,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/typedarray/Int64Array#reduceRight<i64> (; 144 ;) (param $0 i32) (param $1 i32) (param $2 i64) (result i64)
+ (func $~lib/typedarray/Int64Array#reduceRight<i64> (param $0 i32) (param $1 i32) (param $2 i64) (result i64)
   (local $3 i64)
   (local $4 i32)
   (local $5 i32)
@@ -8047,7 +8047,7 @@
   call $~lib/rt/pure/__release
   local.get $9
  )
- (func $std/typedarray/testReduceRight<~lib/typedarray/Int64Array,i64> (; 145 ;)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Int64Array,i64>
   (local $0 i32)
   (local $1 i32)
   (local $2 i64)
@@ -8091,7 +8091,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testReduceRight<~lib/typedarray/Uint64Array,u64>~anonymous|0 (; 146 ;) (param $0 i64) (param $1 i64) (param $2 i32) (param $3 i32) (result i64)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Uint64Array,u64>~anonymous|0 (param $0 i64) (param $1 i64) (param $2 i32) (param $3 i32) (result i64)
   (local $4 i64)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -8104,7 +8104,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/typedarray/Uint64Array#reduceRight<u64> (; 147 ;) (param $0 i32) (param $1 i32) (param $2 i64) (result i64)
+ (func $~lib/typedarray/Uint64Array#reduceRight<u64> (param $0 i32) (param $1 i32) (param $2 i64) (result i64)
   (local $3 i64)
   (local $4 i32)
   (local $5 i32)
@@ -8161,7 +8161,7 @@
   call $~lib/rt/pure/__release
   local.get $9
  )
- (func $std/typedarray/testReduceRight<~lib/typedarray/Uint64Array,u64> (; 148 ;)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Uint64Array,u64>
   (local $0 i32)
   (local $1 i32)
   (local $2 i64)
@@ -8205,7 +8205,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testReduceRight<~lib/typedarray/Float32Array,f32>~anonymous|0 (; 149 ;) (param $0 f32) (param $1 f32) (param $2 i32) (param $3 i32) (result f32)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Float32Array,f32>~anonymous|0 (param $0 f32) (param $1 f32) (param $2 i32) (param $3 i32) (result f32)
   (local $4 f32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -8218,7 +8218,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/typedarray/Float32Array#reduceRight<f32> (; 150 ;) (param $0 i32) (param $1 i32) (param $2 f32) (result f32)
+ (func $~lib/typedarray/Float32Array#reduceRight<f32> (param $0 i32) (param $1 i32) (param $2 f32) (result f32)
   (local $3 f32)
   (local $4 i32)
   (local $5 i32)
@@ -8275,7 +8275,7 @@
   call $~lib/rt/pure/__release
   local.get $9
  )
- (func $std/typedarray/testReduceRight<~lib/typedarray/Float32Array,f32> (; 151 ;)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Float32Array,f32>
   (local $0 i32)
   (local $1 i32)
   (local $2 f32)
@@ -8319,7 +8319,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testReduceRight<~lib/typedarray/Float64Array,f64>~anonymous|0 (; 152 ;) (param $0 f64) (param $1 f64) (param $2 i32) (param $3 i32) (result f64)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Float64Array,f64>~anonymous|0 (param $0 f64) (param $1 f64) (param $2 i32) (param $3 i32) (result f64)
   (local $4 f64)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -8332,7 +8332,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/typedarray/Float64Array#reduceRight<f64> (; 153 ;) (param $0 i32) (param $1 i32) (param $2 f64) (result f64)
+ (func $~lib/typedarray/Float64Array#reduceRight<f64> (param $0 i32) (param $1 i32) (param $2 f64) (result f64)
   (local $3 f64)
   (local $4 i32)
   (local $5 i32)
@@ -8389,7 +8389,7 @@
   call $~lib/rt/pure/__release
   local.get $9
  )
- (func $std/typedarray/testReduceRight<~lib/typedarray/Float64Array,f64> (; 154 ;)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Float64Array,f64>
   (local $0 i32)
   (local $1 i32)
   (local $2 f64)
@@ -8433,7 +8433,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayMap<~lib/typedarray/Int8Array,i8>~anonymous|0 (; 155 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Int8Array,i8>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -8446,7 +8446,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Int8Array#map (; 156 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#map (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -8530,7 +8530,7 @@
   call $~lib/rt/pure/__release
   local.get $9
  )
- (func $std/typedarray/testArrayMap<~lib/typedarray/Int8Array,i8> (; 157 ;)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Int8Array,i8>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -8605,7 +8605,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayMap<~lib/typedarray/Uint8Array,u8>~anonymous|0 (; 158 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Uint8Array,u8>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -8618,7 +8618,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Uint8Array#map (; 159 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#map (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -8702,7 +8702,7 @@
   call $~lib/rt/pure/__release
   local.get $9
  )
- (func $~lib/typedarray/Uint8Array#__get (; 160 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#__get (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -8721,7 +8721,7 @@
   i32.add
   i32.load8_u
  )
- (func $std/typedarray/testArrayMap<~lib/typedarray/Uint8Array,u8> (; 161 ;)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Uint8Array,u8>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -8796,7 +8796,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayMap<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|0 (; 162 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -8809,7 +8809,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Uint8ClampedArray#map (; 163 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8ClampedArray#map (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -8893,7 +8893,7 @@
   call $~lib/rt/pure/__release
   local.get $9
  )
- (func $std/typedarray/testArrayMap<~lib/typedarray/Uint8ClampedArray,u8> (; 164 ;)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Uint8ClampedArray,u8>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -8968,7 +8968,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayMap<~lib/typedarray/Int16Array,i16>~anonymous|0 (; 165 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Int16Array,i16>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -8981,7 +8981,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Int16Array#map (; 166 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#map (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9065,7 +9065,7 @@
   call $~lib/rt/pure/__release
   local.get $9
  )
- (func $~lib/typedarray/Int16Array#__get (; 167 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#__get (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -9088,7 +9088,7 @@
   i32.add
   i32.load16_s
  )
- (func $std/typedarray/testArrayMap<~lib/typedarray/Int16Array,i16> (; 168 ;)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Int16Array,i16>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -9163,7 +9163,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayMap<~lib/typedarray/Uint16Array,u16>~anonymous|0 (; 169 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Uint16Array,u16>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -9176,7 +9176,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Uint16Array#map (; 170 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#map (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9260,7 +9260,7 @@
   call $~lib/rt/pure/__release
   local.get $9
  )
- (func $~lib/typedarray/Uint16Array#__get (; 171 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#__get (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -9283,7 +9283,7 @@
   i32.add
   i32.load16_u
  )
- (func $std/typedarray/testArrayMap<~lib/typedarray/Uint16Array,u16> (; 172 ;)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Uint16Array,u16>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -9358,7 +9358,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayMap<~lib/typedarray/Int32Array,i32>~anonymous|0 (; 173 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Int32Array,i32>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -9371,7 +9371,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Int32Array#map (; 174 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#map (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9455,7 +9455,7 @@
   call $~lib/rt/pure/__release
   local.get $9
  )
- (func $std/typedarray/testArrayMap<~lib/typedarray/Int32Array,i32> (; 175 ;)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Int32Array,i32>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -9530,7 +9530,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayMap<~lib/typedarray/Uint32Array,u32>~anonymous|0 (; 176 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Uint32Array,u32>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -9543,7 +9543,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Uint32Array#map (; 177 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint32Array#map (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9627,7 +9627,7 @@
   call $~lib/rt/pure/__release
   local.get $9
  )
- (func $~lib/typedarray/Uint32Array#__get (; 178 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint32Array#__get (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -9650,7 +9650,7 @@
   i32.add
   i32.load
  )
- (func $std/typedarray/testArrayMap<~lib/typedarray/Uint32Array,u32> (; 179 ;)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Uint32Array,u32>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -9725,7 +9725,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayMap<~lib/typedarray/Int64Array,i64>~anonymous|0 (; 180 ;) (param $0 i64) (param $1 i32) (param $2 i32) (result i64)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Int64Array,i64>~anonymous|0 (param $0 i64) (param $1 i32) (param $2 i32) (result i64)
   (local $3 i64)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -9738,7 +9738,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Int64Array#map (; 181 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int64Array#map (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9822,7 +9822,7 @@
   call $~lib/rt/pure/__release
   local.get $9
  )
- (func $~lib/typedarray/Int64Array#__get (; 182 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $~lib/typedarray/Int64Array#__get (param $0 i32) (param $1 i32) (result i64)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -9845,7 +9845,7 @@
   i32.add
   i64.load
  )
- (func $std/typedarray/testArrayMap<~lib/typedarray/Int64Array,i64> (; 183 ;)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Int64Array,i64>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -9920,7 +9920,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayMap<~lib/typedarray/Uint64Array,u64>~anonymous|0 (; 184 ;) (param $0 i64) (param $1 i32) (param $2 i32) (result i64)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Uint64Array,u64>~anonymous|0 (param $0 i64) (param $1 i32) (param $2 i32) (result i64)
   (local $3 i64)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -9933,7 +9933,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Uint64Array#map (; 185 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint64Array#map (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10017,7 +10017,7 @@
   call $~lib/rt/pure/__release
   local.get $9
  )
- (func $~lib/typedarray/Uint64Array#__get (; 186 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $~lib/typedarray/Uint64Array#__get (param $0 i32) (param $1 i32) (result i64)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -10040,7 +10040,7 @@
   i32.add
   i64.load
  )
- (func $std/typedarray/testArrayMap<~lib/typedarray/Uint64Array,u64> (; 187 ;)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Uint64Array,u64>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -10115,7 +10115,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayMap<~lib/typedarray/Float32Array,f32>~anonymous|0 (; 188 ;) (param $0 f32) (param $1 i32) (param $2 i32) (result f32)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Float32Array,f32>~anonymous|0 (param $0 f32) (param $1 i32) (param $2 i32) (result f32)
   (local $3 f32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -10128,7 +10128,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Float32Array#map (; 189 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#map (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10212,7 +10212,7 @@
   call $~lib/rt/pure/__release
   local.get $9
  )
- (func $~lib/typedarray/Float32Array#__get (; 190 ;) (param $0 i32) (param $1 i32) (result f32)
+ (func $~lib/typedarray/Float32Array#__get (param $0 i32) (param $1 i32) (result f32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -10235,7 +10235,7 @@
   i32.add
   f32.load
  )
- (func $std/typedarray/testArrayMap<~lib/typedarray/Float32Array,f32> (; 191 ;)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Float32Array,f32>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -10310,7 +10310,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayMap<~lib/typedarray/Float64Array,f64>~anonymous|0 (; 192 ;) (param $0 f64) (param $1 i32) (param $2 i32) (result f64)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Float64Array,f64>~anonymous|0 (param $0 f64) (param $1 i32) (param $2 i32) (result f64)
   (local $3 f64)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -10323,7 +10323,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Float64Array#map (; 193 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#map (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10407,7 +10407,7 @@
   call $~lib/rt/pure/__release
   local.get $9
  )
- (func $std/typedarray/testArrayMap<~lib/typedarray/Float64Array,f64> (; 194 ;)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Float64Array,f64>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -10482,7 +10482,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Int8Array,i8>~anonymous|0 (; 195 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Int8Array,i8>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -10499,7 +10499,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/rt/tlsf/reallocateBlock (; 196 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/reallocateBlock (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -10618,7 +10618,7 @@
   end
   local.get $8
  )
- (func $~lib/rt/tlsf/__realloc (; 197 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/__realloc (param $0 i32) (param $1 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
   local.get $0
   call $~lib/rt/tlsf/checkUsedBlock
@@ -10627,7 +10627,7 @@
   i32.const 16
   i32.add
  )
- (func $~lib/typedarray/Int8Array#filter (; 198 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#filter (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10731,7 +10731,7 @@
   call $~lib/rt/pure/__release
   local.get $11
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Int8Array,i8> (; 199 ;)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Int8Array,i8>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -10840,7 +10840,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint8Array,u8>~anonymous|0 (; 200 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint8Array,u8>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -10855,7 +10855,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Uint8Array#filter (; 201 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#filter (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10959,7 +10959,7 @@
   call $~lib/rt/pure/__release
   local.get $11
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint8Array,u8> (; 202 ;)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint8Array,u8>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -11068,7 +11068,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|0 (; 203 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -11083,7 +11083,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Uint8ClampedArray#filter (; 204 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8ClampedArray#filter (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -11187,7 +11187,7 @@
   call $~lib/rt/pure/__release
   local.get $11
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint8ClampedArray,u8> (; 205 ;)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint8ClampedArray,u8>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -11296,7 +11296,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Int16Array,i16>~anonymous|0 (; 206 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Int16Array,i16>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -11313,7 +11313,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Int16Array#filter (; 207 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#filter (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -11417,7 +11417,7 @@
   call $~lib/rt/pure/__release
   local.get $11
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Int16Array,i16> (; 208 ;)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Int16Array,i16>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -11526,7 +11526,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint16Array,u16>~anonymous|0 (; 209 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint16Array,u16>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -11541,7 +11541,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Uint16Array#filter (; 210 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#filter (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -11645,7 +11645,7 @@
   call $~lib/rt/pure/__release
   local.get $11
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint16Array,u16> (; 211 ;)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint16Array,u16>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -11754,7 +11754,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Int32Array,i32>~anonymous|0 (; 212 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Int32Array,i32>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -11767,7 +11767,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Int32Array#filter (; 213 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#filter (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -11871,7 +11871,7 @@
   call $~lib/rt/pure/__release
   local.get $11
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Int32Array,i32> (; 214 ;)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Int32Array,i32>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -11980,7 +11980,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint32Array,u32>~anonymous|0 (; 215 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint32Array,u32>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -11993,7 +11993,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Uint32Array#filter (; 216 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint32Array#filter (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -12097,7 +12097,7 @@
   call $~lib/rt/pure/__release
   local.get $11
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint32Array,u32> (; 217 ;)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint32Array,u32>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -12206,7 +12206,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Int64Array,i64>~anonymous|0 (; 218 ;) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Int64Array,i64>~anonymous|0 (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -12219,7 +12219,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Int64Array#filter (; 219 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int64Array#filter (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -12323,7 +12323,7 @@
   call $~lib/rt/pure/__release
   local.get $12
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Int64Array,i64> (; 220 ;)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Int64Array,i64>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -12432,7 +12432,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint64Array,u64>~anonymous|0 (; 221 ;) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint64Array,u64>~anonymous|0 (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -12445,7 +12445,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Uint64Array#filter (; 222 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint64Array#filter (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -12549,7 +12549,7 @@
   call $~lib/rt/pure/__release
   local.get $12
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint64Array,u64> (; 223 ;)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint64Array,u64>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -12658,7 +12658,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Float32Array,f32>~anonymous|0 (; 224 ;) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Float32Array,f32>~anonymous|0 (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -12671,7 +12671,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Float32Array#filter (; 225 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#filter (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -12775,7 +12775,7 @@
   call $~lib/rt/pure/__release
   local.get $12
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Float32Array,f32> (; 226 ;)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Float32Array,f32>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -12884,7 +12884,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Float64Array,f64>~anonymous|0 (; 227 ;) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Float64Array,f64>~anonymous|0 (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -12897,7 +12897,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Float64Array#filter (; 228 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#filter (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -13001,7 +13001,7 @@
   call $~lib/rt/pure/__release
   local.get $12
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Float64Array,f64> (; 229 ;)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Float64Array,f64>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -13110,7 +13110,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Int8Array,i8>~anonymous|0 (; 230 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Int8Array,i8>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -13127,7 +13127,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Int8Array#some (; 231 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#some (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -13190,7 +13190,7 @@
    local.get $6
   end
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Int8Array,i8>~anonymous|1 (; 232 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Int8Array,i8>~anonymous|1 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -13207,7 +13207,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Int8Array,i8> (; 233 ;)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Int8Array,i8>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -13266,7 +13266,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Uint8Array,u8>~anonymous|0 (; 234 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Uint8Array,u8>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -13281,7 +13281,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Uint8Array#some (; 235 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#some (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -13344,7 +13344,7 @@
    local.get $6
   end
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Uint8Array,u8>~anonymous|1 (; 236 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Uint8Array,u8>~anonymous|1 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -13359,7 +13359,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Uint8Array,u8> (; 237 ;)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Uint8Array,u8>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -13418,7 +13418,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|0 (; 238 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -13433,7 +13433,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Uint8ClampedArray#some (; 239 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8ClampedArray#some (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -13496,7 +13496,7 @@
    local.get $6
   end
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|1 (; 240 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|1 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -13511,7 +13511,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Uint8ClampedArray,u8> (; 241 ;)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Uint8ClampedArray,u8>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -13570,7 +13570,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Int16Array,i16>~anonymous|0 (; 242 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Int16Array,i16>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -13587,7 +13587,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Int16Array#some (; 243 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#some (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -13650,7 +13650,7 @@
    local.get $6
   end
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Int16Array,i16>~anonymous|1 (; 244 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Int16Array,i16>~anonymous|1 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -13667,7 +13667,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Int16Array,i16> (; 245 ;)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Int16Array,i16>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -13726,7 +13726,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Uint16Array,u16>~anonymous|0 (; 246 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Uint16Array,u16>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -13741,7 +13741,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Uint16Array#some (; 247 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#some (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -13804,7 +13804,7 @@
    local.get $6
   end
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Uint16Array,u16>~anonymous|1 (; 248 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Uint16Array,u16>~anonymous|1 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -13819,7 +13819,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Uint16Array,u16> (; 249 ;)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Uint16Array,u16>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -13878,7 +13878,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Int32Array,i32>~anonymous|0 (; 250 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Int32Array,i32>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -13891,7 +13891,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Int32Array#some (; 251 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#some (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -13954,7 +13954,7 @@
    local.get $6
   end
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Int32Array,i32>~anonymous|1 (; 252 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Int32Array,i32>~anonymous|1 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -13967,7 +13967,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Int32Array,i32> (; 253 ;)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Int32Array,i32>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -14026,7 +14026,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Uint32Array,u32>~anonymous|0 (; 254 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Uint32Array,u32>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -14039,7 +14039,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Uint32Array#some (; 255 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint32Array#some (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -14102,7 +14102,7 @@
    local.get $6
   end
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Uint32Array,u32>~anonymous|1 (; 256 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Uint32Array,u32>~anonymous|1 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -14115,7 +14115,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Uint32Array,u32> (; 257 ;)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Uint32Array,u32>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -14174,7 +14174,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Int64Array,i64>~anonymous|0 (; 258 ;) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Int64Array,i64>~anonymous|0 (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -14187,7 +14187,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Int64Array#some (; 259 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int64Array#some (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -14250,7 +14250,7 @@
    local.get $6
   end
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Int64Array,i64>~anonymous|1 (; 260 ;) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Int64Array,i64>~anonymous|1 (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -14263,7 +14263,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Int64Array,i64> (; 261 ;)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Int64Array,i64>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -14322,7 +14322,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Uint64Array,u64>~anonymous|0 (; 262 ;) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Uint64Array,u64>~anonymous|0 (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -14335,7 +14335,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Uint64Array#some (; 263 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint64Array#some (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -14398,7 +14398,7 @@
    local.get $6
   end
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Uint64Array,u64>~anonymous|1 (; 264 ;) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Uint64Array,u64>~anonymous|1 (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -14411,7 +14411,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Uint64Array,u64> (; 265 ;)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Uint64Array,u64>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -14470,7 +14470,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Float32Array,f32>~anonymous|0 (; 266 ;) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Float32Array,f32>~anonymous|0 (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -14483,7 +14483,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Float32Array#some (; 267 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#some (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -14546,7 +14546,7 @@
    local.get $6
   end
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Float32Array,f32>~anonymous|1 (; 268 ;) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Float32Array,f32>~anonymous|1 (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -14559,7 +14559,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Float32Array,f32> (; 269 ;)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Float32Array,f32>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -14618,7 +14618,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Float64Array,f64>~anonymous|0 (; 270 ;) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Float64Array,f64>~anonymous|0 (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -14631,7 +14631,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Float64Array#some (; 271 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#some (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -14694,7 +14694,7 @@
    local.get $6
   end
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Float64Array,f64>~anonymous|1 (; 272 ;) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Float64Array,f64>~anonymous|1 (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -14707,7 +14707,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Float64Array,f64> (; 273 ;)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Float64Array,f64>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -14766,7 +14766,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int8Array,i8>~anonymous|0 (; 274 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int8Array,i8>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -14783,7 +14783,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Int8Array#findIndex (; 275 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#findIndex (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -14846,7 +14846,7 @@
    local.get $6
   end
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int8Array,i8>~anonymous|1 (; 276 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int8Array,i8>~anonymous|1 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -14863,7 +14863,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int8Array,i8> (; 277 ;)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int8Array,i8>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -14923,7 +14923,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint8Array,u8>~anonymous|0 (; 278 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint8Array,u8>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -14938,7 +14938,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Uint8Array#findIndex (; 279 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#findIndex (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -15001,7 +15001,7 @@
    local.get $6
   end
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint8Array,u8>~anonymous|1 (; 280 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint8Array,u8>~anonymous|1 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -15016,7 +15016,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint8Array,u8> (; 281 ;)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint8Array,u8>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -15076,7 +15076,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|0 (; 282 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -15091,7 +15091,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Uint8ClampedArray#findIndex (; 283 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8ClampedArray#findIndex (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -15154,7 +15154,7 @@
    local.get $6
   end
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|1 (; 284 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|1 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -15169,7 +15169,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint8ClampedArray,u8> (; 285 ;)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint8ClampedArray,u8>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -15229,7 +15229,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int16Array,i16>~anonymous|0 (; 286 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int16Array,i16>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -15246,7 +15246,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Int16Array#findIndex (; 287 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#findIndex (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -15309,7 +15309,7 @@
    local.get $6
   end
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int16Array,i16>~anonymous|1 (; 288 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int16Array,i16>~anonymous|1 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -15326,7 +15326,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int16Array,i16> (; 289 ;)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int16Array,i16>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -15386,7 +15386,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint16Array,u16>~anonymous|0 (; 290 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint16Array,u16>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -15401,7 +15401,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Uint16Array#findIndex (; 291 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#findIndex (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -15464,7 +15464,7 @@
    local.get $6
   end
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint16Array,u16>~anonymous|1 (; 292 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint16Array,u16>~anonymous|1 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -15479,7 +15479,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint16Array,u16> (; 293 ;)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint16Array,u16>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -15539,7 +15539,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int32Array,i32>~anonymous|0 (; 294 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int32Array,i32>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -15552,7 +15552,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Int32Array#findIndex (; 295 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#findIndex (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -15615,7 +15615,7 @@
    local.get $6
   end
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int32Array,i32>~anonymous|1 (; 296 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int32Array,i32>~anonymous|1 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -15628,7 +15628,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int32Array,i32> (; 297 ;)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int32Array,i32>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -15688,7 +15688,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint32Array,u32>~anonymous|0 (; 298 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint32Array,u32>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -15701,7 +15701,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Uint32Array#findIndex (; 299 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint32Array#findIndex (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -15764,7 +15764,7 @@
    local.get $6
   end
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint32Array,u32>~anonymous|1 (; 300 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint32Array,u32>~anonymous|1 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -15777,7 +15777,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint32Array,u32> (; 301 ;)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint32Array,u32>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -15837,7 +15837,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int64Array,i64>~anonymous|0 (; 302 ;) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int64Array,i64>~anonymous|0 (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -15850,7 +15850,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Int64Array#findIndex (; 303 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int64Array#findIndex (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -15913,7 +15913,7 @@
    local.get $6
   end
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int64Array,i64>~anonymous|1 (; 304 ;) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int64Array,i64>~anonymous|1 (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -15926,7 +15926,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int64Array,i64> (; 305 ;)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int64Array,i64>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -15986,7 +15986,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint64Array,u64>~anonymous|0 (; 306 ;) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint64Array,u64>~anonymous|0 (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -15999,7 +15999,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Uint64Array#findIndex (; 307 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint64Array#findIndex (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -16062,7 +16062,7 @@
    local.get $6
   end
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint64Array,u64>~anonymous|1 (; 308 ;) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint64Array,u64>~anonymous|1 (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -16075,7 +16075,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint64Array,u64> (; 309 ;)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint64Array,u64>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -16135,7 +16135,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Float32Array,f32>~anonymous|0 (; 310 ;) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Float32Array,f32>~anonymous|0 (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -16148,7 +16148,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Float32Array#findIndex (; 311 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#findIndex (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -16211,7 +16211,7 @@
    local.get $6
   end
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Float32Array,f32>~anonymous|1 (; 312 ;) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Float32Array,f32>~anonymous|1 (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -16224,7 +16224,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Float32Array,f32> (; 313 ;)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Float32Array,f32>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -16284,7 +16284,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Float64Array,f64>~anonymous|0 (; 314 ;) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Float64Array,f64>~anonymous|0 (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -16297,7 +16297,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Float64Array#findIndex (; 315 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#findIndex (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -16360,7 +16360,7 @@
    local.get $6
   end
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Float64Array,f64>~anonymous|1 (; 316 ;) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Float64Array,f64>~anonymous|1 (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -16373,7 +16373,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Float64Array,f64> (; 317 ;)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Float64Array,f64>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -16433,7 +16433,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Int8Array,i8>~anonymous|0 (; 318 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Int8Array,i8>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -16452,7 +16452,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Int8Array#every (; 319 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#every (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -16518,7 +16518,7 @@
    local.get $6
   end
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Int8Array,i8>~anonymous|1 (; 320 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Int8Array,i8>~anonymous|1 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -16535,7 +16535,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Int8Array,i8> (; 321 ;)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Int8Array,i8>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -16594,7 +16594,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint8Array,u8>~anonymous|0 (; 322 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint8Array,u8>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -16611,7 +16611,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Uint8Array#every (; 323 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#every (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -16677,7 +16677,7 @@
    local.get $6
   end
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint8Array,u8>~anonymous|1 (; 324 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint8Array,u8>~anonymous|1 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -16692,7 +16692,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint8Array,u8> (; 325 ;)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint8Array,u8>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -16751,7 +16751,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|0 (; 326 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -16768,7 +16768,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Uint8ClampedArray#every (; 327 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8ClampedArray#every (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -16834,7 +16834,7 @@
    local.get $6
   end
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|1 (; 328 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|1 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -16849,7 +16849,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint8ClampedArray,u8> (; 329 ;)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint8ClampedArray,u8>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -16908,7 +16908,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Int16Array,i16>~anonymous|0 (; 330 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Int16Array,i16>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -16927,7 +16927,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Int16Array#every (; 331 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#every (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -16993,7 +16993,7 @@
    local.get $6
   end
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Int16Array,i16>~anonymous|1 (; 332 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Int16Array,i16>~anonymous|1 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -17010,7 +17010,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Int16Array,i16> (; 333 ;)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Int16Array,i16>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -17069,7 +17069,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint16Array,u16>~anonymous|0 (; 334 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint16Array,u16>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -17086,7 +17086,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Uint16Array#every (; 335 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#every (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -17152,7 +17152,7 @@
    local.get $6
   end
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint16Array,u16>~anonymous|1 (; 336 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint16Array,u16>~anonymous|1 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -17167,7 +17167,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint16Array,u16> (; 337 ;)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint16Array,u16>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -17226,7 +17226,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Int32Array,i32>~anonymous|0 (; 338 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Int32Array,i32>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -17241,7 +17241,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Int32Array#every (; 339 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#every (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -17307,7 +17307,7 @@
    local.get $6
   end
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Int32Array,i32>~anonymous|1 (; 340 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Int32Array,i32>~anonymous|1 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -17320,7 +17320,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Int32Array,i32> (; 341 ;)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Int32Array,i32>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -17379,7 +17379,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint32Array,u32>~anonymous|0 (; 342 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint32Array,u32>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -17394,7 +17394,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Uint32Array#every (; 343 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint32Array#every (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -17460,7 +17460,7 @@
    local.get $6
   end
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint32Array,u32>~anonymous|1 (; 344 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint32Array,u32>~anonymous|1 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -17473,7 +17473,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint32Array,u32> (; 345 ;)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint32Array,u32>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -17532,7 +17532,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Int64Array,i64>~anonymous|0 (; 346 ;) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Int64Array,i64>~anonymous|0 (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -17547,7 +17547,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Int64Array#every (; 347 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int64Array#every (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -17613,7 +17613,7 @@
    local.get $6
   end
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Int64Array,i64>~anonymous|1 (; 348 ;) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Int64Array,i64>~anonymous|1 (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -17626,7 +17626,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Int64Array,i64> (; 349 ;)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Int64Array,i64>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -17685,7 +17685,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint64Array,u64>~anonymous|0 (; 350 ;) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint64Array,u64>~anonymous|0 (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -17700,7 +17700,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Uint64Array#every (; 351 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint64Array#every (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -17766,7 +17766,7 @@
    local.get $6
   end
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint64Array,u64>~anonymous|1 (; 352 ;) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint64Array,u64>~anonymous|1 (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -17779,7 +17779,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint64Array,u64> (; 353 ;)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint64Array,u64>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -17838,7 +17838,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/math/NativeMathf.mod (; 354 ;) (param $0 f32) (param $1 f32) (result f32)
+ (func $~lib/math/NativeMathf.mod (param $0 f32) (param $1 f32) (result f32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -18086,7 +18086,7 @@
   local.get $2
   f32.reinterpret_i32
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Float32Array,f32>~anonymous|0 (; 355 ;) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Float32Array,f32>~anonymous|0 (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -18101,7 +18101,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Float32Array#every (; 356 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#every (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -18167,7 +18167,7 @@
    local.get $6
   end
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Float32Array,f32>~anonymous|1 (; 357 ;) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Float32Array,f32>~anonymous|1 (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -18180,7 +18180,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Float32Array,f32> (; 358 ;)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Float32Array,f32>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -18239,7 +18239,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/math/NativeMath.mod (; 359 ;) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.mod (param $0 f64) (param $1 f64) (result f64)
   (local $2 i64)
   (local $3 i64)
   (local $4 i64)
@@ -18493,7 +18493,7 @@
   local.get $2
   f64.reinterpret_i64
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Float64Array,f64>~anonymous|0 (; 360 ;) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Float64Array,f64>~anonymous|0 (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -18508,7 +18508,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Float64Array#every (; 361 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#every (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -18574,7 +18574,7 @@
    local.get $6
   end
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Float64Array,f64>~anonymous|1 (; 362 ;) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Float64Array,f64>~anonymous|1 (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -18587,7 +18587,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Float64Array,f64> (; 363 ;)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Float64Array,f64>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -18646,7 +18646,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Int8Array,i8>~anonymous|0 (; 364 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Int8Array,i8>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -18706,7 +18706,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int8Array#forEach (; 365 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Int8Array#forEach (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -18755,7 +18755,7 @@
   local.get $3
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Int8Array,i8> (; 366 ;)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Int8Array,i8>
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -18818,7 +18818,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint8Array,u8>~anonymous|0 (; 367 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint8Array,u8>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -18874,7 +18874,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8Array#forEach (; 368 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Uint8Array#forEach (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -18923,7 +18923,7 @@
   local.get $3
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint8Array,u8> (; 369 ;)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint8Array,u8>
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -18980,7 +18980,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|0 (; 370 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -19036,7 +19036,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8ClampedArray#forEach (; 371 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Uint8ClampedArray#forEach (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -19085,7 +19085,7 @@
   local.get $3
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint8ClampedArray,u8> (; 372 ;)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint8ClampedArray,u8>
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -19142,7 +19142,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Int16Array,i16>~anonymous|0 (; 373 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Int16Array,i16>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -19202,7 +19202,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int16Array#forEach (; 374 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Int16Array#forEach (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -19251,7 +19251,7 @@
   local.get $3
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Int16Array,i16> (; 375 ;)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Int16Array,i16>
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -19314,7 +19314,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint16Array,u16>~anonymous|0 (; 376 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint16Array,u16>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -19370,7 +19370,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint16Array#forEach (; 377 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Uint16Array#forEach (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -19419,7 +19419,7 @@
   local.get $3
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint16Array,u16> (; 378 ;)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint16Array,u16>
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -19476,7 +19476,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Int32Array,i32>~anonymous|0 (; 379 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Int32Array,i32>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -19528,7 +19528,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int32Array#forEach (; 380 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Int32Array#forEach (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -19577,7 +19577,7 @@
   local.get $3
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Int32Array,i32> (; 381 ;)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Int32Array,i32>
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -19628,7 +19628,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint32Array,u32>~anonymous|0 (; 382 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint32Array,u32>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -19680,7 +19680,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint32Array#forEach (; 383 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Uint32Array#forEach (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -19729,7 +19729,7 @@
   local.get $3
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint32Array,u32> (; 384 ;)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint32Array,u32>
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -19780,7 +19780,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Int64Array,i64>~anonymous|0 (; 385 ;) (param $0 i64) (param $1 i32) (param $2 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Int64Array,i64>~anonymous|0 (param $0 i64) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -19833,7 +19833,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int64Array#forEach (; 386 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Int64Array#forEach (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -19882,7 +19882,7 @@
   local.get $3
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Int64Array,i64> (; 387 ;)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Int64Array,i64>
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -19936,7 +19936,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint64Array,u64>~anonymous|0 (; 388 ;) (param $0 i64) (param $1 i32) (param $2 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint64Array,u64>~anonymous|0 (param $0 i64) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -19989,7 +19989,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint64Array#forEach (; 389 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Uint64Array#forEach (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -20038,7 +20038,7 @@
   local.get $3
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint64Array,u64> (; 390 ;)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint64Array,u64>
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -20092,7 +20092,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Float32Array,f32>~anonymous|0 (; 391 ;) (param $0 f32) (param $1 i32) (param $2 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Float32Array,f32>~anonymous|0 (param $0 f32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -20145,7 +20145,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float32Array#forEach (; 392 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Float32Array#forEach (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -20194,7 +20194,7 @@
   local.get $3
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Float32Array,f32> (; 393 ;)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Float32Array,f32>
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -20248,7 +20248,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Float64Array,f64>~anonymous|0 (; 394 ;) (param $0 f64) (param $1 i32) (param $2 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Float64Array,f64>~anonymous|0 (param $0 f64) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -20301,7 +20301,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float64Array#forEach (; 395 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Float64Array#forEach (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -20350,7 +20350,7 @@
   local.get $3
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Float64Array,f64> (; 396 ;)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Float64Array,f64>
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -20404,7 +20404,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int8Array#reverse (; 397 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#reverse (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -20468,7 +20468,7 @@
   end
   local.get $1
  )
- (func $std/typedarray/testArrayReverse<~lib/typedarray/Int8Array,i8> (; 398 ;)
+ (func $std/typedarray/testArrayReverse<~lib/typedarray/Int8Array,i8>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -20653,7 +20653,7 @@
   local.get $8
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8Array#reverse (; 399 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#reverse (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -20717,7 +20717,7 @@
   end
   local.get $1
  )
- (func $~lib/typedarray/Uint8Array#subarray (; 400 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#subarray (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -20824,7 +20824,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $std/typedarray/testArrayReverse<~lib/typedarray/Uint8Array,u8> (; 401 ;)
+ (func $std/typedarray/testArrayReverse<~lib/typedarray/Uint8Array,u8>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -21003,7 +21003,7 @@
   local.get $8
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8ClampedArray#reverse (; 402 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint8ClampedArray#reverse (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -21067,7 +21067,7 @@
   end
   local.get $1
  )
- (func $~lib/typedarray/Uint8ClampedArray#subarray (; 403 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint8ClampedArray#subarray (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -21174,7 +21174,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $std/typedarray/testArrayReverse<~lib/typedarray/Uint8ClampedArray,u8> (; 404 ;)
+ (func $std/typedarray/testArrayReverse<~lib/typedarray/Uint8ClampedArray,u8>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -21353,7 +21353,7 @@
   local.get $8
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int16Array#reverse (; 405 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#reverse (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -21417,7 +21417,7 @@
   end
   local.get $1
  )
- (func $~lib/typedarray/Int16Array#subarray (; 406 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#subarray (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -21524,7 +21524,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $std/typedarray/testArrayReverse<~lib/typedarray/Int16Array,i16> (; 407 ;)
+ (func $std/typedarray/testArrayReverse<~lib/typedarray/Int16Array,i16>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -21709,7 +21709,7 @@
   local.get $8
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint16Array#reverse (; 408 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#reverse (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -21773,7 +21773,7 @@
   end
   local.get $1
  )
- (func $~lib/typedarray/Uint16Array#subarray (; 409 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#subarray (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -21880,7 +21880,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $std/typedarray/testArrayReverse<~lib/typedarray/Uint16Array,u16> (; 410 ;)
+ (func $std/typedarray/testArrayReverse<~lib/typedarray/Uint16Array,u16>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -22059,7 +22059,7 @@
   local.get $8
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int32Array#reverse (; 411 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#reverse (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -22123,7 +22123,7 @@
   end
   local.get $1
  )
- (func $std/typedarray/testArrayReverse<~lib/typedarray/Int32Array,i32> (; 412 ;)
+ (func $std/typedarray/testArrayReverse<~lib/typedarray/Int32Array,i32>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -22296,7 +22296,7 @@
   local.get $8
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint32Array#reverse (; 413 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint32Array#reverse (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -22360,7 +22360,7 @@
   end
   local.get $1
  )
- (func $~lib/typedarray/Uint32Array#subarray (; 414 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint32Array#subarray (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -22467,7 +22467,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $std/typedarray/testArrayReverse<~lib/typedarray/Uint32Array,u32> (; 415 ;)
+ (func $std/typedarray/testArrayReverse<~lib/typedarray/Uint32Array,u32>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -22640,7 +22640,7 @@
   local.get $8
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int64Array#reverse (; 416 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int64Array#reverse (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -22704,7 +22704,7 @@
   end
   local.get $1
  )
- (func $~lib/typedarray/Int64Array#subarray (; 417 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int64Array#subarray (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -22811,7 +22811,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $std/typedarray/testArrayReverse<~lib/typedarray/Int64Array,i64> (; 418 ;)
+ (func $std/typedarray/testArrayReverse<~lib/typedarray/Int64Array,i64>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -22987,7 +22987,7 @@
   local.get $8
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint64Array#reverse (; 419 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint64Array#reverse (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -23051,7 +23051,7 @@
   end
   local.get $1
  )
- (func $~lib/typedarray/Uint64Array#subarray (; 420 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint64Array#subarray (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -23158,7 +23158,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $std/typedarray/testArrayReverse<~lib/typedarray/Uint64Array,u64> (; 421 ;)
+ (func $std/typedarray/testArrayReverse<~lib/typedarray/Uint64Array,u64>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -23334,7 +23334,7 @@
   local.get $8
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float32Array#reverse (; 422 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#reverse (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -23398,7 +23398,7 @@
   end
   local.get $1
  )
- (func $~lib/typedarray/Float32Array#subarray (; 423 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#subarray (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -23505,7 +23505,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $std/typedarray/testArrayReverse<~lib/typedarray/Float32Array,f32> (; 424 ;)
+ (func $std/typedarray/testArrayReverse<~lib/typedarray/Float32Array,f32>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -23681,7 +23681,7 @@
   local.get $8
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float64Array#reverse (; 425 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#reverse (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -23745,7 +23745,7 @@
   end
   local.get $1
  )
- (func $std/typedarray/testArrayReverse<~lib/typedarray/Float64Array,f64> (; 426 ;)
+ (func $std/typedarray/testArrayReverse<~lib/typedarray/Float64Array,f64>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -23921,7 +23921,7 @@
   local.get $8
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int8Array#indexOf (; 427 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#indexOf (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -24021,7 +24021,7 @@
    local.get $9
   end
  )
- (func $~lib/typedarray/Int8Array#lastIndexOf (; 428 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#lastIndexOf (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -24117,7 +24117,7 @@
    local.get $9
   end
  )
- (func $~lib/typedarray/Int8Array#lastIndexOf|trampoline (; 429 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#lastIndexOf|trampoline (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -24137,7 +24137,7 @@
   local.get $2
   call $~lib/typedarray/Int8Array#lastIndexOf
  )
- (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Int8Array,i8> (; 430 ;)
+ (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Int8Array,i8>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -24610,7 +24610,7 @@
   local.get $6
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8Array#indexOf (; 431 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#indexOf (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -24708,7 +24708,7 @@
    local.get $9
   end
  )
- (func $~lib/typedarray/Uint8Array#lastIndexOf (; 432 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#lastIndexOf (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -24802,7 +24802,7 @@
    local.get $9
   end
  )
- (func $~lib/typedarray/Uint8Array#lastIndexOf|trampoline (; 433 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#lastIndexOf|trampoline (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -24822,7 +24822,7 @@
   local.get $2
   call $~lib/typedarray/Uint8Array#lastIndexOf
  )
- (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Uint8Array,u8> (; 434 ;)
+ (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Uint8Array,u8>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -25293,7 +25293,7 @@
   local.get $6
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8ClampedArray#indexOf (; 435 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint8ClampedArray#indexOf (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -25391,7 +25391,7 @@
    local.get $9
   end
  )
- (func $~lib/typedarray/Uint8ClampedArray#lastIndexOf (; 436 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint8ClampedArray#lastIndexOf (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -25485,7 +25485,7 @@
    local.get $9
   end
  )
- (func $~lib/typedarray/Uint8ClampedArray#lastIndexOf|trampoline (; 437 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint8ClampedArray#lastIndexOf|trampoline (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -25505,7 +25505,7 @@
   local.get $2
   call $~lib/typedarray/Uint8ClampedArray#lastIndexOf
  )
- (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Uint8ClampedArray,u8> (; 438 ;)
+ (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Uint8ClampedArray,u8>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -25976,7 +25976,7 @@
   local.get $6
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int16Array#indexOf (; 439 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#indexOf (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -26076,7 +26076,7 @@
    local.get $9
   end
  )
- (func $~lib/typedarray/Int16Array#lastIndexOf (; 440 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#lastIndexOf (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -26172,7 +26172,7 @@
    local.get $9
   end
  )
- (func $~lib/typedarray/Int16Array#lastIndexOf|trampoline (; 441 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#lastIndexOf|trampoline (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -26192,7 +26192,7 @@
   local.get $2
   call $~lib/typedarray/Int16Array#lastIndexOf
  )
- (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Int16Array,i16> (; 442 ;)
+ (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Int16Array,i16>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -26665,7 +26665,7 @@
   local.get $6
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint16Array#indexOf (; 443 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#indexOf (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -26763,7 +26763,7 @@
    local.get $9
   end
  )
- (func $~lib/typedarray/Uint16Array#lastIndexOf (; 444 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#lastIndexOf (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -26857,7 +26857,7 @@
    local.get $9
   end
  )
- (func $~lib/typedarray/Uint16Array#lastIndexOf|trampoline (; 445 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#lastIndexOf|trampoline (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -26877,7 +26877,7 @@
   local.get $2
   call $~lib/typedarray/Uint16Array#lastIndexOf
  )
- (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Uint16Array,u16> (; 446 ;)
+ (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Uint16Array,u16>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -27348,7 +27348,7 @@
   local.get $6
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int32Array#indexOf (; 447 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#indexOf (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -27444,7 +27444,7 @@
    local.get $9
   end
  )
- (func $~lib/typedarray/Int32Array#lastIndexOf (; 448 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#lastIndexOf (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -27536,7 +27536,7 @@
    local.get $9
   end
  )
- (func $~lib/typedarray/Int32Array#lastIndexOf|trampoline (; 449 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#lastIndexOf|trampoline (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -27556,7 +27556,7 @@
   local.get $2
   call $~lib/typedarray/Int32Array#lastIndexOf
  )
- (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Int32Array,i32> (; 450 ;)
+ (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Int32Array,i32>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -28025,7 +28025,7 @@
   local.get $6
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint32Array#indexOf (; 451 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint32Array#indexOf (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -28121,7 +28121,7 @@
    local.get $9
   end
  )
- (func $~lib/typedarray/Uint32Array#lastIndexOf (; 452 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint32Array#lastIndexOf (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -28213,7 +28213,7 @@
    local.get $9
   end
  )
- (func $~lib/typedarray/Uint32Array#lastIndexOf|trampoline (; 453 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint32Array#lastIndexOf|trampoline (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -28233,7 +28233,7 @@
   local.get $2
   call $~lib/typedarray/Uint32Array#lastIndexOf
  )
- (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Uint32Array,u32> (; 454 ;)
+ (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Uint32Array,u32>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -28702,7 +28702,7 @@
   local.get $6
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int64Array#indexOf (; 455 ;) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int64Array#indexOf (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i64)
   (local $5 i32)
@@ -28798,7 +28798,7 @@
    local.get $9
   end
  )
- (func $~lib/typedarray/Int64Array#lastIndexOf (; 456 ;) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int64Array#lastIndexOf (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i64)
   (local $5 i32)
@@ -28890,7 +28890,7 @@
    local.get $9
   end
  )
- (func $~lib/typedarray/Int64Array#lastIndexOf|trampoline (; 457 ;) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int64Array#lastIndexOf|trampoline (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -28910,7 +28910,7 @@
   local.get $2
   call $~lib/typedarray/Int64Array#lastIndexOf
  )
- (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Int64Array,i64> (; 458 ;)
+ (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Int64Array,i64>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -29380,7 +29380,7 @@
   local.get $6
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint64Array#indexOf (; 459 ;) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint64Array#indexOf (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i64)
   (local $5 i32)
@@ -29476,7 +29476,7 @@
    local.get $9
   end
  )
- (func $~lib/typedarray/Uint64Array#lastIndexOf (; 460 ;) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint64Array#lastIndexOf (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i64)
   (local $5 i32)
@@ -29568,7 +29568,7 @@
    local.get $9
   end
  )
- (func $~lib/typedarray/Uint64Array#lastIndexOf|trampoline (; 461 ;) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint64Array#lastIndexOf|trampoline (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -29588,7 +29588,7 @@
   local.get $2
   call $~lib/typedarray/Uint64Array#lastIndexOf
  )
- (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Uint64Array,u64> (; 462 ;)
+ (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Uint64Array,u64>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -30058,7 +30058,7 @@
   local.get $6
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float32Array#indexOf (; 463 ;) (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#indexOf (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 f32)
   (local $5 i32)
@@ -30154,7 +30154,7 @@
    local.get $9
   end
  )
- (func $~lib/typedarray/Float32Array#lastIndexOf (; 464 ;) (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#lastIndexOf (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 f32)
   (local $5 i32)
@@ -30246,7 +30246,7 @@
    local.get $9
   end
  )
- (func $~lib/typedarray/Float32Array#lastIndexOf|trampoline (; 465 ;) (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#lastIndexOf|trampoline (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -30266,7 +30266,7 @@
   local.get $2
   call $~lib/typedarray/Float32Array#lastIndexOf
  )
- (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Float32Array,f32> (; 466 ;)
+ (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Float32Array,f32>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -30736,7 +30736,7 @@
   local.get $6
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float64Array#indexOf (; 467 ;) (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#indexOf (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 f64)
   (local $5 i32)
@@ -30832,7 +30832,7 @@
    local.get $9
   end
  )
- (func $~lib/typedarray/Float64Array#lastIndexOf (; 468 ;) (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#lastIndexOf (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 f64)
   (local $5 i32)
@@ -30924,7 +30924,7 @@
    local.get $9
   end
  )
- (func $~lib/typedarray/Float64Array#lastIndexOf|trampoline (; 469 ;) (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#lastIndexOf|trampoline (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -30944,7 +30944,7 @@
   local.get $2
   call $~lib/typedarray/Float64Array#lastIndexOf
  )
- (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Float64Array,f64> (; 470 ;)
+ (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Float64Array,f64>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -31414,7 +31414,7 @@
   local.get $6
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float64Array#includes (; 471 ;) (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#includes (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 f64)
   (local $5 i32)
@@ -31525,7 +31525,7 @@
    br $~lib/typedarray/INCLUDES<~lib/typedarray/Float64Array,f64>|inlined.0
   end
  )
- (func $~lib/typedarray/Float32Array#includes (; 472 ;) (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#includes (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 f32)
   (local $5 i32)
@@ -31636,7 +31636,7 @@
    br $~lib/typedarray/INCLUDES<~lib/typedarray/Float32Array,f32>|inlined.0
   end
  )
- (func $~lib/util/number/decimalCount32 (; 473 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/decimalCount32 (param $0 i32) (result i32)
   local.get $0
   i32.const 100000
   i32.lt_u
@@ -31691,7 +31691,7 @@
   end
   unreachable
  )
- (func $~lib/util/number/utoa32_lut (; 474 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/number/utoa32_lut (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -31831,7 +31831,7 @@
    i32.store16
   end
  )
- (func $~lib/util/number/itoa32 (; 475 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/itoa32 (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -31885,7 +31885,7 @@
   local.get $3
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/itoa<i8> (; 476 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/itoa<i8> (param $0 i32) (result i32)
   local.get $0
   i32.const 24
   i32.shl
@@ -31894,7 +31894,7 @@
   call $~lib/util/number/itoa32
   return
  )
- (func $~lib/string/String#get:length (; 477 ;) (param $0 i32) (result i32)
+ (func $~lib/string/String#get:length (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub
@@ -31902,7 +31902,7 @@
   i32.const 1
   i32.shr_u
  )
- (func $~lib/util/number/itoa_stream<i8> (; 478 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_stream<i8> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -31987,7 +31987,7 @@
   call $~lib/util/number/utoa32_lut
   local.get $4
  )
- (func $~lib/string/String#substring (; 479 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/string/String#substring (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -32094,7 +32094,7 @@
   local.get $11
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/string/joinIntegerArray<i8> (; 480 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<i8> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -32237,7 +32237,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/typedarray/Int8Array#join (; 481 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#join (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   call $~lib/rt/pure/__retain
@@ -32253,7 +32253,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/util/string/compareImpl (; 482 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
+ (func $~lib/util/string/compareImpl (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
@@ -32375,7 +32375,7 @@
   call $~lib/rt/pure/__release
   local.get $7
  )
- (func $~lib/string/String.__eq (; 483 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__eq (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -32448,12 +32448,12 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/typedarray/Int8Array#toString (; 484 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#toString (param $0 i32) (result i32)
   local.get $0
   i32.const 2384
   call $~lib/typedarray/Int8Array#join
  )
- (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Int8Array,i8> (; 485 ;)
+ (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Int8Array,i8>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -32522,7 +32522,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/util/number/utoa32 (; 486 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/utoa32 (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -32556,14 +32556,14 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/itoa<u8> (; 487 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/itoa<u8> (param $0 i32) (result i32)
   local.get $0
   i32.const 255
   i32.and
   call $~lib/util/number/utoa32
   return
  )
- (func $~lib/util/number/itoa_stream<u8> (; 488 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_stream<u8> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -32616,7 +32616,7 @@
   call $~lib/util/number/utoa32_lut
   local.get $4
  )
- (func $~lib/util/string/joinIntegerArray<u8> (; 489 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<u8> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -32759,7 +32759,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/typedarray/Uint8Array#join (; 490 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#join (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   call $~lib/rt/pure/__retain
@@ -32775,12 +32775,12 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/typedarray/Uint8Array#toString (; 491 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#toString (param $0 i32) (result i32)
   local.get $0
   i32.const 2384
   call $~lib/typedarray/Uint8Array#join
  )
- (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Uint8Array,u8> (; 492 ;)
+ (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Uint8Array,u8>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -32849,7 +32849,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8ClampedArray#join (; 493 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8ClampedArray#join (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   call $~lib/rt/pure/__retain
@@ -32865,12 +32865,12 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/typedarray/Uint8ClampedArray#toString (; 494 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint8ClampedArray#toString (param $0 i32) (result i32)
   local.get $0
   i32.const 2384
   call $~lib/typedarray/Uint8ClampedArray#join
  )
- (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Uint8ClampedArray,u8> (; 495 ;)
+ (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Uint8ClampedArray,u8>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -32939,7 +32939,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/util/number/itoa<i16> (; 496 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/itoa<i16> (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.shl
@@ -32948,7 +32948,7 @@
   call $~lib/util/number/itoa32
   return
  )
- (func $~lib/util/number/itoa_stream<i16> (; 497 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_stream<i16> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -33033,7 +33033,7 @@
   call $~lib/util/number/utoa32_lut
   local.get $4
  )
- (func $~lib/util/string/joinIntegerArray<i16> (; 498 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<i16> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -33176,7 +33176,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/typedarray/Int16Array#join (; 499 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#join (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   call $~lib/rt/pure/__retain
@@ -33192,12 +33192,12 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/typedarray/Int16Array#toString (; 500 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#toString (param $0 i32) (result i32)
   local.get $0
   i32.const 2384
   call $~lib/typedarray/Int16Array#join
  )
- (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Int16Array,i16> (; 501 ;)
+ (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Int16Array,i16>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -33266,14 +33266,14 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/util/number/itoa<u16> (; 502 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/itoa<u16> (param $0 i32) (result i32)
   local.get $0
   i32.const 65535
   i32.and
   call $~lib/util/number/utoa32
   return
  )
- (func $~lib/util/number/itoa_stream<u16> (; 503 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_stream<u16> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -33326,7 +33326,7 @@
   call $~lib/util/number/utoa32_lut
   local.get $4
  )
- (func $~lib/util/string/joinIntegerArray<u16> (; 504 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<u16> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -33469,7 +33469,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/typedarray/Uint16Array#join (; 505 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#join (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   call $~lib/rt/pure/__retain
@@ -33485,12 +33485,12 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/typedarray/Uint16Array#toString (; 506 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#toString (param $0 i32) (result i32)
   local.get $0
   i32.const 2384
   call $~lib/typedarray/Uint16Array#join
  )
- (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Uint16Array,u16> (; 507 ;)
+ (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Uint16Array,u16>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -33559,12 +33559,12 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/util/number/itoa<i32> (; 508 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/itoa<i32> (param $0 i32) (result i32)
   local.get $0
   call $~lib/util/number/itoa32
   return
  )
- (func $~lib/util/number/itoa_stream<i32> (; 509 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_stream<i32> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -33629,7 +33629,7 @@
   call $~lib/util/number/utoa32_lut
   local.get $4
  )
- (func $~lib/util/string/joinIntegerArray<i32> (; 510 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<i32> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -33772,7 +33772,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/typedarray/Int32Array#join (; 511 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#join (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   call $~lib/rt/pure/__retain
@@ -33788,12 +33788,12 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/typedarray/Int32Array#toString (; 512 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#toString (param $0 i32) (result i32)
   local.get $0
   i32.const 2384
   call $~lib/typedarray/Int32Array#join
  )
- (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Int32Array,i32> (; 513 ;)
+ (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Int32Array,i32>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -33862,12 +33862,12 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/util/number/itoa<u32> (; 514 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/itoa<u32> (param $0 i32) (result i32)
   local.get $0
   call $~lib/util/number/utoa32
   return
  )
- (func $~lib/util/number/itoa_stream<u32> (; 515 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_stream<u32> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -33912,7 +33912,7 @@
   call $~lib/util/number/utoa32_lut
   local.get $4
  )
- (func $~lib/util/string/joinIntegerArray<u32> (; 516 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<u32> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -34055,7 +34055,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/typedarray/Uint32Array#join (; 517 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint32Array#join (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   call $~lib/rt/pure/__retain
@@ -34071,12 +34071,12 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/typedarray/Uint32Array#toString (; 518 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint32Array#toString (param $0 i32) (result i32)
   local.get $0
   i32.const 2384
   call $~lib/typedarray/Uint32Array#join
  )
- (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Uint32Array,u32> (; 519 ;)
+ (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Uint32Array,u32>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -34145,7 +34145,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/util/number/decimalCount64High (; 520 ;) (param $0 i64) (result i32)
+ (func $~lib/util/number/decimalCount64High (param $0 i64) (result i32)
   local.get $0
   i64.const 1000000000000000
   i64.lt_u
@@ -34204,7 +34204,7 @@
   end
   unreachable
  )
- (func $~lib/util/number/utoa64_lut (; 521 ;) (param $0 i32) (param $1 i64) (param $2 i32)
+ (func $~lib/util/number/utoa64_lut (param $0 i32) (param $1 i64) (param $2 i32)
   (local $3 i32)
   (local $4 i64)
   (local $5 i32)
@@ -34327,7 +34327,7 @@
   local.get $2
   call $~lib/util/number/utoa32_lut
  )
- (func $~lib/util/number/itoa64 (; 522 ;) (param $0 i64) (result i32)
+ (func $~lib/util/number/itoa64 (param $0 i64) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -34416,12 +34416,12 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/itoa<i64> (; 523 ;) (param $0 i64) (result i32)
+ (func $~lib/util/number/itoa<i64> (param $0 i64) (result i32)
   local.get $0
   call $~lib/util/number/itoa64
   return
  )
- (func $~lib/util/number/itoa_stream<i64> (; 524 ;) (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
+ (func $~lib/util/number/itoa_stream<i64> (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -34512,7 +34512,7 @@
   end
   local.get $4
  )
- (func $~lib/util/string/joinIntegerArray<i64> (; 525 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<i64> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -34655,7 +34655,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/typedarray/Int64Array#join (; 526 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int64Array#join (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   call $~lib/rt/pure/__retain
@@ -34671,12 +34671,12 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/typedarray/Int64Array#toString (; 527 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int64Array#toString (param $0 i32) (result i32)
   local.get $0
   i32.const 2384
   call $~lib/typedarray/Int64Array#join
  )
- (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Int64Array,i64> (; 528 ;)
+ (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Int64Array,i64>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -34745,7 +34745,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/util/number/utoa64 (; 529 ;) (param $0 i64) (result i32)
+ (func $~lib/util/number/utoa64 (param $0 i64) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -34811,12 +34811,12 @@
   local.get $1
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/itoa<u64> (; 530 ;) (param $0 i64) (result i32)
+ (func $~lib/util/number/itoa<u64> (param $0 i64) (result i32)
   local.get $0
   call $~lib/util/number/utoa64
   return
  )
- (func $~lib/util/number/itoa_stream<u64> (; 531 ;) (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
+ (func $~lib/util/number/itoa_stream<u64> (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -34887,7 +34887,7 @@
   end
   local.get $4
  )
- (func $~lib/util/string/joinIntegerArray<u64> (; 532 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<u64> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -35030,7 +35030,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/typedarray/Uint64Array#join (; 533 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint64Array#join (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   call $~lib/rt/pure/__retain
@@ -35046,12 +35046,12 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/typedarray/Uint64Array#toString (; 534 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint64Array#toString (param $0 i32) (result i32)
   local.get $0
   i32.const 2384
   call $~lib/typedarray/Uint64Array#join
  )
- (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Uint64Array,u64> (; 535 ;)
+ (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Uint64Array,u64>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -35120,7 +35120,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/util/number/genDigits (; 536 ;) (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (param $6 i32) (result i32)
+ (func $~lib/util/number/genDigits (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (param $6 i32) (result i32)
   (local $7 i32)
   (local $8 i64)
   (local $9 i64)
@@ -35623,7 +35623,7 @@
   end
   unreachable
  )
- (func $~lib/util/number/prettify (; 537 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/prettify (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -35940,7 +35940,7 @@
   end
   unreachable
  )
- (func $~lib/util/number/dtoa_core (; 538 ;) (param $0 i32) (param $1 f64) (result i32)
+ (func $~lib/util/number/dtoa_core (param $0 i32) (param $1 f64) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -36366,7 +36366,7 @@
   local.get $2
   i32.add
  )
- (func $~lib/util/number/dtoa (; 539 ;) (param $0 f64) (result i32)
+ (func $~lib/util/number/dtoa (param $0 f64) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -36427,7 +36427,7 @@
   call $~lib/rt/tlsf/__free
   local.get $3
  )
- (func $~lib/util/number/dtoa_stream (; 540 ;) (param $0 i32) (param $1 i32) (param $2 f64) (result i32)
+ (func $~lib/util/number/dtoa_stream (param $0 i32) (param $1 i32) (param $2 f64) (result i32)
   (local $3 i32)
   local.get $0
   local.get $1
@@ -36505,7 +36505,7 @@
   local.get $2
   call $~lib/util/number/dtoa_core
  )
- (func $~lib/util/string/joinFloatArray<f32> (; 541 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinFloatArray<f32> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -36651,7 +36651,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/typedarray/Float32Array#join (; 542 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#join (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   call $~lib/rt/pure/__retain
@@ -36667,12 +36667,12 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/typedarray/Float32Array#toString (; 543 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#toString (param $0 i32) (result i32)
   local.get $0
   i32.const 2384
   call $~lib/typedarray/Float32Array#join
  )
- (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Float32Array,f32> (; 544 ;)
+ (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Float32Array,f32>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -36741,7 +36741,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/util/string/joinFloatArray<f64> (; 545 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinFloatArray<f64> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -36884,7 +36884,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/typedarray/Float64Array#join (; 546 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#join (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   call $~lib/rt/pure/__retain
@@ -36900,12 +36900,12 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/typedarray/Float64Array#toString (; 547 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#toString (param $0 i32) (result i32)
   local.get $0
   i32.const 2384
   call $~lib/typedarray/Float64Array#join
  )
- (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Float64Array,f64> (; 548 ;)
+ (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Float64Array,f64>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -36974,7 +36974,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/arraybuffer/ArrayBuffer#constructor (; 549 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBuffer#constructor (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   i32.const 1073741808
@@ -36998,13 +36998,13 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~lib/arraybuffer/ArrayBuffer#get:byteLength (; 550 ;) (param $0 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBuffer#get:byteLength (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub
   i32.load offset=12
  )
- (func $~lib/typedarray/Uint8Array.wrap (; 551 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array.wrap (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -37125,7 +37125,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $~lib/typedarray/Uint8Array.wrap|trampoline (; 552 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array.wrap|trampoline (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $2of2
    block $1of2
     block $0of2
@@ -37148,7 +37148,7 @@
   local.get $2
   call $~lib/typedarray/Uint8Array.wrap
  )
- (func $~lib/arraybuffer/ArrayBuffer#slice (; 553 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBuffer#slice (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -37231,7 +37231,7 @@
   local.get $7
   call $~lib/rt/pure/__retain
  )
- (func $~lib/typedarray/Int8Array.wrap (; 554 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int8Array.wrap (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -37352,7 +37352,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $~lib/typedarray/Int8Array.wrap|trampoline (; 555 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int8Array.wrap|trampoline (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $2of2
    block $1of2
     block $0of2
@@ -37375,7 +37375,7 @@
   local.get $2
   call $~lib/typedarray/Int8Array.wrap
  )
- (func $std/typedarray/testArrayWrap<~lib/typedarray/Int8Array,i8> (; 556 ;)
+ (func $std/typedarray/testArrayWrap<~lib/typedarray/Int8Array,i8>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -37489,7 +37489,7 @@
   local.get $7
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayWrap<~lib/typedarray/Uint8Array,u8> (; 557 ;)
+ (func $std/typedarray/testArrayWrap<~lib/typedarray/Uint8Array,u8>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -37601,7 +37601,7 @@
   local.get $7
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8ClampedArray.wrap (; 558 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint8ClampedArray.wrap (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -37722,7 +37722,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $~lib/typedarray/Uint8ClampedArray.wrap|trampoline (; 559 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint8ClampedArray.wrap|trampoline (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $2of2
    block $1of2
     block $0of2
@@ -37745,7 +37745,7 @@
   local.get $2
   call $~lib/typedarray/Uint8ClampedArray.wrap
  )
- (func $std/typedarray/testArrayWrap<~lib/typedarray/Uint8ClampedArray,u8> (; 560 ;)
+ (func $std/typedarray/testArrayWrap<~lib/typedarray/Uint8ClampedArray,u8>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -37857,7 +37857,7 @@
   local.get $7
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int16Array.wrap (; 561 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int16Array.wrap (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -37978,7 +37978,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $~lib/typedarray/Int16Array.wrap|trampoline (; 562 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int16Array.wrap|trampoline (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $2of2
    block $1of2
     block $0of2
@@ -38001,7 +38001,7 @@
   local.get $2
   call $~lib/typedarray/Int16Array.wrap
  )
- (func $std/typedarray/testArrayWrap<~lib/typedarray/Int16Array,i16> (; 563 ;)
+ (func $std/typedarray/testArrayWrap<~lib/typedarray/Int16Array,i16>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -38115,7 +38115,7 @@
   local.get $7
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint16Array.wrap (; 564 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array.wrap (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -38236,7 +38236,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $~lib/typedarray/Uint16Array.wrap|trampoline (; 565 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array.wrap|trampoline (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $2of2
    block $1of2
     block $0of2
@@ -38259,7 +38259,7 @@
   local.get $2
   call $~lib/typedarray/Uint16Array.wrap
  )
- (func $std/typedarray/testArrayWrap<~lib/typedarray/Uint16Array,u16> (; 566 ;)
+ (func $std/typedarray/testArrayWrap<~lib/typedarray/Uint16Array,u16>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -38371,7 +38371,7 @@
   local.get $7
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int32Array.wrap (; 567 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int32Array.wrap (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -38492,7 +38492,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $~lib/typedarray/Int32Array.wrap|trampoline (; 568 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int32Array.wrap|trampoline (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $2of2
    block $1of2
     block $0of2
@@ -38515,7 +38515,7 @@
   local.get $2
   call $~lib/typedarray/Int32Array.wrap
  )
- (func $std/typedarray/testArrayWrap<~lib/typedarray/Int32Array,i32> (; 569 ;)
+ (func $std/typedarray/testArrayWrap<~lib/typedarray/Int32Array,i32>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -38625,7 +38625,7 @@
   local.get $7
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint32Array.wrap (; 570 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint32Array.wrap (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -38746,7 +38746,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $~lib/typedarray/Uint32Array.wrap|trampoline (; 571 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint32Array.wrap|trampoline (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $2of2
    block $1of2
     block $0of2
@@ -38769,7 +38769,7 @@
   local.get $2
   call $~lib/typedarray/Uint32Array.wrap
  )
- (func $std/typedarray/testArrayWrap<~lib/typedarray/Uint32Array,u32> (; 572 ;)
+ (func $std/typedarray/testArrayWrap<~lib/typedarray/Uint32Array,u32>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -38879,7 +38879,7 @@
   local.get $7
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int64Array.wrap (; 573 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int64Array.wrap (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -39000,7 +39000,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $~lib/typedarray/Int64Array.wrap|trampoline (; 574 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int64Array.wrap|trampoline (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $2of2
    block $1of2
     block $0of2
@@ -39023,7 +39023,7 @@
   local.get $2
   call $~lib/typedarray/Int64Array.wrap
  )
- (func $std/typedarray/testArrayWrap<~lib/typedarray/Int64Array,i64> (; 575 ;)
+ (func $std/typedarray/testArrayWrap<~lib/typedarray/Int64Array,i64>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -39134,7 +39134,7 @@
   local.get $7
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint64Array.wrap (; 576 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint64Array.wrap (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -39255,7 +39255,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $~lib/typedarray/Uint64Array.wrap|trampoline (; 577 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint64Array.wrap|trampoline (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $2of2
    block $1of2
     block $0of2
@@ -39278,7 +39278,7 @@
   local.get $2
   call $~lib/typedarray/Uint64Array.wrap
  )
- (func $std/typedarray/testArrayWrap<~lib/typedarray/Uint64Array,u64> (; 578 ;)
+ (func $std/typedarray/testArrayWrap<~lib/typedarray/Uint64Array,u64>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -39389,7 +39389,7 @@
   local.get $7
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float32Array.wrap (; 579 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Float32Array.wrap (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -39510,7 +39510,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $~lib/typedarray/Float32Array.wrap|trampoline (; 580 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Float32Array.wrap|trampoline (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $2of2
    block $1of2
     block $0of2
@@ -39533,7 +39533,7 @@
   local.get $2
   call $~lib/typedarray/Float32Array.wrap
  )
- (func $std/typedarray/testArrayWrap<~lib/typedarray/Float32Array,f32> (; 581 ;)
+ (func $std/typedarray/testArrayWrap<~lib/typedarray/Float32Array,f32>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -39644,7 +39644,7 @@
   local.get $7
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float64Array.wrap (; 582 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Float64Array.wrap (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -39765,7 +39765,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $~lib/typedarray/Float64Array.wrap|trampoline (; 583 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Float64Array.wrap|trampoline (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $2of2
    block $1of2
     block $0of2
@@ -39788,7 +39788,7 @@
   local.get $2
   call $~lib/typedarray/Float64Array.wrap
  )
- (func $std/typedarray/testArrayWrap<~lib/typedarray/Float64Array,f64> (; 584 ;)
+ (func $std/typedarray/testArrayWrap<~lib/typedarray/Float64Array,f64>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -39899,7 +39899,7 @@
   local.get $7
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int8Array#set<~lib/array/Array<i32>> (; 585 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int8Array#set<~lib/array/Array<i32>> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -40001,7 +40001,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/valuesEqual<~lib/typedarray/Int8Array> (; 586 ;) (param $0 i32) (param $1 i32)
+ (func $std/typedarray/valuesEqual<~lib/typedarray/Int8Array> (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -40084,11 +40084,11 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/array/Array<f32>#get:length (; 587 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<f32>#get:length (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/typedarray/Int8Array#set<~lib/array/Array<f32>> (; 588 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int8Array#set<~lib/array/Array<f32>> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -40203,7 +40203,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int8Array#set<~lib/typedarray/Int64Array> (; 589 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int8Array#set<~lib/typedarray/Int64Array> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -40305,11 +40305,11 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/array/Array<f64>#get:length (; 590 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<f64>#get:length (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/typedarray/Int8Array#set<~lib/array/Array<f64>> (; 591 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int8Array#set<~lib/array/Array<f64>> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -40424,7 +40424,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int8Array#set<~lib/typedarray/Uint8Array> (; 592 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int8Array#set<~lib/typedarray/Uint8Array> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -40491,7 +40491,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int8Array#set<~lib/typedarray/Int16Array> (; 593 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int8Array#set<~lib/typedarray/Int16Array> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -40593,7 +40593,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int8Array#set<~lib/array/Array<i8>> (; 594 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int8Array#set<~lib/array/Array<i8>> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -40660,7 +40660,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testTypedArraySet<~lib/typedarray/Int8Array> (; 595 ;)
+ (func $std/typedarray/testTypedArraySet<~lib/typedarray/Int8Array>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -40823,7 +40823,7 @@
   local.get $8
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8Array#set<~lib/array/Array<i32>> (; 596 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint8Array#set<~lib/array/Array<i32>> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -40925,11 +40925,11 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/array/Array<u8>#get:length (; 597 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<u8>#get:length (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<u8>#__unchecked_get (; 598 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u8>#__unchecked_get (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -40938,7 +40938,7 @@
   i32.add
   i32.load8_u
  )
- (func $std/typedarray/valuesEqual<~lib/typedarray/Uint8Array> (; 599 ;) (param $0 i32) (param $1 i32)
+ (func $std/typedarray/valuesEqual<~lib/typedarray/Uint8Array> (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -41021,7 +41021,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8Array#set<~lib/array/Array<f32>> (; 600 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint8Array#set<~lib/array/Array<f32>> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -41136,7 +41136,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8Array#set<~lib/typedarray/Int64Array> (; 601 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint8Array#set<~lib/typedarray/Int64Array> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -41238,7 +41238,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8Array#set<~lib/array/Array<f64>> (; 602 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint8Array#set<~lib/array/Array<f64>> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -41353,7 +41353,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8Array#set<~lib/typedarray/Uint8Array> (; 603 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint8Array#set<~lib/typedarray/Uint8Array> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -41420,7 +41420,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8Array#set<~lib/typedarray/Int16Array> (; 604 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint8Array#set<~lib/typedarray/Int16Array> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -41522,7 +41522,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8Array#set<~lib/array/Array<i8>> (; 605 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint8Array#set<~lib/array/Array<i8>> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -41589,7 +41589,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testTypedArraySet<~lib/typedarray/Uint8Array> (; 606 ;)
+ (func $std/typedarray/testTypedArraySet<~lib/typedarray/Uint8Array>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -41752,7 +41752,7 @@
   local.get $8
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8ClampedArray#set<~lib/array/Array<i32>> (; 607 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint8ClampedArray#set<~lib/array/Array<i32>> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -41869,7 +41869,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/valuesEqual<~lib/typedarray/Uint8ClampedArray> (; 608 ;) (param $0 i32) (param $1 i32)
+ (func $std/typedarray/valuesEqual<~lib/typedarray/Uint8ClampedArray> (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -41952,7 +41952,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8ClampedArray#set<~lib/array/Array<f32>> (; 609 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint8ClampedArray#set<~lib/array/Array<f32>> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -42071,7 +42071,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Int64Array> (; 610 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Int64Array> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -42192,7 +42192,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8ClampedArray#set<~lib/array/Array<f64>> (; 611 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint8ClampedArray#set<~lib/array/Array<f64>> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -42311,7 +42311,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Uint8Array> (; 612 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Uint8Array> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -42378,7 +42378,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Int16Array> (; 613 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Int16Array> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -42495,7 +42495,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8ClampedArray#set<~lib/array/Array<i8>> (; 614 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint8ClampedArray#set<~lib/array/Array<i8>> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -42612,7 +42612,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testTypedArraySet<~lib/typedarray/Uint8ClampedArray> (; 615 ;)
+ (func $std/typedarray/testTypedArraySet<~lib/typedarray/Uint8ClampedArray>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -42775,7 +42775,7 @@
   local.get $8
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int16Array#set<~lib/array/Array<i32>> (; 616 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int16Array#set<~lib/array/Array<i32>> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -42877,11 +42877,11 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/array/Array<i16>#get:length (; 617 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<i16>#get:length (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<i16>#__unchecked_get (; 618 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i16>#__unchecked_get (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -42890,7 +42890,7 @@
   i32.add
   i32.load16_s
  )
- (func $std/typedarray/valuesEqual<~lib/typedarray/Int16Array> (; 619 ;) (param $0 i32) (param $1 i32)
+ (func $std/typedarray/valuesEqual<~lib/typedarray/Int16Array> (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -42973,7 +42973,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int16Array#set<~lib/array/Array<f32>> (; 620 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int16Array#set<~lib/array/Array<f32>> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -43088,7 +43088,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int16Array#set<~lib/typedarray/Int64Array> (; 621 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int16Array#set<~lib/typedarray/Int64Array> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -43190,7 +43190,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int16Array#set<~lib/array/Array<f64>> (; 622 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int16Array#set<~lib/array/Array<f64>> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -43305,7 +43305,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int16Array#set<~lib/typedarray/Uint8Array> (; 623 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int16Array#set<~lib/typedarray/Uint8Array> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -43407,7 +43407,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int16Array#set<~lib/typedarray/Int16Array> (; 624 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int16Array#set<~lib/typedarray/Int16Array> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -43474,7 +43474,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int16Array#set<~lib/array/Array<i8>> (; 625 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int16Array#set<~lib/array/Array<i8>> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -43576,7 +43576,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testTypedArraySet<~lib/typedarray/Int16Array> (; 626 ;)
+ (func $std/typedarray/testTypedArraySet<~lib/typedarray/Int16Array>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -43739,7 +43739,7 @@
   local.get $8
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint16Array#set<~lib/array/Array<i32>> (; 627 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint16Array#set<~lib/array/Array<i32>> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -43841,11 +43841,11 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/array/Array<u16>#get:length (; 628 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<u16>#get:length (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<u16>#__unchecked_get (; 629 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u16>#__unchecked_get (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -43854,7 +43854,7 @@
   i32.add
   i32.load16_u
  )
- (func $std/typedarray/valuesEqual<~lib/typedarray/Uint16Array> (; 630 ;) (param $0 i32) (param $1 i32)
+ (func $std/typedarray/valuesEqual<~lib/typedarray/Uint16Array> (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -43937,7 +43937,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint16Array#set<~lib/array/Array<f32>> (; 631 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint16Array#set<~lib/array/Array<f32>> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -44052,7 +44052,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint16Array#set<~lib/typedarray/Int64Array> (; 632 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint16Array#set<~lib/typedarray/Int64Array> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -44154,7 +44154,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint16Array#set<~lib/array/Array<f64>> (; 633 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint16Array#set<~lib/array/Array<f64>> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -44269,7 +44269,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint16Array#set<~lib/typedarray/Uint8Array> (; 634 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint16Array#set<~lib/typedarray/Uint8Array> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -44371,7 +44371,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint16Array#set<~lib/typedarray/Int16Array> (; 635 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint16Array#set<~lib/typedarray/Int16Array> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -44438,7 +44438,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint16Array#set<~lib/array/Array<i8>> (; 636 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint16Array#set<~lib/array/Array<i8>> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -44540,7 +44540,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testTypedArraySet<~lib/typedarray/Uint16Array> (; 637 ;)
+ (func $std/typedarray/testTypedArraySet<~lib/typedarray/Uint16Array>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -44703,7 +44703,7 @@
   local.get $8
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int32Array#set<~lib/array/Array<i32>> (; 638 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int32Array#set<~lib/array/Array<i32>> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -44770,7 +44770,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/valuesEqual<~lib/typedarray/Int32Array> (; 639 ;) (param $0 i32) (param $1 i32)
+ (func $std/typedarray/valuesEqual<~lib/typedarray/Int32Array> (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -44853,7 +44853,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int32Array#set<~lib/array/Array<f32>> (; 640 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int32Array#set<~lib/array/Array<f32>> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -44968,7 +44968,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int32Array#set<~lib/typedarray/Int64Array> (; 641 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int32Array#set<~lib/typedarray/Int64Array> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -45070,7 +45070,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int32Array#set<~lib/array/Array<f64>> (; 642 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int32Array#set<~lib/array/Array<f64>> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -45185,7 +45185,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int32Array#set<~lib/typedarray/Uint8Array> (; 643 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int32Array#set<~lib/typedarray/Uint8Array> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -45287,7 +45287,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int32Array#set<~lib/typedarray/Int16Array> (; 644 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int32Array#set<~lib/typedarray/Int16Array> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -45389,7 +45389,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int32Array#set<~lib/array/Array<i8>> (; 645 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int32Array#set<~lib/array/Array<i8>> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -45491,7 +45491,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testTypedArraySet<~lib/typedarray/Int32Array> (; 646 ;)
+ (func $std/typedarray/testTypedArraySet<~lib/typedarray/Int32Array>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -45654,7 +45654,7 @@
   local.get $8
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint32Array#set<~lib/array/Array<i32>> (; 647 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint32Array#set<~lib/array/Array<i32>> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -45721,11 +45721,11 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/array/Array<u32>#get:length (; 648 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<u32>#get:length (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<u32>#__unchecked_get (; 649 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u32>#__unchecked_get (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -45734,7 +45734,7 @@
   i32.add
   i32.load
  )
- (func $std/typedarray/valuesEqual<~lib/typedarray/Uint32Array> (; 650 ;) (param $0 i32) (param $1 i32)
+ (func $std/typedarray/valuesEqual<~lib/typedarray/Uint32Array> (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -45817,7 +45817,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint32Array#set<~lib/array/Array<f32>> (; 651 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint32Array#set<~lib/array/Array<f32>> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -45932,7 +45932,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint32Array#set<~lib/typedarray/Int64Array> (; 652 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint32Array#set<~lib/typedarray/Int64Array> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -46034,7 +46034,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint32Array#set<~lib/array/Array<f64>> (; 653 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint32Array#set<~lib/array/Array<f64>> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -46149,7 +46149,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint32Array#set<~lib/typedarray/Uint8Array> (; 654 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint32Array#set<~lib/typedarray/Uint8Array> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -46251,7 +46251,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint32Array#set<~lib/typedarray/Int16Array> (; 655 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint32Array#set<~lib/typedarray/Int16Array> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -46353,7 +46353,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint32Array#set<~lib/array/Array<i8>> (; 656 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint32Array#set<~lib/array/Array<i8>> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -46455,7 +46455,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testTypedArraySet<~lib/typedarray/Uint32Array> (; 657 ;)
+ (func $std/typedarray/testTypedArraySet<~lib/typedarray/Uint32Array>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -46618,7 +46618,7 @@
   local.get $8
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int64Array#set<~lib/array/Array<i32>> (; 658 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int64Array#set<~lib/array/Array<i32>> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -46720,11 +46720,11 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/array/Array<i64>#get:length (; 659 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<i64>#get:length (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<i64>#__unchecked_get (; 660 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $~lib/array/Array<i64>#__unchecked_get (param $0 i32) (param $1 i32) (result i64)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -46733,7 +46733,7 @@
   i32.add
   i64.load
  )
- (func $std/typedarray/valuesEqual<~lib/typedarray/Int64Array> (; 661 ;) (param $0 i32) (param $1 i32)
+ (func $std/typedarray/valuesEqual<~lib/typedarray/Int64Array> (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -46816,7 +46816,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int64Array#set<~lib/array/Array<f32>> (; 662 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int64Array#set<~lib/array/Array<f32>> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -46931,7 +46931,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int64Array#set<~lib/typedarray/Int64Array> (; 663 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int64Array#set<~lib/typedarray/Int64Array> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -46998,7 +46998,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int64Array#set<~lib/array/Array<f64>> (; 664 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int64Array#set<~lib/array/Array<f64>> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -47113,7 +47113,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int64Array#set<~lib/typedarray/Uint8Array> (; 665 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int64Array#set<~lib/typedarray/Uint8Array> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -47215,7 +47215,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int64Array#set<~lib/typedarray/Int16Array> (; 666 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int64Array#set<~lib/typedarray/Int16Array> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -47317,7 +47317,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int64Array#set<~lib/array/Array<i8>> (; 667 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int64Array#set<~lib/array/Array<i8>> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -47419,7 +47419,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testTypedArraySet<~lib/typedarray/Int64Array> (; 668 ;)
+ (func $std/typedarray/testTypedArraySet<~lib/typedarray/Int64Array>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -47582,7 +47582,7 @@
   local.get $8
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint64Array#set<~lib/array/Array<i32>> (; 669 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint64Array#set<~lib/array/Array<i32>> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -47684,11 +47684,11 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/array/Array<u64>#get:length (; 670 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<u64>#get:length (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<u64>#__unchecked_get (; 671 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $~lib/array/Array<u64>#__unchecked_get (param $0 i32) (param $1 i32) (result i64)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -47697,7 +47697,7 @@
   i32.add
   i64.load
  )
- (func $std/typedarray/valuesEqual<~lib/typedarray/Uint64Array> (; 672 ;) (param $0 i32) (param $1 i32)
+ (func $std/typedarray/valuesEqual<~lib/typedarray/Uint64Array> (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -47780,7 +47780,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint64Array#set<~lib/array/Array<f32>> (; 673 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint64Array#set<~lib/array/Array<f32>> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -47895,7 +47895,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint64Array#set<~lib/typedarray/Int64Array> (; 674 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint64Array#set<~lib/typedarray/Int64Array> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -47962,7 +47962,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint64Array#set<~lib/array/Array<f64>> (; 675 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint64Array#set<~lib/array/Array<f64>> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -48077,7 +48077,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint64Array#set<~lib/typedarray/Uint8Array> (; 676 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint64Array#set<~lib/typedarray/Uint8Array> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -48179,7 +48179,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint64Array#set<~lib/typedarray/Int16Array> (; 677 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint64Array#set<~lib/typedarray/Int16Array> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -48281,7 +48281,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint64Array#set<~lib/array/Array<i8>> (; 678 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint64Array#set<~lib/array/Array<i8>> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -48383,7 +48383,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testTypedArraySet<~lib/typedarray/Uint64Array> (; 679 ;)
+ (func $std/typedarray/testTypedArraySet<~lib/typedarray/Uint64Array>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -48546,7 +48546,7 @@
   local.get $8
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float32Array#set<~lib/array/Array<i32>> (; 680 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Float32Array#set<~lib/array/Array<i32>> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -48649,7 +48649,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/array/Array<f32>#__unchecked_get (; 681 ;) (param $0 i32) (param $1 i32) (result f32)
+ (func $~lib/array/Array<f32>#__unchecked_get (param $0 i32) (param $1 i32) (result f32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -48658,7 +48658,7 @@
   i32.add
   f32.load
  )
- (func $std/typedarray/valuesEqual<~lib/typedarray/Float32Array> (; 682 ;) (param $0 i32) (param $1 i32)
+ (func $std/typedarray/valuesEqual<~lib/typedarray/Float32Array> (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -48741,7 +48741,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float32Array#set<~lib/array/Array<f32>> (; 683 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Float32Array#set<~lib/array/Array<f32>> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -48808,7 +48808,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float32Array#set<~lib/typedarray/Int64Array> (; 684 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Float32Array#set<~lib/typedarray/Int64Array> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -48911,7 +48911,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float32Array#set<~lib/typedarray/Uint8Array> (; 685 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Float32Array#set<~lib/typedarray/Uint8Array> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -49014,7 +49014,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float32Array#set<~lib/typedarray/Int16Array> (; 686 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Float32Array#set<~lib/typedarray/Int16Array> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -49117,7 +49117,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float32Array#set<~lib/array/Array<i8>> (; 687 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Float32Array#set<~lib/array/Array<i8>> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -49220,7 +49220,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testTypedArraySet<~lib/typedarray/Float32Array> (; 688 ;)
+ (func $std/typedarray/testTypedArraySet<~lib/typedarray/Float32Array>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -49368,7 +49368,7 @@
   local.get $8
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float64Array#set<~lib/array/Array<i32>> (; 689 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Float64Array#set<~lib/array/Array<i32>> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -49471,7 +49471,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/array/Array<f64>#__unchecked_get (; 690 ;) (param $0 i32) (param $1 i32) (result f64)
+ (func $~lib/array/Array<f64>#__unchecked_get (param $0 i32) (param $1 i32) (result f64)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -49480,7 +49480,7 @@
   i32.add
   f64.load
  )
- (func $std/typedarray/valuesEqual<~lib/typedarray/Float64Array> (; 691 ;) (param $0 i32) (param $1 i32)
+ (func $std/typedarray/valuesEqual<~lib/typedarray/Float64Array> (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -49561,7 +49561,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float64Array#set<~lib/array/Array<f32>> (; 692 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Float64Array#set<~lib/array/Array<f32>> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -49664,7 +49664,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float64Array#set<~lib/typedarray/Int64Array> (; 693 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Float64Array#set<~lib/typedarray/Int64Array> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -49767,7 +49767,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float64Array#set<~lib/typedarray/Uint8Array> (; 694 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Float64Array#set<~lib/typedarray/Uint8Array> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -49870,7 +49870,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float64Array#set<~lib/typedarray/Int16Array> (; 695 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Float64Array#set<~lib/typedarray/Int16Array> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -49973,7 +49973,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float64Array#set<~lib/array/Array<i8>> (; 696 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Float64Array#set<~lib/array/Array<i8>> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -50076,7 +50076,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testTypedArraySet<~lib/typedarray/Float64Array> (; 697 ;)
+ (func $std/typedarray/testTypedArraySet<~lib/typedarray/Float64Array>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -50224,7 +50224,7 @@
   local.get $8
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Float32Array> (; 698 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Float32Array> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -50343,7 +50343,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Int32Array> (; 699 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Int32Array> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -50460,7 +50460,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Uint32Array> (; 700 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Uint32Array> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -50574,7 +50574,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $start:std/typedarray (; 701 ;)
+ (func $start:std/typedarray
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -52823,7 +52823,7 @@
   local.get $20
   call $~lib/rt/pure/__release
  )
- (func $~start (; 702 ;)
+ (func $~start
   global.get $~started
   if
    return
@@ -52833,10 +52833,10 @@
   end
   call $start:std/typedarray
  )
- (func $~lib/rt/pure/__collect (; 703 ;)
+ (func $~lib/rt/pure/__collect
   return
  )
- (func $~lib/rt/pure/decrement (; 704 ;) (param $0 i32)
+ (func $~lib/rt/pure/decrement (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -52913,7 +52913,7 @@
    i32.store offset=4
   end
  )
- (func $~lib/rt/pure/__visit (; 705 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/pure/__visit (param $0 i32) (param $1 i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.lt_u
@@ -52937,76 +52937,76 @@
   i32.sub
   call $~lib/rt/pure/decrement
  )
- (func $~lib/array/Array<i8>#__visit_impl (; 706 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i8>#__visit_impl (param $0 i32) (param $1 i32)
   local.get $0
   i32.load
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/array/Array<i32>#__visit_impl (; 707 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i32>#__visit_impl (param $0 i32) (param $1 i32)
   local.get $0
   i32.load
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/staticarray/StaticArray<u32>#__visit_impl (; 708 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/staticarray/StaticArray<u32>#__visit_impl (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/staticarray/StaticArray<u64>#__visit_impl (; 709 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/staticarray/StaticArray<u64>#__visit_impl (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/staticarray/StaticArray<i16>#__visit_impl (; 710 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/staticarray/StaticArray<i16>#__visit_impl (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/array/Array<f32>#__visit_impl (; 711 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<f32>#__visit_impl (param $0 i32) (param $1 i32)
   local.get $0
   i32.load
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/array/Array<f64>#__visit_impl (; 712 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<f64>#__visit_impl (param $0 i32) (param $1 i32)
   local.get $0
   i32.load
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/array/Array<u8>#__visit_impl (; 713 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<u8>#__visit_impl (param $0 i32) (param $1 i32)
   local.get $0
   i32.load
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/array/Array<i16>#__visit_impl (; 714 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i16>#__visit_impl (param $0 i32) (param $1 i32)
   local.get $0
   i32.load
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/array/Array<u16>#__visit_impl (; 715 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<u16>#__visit_impl (param $0 i32) (param $1 i32)
   local.get $0
   i32.load
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/array/Array<u32>#__visit_impl (; 716 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<u32>#__visit_impl (param $0 i32) (param $1 i32)
   local.get $0
   i32.load
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/array/Array<i64>#__visit_impl (; 717 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i64>#__visit_impl (param $0 i32) (param $1 i32)
   local.get $0
   i32.load
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/array/Array<u64>#__visit_impl (; 718 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<u64>#__visit_impl (param $0 i32) (param $1 i32)
   local.get $0
   i32.load
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/rt/__visit_members (; 719 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/__visit_members (param $0 i32) (param $1 i32)
   (local $2 i32)
   block $switch$1$default
    block $switch$1$case$28

--- a/tests/compiler/switch.optimized.wat
+++ b/tests/compiler/switch.optimized.wat
@@ -7,7 +7,7 @@
  (data (i32.const 1024) "\12\00\00\00\01\00\00\00\01\00\00\00\12\00\00\00s\00w\00i\00t\00c\00h\00.\00t\00s")
  (export "memory" (memory $0))
  (start $~start)
- (func $switch/doSwitch (; 1 ;) (param $0 i32) (result i32)
+ (func $switch/doSwitch (param $0 i32) (result i32)
   block $case4|0
    block $case2|0
     local.get $0
@@ -35,7 +35,7 @@
   end
   i32.const 23
  )
- (func $switch/doSwitchDefaultOmitted (; 2 ;) (param $0 i32) (result i32)
+ (func $switch/doSwitchDefaultOmitted (param $0 i32) (result i32)
   block $break|0
    block $case2|0
     local.get $0
@@ -60,7 +60,7 @@
   end
   i32.const 0
  )
- (func $switch/doSwitchBreakCase (; 3 ;) (param $0 i32) (result i32)
+ (func $switch/doSwitchBreakCase (param $0 i32) (result i32)
   local.get $0
   i32.const 1
   i32.ne
@@ -70,7 +70,7 @@
   end
   i32.const 1
  )
- (func $switch/doSwitchBreakDefault (; 4 ;) (param $0 i32) (result i32)
+ (func $switch/doSwitchBreakDefault (param $0 i32) (result i32)
   local.get $0
   i32.const 1
   i32.eq
@@ -80,7 +80,7 @@
   end
   i32.const 2
  )
- (func $start:switch (; 5 ;)
+ (func $start:switch
   i32.const 0
   call $switch/doSwitch
   if
@@ -394,7 +394,7 @@
    unreachable
   end
  )
- (func $~start (; 6 ;)
+ (func $~start
   call $start:switch
  )
 )

--- a/tests/compiler/switch.untouched.wat
+++ b/tests/compiler/switch.untouched.wat
@@ -8,7 +8,7 @@
  (table $0 1 funcref)
  (export "memory" (memory $0))
  (start $~start)
- (func $switch/doSwitch (; 1 ;) (param $0 i32) (result i32)
+ (func $switch/doSwitch (param $0 i32) (result i32)
   (local $1 i32)
   block $case4|0
    block $case3|0
@@ -46,7 +46,7 @@
   i32.const 23
   return
  )
- (func $switch/doSwitchDefaultOmitted (; 2 ;) (param $0 i32) (result i32)
+ (func $switch/doSwitchDefaultOmitted (param $0 i32) (result i32)
   (local $1 i32)
   block $break|0
    block $case2|0
@@ -77,7 +77,7 @@
   end
   i32.const 0
  )
- (func $switch/doSwitchBreakCase (; 3 ;) (param $0 i32) (result i32)
+ (func $switch/doSwitchBreakCase (param $0 i32) (result i32)
   (local $1 i32)
   block $break|0
    block $case1|0
@@ -97,7 +97,7 @@
   end
   i32.const 1
  )
- (func $switch/doSwitchBreakDefault (; 4 ;) (param $0 i32) (result i32)
+ (func $switch/doSwitchBreakDefault (param $0 i32) (result i32)
   (local $1 i32)
   block $break|0
    block $case1|0
@@ -117,7 +117,7 @@
   end
   i32.const 2
  )
- (func $switch/doSwitchFallThroughCase (; 5 ;) (param $0 i32) (result i32)
+ (func $switch/doSwitchFallThroughCase (param $0 i32) (result i32)
   (local $1 i32)
   block $case1|0
    block $case0|0
@@ -134,7 +134,7 @@
   end
   i32.const 1
  )
- (func $switch/doSwitchFallThroughDefault (; 6 ;) (param $0 i32) (result i32)
+ (func $switch/doSwitchFallThroughDefault (param $0 i32) (result i32)
   (local $1 i32)
   block $case1|0
    block $case0|0
@@ -151,12 +151,12 @@
   end
   i32.const 2
  )
- (func $switch/doSwitchEmpty (; 7 ;) (param $0 i32) (result i32)
+ (func $switch/doSwitchEmpty (param $0 i32) (result i32)
   local.get $0
   drop
   i32.const 2
  )
- (func $start:switch (; 8 ;)
+ (func $start:switch
   i32.const 0
   call $switch/doSwitch
   i32.const 0
@@ -548,7 +548,7 @@
    unreachable
   end
  )
- (func $~start (; 9 ;)
+ (func $~start
   call $start:switch
  )
 )

--- a/tests/compiler/tablebase.untouched.wat
+++ b/tests/compiler/tablebase.untouched.wat
@@ -6,7 +6,7 @@
  (global $tablebase/staticFunction i32 (i32.const 32))
  (global $~lib/ASC_TABLE_BASE i32 (i32.const 32))
  (export "memory" (memory $0))
- (func $tablebase/foo (; 0 ;)
+ (func $tablebase/foo
   nop
  )
 )

--- a/tests/compiler/ternary.optimized.wat
+++ b/tests/compiler/ternary.optimized.wat
@@ -1,15 +1,4 @@
 (module
- (type $none_=>_none (func))
  (memory $0 0)
- (global $ternary/a (mut i32) (i32.const 0))
  (export "memory" (memory $0))
- (start $~start)
- (func $~start (; 0 ;)
-  i32.const 1
-  global.set $ternary/a
-  i32.const 1
-  global.set $ternary/a
-  i32.const 1
-  global.set $ternary/a
- )
 )

--- a/tests/compiler/ternary.untouched.wat
+++ b/tests/compiler/ternary.untouched.wat
@@ -5,7 +5,7 @@
  (global $ternary/a (mut i32) (i32.const 0))
  (export "memory" (memory $0))
  (start $~start)
- (func $start:ternary (; 0 ;)
+ (func $start:ternary
   i32.const 1
   drop
   i32.const 1
@@ -19,7 +19,7 @@
   i32.const 1
   global.set $ternary/a
  )
- (func $~start (; 1 ;)
+ (func $~start
   call $start:ternary
  )
 )

--- a/tests/compiler/typealias.optimized.wat
+++ b/tests/compiler/typealias.optimized.wat
@@ -3,7 +3,7 @@
  (memory $0 0)
  (export "memory" (memory $0))
  (export "alias" (func $typealias/alias))
- (func $typealias/alias (; 0 ;) (param $0 i32) (result i32)
+ (func $typealias/alias (param $0 i32) (result i32)
   local.get $0
  )
 )

--- a/tests/compiler/typealias.untouched.wat
+++ b/tests/compiler/typealias.untouched.wat
@@ -4,7 +4,7 @@
  (table $0 1 funcref)
  (export "memory" (memory $0))
  (export "alias" (func $typealias/alias))
- (func $typealias/alias (; 0 ;) (param $0 i32) (result i32)
+ (func $typealias/alias (param $0 i32) (result i32)
   local.get $0
  )
 )

--- a/tests/compiler/typeof.optimized.wat
+++ b/tests/compiler/typeof.optimized.wat
@@ -14,13 +14,10 @@
  (data (i32.const 1200) "\02\00\00\00\01\00\00\00\01\00\00\00\02\00\00\001")
  (data (i32.const 1232) "\0c\00\00\00\01\00\00\00\01\00\00\00\0c\00\00\00s\00t\00r\00i\00n\00g")
  (data (i32.const 1264) "\12\00\00\00\01\00\00\00\01\00\00\00\12\00\00\00u\00n\00d\00e\00f\00i\00n\00e\00d")
- (global $~lib/rt/stub/startOffset (mut i32) (i32.const 0))
- (global $~lib/rt/stub/offset (mut i32) (i32.const 0))
- (global $typeof/c (mut i32) (i32.const 0))
  (global $~started (mut i32) (i32.const 0))
  (export "_start" (func $~start))
  (export "memory" (memory $0))
- (func $~lib/string/String#get:length (; 1 ;) (param $0 i32) (result i32)
+ (func $~lib/string/String#get:length (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub
@@ -28,7 +25,7 @@
   i32.const 1
   i32.shr_u
  )
- (func $~lib/util/string/compareImpl (; 2 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/compareImpl (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -104,7 +101,7 @@
   end
   i32.const 0
  )
- (func $~lib/string/String.__eq (; 3 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__eq (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -136,7 +133,7 @@
   end
   i32.const 0
  )
- (func $start:typeof (; 4 ;)
+ (func $start:typeof
   (local $0 i32)
   (local $1 i32)
   i32.const 1072
@@ -355,10 +352,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1312
-  global.set $~lib/rt/stub/startOffset
-  i32.const 1312
-  global.set $~lib/rt/stub/offset
   i32.const 1344
   memory.size
   local.tee $1
@@ -393,8 +386,6 @@
     end
    end
   end
-  i32.const 1344
-  global.set $~lib/rt/stub/offset
   i32.const 1312
   i32.const 16
   i32.store
@@ -407,8 +398,6 @@
   i32.const 1324
   i32.const 0
   i32.store
-  i32.const 1328
-  global.set $typeof/c
   i32.const 1072
   i32.const 1072
   call $~lib/string/String.__eq
@@ -470,7 +459,7 @@
    unreachable
   end
  )
- (func $~start (; 5 ;)
+ (func $~start
   global.get $~started
   if
    return

--- a/tests/compiler/typeof.untouched.wat
+++ b/tests/compiler/typeof.untouched.wat
@@ -33,13 +33,13 @@
  (global $~lib/heap/__heap_base i32 (i32.const 292))
  (export "_start" (func $~start))
  (export "memory" (memory $0))
- (func $~lib/rt/stub/__retain (; 1 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/stub/__retain (param $0 i32) (result i32)
   local.get $0
  )
- (func $~lib/rt/stub/__release (; 2 ;) (param $0 i32)
+ (func $~lib/rt/stub/__release (param $0 i32)
   nop
  )
- (func $~lib/string/String#get:length (; 3 ;) (param $0 i32) (result i32)
+ (func $~lib/string/String#get:length (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub
@@ -47,7 +47,7 @@
   i32.const 1
   i32.shr_u
  )
- (func $~lib/util/string/compareImpl (; 4 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
+ (func $~lib/util/string/compareImpl (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
@@ -169,7 +169,7 @@
   call $~lib/rt/stub/__release
   local.get $7
  )
- (func $~lib/string/String.__eq (; 5 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__eq (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -242,10 +242,10 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $start:typeof~anonymous|0 (; 6 ;)
+ (func $start:typeof~anonymous|0
   nop
  )
- (func $~lib/rt/stub/maybeGrowMemory (; 7 ;) (param $0 i32)
+ (func $~lib/rt/stub/maybeGrowMemory (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -299,7 +299,7 @@
   local.get $0
   global.set $~lib/rt/stub/offset
  )
- (func $~lib/rt/stub/__alloc (; 8 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/stub/__alloc (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -352,7 +352,7 @@
   i32.store offset=12
   local.get $2
  )
- (func $typeof/SomeClass#constructor (; 9 ;) (param $0 i32) (result i32)
+ (func $typeof/SomeClass#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -364,7 +364,7 @@
   end
   local.get $0
  )
- (func $start:typeof (; 10 ;)
+ (func $start:typeof
   i32.const 64
   i32.const 64
   call $~lib/string/String.__eq
@@ -655,7 +655,7 @@
    unreachable
   end
  )
- (func $~start (; 11 ;)
+ (func $~start
   global.get $~started
   if
    return

--- a/tests/compiler/unary.optimized.wat
+++ b/tests/compiler/unary.optimized.wat
@@ -7,7 +7,7 @@
  (global $unary/F (mut f64) (f64.const 0))
  (export "memory" (memory $0))
  (start $~start)
- (func $start:unary (; 0 ;)
+ (func $start:unary
   (local $0 i32)
   (local $1 i64)
   (local $2 f32)
@@ -205,7 +205,7 @@
   local.get $3
   global.set $unary/F
  )
- (func $~start (; 1 ;)
+ (func $~start
   call $start:unary
  )
 )

--- a/tests/compiler/unary.untouched.wat
+++ b/tests/compiler/unary.untouched.wat
@@ -8,7 +8,7 @@
  (global $unary/F (mut f64) (f64.const 0))
  (export "memory" (memory $0))
  (start $~start)
- (func $start:unary (; 0 ;)
+ (func $start:unary
   (local $0 f64)
   (local $1 i32)
   (local $2 i64)
@@ -379,7 +379,7 @@
   local.get $0
   global.set $unary/F
  )
- (func $~start (; 1 ;)
+ (func $~start
   call $start:unary
  )
 )

--- a/tests/compiler/void.untouched.wat
+++ b/tests/compiler/void.untouched.wat
@@ -7,10 +7,10 @@
  (global $void/u8Val2 (mut i32) (i32.const 255))
  (export "memory" (memory $0))
  (start $~start)
- (func $void/anInt (; 0 ;) (result i32)
+ (func $void/anInt (result i32)
   i32.const 2
  )
- (func $start:void (; 1 ;)
+ (func $start:void
   i32.const 1
   drop
   call $void/anInt
@@ -20,7 +20,7 @@
   i32.add
   drop
  )
- (func $~start (; 2 ;)
+ (func $~start
   call $start:void
  )
 )

--- a/tests/compiler/wasi/abort.optimized.wat
+++ b/tests/compiler/wasi/abort.optimized.wat
@@ -12,7 +12,7 @@
  (export "_start" (func $~start))
  (export "memory" (memory $0))
  (export "test" (func $wasi/abort/test))
- (func $~lib/string/String#get:length (; 2 ;) (param $0 i32) (result i32)
+ (func $~lib/string/String#get:length (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub
@@ -20,7 +20,7 @@
   i32.const 1
   i32.shr_u
  )
- (func $~lib/string/String.UTF8.encodeUnsafe (; 3 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/string/String.UTF8.encodeUnsafe (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -192,7 +192,7 @@
   local.get $2
   i32.sub
  )
- (func $~lib/util/number/decimalCount32 (; 4 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/decimalCount32 (param $0 i32) (result i32)
   local.get $0
   i32.const 10
   i32.ge_u
@@ -234,7 +234,7 @@
   i32.lt_u
   select
  )
- (func $~lib/wasi/index/abort (; 5 ;)
+ (func $~lib/wasi/index/abort
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -349,11 +349,11 @@
   i32.const 255
   call $~lib/bindings/wasi_snapshot_preview1/proc_exit
  )
- (func $wasi/abort/test (; 6 ;)
+ (func $wasi/abort/test
   call $~lib/wasi/index/abort
   unreachable
  )
- (func $~start (; 7 ;)
+ (func $~start
   nop
  )
 )

--- a/tests/compiler/wasi/abort.untouched.wat
+++ b/tests/compiler/wasi/abort.untouched.wat
@@ -13,10 +13,10 @@
  (export "_start" (func $~start))
  (export "memory" (memory $0))
  (export "test" (func $wasi/abort/test))
- (func $~lib/rt/stub/__retain (; 2 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/stub/__retain (param $0 i32) (result i32)
   local.get $0
  )
- (func $~lib/string/String#get:length (; 3 ;) (param $0 i32) (result i32)
+ (func $~lib/string/String#get:length (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub
@@ -24,7 +24,7 @@
   i32.const 1
   i32.shr_u
  )
- (func $~lib/string/String.UTF8.encodeUnsafe (; 4 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $~lib/string/String.UTF8.encodeUnsafe (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -240,7 +240,7 @@
   local.get $2
   i32.sub
  )
- (func $~lib/util/number/decimalCount32 (; 5 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/decimalCount32 (param $0 i32) (result i32)
   local.get $0
   i32.const 100000
   i32.lt_u
@@ -295,10 +295,10 @@
   end
   unreachable
  )
- (func $~lib/rt/stub/__release (; 6 ;) (param $0 i32)
+ (func $~lib/rt/stub/__release (param $0 i32)
   nop
  )
- (func $~lib/wasi/index/abort (; 7 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/wasi/index/abort (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -464,7 +464,7 @@
   local.get $1
   call $~lib/rt/stub/__release
  )
- (func $wasi/abort/test (; 8 ;)
+ (func $wasi/abort/test
   i32.const 0
   i32.eqz
   if
@@ -476,7 +476,7 @@
    unreachable
   end
  )
- (func $~start (; 9 ;)
+ (func $~start
   nop
  )
 )

--- a/tests/compiler/wasi/seed.optimized.wat
+++ b/tests/compiler/wasi/seed.optimized.wat
@@ -19,7 +19,7 @@
  (export "_start" (func $~start))
  (export "memory" (memory $0))
  (export "test" (func $wasi/seed/test))
- (func $~lib/math/murmurHash3 (; 3 ;) (param $0 i64) (result i64)
+ (func $~lib/math/murmurHash3 (param $0 i64) (result i64)
   local.get $0
   local.get $0
   i64.const 33
@@ -40,7 +40,7 @@
   i64.shr_u
   i64.xor
  )
- (func $~lib/math/splitMix32 (; 4 ;) (param $0 i32) (result i32)
+ (func $~lib/math/splitMix32 (param $0 i32) (result i32)
   local.get $0
   i32.const 1831565813
   i32.add
@@ -72,7 +72,7 @@
   i32.shr_u
   i32.xor
  )
- (func $~lib/string/String.UTF8.encodeUnsafe (; 5 ;) (param $0 i32) (result i32)
+ (func $~lib/string/String.UTF8.encodeUnsafe (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -247,7 +247,7 @@
   i32.const 23
   i32.sub
  )
- (func $~lib/util/number/decimalCount32 (; 6 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/decimalCount32 (param $0 i32) (result i32)
   local.get $0
   i32.const 10
   i32.ge_u
@@ -289,7 +289,7 @@
   i32.lt_u
   select
  )
- (func $~lib/wasi/index/abort (; 7 ;)
+ (func $~lib/wasi/index/abort
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -394,7 +394,7 @@
   i32.const 255
   call $~lib/bindings/wasi_snapshot_preview1/proc_exit
  )
- (func $~lib/math/NativeMath.random (; 8 ;) (result f64)
+ (func $~lib/math/NativeMath.random (result f64)
   (local $0 i64)
   (local $1 i64)
   global.get $~lib/math/random_seeded
@@ -490,10 +490,10 @@
   f64.const 1
   f64.sub
  )
- (func $wasi/seed/test (; 9 ;) (result f64)
+ (func $wasi/seed/test (result f64)
   call $~lib/math/NativeMath.random
  )
- (func $~start (; 10 ;)
+ (func $~start
   nop
  )
 )

--- a/tests/compiler/wasi/seed.untouched.wat
+++ b/tests/compiler/wasi/seed.untouched.wat
@@ -22,7 +22,7 @@
  (export "_start" (func $~start))
  (export "memory" (memory $0))
  (export "test" (func $wasi/seed/test))
- (func $~lib/wasi/index/seed (; 3 ;) (result f64)
+ (func $~lib/wasi/index/seed (result f64)
   (local $0 i64)
   (local $1 i64)
   (local $2 i32)
@@ -51,7 +51,7 @@
   local.get $1
   f64.reinterpret_i64
  )
- (func $~lib/math/murmurHash3 (; 4 ;) (param $0 i64) (result i64)
+ (func $~lib/math/murmurHash3 (param $0 i64) (result i64)
   local.get $0
   local.get $0
   i64.const 33
@@ -80,7 +80,7 @@
   local.set $0
   local.get $0
  )
- (func $~lib/math/splitMix32 (; 5 ;) (param $0 i32) (result i32)
+ (func $~lib/math/splitMix32 (param $0 i32) (result i32)
   local.get $0
   i32.const 1831565813
   i32.add
@@ -115,10 +115,10 @@
   i32.shr_u
   i32.xor
  )
- (func $~lib/rt/stub/__retain (; 6 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/stub/__retain (param $0 i32) (result i32)
   local.get $0
  )
- (func $~lib/string/String#get:length (; 7 ;) (param $0 i32) (result i32)
+ (func $~lib/string/String#get:length (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub
@@ -126,7 +126,7 @@
   i32.const 1
   i32.shr_u
  )
- (func $~lib/string/String.UTF8.encodeUnsafe (; 8 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $~lib/string/String.UTF8.encodeUnsafe (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -342,7 +342,7 @@
   local.get $2
   i32.sub
  )
- (func $~lib/util/number/decimalCount32 (; 9 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/decimalCount32 (param $0 i32) (result i32)
   local.get $0
   i32.const 100000
   i32.lt_u
@@ -397,10 +397,10 @@
   end
   unreachable
  )
- (func $~lib/rt/stub/__release (; 10 ;) (param $0 i32)
+ (func $~lib/rt/stub/__release (param $0 i32)
   nop
  )
- (func $~lib/wasi/index/abort (; 11 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/wasi/index/abort (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -566,7 +566,7 @@
   local.get $1
   call $~lib/rt/stub/__release
  )
- (func $~lib/math/NativeMath.seedRandom (; 12 ;) (param $0 i64)
+ (func $~lib/math/NativeMath.seedRandom (param $0 i64)
   i32.const 1
   global.set $~lib/math/random_seeded
   local.get $0
@@ -618,7 +618,7 @@
    unreachable
   end
  )
- (func $~lib/math/NativeMath.random (; 13 ;) (result f64)
+ (func $~lib/math/NativeMath.random (result f64)
   (local $0 i64)
   (local $1 i64)
   (local $2 i64)
@@ -670,10 +670,10 @@
   f64.const 1
   f64.sub
  )
- (func $wasi/seed/test (; 14 ;) (result f64)
+ (func $wasi/seed/test (result f64)
   call $~lib/math/NativeMath.random
  )
- (func $~start (; 15 ;)
+ (func $~start
   nop
  )
 )

--- a/tests/compiler/wasi/snapshot_preview1.optimized.wat
+++ b/tests/compiler/wasi/snapshot_preview1.optimized.wat
@@ -1,11 +1,4 @@
 (module
- (type $none_=>_none (func))
  (memory $0 0)
- (global $wasi/snapshot_preview1/sig (mut i32) (i32.const 1))
  (export "memory" (memory $0))
- (start $~start)
- (func $~start (; 0 ;)
-  i32.const 9
-  global.set $wasi/snapshot_preview1/sig
- )
 )

--- a/tests/compiler/wasi/snapshot_preview1.untouched.wat
+++ b/tests/compiler/wasi/snapshot_preview1.untouched.wat
@@ -9,11 +9,11 @@
  (global $wasi/snapshot_preview1/sig (mut i32) (i32.const 1))
  (export "memory" (memory $0))
  (start $~start)
- (func $start:wasi/snapshot_preview1 (; 0 ;)
+ (func $start:wasi/snapshot_preview1
   i32.const 9
   global.set $wasi/snapshot_preview1/sig
  )
- (func $~start (; 1 ;)
+ (func $~start
   call $start:wasi/snapshot_preview1
  )
 )

--- a/tests/compiler/wasi/trace.optimized.wat
+++ b/tests/compiler/wasi/trace.optimized.wat
@@ -18,7 +18,6 @@
  (data (i32.const 1792) "\ae\00\00\00\01\00\00\00\04\00\00\00\ae\00\00\00<\fbW\fbr\fb\8c\fb\a7\fb\c1\fb\dc\fb\f6\fb\11\fc,\fcF\fca\fc{\fc\96\fc\b1\fc\cb\fc\e6\fc\00\fd\1b\fd5\fdP\fdk\fd\85\fd\a0\fd\ba\fd\d5\fd\ef\fd\n\fe%\fe?\feZ\fet\fe\8f\fe\a9\fe\c4\fe\df\fe\f9\fe\14\ff.\ffI\ffc\ff~\ff\99\ff\b3\ff\ce\ff\e8\ff\03\00\1e\008\00S\00m\00\88\00\a2\00\bd\00\d8\00\f2\00\0d\01\'\01B\01\\\01w\01\92\01\ac\01\c7\01\e1\01\fc\01\16\021\02L\02f\02\81\02\9b\02\b6\02\d0\02\eb\02\06\03 \03;\03U\03p\03\8b\03\a5\03\c0\03\da\03\f5\03\0f\04*\04")
  (data (i32.const 1984) "(\00\00\00\01\00\00\00\05\00\00\00(\00\00\00\01\00\00\00\n\00\00\00d\00\00\00\e8\03\00\00\10\'\00\00\a0\86\01\00@B\0f\00\80\96\98\00\00\e1\f5\05\00\ca\9a;")
  (data (i32.const 2048) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00s\00t\00u\00b\00.\00t\00s")
- (global $~lib/rt/stub/startOffset (mut i32) (i32.const 0))
  (global $~lib/rt/stub/offset (mut i32) (i32.const 0))
  (global $~lib/util/number/_frc_plus (mut i64) (i64.const 0))
  (global $~lib/util/number/_frc_minus (mut i64) (i64.const 0))
@@ -29,7 +28,7 @@
  (global $~started (mut i32) (i32.const 0))
  (export "_start" (func $~start))
  (export "memory" (memory $0))
- (func $~lib/string/String.UTF8.byteLength (; 2 ;) (result i32)
+ (func $~lib/string/String.UTF8.byteLength (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -110,7 +109,7 @@
   end
   local.get $1
  )
- (func $~lib/rt/stub/__alloc (; 3 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/stub/__alloc (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -194,7 +193,7 @@
   i32.store offset=12
   local.get $3
  )
- (func $~lib/string/String#get:length (; 4 ;) (param $0 i32) (result i32)
+ (func $~lib/string/String#get:length (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub
@@ -202,7 +201,7 @@
   i32.const 1
   i32.shr_u
  )
- (func $~lib/string/String.UTF8.encodeUnsafe (; 5 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/string/String.UTF8.encodeUnsafe (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -374,7 +373,7 @@
   local.get $2
   i32.sub
  )
- (func $~lib/util/number/decimalCount32 (; 6 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/decimalCount32 (param $0 i32) (result i32)
   local.get $0
   i32.const 10
   i32.ge_u
@@ -416,7 +415,7 @@
   i32.lt_u
   select
  )
- (func $~lib/util/number/genDigits (; 7 ;) (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (param $6 i32) (result i32)
+ (func $~lib/util/number/genDigits (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (param $6 i32) (result i32)
   (local $7 i32)
   (local $8 i64)
   (local $9 i64)
@@ -807,7 +806,7 @@
    local.get $6
   end
  )
- (func $~lib/memory/memory.copy (; 8 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/memory/memory.copy (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   block $~lib/util/memory/memmove|inlined.0
@@ -980,7 +979,7 @@
    end
   end
  )
- (func $~lib/util/number/utoa_simple<u32> (; 9 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/number/utoa_simple<u32> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   loop $do-continue|0
    local.get $1
@@ -1007,7 +1006,7 @@
    br_if $do-continue|0
   end
  )
- (func $~lib/util/number/prettify (; 10 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/prettify (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   i32.eqz
@@ -1252,7 +1251,7 @@
    end
   end
  )
- (func $~lib/util/number/dtoa_core (; 11 ;) (param $0 i32) (param $1 f64) (result i32)
+ (func $~lib/util/number/dtoa_core (param $0 i32) (param $1 f64) (result i32)
   (local $2 i64)
   (local $3 i64)
   (local $4 i32)
@@ -1544,7 +1543,7 @@
   local.get $7
   i32.add
  )
- (func $~lib/util/number/dtoa_stream (; 12 ;) (param $0 i32) (param $1 f64) (result i32)
+ (func $~lib/util/number/dtoa_stream (param $0 i32) (param $1 f64) (result i32)
   (local $2 i32)
   local.get $1
   f64.const 0
@@ -1614,7 +1613,7 @@
   local.get $1
   call $~lib/util/number/dtoa_core
  )
- (func $~lib/wasi/index/abort (; 13 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/wasi/index/abort (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1713,7 +1712,7 @@
   i32.const 255
   call $~lib/bindings/wasi_snapshot_preview1/proc_exit
  )
- (func $~lib/wasi/index/trace (; 14 ;) (param $0 i32) (param $1 f64) (param $2 f64) (param $3 f64) (param $4 f64) (param $5 f64)
+ (func $~lib/wasi/index/trace (param $0 i32) (param $1 f64) (param $2 f64) (param $3 f64) (param $4 f64) (param $5 f64)
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
@@ -1925,7 +1924,7 @@
    global.set $~lib/rt/stub/offset
   end
  )
- (func $~start (; 15 ;)
+ (func $~start
   global.get $~started
   if
    return
@@ -1933,8 +1932,6 @@
    i32.const 1
    global.set $~started
   end
-  i32.const 2096
-  global.set $~lib/rt/stub/startOffset
   i32.const 2096
   global.set $~lib/rt/stub/offset
   i32.const 0

--- a/tests/compiler/wasi/trace.untouched.wat
+++ b/tests/compiler/wasi/trace.untouched.wat
@@ -34,13 +34,13 @@
  (global $~lib/heap/__heap_base i32 (i32.const 1504))
  (export "_start" (func $~start))
  (export "memory" (memory $0))
- (func $~lib/rt/stub/__retain (; 2 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/stub/__retain (param $0 i32) (result i32)
   local.get $0
  )
- (func $~lib/rt/stub/__release (; 3 ;) (param $0 i32)
+ (func $~lib/rt/stub/__release (param $0 i32)
   nop
  )
- (func $~lib/string/String.UTF8.byteLength (; 4 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.UTF8.byteLength (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -151,7 +151,7 @@
   call $~lib/rt/stub/__release
   local.get $5
  )
- (func $~lib/rt/stub/maybeGrowMemory (; 5 ;) (param $0 i32)
+ (func $~lib/rt/stub/maybeGrowMemory (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -205,7 +205,7 @@
   local.get $0
   global.set $~lib/rt/stub/offset
  )
- (func $~lib/rt/stub/__alloc (; 6 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/stub/__alloc (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -258,7 +258,7 @@
   i32.store offset=12
   local.get $2
  )
- (func $~lib/string/String#get:length (; 7 ;) (param $0 i32) (result i32)
+ (func $~lib/string/String#get:length (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub
@@ -266,7 +266,7 @@
   i32.const 1
   i32.shr_u
  )
- (func $~lib/string/String.UTF8.encodeUnsafe (; 8 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $~lib/string/String.UTF8.encodeUnsafe (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -482,7 +482,7 @@
   local.get $2
   i32.sub
  )
- (func $~lib/util/number/decimalCount32 (; 9 ;) (param $0 i32) (result i32)
+ (func $~lib/util/number/decimalCount32 (param $0 i32) (result i32)
   local.get $0
   i32.const 100000
   i32.lt_u
@@ -537,7 +537,7 @@
   end
   unreachable
  )
- (func $~lib/util/number/genDigits (; 10 ;) (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (param $6 i32) (result i32)
+ (func $~lib/util/number/genDigits (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (param $6 i32) (result i32)
   (local $7 i32)
   (local $8 i64)
   (local $9 i64)
@@ -1040,7 +1040,7 @@
   end
   unreachable
  )
- (func $~lib/util/memory/memcpy (; 11 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/memory/memcpy (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2064,7 +2064,7 @@
    i32.store8
   end
  )
- (func $~lib/memory/memory.copy (; 12 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/memory/memory.copy (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2284,7 +2284,7 @@
    end
   end
  )
- (func $~lib/util/number/utoa32_lut (; 13 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/number/utoa32_lut (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2424,7 +2424,7 @@
    i32.store16
   end
  )
- (func $~lib/util/number/prettify (; 14 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/prettify (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2741,7 +2741,7 @@
   end
   unreachable
  )
- (func $~lib/util/number/dtoa_core (; 15 ;) (param $0 i32) (param $1 f64) (result i32)
+ (func $~lib/util/number/dtoa_core (param $0 i32) (param $1 f64) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3167,7 +3167,7 @@
   local.get $2
   i32.add
  )
- (func $~lib/util/number/dtoa_stream (; 16 ;) (param $0 i32) (param $1 i32) (param $2 f64) (result i32)
+ (func $~lib/util/number/dtoa_stream (param $0 i32) (param $1 i32) (param $2 f64) (result i32)
   (local $3 i32)
   local.get $0
   local.get $1
@@ -3245,7 +3245,7 @@
   local.get $2
   call $~lib/util/number/dtoa_core
  )
- (func $~lib/wasi/index/abort (; 17 ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/wasi/index/abort (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -3411,7 +3411,7 @@
   local.get $1
   call $~lib/rt/stub/__release
  )
- (func $~lib/rt/stub/__free (; 18 ;) (param $0 i32)
+ (func $~lib/rt/stub/__free (param $0 i32)
   (local $1 i32)
   local.get $0
   i32.const 0
@@ -3461,7 +3461,7 @@
    global.set $~lib/rt/stub/offset
   end
  )
- (func $~lib/wasi/index/trace (; 19 ;) (param $0 i32) (param $1 i32) (param $2 f64) (param $3 f64) (param $4 f64) (param $5 f64) (param $6 f64)
+ (func $~lib/wasi/index/trace (param $0 i32) (param $1 i32) (param $2 f64) (param $3 f64) (param $4 f64) (param $5 f64) (param $6 f64)
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
@@ -3670,7 +3670,7 @@
   local.get $0
   call $~lib/rt/stub/__release
  )
- (func $start:wasi/trace (; 20 ;)
+ (func $start:wasi/trace
   global.get $~lib/heap/__heap_base
   i32.const 15
   i32.add
@@ -3707,7 +3707,7 @@
   f64.neg
   call $~lib/wasi/index/trace
  )
- (func $~start (; 21 ;)
+ (func $~start
   global.get $~started
   if
    return

--- a/tests/compiler/while.optimized.wat
+++ b/tests/compiler/while.optimized.wat
@@ -22,7 +22,7 @@
  (global $~started (mut i32) (i32.const 0))
  (export "_start" (func $~start))
  (export "memory" (memory $0))
- (func $while/testNested (; 5 ;)
+ (func $while/testNested
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -110,7 +110,7 @@
   i32.const 1
   global.set $while/ran
  )
- (func $~lib/rt/tlsf/removeBlock (; 6 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/removeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -272,7 +272,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/insertBlock (; 7 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/insertBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -551,7 +551,7 @@
   i32.or
   i32.store offset=4
  )
- (func $~lib/rt/tlsf/addMemory (; 8 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $2
@@ -665,7 +665,7 @@
   local.get $1
   call $~lib/rt/tlsf/insertBlock
  )
- (func $~lib/rt/tlsf/maybeInitialize (; 9 ;) (result i32)
+ (func $~lib/rt/tlsf/maybeInitialize (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -752,7 +752,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/tlsf/searchBlock (; 10 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/tlsf/searchBlock (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   nop
@@ -810,7 +810,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/allocateBlock (; 11 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/tlsf/allocateBlock (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -982,7 +982,7 @@
   call $~lib/rt/rtrace/onalloc
   local.get $1
  )
- (func $while/Ref#constructor (; 12 ;) (result i32)
+ (func $while/Ref#constructor (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -1038,7 +1038,7 @@
   end
   local.get $1
  )
- (func $~lib/rt/pure/__release (; 13 ;) (param $0 i32)
+ (func $~lib/rt/pure/__release (param $0 i32)
   local.get $0
   i32.const 1216
   i32.gt_u
@@ -1049,7 +1049,7 @@
    call $~lib/rt/pure/decrement
   end
  )
- (func $start:while (; 14 ;)
+ (func $start:while
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -1418,7 +1418,7 @@
    unreachable
   end
  )
- (func $~start (; 15 ;)
+ (func $~start
   global.get $~started
   if
    return
@@ -1428,7 +1428,7 @@
   end
   call $start:while
  )
- (func $~lib/rt/pure/decrement (; 16 ;) (param $0 i32)
+ (func $~lib/rt/pure/decrement (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0

--- a/tests/compiler/while.untouched.wat
+++ b/tests/compiler/while.untouched.wat
@@ -28,7 +28,7 @@
  (global $~lib/heap/__heap_base i32 (i32.const 208))
  (export "_start" (func $~start))
  (export "memory" (memory $0))
- (func $while/testSimple (; 5 ;)
+ (func $while/testSimple
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -79,7 +79,7 @@
   i32.const 1
   global.set $while/ran
  )
- (func $while/testNested (; 6 ;)
+ (func $while/testNested
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -186,7 +186,7 @@
   i32.const 1
   global.set $while/ran
  )
- (func $while/testEmpty (; 7 ;)
+ (func $while/testEmpty
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -243,7 +243,7 @@
   i32.const 1
   global.set $while/ran
  )
- (func $while/testAlwaysTrue (; 8 ;)
+ (func $while/testAlwaysTrue
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -282,7 +282,7 @@
   i32.const 1
   global.set $while/ran
  )
- (func $while/testAlwaysTrueNeverBreaks (; 9 ;) (result i32)
+ (func $while/testAlwaysTrueNeverBreaks (result i32)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -307,7 +307,7 @@
   end
   unreachable
  )
- (func $while/testAlwaysFalse (; 10 ;)
+ (func $while/testAlwaysFalse
   (local $0 i32)
   i32.const 0
   local.set $0
@@ -326,7 +326,7 @@
   i32.const 1
   global.set $while/ran
  )
- (func $while/testAlwaysBreaks (; 11 ;)
+ (func $while/testAlwaysBreaks
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -359,7 +359,7 @@
   i32.const 1
   global.set $while/ran
  )
- (func $while/testAlwaysReturns (; 12 ;)
+ (func $while/testAlwaysReturns
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -388,7 +388,7 @@
    unreachable
   end
  )
- (func $while/testContinue (; 13 ;)
+ (func $while/testContinue
   (local $0 i32)
   (local $1 i32)
   i32.const 10
@@ -420,7 +420,7 @@
   i32.const 1
   global.set $while/ran
  )
- (func $while/testNestedContinue (; 14 ;)
+ (func $while/testNestedContinue
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -480,7 +480,7 @@
   i32.const 1
   global.set $while/ran
  )
- (func $~lib/rt/tlsf/removeBlock (; 15 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/removeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -690,7 +690,7 @@
    end
   end
  )
- (func $~lib/rt/tlsf/insertBlock (; 16 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/insertBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1040,7 +1040,7 @@
   local.get $7
   i32.store offset=4
  )
- (func $~lib/rt/tlsf/addMemory (; 17 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1188,7 +1188,7 @@
   call $~lib/rt/tlsf/insertBlock
   i32.const 1
  )
- (func $~lib/rt/tlsf/maybeInitialize (; 18 ;) (result i32)
+ (func $~lib/rt/tlsf/maybeInitialize (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -1342,7 +1342,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/tlsf/prepareSize (; 19 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/tlsf/prepareSize (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -1371,7 +1371,7 @@
   i32.gt_u
   select
  )
- (func $~lib/rt/tlsf/searchBlock (; 20 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/searchBlock (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1554,7 +1554,7 @@
   end
   local.get $7
  )
- (func $~lib/rt/tlsf/growMemory (; 21 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/growMemory (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1638,7 +1638,7 @@
   call $~lib/rt/tlsf/addMemory
   drop
  )
- (func $~lib/rt/tlsf/prepareBlock (; 22 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/rt/tlsf/prepareBlock (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1733,7 +1733,7 @@
    i32.store
   end
  )
- (func $~lib/rt/tlsf/allocateBlock (; 23 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/allocateBlock (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   global.get $~lib/rt/tlsf/collectLock
@@ -1844,7 +1844,7 @@
   call $~lib/rt/rtrace/onalloc
   local.get $4
  )
- (func $~lib/rt/tlsf/__alloc (; 24 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/__alloc (param $0 i32) (param $1 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
   local.get $0
   local.get $1
@@ -1852,7 +1852,7 @@
   i32.const 16
   i32.add
  )
- (func $~lib/rt/pure/increment (; 25 ;) (param $0 i32)
+ (func $~lib/rt/pure/increment (param $0 i32)
   (local $1 i32)
   local.get $0
   i32.load offset=4
@@ -1897,7 +1897,7 @@
    unreachable
   end
  )
- (func $~lib/rt/pure/__retain (; 26 ;) (param $0 i32) (result i32)
+ (func $~lib/rt/pure/__retain (param $0 i32) (result i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.gt_u
@@ -1909,7 +1909,7 @@
   end
   local.get $0
  )
- (func $while/Ref#constructor (; 27 ;) (param $0 i32) (result i32)
+ (func $while/Ref#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -1921,7 +1921,7 @@
   end
   local.get $0
  )
- (func $~lib/rt/pure/__release (; 28 ;) (param $0 i32)
+ (func $~lib/rt/pure/__release (param $0 i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.gt_u
@@ -1932,7 +1932,7 @@
    call $~lib/rt/pure/decrement
   end
  )
- (func $while/testRef (; 29 ;)
+ (func $while/testRef
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -2009,11 +2009,11 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $while/getRef (; 30 ;) (result i32)
+ (func $while/getRef (result i32)
   i32.const 0
   call $while/Ref#constructor
  )
- (func $while/testRefAutorelease (; 31 ;)
+ (func $while/testRefAutorelease
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -2088,7 +2088,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $start:while (; 32 ;)
+ (func $start:while
   i32.const 0
   global.set $while/ran
   call $while/testSimple
@@ -2245,7 +2245,7 @@
    unreachable
   end
  )
- (func $~start (; 33 ;)
+ (func $~start
   global.get $~started
   if
    return
@@ -2255,10 +2255,10 @@
   end
   call $start:while
  )
- (func $~lib/rt/pure/__collect (; 34 ;)
+ (func $~lib/rt/pure/__collect
   return
  )
- (func $~lib/rt/tlsf/freeBlock (; 35 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/freeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $1
   i32.load
@@ -2274,7 +2274,7 @@
   local.get $1
   call $~lib/rt/rtrace/onfree
  )
- (func $~lib/rt/pure/decrement (; 36 ;) (param $0 i32)
+ (func $~lib/rt/pure/decrement (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -2351,7 +2351,7 @@
    i32.store offset=4
   end
  )
- (func $~lib/rt/pure/__visit (; 37 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/pure/__visit (param $0 i32) (param $1 i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.lt_u
@@ -2375,7 +2375,7 @@
   i32.sub
   call $~lib/rt/pure/decrement
  )
- (func $~lib/rt/__visit_members (; 38 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/__visit_members (param $0 i32) (param $1 i32)
   (local $2 i32)
   block $switch$1$default
    block $switch$1$case$4

--- a/tests/compiler/wildcard-export.untouched.wat
+++ b/tests/compiler/wildcard-export.untouched.wat
@@ -12,17 +12,17 @@
  (export "renamed_b" (global $export/b))
  (export "renamed_renamed_b" (global $export/b))
  (start $~start)
- (func $export/add (; 0 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $export/add (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.add
  )
- (func $export/mul (; 1 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $export/mul (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.mul
  )
- (func $start:reexport (; 2 ;)
+ (func $start:reexport
   i32.const 1
   i32.const 2
   call $export/add
@@ -32,13 +32,13 @@
   i32.add
   drop
  )
- (func $start:rereexport (; 3 ;)
+ (func $start:rereexport
   call $start:reexport
  )
- (func $start:wildcard-export (; 4 ;)
+ (func $start:wildcard-export
   call $start:rereexport
  )
- (func $~start (; 5 ;)
+ (func $~start
   call $start:wildcard-export
  )
 )


### PR DESCRIPTION
As usual, this updates Binaryen and other dependencies to the latest and greatest.

Includes
* `v128.abs<T>` for 8/16/32 bit integers incl. `i8x16.abs`, `i16x8.abs`, `i32x4.abs`
* `v128.bitmask<T>` including `i8x16.bitmask`, `i16x8.bitmask`, `i32x4.bitmask`
* `tuple.create` / `tuple.extract` pseudo instructions for multi value types
* `BinaryenType` now being `usize`, unfortunately triggering lots of 32/64 conversion warnings in switches when compiling to Wasm