### PR TITLE
Fix asc build

### DIFF
--- a/src/glue/binaryen.js
+++ b/src/glue/binaryen.js
@@ -3,7 +3,7 @@
  * @license Apache-2.0
  */
 
-const binaryen = global.Binaryen || (global.Binaryen = require("binaryen"));
+const binaryen = global.binaryen || (global.binaryen = require("binaryen"));
 
 module.exports = binaryen;
 

--- a/tests/decompiler.js
+++ b/tests/decompiler.js
@@ -1,4 +1,4 @@
-var binaryen = global.Binaryen = require("../lib/binaryen");
+var binaryen = global.binaryen = require("../lib/binaryen");
 
 require("ts-node").register({ project: require("path").join(__dirname, "..", "src", "tsconfig.json") });
 require("../src/glue/js");

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -64,7 +64,9 @@ const bin = {
   context: path.join(__dirname, "cli"),
   entry: [ "./asc.js" ],
   externals: [
-    { "../dist/assemblyscript.js": "assemblyscript" }
+    "binaryen",
+    "assemblyscript",
+    "ts-node"
   ],
   node: {
     "buffer": false,


### PR DESCRIPTION
While investigating build times on CI I noticed that asc builds are 4.5mb and include Binaryen. This must have gone wrong when `binaryen.ready` was introduced a while ago, leading to CI spending most of the time in webpack, so this PR fixes that (faster builds, ~830kb asc).