### PR TITLE
Closures

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "assemblyscript",
+  "name": "assemblyscript-closures-beta",
   "version": "0.10.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "assemblyscript",
-  "description": "A TypeScript to WebAssembly compiler.",
+  "name": "assemblyscript-closures-beta",
+  "description": "AssemblyScript, but with Closures! (experimental).",
   "keywords": [
     "typescript",
     "webassembly",
@@ -15,10 +15,10 @@
   "homepage": "https://assemblyscript.org",
   "repository": {
     "type": "git",
-    "url": "https://github.com/AssemblyScript/assemblyscript.git"
+    "url": "https://github.com/DuncanUszkay1/assemblyscript.git"
   },
   "bugs": {
-    "url": "https://github.com/AssemblyScript/assemblyscript/issues"
+    "url": "https://github.com/DuncanUszkay1/assemblyscript/issues"
   },
   "dependencies": {
     "binaryen": "93.0.0-nightly.20200514",

--- a/src/common.ts
+++ b/src/common.ts
@@ -71,7 +71,7 @@ export enum CommonFlags {
   /** Is a virtual method. */
   VIRTUAL = 1 << 26,
   /** Is (part of) a closure. */
-  CLOSURE = 1 << 27,
+  IN_SCOPE_CLOSURE = 1 << 27,
 
   // Other
 

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -195,6 +195,8 @@ import {
   isPowerOf2
 } from "./util";
 
+const CLOSURE_TAG = 1 << 31;
+
 /** Compiler options. */
 export class Options {
 
@@ -1181,7 +1183,7 @@ export class Compiler extends DiagnosticEmitter {
         );
       }
       module.addGlobal(internalName, nativeType, true, this.makeZero(type));
-      if (type.isManaged && !this.skippedAutoreleases.has(initExpr)) initExpr = this.makeRetain(initExpr);
+      if (type.isManaged && !this.skippedAutoreleases.has(initExpr)) initExpr = this.makeRetain(initExpr, type);
       this.currentBody.push(
         module.global_set(internalName, initExpr)
       );
@@ -1373,7 +1375,8 @@ export class Compiler extends DiagnosticEmitter {
           stmts.push(
             module.local_set(index,
               this.makeRetain(
-                module.local_get(index, type.toNativeType())
+                module.local_get(index, type.toNativeType()),
+                type
               )
             )
           );
@@ -1676,7 +1679,7 @@ export class Compiler extends DiagnosticEmitter {
       module.local_get(0, nativeThisType),
       nativeValueType, instance.memoryOffset
     );
-    if (type.isManaged) valueExpr = this.makeRetain(valueExpr);
+    if (type.isManaged) valueExpr = this.makeRetain(valueExpr, type);
     instance.getterRef = module.addFunction(instance.internalGetterName, nativeThisType, nativeValueType, null, valueExpr);
     if (instance.setterRef) {
       instance.set(CommonFlags.COMPILED);
@@ -1713,9 +1716,9 @@ export class Compiler extends DiagnosticEmitter {
           ),
           module.block(null, [
             module.drop(
-              this.makeRetain(module.local_get(1, nativeValueType))
+              this.makeRetain(module.local_get(1, nativeValueType), type)
             ),
-            this.makeRelease(module.local_get(2, nativeValueType))
+            this.makeRelease(module.local_get(2, nativeValueType), type)
           ])
         ),
         module.local_get(1, nativeValueType)
@@ -1940,6 +1943,7 @@ export class Compiler extends DiagnosticEmitter {
     var tableBase = this.options.tableBase;
     if (!tableBase) tableBase = 1; // leave first elem blank
     index = tableBase + functionTable.length;
+    assert(u32(index) < u32(2147483648));
     functionTable.push(instance);
     instance.functionTableIndex = index;
     return index;
@@ -2752,6 +2756,24 @@ export class Compiler extends DiagnosticEmitter {
     // Remember that this flow returns
     flow.set(FlowFlags.RETURNS | FlowFlags.TERMINATES);
 
+    // Prevent returning a closure in an exported function, since interop with closures is
+    // not yet supported
+    var returnSignature = returnType.signatureReference;
+    if (returnSignature !== null && flow.parentFunction.is(CommonFlags.EXPORT)) {
+      var returnValueLocalIndex = flow.getTempLocal(returnType).index;
+      var nativeReturnType = returnType.toNativeType();
+      expr = module.flatten([
+        module.local_set(returnValueLocalIndex, expr),
+        this.ifClosure(
+          module.local_get(returnValueLocalIndex, nativeReturnType),
+          this.makeAbort(null, statement), // TODO: throw
+          module.nop()
+        ),
+        module.local_get(returnValueLocalIndex, nativeReturnType)
+      ], nativeReturnType)
+    }
+
+
     // If the last statement anyway, make it the block's return value
     if (isLastInBody && expr != 0 && returnType != Type.void) {
       if (!stmts.length) return expr;
@@ -3106,7 +3128,7 @@ export class Compiler extends DiagnosticEmitter {
               module.local_set(local.index,
                 initAutoreleaseSkipped
                   ? initExpr
-                  : this.makeRetain(initExpr)
+                  : this.makeRetain(initExpr, type)
               )
             );
           } else {
@@ -3501,7 +3523,7 @@ export class Compiler extends DiagnosticEmitter {
       // check if that worked, and if it didn't, keep the reference alive
       if (!this.skippedAutoreleases.has(expr)) {
         let index = this.tryUndoAutorelease(expr, flow);
-        if (index == -1) expr = this.makeRetain(expr);
+        if (index == -1) expr = this.makeRetain(expr, returnType);
         this.skippedAutoreleases.add(expr);
       }
     }
@@ -3549,6 +3571,24 @@ export class Compiler extends DiagnosticEmitter {
           expr = this.makeRuntimeNonNullCheck(expr, fromType, reportNode);
         }
         fromType = fromType.nonNullableType;
+      }
+      var toSignature = toType.signatureReference;
+      var fromSignature = fromType.signatureReference;
+      if (toSignature !== null && fromSignature !== null && fromSignature.externalEquals(toSignature) && fromType.is(TypeFlags.IN_SCOPE_CLOSURE)) {
+        // When we convert from the closure type into a function pointer, we first
+        // update the local copy of the scope with the newest values
+        var tempResult = this.currentFlow.getTempLocal(fromType);
+        var convertExpr = module.block(null, [
+          module.local_set(
+            tempResult.index,
+            expr
+          ),
+          this.injectClosedLocals(tempResult),
+          this.getClosureReference(module.local_get(tempResult.index, fromType.toNativeType()))
+        ], toType.toNativeType());
+
+        //this.currentFlow.freeTempLocal(tempResult);
+        return convertExpr;
       }
       if (fromType.isAssignableTo(toType)) { // downcast or same
         assert(fromType.kind == toType.kind);
@@ -5645,7 +5685,7 @@ export class Compiler extends DiagnosticEmitter {
               if (!leftAutoreleaseSkipped) {
                 retainLeftInElse = true;
               } else {
-                rightExpr = this.makeRetain(rightExpr);
+                rightExpr = this.makeRetain(rightExpr, rightType);
                 rightAutoreleaseSkipped = true;
               }
             } else if (!(constraints & Constraints.WILL_RETAIN)) { // otherwise keep right alive a little longer
@@ -5656,7 +5696,8 @@ export class Compiler extends DiagnosticEmitter {
             if (leftAutoreleaseSkipped) { // left turned out to be true'ish and is dropped
               rightStmts.unshift(
                 this.makeRelease(
-                  module.local_get(temp.index, leftType.toNativeType())
+                  module.local_get(temp.index, leftType.toNativeType()),
+                  leftType
                 )
               );
             }
@@ -5669,7 +5710,8 @@ export class Compiler extends DiagnosticEmitter {
               rightExpr,
               retainLeftInElse
                 ? this.makeRetain(
-                    module.local_get(temp.index, leftType.toNativeType())
+                    module.local_get(temp.index, leftType.toNativeType()),
+                    leftType
                   )
                 : module.local_get(temp.index, leftType.toNativeType())
             );
@@ -5749,7 +5791,7 @@ export class Compiler extends DiagnosticEmitter {
               if (!leftAutoreleaseSkipped) {
                 retainLeftInThen = true;
               } else {
-                rightExpr = this.makeRetain(rightExpr);
+                rightExpr = this.makeRetain(rightExpr, rightType);
                 rightAutoreleaseSkipped = true;
               }
             } else if (!(constraints & Constraints.WILL_RETAIN)) { // otherwise keep right alive a little longer
@@ -5762,7 +5804,8 @@ export class Compiler extends DiagnosticEmitter {
               // once implicit conversion with strings is performed and left is "", so:
               rightStmts.unshift(
                 this.makeRelease(
-                  module.local_get(temp.index, leftType.toNativeType())
+                  module.local_get(temp.index, leftType.toNativeType()),
+                  leftType
                 )
               );
             }
@@ -5774,7 +5817,8 @@ export class Compiler extends DiagnosticEmitter {
               this.makeIsTrueish(leftExpr, leftType),
               retainLeftInThen
                 ? this.makeRetain(
-                    module.local_get(temp.index, leftType.toNativeType())
+                    module.local_get(temp.index, leftType.toNativeType()),
+                    leftType
                   )
                 : module.local_get(temp.index, leftType.toNativeType()),
               rightExpr
@@ -6003,6 +6047,14 @@ export class Compiler extends DiagnosticEmitter {
     switch (target.kind) {
       case ElementKind.LOCAL: {
         let local = <Local>target;
+        if (local.closureContextOffset > 0) {
+          // TODO: ability to update closed over locals
+          this.error(
+            DiagnosticCode.Not_implemented,
+            valueExpression.range
+          );
+          return module.unreachable();
+        }
         if (flow.isLocalFlag(local.index, LocalFlags.CONSTANT, true)) {
           this.error(
             DiagnosticCode.Cannot_assign_to_0_because_it_is_a_constant_or_a_read_only_property,
@@ -6191,6 +6243,7 @@ export class Compiler extends DiagnosticEmitter {
         valueExpr = this.makeReplace(
           valueExpr,
           module.local_get(localIndex, type.toNativeType()),
+          type,
           alreadyRetained
         );
         if (tee) { // local = REPLACE(local, value)
@@ -6203,7 +6256,7 @@ export class Compiler extends DiagnosticEmitter {
       } else {
         flow.unsetLocalFlag(localIndex, LocalFlags.CONDITIONALLY_RETAINED);
         flow.setLocalFlag(localIndex, LocalFlags.RETAINED);
-        if (!alreadyRetained) valueExpr = this.makeRetain(valueExpr);
+        if (!alreadyRetained) valueExpr = this.makeRetain(valueExpr, type);
         if (tee) { // local = __retain(value, local)
           this.currentType = type;
           return module.local_tee(localIndex, valueExpr);
@@ -6247,6 +6300,7 @@ export class Compiler extends DiagnosticEmitter {
         this.makeReplace(
           valueExpr,
           module.global_get(global.internalName, nativeType),
+          type,
           alreadyRetained
         )
       );
@@ -6320,6 +6374,7 @@ export class Compiler extends DiagnosticEmitter {
                 module.local_get(tempThis.index, nativeThisType),
                 nativeFieldType, field.memoryOffset
               ),
+              fieldType,
               alreadyRetained
             ),
             nativeFieldType, field.memoryOffset
@@ -6337,6 +6392,7 @@ export class Compiler extends DiagnosticEmitter {
               module.local_get(tempThis.index, nativeThisType),
               nativeFieldType, field.memoryOffset
             ),
+            fieldType,
             alreadyRetained
           ),
           nativeFieldType, field.memoryOffset
@@ -6370,6 +6426,30 @@ export class Compiler extends DiagnosticEmitter {
         );
       }
     }
+  }
+
+  private injectClosedLocals(
+    closureContextLocal: Local
+  ): ExpressionRef {
+    var module = this.module;
+    var type = closureContextLocal.type;
+    var locals = assert(type.locals);
+    let _values = Map_values(locals);
+    var exprs = new Array<ExpressionRef>(_values.length);
+    assert(type.is(TypeFlags.REFERENCE));
+    for (let i = 0, k = _values.length; i < k; ++i) {
+      let local = unchecked(_values[i]);
+      let nativeType = local.type.toNativeType();
+      assert(local.closureContextOffset > 0);
+      exprs[i] = module.store(
+        local.type.byteSize,
+        module.local_get(closureContextLocal.index, this.options.nativeSizeType),
+        module.local_get(local.index, nativeType),
+        nativeType,
+        local.closureContextOffset
+      );
+    }
+    return module.block(null, exprs);
   }
 
   /** Compiles a call expression according to the specified context. */
@@ -6472,7 +6552,36 @@ export class Compiler extends DiagnosticEmitter {
       // indirect call: index argument with signature (non-generic, can't be inlined)
       case ElementKind.LOCAL: {
         let local = <Local>target;
-        signature = local.type.signatureReference;
+        let nativeSizeType = this.options.nativeSizeType;
+        signature = assert(local.type.signatureReference);
+        if (local.type.is(TypeFlags.IN_SCOPE_CLOSURE)) {
+          if (this.currentFlow.parentFunction.parent.kind == ElementKind.FUNCTION) {
+            this.error(
+              DiagnosticCode.Not_implemented,
+              expression.expression.range
+            );
+            return module.unreachable();
+          }
+          // If we're calling a local we know to be a closure, then we must still be in the creator functions
+          // scope. Because of this, we should update the values of locals that are still available
+          return module.block(null, [
+            this.injectClosedLocals(local),
+            this.compileCallIndirect(
+              assert(signature),
+              module.load(
+                local.type.byteSize,
+                local.type.is(TypeFlags.SIGNED),
+                module.local_get(local.index, nativeSizeType),
+                this.options.nativeSizeType,
+                0
+              ),
+              expression.args,
+              expression,
+              module.local_get(local.index, nativeSizeType),
+              contextualType == Type.void
+            )
+          ], signature.returnType.toNativeType());
+        }
         if (signature) {
           if (local.is(CommonFlags.INLINED)) {
             indexArg = module.i32(i64_low(local.constantIntegerValue));
@@ -6577,14 +6686,47 @@ export class Compiler extends DiagnosticEmitter {
         return module.unreachable();
       }
     }
-    return this.compileCallIndirect(
-      assert(signature), // FIXME: bootstrap can't see this yet
-      indexArg,
-      expression.args,
-      expression,
-      0,
-      contextualType == Type.void
-    );
+    // Once we get here, we have a function reference. With the new scheme, this function
+    // could possibly be a closure. So here we check to see if it's a closure, then apply
+    // the appropriate call logic
+    signature = assert(signature) // FIXME: asc can't see this yet
+    var returnType = signature.returnType;
+    var tempFunctionReferenceLocal = this.currentFlow.getTempLocal(this.options.usizeType);
+    var usize = this.options.nativeSizeType;
+    return module.block(null, [
+      module.local_set(tempFunctionReferenceLocal.index, indexArg),
+      this.ifClosure(
+        module.local_get(tempFunctionReferenceLocal.index, usize),
+        this.compileCallIndirect( // If this is a closure
+          signature.toClosureSignature(),
+          module.block(null, [
+            module.load(
+              4,
+              true,
+              this.getClosurePtr(
+                module.local_get(tempFunctionReferenceLocal.index, usize),
+              ),
+              usize,
+              0
+            ),
+          ], this.options.nativeSizeType),
+          expression.args,
+          expression,
+          this.getClosurePtr(
+            module.local_get(tempFunctionReferenceLocal.index, usize),
+          ),
+          contextualType == Type.void
+        ),
+        this.compileCallIndirect( // If this function isn't a closure
+          signature,
+          module.local_get(tempFunctionReferenceLocal.index, usize),
+          expression.args,
+          expression,
+          0,
+          contextualType == Type.void
+        )
+      )
+    ], constraints & Constraints.WILL_DROP ? contextualType.toNativeType() : returnType.toNativeType())
   }
 
   private compileCallExpressionBuiltin(
@@ -6832,7 +6974,7 @@ export class Compiler extends DiagnosticEmitter {
       if (flow.isNonnull(paramExpr, paramType)) flow.setLocalFlag(argumentLocal.index, LocalFlags.NONNULL);
       // inlining is aware of skipped autoreleases:
       if (paramType.isManaged) {
-        if (!this.skippedAutoreleases.has(paramExpr)) paramExpr = this.makeRetain(paramExpr);
+        if (!this.skippedAutoreleases.has(paramExpr)) paramExpr = this.makeRetain(paramExpr, paramType);
         flow.setLocalFlag(argumentLocal.index, LocalFlags.RETAINED);
       }
       body.unshift(
@@ -6876,7 +7018,7 @@ export class Compiler extends DiagnosticEmitter {
       if (flow.isNonnull(initExpr, initType)) flow.setLocalFlag(argumentLocal.index, LocalFlags.NONNULL);
       if (initType.isManaged) {
         flow.setLocalFlag(argumentLocal.index, LocalFlags.RETAINED);
-        if (!this.skippedAutoreleases.has(initExpr)) initExpr = this.makeRetain(initExpr);
+        if (!this.skippedAutoreleases.has(initExpr)) initExpr = this.makeRetain(initExpr, initType);
       }
       body.push(
         module.local_set(argumentLocal.index, initExpr)
@@ -6900,7 +7042,7 @@ export class Compiler extends DiagnosticEmitter {
     this.currentType = returnType;
     if (returnType.isManaged) {
       if (immediatelyDropped) {
-        expr = this.makeRelease(expr);
+        expr = this.makeRelease(expr, returnType);
         this.currentType = Type.void;
       }
     }
@@ -7237,16 +7379,76 @@ export class Compiler extends DiagnosticEmitter {
   // <reference-counting>
 
   /** Makes a retain call, retaining the expression's value. */
-  makeRetain(expr: ExpressionRef): ExpressionRef {
+  makeRetain(
+    expr: ExpressionRef,
+    type: Type | null = null
+  ): ExpressionRef {
+    var module = this.module;
+
     var retainInstance = this.program.retainInstance;
     this.compileFunction(retainInstance);
-    return this.module.call(retainInstance.internalName, [ expr ], this.options.nativeSizeType);
+    if (type !== null && type.isFunctionIndex) {
+      var exprLocal = this.currentFlow.getTempLocal(type);
+      var exprLocalIndex = exprLocal.index;
+      var nativeType = type.toNativeType();
+      var usize = this.options.nativeSizeType;
+      var functionRetainCall = module.block(null, [
+        module.local_set(exprLocalIndex, expr),
+        module.drop(
+          module.call(
+            retainInstance.internalName,
+            [
+              this.ifClosure(
+                module.local_get(exprLocalIndex, nativeType),
+                this.getClosurePtr(module.local_get(exprLocalIndex, nativeType)),
+                usize == NativeType.I32 ? module.i32(0) : module.i64(0)
+              )
+            ],
+            usize
+          )
+        ),
+        module.local_get(exprLocalIndex, nativeType)
+      ], nativeType);
+
+      //this.currentFlow.freeTempLocal(exprLocal);
+
+      return functionRetainCall;
+    }
+
+    return module.call(retainInstance.internalName, [ expr ], this.options.nativeSizeType);
   }
 
   /** Makes a release call, releasing the expression's value. Changes the current type to void.*/
-  makeRelease(expr: ExpressionRef): ExpressionRef {
+  makeRelease(expr: ExpressionRef, type: Type | null = null): ExpressionRef {
+    var module = this.module;
+
     var releaseInstance = this.program.releaseInstance;
     this.compileFunction(releaseInstance);
+
+    if (type !== null && type.isFunctionIndex) {
+      var exprLocal = this.currentFlow.getTempLocal(type);
+      var exprLocalIndex = exprLocal.index;
+      var nativeType = type.toNativeType()
+      var functionReleaseCall = module.block(null, [
+        module.local_set(exprLocalIndex, expr),
+        module.call(
+          releaseInstance.internalName,
+          [
+            this.ifClosure(
+              module.local_get(exprLocalIndex, nativeType),
+              this.getClosurePtr(module.local_get(exprLocalIndex, nativeType)),
+              this.options.nativeSizeType == NativeType.I32 ? module.i32(0) : module.i64(0)
+            )
+          ],
+          NativeType.None
+        )
+      ], NativeType.None);
+
+      // TODO: fix a bug in which this free causes some overwrites
+      //this.currentFlow.freeTempLocal(exprLocal);
+
+      return functionReleaseCall;
+    }
     return this.module.call(releaseInstance.internalName, [ expr ], NativeType.None);
   }
 
@@ -7256,6 +7458,8 @@ export class Compiler extends DiagnosticEmitter {
     newExpr: ExpressionRef,
     /** Old value being replaced. */
     oldExpr: ExpressionRef,
+    /** Expression type. */
+    type: Type,
     /** Whether the new value is already retained. */
     alreadyRetained: bool = false,
   ): ExpressionRef {
@@ -7268,7 +7472,7 @@ export class Compiler extends DiagnosticEmitter {
       let temp = flow.getTempLocal(this.options.usizeType, findUsedLocals(oldExpr));
       let ret = module.block(null, [
         module.local_set(temp.index, newExpr),
-        this.makeRelease(oldExpr),
+        this.makeRelease(oldExpr, type),
         module.local_get(temp.index, nativeSizeType)
       ], nativeSizeType);
       flow.freeTempLocal(temp);
@@ -7289,9 +7493,9 @@ export class Compiler extends DiagnosticEmitter {
           ),
           module.block(null, [
             module.local_set(temp1.index,
-              this.makeRetain(module.local_get(temp1.index, nativeSizeType))
+              this.makeRetain(module.local_get(temp1.index, nativeSizeType), type)
             ),
-            this.makeRelease(module.local_get(temp2.index, nativeSizeType))
+            this.makeRelease(module.local_get(temp2.index, nativeSizeType), type)
           ])
         ),
         module.local_get(temp1.index, nativeSizeType)
@@ -7398,7 +7602,7 @@ export class Compiler extends DiagnosticEmitter {
       // If it worked, autorelease in `outerFlow` instead
       ? this.makeAutorelease(expr, type, outerFlow)
       // If it didn't work, extend the lifetime into `outerFlow`
-      : this.makeAutorelease(this.makeRetain(expr), type, outerFlow);
+      : this.makeAutorelease(this.makeRetain(expr, type), type, outerFlow);
   }
 
   /** Performs any queued autoreleases in the specified flow. */
@@ -7428,7 +7632,8 @@ export class Compiler extends DiagnosticEmitter {
             if (finalize) flow.unsetLocalFlag(localIndex, LocalFlags.ANY_RETAINED);
             stmts.push(
               this.makeRelease(
-                module.local_get(localIndex, local.type.toNativeType())
+                module.local_get(localIndex, local.type.toNativeType()),
+                local.type
               )
             );
           }
@@ -7523,7 +7728,8 @@ export class Compiler extends DiagnosticEmitter {
       flow.unsetLocalFlag(localIndex, LocalFlags.ANY_RETAINED);
       stmts.push(
         this.makeRelease(
-          module.local_get(localIndex, local.type.toNativeType())
+          module.local_get(localIndex, local.type.toNativeType()),
+          local.type
         )
       );
     }
@@ -7660,7 +7866,7 @@ export class Compiler extends DiagnosticEmitter {
           this.currentType = returnType;
           if (returnType.isManaged) {
             if (immediatelyDropped) {
-              expr = this.makeRelease(expr);
+              expr = this.makeRelease(expr, returnType);
               this.currentType = Type.void;
             } else if (!skipAutorelease) {
               expr = this.makeAutorelease(expr, returnType);
@@ -7686,7 +7892,7 @@ export class Compiler extends DiagnosticEmitter {
     this.currentType = returnType;
     if (returnType.isManaged) {
       if (immediatelyDropped) {
-        expr = this.makeRelease(expr);
+        expr = this.makeRelease(expr, returnType);
         this.currentType = Type.void;
       } else if (!skipAutorelease) {
         expr = this.makeAutorelease(expr, returnType);
@@ -7799,7 +8005,7 @@ export class Compiler extends DiagnosticEmitter {
     this.currentType = returnType;
     if (returnType.isManaged) {
       if (immediatelyDropped) {
-        expr = this.makeRelease(expr);
+        expr = this.makeRelease(expr, returnType);
         this.currentType = Type.void;
       } else {
         expr = this.makeAutorelease(expr, returnType);
@@ -7979,24 +8185,137 @@ export class Compiler extends DiagnosticEmitter {
         prototype.name,
         prototype,
         null,
-        signature,
+        prototype.hasNestedDefinition ? signature.toClosureSignature() : signature,
         contextualTypeArguments
       );
       if (!this.compileFunction(instance)) return this.module.unreachable();
-      this.currentType = contextualSignature.type;
-
     // otherwise compile like a normal function
     } else {
       instance = this.resolver.resolveFunction(prototype, null, contextualTypeArguments);
       if (!instance) return this.module.unreachable();
       this.compileFunction(instance);
-      this.currentType = instance.signature.type;
     }
 
+    // if this anonymous function turns out to be a non-closure, recompile a version
+    // of the function without context, deleting the previous function
+    if (instance.closedLocals.size == 0 && instance.prototype.hasNestedDefinition) {
+      this.module.removeFunction(instance.internalName);
+      instance = new Function(
+        instance.prototype.name + "~nonClosure",
+        instance.prototype,
+        null,
+        instance.signature.toAnonymousSignature(),
+        contextualTypeArguments
+      );
+      this.compileFunction(instance);
+    }
+    this.currentType = instance.signature.type;
+
     var index = this.ensureFunctionTableEntry(instance); // reports
-    return index < 0
-      ? this.module.unreachable()
-      : this.module.i32(index);
+
+    if(index < 0) return this.module.unreachable();
+
+    var usize = this.options.usizeType;
+    var nativeUsize = this.options.nativeSizeType;
+    var wasm64 = nativeUsize == NativeType.I64;
+
+    if(instance.closedLocals.size > 0) {
+      this.warning(
+        DiagnosticCode.Closure_support_is_experimental,
+        instance.prototype.declaration.range
+      )
+
+      // Append the appropriate signature and flags for this closure type, then set it to currentType
+      this.currentType = Type.closure32;
+      this.currentType.signatureReference = instance.signature;
+
+      // create a local which will hold our closure
+      var tempLocal = flow.getAutoreleaseLocal(this.currentType);
+      var tempLocalIndex = tempLocal.index;
+
+      // copied closed locals into type
+      this.currentType.locals = instance.closedLocals;
+
+      const closureSize = instance.nextGlobalClosureOffset;
+
+      var allocInstance = this.program.allocInstance;
+      this.compileFunction(allocInstance);
+
+      var closureExpr = this.module.flatten([
+        this.module.local_set( // Allocate memory for the closure
+          tempLocalIndex,
+          this.makeRetain(
+            this.module.call(allocInstance.internalName, [
+              wasm64 ? this.module.i64(closureSize) : this.module.i32(closureSize),
+              wasm64 ? this.module.i64(0) : this.module.i32(0)
+            ], nativeUsize)
+          )
+        ),
+        this.module.store( // Store the function pointer at the first index
+          4,
+          this.module.local_get(tempLocalIndex, nativeUsize),
+          wasm64 ? this.module.i64(index) : this.module.i32(index),
+          nativeUsize,
+          0
+        ),
+        this.module.local_get(tempLocalIndex, nativeUsize) // load the closure locals index
+      ], nativeUsize);
+
+      //flow.freeTempLocal(tempLocal);
+
+      return closureExpr;
+    }
+
+    return wasm64 ? this.module.i64(index) : this.module.i32(index);
+  }
+
+  private ifClosure(
+    indexExpr: ExpressionRef,
+    thenExpr: ExpressionRef,
+    elseExpr: ExpressionRef
+  ): ExpressionRef {
+    var module = this.module;
+    var wasm64 = this.options.nativeSizeType == NativeType.I64
+
+    return module.if(
+      module.binary(
+        wasm64 ? BinaryOp.EqI64 : BinaryOp.EqI32,
+        module.binary(
+          wasm64 ? BinaryOp.AndI64 : BinaryOp.AndI32,
+          indexExpr,
+          wasm64 ? module.i64(CLOSURE_TAG) : module.i32(CLOSURE_TAG)
+        ),
+        wasm64 ? module.i64(CLOSURE_TAG) : module.i32(CLOSURE_TAG)
+      ),
+      thenExpr,
+      elseExpr
+    )
+  }
+
+  private getClosurePtr(closureExpr: ExpressionRef): ExpressionRef {
+    var module = this.module;
+    var wasm64 = this.options.nativeSizeType == NativeType.I64
+
+    return module.binary(
+      wasm64 ? BinaryOp.ShlI64 : BinaryOp.ShlI32,
+      closureExpr,
+      wasm64 ? module.i64(4) : module.i32(4)
+    )
+  }
+
+  private getClosureReference(closureExpr: ExpressionRef): ExpressionRef {
+    var module = this.module;
+    var wasm64 = this.options.nativeSizeType == NativeType.I64
+
+    return module.binary(
+      wasm64 ? BinaryOp.OrI64 : BinaryOp.OrI32,
+      module.binary(
+        wasm64 ? BinaryOp.ShrI64 : BinaryOp.ShrI32,
+        closureExpr,
+        wasm64 ? module.i64(4) : module.i32(4)
+      ),
+      wasm64 ? module.i64(CLOSURE_TAG) : module.i32(CLOSURE_TAG)
+    )
   }
 
   /** Makes sure the enclosing source file of the specified expression has been compiled. */
@@ -8134,6 +8453,20 @@ export class Compiler extends DiagnosticEmitter {
         let local = <Local>target;
         let localType = local.type;
         assert(localType != Type.void);
+        var localClosureContextOffset = local.closureContextOffset;
+        if (localClosureContextOffset > 0) {
+          let contextLocal = assert(flow.lookupLocal(CommonNames.this_));
+
+          // TODO: replace this with a class field access, once we are able to construct the class before
+          // compiling
+          return module.load(
+            local.type.byteSize,
+            local.type.is(TypeFlags.SIGNED),
+            this.module.local_get(contextLocal.index, this.options.nativeSizeType),
+            local.type.toNativeType(),
+            localClosureContextOffset
+          );
+        }
         if (local.is(CommonFlags.INLINED)) {
           return this.compileInlineConstant(local, contextualType, constraints);
         }
@@ -8577,7 +8910,7 @@ export class Compiler extends DiagnosticEmitter {
             : module.i32(i64_low(bufferAddress))
         ], expression);
         this.currentType = arrayType;
-        expr = this.makeRetain(expr);
+        expr = this.makeRetain(expr, arrayType);
         if (arrayType.isManaged) {
           if (!(constraints & Constraints.WILL_RETAIN)) {
             expr = this.makeAutorelease(expr, arrayType);
@@ -8639,7 +8972,7 @@ export class Compiler extends DiagnosticEmitter {
       if (isManaged) {
         // value = __retain(value)
         if (!this.skippedAutoreleases.has(valueExpr)) {
-          valueExpr = this.makeRetain(valueExpr);
+          valueExpr = this.makeRetain(valueExpr, elementType);
         }
       }
       // store<T>(tempData, value, immOffset)
@@ -8796,7 +9129,7 @@ export class Compiler extends DiagnosticEmitter {
       if (isManaged) {
         // value = __retain(value)
         if (!this.skippedAutoreleases.has(valueExpr)) {
-          valueExpr = this.makeRetain(valueExpr);
+          valueExpr = this.makeRetain(valueExpr, elementType);
         }
       }
       // store<T>(tempThis, value, immOffset)
@@ -9388,18 +9721,18 @@ export class Compiler extends DiagnosticEmitter {
 
     if (ifThenAutoreleaseSkipped != ifElseAutoreleaseSkipped) { // unify to both skipped
       if (!ifThenAutoreleaseSkipped) {
-        ifThenExpr = this.makeRetain(ifThenExpr);
+        ifThenExpr = this.makeRetain(ifThenExpr, commonType);
         ifThenAutoreleaseSkipped = true;
       } else {
-        ifElseExpr = this.makeRetain(ifElseExpr);
+        ifElseExpr = this.makeRetain(ifElseExpr, commonType);
         ifElseAutoreleaseSkipped = true;
       }
     } else if (!ifThenAutoreleaseSkipped && commonType.isManaged) { // keep alive a little longer
       if (constraints & Constraints.WILL_RETAIN) { // try to undo both
         let ifThenIndex = this.tryUndoAutorelease(ifThenExpr, ifThenFlow);
-        if (ifThenIndex == -1) ifThenExpr = this.makeRetain(ifThenExpr);
+        if (ifThenIndex == -1) ifThenExpr = this.makeRetain(ifThenExpr, commonType);
         let ifElseIndex = this.tryUndoAutorelease(ifElseExpr, ifElseFlow);
-        if (ifElseIndex == -1) ifElseExpr = this.makeRetain(ifElseExpr);
+        if (ifElseIndex == -1) ifElseExpr = this.makeRetain(ifElseExpr, commonType);
         ifThenAutoreleaseSkipped = true;
         ifElseAutoreleaseSkipped = true;
       } else {
@@ -9634,7 +9967,6 @@ export class Compiler extends DiagnosticEmitter {
         break;
       }
       default: {
-        assert(false);
         return module.unreachable();
       }
     }
@@ -10470,7 +10802,7 @@ export class Compiler extends DiagnosticEmitter {
             : 1 + parameterIndex, // this is local 0
           nativeFieldType
         );
-        if (fieldType.isManaged) initExpr = this.makeRetain(initExpr);
+        if (fieldType.isManaged) initExpr = this.makeRetain(initExpr, fieldType);
 
       // fall back to use initializer if present
       } else if (initializerNode) {
@@ -10478,7 +10810,7 @@ export class Compiler extends DiagnosticEmitter {
           Constraints.CONV_IMPLICIT | Constraints.WILL_RETAIN
         );
         if (fieldType.isManaged && !this.skippedAutoreleases.has(initExpr)) {
-          initExpr = this.makeRetain(initExpr);
+          initExpr = this.makeRetain(initExpr, fieldType);
         }
 
       // otherwise initialize with zero

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -6050,8 +6050,9 @@ export class Compiler extends DiagnosticEmitter {
         if (local.closureContextOffset > 0) {
           // TODO: ability to update closed over locals
           this.error(
-            DiagnosticCode.Not_implemented,
-            valueExpression.range
+            DiagnosticCode.Not_implemented_0,
+            valueExpression.range,
+            "Updating closed locals"
           );
           return module.unreachable();
         }
@@ -6557,8 +6558,9 @@ export class Compiler extends DiagnosticEmitter {
         if (local.type.is(TypeFlags.IN_SCOPE_CLOSURE)) {
           if (this.currentFlow.parentFunction.parent.kind == ElementKind.FUNCTION) {
             this.error(
-              DiagnosticCode.Not_implemented,
-              expression.expression.range
+              DiagnosticCode.Not_implemented_0,
+              expression.expression.range,
+              "Calling a Closure from an anonymous function that shares the same parent."
             );
             return module.unreachable();
           }

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -1684,7 +1684,7 @@ export class Compiler extends DiagnosticEmitter {
     // We need to hardcode the local index used by makeRetain because there is no corresponding flow
     if (type.isManaged) {
       valueExpr = this.makeRetain(valueExpr, type, 1);
-      varTypes = [ NativeType.I32 ]
+      varTypes = [ NativeType.I32 ];
     }
 
     instance.getterRef = module.addFunction(instance.internalGetterName, nativeThisType, nativeValueType, varTypes, valueExpr);
@@ -2777,7 +2777,7 @@ export class Compiler extends DiagnosticEmitter {
           module.nop()
         ),
         module.local_get(returnValueLocalIndex, nativeReturnType)
-      ], nativeReturnType)
+      ], nativeReturnType);
     }
 
 
@@ -3594,7 +3594,7 @@ export class Compiler extends DiagnosticEmitter {
           this.getClosureReference(module.local_get(tempResult.index, fromType.toNativeType()))
         ], toType.toNativeType());
 
-        //this.currentFlow.freeTempLocal(tempResult);
+        // this.currentFlow.freeTempLocal(tempResult);
         return convertExpr;
       }
       if (fromType.isAssignableTo(toType)) { // downcast or same
@@ -6698,7 +6698,7 @@ export class Compiler extends DiagnosticEmitter {
     // Once we get here, we have a function reference. With the new scheme, this function
     // could possibly be a closure. So here we check to see if it's a closure, then apply
     // the appropriate call logic
-    signature = assert(signature) // FIXME: asc can't see this yet
+    signature = assert(signature); // FIXME: asc can't see this yet
     var returnType = signature.returnType;
     var tempFunctionReferenceLocal = this.currentFlow.getTempLocal(this.options.usizeType);
     var usize = this.options.nativeSizeType;
@@ -6735,7 +6735,7 @@ export class Compiler extends DiagnosticEmitter {
           contextualType == Type.void
         )
       )
-    ], constraints & Constraints.WILL_DROP ? contextualType.toNativeType() : returnType.toNativeType())
+    ], constraints & Constraints.WILL_DROP ? contextualType.toNativeType() : returnType.toNativeType());
   }
 
   private compileCallExpressionBuiltin(
@@ -7422,7 +7422,7 @@ export class Compiler extends DiagnosticEmitter {
         module.local_get(exprLocalIndex, nativeType)
       ], nativeType);
 
-      //this.currentFlow.freeTempLocal(exprLocal);
+      // this.currentFlow.freeTempLocal(exprLocal);
 
       return functionRetainCall;
     }
@@ -7442,7 +7442,7 @@ export class Compiler extends DiagnosticEmitter {
         var exprLocal = this.currentFlow.getTempLocal(type);
         exprLocalIndex = exprLocal.index;
       }
-      var nativeType = type.toNativeType()
+      var nativeType = type.toNativeType();
       var functionReleaseCall = module.block(null, [
         module.local_set(exprLocalIndex, expr),
         module.call(
@@ -7459,7 +7459,7 @@ export class Compiler extends DiagnosticEmitter {
       ], NativeType.None);
 
       // TODO: fix a bug in which this free causes some overwrites
-      //this.currentFlow.freeTempLocal(exprLocal);
+      // this.currentFlow.freeTempLocal(exprLocal);
 
       return functionReleaseCall;
     }
@@ -8229,7 +8229,6 @@ export class Compiler extends DiagnosticEmitter {
 
     if(index < 0) return this.module.unreachable();
 
-    var usize = this.options.usizeType;
     var nativeUsize = this.options.nativeSizeType;
     var wasm64 = nativeUsize == NativeType.I64;
 
@@ -8237,7 +8236,7 @@ export class Compiler extends DiagnosticEmitter {
       this.warning(
         DiagnosticCode.Closure_support_is_experimental,
         instance.prototype.declaration.range
-      )
+      );
 
       // Append the appropriate signature and flags for this closure type, then set it to currentType
       this.currentType = Type.closure32;
@@ -8275,7 +8274,7 @@ export class Compiler extends DiagnosticEmitter {
         this.module.local_get(tempLocalIndex, nativeUsize) // load the closure locals index
       ], nativeUsize);
 
-      //flow.freeTempLocal(tempLocal);
+      // flow.freeTempLocal(tempLocal);
 
       return closureExpr;
     }
@@ -8289,7 +8288,7 @@ export class Compiler extends DiagnosticEmitter {
     elseExpr: ExpressionRef
   ): ExpressionRef {
     var module = this.module;
-    var wasm64 = this.options.nativeSizeType == NativeType.I64
+    var wasm64 = this.options.nativeSizeType == NativeType.I64;
 
     return module.if(
       module.binary(
@@ -8303,23 +8302,23 @@ export class Compiler extends DiagnosticEmitter {
       ),
       thenExpr,
       elseExpr
-    )
+    );
   }
 
   private getClosurePtr(closureExpr: ExpressionRef): ExpressionRef {
     var module = this.module;
-    var wasm64 = this.options.nativeSizeType == NativeType.I64
+    var wasm64 = this.options.nativeSizeType == NativeType.I64;
 
     return module.binary(
       wasm64 ? BinaryOp.ShlI64 : BinaryOp.ShlI32,
       closureExpr,
       wasm64 ? module.i64(4) : module.i32(4)
-    )
+    );
   }
 
   private getClosureReference(closureExpr: ExpressionRef): ExpressionRef {
     var module = this.module;
-    var wasm64 = this.options.nativeSizeType == NativeType.I64
+    var wasm64 = this.options.nativeSizeType == NativeType.I64;
 
     return module.binary(
       wasm64 ? BinaryOp.OrI64 : BinaryOp.OrI32,
@@ -8329,7 +8328,7 @@ export class Compiler extends DiagnosticEmitter {
         wasm64 ? module.i64(4) : module.i32(4)
       ),
       wasm64 ? module.i64(CLOSURE_TAG) : module.i32(CLOSURE_TAG)
-    )
+    );
   }
 
   /** Makes sure the enclosing source file of the specified expression has been compiled. */

--- a/src/diagnosticMessages.generated.ts
+++ b/src/diagnosticMessages.generated.ts
@@ -173,6 +173,7 @@ export enum DiagnosticCode {
   File_0_not_found = 6054,
   Numeric_separators_are_not_allowed_here = 6188,
   Multiple_consecutive_numeric_separators_are_not_permitted = 6189,
+  Closure_support_is_experimental = 6190,
   _super_must_be_called_before_accessing_this_in_the_constructor_of_a_derived_class = 17009,
   _super_must_be_called_before_accessing_a_property_of_super_in_the_constructor_of_a_derived_class = 17011
 }
@@ -346,6 +347,7 @@ export function diagnosticCodeToString(code: DiagnosticCode): string {
     case 6054: return "File '{0}' not found.";
     case 6188: return "Numeric separators are not allowed here.";
     case 6189: return "Multiple consecutive numeric separators are not permitted.";
+    case 6190: return "Closure support is experimental.";
     case 17009: return "'super' must be called before accessing 'this' in the constructor of a derived class.";
     case 17011: return "'super' must be called before accessing a property of 'super' in the constructor of a derived class.";
     default: return "";

--- a/src/diagnosticMessages.json
+++ b/src/diagnosticMessages.json
@@ -170,6 +170,7 @@
   "File '{0}' not found.": 6054,
   "Numeric separators are not allowed here.": 6188,
   "Multiple consecutive numeric separators are not permitted.": 6189,
+  "Closure support is experimental.": 6190,
   "'super' must be called before accessing 'this' in the constructor of a derived class.": 17009,
   "'super' must be called before accessing a property of 'super' in the constructor of a derived class.": 17011
 }

--- a/src/program.ts
+++ b/src/program.ts
@@ -3565,7 +3565,7 @@ export class Function extends TypedElement {
       var parentFunction = <Function>this.parent;
       var parentResult = parentFunction.flow.lookup(name);
       if (parentResult === null) return null;
-      if (parentFunction.closedLocals.size > 0) { //TODO allow nested closure definitions
+      if (parentFunction.closedLocals.size > 0) { // TODO allow nested closure definitions
         this.program.error(
           DiagnosticCode.Not_implemented_0,
           this.identifierNode.range,

--- a/src/program.ts
+++ b/src/program.ts
@@ -3567,8 +3567,9 @@ export class Function extends TypedElement {
       if (parentResult === null) return null;
       if (parentFunction.closedLocals.size > 0) { //TODO allow nested closure definitions
         this.program.error(
-          DiagnosticCode.Not_implemented,
-          this.identifierNode.range, this.identifierNode.text
+          DiagnosticCode.Not_implemented_0,
+          this.identifierNode.range,
+          "Nested Closure Declarations"
         );
         return null;
       }

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -2750,6 +2750,7 @@ export class Resolver extends DiagnosticEmitter {
     var signature = new Signature(this.program, parameterTypes, returnType, thisType);
     signature.parameterNames = parameterNames;
     signature.requiredParameters = requiredParameters;
+    if (prototype.hasNestedDefinition) signature = signature.toClosureSignature();
 
     var nameInclTypeParameters = prototype.name;
     if (instanceKey.length) nameInclTypeParameters += "<" + instanceKey + ">";

--- a/tests/compiler/assert-nonnull.optimized.wat
+++ b/tests/compiler/assert-nonnull.optimized.wat
@@ -187,10 +187,29 @@
   unreachable
  )
  (func $assert-nonnull/testFn (param $0 i32) (result i32)
+  (local $1 i32)
   local.get $0
-  call_indirect (type $none_=>_i32)
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $0
+   i32.const 4
+   i32.shl
+   local.tee $0
+   i32.load
+   local.set $1
+   local.get $0
+   local.get $1
+   call_indirect (type $i32_=>_i32)
+  else
+   local.get $0
+   call_indirect (type $none_=>_i32)
+  end
  )
  (func $assert-nonnull/testFn2 (param $0 i32) (result i32)
+  (local $1 i32)
   local.get $0
   i32.eqz
   if
@@ -202,14 +221,47 @@
    unreachable
   end
   local.get $0
-  call_indirect (type $none_=>_i32)
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $0
+   i32.const 4
+   i32.shl
+   local.tee $0
+   i32.load
+   local.set $1
+   local.get $0
+   local.get $1
+   call_indirect (type $i32_=>_i32)
+  else
+   local.get $0
+   call_indirect (type $none_=>_i32)
+  end
  )
  (func $assert-nonnull/testRet (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
-  call_indirect (type $none_=>_i32)
-  local.tee $1
-  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $0
+   i32.const 4
+   i32.shl
+   local.tee $0
+   i32.load
+   local.set $1
+   local.get $0
+   local.get $1
+   call_indirect (type $i32_=>_i32)
+  else
+   local.get $0
+   call_indirect (type $none_=>_i32)
+  end
+  local.tee $0
   i32.eqz
   if
    i32.const 0
@@ -219,19 +271,56 @@
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $0
  )
  (func $assert-nonnull/testObjFn (param $0 i32) (result i32)
+  (local $1 i32)
   local.get $0
   i32.load offset=4
-  call_indirect (type $none_=>_i32)
+  local.tee $0
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $0
+   i32.const 4
+   i32.shl
+   local.tee $0
+   i32.load
+   local.set $1
+   local.get $0
+   local.get $1
+   call_indirect (type $i32_=>_i32)
+  else
+   local.get $0
+   call_indirect (type $none_=>_i32)
+  end
  )
  (func $assert-nonnull/testObjRet (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   i32.load offset=4
-  call_indirect (type $none_=>_i32)
-  local.tee $1
-  local.get $1
+  local.tee $0
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $0
+   i32.const 4
+   i32.shl
+   local.tee $0
+   i32.load
+   local.set $1
+   local.get $0
+   local.get $1
+   call_indirect (type $i32_=>_i32)
+  else
+   local.get $0
+   call_indirect (type $none_=>_i32)
+  end
+  local.tee $0
   i32.eqz
   if
    i32.const 0
@@ -241,5 +330,6 @@
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $0
  )
 )

--- a/tests/compiler/assert-nonnull.untouched.wat
+++ b/tests/compiler/assert-nonnull.untouched.wat
@@ -337,19 +337,110 @@
  )
  (func $assert-nonnull/testFn (param $0 i32) (result i32)
   (local $1 i32)
-  i32.const 0
-  global.set $~argumentsLength
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   local.get $0
-  call_indirect (type $none_=>_i32)
-  local.tee $1
+  local.set $1
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $1
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/stub/__retain
+  drop
+  local.get $1
+  local.set $0
+  local.get $0
+  local.set $2
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+   i32.const 0
+   global.set $~argumentsLength
+   local.get $2
+   i32.const 4
+   i32.shl
+   i32.load
+   call_indirect (type $i32_=>_i32)
+   local.tee $3
+  else
+   i32.const 0
+   global.set $~argumentsLength
+   local.get $2
+   call_indirect (type $none_=>_i32)
+   local.tee $4
+  end
+  call $~lib/rt/stub/__retain
+  local.set $6
+  local.get $3
+  call $~lib/rt/stub/__release
+  local.get $4
+  call $~lib/rt/stub/__release
+  local.get $0
+  local.set $5
+  local.get $5
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $5
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/stub/__release
+  local.get $6
  )
  (func $assert-nonnull/testFn2 (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
   local.get $0
-  local.tee $1
+  local.set $1
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
   if (result i32)
    local.get $1
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/stub/__retain
+  drop
+  local.get $1
+  local.set $0
+  local.get $0
+  local.tee $2
+  if (result i32)
+   local.get $2
   else
    i32.const 0
    i32.const 32
@@ -359,23 +450,140 @@
    unreachable
   end
   local.set $2
-  i32.const 0
-  global.set $~argumentsLength
   local.get $2
-  call_indirect (type $none_=>_i32)
-  local.tee $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/stub/__retain
+  drop
+  local.get $2
+  local.set $3
+  local.get $3
+  local.set $4
+  local.get $4
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $4
+   i32.const 4
+   i32.shl
+   i32.const 0
+   global.set $~argumentsLength
+   local.get $4
+   i32.const 4
+   i32.shl
+   i32.load
+   call_indirect (type $i32_=>_i32)
+   local.tee $5
+  else
+   i32.const 0
+   global.set $~argumentsLength
+   local.get $4
+   call_indirect (type $none_=>_i32)
+   local.tee $6
+  end
+  call $~lib/rt/stub/__retain
+  local.set $9
+  local.get $5
+  call $~lib/rt/stub/__release
+  local.get $6
+  call $~lib/rt/stub/__release
+  local.get $0
+  local.set $7
+  local.get $7
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $7
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/stub/__release
+  local.get $3
+  local.set $8
+  local.get $8
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $8
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/stub/__release
+  local.get $9
  )
  (func $assert-nonnull/testRet (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
-  i32.const 0
-  global.set $~argumentsLength
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   local.get $0
-  call_indirect (type $none_=>_i32)
-  local.tee $1
-  local.tee $2
+  local.set $1
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $1
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/stub/__retain
+  drop
+  local.get $1
+  local.set $0
+  local.get $0
+  local.set $2
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
   if (result i32)
    local.get $2
+   i32.const 4
+   i32.shl
+   i32.const 0
+   global.set $~argumentsLength
+   local.get $2
+   i32.const 4
+   i32.shl
+   i32.load
+   call_indirect (type $i32_=>_i32)
+   local.tee $3
+  else
+   i32.const 0
+   global.set $~argumentsLength
+   local.get $2
+   call_indirect (type $none_=>_i32)
+   local.tee $4
+  end
+  local.tee $5
+  if (result i32)
+   local.get $5
   else
    i32.const 0
    i32.const 32
@@ -385,43 +593,111 @@
    unreachable
   end
   call $~lib/rt/stub/__retain
-  local.set $2
-  local.get $1
+  local.set $6
+  local.get $3
   call $~lib/rt/stub/__release
-  local.get $2
+  local.get $4
+  call $~lib/rt/stub/__release
+  local.get $0
+  local.set $5
+  local.get $5
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $5
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/stub/__release
+  local.get $6
  )
  (func $assert-nonnull/testObjFn (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
   local.get $0
   call $~lib/rt/stub/__retain
   local.set $0
-  i32.const 0
-  global.set $~argumentsLength
   local.get $0
   i32.load offset=4
-  call_indirect (type $none_=>_i32)
-  local.tee $1
-  local.set $2
+  local.set $1
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $1
+   i32.const 4
+   i32.shl
+   i32.const 0
+   global.set $~argumentsLength
+   local.get $1
+   i32.const 4
+   i32.shl
+   i32.load
+   call_indirect (type $i32_=>_i32)
+   local.tee $2
+  else
+   i32.const 0
+   global.set $~argumentsLength
+   local.get $1
+   call_indirect (type $none_=>_i32)
+   local.tee $3
+  end
+  call $~lib/rt/stub/__retain
+  local.set $4
+  local.get $2
+  call $~lib/rt/stub/__release
+  local.get $3
+  call $~lib/rt/stub/__release
   local.get $0
   call $~lib/rt/stub/__release
-  local.get $2
+  local.get $4
  )
  (func $assert-nonnull/testObjRet (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
   local.get $0
   call $~lib/rt/stub/__retain
   local.set $0
-  i32.const 0
-  global.set $~argumentsLength
   local.get $0
   i32.load offset=4
-  call_indirect (type $none_=>_i32)
-  local.tee $1
-  local.tee $2
+  local.set $1
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
   if (result i32)
-   local.get $2
+   local.get $1
+   i32.const 4
+   i32.shl
+   i32.const 0
+   global.set $~argumentsLength
+   local.get $1
+   i32.const 4
+   i32.shl
+   i32.load
+   call_indirect (type $i32_=>_i32)
+   local.tee $2
+  else
+   i32.const 0
+   global.set $~argumentsLength
+   local.get $1
+   call_indirect (type $none_=>_i32)
+   local.tee $3
+  end
+  local.tee $4
+  if (result i32)
+   local.get $4
   else
    i32.const 0
    i32.const 32
@@ -431,11 +707,13 @@
    unreachable
   end
   call $~lib/rt/stub/__retain
-  local.set $2
-  local.get $1
+  local.set $4
+  local.get $2
+  call $~lib/rt/stub/__release
+  local.get $3
   call $~lib/rt/stub/__release
   local.get $0
   call $~lib/rt/stub/__release
-  local.get $2
+  local.get $4
  )
 )

--- a/tests/compiler/builtins.optimized.wat
+++ b/tests/compiler/builtins.optimized.wat
@@ -36,7 +36,7 @@
  (global $builtins/f (mut f32) (f32.const 0))
  (global $builtins/F (mut f64) (f64.const 0))
  (export "memory" (memory $0))
- (export "test" (func $start:builtins~anonymous|0))
+ (export "test" (func $start:builtins~anonymous|0~nonClosure))
  (start $~start)
  (func $~lib/atomics/Atomics.isLockFree (param $0 i32) (result i32)
   i32.const 1
@@ -169,7 +169,7 @@
   end
   i32.const 0
  )
- (func $start:builtins~anonymous|0
+ (func $start:builtins~anonymous|0~nonClosure
   nop
  )
  (func $start:builtins

--- a/tests/compiler/builtins.untouched.wat
+++ b/tests/compiler/builtins.untouched.wat
@@ -33,7 +33,7 @@
  (data (i32.const 704) "\08\00\00\00\01\00\00\00\01\00\00\00\08\00\00\00v\00o\00i\00d\00")
  (data (i32.const 736) "\14\00\00\00\01\00\00\00\01\00\00\00\14\00\00\00s\00o\00m\00e\00 \00v\00a\00l\00u\00e\00")
  (table $0 3 funcref)
- (elem (i32.const 1) $start:builtins~anonymous|0 $start:builtins~anonymous|1)
+ (elem (i32.const 1) $start:builtins~anonymous|0~nonClosure $start:builtins~anonymous|1~nonClosure)
  (global $builtins/b (mut i32) (i32.const 0))
  (global $builtins/i (mut i32) (i32.const 0))
  (global $builtins/I (mut i64) (i64.const 0))
@@ -309,10 +309,10 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $start:builtins~anonymous|0
+ (func $start:builtins~anonymous|0~nonClosure
   nop
  )
- (func $start:builtins~anonymous|1 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $start:builtins~anonymous|1~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   nop
  )
  (func $start:builtins

--- a/tests/compiler/call-optional.untouched.wat
+++ b/tests/compiler/call-optional.untouched.wat
@@ -1,5 +1,6 @@
 (module
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
+ (type $i32_i32_i32_i32_=>_i32 (func (param i32 i32 i32 i32) (result i32)))
  (type $none_=>_none (func))
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
@@ -42,6 +43,9 @@
   call $call-optional/opt
  )
  (func $start:call-optional
+  (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
   i32.const 3
   i32.const 0
   i32.const 1
@@ -91,13 +95,36 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 3
-  i32.const 0
-  i32.const 0
-  i32.const 1
-  global.set $~argumentsLength
   global.get $call-optional/optIndirect
-  call_indirect (type $i32_i32_i32_=>_i32)
+  local.set $0
+  local.get $0
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $0
+   i32.const 4
+   i32.shl
+   i32.const 3
+   i32.const 0
+   i32.const 0
+   i32.const 1
+   global.set $~argumentsLength
+   local.get $0
+   i32.const 4
+   i32.shl
+   i32.load
+   call_indirect (type $i32_i32_i32_i32_=>_i32)
+  else
+   i32.const 3
+   i32.const 0
+   i32.const 0
+   i32.const 1
+   global.set $~argumentsLength
+   local.get $0
+   call_indirect (type $i32_i32_i32_=>_i32)
+  end
   i32.const 0
   i32.eq
   i32.eqz
@@ -109,13 +136,36 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 3
-  i32.const 4
-  i32.const 0
-  i32.const 2
-  global.set $~argumentsLength
   global.get $call-optional/optIndirect
-  call_indirect (type $i32_i32_i32_=>_i32)
+  local.set $1
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $1
+   i32.const 4
+   i32.shl
+   i32.const 3
+   i32.const 4
+   i32.const 0
+   i32.const 2
+   global.set $~argumentsLength
+   local.get $1
+   i32.const 4
+   i32.shl
+   i32.load
+   call_indirect (type $i32_i32_i32_i32_=>_i32)
+  else
+   i32.const 3
+   i32.const 4
+   i32.const 0
+   i32.const 2
+   global.set $~argumentsLength
+   local.get $1
+   call_indirect (type $i32_i32_i32_=>_i32)
+  end
   i32.const 5
   i32.eq
   i32.eqz
@@ -127,13 +177,36 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 3
-  i32.const 4
-  i32.const 5
-  i32.const 3
-  global.set $~argumentsLength
   global.get $call-optional/optIndirect
-  call_indirect (type $i32_i32_i32_=>_i32)
+  local.set $2
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+   i32.const 3
+   i32.const 4
+   i32.const 5
+   i32.const 3
+   global.set $~argumentsLength
+   local.get $2
+   i32.const 4
+   i32.shl
+   i32.load
+   call_indirect (type $i32_i32_i32_i32_=>_i32)
+  else
+   i32.const 3
+   i32.const 4
+   i32.const 5
+   i32.const 3
+   global.set $~argumentsLength
+   local.get $2
+   call_indirect (type $i32_i32_i32_=>_i32)
+  end
   i32.const 12
   i32.eq
   i32.eqz

--- a/tests/compiler/class-static-function.untouched.wat
+++ b/tests/compiler/class-static-function.untouched.wat
@@ -1,8 +1,9 @@
 (module
+ (type $i32_=>_i32 (func (param i32) (result i32)))
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
+ (type $i32_=>_none (func (param i32)))
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
- (type $i32_=>_i32 (func (param i32) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 16) "0\00\00\00\01\00\00\00\01\00\00\000\00\00\00c\00l\00a\00s\00s\00-\00s\00t\00a\00t\00i\00c\00-\00f\00u\00n\00c\00t\00i\00o\00n\00.\00t\00s\00")
@@ -14,11 +15,76 @@
  (func $class-static-function/Example.staticFunc (result i32)
   i32.const 42
  )
- (func $class-static-function/call (param $0 i32) (result i32)
-  i32.const 0
-  global.set $~argumentsLength
+ (func $~lib/rt/stub/__retain (param $0 i32) (result i32)
   local.get $0
-  call_indirect (type $none_=>_i32)
+ )
+ (func $~lib/rt/stub/__release (param $0 i32)
+  nop
+ )
+ (func $class-static-function/call (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  local.get $0
+  local.set $1
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $1
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/stub/__retain
+  drop
+  local.get $1
+  local.set $0
+  local.get $0
+  local.set $2
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+   i32.const 0
+   global.set $~argumentsLength
+   local.get $2
+   i32.const 4
+   i32.shl
+   i32.load
+   call_indirect (type $i32_=>_i32)
+  else
+   i32.const 0
+   global.set $~argumentsLength
+   local.get $2
+   call_indirect (type $none_=>_i32)
+  end
+  local.set $4
+  local.get $0
+  local.set $3
+  local.get $3
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $3
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/stub/__release
+  local.get $4
  )
  (func $start:class-static-function
   i32.const 1

--- a/tests/compiler/closure-limitations-runtime.json
+++ b/tests/compiler/closure-limitations-runtime.json
@@ -1,0 +1,6 @@
+{
+  "asc_flags": [
+    "--runtime none"
+  ],
+  "skipInstantiate": true
+}

--- a/tests/compiler/closure-limitations-runtime.optimized.wat
+++ b/tests/compiler/closure-limitations-runtime.optimized.wat
@@ -1,0 +1,108 @@
+(module
+ (type $none_=>_none (func))
+ (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
+ (type $none_=>_i32 (func (result i32)))
+ (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
+ (memory $0 1)
+ (data (i32.const 1024) "<\00\00\00\01\00\00\00\01\00\00\00<\00\00\00c\00l\00o\00s\00u\00r\00e\00-\00l\00i\00m\00i\00t\00a\00t\00i\00o\00n\00s\00-\00r\00u\00n\00t\00i\00m\00e\00.\00t\00s")
+ (global $~lib/rt/stub/offset (mut i32) (i32.const 0))
+ (export "memory" (memory $0))
+ (export "exportedClosureReturns" (func $closure-limitations-runtime/exportedClosureReturns))
+ (start $~start)
+ (func $closure-limitations-runtime/exportedClosureReturns (result i32)
+  (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  global.get $~lib/rt/stub/offset
+  i32.const 16
+  i32.add
+  local.tee $0
+  i32.const 16
+  i32.add
+  local.tee $1
+  memory.size
+  local.tee $3
+  i32.const 16
+  i32.shl
+  local.tee $2
+  i32.gt_u
+  if
+   local.get $3
+   local.get $1
+   local.get $2
+   i32.sub
+   i32.const 65535
+   i32.add
+   i32.const -65536
+   i32.and
+   i32.const 16
+   i32.shr_u
+   local.tee $2
+   local.get $3
+   local.get $2
+   i32.gt_s
+   select
+   memory.grow
+   i32.const 0
+   i32.lt_s
+   if
+    local.get $2
+    memory.grow
+    i32.const 0
+    i32.lt_s
+    if
+     unreachable
+    end
+   end
+  end
+  local.get $1
+  global.set $~lib/rt/stub/offset
+  local.get $0
+  i32.const 16
+  i32.sub
+  local.tee $1
+  i32.const 16
+  i32.store
+  local.get $1
+  i32.const 1
+  i32.store offset=4
+  local.get $1
+  i32.const 0
+  i32.store offset=8
+  local.get $1
+  i32.const 8
+  i32.store offset=12
+  local.get $0
+  i32.const 1
+  i32.store
+  local.get $0
+  i32.const 0
+  i32.store offset=1
+  local.get $0
+  i32.const 4
+  i32.shr_s
+  i32.const -2147483648
+  i32.or
+  local.tee $0
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if
+   i32.const 0
+   i32.const 1040
+   i32.const 3
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+ )
+ (func $~start
+  i32.const 1104
+  global.set $~lib/rt/stub/offset
+  call $closure-limitations-runtime/exportedClosureReturns
+  drop
+ )
+)

--- a/tests/compiler/closure-limitations-runtime.optimized.wat
+++ b/tests/compiler/closure-limitations-runtime.optimized.wat
@@ -78,7 +78,7 @@
   i32.store
   local.get $0
   i32.const 0
-  i32.store offset=1
+  i32.store offset=4
   local.get $0
   i32.const 4
   i32.shr_s

--- a/tests/compiler/closure-limitations-runtime.ts
+++ b/tests/compiler/closure-limitations-runtime.ts
@@ -1,0 +1,7 @@
+export function exportedClosureReturns(): (value: i32) => i32 {
+  var $local0 = 0;
+  return function inner(value: i32) {
+    return $local0;
+  };
+}
+exportedClosureReturns();

--- a/tests/compiler/closure-limitations-runtime.ts
+++ b/tests/compiler/closure-limitations-runtime.ts
@@ -1,6 +1,6 @@
 export function exportedClosureReturns(): (value: i32) => i32 {
   var $local0 = 0;
-  return function inner(value: i32) {
+  return function inner(value: i32): i32 {
     return $local0;
   };
 }

--- a/tests/compiler/closure-limitations-runtime.untouched.wat
+++ b/tests/compiler/closure-limitations-runtime.untouched.wat
@@ -155,7 +155,7 @@
   local.set $2
   local.get $2
   local.get $0
-  i32.store offset=1
+  i32.store offset=4
   local.get $2
   i32.const 4
   i32.shr_s

--- a/tests/compiler/closure-limitations-runtime.untouched.wat
+++ b/tests/compiler/closure-limitations-runtime.untouched.wat
@@ -1,19 +1,25 @@
 (module
- (type $i32_=>_i32 (func (param i32) (result i32)))
- (type $none_=>_i32 (func (result i32)))
- (type $i32_=>_none (func (param i32)))
  (type $none_=>_none (func))
+ (type $i32_=>_none (func (param i32)))
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
- (memory $0 0)
+ (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
+ (type $none_=>_i32 (func (result i32)))
+ (type $i32_=>_i32 (func (param i32) (result i32)))
+ (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
+ (memory $0 1)
+ (data (i32.const 16) "<\00\00\00\01\00\00\00\01\00\00\00<\00\00\00c\00l\00o\00s\00u\00r\00e\00-\00l\00i\00m\00i\00t\00a\00t\00i\00o\00n\00s\00-\00r\00u\00n\00t\00i\00m\00e\00.\00t\00s\00")
  (table $0 2 funcref)
- (elem (i32.const 1) $getter-call/C#get:x~anonymous|0~nonClosure)
+ (elem (i32.const 1) $closure-limitations-runtime/exportedClosureReturns~inner)
  (global $~lib/rt/stub/startOffset (mut i32) (i32.const 0))
  (global $~lib/rt/stub/offset (mut i32) (i32.const 0))
- (global $~argumentsLength (mut i32) (i32.const 0))
- (global $~lib/heap/__heap_base i32 (i32.const 8))
+ (global $~lib/heap/__heap_base i32 (i32.const 92))
  (export "memory" (memory $0))
- (export "test" (func $getter-call/test))
+ (export "exportedClosureReturns" (func $closure-limitations-runtime/exportedClosureReturns))
  (start $~start)
+ (func $closure-limitations-runtime/exportedClosureReturns~inner (param $0 i32) (param $1 i32) (result i32)
+  local.get $0
+  i32.load offset=4
+ )
  (func $~lib/rt/stub/maybeGrowMemory (param $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -126,83 +132,35 @@
  (func $~lib/rt/stub/__retain (param $0 i32) (result i32)
   local.get $0
  )
- (func $getter-call/C#constructor (param $0 i32) (result i32)
-  local.get $0
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 3
-   call $~lib/rt/stub/__alloc
-   call $~lib/rt/stub/__retain
-   local.set $0
-  end
-  local.get $0
- )
- (func $getter-call/C#get:x~anonymous|0~nonClosure (result i32)
-  i32.const 42
- )
- (func $getter-call/C#get:x (param $0 i32) (result i32)
-  (local $1 i32)
-  i32.const 1
-  local.set $1
-  local.get $1
-  i32.const -2147483648
-  i32.and
-  i32.const -2147483648
-  i32.eq
-  if (result i32)
-   local.get $1
-   i32.const 4
-   i32.shl
-  else
-   i32.const 0
-  end
-  call $~lib/rt/stub/__retain
-  drop
-  local.get $1
- )
  (func $~lib/rt/stub/__release (param $0 i32)
   nop
  )
- (func $getter-call/test (result i32)
+ (func $closure-limitations-runtime/exportedClosureReturns (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   i32.const 0
-  call $getter-call/C#constructor
   local.set $0
-  local.get $0
-  call $getter-call/C#get:x
-  local.tee $1
+  i32.const 8
+  i32.const 0
+  call $~lib/rt/stub/__alloc
+  call $~lib/rt/stub/__retain
+  local.set $1
+  local.get $1
+  i32.const 1
+  i32.store
+  local.get $1
   local.set $2
   local.get $2
-  i32.const -2147483648
-  i32.and
-  i32.const -2147483648
-  i32.eq
-  if (result i32)
-   local.get $2
-   i32.const 4
-   i32.shl
-   i32.const 0
-   global.set $~argumentsLength
-   local.get $2
-   i32.const 4
-   i32.shl
-   i32.load
-   call_indirect (type $i32_=>_i32)
-  else
-   i32.const 0
-   global.set $~argumentsLength
-   local.get $2
-   call_indirect (type $none_=>_i32)
-  end
-  local.set $4
   local.get $0
-  call $~lib/rt/stub/__release
-  local.get $1
+  i32.store offset=1
+  local.get $2
+  i32.const 4
+  i32.shr_s
+  i32.const -2147483648
+  i32.or
   local.set $3
   local.get $3
   i32.const -2147483648
@@ -216,10 +174,33 @@
   else
    i32.const 0
   end
+  call $~lib/rt/stub/__retain
+  drop
+  local.get $3
+  local.set $4
+  local.get $1
   call $~lib/rt/stub/__release
   local.get $4
+  local.set $1
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  else
+   nop
+  end
+  local.get $1
  )
- (func $~start
+ (func $start:closure-limitations-runtime
+  (local $0 i32)
   global.get $~lib/heap/__heap_base
   i32.const 15
   i32.add
@@ -230,5 +211,23 @@
   global.set $~lib/rt/stub/startOffset
   global.get $~lib/rt/stub/startOffset
   global.set $~lib/rt/stub/offset
+  call $closure-limitations-runtime/exportedClosureReturns
+  local.set $0
+  local.get $0
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $0
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/stub/__release
+ )
+ (func $~start
+  call $start:closure-limitations-runtime
  )
 )

--- a/tests/compiler/closure-limitations.json
+++ b/tests/compiler/closure-limitations.json
@@ -3,8 +3,8 @@
     "--runtime none"
   ],
   "stderr": [
-    "AS100: Not implemented.",
-    "AS100: Not implemented.",
+    "AS100: Not implemented: Updating closed locals",
+    "AS100: Not implemented: Calling a Closure from an anonymous function that shares the same parent.",
     "EOF"
   ]
 }

--- a/tests/compiler/closure-limitations.json
+++ b/tests/compiler/closure-limitations.json
@@ -1,0 +1,10 @@
+{
+  "asc_flags": [
+    "--runtime none"
+  ],
+  "stderr": [
+    "AS100: Not implemented.",
+    "AS100: Not implemented.",
+    "EOF"
+  ]
+}

--- a/tests/compiler/closure-limitations.optimized.wat
+++ b/tests/compiler/closure-limitations.optimized.wat
@@ -1,0 +1,4 @@
+(module
+ (memory $0 0)
+ (export "memory" (memory $0))
+)

--- a/tests/compiler/closure-limitations.ts
+++ b/tests/compiler/closure-limitations.ts
@@ -11,12 +11,12 @@ function inScopeNestedCalls(): (value: i32) => i32 {
   var x = 0;
   var f = (): i32 => {
     return x;
-  }
+  };
   var p = (value: i32): i32 => {
     return f();
-  }
+  };
   return p;
 }
 inScopeNestedCalls();
 
-ERROR("EOF")
+ERROR("EOF");

--- a/tests/compiler/closure-limitations.ts
+++ b/tests/compiler/closure-limitations.ts
@@ -1,0 +1,22 @@
+function closureWrites(): (value: i32) => i32 {
+  var $local0 = 0;
+  return function inner(value: i32) {
+    $local0 = $local0 + 1;
+    return $local0;
+  };
+}
+closureWrites();
+
+function inScopeNestedCalls(): (value: i32) => i32 {
+  var x = 0;
+  var f = (): i32 => {
+    return x;
+  }
+  var p = (value: i32): i32 => {
+    return f();
+  }
+  return p;
+}
+inScopeNestedCalls();
+
+ERROR("EOF")

--- a/tests/compiler/closure-limitations.untouched.wat
+++ b/tests/compiler/closure-limitations.untouched.wat
@@ -1,0 +1,5 @@
+(module
+ (memory $0 0)
+ (table $0 1 funcref)
+ (export "memory" (memory $0))
+)

--- a/tests/compiler/closure.json
+++ b/tests/compiler/closure.json
@@ -1,11 +1,6 @@
 {
   "asc_flags": [
-    "--runtime none"
-  ],
-  "stderr": [
-    "AS100: Not implemented: Closures",
-    "AS100: Not implemented: Closures",
-    "Cannot find name '$local0'.",
-    "EOF"
+    "--runtime full",
+    "--use ASC_RTRACE=1"
   ]
 }

--- a/tests/compiler/closure.optimized.wat
+++ b/tests/compiler/closure.optimized.wat
@@ -1,0 +1,1675 @@
+(module
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
+ (type $i32_=>_none (func (param i32)))
+ (type $none_=>_i32 (func (result i32)))
+ (type $i32_=>_i32 (func (param i32) (result i32)))
+ (type $none_=>_none (func))
+ (type $i32_i32_=>_none (func (param i32 i32)))
+ (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
+ (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
+ (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
+ (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
+ (import "rtrace" "onalloc" (func $~lib/rt/rtrace/onalloc (param i32)))
+ (import "rtrace" "onincrement" (func $~lib/rt/rtrace/onincrement (param i32)))
+ (import "rtrace" "ondecrement" (func $~lib/rt/rtrace/ondecrement (param i32)))
+ (import "rtrace" "onfree" (func $~lib/rt/rtrace/onfree (param i32)))
+ (memory $0 1)
+ (data (i32.const 1024) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s")
+ (data (i32.const 1072) "(\00\00\00\01\00\00\00\01\00\00\00(\00\00\00a\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e")
+ (data (i32.const 1136) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00p\00u\00r\00e\00.\00t\00s")
+ (data (i32.const 1184) "\14\00\00\00\01\00\00\00\01\00\00\00\14\00\00\00c\00l\00o\00s\00u\00r\00e\00.\00t\00s")
+ (data (i32.const 1232) "\03\00\00\00 \00\00\00\00\00\00\00 \00\00\00\00\00\00\00 ")
+ (table $0 10 funcref)
+ (elem (i32.const 1) $closure/testParam~inner $closure/testParam~inner $closure/testParam~inner $closure/complexCreateClosure~anonymous|0 $closure/complexCreateClosure~anonymous|1 $closure/nestedExecutionTest~anonymous|0 $closure/createClosure~anonymous|0 $closure/runInline~anonymous|0 $closure/returnOverBoundary~anonymous|0~nonClosure)
+ (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
+ (global $~lib/rt/tlsf/collectLock (mut i32) (i32.const 0))
+ (global $~lib/rt/__rtti_base i32 (i32.const 1232))
+ (export "memory" (memory $0))
+ (export "__alloc" (func $~lib/rt/tlsf/__alloc))
+ (export "__retain" (func $~lib/rt/pure/__retain))
+ (export "__release" (func $~lib/rt/pure/__release))
+ (export "__collect" (func $~lib/rt/pure/__collect))
+ (export "__rtti_base" (global $~lib/rt/__rtti_base))
+ (export "returnOverBoundary" (func $closure/returnOverBoundary))
+ (start $~start)
+ (func $~lib/rt/tlsf/removeBlock (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  local.get $1
+  i32.load
+  local.tee $2
+  i32.const 1
+  i32.and
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1040
+   i32.const 277
+   i32.const 14
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $2
+  i32.const -4
+  i32.and
+  local.tee $2
+  i32.const 16
+  i32.ge_u
+  if (result i32)
+   local.get $2
+   i32.const 1073741808
+   i32.lt_u
+  else
+   i32.const 0
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1040
+   i32.const 279
+   i32.const 14
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $2
+  i32.const 256
+  i32.lt_u
+  if
+   local.get $2
+   i32.const 4
+   i32.shr_u
+   local.set $2
+  else
+   local.get $2
+   i32.const 31
+   local.get $2
+   i32.clz
+   i32.sub
+   local.tee $4
+   i32.const 4
+   i32.sub
+   i32.shr_u
+   i32.const 16
+   i32.xor
+   local.set $2
+   local.get $4
+   i32.const 7
+   i32.sub
+   local.set $4
+  end
+  local.get $2
+  i32.const 16
+  i32.lt_u
+  i32.const 0
+  local.get $4
+  i32.const 23
+  i32.lt_u
+  select
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1040
+   i32.const 292
+   i32.const 14
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $1
+  i32.load offset=20
+  local.set $3
+  local.get $1
+  i32.load offset=16
+  local.tee $5
+  if
+   local.get $5
+   local.get $3
+   i32.store offset=20
+  end
+  local.get $3
+  if
+   local.get $3
+   local.get $5
+   i32.store offset=16
+  end
+  local.get $1
+  local.get $0
+  local.get $2
+  local.get $4
+  i32.const 4
+  i32.shl
+  i32.add
+  i32.const 2
+  i32.shl
+  i32.add
+  i32.load offset=96
+  i32.eq
+  if
+   local.get $0
+   local.get $2
+   local.get $4
+   i32.const 4
+   i32.shl
+   i32.add
+   i32.const 2
+   i32.shl
+   i32.add
+   local.get $3
+   i32.store offset=96
+   local.get $3
+   i32.eqz
+   if
+    local.get $0
+    local.get $4
+    i32.const 2
+    i32.shl
+    i32.add
+    local.tee $3
+    i32.load offset=4
+    i32.const 1
+    local.get $2
+    i32.shl
+    i32.const -1
+    i32.xor
+    i32.and
+    local.set $1
+    local.get $3
+    local.get $1
+    i32.store offset=4
+    local.get $1
+    i32.eqz
+    if
+     local.get $0
+     local.get $0
+     i32.load
+     i32.const 1
+     local.get $4
+     i32.shl
+     i32.const -1
+     i32.xor
+     i32.and
+     i32.store
+    end
+   end
+  end
+ )
+ (func $~lib/rt/tlsf/insertBlock (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  local.get $1
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1040
+   i32.const 205
+   i32.const 14
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $1
+  i32.load
+  local.tee $3
+  i32.const 1
+  i32.and
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1040
+   i32.const 207
+   i32.const 14
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $1
+  i32.const 16
+  i32.add
+  local.get $1
+  i32.load
+  i32.const -4
+  i32.and
+  i32.add
+  local.tee $4
+  i32.load
+  local.tee $5
+  i32.const 1
+  i32.and
+  if
+   local.get $3
+   i32.const -4
+   i32.and
+   i32.const 16
+   i32.add
+   local.get $5
+   i32.const -4
+   i32.and
+   i32.add
+   local.tee $2
+   i32.const 1073741808
+   i32.lt_u
+   if
+    local.get $0
+    local.get $4
+    call $~lib/rt/tlsf/removeBlock
+    local.get $1
+    local.get $2
+    local.get $3
+    i32.const 3
+    i32.and
+    i32.or
+    local.tee $3
+    i32.store
+    local.get $1
+    i32.const 16
+    i32.add
+    local.get $1
+    i32.load
+    i32.const -4
+    i32.and
+    i32.add
+    local.tee $4
+    i32.load
+    local.set $5
+   end
+  end
+  local.get $3
+  i32.const 2
+  i32.and
+  if
+   local.get $1
+   i32.const 4
+   i32.sub
+   i32.load
+   local.tee $2
+   i32.load
+   local.tee $7
+   i32.const 1
+   i32.and
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 1040
+    i32.const 228
+    i32.const 16
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $7
+   i32.const -4
+   i32.and
+   i32.const 16
+   i32.add
+   local.get $3
+   i32.const -4
+   i32.and
+   i32.add
+   local.tee $8
+   i32.const 1073741808
+   i32.lt_u
+   if
+    local.get $0
+    local.get $2
+    call $~lib/rt/tlsf/removeBlock
+    local.get $2
+    local.get $8
+    local.get $7
+    i32.const 3
+    i32.and
+    i32.or
+    local.tee $3
+    i32.store
+    local.get $2
+    local.set $1
+   end
+  end
+  local.get $4
+  local.get $5
+  i32.const 2
+  i32.or
+  i32.store
+  local.get $3
+  i32.const -4
+  i32.and
+  local.tee $2
+  i32.const 16
+  i32.ge_u
+  if (result i32)
+   local.get $2
+   i32.const 1073741808
+   i32.lt_u
+  else
+   i32.const 0
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1040
+   i32.const 243
+   i32.const 14
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $2
+  local.get $1
+  i32.const 16
+  i32.add
+  i32.add
+  local.get $4
+  i32.ne
+  if
+   i32.const 0
+   i32.const 1040
+   i32.const 244
+   i32.const 14
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $4
+  i32.const 4
+  i32.sub
+  local.get $1
+  i32.store
+  local.get $2
+  i32.const 256
+  i32.lt_u
+  if
+   local.get $2
+   i32.const 4
+   i32.shr_u
+   local.set $2
+  else
+   local.get $2
+   i32.const 31
+   local.get $2
+   i32.clz
+   i32.sub
+   local.tee $3
+   i32.const 4
+   i32.sub
+   i32.shr_u
+   i32.const 16
+   i32.xor
+   local.set $2
+   local.get $3
+   i32.const 7
+   i32.sub
+   local.set $6
+  end
+  local.get $2
+  i32.const 16
+  i32.lt_u
+  i32.const 0
+  local.get $6
+  i32.const 23
+  i32.lt_u
+  select
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1040
+   i32.const 260
+   i32.const 14
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  local.get $2
+  local.get $6
+  i32.const 4
+  i32.shl
+  i32.add
+  i32.const 2
+  i32.shl
+  i32.add
+  i32.load offset=96
+  local.set $3
+  local.get $1
+  i32.const 0
+  i32.store offset=16
+  local.get $1
+  local.get $3
+  i32.store offset=20
+  local.get $3
+  if
+   local.get $3
+   local.get $1
+   i32.store offset=16
+  end
+  local.get $0
+  local.get $2
+  local.get $6
+  i32.const 4
+  i32.shl
+  i32.add
+  i32.const 2
+  i32.shl
+  i32.add
+  local.get $1
+  i32.store offset=96
+  local.get $0
+  local.get $0
+  i32.load
+  i32.const 1
+  local.get $6
+  i32.shl
+  i32.or
+  i32.store
+  local.get $0
+  local.get $6
+  i32.const 2
+  i32.shl
+  i32.add
+  local.tee $0
+  local.get $0
+  i32.load offset=4
+  i32.const 1
+  local.get $2
+  i32.shl
+  i32.or
+  i32.store offset=4
+ )
+ (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  local.get $2
+  i32.const 15
+  i32.and
+  i32.eqz
+  i32.const 0
+  local.get $1
+  i32.const 15
+  i32.and
+  i32.eqz
+  i32.const 0
+  local.get $1
+  local.get $2
+  i32.le_u
+  select
+  select
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1040
+   i32.const 386
+   i32.const 5
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.load offset=1568
+  local.tee $3
+  if
+   local.get $1
+   local.get $3
+   i32.const 16
+   i32.add
+   i32.lt_u
+   if
+    i32.const 0
+    i32.const 1040
+    i32.const 396
+    i32.const 16
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $3
+   local.get $1
+   i32.const 16
+   i32.sub
+   i32.eq
+   if
+    local.get $3
+    i32.load
+    local.set $4
+    local.get $1
+    i32.const 16
+    i32.sub
+    local.set $1
+   end
+  else
+   local.get $1
+   local.get $0
+   i32.const 1572
+   i32.add
+   i32.lt_u
+   if
+    i32.const 0
+    i32.const 1040
+    i32.const 408
+    i32.const 5
+    call $~lib/builtins/abort
+    unreachable
+   end
+  end
+  local.get $2
+  local.get $1
+  i32.sub
+  local.tee $2
+  i32.const 48
+  i32.lt_u
+  if
+   return
+  end
+  local.get $1
+  local.get $4
+  i32.const 2
+  i32.and
+  local.get $2
+  i32.const 32
+  i32.sub
+  i32.const 1
+  i32.or
+  i32.or
+  i32.store
+  local.get $1
+  i32.const 0
+  i32.store offset=16
+  local.get $1
+  i32.const 0
+  i32.store offset=20
+  local.get $1
+  local.get $2
+  i32.add
+  i32.const 16
+  i32.sub
+  local.tee $2
+  i32.const 2
+  i32.store
+  local.get $0
+  local.get $2
+  i32.store offset=1568
+  local.get $0
+  local.get $1
+  call $~lib/rt/tlsf/insertBlock
+ )
+ (func $~lib/rt/tlsf/maybeInitialize (result i32)
+  (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  global.get $~lib/rt/tlsf/ROOT
+  local.tee $0
+  i32.eqz
+  if
+   i32.const 1
+   memory.size
+   local.tee $0
+   i32.gt_s
+   if (result i32)
+    i32.const 1
+    local.get $0
+    i32.sub
+    memory.grow
+    i32.const 0
+    i32.lt_s
+   else
+    i32.const 0
+   end
+   if
+    unreachable
+   end
+   i32.const 1264
+   local.tee $0
+   i32.const 0
+   i32.store
+   i32.const 2832
+   i32.const 0
+   i32.store
+   loop $for-loop|0
+    local.get $1
+    i32.const 23
+    i32.lt_u
+    if
+     local.get $1
+     i32.const 2
+     i32.shl
+     i32.const 1264
+     i32.add
+     i32.const 0
+     i32.store offset=4
+     i32.const 0
+     local.set $2
+     loop $for-loop|1
+      local.get $2
+      i32.const 16
+      i32.lt_u
+      if
+       local.get $1
+       i32.const 4
+       i32.shl
+       local.get $2
+       i32.add
+       i32.const 2
+       i32.shl
+       i32.const 1264
+       i32.add
+       i32.const 0
+       i32.store offset=96
+       local.get $2
+       i32.const 1
+       i32.add
+       local.set $2
+       br $for-loop|1
+      end
+     end
+     local.get $1
+     i32.const 1
+     i32.add
+     local.set $1
+     br $for-loop|0
+    end
+   end
+   i32.const 1264
+   i32.const 2848
+   memory.size
+   i32.const 16
+   i32.shl
+   call $~lib/rt/tlsf/addMemory
+   i32.const 1264
+   global.set $~lib/rt/tlsf/ROOT
+  end
+  local.get $0
+ )
+ (func $~lib/rt/tlsf/searchBlock (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  local.get $1
+  i32.const 256
+  i32.lt_u
+  if
+   local.get $1
+   i32.const 4
+   i32.shr_u
+   local.set $1
+  else
+   local.get $1
+   i32.const 536870904
+   i32.lt_u
+   if
+    local.get $1
+    i32.const 1
+    i32.const 27
+    local.get $1
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.add
+    i32.const 1
+    i32.sub
+    local.set $1
+   end
+   local.get $1
+   i32.const 31
+   local.get $1
+   i32.clz
+   i32.sub
+   local.tee $2
+   i32.const 4
+   i32.sub
+   i32.shr_u
+   i32.const 16
+   i32.xor
+   local.set $1
+   local.get $2
+   i32.const 7
+   i32.sub
+   local.set $2
+  end
+  local.get $1
+  i32.const 16
+  i32.lt_u
+  i32.const 0
+  local.get $2
+  i32.const 23
+  i32.lt_u
+  select
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1040
+   i32.const 338
+   i32.const 14
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  local.get $2
+  i32.const 2
+  i32.shl
+  i32.add
+  i32.load offset=4
+  i32.const -1
+  local.get $1
+  i32.shl
+  i32.and
+  local.tee $1
+  if (result i32)
+   local.get $0
+   local.get $1
+   i32.ctz
+   local.get $2
+   i32.const 4
+   i32.shl
+   i32.add
+   i32.const 2
+   i32.shl
+   i32.add
+   i32.load offset=96
+  else
+   local.get $0
+   i32.load
+   i32.const -1
+   local.get $2
+   i32.const 1
+   i32.add
+   i32.shl
+   i32.and
+   local.tee $1
+   if (result i32)
+    local.get $0
+    local.get $1
+    i32.ctz
+    local.tee $1
+    i32.const 2
+    i32.shl
+    i32.add
+    i32.load offset=4
+    local.tee $2
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 1040
+     i32.const 351
+     i32.const 18
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $0
+    local.get $2
+    i32.ctz
+    local.get $1
+    i32.const 4
+    i32.shl
+    i32.add
+    i32.const 2
+    i32.shl
+    i32.add
+    i32.load offset=96
+   else
+    i32.const 0
+   end
+  end
+ )
+ (func $~lib/rt/tlsf/prepareBlock (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  local.get $1
+  i32.load
+  local.set $3
+  local.get $2
+  i32.const 15
+  i32.and
+  if
+   i32.const 0
+   i32.const 1040
+   i32.const 365
+   i32.const 14
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $3
+  i32.const -4
+  i32.and
+  local.get $2
+  i32.sub
+  local.tee $4
+  i32.const 32
+  i32.ge_u
+  if
+   local.get $1
+   local.get $2
+   local.get $3
+   i32.const 2
+   i32.and
+   i32.or
+   i32.store
+   local.get $2
+   local.get $1
+   i32.const 16
+   i32.add
+   i32.add
+   local.tee $1
+   local.get $4
+   i32.const 16
+   i32.sub
+   i32.const 1
+   i32.or
+   i32.store
+   local.get $0
+   local.get $1
+   call $~lib/rt/tlsf/insertBlock
+  else
+   local.get $1
+   local.get $3
+   i32.const -2
+   i32.and
+   i32.store
+   local.get $1
+   i32.const 16
+   i32.add
+   local.tee $0
+   local.get $1
+   i32.load
+   i32.const -4
+   i32.and
+   i32.add
+   local.get $0
+   local.get $1
+   i32.load
+   i32.const -4
+   i32.and
+   i32.add
+   i32.load
+   i32.const -3
+   i32.and
+   i32.store
+  end
+ )
+ (func $~lib/rt/tlsf/allocateBlock (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  global.get $~lib/rt/tlsf/collectLock
+  if
+   i32.const 0
+   i32.const 1040
+   i32.const 501
+   i32.const 14
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $1
+  i32.const 1073741808
+  i32.ge_u
+  if
+   i32.const 1088
+   i32.const 1040
+   i32.const 461
+   i32.const 30
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  local.get $1
+  i32.const 15
+  i32.add
+  i32.const -16
+  i32.and
+  local.tee $3
+  i32.const 16
+  local.get $3
+  i32.const 16
+  i32.gt_u
+  select
+  local.tee $4
+  call $~lib/rt/tlsf/searchBlock
+  local.tee $3
+  i32.eqz
+  if
+   i32.const 1
+   global.set $~lib/rt/tlsf/collectLock
+   i32.const 0
+   global.set $~lib/rt/tlsf/collectLock
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/searchBlock
+   local.tee $3
+   i32.eqz
+   if
+    i32.const 16
+    memory.size
+    local.tee $3
+    i32.const 16
+    i32.shl
+    i32.const 16
+    i32.sub
+    local.get $0
+    i32.load offset=1568
+    i32.ne
+    i32.shl
+    local.get $4
+    i32.const 1
+    i32.const 27
+    local.get $4
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.const 1
+    i32.sub
+    i32.add
+    local.get $4
+    local.get $4
+    i32.const 536870904
+    i32.lt_u
+    select
+    i32.add
+    i32.const 65535
+    i32.add
+    i32.const -65536
+    i32.and
+    i32.const 16
+    i32.shr_u
+    local.set $5
+    local.get $3
+    local.get $5
+    local.get $3
+    local.get $5
+    i32.gt_s
+    select
+    memory.grow
+    i32.const 0
+    i32.lt_s
+    if
+     local.get $5
+     memory.grow
+     i32.const 0
+     i32.lt_s
+     if
+      unreachable
+     end
+    end
+    local.get $0
+    local.get $3
+    i32.const 16
+    i32.shl
+    memory.size
+    i32.const 16
+    i32.shl
+    call $~lib/rt/tlsf/addMemory
+    local.get $0
+    local.get $4
+    call $~lib/rt/tlsf/searchBlock
+    local.tee $3
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 1040
+     i32.const 513
+     i32.const 20
+     call $~lib/builtins/abort
+     unreachable
+    end
+   end
+  end
+  local.get $3
+  i32.load
+  i32.const -4
+  i32.and
+  local.get $4
+  i32.lt_u
+  if
+   i32.const 0
+   i32.const 1040
+   i32.const 521
+   i32.const 14
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $3
+  i32.const 0
+  i32.store offset=4
+  local.get $3
+  local.get $2
+  i32.store offset=8
+  local.get $3
+  local.get $1
+  i32.store offset=12
+  local.get $0
+  local.get $3
+  call $~lib/rt/tlsf/removeBlock
+  local.get $0
+  local.get $3
+  local.get $4
+  call $~lib/rt/tlsf/prepareBlock
+  local.get $3
+  call $~lib/rt/rtrace/onalloc
+  local.get $3
+ )
+ (func $~lib/rt/tlsf/__alloc (param $0 i32) (param $1 i32) (result i32)
+  call $~lib/rt/tlsf/maybeInitialize
+  local.get $0
+  local.get $1
+  call $~lib/rt/tlsf/allocateBlock
+  i32.const 16
+  i32.add
+ )
+ (func $~lib/rt/pure/__retain (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  local.get $0
+  i32.const 1260
+  i32.gt_u
+  if
+   local.get $0
+   i32.const 16
+   i32.sub
+   local.tee $1
+   i32.load offset=4
+   local.tee $2
+   i32.const -268435456
+   i32.and
+   local.get $2
+   i32.const 1
+   i32.add
+   i32.const -268435456
+   i32.and
+   i32.ne
+   if
+    i32.const 0
+    i32.const 1152
+    i32.const 109
+    i32.const 3
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $1
+   local.get $2
+   i32.const 1
+   i32.add
+   i32.store offset=4
+   local.get $1
+   call $~lib/rt/rtrace/onincrement
+   local.get $1
+   i32.load
+   i32.const 1
+   i32.and
+   if
+    i32.const 0
+    i32.const 1152
+    i32.const 112
+    i32.const 14
+    call $~lib/builtins/abort
+    unreachable
+   end
+  end
+  local.get $0
+ )
+ (func $~lib/rt/pure/__release (param $0 i32)
+  local.get $0
+  i32.const 1260
+  i32.gt_u
+  if
+   local.get $0
+   i32.const 16
+   i32.sub
+   call $~lib/rt/pure/decrement
+  end
+ )
+ (func $closure/testParam~inner (param $0 i32) (param $1 i32) (result i32)
+  local.get $0
+  i32.load offset=4
+ )
+ (func $closure/complexCreateClosure~anonymous|0 (param $0 i32) (param $1 i32) (result i32)
+  local.get $0
+  i32.load offset=4
+  local.get $0
+  i32.load offset=8
+  i32.add
+  local.get $0
+  i32.load offset=12
+  i32.sub
+ )
+ (func $closure/complexCreateClosure~anonymous|1 (param $0 i32) (param $1 i32) (result i32)
+  local.get $0
+  i32.load offset=12
+  local.get $0
+  i32.load offset=4
+  local.get $0
+  i32.load offset=8
+  i32.sub
+  i32.add
+ )
+ (func $closure/nestedExecutionTest~anonymous|0 (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  local.get $1
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $1
+  local.tee $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+   local.tee $1
+   local.get $0
+   i32.load offset=4
+   local.get $1
+   i32.load
+   call_indirect (type $i32_i32_=>_i32)
+  else
+   local.get $0
+   i32.load offset=4
+   local.get $2
+   call_indirect (type $i32_=>_i32)
+  end
+  drop
+  local.get $0
+  i32.load offset=8
+  local.get $2
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  call $~lib/rt/pure/__release
+ )
+ (func $closure/nestedExecutionTest
+  (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  i32.const 16
+  i32.const 0
+  call $~lib/rt/tlsf/__alloc
+  call $~lib/rt/pure/__retain
+  local.tee $2
+  i32.const 4
+  i32.store
+  i32.const 16
+  i32.const 0
+  call $~lib/rt/tlsf/__alloc
+  call $~lib/rt/pure/__retain
+  local.tee $0
+  i32.const 5
+  i32.store
+  local.get $0
+  i32.const 11
+  i32.store offset=4
+  local.get $0
+  i32.const 4
+  i32.store offset=8
+  local.get $0
+  i32.const 7
+  i32.store offset=12
+  local.get $0
+  i32.const 4
+  i32.shr_s
+  i32.const -2147483648
+  i32.or
+  local.tee $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $1
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  call $~lib/rt/pure/__release
+  local.get $0
+  call $~lib/rt/pure/__release
+  i32.const 12
+  i32.const 0
+  call $~lib/rt/tlsf/__alloc
+  call $~lib/rt/pure/__retain
+  local.tee $0
+  i32.const 6
+  i32.store
+  local.get $0
+  i32.const 1
+  i32.store offset=4
+  local.get $0
+  i32.const 7
+  i32.store offset=8
+  local.get $0
+  local.get $1
+  local.get $0
+  i32.load
+  call_indirect (type $i32_i32_=>_i32)
+  drop
+  local.get $0
+  call $~lib/rt/pure/__release
+  local.get $1
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  call $~lib/rt/pure/__release
+ )
+ (func $closure/createClosure~anonymous|0 (param $0 i32) (param $1 i32) (result i32)
+  local.get $1
+  local.get $0
+  i32.load offset=4
+  i32.add
+ )
+ (func $closure/createClosure (result i32)
+  (local $0 i32)
+  (local $1 i32)
+  i32.const 8
+  i32.const 0
+  call $~lib/rt/tlsf/__alloc
+  call $~lib/rt/pure/__retain
+  local.tee $0
+  i32.const 7
+  i32.store
+  local.get $0
+  i32.const 1
+  i32.store offset=4
+  local.get $0
+  i32.const 4
+  i32.shr_s
+  i32.const -2147483648
+  i32.or
+  local.tee $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $1
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $0
+  call $~lib/rt/pure/__release
+  local.get $1
+ )
+ (func $closure/runInline~anonymous|0 (param $0 i32) (result i32)
+  local.get $0
+  i32.load offset=12
+  local.get $0
+  i32.load offset=4
+  local.get $0
+  i32.load offset=8
+  i32.add
+  i32.add
+ )
+ (func $closure/returnOverBoundary~anonymous|0~nonClosure (result i32)
+  i32.const 6
+ )
+ (func $closure/returnOverBoundary (result i32)
+  i32.const 9
+ )
+ (func $start:closure
+  (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  i32.const 8
+  i32.const 0
+  call $~lib/rt/tlsf/__alloc
+  call $~lib/rt/pure/__retain
+  local.tee $0
+  i32.const 1
+  i32.store
+  local.get $0
+  i32.const 2
+  i32.store offset=4
+  local.get $0
+  i32.const 4
+  i32.shr_s
+  i32.const -2147483648
+  i32.or
+  local.tee $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $1
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $0
+  call $~lib/rt/pure/__release
+  local.get $1
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  call $~lib/rt/pure/__release
+  i32.const 8
+  i32.const 0
+  call $~lib/rt/tlsf/__alloc
+  call $~lib/rt/pure/__retain
+  local.tee $0
+  i32.const 2
+  i32.store
+  local.get $0
+  i32.const 0
+  i32.store offset=4
+  local.get $0
+  i32.const 4
+  i32.shr_s
+  i32.const -2147483648
+  i32.or
+  local.tee $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $1
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $0
+  call $~lib/rt/pure/__release
+  local.get $1
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  call $~lib/rt/pure/__release
+  i32.const 8
+  i32.const 0
+  call $~lib/rt/tlsf/__alloc
+  call $~lib/rt/pure/__retain
+  local.tee $0
+  i32.const 3
+  i32.store
+  local.get $0
+  i32.const 0
+  i32.store offset=4
+  local.get $0
+  i32.const 4
+  i32.shr_s
+  i32.const -2147483648
+  i32.or
+  local.tee $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $1
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $0
+  call $~lib/rt/pure/__release
+  local.get $1
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  call $~lib/rt/pure/__release
+  call $closure/nestedExecutionTest
+  call $closure/createClosure
+  local.tee $0
+  local.set $1
+  local.get $0
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $0
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  local.tee $2
+  select
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  if (result i32)
+   local.get $1
+   i32.const 4
+   i32.shl
+   local.tee $2
+   i32.const 1
+   local.get $2
+   i32.load
+   call_indirect (type $i32_i32_=>_i32)
+  else
+   i32.const 1
+   local.get $1
+   call_indirect (type $i32_=>_i32)
+  end
+  drop
+  local.get $1
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  call $~lib/rt/pure/__release
+  local.get $0
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $0
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  call $~lib/rt/pure/__release
+  i32.const 16
+  i32.const 0
+  call $~lib/rt/tlsf/__alloc
+  call $~lib/rt/pure/__retain
+  local.tee $0
+  i32.const 8
+  i32.store
+  local.get $0
+  i32.const 1
+  i32.store offset=4
+  local.get $0
+  i32.const 1
+  i32.store offset=8
+  local.get $0
+  i32.const 1
+  i32.store offset=12
+  local.get $0
+  i32.const 4
+  i32.shr_s
+  i32.const -2147483648
+  i32.or
+  local.tee $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $1
+   i32.const 4
+   i32.shl
+   local.tee $1
+   local.get $1
+   i32.load
+   call_indirect (type $i32_=>_i32)
+  else
+   local.get $1
+   call_indirect (type $none_=>_i32)
+  end
+  drop
+  local.get $0
+  call $~lib/rt/pure/__release
+  call $closure/createClosure
+  local.tee $0
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $0
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  i32.const 0
+  call $~lib/rt/pure/__release
+ )
+ (func $~start
+  call $start:closure
+ )
+ (func $~lib/rt/pure/__collect
+  nop
+ )
+ (func $~lib/rt/pure/decrement (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  local.get $0
+  i32.load offset=4
+  local.tee $2
+  i32.const 268435455
+  i32.and
+  local.set $1
+  local.get $0
+  call $~lib/rt/rtrace/ondecrement
+  local.get $0
+  i32.load
+  i32.const 1
+  i32.and
+  if
+   i32.const 0
+   i32.const 1152
+   i32.const 122
+   i32.const 14
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $1
+  i32.const 1
+  i32.eq
+  if
+   block $__inlined_func$~lib/rt/__visit_members
+    block $switch$1$default
+     block $switch$1$case$4
+      local.get $0
+      i32.const 8
+      i32.add
+      i32.load
+      br_table $__inlined_func$~lib/rt/__visit_members $__inlined_func$~lib/rt/__visit_members $switch$1$case$4 $switch$1$default
+     end
+     local.get $0
+     i32.load offset=16
+     local.tee $1
+     if
+      local.get $1
+      i32.const 1260
+      i32.ge_u
+      if
+       local.get $1
+       i32.const 16
+       i32.sub
+       call $~lib/rt/pure/decrement
+      end
+     end
+     br $__inlined_func$~lib/rt/__visit_members
+    end
+    unreachable
+   end
+   local.get $2
+   i32.const -2147483648
+   i32.and
+   if
+    i32.const 0
+    i32.const 1152
+    i32.const 126
+    i32.const 18
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $0
+   local.get $0
+   i32.load
+   i32.const 1
+   i32.or
+   i32.store
+   global.get $~lib/rt/tlsf/ROOT
+   local.get $0
+   call $~lib/rt/tlsf/insertBlock
+   local.get $0
+   call $~lib/rt/rtrace/onfree
+  else
+   local.get $1
+   i32.const 0
+   i32.le_u
+   if
+    i32.const 0
+    i32.const 1152
+    i32.const 136
+    i32.const 16
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $0
+   local.get $1
+   i32.const 1
+   i32.sub
+   local.get $2
+   i32.const -268435456
+   i32.and
+   i32.or
+   i32.store offset=4
+  end
+ )
+)

--- a/tests/compiler/closure.optimized.wat
+++ b/tests/compiler/closure.optimized.wat
@@ -886,7 +886,7 @@
   if
    i32.const 0
    i32.const 1040
-   i32.const 501
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -997,7 +997,7 @@
     if
      i32.const 0
      i32.const 1040
-     i32.const 513
+     i32.const 512
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -1013,7 +1013,7 @@
   if
    i32.const 0
    i32.const 1040
-   i32.const 521
+   i32.const 520
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/closure.ts
+++ b/tests/compiler/closure.ts
@@ -16,9 +16,60 @@ testVar();
 function testLet(): (value: i32) => i32 {
   let $local0 = 0;
   return function inner(value: i32) {
-    return $local0; // closure
+    return $local0;
   };
 }
 testLet();
 
-ERROR("EOF");
+function nestedExecutionTest(arg: i32): i32 {
+  var x = 7;
+  var f = complexCreateClosure(arg);
+  var g = (fn: (x3: i32) => i32): i32 => {
+    var first = fn(arg);
+    return x;
+  }
+  return g(f);
+}
+nestedExecutionTest(1);
+
+function passItAround(arg: i32): usize {
+  return runClosure(createClosure(arg));
+}
+passItAround(1)
+
+function runInline(arg: i32, foo: i32, bar: i32): i32 {
+  return ((): i32 => { return arg + foo + bar; } )();
+}
+runInline(1,1,1)
+
+function fallOutOfScope(arg: i32): i32 {
+  var releaseMe = createClosure(arg);
+  return 10;
+}
+fallOutOfScope(1)
+
+function createClosure(arg: i32): (x3: i32) => i32 {
+  var closure = (x3: i32): i32 => { return arg + x3 }
+  return closure;
+}
+
+function complexCreateClosure(arg: i32): (x3: i32) => i32 {
+  var foo = 2
+  var bar = 3
+  var baz = 4
+  var f = (x1: i32): i32 => { return foo + bar - baz; }
+  var g = (x2: i32): i32 => { return (bar - baz) + foo; }
+  foo = 7
+  bar = 11
+  return g;
+}
+
+function runClosure(closureToRun: (x3: i32) => i32): i32 {
+  return closureToRun(1);
+}
+
+// Ensure that non-closures do not abort upon returning
+export function returnOverBoundary(): () => i32 {
+  return function(): i32 { return 6; }
+}
+returnOverBoundary();

--- a/tests/compiler/closure.ts
+++ b/tests/compiler/closure.ts
@@ -27,7 +27,7 @@ function nestedExecutionTest(arg: i32): i32 {
   var g = (fn: (x3: i32) => i32): i32 => {
     var first = fn(arg);
     return x;
-  }
+  };
   return g(f);
 }
 nestedExecutionTest(1);
@@ -35,32 +35,32 @@ nestedExecutionTest(1);
 function passItAround(arg: i32): usize {
   return runClosure(createClosure(arg));
 }
-passItAround(1)
+passItAround(1);
 
 function runInline(arg: i32, foo: i32, bar: i32): i32 {
   return ((): i32 => { return arg + foo + bar; } )();
 }
-runInline(1,1,1)
+runInline(1,1,1);
 
 function fallOutOfScope(arg: i32): i32 {
   var releaseMe = createClosure(arg);
   return 10;
 }
-fallOutOfScope(1)
+fallOutOfScope(1);
 
 function createClosure(arg: i32): (x3: i32) => i32 {
-  var closure = (x3: i32): i32 => { return arg + x3 }
+  var closure = (x3: i32): i32 => { return arg + x3; };
   return closure;
 }
 
 function complexCreateClosure(arg: i32): (x3: i32) => i32 {
-  var foo = 2
-  var bar = 3
-  var baz = 4
-  var f = (x1: i32): i32 => { return foo + bar - baz; }
-  var g = (x2: i32): i32 => { return (bar - baz) + foo; }
-  foo = 7
-  bar = 11
+  var foo = 2;
+  var bar = 3;
+  var baz = 4;
+  var f = (x1: i32): i32 => { return foo + bar - baz; };
+  var g = (x2: i32): i32 => { return (bar - baz) + foo; };
+  foo = 7;
+  bar = 11;
   return g;
 }
 
@@ -70,6 +70,6 @@ function runClosure(closureToRun: (x3: i32) => i32): i32 {
 
 // Ensure that non-closures do not abort upon returning
 export function returnOverBoundary(): () => i32 {
-  return function(): i32 { return 6; }
+  return function(): i32 { return 6; };
 }
 returnOverBoundary();

--- a/tests/compiler/closure.untouched.wat
+++ b/tests/compiler/closure.untouched.wat
@@ -1,36 +1,41 @@
 (module
- (type $none_=>_i32 (func (result i32)))
- (type $i32_=>_i32 (func (param i32) (result i32)))
- (type $i32_i32_=>_none (func (param i32 i32)))
- (type $i32_=>_none (func (param i32)))
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
+ (type $i32_=>_i32 (func (param i32) (result i32)))
+ (type $i32_=>_none (func (param i32)))
+ (type $i32_i32_=>_none (func (param i32 i32)))
+ (type $none_=>_i32 (func (result i32)))
  (type $none_=>_none (func))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
+ (import "rtrace" "onalloc" (func $~lib/rt/rtrace/onalloc (param i32)))
+ (import "rtrace" "onincrement" (func $~lib/rt/rtrace/onincrement (param i32)))
+ (import "rtrace" "ondecrement" (func $~lib/rt/rtrace/ondecrement (param i32)))
+ (import "rtrace" "onfree" (func $~lib/rt/rtrace/onfree (param i32)))
  (memory $0 1)
  (data (i32.const 16) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s\00")
  (data (i32.const 64) "(\00\00\00\01\00\00\00\01\00\00\00(\00\00\00a\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e\00")
  (data (i32.const 128) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00p\00u\00r\00e\00.\00t\00s\00")
- (table $0 7 funcref)
- (elem (i32.const 1) $start:retain-return~anonymous|0~nonClosure $start:retain-return~anonymous|1~nonClosure $start:retain-return~anonymous|2~nonClosure $start:retain-return~anonymous|3~nonClosure $start:retain-return~anonymous|4~nonClosure $start:retain-return~anonymous|5~nonClosure)
+ (data (i32.const 176) "\14\00\00\00\01\00\00\00\01\00\00\00\14\00\00\00c\00l\00o\00s\00u\00r\00e\00.\00t\00s\00")
+ (data (i32.const 224) "\03\00\00\00 \00\00\00\00\00\00\00 \00\00\00\00\00\00\00 \00\00\00\00\00\00\00")
+ (table $0 10 funcref)
+ (elem (i32.const 1) $closure/testParam~inner $closure/testVar~inner $closure/testLet~inner $closure/complexCreateClosure~anonymous|0 $closure/complexCreateClosure~anonymous|1 $closure/nestedExecutionTest~anonymous|0 $closure/createClosure~anonymous|0 $closure/runInline~anonymous|0 $closure/returnOverBoundary~anonymous|0~nonClosure)
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
  (global $~lib/ASC_LOW_MEMORY_LIMIT i32 (i32.const 0))
  (global $~lib/rt/tlsf/collectLock (mut i32) (i32.const 0))
  (global $~lib/gc/gc.auto (mut i32) (i32.const 1))
- (global $retain-return/ref (mut i32) (i32.const 0))
- (global $retain-return/returnNewFnExpr (mut i32) (i32.const 1))
  (global $~argumentsLength (mut i32) (i32.const 0))
- (global $retain-return/returnLocalFnExpr (mut i32) (i32.const 2))
- (global $retain-return/returnGlobalFnExpr (mut i32) (i32.const 3))
- (global $retain-return/returnNewFnBlock (mut i32) (i32.const 4))
- (global $retain-return/returnLocalFnBlock (mut i32) (i32.const 5))
- (global $retain-return/returnGlobalFnBlock (mut i32) (i32.const 6))
- (global $~started (mut i32) (i32.const 0))
- (global $~lib/heap/__heap_base i32 (i32.const 176))
- (export "_start" (func $~start))
+ (global $~lib/rt/__rtti_base i32 (i32.const 224))
+ (global $~lib/heap/__heap_base i32 (i32.const 252))
  (export "memory" (memory $0))
+ (export "__alloc" (func $~lib/rt/tlsf/__alloc))
+ (export "__retain" (func $~lib/rt/pure/__retain))
+ (export "__release" (func $~lib/rt/pure/__release))
+ (export "__collect" (func $~lib/rt/pure/__collect))
+ (export "__rtti_base" (global $~lib/rt/__rtti_base))
+ (export "returnOverBoundary" (func $closure/returnOverBoundary))
+ (start $~start)
  (func $~lib/rt/tlsf/removeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -1335,7 +1340,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 500
+   i32.const 501
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1382,7 +1387,7 @@
      if
       i32.const 0
       i32.const 32
-      i32.const 512
+      i32.const 513
       i32.const 20
       call $~lib/builtins/abort
       unreachable
@@ -1403,7 +1408,7 @@
     if
      i32.const 0
      i32.const 32
-     i32.const 517
+     i32.const 518
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1424,7 +1429,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 520
+   i32.const 521
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1445,8 +1450,10 @@
   local.get $4
   local.get $3
   call $~lib/rt/tlsf/prepareBlock
-  i32.const 0
+  i32.const 1
   drop
+  local.get $4
+  call $~lib/rt/rtrace/onalloc
   local.get $4
  )
  (func $~lib/rt/tlsf/__alloc (param $0 i32) (param $1 i32) (result i32)
@@ -1489,8 +1496,10 @@
   i32.const 1
   i32.add
   i32.store offset=4
-  i32.const 0
+  i32.const 1
   drop
+  local.get $0
+  call $~lib/rt/rtrace/onincrement
   i32.const 1
   drop
   local.get $0
@@ -1520,22 +1529,6 @@
   end
   local.get $0
  )
- (func $retain-return/Ref#constructor (param $0 i32) (result i32)
-  local.get $0
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 3
-   call $~lib/rt/tlsf/__alloc
-   call $~lib/rt/pure/__retain
-   local.set $0
-  end
-  local.get $0
- )
- (func $retain-return/returnNew (result i32)
-  i32.const 0
-  call $retain-return/Ref#constructor
- )
  (func $~lib/rt/pure/__release (param $0 i32)
   local.get $0
   global.get $~lib/heap/__heap_base
@@ -1547,48 +1540,177 @@
    call $~lib/rt/pure/decrement
   end
  )
- (func $retain-return/returnLocal (result i32)
+ (func $closure/testParam~inner (param $0 i32) (param $1 i32) (result i32)
+  local.get $0
+  i32.load offset=4
+ )
+ (func $closure/testParam (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  i32.const 8
+  i32.const 0
+  call $~lib/rt/tlsf/__alloc
+  call $~lib/rt/pure/__retain
+  local.set $2
+  local.get $2
+  i32.const 1
+  i32.store
+  local.get $2
+  local.set $3
+  local.get $3
+  local.get $1
+  i32.store offset=4
+  local.get $3
+  i32.const 4
+  i32.shr_s
+  i32.const -2147483648
+  i32.or
+  local.set $4
+  local.get $4
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $4
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $4
+  local.set $5
+  local.get $2
+  call $~lib/rt/pure/__release
+  local.get $5
+ )
+ (func $closure/testVar~inner (param $0 i32) (param $1 i32) (result i32)
+  local.get $0
+  i32.load offset=4
+ )
+ (func $closure/testVar (result i32)
   (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
   i32.const 0
-  call $retain-return/Ref#constructor
   local.set $0
-  local.get $0
- )
- (func $retain-return/returnGlobal (result i32)
-  global.get $retain-return/ref
-  call $~lib/rt/pure/__retain
- )
- (func $start:retain-return~anonymous|0~nonClosure (result i32)
+  i32.const 8
   i32.const 0
-  call $retain-return/Ref#constructor
- )
- (func $start:retain-return~anonymous|1~nonClosure (param $0 i32) (result i32)
-  local.get $0
+  call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
-  local.set $0
+  local.set $1
+  local.get $1
+  i32.const 2
+  i32.store
+  local.get $1
+  local.set $2
+  local.get $2
   local.get $0
- )
- (func $start:retain-return~anonymous|2~nonClosure (result i32)
-  global.get $retain-return/ref
+  i32.store offset=4
+  local.get $2
+  i32.const 4
+  i32.shr_s
+  i32.const -2147483648
+  i32.or
+  local.set $3
+  local.get $3
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $3
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
   call $~lib/rt/pure/__retain
+  drop
+  local.get $3
+  local.set $4
+  local.get $1
+  call $~lib/rt/pure/__release
+  local.get $4
  )
- (func $start:retain-return~anonymous|3~nonClosure (result i32)
-  i32.const 0
-  call $retain-return/Ref#constructor
+ (func $closure/testLet~inner (param $0 i32) (param $1 i32) (result i32)
+  local.get $0
+  i32.load offset=4
  )
- (func $start:retain-return~anonymous|4~nonClosure (result i32)
+ (func $closure/testLet (result i32)
   (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
   i32.const 0
-  call $retain-return/Ref#constructor
   local.set $0
-  local.get $0
- )
- (func $start:retain-return~anonymous|5~nonClosure (result i32)
-  global.get $retain-return/ref
+  i32.const 8
+  i32.const 0
+  call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
+  local.set $1
+  local.get $1
+  i32.const 3
+  i32.store
+  local.get $1
+  local.set $2
+  local.get $2
+  local.get $0
+  i32.store offset=4
+  local.get $2
+  i32.const 4
+  i32.shr_s
+  i32.const -2147483648
+  i32.or
+  local.set $3
+  local.get $3
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $3
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $3
+  local.set $4
+  local.get $1
+  call $~lib/rt/pure/__release
+  local.get $4
  )
- (func $start:retain-return
-  (local $0 i32)
+ (func $closure/complexCreateClosure~anonymous|0 (param $0 i32) (param $1 i32) (result i32)
+  local.get $0
+  i32.load offset=4
+  local.get $0
+  i32.load offset=8
+  i32.add
+  local.get $0
+  i32.load offset=12
+  i32.sub
+ )
+ (func $closure/complexCreateClosure~anonymous|1 (param $0 i32) (param $1 i32) (result i32)
+  local.get $0
+  i32.load offset=4
+  local.get $0
+  i32.load offset=8
+  i32.sub
+  local.get $0
+  i32.load offset=12
+  i32.add
+ )
+ (func $closure/complexCreateClosure (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -1599,51 +1721,465 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
-  (local $11 i32)
-  (local $12 i32)
-  (local $13 i32)
-  call $retain-return/returnNew
-  call $~lib/rt/pure/__release
-  call $retain-return/returnNew
-  call $~lib/rt/pure/__release
-  call $retain-return/returnLocal
-  call $~lib/rt/pure/__release
-  call $retain-return/returnLocal
-  call $~lib/rt/pure/__release
+  i32.const 2
+  local.set $1
+  i32.const 3
+  local.set $2
+  i32.const 4
+  local.set $3
+  i32.const 16
   i32.const 0
-  call $retain-return/Ref#constructor
-  global.set $retain-return/ref
-  call $retain-return/returnGlobal
+  call $~lib/rt/tlsf/__alloc
+  call $~lib/rt/pure/__retain
+  local.set $4
+  local.get $4
+  i32.const 4
+  i32.store
+  local.get $4
+  local.set $5
+  i32.const 16
+  i32.const 0
+  call $~lib/rt/tlsf/__alloc
+  call $~lib/rt/pure/__retain
+  local.set $6
+  local.get $6
+  i32.const 5
+  i32.store
+  local.get $6
+  local.set $7
+  i32.const 7
+  local.set $1
+  i32.const 11
+  local.set $2
+  local.get $7
+  local.set $8
+  local.get $8
+  local.get $2
+  i32.store offset=4
+  local.get $8
+  local.get $3
+  i32.store offset=8
+  local.get $8
+  local.get $1
+  i32.store offset=12
+  local.get $8
+  i32.const 4
+  i32.shr_s
+  i32.const -2147483648
+  i32.or
+  local.set $9
+  local.get $9
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $9
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $9
+  local.set $10
+  local.get $4
   call $~lib/rt/pure/__release
-  call $retain-return/returnGlobal
+  local.get $6
   call $~lib/rt/pure/__release
-  global.get $retain-return/returnNewFnExpr
+  local.get $10
+ )
+ (func $closure/nestedExecutionTest~anonymous|0 (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  local.get $1
+  local.set $1
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $1
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $1
+  local.set $1
+  local.get $1
+  local.set $2
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+   local.get $0
+   i32.load offset=4
+   i32.const 1
+   global.set $~argumentsLength
+   local.get $2
+   i32.const 4
+   i32.shl
+   i32.load
+   call_indirect (type $i32_i32_=>_i32)
+  else
+   local.get $0
+   i32.load offset=4
+   i32.const 1
+   global.set $~argumentsLength
+   local.get $2
+   call_indirect (type $i32_=>_i32)
+  end
+  local.set $3
+  local.get $0
+  i32.load offset=8
+  local.set $5
+  local.get $1
+  local.set $4
+  local.get $4
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $4
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $5
+ )
+ (func $closure/nestedExecutionTest (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  i32.const 7
+  local.set $1
+  local.get $0
+  call $closure/complexCreateClosure
+  local.set $2
+  i32.const 12
+  i32.const 0
+  call $~lib/rt/tlsf/__alloc
+  call $~lib/rt/pure/__retain
+  local.set $3
+  local.get $3
+  i32.const 6
+  i32.store
+  local.get $3
+  local.set $4
+  local.get $4
+  local.get $0
+  i32.store offset=4
+  local.get $4
+  local.get $1
+  i32.store offset=8
+  local.get $4
+  local.get $2
+  i32.const 1
+  global.set $~argumentsLength
+  local.get $4
+  i32.load
+  call_indirect (type $i32_i32_=>_i32)
+  local.set $6
+  local.get $3
+  call $~lib/rt/pure/__release
+  local.get $2
+  local.set $5
+  local.get $5
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $5
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $6
+ )
+ (func $closure/createClosure~anonymous|0 (param $0 i32) (param $1 i32) (result i32)
+  local.get $0
+  i32.load offset=4
+  local.get $1
+  i32.add
+ )
+ (func $closure/createClosure (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  i32.const 8
+  i32.const 0
+  call $~lib/rt/tlsf/__alloc
+  call $~lib/rt/pure/__retain
+  local.set $1
+  local.get $1
+  i32.const 7
+  i32.store
+  local.get $1
+  local.set $2
+  local.get $2
+  local.set $3
+  local.get $3
+  local.get $0
+  i32.store offset=4
+  local.get $3
+  i32.const 4
+  i32.shr_s
+  i32.const -2147483648
+  i32.or
+  local.set $4
+  local.get $4
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $4
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $4
+  local.set $5
+  local.get $1
+  call $~lib/rt/pure/__release
+  local.get $5
+ )
+ (func $closure/runClosure (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  local.get $0
+  local.set $1
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $1
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $1
+  local.set $0
+  local.get $0
+  local.set $2
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+   i32.const 1
+   i32.const 1
+   global.set $~argumentsLength
+   local.get $2
+   i32.const 4
+   i32.shl
+   i32.load
+   call_indirect (type $i32_i32_=>_i32)
+  else
+   i32.const 1
+   i32.const 1
+   global.set $~argumentsLength
+   local.get $2
+   call_indirect (type $i32_=>_i32)
+  end
+  local.set $4
+  local.get $0
+  local.set $3
+  local.get $3
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $3
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $4
+ )
+ (func $closure/passItAround (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  local.get $0
+  call $closure/createClosure
+  local.tee $1
+  call $closure/runClosure
+  local.set $3
+  local.get $1
+  local.set $2
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $3
+ )
+ (func $closure/runInline~anonymous|0 (param $0 i32) (result i32)
+  local.get $0
+  i32.load offset=4
+  local.get $0
+  i32.load offset=8
+  i32.add
+  local.get $0
+  i32.load offset=12
+  i32.add
+ )
+ (func $closure/runInline (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  i32.const 16
+  i32.const 0
+  call $~lib/rt/tlsf/__alloc
+  call $~lib/rt/pure/__retain
+  local.set $3
+  local.get $3
+  i32.const 8
+  i32.store
+  local.get $3
+  local.set $4
+  local.get $4
+  local.get $0
+  i32.store offset=4
+  local.get $4
+  local.get $1
+  i32.store offset=8
+  local.get $4
+  local.get $2
+  i32.store offset=12
+  local.get $4
+  i32.const 4
+  i32.shr_s
+  i32.const -2147483648
+  i32.or
+  local.set $5
+  local.get $5
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $5
+   i32.const 4
+   i32.shl
+   i32.const 0
+   global.set $~argumentsLength
+   local.get $5
+   i32.const 4
+   i32.shl
+   i32.load
+   call_indirect (type $i32_=>_i32)
+  else
+   i32.const 0
+   global.set $~argumentsLength
+   local.get $5
+   call_indirect (type $none_=>_i32)
+  end
+  local.set $6
+  local.get $3
+  call $~lib/rt/pure/__release
+  local.get $6
+ )
+ (func $closure/fallOutOfScope (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  local.get $0
+  call $closure/createClosure
+  local.set $1
+  i32.const 10
+  local.set $3
+  local.get $1
+  local.set $2
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $3
+ )
+ (func $closure/returnOverBoundary~anonymous|0~nonClosure (result i32)
+  i32.const 6
+ )
+ (func $closure/returnOverBoundary (result i32)
+  (local $0 i32)
+  (local $1 i32)
+  i32.const 9
   local.set $0
   local.get $0
   i32.const -2147483648
   i32.and
   i32.const -2147483648
   i32.eq
-  if
+  if (result i32)
    local.get $0
    i32.const 4
    i32.shl
-   i32.const 0
-   global.set $~argumentsLength
-   local.get $0
-   i32.const 4
-   i32.shl
-   i32.load
-   call_indirect (type $i32_=>_i32)
-   call $~lib/rt/pure/__release
   else
    i32.const 0
-   global.set $~argumentsLength
-   local.get $0
-   call_indirect (type $none_=>_i32)
-   call $~lib/rt/pure/__release
   end
-  global.get $retain-return/returnNewFnExpr
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $0
   local.set $1
   local.get $1
   i32.const -2147483648
@@ -1651,312 +2187,101 @@
   i32.const -2147483648
   i32.eq
   if
-   local.get $1
-   i32.const 4
-   i32.shl
    i32.const 0
-   global.set $~argumentsLength
-   local.get $1
+   i32.const 192
+   i32.const 73
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  else
+   nop
+  end
+  local.get $1
+ )
+ (func $start:closure
+  (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  i32.const 1
+  i32.const 2
+  call $closure/testParam
+  local.set $0
+  local.get $0
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $0
    i32.const 4
    i32.shl
-   i32.load
-   call_indirect (type $i32_=>_i32)
-   call $~lib/rt/pure/__release
   else
    i32.const 0
-   global.set $~argumentsLength
-   local.get $1
-   call_indirect (type $none_=>_i32)
-   call $~lib/rt/pure/__release
   end
-  global.get $retain-return/returnLocalFnExpr
+  call $~lib/rt/pure/__release
+  call $closure/testVar
+  local.set $1
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $1
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  call $closure/testLet
   local.set $2
   local.get $2
   i32.const -2147483648
   i32.and
   i32.const -2147483648
   i32.eq
-  if
+  if (result i32)
    local.get $2
    i32.const 4
    i32.shl
-   global.get $retain-return/ref
-   i32.const 1
-   global.set $~argumentsLength
-   local.get $2
-   i32.const 4
-   i32.shl
-   i32.load
-   call_indirect (type $i32_i32_=>_i32)
-   call $~lib/rt/pure/__release
   else
-   global.get $retain-return/ref
-   i32.const 1
-   global.set $~argumentsLength
-   local.get $2
-   call_indirect (type $i32_=>_i32)
-   call $~lib/rt/pure/__release
+   i32.const 0
   end
-  global.get $retain-return/returnLocalFnExpr
+  call $~lib/rt/pure/__release
+  i32.const 1
+  call $closure/nestedExecutionTest
+  drop
+  i32.const 1
+  call $closure/passItAround
+  drop
+  i32.const 1
+  i32.const 1
+  i32.const 1
+  call $closure/runInline
+  drop
+  i32.const 1
+  call $closure/fallOutOfScope
+  drop
+  call $closure/returnOverBoundary
   local.set $3
   local.get $3
   i32.const -2147483648
   i32.and
   i32.const -2147483648
   i32.eq
-  if
+  if (result i32)
    local.get $3
    i32.const 4
    i32.shl
-   global.get $retain-return/ref
-   i32.const 1
-   global.set $~argumentsLength
-   local.get $3
-   i32.const 4
-   i32.shl
-   i32.load
-   call_indirect (type $i32_i32_=>_i32)
-   call $~lib/rt/pure/__release
-  else
-   global.get $retain-return/ref
-   i32.const 1
-   global.set $~argumentsLength
-   local.get $3
-   call_indirect (type $i32_=>_i32)
-   call $~lib/rt/pure/__release
-  end
-  global.get $retain-return/returnGlobalFnExpr
-  local.set $4
-  local.get $4
-  i32.const -2147483648
-  i32.and
-  i32.const -2147483648
-  i32.eq
-  if
-   local.get $4
-   i32.const 4
-   i32.shl
-   i32.const 0
-   global.set $~argumentsLength
-   local.get $4
-   i32.const 4
-   i32.shl
-   i32.load
-   call_indirect (type $i32_=>_i32)
-   call $~lib/rt/pure/__release
   else
    i32.const 0
-   global.set $~argumentsLength
-   local.get $4
-   call_indirect (type $none_=>_i32)
-   call $~lib/rt/pure/__release
   end
-  global.get $retain-return/returnGlobalFnExpr
-  local.set $5
-  local.get $5
-  i32.const -2147483648
-  i32.and
-  i32.const -2147483648
-  i32.eq
-  if
-   local.get $5
-   i32.const 4
-   i32.shl
-   i32.const 0
-   global.set $~argumentsLength
-   local.get $5
-   i32.const 4
-   i32.shl
-   i32.load
-   call_indirect (type $i32_=>_i32)
-   call $~lib/rt/pure/__release
-  else
-   i32.const 0
-   global.set $~argumentsLength
-   local.get $5
-   call_indirect (type $none_=>_i32)
-   call $~lib/rt/pure/__release
-  end
-  global.get $retain-return/returnNewFnBlock
-  local.set $6
-  local.get $6
-  i32.const -2147483648
-  i32.and
-  i32.const -2147483648
-  i32.eq
-  if
-   local.get $6
-   i32.const 4
-   i32.shl
-   i32.const 0
-   global.set $~argumentsLength
-   local.get $6
-   i32.const 4
-   i32.shl
-   i32.load
-   call_indirect (type $i32_=>_i32)
-   call $~lib/rt/pure/__release
-  else
-   i32.const 0
-   global.set $~argumentsLength
-   local.get $6
-   call_indirect (type $none_=>_i32)
-   call $~lib/rt/pure/__release
-  end
-  global.get $retain-return/returnNewFnBlock
-  local.set $7
-  local.get $7
-  i32.const -2147483648
-  i32.and
-  i32.const -2147483648
-  i32.eq
-  if
-   local.get $7
-   i32.const 4
-   i32.shl
-   i32.const 0
-   global.set $~argumentsLength
-   local.get $7
-   i32.const 4
-   i32.shl
-   i32.load
-   call_indirect (type $i32_=>_i32)
-   call $~lib/rt/pure/__release
-  else
-   i32.const 0
-   global.set $~argumentsLength
-   local.get $7
-   call_indirect (type $none_=>_i32)
-   call $~lib/rt/pure/__release
-  end
-  global.get $retain-return/returnLocalFnBlock
-  local.set $8
-  local.get $8
-  i32.const -2147483648
-  i32.and
-  i32.const -2147483648
-  i32.eq
-  if
-   local.get $8
-   i32.const 4
-   i32.shl
-   i32.const 0
-   global.set $~argumentsLength
-   local.get $8
-   i32.const 4
-   i32.shl
-   i32.load
-   call_indirect (type $i32_=>_i32)
-   call $~lib/rt/pure/__release
-  else
-   i32.const 0
-   global.set $~argumentsLength
-   local.get $8
-   call_indirect (type $none_=>_i32)
-   call $~lib/rt/pure/__release
-  end
-  global.get $retain-return/returnLocalFnBlock
-  local.set $9
-  local.get $9
-  i32.const -2147483648
-  i32.and
-  i32.const -2147483648
-  i32.eq
-  if
-   local.get $9
-   i32.const 4
-   i32.shl
-   i32.const 0
-   global.set $~argumentsLength
-   local.get $9
-   i32.const 4
-   i32.shl
-   i32.load
-   call_indirect (type $i32_=>_i32)
-   call $~lib/rt/pure/__release
-  else
-   i32.const 0
-   global.set $~argumentsLength
-   local.get $9
-   call_indirect (type $none_=>_i32)
-   call $~lib/rt/pure/__release
-  end
-  global.get $retain-return/returnGlobalFnBlock
-  local.set $10
-  local.get $10
-  i32.const -2147483648
-  i32.and
-  i32.const -2147483648
-  i32.eq
-  if
-   local.get $10
-   i32.const 4
-   i32.shl
-   i32.const 0
-   global.set $~argumentsLength
-   local.get $10
-   i32.const 4
-   i32.shl
-   i32.load
-   call_indirect (type $i32_=>_i32)
-   call $~lib/rt/pure/__release
-  else
-   i32.const 0
-   global.set $~argumentsLength
-   local.get $10
-   call_indirect (type $none_=>_i32)
-   call $~lib/rt/pure/__release
-  end
-  global.get $retain-return/returnGlobalFnBlock
-  local.set $11
-  local.get $11
-  i32.const -2147483648
-  i32.and
-  i32.const -2147483648
-  i32.eq
-  if
-   local.get $11
-   i32.const 4
-   i32.shl
-   i32.const 0
-   global.set $~argumentsLength
-   local.get $11
-   i32.const 4
-   i32.shl
-   i32.load
-   call_indirect (type $i32_=>_i32)
-   call $~lib/rt/pure/__release
-  else
-   i32.const 0
-   global.set $~argumentsLength
-   local.get $11
-   call_indirect (type $none_=>_i32)
-   call $~lib/rt/pure/__release
-  end
-  i32.const 0
-  local.tee $12
-  global.get $retain-return/ref
-  local.tee $13
-  i32.ne
-  if
-   local.get $12
-   call $~lib/rt/pure/__retain
-   local.set $12
-   local.get $13
-   call $~lib/rt/pure/__release
-  end
-  local.get $12
-  global.set $retain-return/ref
+  call $~lib/rt/pure/__release
  )
  (func $~start
-  global.get $~started
-  if
-   return
-  else
-   i32.const 1
-   global.set $~started
-  end
-  call $start:retain-return
+  call $start:closure
  )
  (func $~lib/rt/pure/__collect
   i32.const 1
@@ -1976,8 +2301,10 @@
   local.get $0
   local.get $1
   call $~lib/rt/tlsf/insertBlock
-  i32.const 0
+  i32.const 1
   drop
+  local.get $1
+  call $~lib/rt/rtrace/onfree
  )
  (func $~lib/rt/pure/finalize (param $0 i32)
   i32.const 0
@@ -1996,8 +2323,10 @@
   i32.const 268435455
   i32.and
   local.set $2
-  i32.const 0
+  i32.const 1
   drop
+  local.get $0
+  call $~lib/rt/rtrace/ondecrement
   i32.const 1
   drop
   local.get $0
@@ -2109,7 +2438,7 @@
      i32.const 8
      i32.sub
      i32.load
-     br_table $switch$1$case$2 $switch$1$case$2 $switch$1$case$4 $switch$1$case$2 $switch$1$default
+     br_table $switch$1$case$2 $switch$1$case$2 $switch$1$case$4 $switch$1$default
     end
     return
    end

--- a/tests/compiler/closure.untouched.wat
+++ b/tests/compiler/closure.untouched.wat
@@ -1340,7 +1340,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 501
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1387,7 +1387,7 @@
      if
       i32.const 0
       i32.const 32
-      i32.const 513
+      i32.const 512
       i32.const 20
       call $~lib/builtins/abort
       unreachable
@@ -1408,7 +1408,7 @@
     if
      i32.const 0
      i32.const 32
-     i32.const 518
+     i32.const 517
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1429,7 +1429,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 521
+   i32.const 520
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/exportimport-table.optimized.wat
+++ b/tests/compiler/exportimport-table.optimized.wat
@@ -1,11 +1,11 @@
 (module
  (type $none_=>_none (func))
  (import "env" "table" (table $0 2 funcref))
- (elem (i32.const 1) $start:exportimport-table~anonymous|0)
+ (elem (i32.const 1) $start:exportimport-table~anonymous|0~nonClosure)
  (memory $0 0)
  (export "memory" (memory $0))
  (export "table" (table $0))
- (func $start:exportimport-table~anonymous|0
+ (func $start:exportimport-table~anonymous|0~nonClosure
   nop
  )
 )

--- a/tests/compiler/exportimport-table.untouched.wat
+++ b/tests/compiler/exportimport-table.untouched.wat
@@ -1,13 +1,13 @@
 (module
  (type $none_=>_none (func))
  (import "env" "table" (table $0 2 funcref))
- (elem (i32.const 1) $start:exportimport-table~anonymous|0)
+ (elem (i32.const 1) $start:exportimport-table~anonymous|0~nonClosure)
  (memory $0 0)
  (global $exportimport-table/f (mut i32) (i32.const 1))
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $~start)
- (func $start:exportimport-table~anonymous|0
+ (func $start:exportimport-table~anonymous|0~nonClosure
   nop
  )
  (func $start:exportimport-table

--- a/tests/compiler/extends-recursive.untouched.wat
+++ b/tests/compiler/extends-recursive.untouched.wat
@@ -159,6 +159,7 @@
   local.get $0
  )
  (func $extends-recursive/Parent#get:child (param $0 i32) (result i32)
+  (local $1 i32)
   local.get $0
   i32.load
   call $~lib/rt/stub/__retain

--- a/tests/compiler/function-expression.optimized.wat
+++ b/tests/compiler/function-expression.optimized.wat
@@ -1,5 +1,99 @@
 (module
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
+ (type $none_=>_none (func))
+ (type $i32_=>_i32 (func (param i32) (result i32)))
+ (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
+ (type $none_=>_i32 (func (result i32)))
+ (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
+ (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 1024) ",\00\00\00\01\00\00\00\01\00\00\00,\00\00\00f\00u\00n\00c\00t\00i\00o\00n\00-\00e\00x\00p\00r\00e\00s\00s\00i\00o\00n\00.\00t\00s")
+ (table $0 12 funcref)
+ (elem (i32.const 1) $start:function-expression~anonymous|0~nonClosure $start:function-expression~anonymous|0~nonClosure $start:function-expression~someName~nonClosure $start:function-expression~anonymous|2~nonClosure $start:function-expression~anonymous|3~nonClosure $start:function-expression~anonymous|4~nonClosure $start:function-expression~anonymous|5~nonClosure $start:function-expression~anonymous|3~nonClosure $start:function-expression~anonymous|4~nonClosure $start:function-expression~anonymous|5~nonClosure $start:function-expression~anonymous|2~nonClosure)
  (export "memory" (memory $0))
+ (start $~start)
+ (func $start:function-expression~anonymous|0~nonClosure (param $0 i32) (result i32)
+  local.get $0
+ )
+ (func $start:function-expression~someName~nonClosure
+  nop
+ )
+ (func $start:function-expression~anonymous|2~nonClosure (result i32)
+  i32.const 1
+ )
+ (func $start:function-expression~anonymous|3~nonClosure (param $0 i32) (param $1 i32) (result i32)
+  local.get $0
+  local.get $1
+  i32.add
+ )
+ (func $function-expression/testOmitted (param $0 i32) (result i32)
+  (local $1 i32)
+  local.get $0
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $0
+   i32.const 4
+   i32.shl
+   local.tee $0
+   i32.load
+   local.set $1
+   local.get $0
+   i32.const 1
+   i32.const 2
+   local.get $1
+   call_indirect (type $i32_i32_i32_=>_i32)
+  else
+   i32.const 1
+   i32.const 2
+   local.get $0
+   call_indirect (type $i32_i32_=>_i32)
+  end
+ )
+ (func $start:function-expression~anonymous|4~nonClosure (param $0 i32) (param $1 i32) (result i32)
+  local.get $0
+ )
+ (func $start:function-expression~anonymous|5~nonClosure (param $0 i32) (param $1 i32) (result i32)
+  i32.const 42
+ )
+ (func $~start
+  i32.const 5
+  call $function-expression/testOmitted
+  i32.const 3
+  i32.ne
+  if
+   i32.const 0
+   i32.const 1040
+   i32.const 21
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 6
+  call $function-expression/testOmitted
+  i32.const 1
+  i32.ne
+  if
+   i32.const 0
+   i32.const 1040
+   i32.const 22
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 7
+  call $function-expression/testOmitted
+  i32.const 42
+  i32.ne
+  if
+   i32.const 0
+   i32.const 1040
+   i32.const 23
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+ )
 )

--- a/tests/compiler/function-expression.untouched.wat
+++ b/tests/compiler/function-expression.untouched.wat
@@ -1,14 +1,16 @@
 (module
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
- (type $none_=>_i32 (func (result i32)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
+ (type $none_=>_i32 (func (result i32)))
  (type $none_=>_none (func))
+ (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
+ (type $i32_=>_none (func (param i32)))
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 16) ",\00\00\00\01\00\00\00\01\00\00\00,\00\00\00f\00u\00n\00c\00t\00i\00o\00n\00-\00e\00x\00p\00r\00e\00s\00s\00i\00o\00n\00.\00t\00s\00")
  (table $0 12 funcref)
- (elem (i32.const 1) $start:function-expression~anonymous|0 $start:function-expression~anonymous|1 $start:function-expression~someName $start:function-expression~anonymous|2 $start:function-expression~anonymous|3 $start:function-expression~anonymous|4 $start:function-expression~anonymous|5 $function-expression/testOmittedReturn1~anonymous|0 $function-expression/testOmittedReturn2~anonymous|0 $function-expression/testOmittedReturn3~anonymous|0 $function-expression/testNullable~anonymous|0)
+ (elem (i32.const 1) $start:function-expression~anonymous|0~nonClosure $start:function-expression~anonymous|1~nonClosure $start:function-expression~someName~nonClosure $start:function-expression~anonymous|2~nonClosure $start:function-expression~anonymous|3~nonClosure $start:function-expression~anonymous|4~nonClosure $start:function-expression~anonymous|5~nonClosure $function-expression/testOmittedReturn1~anonymous|0~nonClosure $function-expression/testOmittedReturn2~anonymous|0~nonClosure $function-expression/testOmittedReturn3~anonymous|0~nonClosure $function-expression/testNullable~anonymous|0~nonClosure)
  (global $function-expression/f1 (mut i32) (i32.const 1))
  (global $~argumentsLength (mut i32) (i32.const 0))
  (global $function-expression/f2 (mut i32) (i32.const 2))
@@ -16,77 +18,265 @@
  (global $function-expression/f4 (mut i32) (i32.const 4))
  (export "memory" (memory $0))
  (start $~start)
- (func $start:function-expression~anonymous|0 (param $0 i32) (result i32)
+ (func $start:function-expression~anonymous|0~nonClosure (param $0 i32) (result i32)
   local.get $0
  )
- (func $start:function-expression~anonymous|1 (param $0 i32) (result i32)
+ (func $start:function-expression~anonymous|1~nonClosure (param $0 i32) (result i32)
   local.get $0
  )
- (func $start:function-expression~someName
+ (func $start:function-expression~someName~nonClosure
   nop
  )
- (func $start:function-expression~anonymous|2 (result i32)
+ (func $start:function-expression~anonymous|2~nonClosure (result i32)
   i32.const 1
  )
- (func $start:function-expression~anonymous|3 (param $0 i32) (param $1 i32) (result i32)
+ (func $start:function-expression~anonymous|3~nonClosure (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.add
  )
+ (func $~lib/rt/stub/__retain (param $0 i32) (result i32)
+  local.get $0
+ )
+ (func $~lib/rt/stub/__release (param $0 i32)
+  nop
+ )
  (func $function-expression/testOmitted (param $0 i32) (result i32)
-  i32.const 1
-  i32.const 2
-  i32.const 2
-  global.set $~argumentsLength
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
   local.get $0
-  call_indirect (type $i32_i32_=>_i32)
+  local.set $1
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $1
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/stub/__retain
+  drop
+  local.get $1
+  local.set $0
+  local.get $0
+  local.set $2
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+   i32.const 1
+   i32.const 2
+   i32.const 2
+   global.set $~argumentsLength
+   local.get $2
+   i32.const 4
+   i32.shl
+   i32.load
+   call_indirect (type $i32_i32_i32_=>_i32)
+  else
+   i32.const 1
+   i32.const 2
+   i32.const 2
+   global.set $~argumentsLength
+   local.get $2
+   call_indirect (type $i32_i32_=>_i32)
+  end
+  local.set $4
+  local.get $0
+  local.set $3
+  local.get $3
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $3
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/stub/__release
+  local.get $4
  )
- (func $start:function-expression~anonymous|4 (param $0 i32) (param $1 i32) (result i32)
+ (func $start:function-expression~anonymous|4~nonClosure (param $0 i32) (param $1 i32) (result i32)
   local.get $0
  )
- (func $start:function-expression~anonymous|5 (param $0 i32) (param $1 i32) (result i32)
+ (func $start:function-expression~anonymous|5~nonClosure (param $0 i32) (param $1 i32) (result i32)
   i32.const 42
  )
- (func $function-expression/testOmittedReturn1~anonymous|0 (param $0 i32) (param $1 i32) (result i32)
+ (func $function-expression/testOmittedReturn1~anonymous|0~nonClosure (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.add
  )
  (func $function-expression/testOmittedReturn1 (result i32)
+  (local $0 i32)
   i32.const 8
+  local.set $0
+  local.get $0
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $0
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/stub/__retain
+  drop
+  local.get $0
  )
- (func $function-expression/testOmittedReturn2~anonymous|0 (param $0 i32) (param $1 i32) (result i32)
+ (func $function-expression/testOmittedReturn2~anonymous|0~nonClosure (param $0 i32) (param $1 i32) (result i32)
   local.get $0
  )
  (func $function-expression/testOmittedReturn2 (result i32)
+  (local $0 i32)
   i32.const 9
+  local.set $0
+  local.get $0
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $0
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/stub/__retain
+  drop
+  local.get $0
  )
- (func $function-expression/testOmittedReturn3~anonymous|0 (param $0 i32) (param $1 i32) (result i32)
+ (func $function-expression/testOmittedReturn3~anonymous|0~nonClosure (param $0 i32) (param $1 i32) (result i32)
   i32.const 42
  )
  (func $function-expression/testOmittedReturn3 (result i32)
+  (local $0 i32)
   i32.const 10
+  local.set $0
+  local.get $0
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $0
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/stub/__retain
+  drop
+  local.get $0
  )
- (func $function-expression/testNullable~anonymous|0 (result i32)
+ (func $function-expression/testNullable~anonymous|0~nonClosure (result i32)
   i32.const 1
  )
  (func $function-expression/testNullable (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
   local.get $0
   if
    i32.const 11
+   local.set $1
+   local.get $1
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $1
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
+   call $~lib/rt/stub/__retain
+   drop
+   local.get $1
    return
   else
    i32.const 0
+   local.set $2
+   local.get $2
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $2
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
+   call $~lib/rt/stub/__retain
+   drop
+   local.get $2
    return
   end
   unreachable
  )
  (func $start:function-expression
-  i32.const 1
-  i32.const 1
-  global.set $~argumentsLength
+  (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
   global.get $function-expression/f1
-  call_indirect (type $i32_=>_i32)
+  local.set $0
+  local.get $0
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $0
+   i32.const 4
+   i32.shl
+   i32.const 1
+   i32.const 1
+   global.set $~argumentsLength
+   local.get $0
+   i32.const 4
+   i32.shl
+   i32.load
+   call_indirect (type $i32_i32_=>_i32)
+  else
+   i32.const 1
+   i32.const 1
+   global.set $~argumentsLength
+   local.get $0
+   call_indirect (type $i32_=>_i32)
+  end
   i32.const 1
   i32.eq
   i32.eqz
@@ -98,11 +288,32 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 2
-  i32.const 1
-  global.set $~argumentsLength
   global.get $function-expression/f2
-  call_indirect (type $i32_=>_i32)
+  local.set $1
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $1
+   i32.const 4
+   i32.shl
+   i32.const 2
+   i32.const 1
+   global.set $~argumentsLength
+   local.get $1
+   i32.const 4
+   i32.shl
+   i32.load
+   call_indirect (type $i32_i32_=>_i32)
+  else
+   i32.const 2
+   i32.const 1
+   global.set $~argumentsLength
+   local.get $1
+   call_indirect (type $i32_=>_i32)
+  end
   i32.const 2
   i32.eq
   i32.eqz
@@ -114,14 +325,54 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 0
-  global.set $~argumentsLength
   global.get $function-expression/f3
-  call_indirect (type $none_=>_none)
-  i32.const 0
-  global.set $~argumentsLength
+  local.set $2
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if
+   local.get $2
+   i32.const 4
+   i32.shl
+   i32.const 0
+   global.set $~argumentsLength
+   local.get $2
+   i32.const 4
+   i32.shl
+   i32.load
+   call_indirect (type $i32_=>_none)
+  else
+   i32.const 0
+   global.set $~argumentsLength
+   local.get $2
+   call_indirect (type $none_=>_none)
+  end
   global.get $function-expression/f4
-  call_indirect (type $none_=>_i32)
+  local.set $3
+  local.get $3
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $3
+   i32.const 4
+   i32.shl
+   i32.const 0
+   global.set $~argumentsLength
+   local.get $3
+   i32.const 4
+   i32.shl
+   i32.load
+   call_indirect (type $i32_=>_i32)
+  else
+   i32.const 0
+   global.set $~argumentsLength
+   local.get $3
+   call_indirect (type $none_=>_i32)
+  end
   i32.const 1
   i32.eq
   i32.eqz
@@ -172,12 +423,35 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1
-  i32.const 2
-  i32.const 2
-  global.set $~argumentsLength
   call $function-expression/testOmittedReturn1
-  call_indirect (type $i32_i32_=>_i32)
+  local.tee $4
+  local.set $5
+  local.get $5
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $5
+   i32.const 4
+   i32.shl
+   i32.const 1
+   i32.const 2
+   i32.const 2
+   global.set $~argumentsLength
+   local.get $5
+   i32.const 4
+   i32.shl
+   i32.load
+   call_indirect (type $i32_i32_i32_=>_i32)
+  else
+   i32.const 1
+   i32.const 2
+   i32.const 2
+   global.set $~argumentsLength
+   local.get $5
+   call_indirect (type $i32_i32_=>_i32)
+  end
   i32.const 3
   i32.eq
   i32.eqz
@@ -189,12 +463,35 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1
-  i32.const 2
-  i32.const 2
-  global.set $~argumentsLength
   call $function-expression/testOmittedReturn2
-  call_indirect (type $i32_i32_=>_i32)
+  local.tee $6
+  local.set $7
+  local.get $7
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $7
+   i32.const 4
+   i32.shl
+   i32.const 1
+   i32.const 2
+   i32.const 2
+   global.set $~argumentsLength
+   local.get $7
+   i32.const 4
+   i32.shl
+   i32.load
+   call_indirect (type $i32_i32_i32_=>_i32)
+  else
+   i32.const 1
+   i32.const 2
+   i32.const 2
+   global.set $~argumentsLength
+   local.get $7
+   call_indirect (type $i32_i32_=>_i32)
+  end
   i32.const 1
   i32.eq
   i32.eqz
@@ -206,12 +503,35 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1
-  i32.const 2
-  i32.const 2
-  global.set $~argumentsLength
   call $function-expression/testOmittedReturn3
-  call_indirect (type $i32_i32_=>_i32)
+  local.tee $8
+  local.set $9
+  local.get $9
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $9
+   i32.const 4
+   i32.shl
+   i32.const 1
+   i32.const 2
+   i32.const 2
+   global.set $~argumentsLength
+   local.get $9
+   i32.const 4
+   i32.shl
+   i32.load
+   call_indirect (type $i32_i32_i32_=>_i32)
+  else
+   i32.const 1
+   i32.const 2
+   i32.const 2
+   global.set $~argumentsLength
+   local.get $9
+   call_indirect (type $i32_i32_=>_i32)
+  end
   i32.const 42
   i32.eq
   i32.eqz
@@ -225,6 +545,7 @@
   end
   i32.const 0
   call $function-expression/testNullable
+  local.tee $10
   i32.const 0
   i32.eq
   i32.eqz
@@ -236,6 +557,66 @@
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $4
+  local.set $11
+  local.get $11
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $11
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/stub/__release
+  local.get $6
+  local.set $12
+  local.get $12
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $12
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/stub/__release
+  local.get $8
+  local.set $13
+  local.get $13
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $13
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/stub/__release
+  local.get $10
+  local.set $14
+  local.get $14
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $14
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/stub/__release
  )
  (func $~start
   call $start:function-expression

--- a/tests/compiler/function-types.optimized.wat
+++ b/tests/compiler/function-types.optimized.wat
@@ -1,5 +1,114 @@
 (module
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
+ (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
+ (type $none_=>_none (func))
+ (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
+ (type $i64_i64_=>_i64 (func (param i64 i64) (result i64)))
+ (type $f64_f64_=>_f64 (func (param f64 f64) (result f64)))
+ (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 1024) "\"\00\00\00\01\00\00\00\01\00\00\00\"\00\00\00f\00u\00n\00c\00t\00i\00o\00n\00-\00t\00y\00p\00e\00s\00.\00t\00s")
+ (table $0 5 funcref)
+ (elem (i32.const 1) $function-types/makeAdder<i32>~anonymous|0~nonClosure $function-types/makeAdder<i64>~anonymous|0~nonClosure $function-types/makeAdder<f64>~anonymous|0~nonClosure $function-types/makeAdder<i32>~anonymous|0~nonClosure)
  (export "memory" (memory $0))
+ (start $~start)
+ (func $function-types/makeAdder<i32>~anonymous|0~nonClosure (param $0 i32) (param $1 i32) (result i32)
+  local.get $0
+  local.get $1
+  i32.add
+ )
+ (func $function-types/makeAdder<i64>~anonymous|0~nonClosure (param $0 i64) (param $1 i64) (result i64)
+  local.get $0
+  local.get $1
+  i64.add
+ )
+ (func $function-types/makeAdder<f64>~anonymous|0~nonClosure (param $0 f64) (param $1 f64) (result f64)
+  local.get $0
+  local.get $1
+  f64.add
+ )
+ (func $function-types/doAddWithFn<i32> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (local $3 i32)
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+   local.tee $2
+   i32.load
+   local.set $3
+   local.get $2
+   local.get $0
+   local.get $1
+   local.get $3
+   call_indirect (type $i32_i32_i32_=>_i32)
+  else
+   local.get $0
+   local.get $1
+   local.get $2
+   call_indirect (type $i32_i32_=>_i32)
+  end
+ )
+ (func $~start
+  i32.const 2
+  i32.const 3
+  i32.const 1
+  call $function-types/doAddWithFn<i32>
+  i32.const 5
+  i32.ne
+  if
+   i32.const 0
+   i32.const 1040
+   i32.const 23
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 4
+  i32.const 5
+  i32.const 4
+  call $function-types/doAddWithFn<i32>
+  i32.const 9
+  i32.ne
+  if
+   i32.const 0
+   i32.const 1040
+   i32.const 35
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 1
+  i32.const 2
+  i32.const 1
+  call $function-types/doAddWithFn<i32>
+  i32.const 3
+  i32.ne
+  if
+   i32.const 0
+   i32.const 1040
+   i32.const 41
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 1
+  i32.const 2
+  i32.const 1
+  call $function-types/doAddWithFn<i32>
+  i32.const 3
+  i32.ne
+  if
+   i32.const 0
+   i32.const 1040
+   i32.const 42
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+ )
 )

--- a/tests/compiler/function-types.untouched.wat
+++ b/tests/compiler/function-types.untouched.wat
@@ -1,60 +1,226 @@
 (module
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
- (type $none_=>_i32 (func (result i32)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
+ (type $none_=>_i32 (func (result i32)))
  (type $none_=>_none (func))
  (type $i64_i64_=>_i64 (func (param i64 i64) (result i64)))
  (type $f64_f64_=>_f64 (func (param f64 f64) (result f64)))
+ (type $i32_=>_none (func (param i32)))
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
+ (type $i32_=>_i32 (func (param i32) (result i32)))
+ (type $i32_i64_i64_=>_i64 (func (param i32 i64 i64) (result i64)))
+ (type $i32_f64_f64_=>_f64 (func (param i32 f64 f64) (result f64)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 16) "\"\00\00\00\01\00\00\00\01\00\00\00\"\00\00\00f\00u\00n\00c\00t\00i\00o\00n\00-\00t\00y\00p\00e\00s\00.\00t\00s\00")
  (table $0 5 funcref)
- (elem (i32.const 1) $function-types/makeAdder<i32>~anonymous|0 $function-types/makeAdder<i64>~anonymous|0 $function-types/makeAdder<f64>~anonymous|0 $function-types/addI32)
+ (elem (i32.const 1) $function-types/makeAdder<i32>~anonymous|0~nonClosure $function-types/makeAdder<i64>~anonymous|0~nonClosure $function-types/makeAdder<f64>~anonymous|0~nonClosure $function-types/addI32)
  (global $function-types/i32Adder (mut i32) (i32.const 0))
  (global $~argumentsLength (mut i32) (i32.const 0))
  (global $function-types/i64Adder (mut i32) (i32.const 0))
  (export "memory" (memory $0))
  (start $~start)
- (func $function-types/makeAdder<i32>~anonymous|0 (param $0 i32) (param $1 i32) (result i32)
+ (func $function-types/makeAdder<i32>~anonymous|0~nonClosure (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.add
  )
- (func $function-types/makeAdder<i32> (result i32)
-  i32.const 1
+ (func $~lib/rt/stub/__retain (param $0 i32) (result i32)
+  local.get $0
  )
- (func $function-types/makeAdder<i64>~anonymous|0 (param $0 i64) (param $1 i64) (result i64)
+ (func $function-types/makeAdder<i32> (result i32)
+  (local $0 i32)
+  i32.const 1
+  local.set $0
+  local.get $0
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $0
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/stub/__retain
+  drop
+  local.get $0
+ )
+ (func $function-types/makeAdder<i64>~anonymous|0~nonClosure (param $0 i64) (param $1 i64) (result i64)
   local.get $0
   local.get $1
   i64.add
  )
  (func $function-types/makeAdder<i64> (result i32)
+  (local $0 i32)
   i32.const 2
+  local.set $0
+  local.get $0
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $0
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/stub/__retain
+  drop
+  local.get $0
  )
- (func $function-types/makeAdder<f64>~anonymous|0 (param $0 f64) (param $1 f64) (result f64)
+ (func $function-types/makeAdder<f64>~anonymous|0~nonClosure (param $0 f64) (param $1 f64) (result f64)
   local.get $0
   local.get $1
   f64.add
  )
  (func $function-types/makeAdder<f64> (result i32)
+  (local $0 i32)
   i32.const 3
+  local.set $0
+  local.get $0
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $0
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/stub/__retain
+  drop
+  local.get $0
+ )
+ (func $~lib/rt/stub/__release (param $0 i32)
+  nop
  )
  (func $function-types/doAddWithFn<i32> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  local.get $0
-  local.get $1
-  i32.const 2
-  global.set $~argumentsLength
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   local.get $2
-  call_indirect (type $i32_i32_=>_i32)
+  local.set $3
+  local.get $3
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $3
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/stub/__retain
+  drop
+  local.get $3
+  local.set $2
+  local.get $2
+  local.set $4
+  local.get $4
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $4
+   i32.const 4
+   i32.shl
+   local.get $0
+   local.get $1
+   i32.const 2
+   global.set $~argumentsLength
+   local.get $4
+   i32.const 4
+   i32.shl
+   i32.load
+   call_indirect (type $i32_i32_i32_=>_i32)
+  else
+   local.get $0
+   local.get $1
+   i32.const 2
+   global.set $~argumentsLength
+   local.get $4
+   call_indirect (type $i32_i32_=>_i32)
+  end
+  local.set $6
+  local.get $2
+  local.set $5
+  local.get $5
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $5
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/stub/__release
+  local.get $6
  )
  (func $function-types/doAdd<i32> (param $0 i32) (param $1 i32) (result i32)
-  local.get $0
-  local.get $1
-  i32.const 2
-  global.set $~argumentsLength
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
   call $function-types/makeAdder<i32>
-  call_indirect (type $i32_i32_=>_i32)
+  local.tee $2
+  local.set $3
+  local.get $3
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $3
+   i32.const 4
+   i32.shl
+   local.get $0
+   local.get $1
+   i32.const 2
+   global.set $~argumentsLength
+   local.get $3
+   i32.const 4
+   i32.shl
+   i32.load
+   call_indirect (type $i32_i32_i32_=>_i32)
+  else
+   local.get $0
+   local.get $1
+   i32.const 2
+   global.set $~argumentsLength
+   local.get $3
+   call_indirect (type $i32_i32_=>_i32)
+  end
+  local.set $5
+  local.get $2
+  local.set $4
+  local.get $4
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $4
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/stub/__release
+  local.get $5
  )
  (func $function-types/addI32 (param $0 i32) (param $1 i32) (result i32)
   local.get $0
@@ -62,14 +228,78 @@
   i32.add
  )
  (func $function-types/makeAndAdd<i32> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  local.get $0
-  local.get $1
-  i32.const 2
-  global.set $~argumentsLength
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   local.get $2
-  call_indirect (type $i32_i32_=>_i32)
+  local.set $3
+  local.get $3
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $3
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/stub/__retain
+  drop
+  local.get $3
+  local.set $2
+  local.get $2
+  local.set $4
+  local.get $4
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $4
+   i32.const 4
+   i32.shl
+   local.get $0
+   local.get $1
+   i32.const 2
+   global.set $~argumentsLength
+   local.get $4
+   i32.const 4
+   i32.shl
+   i32.load
+   call_indirect (type $i32_i32_i32_=>_i32)
+  else
+   local.get $0
+   local.get $1
+   i32.const 2
+   global.set $~argumentsLength
+   local.get $4
+   call_indirect (type $i32_i32_=>_i32)
+  end
+  local.set $6
+  local.get $2
+  local.set $5
+  local.get $5
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $5
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/stub/__release
+  local.get $6
  )
  (func $function-types/makeAndAdd<i32>@varargs (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -81,22 +311,69 @@
     unreachable
    end
    call $function-types/makeAdder<i32>
+   local.tee $3
    local.set $2
   end
   local.get $0
   local.get $1
   local.get $2
   call $function-types/makeAndAdd<i32>
+  local.set $5
+  local.get $3
+  local.set $4
+  local.get $4
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $4
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/stub/__release
+  local.get $5
  )
  (func $start:function-types
+  (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   call $function-types/makeAdder<i32>
   global.set $function-types/i32Adder
-  i32.const 1
-  i32.const 2
-  i32.const 2
-  global.set $~argumentsLength
   global.get $function-types/i32Adder
-  call_indirect (type $i32_i32_=>_i32)
+  local.set $0
+  local.get $0
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $0
+   i32.const 4
+   i32.shl
+   i32.const 1
+   i32.const 2
+   i32.const 2
+   global.set $~argumentsLength
+   local.get $0
+   i32.const 4
+   i32.shl
+   i32.load
+   call_indirect (type $i32_i32_i32_=>_i32)
+  else
+   i32.const 1
+   i32.const 2
+   i32.const 2
+   global.set $~argumentsLength
+   local.get $0
+   call_indirect (type $i32_i32_=>_i32)
+  end
   i32.const 3
   i32.eq
   i32.eqz
@@ -110,12 +387,34 @@
   end
   call $function-types/makeAdder<i64>
   global.set $function-types/i64Adder
-  i64.const 10
-  i64.const 20
-  i32.const 2
-  global.set $~argumentsLength
   global.get $function-types/i64Adder
-  call_indirect (type $i64_i64_=>_i64)
+  local.set $1
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i64)
+   local.get $1
+   i32.const 4
+   i32.shl
+   i64.const 10
+   i64.const 20
+   i32.const 2
+   global.set $~argumentsLength
+   local.get $1
+   i32.const 4
+   i32.shl
+   i32.load
+   call_indirect (type $i32_i64_i64_=>_i64)
+  else
+   i64.const 10
+   i64.const 20
+   i32.const 2
+   global.set $~argumentsLength
+   local.get $1
+   call_indirect (type $i64_i64_=>_i64)
+  end
   i64.const 30
   i64.eq
   i32.eqz
@@ -127,12 +426,35 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.5
-  f64.const 2.5
-  i32.const 2
-  global.set $~argumentsLength
   call $function-types/makeAdder<f64>
-  call_indirect (type $f64_f64_=>_f64)
+  local.tee $2
+  local.set $3
+  local.get $3
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result f64)
+   local.get $3
+   i32.const 4
+   i32.shl
+   f64.const 1.5
+   f64.const 2.5
+   i32.const 2
+   global.set $~argumentsLength
+   local.get $3
+   i32.const 4
+   i32.shl
+   i32.load
+   call_indirect (type $i32_f64_f64_=>_f64)
+  else
+   f64.const 1.5
+   f64.const 2.5
+   i32.const 2
+   global.set $~argumentsLength
+   local.get $3
+   call_indirect (type $f64_f64_=>_f64)
+  end
   f64.const 4
   f64.eq
   i32.eqz
@@ -208,6 +530,7 @@
   i32.const 1
   i32.const 2
   call $function-types/makeAdder<i32>
+  local.tee $4
   call $function-types/makeAndAdd<i32>
   i32.const 3
   i32.eq
@@ -220,6 +543,36 @@
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $2
+  local.set $5
+  local.get $5
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $5
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/stub/__release
+  local.get $4
+  local.set $6
+  local.get $6
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $6
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/stub/__release
  )
  (func $~start
   call $start:function-types

--- a/tests/compiler/implicit-getter-setter.untouched.wat
+++ b/tests/compiler/implicit-getter-setter.untouched.wat
@@ -1591,6 +1591,7 @@
   local.get $0
  )
  (func $implicit-getter-setter/Managed#get:foo (param $0 i32) (result i32)
+  (local $1 i32)
   local.get $0
   i32.load
   call $~lib/rt/pure/__retain

--- a/tests/compiler/infer-generic.optimized.wat
+++ b/tests/compiler/infer-generic.optimized.wat
@@ -1,8 +1,10 @@
 (module
- (type $none_=>_none (func))
  (type $i32_=>_i32 (func (param i32) (result i32)))
+ (type $none_=>_none (func))
+ (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $i32_f32_i32_i32_=>_i32 (func (param i32 f32 i32 i32) (result i32)))
  (type $f32_=>_f32 (func (param f32) (result f32)))
+ (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 1024) " \00\00\00\01\00\00\00\01\00\00\00 \00\00\00i\00n\00f\00e\00r\00-\00g\00e\00n\00e\00r\00i\00c\00.\00t\00s")
  (data (i32.const 1072) "\0c\00\00\00\01\00\00\00\00\00\00\00\0c\00\00\00\00\00\80?\00\00\00@\00\00@@")
@@ -10,10 +12,10 @@
  (export "memory" (memory $0))
  (export "test1" (func $infer-generic/test1))
  (export "test2" (func $infer-generic/test2))
- (export "test3" (func $infer-generic/test2))
- (export "test4" (func $infer-generic/test2))
+ (export "test3" (func $infer-generic/test3))
+ (export "test4" (func $infer-generic/test4))
  (start $~start)
- (func $start:infer-generic~anonymous|0 (param $0 i32) (param $1 f32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:infer-generic~anonymous|0~nonClosure (param $0 i32) (param $1 f32) (param $2 i32) (param $3 i32) (result i32)
   local.get $1
   f32.const 0
   f32.ne
@@ -27,23 +29,58 @@
  (func $infer-generic/test2 (param $0 i32) (result i32)
   local.get $0
  )
+ (func $infer-generic/test3 (param $0 i32) (result i32)
+  local.get $0
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if
+   i32.const 0
+   i32.const 1040
+   i32.const 28
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+ )
+ (func $infer-generic/test4 (param $0 i32) (result i32)
+  local.get $0
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if
+   i32.const 0
+   i32.const 1040
+   i32.const 38
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+ )
  (func $~start
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
   i32.const 1132
   i32.load
   local.set $2
   loop $for-loop|0
-   local.get $0
    local.get $2
    i32.const 1132
    i32.load
    local.tee $3
+   i32.lt_s
+   local.set $4
+   local.get $0
    local.get $2
    local.get $3
-   i32.lt_s
+   local.get $4
    select
    i32.lt_s
    if
@@ -57,7 +94,7 @@
     f32.load
     local.get $0
     i32.const 1120
-    call $start:infer-generic~anonymous|0
+    call $start:infer-generic~anonymous|0~nonClosure
     local.set $1
     local.get $0
     i32.const 1

--- a/tests/compiler/infer-generic.untouched.wat
+++ b/tests/compiler/infer-generic.untouched.wat
@@ -6,6 +6,7 @@
  (type $i32_=>_none (func (param i32)))
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
+ (type $i32_i32_f32_i32_i32_=>_i32 (func (param i32 i32 f32 i32 i32) (result i32)))
  (type $f64_f64_=>_i32 (func (param f64 f64) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (memory $0 1)
@@ -13,7 +14,7 @@
  (data (i32.const 64) "\0c\00\00\00\01\00\00\00\00\00\00\00\0c\00\00\00\00\00\80?\00\00\00@\00\00@@")
  (data (i32.const 96) "\10\00\00\00\01\00\00\00\03\00\00\00\10\00\00\00P\00\00\00P\00\00\00\0c\00\00\00\03\00\00\00")
  (table $0 2 funcref)
- (elem (i32.const 1) $start:infer-generic~anonymous|0)
+ (elem (i32.const 1) $start:infer-generic~anonymous|0~nonClosure)
  (global $infer-generic/arr i32 (i32.const 112))
  (global $~argumentsLength (mut i32) (i32.const 0))
  (export "memory" (memory $0))
@@ -33,7 +34,7 @@
  (func $~lib/rt/stub/__release (param $0 i32)
   nop
  )
- (func $start:infer-generic~anonymous|0 (param $0 i32) (param $1 f32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:infer-generic~anonymous|0~nonClosure (param $0 i32) (param $1 f32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/stub/__retain
@@ -57,51 +58,117 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  local.get $2
+  (local $8 i32)
+  local.get $1
   local.set $3
-  i32.const 0
+  local.get $3
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $3
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/stub/__retain
+  drop
+  local.get $3
+  local.set $1
+  local.get $2
   local.set $4
+  i32.const 0
+  local.set $5
   local.get $0
   i32.load offset=12
-  local.set $5
+  local.set $6
   loop $for-loop|0
-   local.get $4
    local.get $5
-   local.tee $6
+   local.get $6
+   local.tee $7
    local.get $0
    i32.load offset=12
-   local.tee $7
-   local.get $6
+   local.tee $8
    local.get $7
+   local.get $8
    i32.lt_s
    select
    i32.lt_s
-   local.set $6
-   local.get $6
+   local.set $7
+   local.get $7
    if
-    local.get $3
-    local.get $0
-    i32.load offset=4
-    local.get $4
-    i32.const 2
-    i32.shl
-    i32.add
-    f32.load
-    local.get $4
-    local.get $0
-    i32.const 4
-    global.set $~argumentsLength
     local.get $1
-    call_indirect (type $i32_f32_i32_i32_=>_i32)
-    local.set $3
-    local.get $4
+    local.set $8
+    local.get $8
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result i32)
+     local.get $8
+     i32.const 4
+     i32.shl
+     local.get $4
+     local.get $0
+     i32.load offset=4
+     local.get $5
+     i32.const 2
+     i32.shl
+     i32.add
+     f32.load
+     local.get $5
+     local.get $0
+     i32.const 4
+     global.set $~argumentsLength
+     local.get $8
+     i32.const 4
+     i32.shl
+     i32.load
+     call_indirect (type $i32_i32_f32_i32_i32_=>_i32)
+    else
+     local.get $4
+     local.get $0
+     i32.load offset=4
+     local.get $5
+     i32.const 2
+     i32.shl
+     i32.add
+     f32.load
+     local.get $5
+     local.get $0
+     i32.const 4
+     global.set $~argumentsLength
+     local.get $8
+     call_indirect (type $i32_f32_i32_i32_=>_i32)
+    end
+    local.set $4
+    local.get $5
     i32.const 1
     i32.add
-    local.set $4
+    local.set $5
     br $for-loop|0
    end
   end
-  local.get $3
+  local.get $4
+  local.set $5
+  local.get $1
+  local.set $6
+  local.get $6
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $6
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/stub/__release
+  local.get $5
  )
  (func $start:infer-generic
   (local $0 i32)
@@ -150,18 +217,166 @@
   local.get $1
  )
  (func $infer-generic/inferEncapsulatedFunction<f32,f64> (param $0 i32) (result i32)
+  (local $1 i32)
+  local.get $0
+  local.set $1
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $1
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/stub/__retain
+  drop
+  local.get $1
+  local.set $0
   local.get $0
  )
  (func $infer-generic/test3 (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  local.get $0
+  local.set $1
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $1
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/stub/__retain
+  drop
+  local.get $1
+  local.set $0
   local.get $0
   call $infer-generic/inferEncapsulatedFunction<f32,f64>
+  local.set $3
+  local.get $0
+  local.set $2
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/stub/__release
+  local.get $3
+  local.set $3
+  local.get $3
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 28
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  else
+   nop
+  end
+  local.get $3
  )
  (func $infer-generic/inferEncapsulatedFunctionMixed<f32,f64> (param $0 i32) (result i32)
+  (local $1 i32)
+  local.get $0
+  local.set $1
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $1
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/stub/__retain
+  drop
+  local.get $1
+  local.set $0
   local.get $0
  )
  (func $infer-generic/test4 (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  local.get $0
+  local.set $1
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $1
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/stub/__retain
+  drop
+  local.get $1
+  local.set $0
   local.get $0
   call $infer-generic/inferEncapsulatedFunctionMixed<f32,f64>
+  local.set $3
+  local.get $0
+  local.set $2
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/stub/__release
+  local.get $3
+  local.set $3
+  local.get $3
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 38
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  else
+   nop
+  end
+  local.get $3
  )
  (func $~start
   call $start:infer-generic

--- a/tests/compiler/inlining.untouched.wat
+++ b/tests/compiler/inlining.untouched.wat
@@ -2,14 +2,14 @@
  (type $none_=>_none (func))
  (type $i32_=>_i32 (func (param i32) (result i32)))
  (type $i32_=>_none (func (param i32)))
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $none_=>_i32 (func (result i32)))
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 16) "\16\00\00\00\01\00\00\00\01\00\00\00\16\00\00\00i\00n\00l\00i\00n\00i\00n\00g\00.\00t\00s\00")
  (table $0 2 funcref)
- (elem (i32.const 1) $inlining/func_fe~anonymous|0)
+ (elem (i32.const 1) $inlining/func_fe~anonymous|0~nonClosure)
  (global $inlining/constantGlobal i32 (i32.const 1))
  (global $~argumentsLength (mut i32) (i32.const 0))
  (global $~lib/rt/stub/startOffset (mut i32) (i32.const 0))
@@ -23,7 +23,7 @@
   i32.const 2
   i32.add
  )
- (func $inlining/func_fe~anonymous|0 (param $0 i32) (result i32)
+ (func $inlining/func_fe~anonymous|0~nonClosure (param $0 i32) (result i32)
   local.get $0
  )
  (func $~lib/rt/stub/__retain (param $0 i32) (result i32)
@@ -41,6 +41,7 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
   f32.const -1
   local.set $0
   f64.const -2
@@ -161,11 +162,49 @@
   drop
   i32.const 0
   local.set $2
-  i32.const 2
   i32.const 1
-  global.set $~argumentsLength
-  i32.const 1
-  call_indirect (type $i32_=>_i32)
+  local.set $2
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/stub/__retain
+  drop
+  local.get $2
+  local.tee $3
+  local.set $4
+  local.get $4
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $4
+   i32.const 4
+   i32.shl
+   i32.const 2
+   i32.const 1
+   global.set $~argumentsLength
+   local.get $4
+   i32.const 4
+   i32.shl
+   i32.load
+   call_indirect (type $i32_i32_=>_i32)
+  else
+   i32.const 2
+   i32.const 1
+   global.set $~argumentsLength
+   local.get $4
+   call_indirect (type $i32_=>_i32)
+  end
   i32.const 2
   i32.eq
   i32.eqz
@@ -180,9 +219,9 @@
   i32.const 42
   local.set $6
   i32.const 2
-  local.set $2
+  local.set $5
   local.get $6
-  local.get $2
+  local.get $5
   i32.add
   i32.const 44
   i32.eq
@@ -191,14 +230,14 @@
   call $~lib/rt/stub/__retain
   local.set $7
   local.get $7
-  local.set $4
-  i32.const 43
   local.set $5
+  i32.const 43
+  local.set $6
   i32.const 3
-  local.set $2
-  local.get $4
+  local.set $8
+  local.get $5
   call $~lib/rt/stub/__retain
-  local.tee $2
+  local.tee $8
   i32.const 123
   i32.eq
   i32.eqz
@@ -210,7 +249,22 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $3
+  local.set $5
+  local.get $5
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $5
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/stub/__release
+  local.get $8
   call $~lib/rt/stub/__release
   local.get $7
   call $~lib/rt/stub/__release

--- a/tests/compiler/resolve-function-expression.untouched.wat
+++ b/tests/compiler/resolve-function-expression.untouched.wat
@@ -20,7 +20,7 @@
  (data (i32.const 1760) "H\00\00\00\01\00\00\00\01\00\00\00H\00\00\000\001\002\003\004\005\006\007\008\009\00a\00b\00c\00d\00e\00f\00g\00h\00i\00j\00k\00l\00m\00n\00o\00p\00q\00r\00s\00t\00u\00v\00w\00x\00y\00z\00")
  (data (i32.const 1856) "\04\00\00\00\01\00\00\00\01\00\00\00\04\00\00\004\002\00")
  (table $0 4 funcref)
- (elem (i32.const 1) $start:resolve-function-expression~anonymous|0 $start:resolve-function-expression~anonymous|1 $start:resolve-function-expression~anonymous|2)
+ (elem (i32.const 1) $start:resolve-function-expression~anonymous|0~nonClosure $start:resolve-function-expression~anonymous|1~nonClosure $start:resolve-function-expression~anonymous|2~nonClosure)
  (global $~argumentsLength (mut i32) (i32.const 0))
  (global $~lib/rt/stub/startOffset (mut i32) (i32.const 0))
  (global $~lib/rt/stub/offset (mut i32) (i32.const 0))
@@ -28,17 +28,17 @@
  (global $~lib/heap/__heap_base i32 (i32.const 1876))
  (export "memory" (memory $0))
  (start $~start)
- (func $start:resolve-function-expression~anonymous|0 (param $0 i32) (result i32)
+ (func $start:resolve-function-expression~anonymous|0~nonClosure (param $0 i32) (result i32)
   local.get $0
   i32.const 40
   i32.add
  )
- (func $start:resolve-function-expression~anonymous|1 (param $0 i32) (result i32)
+ (func $start:resolve-function-expression~anonymous|1~nonClosure (param $0 i32) (result i32)
   local.get $0
   i32.const 41
   i32.add
  )
- (func $start:resolve-function-expression~anonymous|2 (param $0 i32) (result i32)
+ (func $start:resolve-function-expression~anonymous|2~nonClosure (param $0 i32) (result i32)
   local.get $0
   i32.const 42
   i32.add
@@ -933,11 +933,35 @@
  )
  (func $start:resolve-function-expression
   (local $0 i32)
-  i32.const 2
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
   i32.const 1
-  global.set $~argumentsLength
-  i32.const 1
-  call_indirect (type $i32_=>_i32)
+  local.set $0
+  local.get $0
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $0
+   i32.const 4
+   i32.shl
+   i32.const 2
+   i32.const 1
+   global.set $~argumentsLength
+   local.get $0
+   i32.const 4
+   i32.shl
+   i32.load
+   call_indirect (type $i32_i32_=>_i32)
+  else
+   i32.const 2
+   i32.const 1
+   global.set $~argumentsLength
+   local.get $0
+   call_indirect (type $i32_=>_i32)
+  end
   i32.const 42
   i32.eq
   i32.eqz
@@ -949,11 +973,32 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1
-  i32.const 1
-  global.set $~argumentsLength
   i32.const 2
-  call_indirect (type $i32_=>_i32)
+  local.set $1
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $1
+   i32.const 4
+   i32.shl
+   i32.const 1
+   i32.const 1
+   global.set $~argumentsLength
+   local.get $1
+   i32.const 4
+   i32.shl
+   i32.load
+   call_indirect (type $i32_i32_=>_i32)
+  else
+   i32.const 1
+   i32.const 1
+   global.set $~argumentsLength
+   local.get $1
+   call_indirect (type $i32_=>_i32)
+  end
   i32.const 42
   i32.eq
   i32.eqz
@@ -975,14 +1020,35 @@
   global.set $~lib/rt/stub/startOffset
   global.get $~lib/rt/stub/startOffset
   global.set $~lib/rt/stub/offset
-  i32.const 0
-  i32.const 1
-  global.set $~argumentsLength
   i32.const 3
-  call_indirect (type $i32_=>_i32)
+  local.set $2
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+   i32.const 0
+   i32.const 1
+   global.set $~argumentsLength
+   local.get $2
+   i32.const 4
+   i32.shl
+   i32.load
+   call_indirect (type $i32_i32_=>_i32)
+  else
+   i32.const 0
+   i32.const 1
+   global.set $~argumentsLength
+   local.get $2
+   call_indirect (type $i32_=>_i32)
+  end
   i32.const 10
   call $~lib/number/I32#toString
-  local.tee $0
+  local.tee $3
   i32.const 1872
   call $~lib/string/String.__eq
   i32.eqz
@@ -994,7 +1060,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $3
   call $~lib/rt/stub/__release
  )
  (func $~start

--- a/tests/compiler/resolve-ternary.untouched.wat
+++ b/tests/compiler/resolve-ternary.untouched.wat
@@ -1,8 +1,8 @@
 (module
  (type $i32_=>_i32 (func (param i32) (result i32)))
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_i32_=>_none (func (param i32 i32)))
  (type $i32_=>_none (func (param i32)))
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (type $none_=>_none (func))
@@ -40,7 +40,7 @@
  (data (i32.const 3104) "\06\00\00\00\01\00\00\00\01\00\00\00\06\00\00\001\00.\000\00")
  (data (i32.const 3136) "\03\00\00\00 \00\00\00\00\00\00\00 \00\00\00\00\00\00\00 \00\00\00\00\00\00\00")
  (table $0 5 funcref)
- (elem (i32.const 1) $start:resolve-ternary~anonymous|0 $start:resolve-ternary~anonymous|1 $resolve-ternary/g1 $resolve-ternary/g2)
+ (elem (i32.const 1) $start:resolve-ternary~anonymous|0~nonClosure $start:resolve-ternary~anonymous|1~nonClosure $resolve-ternary/g1 $resolve-ternary/g2)
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
  (global $~lib/ASC_LOW_MEMORY_LIMIT i32 (i32.const 0))
  (global $~lib/rt/tlsf/collectLock (mut i32) (i32.const 0))
@@ -5087,12 +5087,12 @@
   local.get $0
   call $~lib/util/number/dtoa
  )
- (func $start:resolve-ternary~anonymous|0 (param $0 i32) (result i32)
+ (func $start:resolve-ternary~anonymous|0~nonClosure (param $0 i32) (result i32)
   local.get $0
   i32.const 1
   i32.add
  )
- (func $start:resolve-ternary~anonymous|1 (param $0 i32) (result i32)
+ (func $start:resolve-ternary~anonymous|1~nonClosure (param $0 i32) (result i32)
   local.get $0
   i32.const 2
   i32.add
@@ -5110,6 +5110,24 @@
  (func $start:resolve-ternary
   (local $0 i32)
   (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
   global.get $resolve-ternary/b
   if (result i32)
    i32.const 1
@@ -5150,16 +5168,71 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1
-  i32.const 1
-  global.set $~argumentsLength
   global.get $resolve-ternary/b
   if (result i32)
    global.get $resolve-ternary/f1
+   local.set $2
+   local.get $2
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $2
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
+   call $~lib/rt/pure/__retain
+   drop
+   local.get $2
+   local.tee $3
   else
    global.get $resolve-ternary/f2
+   local.set $4
+   local.get $4
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $4
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
+   call $~lib/rt/pure/__retain
+   drop
+   local.get $4
+   local.tee $5
   end
-  call_indirect (type $i32_=>_i32)
+  local.set $6
+  local.get $6
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $6
+   i32.const 4
+   i32.shl
+   i32.const 1
+   i32.const 1
+   global.set $~argumentsLength
+   local.get $6
+   i32.const 4
+   i32.shl
+   i32.load
+   call_indirect (type $i32_i32_=>_i32)
+  else
+   i32.const 1
+   i32.const 1
+   global.set $~argumentsLength
+   local.get $6
+   call_indirect (type $i32_=>_i32)
+  end
   i32.const 2
   i32.eq
   i32.eqz
@@ -5171,16 +5244,71 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1
-  i32.const 1
-  global.set $~argumentsLength
   global.get $resolve-ternary/b
   if (result i32)
    i32.const 3
+   local.set $7
+   local.get $7
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $7
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
+   call $~lib/rt/pure/__retain
+   drop
+   local.get $7
+   local.tee $8
   else
    i32.const 4
+   local.set $9
+   local.get $9
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $9
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
+   call $~lib/rt/pure/__retain
+   drop
+   local.get $9
+   local.tee $10
   end
-  call_indirect (type $i32_=>_i32)
+  local.set $11
+  local.get $11
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $11
+   i32.const 4
+   i32.shl
+   i32.const 1
+   i32.const 1
+   global.set $~argumentsLength
+   local.get $11
+   i32.const 4
+   i32.shl
+   i32.load
+   call_indirect (type $i32_i32_=>_i32)
+  else
+   i32.const 1
+   i32.const 1
+   global.set $~argumentsLength
+   local.get $11
+   call_indirect (type $i32_=>_i32)
+  end
   i32.const 4
   i32.eq
   i32.eqz
@@ -5192,16 +5320,71 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1
-  i32.const 1
-  global.set $~argumentsLength
   global.get $resolve-ternary/b
   if (result i32)
    global.get $resolve-ternary/f2
+   local.set $12
+   local.get $12
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $12
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
+   call $~lib/rt/pure/__retain
+   drop
+   local.get $12
+   local.tee $13
   else
    i32.const 4
+   local.set $14
+   local.get $14
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $14
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
+   call $~lib/rt/pure/__retain
+   drop
+   local.get $14
+   local.tee $15
   end
-  call_indirect (type $i32_=>_i32)
+  local.set $16
+  local.get $16
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $16
+   i32.const 4
+   i32.shl
+   i32.const 1
+   i32.const 1
+   global.set $~argumentsLength
+   local.get $16
+   i32.const 4
+   i32.shl
+   i32.load
+   call_indirect (type $i32_i32_=>_i32)
+  else
+   i32.const 1
+   i32.const 1
+   global.set $~argumentsLength
+   local.get $16
+   call_indirect (type $i32_=>_i32)
+  end
   i32.const 3
   i32.eq
   i32.eqz
@@ -5216,6 +5399,51 @@
   local.get $0
   call $~lib/rt/pure/__release
   local.get $1
+  call $~lib/rt/pure/__release
+  local.get $5
+  local.set $17
+  local.get $17
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $17
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $10
+  local.set $18
+  local.get $18
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $18
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $15
+  local.set $19
+  local.get $19
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $19
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
   call $~lib/rt/pure/__release
  )
  (func $~start

--- a/tests/compiler/retain-release.optimized.wat
+++ b/tests/compiler/retain-release.optimized.wat
@@ -2,8 +2,9 @@
  (type $i32_=>_none (func (param i32)))
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
- (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
+ (type $i32_i32_=>_none (func (param i32 i32)))
+ (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (memory $0 1)
@@ -214,14 +215,52 @@
   end
  )
  (func $retain-release/provideRefIndirect (param $0 i32)
-  global.get $retain-release/REF
+  (local $1 i32)
   local.get $0
-  call_indirect (type $i32_=>_none)
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if
+   local.get $0
+   i32.const 4
+   i32.shl
+   local.tee $0
+   i32.load
+   local.set $1
+   local.get $0
+   global.get $retain-release/REF
+   local.get $1
+   call_indirect (type $i32_i32_=>_none)
+  else
+   global.get $retain-release/REF
+   local.get $0
+   call_indirect (type $i32_=>_none)
+  end
  )
  (func $retain-release/receiveRefIndirect (param $0 i32)
+  (local $1 i32)
   local.get $0
-  call_indirect (type $none_=>_i32)
-  drop
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if
+   local.get $0
+   i32.const 4
+   i32.shl
+   local.tee $0
+   i32.load
+   local.set $1
+   local.get $0
+   local.get $1
+   call_indirect (type $i32_=>_i32)
+   drop
+  else
+   local.get $0
+   call_indirect (type $none_=>_i32)
+   drop
+  end
  )
  (func $~start
   (local $0 i32)

--- a/tests/compiler/retain-release.untouched.wat
+++ b/tests/compiler/retain-release.untouched.wat
@@ -3,6 +3,7 @@
  (type $none_=>_none (func))
  (type $i32_=>_i32 (func (param i32) (result i32)))
  (type $none_=>_i32 (func (result i32)))
+ (type $i32_i32_=>_none (func (param i32 i32)))
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
@@ -773,29 +774,203 @@
   call $~lib/rt/stub/__release
  )
  (func $retain-release/provideRefIndirect (param $0 i32)
-  global.get $retain-release/REF
-  i32.const 1
-  global.set $~argumentsLength
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
   local.get $0
-  call_indirect (type $i32_=>_none)
+  local.set $1
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $1
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/stub/__retain
+  drop
+  local.get $1
+  local.set $0
+  local.get $0
+  local.set $2
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if
+   local.get $2
+   i32.const 4
+   i32.shl
+   global.get $retain-release/REF
+   i32.const 1
+   global.set $~argumentsLength
+   local.get $2
+   i32.const 4
+   i32.shl
+   i32.load
+   call_indirect (type $i32_i32_=>_none)
+  else
+   global.get $retain-release/REF
+   i32.const 1
+   global.set $~argumentsLength
+   local.get $2
+   call_indirect (type $i32_=>_none)
+  end
+  local.get $0
+  local.set $3
+  local.get $3
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $3
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/stub/__release
  )
  (func $retain-release/receiveRefIndirect (param $0 i32)
   (local $1 i32)
-  i32.const 0
-  global.set $~argumentsLength
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
   local.get $0
-  call_indirect (type $none_=>_i32)
-  local.tee $1
-  i32.eqz
+  local.set $1
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $1
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/stub/__retain
   drop
   local.get $1
+  local.set $0
+  local.get $0
+  local.set $2
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+   i32.const 0
+   global.set $~argumentsLength
+   local.get $2
+   i32.const 4
+   i32.shl
+   i32.load
+   call_indirect (type $i32_=>_i32)
+   local.tee $3
+  else
+   i32.const 0
+   global.set $~argumentsLength
+   local.get $2
+   call_indirect (type $none_=>_i32)
+   local.tee $4
+  end
+  i32.eqz
+  drop
+  local.get $3
+  call $~lib/rt/stub/__release
+  local.get $4
+  call $~lib/rt/stub/__release
+  local.get $0
+  local.set $5
+  local.get $5
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $5
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
   call $~lib/rt/stub/__release
  )
  (func $retain-release/receiveRefIndirectDrop (param $0 i32)
-  i32.const 0
-  global.set $~argumentsLength
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
   local.get $0
-  call_indirect (type $none_=>_i32)
+  local.set $1
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $1
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/stub/__retain
+  drop
+  local.get $1
+  local.set $0
+  local.get $0
+  local.set $2
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if
+   local.get $2
+   i32.const 4
+   i32.shl
+   i32.const 0
+   global.set $~argumentsLength
+   local.get $2
+   i32.const 4
+   i32.shl
+   i32.load
+   call_indirect (type $i32_=>_i32)
+   call $~lib/rt/stub/__release
+  else
+   i32.const 0
+   global.set $~argumentsLength
+   local.get $2
+   call_indirect (type $none_=>_i32)
+   call $~lib/rt/stub/__release
+  end
+  local.get $0
+  local.set $3
+  local.get $3
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $3
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
   call $~lib/rt/stub/__release
  )
  (func $~start

--- a/tests/compiler/std/array.optimized.wat
+++ b/tests/compiler/std/array.optimized.wat
@@ -1,16 +1,17 @@
 (module
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
- (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
- (type $i32_i32_=>_none (func (param i32 i32)))
  (type $i32_i32_i32_i32_=>_i32 (func (param i32 i32 i32 i32) (result i32)))
+ (type $i32_i32_=>_none (func (param i32 i32)))
+ (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
  (type $i32_=>_none (func (param i32)))
  (type $none_=>_i32 (func (result i32)))
  (type $none_=>_f64 (func (result f64)))
  (type $none_=>_none (func))
- (type $i32_i32_i64_=>_i32 (func (param i32 i32 i64) (result i32)))
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
+ (type $i32_i32_i32_i32_i32_=>_i32 (func (param i32 i32 i32 i32 i32) (result i32)))
+ (type $i32_i32_i64_=>_i32 (func (param i32 i32 i64) (result i32)))
  (type $i32_i64_i32_=>_none (func (param i32 i64 i32)))
  (type $i64_=>_none (func (param i64)))
  (type $i32_i32_f64_=>_i32 (func (param i32 i32 f64) (result i32)))
@@ -236,11 +237,12 @@
  (data (i32.const 10004) "\01")
  (data (i32.const 10020) "\01")
  (table $0 57 funcref)
- (elem (i32.const 1) $start:std/array~anonymous|0 $start:std/array~anonymous|1 $start:std/array~anonymous|2 $start:std/array~anonymous|3 $start:std/array~anonymous|2 $start:std/array~anonymous|5 $start:std/array~anonymous|6 $start:std/array~anonymous|7 $start:std/array~anonymous|8 $start:std/array~anonymous|9 $start:std/array~anonymous|10 $start:std/array~anonymous|11 $start:std/array~anonymous|12 $start:std/array~anonymous|13 $start:std/array~anonymous|14 $start:std/array~anonymous|15 $start:std/array~anonymous|16 $start:std/array~anonymous|17 $start:std/array~anonymous|16 $start:std/array~anonymous|19 $start:std/array~anonymous|20 $start:std/array~anonymous|21 $start:std/array~anonymous|22 $start:std/array~anonymous|23 $start:std/array~anonymous|24 $start:std/array~anonymous|25 $start:std/array~anonymous|26 $start:std/array~anonymous|27 $start:std/array~anonymous|28 $start:std/array~anonymous|29 $start:std/array~anonymous|29 $start:std/array~anonymous|31 $start:std/array~anonymous|32 $start:std/array~anonymous|33 $start:std/array~anonymous|29 $start:std/array~anonymous|35 $start:std/array~anonymous|29 $start:std/array~anonymous|29 $start:std/array~anonymous|31 $start:std/array~anonymous|32 $start:std/array~anonymous|33 $start:std/array~anonymous|29 $start:std/array~anonymous|35 $~lib/util/sort/COMPARATOR<f32>~anonymous|0 $~lib/util/sort/COMPARATOR<f64>~anonymous|0 $~lib/util/sort/COMPARATOR<i32>~anonymous|0 $~lib/util/sort/COMPARATOR<u32>~anonymous|0 $~lib/util/sort/COMPARATOR<i32>~anonymous|0 $~lib/util/sort/COMPARATOR<i32>~anonymous|0 $start:std/array~anonymous|44 $~lib/util/sort/COMPARATOR<i32>~anonymous|0 $start:std/array~anonymous|44 $start:std/array~anonymous|47 $start:std/array~anonymous|48 $~lib/util/sort/COMPARATOR<~lib/string/String | null>~anonymous|0 $~lib/util/sort/COMPARATOR<~lib/string/String | null>~anonymous|0)
+ (elem (i32.const 1) $start:std/array~anonymous|0~nonClosure $start:std/array~anonymous|1~nonClosure $start:std/array~anonymous|2~nonClosure $start:std/array~anonymous|3~nonClosure $start:std/array~anonymous|2~nonClosure $start:std/array~anonymous|5~nonClosure $start:std/array~anonymous|6~nonClosure $start:std/array~anonymous|7~nonClosure $start:std/array~anonymous|8~nonClosure $start:std/array~anonymous|9~nonClosure $start:std/array~anonymous|10~nonClosure $start:std/array~anonymous|11~nonClosure $start:std/array~anonymous|12~nonClosure $start:std/array~anonymous|13~nonClosure $start:std/array~anonymous|14~nonClosure $start:std/array~anonymous|15~nonClosure $start:std/array~anonymous|16~nonClosure $start:std/array~anonymous|17~nonClosure $start:std/array~anonymous|16~nonClosure $start:std/array~anonymous|19~nonClosure $start:std/array~anonymous|20~nonClosure $start:std/array~anonymous|21~nonClosure $start:std/array~anonymous|22~nonClosure $start:std/array~anonymous|23~nonClosure $start:std/array~anonymous|24~nonClosure $start:std/array~anonymous|25~nonClosure $start:std/array~anonymous|26~nonClosure $start:std/array~anonymous|27~nonClosure $start:std/array~anonymous|28~nonClosure $start:std/array~anonymous|29~nonClosure $start:std/array~anonymous|29~nonClosure $start:std/array~anonymous|31~nonClosure $start:std/array~anonymous|32~nonClosure $start:std/array~anonymous|33~nonClosure $start:std/array~anonymous|29~nonClosure $start:std/array~anonymous|35~nonClosure $start:std/array~anonymous|29~nonClosure $start:std/array~anonymous|29~nonClosure $start:std/array~anonymous|31~nonClosure $start:std/array~anonymous|32~nonClosure $start:std/array~anonymous|33~nonClosure $start:std/array~anonymous|29~nonClosure $start:std/array~anonymous|35~nonClosure $~lib/util/sort/COMPARATOR<f32>~anonymous|0~nonClosure $~lib/util/sort/COMPARATOR<f64>~anonymous|0~nonClosure $~lib/util/sort/COMPARATOR<i32>~anonymous|0~nonClosure $~lib/util/sort/COMPARATOR<u32>~anonymous|0~nonClosure $~lib/util/sort/COMPARATOR<i32>~anonymous|0~nonClosure $~lib/util/sort/COMPARATOR<i32>~anonymous|0~nonClosure $start:std/array~anonymous|44~nonClosure $~lib/util/sort/COMPARATOR<i32>~anonymous|0~nonClosure $start:std/array~anonymous|44~nonClosure $start:std/array~anonymous|47~nonClosure $start:std/array~anonymous|48~nonClosure $~lib/util/sort/COMPARATOR<~lib/string/String | null>~anonymous|0~nonClosure $~lib/util/sort/COMPARATOR<~lib/string/String | null>~anonymous|0~nonClosure)
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/collectLock (mut i32) (i32.const 0))
  (global $std/array/arr (mut i32) (i32.const 0))
  (global $std/array/i (mut i32) (i32.const 0))
+ (global $~argumentsLength (mut i32) (i32.const 0))
  (global $~lib/math/random_seeded (mut i32) (i32.const 0))
  (global $~lib/math/random_state0_64 (mut i64) (i64.const 0))
  (global $~lib/math/random_state1_64 (mut i64) (i64.const 0))
@@ -2957,7 +2959,7 @@
   local.get $2
   i32.store
  )
- (func $start:std/array~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|0~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.eqz
  )
@@ -2965,57 +2967,127 @@
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
+  local.get $1
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  call $~lib/rt/pure/__retain
+  drop
   local.get $0
   i32.load offset=12
-  local.set $4
+  local.set $5
   loop $for-loop|0
-   local.get $2
-   local.get $4
+   local.get $3
+   local.get $5
    local.get $0
    i32.load offset=12
-   local.tee $3
-   local.get $4
-   local.get $3
+   local.tee $2
+   local.get $5
+   local.get $2
    i32.lt_s
    select
    i32.lt_s
    if
-    local.get $0
-    i32.load offset=4
-    local.get $2
-    i32.const 2
-    i32.shl
-    i32.add
-    i32.load
-    local.tee $3
-    local.get $2
-    local.get $0
     local.get $1
-    call_indirect (type $i32_i32_i32_=>_i32)
-    if
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result i32)
+     local.get $0
+     i32.load offset=4
+     local.get $3
+     i32.const 2
+     i32.shl
+     i32.add
+     i32.load
+     local.set $4
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $1
+     i32.const 4
+     i32.shl
+     local.tee $2
+     local.get $4
+     local.get $3
+     local.get $0
      local.get $2
+     i32.load
+     call_indirect (type $i32_i32_i32_i32_=>_i32)
+    else
+     local.get $0
+     i32.load offset=4
+     local.get $3
+     i32.const 2
+     i32.shl
+     i32.add
+     i32.load
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $3
+     local.get $0
+     local.get $1
+     call_indirect (type $i32_i32_i32_=>_i32)
+    end
+    if
+     local.get $1
+     local.tee $0
+     i32.const -2147483648
+     i32.and
+     i32.const -2147483648
+     i32.eq
+     if (result i32)
+      local.get $0
+      i32.const 4
+      i32.shl
+     else
+      i32.const 0
+     end
+     call $~lib/rt/pure/__release
+     local.get $3
      return
     end
-    local.get $2
+    local.get $3
     i32.const 1
     i32.add
-    local.set $2
+    local.set $3
     br $for-loop|0
    end
   end
+  local.get $1
+  local.tee $0
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $0
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
   i32.const -1
  )
- (func $start:std/array~anonymous|1 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|1~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 1
   i32.eq
  )
- (func $start:std/array~anonymous|2 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|2~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 100
   i32.eq
  )
- (func $start:std/array~anonymous|3 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|3~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $2
   i32.const 100
   call $~lib/array/Array<i32>#push
@@ -3023,7 +3095,7 @@
   i32.const 100
   i32.eq
  )
- (func $start:std/array~anonymous|5 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|5~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $2
   call $~lib/array/Array<i32>#pop
   drop
@@ -3031,7 +3103,7 @@
   i32.const 100
   i32.eq
  )
- (func $start:std/array~anonymous|6 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|6~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 0
   i32.ge_s
@@ -3040,53 +3112,123 @@
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
+  local.get $1
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  call $~lib/rt/pure/__retain
+  drop
   local.get $0
   i32.load offset=12
-  local.set $4
+  local.set $5
   loop $for-loop|0
-   local.get $2
-   local.get $4
+   local.get $3
+   local.get $5
    local.get $0
    i32.load offset=12
-   local.tee $3
-   local.get $4
-   local.get $3
+   local.tee $2
+   local.get $5
+   local.get $2
    i32.lt_s
    select
    i32.lt_s
    if
-    local.get $0
-    i32.load offset=4
-    local.get $2
-    i32.const 2
-    i32.shl
-    i32.add
-    i32.load
-    local.tee $3
-    local.get $2
-    local.get $0
     local.get $1
-    call_indirect (type $i32_i32_i32_=>_i32)
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result i32)
+     local.get $0
+     i32.load offset=4
+     local.get $3
+     i32.const 2
+     i32.shl
+     i32.add
+     i32.load
+     local.set $4
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $1
+     i32.const 4
+     i32.shl
+     local.tee $2
+     local.get $4
+     local.get $3
+     local.get $0
+     local.get $2
+     i32.load
+     call_indirect (type $i32_i32_i32_i32_=>_i32)
+    else
+     local.get $0
+     i32.load offset=4
+     local.get $3
+     i32.const 2
+     i32.shl
+     i32.add
+     i32.load
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $3
+     local.get $0
+     local.get $1
+     call_indirect (type $i32_i32_i32_=>_i32)
+    end
     i32.eqz
     if
+     local.get $1
+     local.tee $0
+     i32.const -2147483648
+     i32.and
+     i32.const -2147483648
+     i32.eq
+     if (result i32)
+      local.get $0
+      i32.const 4
+      i32.shl
+     else
+      i32.const 0
+     end
+     call $~lib/rt/pure/__release
      i32.const 0
      return
     end
-    local.get $2
+    local.get $3
     i32.const 1
     i32.add
-    local.set $2
+    local.set $3
     br $for-loop|0
    end
   end
+  local.get $1
+  local.tee $0
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $0
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
   i32.const 1
  )
- (func $start:std/array~anonymous|7 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|7~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 0
   i32.le_s
  )
- (func $start:std/array~anonymous|8 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|8~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $2
   i32.const 100
   call $~lib/array/Array<i32>#push
@@ -3094,12 +3236,12 @@
   i32.const 10
   i32.lt_s
  )
- (func $start:std/array~anonymous|9 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|9~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 10
   i32.lt_s
  )
- (func $start:std/array~anonymous|10 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|10~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $2
   call $~lib/array/Array<i32>#pop
   drop
@@ -3107,7 +3249,7 @@
   i32.const 3
   i32.lt_s
  )
- (func $start:std/array~anonymous|11 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|11~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 3
   i32.ge_s
@@ -3116,52 +3258,122 @@
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
+  local.get $1
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  call $~lib/rt/pure/__retain
+  drop
   local.get $0
   i32.load offset=12
-  local.set $4
+  local.set $5
   loop $for-loop|0
-   local.get $2
-   local.get $4
+   local.get $3
+   local.get $5
    local.get $0
    i32.load offset=12
-   local.tee $3
-   local.get $4
-   local.get $3
+   local.tee $2
+   local.get $5
+   local.get $2
    i32.lt_s
    select
    i32.lt_s
    if
-    local.get $0
-    i32.load offset=4
-    local.get $2
-    i32.const 2
-    i32.shl
-    i32.add
-    i32.load
-    local.tee $3
-    local.get $2
-    local.get $0
     local.get $1
-    call_indirect (type $i32_i32_i32_=>_i32)
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result i32)
+     local.get $0
+     i32.load offset=4
+     local.get $3
+     i32.const 2
+     i32.shl
+     i32.add
+     i32.load
+     local.set $4
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $1
+     i32.const 4
+     i32.shl
+     local.tee $2
+     local.get $4
+     local.get $3
+     local.get $0
+     local.get $2
+     i32.load
+     call_indirect (type $i32_i32_i32_i32_=>_i32)
+    else
+     local.get $0
+     i32.load offset=4
+     local.get $3
+     i32.const 2
+     i32.shl
+     i32.add
+     i32.load
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $3
+     local.get $0
+     local.get $1
+     call_indirect (type $i32_i32_i32_=>_i32)
+    end
     if
+     local.get $1
+     local.tee $0
+     i32.const -2147483648
+     i32.and
+     i32.const -2147483648
+     i32.eq
+     if (result i32)
+      local.get $0
+      i32.const 4
+      i32.shl
+     else
+      i32.const 0
+     end
+     call $~lib/rt/pure/__release
      i32.const 1
      return
     end
-    local.get $2
+    local.get $3
     i32.const 1
     i32.add
-    local.set $2
+    local.set $3
     br $for-loop|0
    end
   end
+  local.get $1
+  local.tee $0
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $0
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
   i32.const 0
  )
- (func $start:std/array~anonymous|12 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|12~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const -1
   i32.le_s
  )
- (func $start:std/array~anonymous|13 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|13~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $2
   i32.const 100
   call $~lib/array/Array<i32>#push
@@ -3169,12 +3381,12 @@
   i32.const 10
   i32.gt_s
  )
- (func $start:std/array~anonymous|14 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|14~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 10
   i32.gt_s
  )
- (func $start:std/array~anonymous|15 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|15~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $2
   call $~lib/array/Array<i32>#pop
   drop
@@ -3182,7 +3394,7 @@
   i32.const 3
   i32.gt_s
  )
- (func $start:std/array~anonymous|16 (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $start:std/array~anonymous|16~nonClosure (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $0
   global.get $std/array/i
   i32.add
@@ -3192,42 +3404,98 @@
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
+  local.get $1
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  call $~lib/rt/pure/__retain
+  drop
   local.get $0
   i32.load offset=12
-  local.set $4
+  local.set $5
   loop $for-loop|0
-   local.get $2
-   local.get $4
+   local.get $3
+   local.get $5
    local.get $0
    i32.load offset=12
-   local.tee $3
-   local.get $4
-   local.get $3
+   local.tee $2
+   local.get $5
+   local.get $2
    i32.lt_s
    select
    i32.lt_s
    if
-    local.get $0
-    i32.load offset=4
-    local.get $2
-    i32.const 2
-    i32.shl
-    i32.add
-    i32.load
-    local.tee $3
-    local.get $2
-    local.get $0
     local.get $1
-    call_indirect (type $i32_i32_i32_=>_none)
-    local.get $2
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if
+     local.get $0
+     i32.load offset=4
+     local.get $3
+     i32.const 2
+     i32.shl
+     i32.add
+     i32.load
+     local.set $4
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $1
+     i32.const 4
+     i32.shl
+     local.tee $2
+     local.get $4
+     local.get $3
+     local.get $0
+     local.get $2
+     i32.load
+     call_indirect (type $i32_i32_i32_i32_=>_none)
+    else
+     local.get $0
+     i32.load offset=4
+     local.get $3
+     i32.const 2
+     i32.shl
+     i32.add
+     i32.load
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $3
+     local.get $0
+     local.get $1
+     call_indirect (type $i32_i32_i32_=>_none)
+    end
+    local.get $3
     i32.const 1
     i32.add
-    local.set $2
+    local.set $3
     br $for-loop|0
    end
   end
+  local.get $1
+  local.tee $0
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $0
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
  )
- (func $start:std/array~anonymous|17 (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $start:std/array~anonymous|17~nonClosure (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $2
   i32.const 100
   call $~lib/array/Array<i32>#push
@@ -3236,7 +3504,7 @@
   i32.add
   global.set $std/array/i
  )
- (func $start:std/array~anonymous|19 (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $start:std/array~anonymous|19~nonClosure (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $2
   call $~lib/array/Array<i32>#pop
   drop
@@ -3245,7 +3513,7 @@
   i32.add
   global.set $std/array/i
  )
- (func $start:std/array~anonymous|20 (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $start:std/array~anonymous|20~nonClosure (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $1
   i32.eqz
@@ -3338,7 +3606,7 @@
    end
   end
  )
- (func $start:std/array~anonymous|21 (param $0 i32) (param $1 i32) (param $2 i32) (result f32)
+ (func $start:std/array~anonymous|21~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result f32)
   local.get $0
   f32.convert_i32_s
  )
@@ -3363,7 +3631,7 @@
   i32.add
   f32.load
  )
- (func $start:std/array~anonymous|22 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|22~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $2
   i32.const 100
   call $~lib/array/Array<i32>#push
@@ -3380,9 +3648,21 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  local.get $1
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  call $~lib/rt/pure/__retain
+  drop
   local.get $0
   i32.load offset=12
-  local.tee $4
+  local.tee $6
   i32.const 2
   i32.const 3
   i32.const 0
@@ -3390,54 +3670,97 @@
   call $~lib/rt/pure/__retain
   local.tee $5
   i32.load offset=4
-  local.set $6
+  local.set $7
   loop $for-loop|0
-   local.get $2
-   local.get $4
+   local.get $3
+   local.get $6
    local.get $0
    i32.load offset=12
-   local.tee $3
-   local.get $4
-   local.get $3
+   local.tee $2
+   local.get $6
+   local.get $2
    i32.lt_s
    select
    i32.lt_s
    if
-    local.get $2
+    local.get $7
+    local.get $3
     i32.const 2
     i32.shl
-    local.tee $3
-    local.get $0
-    i32.load offset=4
     i32.add
-    i32.load
-    local.set $7
-    local.get $3
-    local.get $6
-    i32.add
-    local.get $7
-    local.get $2
-    local.get $0
     local.get $1
-    call_indirect (type $i32_i32_i32_=>_i32)
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result i32)
+     local.get $0
+     i32.load offset=4
+     local.get $3
+     i32.const 2
+     i32.shl
+     i32.add
+     i32.load
+     local.set $4
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $1
+     i32.const 4
+     i32.shl
+     local.tee $2
+     local.get $4
+     local.get $3
+     local.get $0
+     local.get $2
+     i32.load
+     call_indirect (type $i32_i32_i32_i32_=>_i32)
+    else
+     local.get $0
+     i32.load offset=4
+     local.get $3
+     i32.const 2
+     i32.shl
+     i32.add
+     i32.load
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $3
+     local.get $0
+     local.get $1
+     call_indirect (type $i32_i32_i32_=>_i32)
+    end
     i32.store
-    local.get $2
+    local.get $3
     i32.const 1
     i32.add
-    local.set $2
+    local.set $3
     br $for-loop|0
    end
   end
+  local.get $1
+  local.tee $0
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $0
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
   local.get $5
  )
- (func $start:std/array~anonymous|23 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|23~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   global.get $std/array/i
   i32.add
   global.set $std/array/i
   local.get $0
  )
- (func $start:std/array~anonymous|24 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|24~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $2
   call $~lib/array/Array<i32>#pop
   drop
@@ -3447,7 +3770,7 @@
   global.set $std/array/i
   local.get $0
  )
- (func $start:std/array~anonymous|25 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|25~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 2
   i32.ge_s
@@ -3457,6 +3780,19 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  local.get $1
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  call $~lib/rt/pure/__retain
+  drop
   i32.const 0
   i32.const 2
   i32.const 3
@@ -3466,46 +3802,83 @@
   local.set $4
   local.get $0
   i32.load offset=12
-  local.set $5
+  local.set $6
   loop $for-loop|0
-   local.get $2
-   local.get $5
+   local.get $3
+   local.get $6
    local.get $0
    i32.load offset=12
-   local.tee $3
-   local.get $5
-   local.get $3
+   local.tee $2
+   local.get $6
+   local.get $2
    i32.lt_s
    select
    i32.lt_s
    if
     local.get $0
     i32.load offset=4
-    local.get $2
+    local.get $3
     i32.const 2
     i32.shl
     i32.add
     i32.load
-    local.tee $3
-    local.get $2
-    local.get $0
+    local.set $5
     local.get $1
-    call_indirect (type $i32_i32_i32_=>_i32)
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result i32)
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $1
+     i32.const 4
+     i32.shl
+     local.tee $2
+     local.get $5
+     local.get $3
+     local.get $0
+     local.get $2
+     i32.load
+     call_indirect (type $i32_i32_i32_i32_=>_i32)
+    else
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $5
+     local.get $3
+     local.get $0
+     local.get $1
+     call_indirect (type $i32_i32_i32_=>_i32)
+    end
     if
      local.get $4
-     local.get $3
+     local.get $5
      call $~lib/array/Array<i32>#push
     end
-    local.get $2
+    local.get $3
     i32.const 1
     i32.add
-    local.set $2
+    local.set $3
     br $for-loop|0
    end
   end
+  local.get $1
+  local.tee $0
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $0
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
   local.get $4
  )
- (func $start:std/array~anonymous|26 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|26~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $2
   i32.const 100
   call $~lib/array/Array<i32>#push
@@ -3517,7 +3890,7 @@
   i32.const 2
   i32.ge_s
  )
- (func $start:std/array~anonymous|27 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|27~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   global.get $std/array/i
   i32.add
@@ -3526,7 +3899,7 @@
   i32.const 2
   i32.ge_s
  )
- (func $start:std/array~anonymous|28 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|28~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $2
   call $~lib/array/Array<i32>#pop
   drop
@@ -3538,7 +3911,7 @@
   i32.const 2
   i32.ge_s
  )
- (func $start:std/array~anonymous|29 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|29~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   local.get $0
   local.get $1
   i32.add
@@ -3547,45 +3920,104 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  local.get $1
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  call $~lib/rt/pure/__retain
+  drop
   local.get $0
   i32.load offset=12
-  local.set $5
+  local.set $6
   loop $for-loop|0
-   local.get $3
-   local.get $5
+   local.get $4
+   local.get $6
    local.get $0
    i32.load offset=12
-   local.tee $4
-   local.get $5
-   local.get $4
+   local.tee $3
+   local.get $6
+   local.get $3
    i32.lt_s
    select
    i32.lt_s
    if
-    local.get $2
-    local.get $0
-    i32.load offset=4
-    local.get $3
-    i32.const 2
-    i32.shl
-    i32.add
-    i32.load
-    local.tee $4
-    local.get $3
-    local.get $0
     local.get $1
-    call_indirect (type $i32_i32_i32_i32_=>_i32)
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result i32)
+     local.get $0
+     i32.load offset=4
+     local.get $4
+     i32.const 2
+     i32.shl
+     i32.add
+     i32.load
+     local.set $5
+     i32.const 4
+     global.set $~argumentsLength
+     local.get $1
+     i32.const 4
+     i32.shl
+     local.tee $3
+     local.get $2
+     local.get $5
+     local.get $4
+     local.get $0
+     local.get $3
+     i32.load
+     call_indirect (type $i32_i32_i32_i32_i32_=>_i32)
+    else
+     local.get $0
+     i32.load offset=4
+     local.get $4
+     i32.const 2
+     i32.shl
+     i32.add
+     i32.load
+     local.set $5
+     i32.const 4
+     global.set $~argumentsLength
+     local.get $2
+     local.get $5
+     local.get $4
+     local.get $0
+     local.get $1
+     call_indirect (type $i32_i32_i32_i32_=>_i32)
+    end
     local.set $2
-    local.get $3
+    local.get $4
     i32.const 1
     i32.add
-    local.set $3
+    local.set $4
     br $for-loop|0
    end
   end
+  local.get $1
+  local.tee $0
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $0
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
   local.get $2
  )
- (func $start:std/array~anonymous|31 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|31~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   i32.const 1
   local.get $1
   i32.const 2
@@ -3593,7 +4025,7 @@
   local.get $0
   select
  )
- (func $start:std/array~anonymous|32 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|32~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   i32.const 1
   local.get $1
   i32.const 100
@@ -3601,7 +4033,7 @@
   local.get $0
   select
  )
- (func $start:std/array~anonymous|33 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|33~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   local.get $3
   i32.const 1
   call $~lib/array/Array<i32>#push
@@ -3609,7 +4041,7 @@
   local.get $1
   i32.add
  )
- (func $start:std/array~anonymous|35 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|35~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   local.get $3
   call $~lib/array/Array<i32>#pop
   drop
@@ -3620,36 +4052,96 @@
  (func $~lib/array/Array<i32>#reduceRight<i32> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
+  local.get $1
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  call $~lib/rt/pure/__retain
+  drop
   local.get $0
   i32.load offset=12
   i32.const 1
   i32.sub
-  local.set $3
+  local.set $4
   loop $for-loop|0
-   local.get $3
+   local.get $4
    i32.const 0
    i32.ge_s
    if
-    local.get $2
-    local.get $0
-    i32.load offset=4
-    local.get $3
-    i32.const 2
-    i32.shl
-    i32.add
-    i32.load
-    local.get $3
-    local.get $0
     local.get $1
-    call_indirect (type $i32_i32_i32_i32_=>_i32)
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result i32)
+     local.get $0
+     i32.load offset=4
+     local.get $4
+     i32.const 2
+     i32.shl
+     i32.add
+     i32.load
+     local.set $5
+     i32.const 4
+     global.set $~argumentsLength
+     local.get $1
+     i32.const 4
+     i32.shl
+     local.tee $3
+     local.get $2
+     local.get $5
+     local.get $4
+     local.get $0
+     local.get $3
+     i32.load
+     call_indirect (type $i32_i32_i32_i32_i32_=>_i32)
+    else
+     local.get $0
+     i32.load offset=4
+     local.get $4
+     i32.const 2
+     i32.shl
+     i32.add
+     i32.load
+     local.set $5
+     i32.const 4
+     global.set $~argumentsLength
+     local.get $2
+     local.get $5
+     local.get $4
+     local.get $0
+     local.get $1
+     call_indirect (type $i32_i32_i32_i32_=>_i32)
+    end
     local.set $2
-    local.get $3
+    local.get $4
     i32.const 1
     i32.sub
-    local.set $3
+    local.set $4
     br $for-loop|0
    end
   end
+  local.get $1
+  local.tee $0
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $0
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
   local.get $2
  )
  (func $~lib/math/murmurHash3 (param $0 i64) (result i64)
@@ -3750,6 +4242,84 @@
    unreachable
   end
  )
+ (func $~lib/util/sort/insertionSort<f32> (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 f32)
+  (local $5 f32)
+  (local $6 i32)
+  loop $for-loop|0
+   local.get $6
+   local.get $1
+   i32.lt_s
+   if
+    local.get $0
+    local.get $6
+    i32.const 2
+    i32.shl
+    i32.add
+    f32.load
+    local.set $5
+    local.get $6
+    i32.const 1
+    i32.sub
+    local.set $3
+    loop $while-continue|1
+     local.get $3
+     i32.const 0
+     i32.ge_s
+     if
+      block $while-break|1
+       local.get $0
+       local.get $3
+       i32.const 2
+       i32.shl
+       i32.add
+       f32.load
+       local.set $4
+       i32.const 2
+       global.set $~argumentsLength
+       local.get $5
+       local.get $4
+       call $~lib/util/sort/COMPARATOR<f32>~anonymous|0~nonClosure
+       i32.const 0
+       i32.ge_s
+       br_if $while-break|1
+       local.get $3
+       local.tee $2
+       i32.const 1
+       i32.sub
+       local.set $3
+       local.get $0
+       local.get $2
+       i32.const 1
+       i32.add
+       i32.const 2
+       i32.shl
+       i32.add
+       local.get $4
+       f32.store
+       br $while-continue|1
+      end
+     end
+    end
+    local.get $0
+    local.get $3
+    i32.const 1
+    i32.add
+    i32.const 2
+    i32.shl
+    i32.add
+    local.get $5
+    f32.store
+    local.get $6
+    i32.const 1
+    i32.add
+    local.set $6
+    br $for-loop|0
+   end
+  end
+ )
  (func $~lib/util/sort/weakHeapSort<f32> (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -3820,15 +4390,19 @@
     i32.shl
     i32.add
     f32.load
-    local.tee $4
+    local.set $4
     local.get $0
     local.get $3
     i32.const 2
     i32.shl
     i32.add
     f32.load
-    local.tee $6
-    call $~lib/util/sort/COMPARATOR<f32>~anonymous|0
+    local.set $6
+    i32.const 2
+    global.set $~argumentsLength
+    local.get $4
+    local.get $6
+    call $~lib/util/sort/COMPARATOR<f32>~anonymous|0~nonClosure
     i32.const 0
     i32.lt_s
     if
@@ -3932,15 +4506,19 @@
      if
       local.get $0
       f32.load
-      local.tee $4
+      local.set $4
       local.get $0
       local.get $1
       i32.const 2
       i32.shl
       i32.add
       f32.load
-      local.tee $6
-      call $~lib/util/sort/COMPARATOR<f32>~anonymous|0
+      local.set $6
+      i32.const 2
+      global.set $~argumentsLength
+      local.get $4
+      local.get $6
+      call $~lib/util/sort/COMPARATOR<f32>~anonymous|0~nonClosure
       i32.const 0
       i32.lt_s
       if
@@ -4001,7 +4579,7 @@
   local.get $4
   f32.store
  )
- (func $~lib/util/sort/COMPARATOR<f32>~anonymous|0 (param $0 f32) (param $1 f32) (result i32)
+ (func $~lib/util/sort/COMPARATOR<f32>~anonymous|0~nonClosure (param $0 f32) (param $1 f32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -4029,6 +4607,84 @@
   local.get $3
   i32.lt_s
   i32.sub
+ )
+ (func $~lib/util/sort/insertionSort<f64> (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 f64)
+  (local $5 f64)
+  (local $6 i32)
+  loop $for-loop|0
+   local.get $6
+   local.get $1
+   i32.lt_s
+   if
+    local.get $0
+    local.get $6
+    i32.const 3
+    i32.shl
+    i32.add
+    f64.load
+    local.set $5
+    local.get $6
+    i32.const 1
+    i32.sub
+    local.set $3
+    loop $while-continue|1
+     local.get $3
+     i32.const 0
+     i32.ge_s
+     if
+      block $while-break|1
+       local.get $0
+       local.get $3
+       i32.const 3
+       i32.shl
+       i32.add
+       f64.load
+       local.set $4
+       i32.const 2
+       global.set $~argumentsLength
+       local.get $5
+       local.get $4
+       call $~lib/util/sort/COMPARATOR<f64>~anonymous|0~nonClosure
+       i32.const 0
+       i32.ge_s
+       br_if $while-break|1
+       local.get $3
+       local.tee $2
+       i32.const 1
+       i32.sub
+       local.set $3
+       local.get $0
+       local.get $2
+       i32.const 1
+       i32.add
+       i32.const 3
+       i32.shl
+       i32.add
+       local.get $4
+       f64.store
+       br $while-continue|1
+      end
+     end
+    end
+    local.get $0
+    local.get $3
+    i32.const 1
+    i32.add
+    i32.const 3
+    i32.shl
+    i32.add
+    local.get $5
+    f64.store
+    local.get $6
+    i32.const 1
+    i32.add
+    local.set $6
+    br $for-loop|0
+   end
+  end
  )
  (func $~lib/util/sort/weakHeapSort<f64> (param $0 i32) (param $1 i32)
   (local $2 i32)
@@ -4100,15 +4756,19 @@
     i32.shl
     i32.add
     f64.load
-    local.tee $4
+    local.set $4
     local.get $0
     local.get $3
     i32.const 3
     i32.shl
     i32.add
     f64.load
-    local.tee $6
-    call $~lib/util/sort/COMPARATOR<f64>~anonymous|0
+    local.set $6
+    i32.const 2
+    global.set $~argumentsLength
+    local.get $4
+    local.get $6
+    call $~lib/util/sort/COMPARATOR<f64>~anonymous|0~nonClosure
     i32.const 0
     i32.lt_s
     if
@@ -4212,15 +4872,19 @@
      if
       local.get $0
       f64.load
-      local.tee $4
+      local.set $4
       local.get $0
       local.get $1
       i32.const 3
       i32.shl
       i32.add
       f64.load
-      local.tee $6
-      call $~lib/util/sort/COMPARATOR<f64>~anonymous|0
+      local.set $6
+      i32.const 2
+      global.set $~argumentsLength
+      local.get $4
+      local.get $6
+      call $~lib/util/sort/COMPARATOR<f64>~anonymous|0~nonClosure
       i32.const 0
       i32.lt_s
       if
@@ -4281,7 +4945,7 @@
   local.get $4
   f64.store
  )
- (func $~lib/util/sort/COMPARATOR<f64>~anonymous|0 (param $0 f64) (param $1 f64) (result i32)
+ (func $~lib/util/sort/COMPARATOR<f64>~anonymous|0~nonClosure (param $0 f64) (param $1 f64) (result i32)
   (local $2 i64)
   (local $3 i64)
   local.get $0
@@ -4331,6 +4995,128 @@
   i32.add
   f64.load
  )
+ (func $~lib/util/sort/insertionSort<i32> (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  local.get $2
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  call $~lib/rt/pure/__retain
+  drop
+  loop $for-loop|0
+   local.get $5
+   local.get $1
+   i32.lt_s
+   if
+    local.get $0
+    local.get $5
+    i32.const 2
+    i32.shl
+    i32.add
+    i32.load
+    local.set $6
+    local.get $5
+    i32.const 1
+    i32.sub
+    local.set $4
+    loop $while-continue|1
+     local.get $4
+     i32.const 0
+     i32.ge_s
+     if
+      block $while-break|1
+       local.get $0
+       local.get $4
+       i32.const 2
+       i32.shl
+       i32.add
+       i32.load
+       local.set $7
+       local.get $2
+       i32.const -2147483648
+       i32.and
+       i32.const -2147483648
+       i32.eq
+       if (result i32)
+        i32.const 2
+        global.set $~argumentsLength
+        local.get $2
+        i32.const 4
+        i32.shl
+        local.tee $3
+        local.get $6
+        local.get $7
+        local.get $3
+        i32.load
+        call_indirect (type $i32_i32_i32_=>_i32)
+       else
+        i32.const 2
+        global.set $~argumentsLength
+        local.get $6
+        local.get $7
+        local.get $2
+        call_indirect (type $i32_i32_=>_i32)
+       end
+       i32.const 0
+       i32.ge_s
+       br_if $while-break|1
+       local.get $4
+       local.tee $3
+       i32.const 1
+       i32.sub
+       local.set $4
+       local.get $0
+       local.get $3
+       i32.const 1
+       i32.add
+       i32.const 2
+       i32.shl
+       i32.add
+       local.get $7
+       i32.store
+       br $while-continue|1
+      end
+     end
+    end
+    local.get $0
+    local.get $4
+    i32.const 1
+    i32.add
+    i32.const 2
+    i32.shl
+    i32.add
+    local.get $6
+    i32.store
+    local.get $5
+    i32.const 1
+    i32.add
+    local.set $5
+    br $for-loop|0
+   end
+  end
+  local.get $2
+  local.tee $0
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  call $~lib/rt/pure/__release
+ )
  (func $~lib/util/sort/weakHeapSort<i32> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4338,6 +5124,18 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  local.get $2
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  call $~lib/rt/pure/__retain
+  drop
   local.get $1
   i32.const 31
   i32.add
@@ -4348,7 +5146,7 @@
   local.tee $3
   i32.const 0
   call $~lib/rt/tlsf/__alloc
-  local.tee $5
+  local.tee $7
   i32.const 0
   local.get $3
   call $~lib/memory/memory.fill
@@ -4367,7 +5165,7 @@
      local.get $3
      i32.const 1
      i32.and
-     local.get $5
+     local.get $7
      local.get $3
      i32.const 6
      i32.shr_u
@@ -4396,33 +5194,56 @@
     local.get $3
     i32.const 1
     i32.shr_s
-    local.tee $7
+    local.tee $8
     i32.const 2
     i32.shl
     i32.add
     i32.load
-    local.tee $3
+    local.set $3
     local.get $0
     local.get $4
     i32.const 2
     i32.shl
     i32.add
     i32.load
-    local.tee $6
+    local.set $5
     local.get $2
-    call_indirect (type $i32_i32_=>_i32)
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result i32)
+     i32.const 2
+     global.set $~argumentsLength
+     local.get $2
+     i32.const 4
+     i32.shl
+     local.tee $6
+     local.get $3
+     local.get $5
+     local.get $6
+     i32.load
+     call_indirect (type $i32_i32_i32_=>_i32)
+    else
+     i32.const 2
+     global.set $~argumentsLength
+     local.get $3
+     local.get $5
+     local.get $2
+     call_indirect (type $i32_i32_=>_i32)
+    end
     i32.const 0
     i32.lt_s
     if
-     local.get $5
+     local.get $7
      local.get $4
      i32.const 5
      i32.shr_u
      i32.const 2
      i32.shl
      i32.add
-     local.tee $8
-     local.get $8
+     local.tee $6
+     local.get $6
      i32.load
      i32.const 1
      local.get $4
@@ -4439,11 +5260,11 @@
      local.get $3
      i32.store
      local.get $0
-     local.get $7
+     local.get $8
      i32.const 2
      i32.shl
      i32.add
-     local.get $6
+     local.get $5
      i32.store
     end
     local.get $4
@@ -4480,7 +5301,7 @@
     i32.const 1
     local.set $1
     loop $while-continue|3
-     local.get $5
+     local.get $7
      local.get $1
      i32.const 5
      i32.shr_u
@@ -4514,28 +5335,51 @@
      if
       local.get $0
       i32.load
-      local.tee $3
+      local.set $3
       local.get $0
       local.get $1
       i32.const 2
       i32.shl
       i32.add
       i32.load
-      local.tee $6
+      local.set $5
       local.get $2
-      call_indirect (type $i32_i32_=>_i32)
+      i32.const -2147483648
+      i32.and
+      i32.const -2147483648
+      i32.eq
+      if (result i32)
+       i32.const 2
+       global.set $~argumentsLength
+       local.get $2
+       i32.const 4
+       i32.shl
+       local.tee $6
+       local.get $3
+       local.get $5
+       local.get $6
+       i32.load
+       call_indirect (type $i32_i32_i32_=>_i32)
+      else
+       i32.const 2
+       global.set $~argumentsLength
+       local.get $3
+       local.get $5
+       local.get $2
+       call_indirect (type $i32_i32_=>_i32)
+      end
       i32.const 0
       i32.lt_s
       if
-       local.get $5
+       local.get $7
        local.get $1
        i32.const 5
        i32.shr_u
        i32.const 2
        i32.shl
        i32.add
-       local.tee $7
-       local.get $7
+       local.tee $6
+       local.get $6
        i32.load
        i32.const 1
        local.get $1
@@ -4552,7 +5396,7 @@
        local.get $3
        i32.store
        local.get $0
-       local.get $6
+       local.get $5
        i32.store
       end
       local.get $1
@@ -4570,7 +5414,7 @@
    end
   end
   call $~lib/rt/tlsf/maybeInitialize
-  local.get $5
+  local.get $7
   call $~lib/rt/tlsf/checkUsedBlock
   call $~lib/rt/tlsf/freeBlock
   local.get $0
@@ -4583,145 +5427,186 @@
   local.get $0
   local.get $1
   i32.store
+  local.get $2
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  call $~lib/rt/pure/__release
  )
  (func $~lib/array/Array<i32>#sort (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
+  local.get $1
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  call $~lib/rt/pure/__retain
+  drop
   local.get $0
   i32.load offset=12
-  local.tee $3
+  local.tee $2
   i32.const 1
   i32.le_s
   if
    local.get $0
    call $~lib/rt/pure/__retain
+   local.get $1
+   local.tee $0
+   i32.const 4
+   i32.shl
+   i32.const 0
+   local.get $0
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   select
+   call $~lib/rt/pure/__release
    return
   end
   local.get $0
   i32.load offset=4
-  local.set $2
-  local.get $3
+  local.set $3
+  local.get $2
   i32.const 2
   i32.eq
   if
-   local.get $2
+   local.get $3
    i32.load offset=4
-   local.tee $3
-   local.get $2
+   local.set $4
+   local.get $3
    i32.load
-   local.tee $5
+   local.set $5
    local.get $1
-   call_indirect (type $i32_i32_=>_i32)
+   local.tee $2
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    i32.const 2
+    global.set $~argumentsLength
+    local.get $2
+    i32.const 4
+    i32.shl
+    local.tee $2
+    local.get $4
+    local.get $5
+    local.get $2
+    i32.load
+    call_indirect (type $i32_i32_i32_=>_i32)
+   else
+    i32.const 2
+    global.set $~argumentsLength
+    local.get $4
+    local.get $5
+    local.get $2
+    call_indirect (type $i32_i32_=>_i32)
+   end
    i32.const 0
    i32.lt_s
    if
-    local.get $2
+    local.get $3
     local.get $5
     i32.store offset=4
-    local.get $2
     local.get $3
+    local.get $4
     i32.store
    end
    local.get $0
    call $~lib/rt/pure/__retain
+   local.get $1
+   local.tee $0
+   i32.const 4
+   i32.shl
+   i32.const 0
+   local.get $0
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   select
+   call $~lib/rt/pure/__release
    return
   end
-  local.get $3
+  local.get $2
+  local.set $4
+  local.get $1
+  local.tee $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $4
   i32.const 256
   i32.lt_s
   if
    local.get $3
-   local.set $5
-   local.get $1
-   local.set $7
-   loop $for-loop|0
-    local.get $4
-    local.get $5
-    i32.lt_s
-    if
-     local.get $2
-     local.get $4
-     i32.const 2
-     i32.shl
-     i32.add
-     i32.load
-     local.set $6
-     local.get $4
-     i32.const 1
-     i32.sub
-     local.set $1
-     loop $while-continue|1
-      local.get $1
-      i32.const 0
-      i32.ge_s
-      if
-       local.get $6
-       local.get $2
-       local.get $1
-       i32.const 2
-       i32.shl
-       i32.add
-       i32.load
-       local.tee $8
-       local.get $7
-       call_indirect (type $i32_i32_=>_i32)
-       i32.const 0
-       i32.lt_s
-       if
-        local.get $1
-        local.tee $3
-        i32.const 1
-        i32.sub
-        local.set $1
-        local.get $2
-        local.get $3
-        i32.const 1
-        i32.add
-        i32.const 2
-        i32.shl
-        i32.add
-        local.get $8
-        i32.store
-        br $while-continue|1
-       end
-      end
-     end
-     local.get $2
-     local.get $1
-     i32.const 1
-     i32.add
-     i32.const 2
-     i32.shl
-     i32.add
-     local.get $6
-     i32.store
-     local.get $4
-     i32.const 1
-     i32.add
-     local.set $4
-     br $for-loop|0
-    end
-   end
-  else
+   local.get $4
    local.get $2
+   call $~lib/util/sort/insertionSort<i32>
+  else
    local.get $3
-   local.get $1
+   local.get $4
+   local.get $2
    call $~lib/util/sort/weakHeapSort<i32>
   end
+  local.get $2
+  local.tee $3
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__retain
+  local.get $1
+  local.tee $0
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $0
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  call $~lib/rt/pure/__release
  )
- (func $~lib/util/sort/COMPARATOR<i32>~anonymous|0 (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/sort/COMPARATOR<i32>~anonymous|0~nonClosure (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.sub
  )
- (func $~lib/util/sort/COMPARATOR<u32>~anonymous|0 (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/sort/COMPARATOR<u32>~anonymous|0~nonClosure (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.gt_u
@@ -4827,28 +5712,62 @@
   end
   local.get $2
  )
- (func $std/array/assertSorted<i32> (param $0 i32) (param $1 i32)
+ (func $std/array/isSorted<i32> (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  block $__inlined_func$std/array/isSorted<i32> (result i32)
-   i32.const 1
-   local.set $2
-   local.get $0
-   local.get $1
-   call $~lib/array/Array<i32>#sort
-   local.tee $3
-   local.tee $0
-   i32.load offset=12
-   local.set $4
-   loop $for-loop|0
-    local.get $2
-    local.get $4
-    i32.lt_s
-    if
-     i32.const 0
+  local.get $1
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  call $~lib/rt/pure/__retain
+  drop
+  i32.const 1
+  local.set $2
+  local.get $0
+  i32.load offset=12
+  local.set $5
+  loop $for-loop|0
+   local.get $2
+   local.get $5
+   i32.lt_s
+   if
+    local.get $1
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result i32)
+     local.get $0
+     local.get $2
+     i32.const 1
+     i32.sub
+     call $~lib/array/Array<u32>#__get
+     local.set $3
+     local.get $0
+     local.get $2
+     call $~lib/array/Array<u32>#__get
+     local.set $4
+     i32.const 2
+     global.set $~argumentsLength
+     local.get $1
+     i32.const 4
+     i32.shl
+     local.tee $6
+     local.get $3
+     local.get $4
+     local.get $6
+     i32.load
+     call_indirect (type $i32_i32_i32_=>_i32)
+    else
      local.get $0
      local.get $2
      i32.const 1
@@ -4857,21 +5776,70 @@
      local.get $0
      local.get $2
      call $~lib/array/Array<u32>#__get
+     i32.const 2
+     global.set $~argumentsLength
      local.get $1
      call_indirect (type $i32_i32_=>_i32)
-     i32.const 0
-     i32.gt_s
-     br_if $__inlined_func$std/array/isSorted<i32>
-     drop
-     local.get $2
-     i32.const 1
-     i32.add
-     local.set $2
-     br $for-loop|0
     end
+    i32.const 0
+    i32.gt_s
+    if
+     local.get $1
+     i32.const 4
+     i32.shl
+     i32.const 0
+     local.get $1
+     i32.const -2147483648
+     i32.and
+     i32.const -2147483648
+     i32.eq
+     select
+     call $~lib/rt/pure/__release
+     i32.const 0
+     return
+    end
+    local.get $2
+    i32.const 1
+    i32.add
+    local.set $2
+    br $for-loop|0
    end
-   i32.const 1
   end
+  local.get $1
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  call $~lib/rt/pure/__release
+  i32.const 1
+ )
+ (func $std/array/assertSorted<i32> (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  local.get $1
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $0
+  local.tee $2
+  local.get $1
+  local.tee $0
+  call $~lib/array/Array<i32>#sort
+  local.tee $2
+  local.get $0
+  call $std/array/isSorted<i32>
   i32.eqz
   if
    i32.const 0
@@ -4881,10 +5849,21 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $2
+  call $~lib/rt/pure/__release
+  local.get $0
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $0
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
   call $~lib/rt/pure/__release
  )
- (func $start:std/array~anonymous|44 (param $0 i32) (param $1 i32) (result i32)
+ (func $start:std/array~anonymous|44~nonClosure (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.sub
@@ -5021,7 +6000,7 @@
   end
   local.get $2
  )
- (func $start:std/array~anonymous|47 (param $0 i32) (param $1 i32) (result i32)
+ (func $start:std/array~anonymous|47~nonClosure (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.const 0
   call $~lib/array/Array<u32>#__get
@@ -5035,179 +6014,300 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
+  local.get $1
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  call $~lib/rt/pure/__retain
+  drop
   local.get $0
   i32.load offset=12
-  local.tee $5
+  local.tee $3
   i32.const 1
   i32.le_s
   if
    local.get $0
    call $~lib/rt/pure/__retain
+   local.get $1
+   local.tee $0
+   i32.const 4
+   i32.shl
+   i32.const 0
+   local.get $1
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   select
+   call $~lib/rt/pure/__release
    return
   end
   local.get $0
   i32.load offset=4
-  local.set $2
-  local.get $5
+  local.set $4
+  local.get $3
   i32.const 2
   i32.eq
   if
-   local.get $2
+   local.get $4
    i32.load offset=4
-   local.tee $3
-   local.get $2
+   local.set $5
+   local.get $4
    i32.load
-   local.tee $5
+   local.set $3
    local.get $1
-   call_indirect (type $i32_i32_=>_i32)
+   local.set $2
+   local.get $1
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    i32.const 2
+    global.set $~argumentsLength
+    local.get $2
+    i32.const 4
+    i32.shl
+    local.tee $2
+    local.get $5
+    local.get $3
+    local.get $2
+    i32.load
+    call_indirect (type $i32_i32_i32_=>_i32)
+   else
+    i32.const 2
+    global.set $~argumentsLength
+    local.get $5
+    local.get $3
+    local.get $2
+    call_indirect (type $i32_i32_=>_i32)
+   end
    i32.const 0
    i32.lt_s
    if
-    local.get $2
-    local.get $5
-    i32.store offset=4
-    local.get $2
+    local.get $4
     local.get $3
+    i32.store offset=4
+    local.get $4
+    local.get $5
     i32.store
    end
    local.get $0
    call $~lib/rt/pure/__retain
+   local.get $1
+   local.tee $0
+   i32.const 4
+   i32.shl
+   i32.const 0
+   local.get $1
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   select
+   call $~lib/rt/pure/__release
    return
   end
-  local.get $2
-  local.set $3
   local.get $1
-  local.set $7
-  loop $for-loop|0
-   local.get $4
-   local.get $5
-   i32.lt_s
-   if
-    local.get $3
-    local.get $4
-    i32.const 2
-    i32.shl
-    i32.add
-    i32.load
-    local.set $6
-    local.get $4
-    i32.const 1
-    i32.sub
-    local.set $1
-    loop $while-continue|1
-     local.get $1
-     i32.const 0
-     i32.ge_s
-     if
-      local.get $6
-      local.get $3
-      local.get $1
-      i32.const 2
-      i32.shl
-      i32.add
-      i32.load
-      local.tee $8
-      local.get $7
-      call_indirect (type $i32_i32_=>_i32)
-      i32.const 0
-      i32.lt_s
-      if
-       local.get $1
-       local.tee $2
-       i32.const 1
-       i32.sub
-       local.set $1
-       local.get $3
-       local.get $2
-       i32.const 1
-       i32.add
-       i32.const 2
-       i32.shl
-       i32.add
-       local.get $8
-       i32.store
-       br $while-continue|1
-      end
-     end
-    end
-    local.get $3
-    local.get $1
-    i32.const 1
-    i32.add
-    i32.const 2
-    i32.shl
-    i32.add
-    local.get $6
-    i32.store
-    local.get $4
-    i32.const 1
-    i32.add
-    local.set $4
-    br $for-loop|0
-   end
-  end
+  local.tee $2
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $4
+  local.get $3
+  local.get $1
+  call $~lib/util/sort/insertionSort<i32>
+  local.get $1
+  local.tee $3
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__retain
+  local.get $1
+  local.tee $0
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  call $~lib/rt/pure/__release
  )
- (func $std/array/assertSorted<~lib/array/Array<i32>> (param $0 i32) (param $1 i32)
+ (func $std/array/isSorted<~lib/array/Array<i32>> (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  block $__inlined_func$std/array/isSorted<~lib/array/Array<i32>> (result i32)
-   i32.const 1
-   local.set $2
-   local.get $0
-   local.get $1
-   call $~lib/array/Array<~lib/array/Array<i32>>#sort
-   local.tee $5
-   local.tee $4
-   i32.load offset=12
-   local.set $6
-   loop $for-loop|0
-    local.get $2
-    local.get $6
-    i32.lt_s
-    if
-     local.get $4
+  (local $7 i32)
+  (local $8 i32)
+  local.get $1
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  call $~lib/rt/pure/__retain
+  drop
+  i32.const 1
+  local.set $2
+  local.get $0
+  i32.load offset=12
+  local.set $7
+  loop $for-loop|0
+   local.get $2
+   local.get $7
+   i32.lt_s
+   if
+    local.get $1
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result i32)
+     local.get $0
      local.get $2
      i32.const 1
      i32.sub
      call $~lib/array/Array<std/array/Ref>#__get
-     local.tee $0
-     local.get $4
+     local.set $3
+     local.get $0
      local.get $2
      call $~lib/array/Array<std/array/Ref>#__get
-     local.tee $3
+     local.set $4
+     i32.const 2
+     global.set $~argumentsLength
+     local.get $1
+     i32.const 4
+     i32.shl
+     local.tee $8
+     local.get $3
+     local.get $4
+     local.get $8
+     i32.load
+     call_indirect (type $i32_i32_i32_=>_i32)
+    else
+     local.get $0
+     local.get $2
+     i32.const 1
+     i32.sub
+     call $~lib/array/Array<std/array/Ref>#__get
+     local.set $5
+     local.get $0
+     local.get $2
+     call $~lib/array/Array<std/array/Ref>#__get
+     local.set $6
+     i32.const 2
+     global.set $~argumentsLength
+     local.get $5
+     local.get $6
      local.get $1
      call_indirect (type $i32_i32_=>_i32)
+    end
+    i32.const 0
+    i32.gt_s
+    if
+     local.get $1
+     i32.const 4
+     i32.shl
      i32.const 0
-     i32.gt_s
-     if
-      local.get $0
-      call $~lib/rt/pure/__release
-      local.get $3
-      call $~lib/rt/pure/__release
-      i32.const 0
-      br $__inlined_func$std/array/isSorted<~lib/array/Array<i32>>
-     end
-     local.get $0
+     local.get $1
+     i32.const -2147483648
+     i32.and
+     i32.const -2147483648
+     i32.eq
+     select
      call $~lib/rt/pure/__release
      local.get $3
      call $~lib/rt/pure/__release
-     local.get $2
-     i32.const 1
-     i32.add
-     local.set $2
-     br $for-loop|0
+     local.get $4
+     call $~lib/rt/pure/__release
+     local.get $5
+     call $~lib/rt/pure/__release
+     local.get $6
+     call $~lib/rt/pure/__release
+     i32.const 0
+     return
     end
+    local.get $3
+    call $~lib/rt/pure/__release
+    local.get $4
+    call $~lib/rt/pure/__release
+    local.get $5
+    call $~lib/rt/pure/__release
+    local.get $6
+    call $~lib/rt/pure/__release
+    local.get $2
+    i32.const 1
+    i32.add
+    local.set $2
+    br $for-loop|0
    end
-   i32.const 1
   end
+  local.get $1
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  call $~lib/rt/pure/__release
+  i32.const 1
+ )
+ (func $std/array/assertSorted<~lib/array/Array<i32>> (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  local.get $1
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $0
+  local.tee $2
+  local.get $1
+  local.tee $0
+  call $~lib/array/Array<~lib/array/Array<i32>>#sort
+  local.tee $2
+  local.get $0
+  call $std/array/isSorted<~lib/array/Array<i32>>
   i32.eqz
   if
    i32.const 0
@@ -5217,7 +6317,18 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $2
+  call $~lib/rt/pure/__release
+  local.get $0
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $0
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
   call $~lib/rt/pure/__release
  )
  (func $std/array/createReverseOrderedElementsArray (result i32)
@@ -5304,12 +6415,140 @@
   end
   local.get $2
  )
- (func $start:std/array~anonymous|48 (param $0 i32) (param $1 i32) (result i32)
+ (func $start:std/array~anonymous|48~nonClosure (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load
   local.get $1
   i32.load
   i32.sub
+ )
+ (func $std/array/isSorted<~lib/string/String | null> (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  local.get $1
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  call $~lib/rt/pure/__retain
+  drop
+  i32.const 1
+  local.set $2
+  local.get $0
+  i32.load offset=12
+  local.set $7
+  loop $for-loop|0
+   local.get $2
+   local.get $7
+   i32.lt_s
+   if
+    local.get $1
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result i32)
+     local.get $0
+     local.get $2
+     i32.const 1
+     i32.sub
+     call $~lib/array/Array<std/array/Ref | null>#__get
+     local.set $3
+     local.get $0
+     local.get $2
+     call $~lib/array/Array<std/array/Ref | null>#__get
+     local.set $4
+     i32.const 2
+     global.set $~argumentsLength
+     local.get $1
+     i32.const 4
+     i32.shl
+     local.tee $8
+     local.get $3
+     local.get $4
+     local.get $8
+     i32.load
+     call_indirect (type $i32_i32_i32_=>_i32)
+    else
+     local.get $0
+     local.get $2
+     i32.const 1
+     i32.sub
+     call $~lib/array/Array<std/array/Ref | null>#__get
+     local.set $5
+     local.get $0
+     local.get $2
+     call $~lib/array/Array<std/array/Ref | null>#__get
+     local.set $6
+     i32.const 2
+     global.set $~argumentsLength
+     local.get $5
+     local.get $6
+     local.get $1
+     call_indirect (type $i32_i32_=>_i32)
+    end
+    i32.const 0
+    i32.gt_s
+    if
+     local.get $1
+     i32.const 4
+     i32.shl
+     i32.const 0
+     local.get $1
+     i32.const -2147483648
+     i32.and
+     i32.const -2147483648
+     i32.eq
+     select
+     call $~lib/rt/pure/__release
+     local.get $3
+     call $~lib/rt/pure/__release
+     local.get $4
+     call $~lib/rt/pure/__release
+     local.get $5
+     call $~lib/rt/pure/__release
+     local.get $6
+     call $~lib/rt/pure/__release
+     i32.const 0
+     return
+    end
+    local.get $3
+    call $~lib/rt/pure/__release
+    local.get $4
+    call $~lib/rt/pure/__release
+    local.get $5
+    call $~lib/rt/pure/__release
+    local.get $6
+    call $~lib/rt/pure/__release
+    local.get $2
+    i32.const 1
+    i32.add
+    local.set $2
+    br $for-loop|0
+   end
+  end
+  local.get $1
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  call $~lib/rt/pure/__release
+  i32.const 1
  )
  (func $~lib/string/String#get:length (param $0 i32) (result i32)
   local.get $0
@@ -5395,7 +6634,7 @@
   end
   i32.const 0
  )
- (func $~lib/util/sort/COMPARATOR<~lib/string/String | null>~anonymous|0 (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/sort/COMPARATOR<~lib/string/String | null>~anonymous|0~nonClosure (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   block $folding-inner0
@@ -9545,13 +10784,13 @@
   (local $11 i32)
   (local $12 i32)
   (local $13 i32)
-  (local $14 f32)
-  (local $15 f64)
+  (local $14 i32)
+  (local $15 i32)
   (local $16 i32)
   (local $17 i32)
   (local $18 i32)
-  (local $19 i32)
-  (local $20 i32)
+  (local $19 f32)
+  (local $20 f64)
   (local $21 i32)
   (local $22 i32)
   (local $23 i32)
@@ -9602,34 +10841,34 @@
   i32.const 5
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
-  local.tee $1
+  local.tee $2
   i32.eqz
   if
    i32.const 12
    i32.const 2
    call $~lib/rt/tlsf/__alloc
    call $~lib/rt/pure/__retain
-   local.set $1
+   local.set $2
   end
-  local.get $1
+  local.get $2
   i32.const 0
   i32.store
-  local.get $1
+  local.get $2
   i32.const 0
   i32.store offset=4
-  local.get $1
+  local.get $2
   i32.const 0
   i32.store offset=8
   i32.const 1
   i32.const 0
   call $~lib/rt/tlsf/__alloc
-  local.tee $2
+  local.tee $1
   i32.const 0
   i32.const 1
   call $~lib/memory/memory.fill
-  local.get $2
-  local.tee $0
   local.get $1
+  local.tee $0
+  local.get $2
   i32.load
   local.tee $4
   i32.ne
@@ -9640,13 +10879,13 @@
    local.get $4
    call $~lib/rt/pure/__release
   end
-  local.get $1
+  local.get $2
   local.get $0
   i32.store
-  local.get $1
   local.get $2
-  i32.store offset=4
   local.get $1
+  i32.store offset=4
+  local.get $2
   i32.const 1
   i32.store offset=8
   global.get $std/array/arr
@@ -9660,7 +10899,7 @@
    unreachable
   end
   call $~lib/rt/pure/__release
-  local.get $1
+  local.get $2
   call $~lib/rt/pure/__release
   i32.const 5
   i32.const 0
@@ -9777,7 +11016,7 @@
   i32.const 1664
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $5
+  local.tee $9
   call $std/array/isArraysEqual<u8>
   i32.eqz
   if
@@ -9798,7 +11037,7 @@
   call $~lib/rt/pure/__release
   local.get $4
   call $~lib/rt/pure/__release
-  local.get $5
+  local.get $9
   call $~lib/rt/pure/__release
   i32.const 5
   i32.const 2
@@ -9919,7 +11158,7 @@
   i32.const 1936
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $5
+  local.tee $9
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -9941,7 +11180,7 @@
   call $~lib/rt/pure/__release
   local.get $4
   call $~lib/rt/pure/__release
-  local.get $5
+  local.get $9
   call $~lib/rt/pure/__release
   global.get $std/array/arr
   i32.load offset=12
@@ -10214,27 +11453,27 @@
   i32.store offset=4
   local.get $0
   i32.load offset=12
-  local.tee $2
+  local.tee $1
   i32.const 0
   i32.gt_s
   if
    local.get $0
    i32.load offset=4
-   local.tee $1
-   local.get $2
+   local.tee $2
+   local.get $1
    i32.const 2
    i32.shl
    i32.add
-   local.set $2
+   local.set $1
    loop $do-continue|0
-    local.get $1
+    local.get $2
     i32.load
     call $~lib/rt/pure/__release
-    local.get $1
+    local.get $2
     i32.const 4
     i32.add
-    local.tee $1
-    local.get $2
+    local.tee $2
+    local.get $1
     i32.lt_u
     br_if $do-continue|0
    end
@@ -10593,7 +11832,7 @@
   i32.const 2208
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $5
+  local.tee $9
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -10619,14 +11858,14 @@
   i32.const 2
   i32.const 2147483647
   call $~lib/array/Array<i32>#copyWithin
-  local.tee $16
+  local.tee $14
   i32.const 5
   i32.const 2
   i32.const 3
   i32.const 2304
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $20
+  local.tee $25
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -10651,14 +11890,14 @@
   i32.const 2
   i32.const 2147483647
   call $~lib/array/Array<i32>#copyWithin
-  local.tee $25
+  local.tee $5
   i32.const 5
   i32.const 2
   i32.const 3
   i32.const 2400
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $6
+  local.tee $8
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -10683,14 +11922,14 @@
   i32.const 3
   i32.const 4
   call $~lib/array/Array<i32>#copyWithin
-  local.tee $8
+  local.tee $7
   i32.const 5
   i32.const 2
   i32.const 3
   i32.const 2496
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $9
+  local.tee $10
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -10715,14 +11954,14 @@
   i32.const 3
   i32.const 4
   call $~lib/array/Array<i32>#copyWithin
-  local.tee $11
+  local.tee $12
   i32.const 5
   i32.const 2
   i32.const 3
   i32.const 2592
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $13
+  local.tee $15
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -10747,7 +11986,7 @@
   i32.const 2
   i32.const 4
   call $~lib/array/Array<i32>#copyWithin
-  local.tee $30
+  local.tee $16
   i32.const 5
   i32.const 2
   i32.const 3
@@ -10779,14 +12018,14 @@
   i32.const -2
   i32.const 2147483647
   call $~lib/array/Array<i32>#copyWithin
-  local.tee $18
+  local.tee $30
   i32.const 5
   i32.const 2
   i32.const 3
   i32.const 2784
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $19
+  local.tee $18
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -10811,7 +12050,7 @@
   i32.const -2
   i32.const -1
   call $~lib/array/Array<i32>#copyWithin
-  local.tee $12
+  local.tee $13
   i32.const 5
   i32.const 2
   i32.const 3
@@ -10937,33 +12176,33 @@
   call $~lib/rt/pure/__release
   local.get $4
   call $~lib/rt/pure/__release
-  local.get $5
+  local.get $9
   call $~lib/rt/pure/__release
-  local.get $16
-  call $~lib/rt/pure/__release
-  local.get $20
+  local.get $14
   call $~lib/rt/pure/__release
   local.get $25
   call $~lib/rt/pure/__release
-  local.get $6
+  local.get $5
   call $~lib/rt/pure/__release
   local.get $8
   call $~lib/rt/pure/__release
-  local.get $9
+  local.get $7
   call $~lib/rt/pure/__release
-  local.get $11
+  local.get $10
   call $~lib/rt/pure/__release
-  local.get $13
+  local.get $12
   call $~lib/rt/pure/__release
-  local.get $30
+  local.get $15
+  call $~lib/rt/pure/__release
+  local.get $16
   call $~lib/rt/pure/__release
   local.get $17
   call $~lib/rt/pure/__release
+  local.get $30
+  call $~lib/rt/pure/__release
   local.get $18
   call $~lib/rt/pure/__release
-  local.get $19
-  call $~lib/rt/pure/__release
-  local.get $12
+  local.get $13
   call $~lib/rt/pure/__release
   local.get $21
   call $~lib/rt/pure/__release
@@ -11369,30 +12608,30 @@
    i32.const 2
    i32.shl
    i32.add
-   local.set $1
+   local.set $2
    loop $while-continue|0
     local.get $0
-    local.get $1
+    local.get $2
     i32.lt_u
     if
      local.get $0
      i32.load
-     local.set $2
+     local.set $1
      local.get $0
-     local.get $1
+     local.get $2
      i32.load
      i32.store
-     local.get $1
      local.get $2
+     local.get $1
      i32.store
      local.get $0
      i32.const 4
      i32.add
      local.set $0
-     local.get $1
+     local.get $2
      i32.const 4
      i32.sub
-     local.set $1
+     local.set $2
      br $while-continue|0
     end
    end
@@ -11695,7 +12934,7 @@
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
   local.tee $2
-  local.set $5
+  local.set $9
   i32.const 0
   local.set $0
   block $__inlined_func$~lib/array/Array<f64>#indexOf
@@ -11714,7 +12953,7 @@
     local.set $0
     br $__inlined_func$~lib/array/Array<f64>#indexOf
    end
-   local.get $5
+   local.get $9
    i32.load offset=4
    local.set $4
    loop $while-continue|023
@@ -11916,27 +13155,27 @@
    drop
    local.get $2
    i32.load offset=4
-   local.set $5
+   local.set $9
    loop $while-continue|024
     local.get $0
     local.get $3
     i32.lt_s
     if
      i32.const 1
-     local.get $5
+     local.get $9
      local.get $0
      i32.const 2
      i32.shl
      i32.add
      f32.load
-     local.tee $14
+     local.tee $19
      f32.const nan:0x400000
      f32.eq
      if (result i32)
       i32.const 1
      else
-      local.get $14
-      local.get $14
+      local.get $19
+      local.get $19
       f32.ne
      end
      br_if $__inlined_func$~lib/array/Array<f32>#includes
@@ -11961,7 +13200,7 @@
   end
   block $__inlined_func$~lib/array/Array<f64>#includes (result i32)
    i32.const 0
-   local.set $1
+   local.set $0
    i32.const 0
    i32.const 1
    i32.const 3
@@ -11983,35 +13222,35 @@
    drop
    local.get $3
    i32.load offset=4
-   local.set $16
+   local.set $14
    loop $while-continue|025
-    local.get $1
+    local.get $0
     local.get $4
     i32.lt_s
     if
      i32.const 1
-     local.get $16
-     local.get $1
+     local.get $14
+     local.get $0
      i32.const 3
      i32.shl
      i32.add
      f64.load
-     local.tee $15
+     local.tee $20
      f64.const nan:0x8000000000000
      f64.eq
      if (result i32)
       i32.const 1
      else
-      local.get $15
-      local.get $15
+      local.get $20
+      local.get $20
       f64.ne
      end
      br_if $__inlined_func$~lib/array/Array<f64>#includes
      drop
-     local.get $1
+     local.get $0
      i32.const 1
      i32.add
-     local.set $1
+     local.set $0
      br $while-continue|025
     end
    end
@@ -12146,14 +13385,14 @@
   i32.const 0
   i32.const 0
   call $~lib/array/Array<i32>#splice
-  local.tee $6
+  local.tee $8
   i32.const 0
   i32.const 2
   i32.const 3
   i32.const 3504
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $8
+  local.tee $7
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -12172,7 +13411,7 @@
   i32.const 3520
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $9
+  local.tee $10
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -12197,14 +13436,14 @@
   i32.const 2
   i32.const 2147483647
   call $~lib/array/Array<i32>#splice
-  local.tee $11
+  local.tee $12
   i32.const 3
   i32.const 2
   i32.const 3
   i32.const 3616
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $13
+  local.tee $15
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -12223,7 +13462,7 @@
   i32.const 3648
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $17
+  local.tee $16
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -12248,14 +13487,14 @@
   i32.const 2
   i32.const 2
   call $~lib/array/Array<i32>#splice
-  local.tee $18
+  local.tee $17
   i32.const 2
   i32.const 2
   i32.const 3
   i32.const 3728
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $19
+  local.tee $18
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -12274,7 +13513,7 @@
   i32.const 3760
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $12
+  local.tee $13
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -12799,7 +14038,7 @@
   local.tee $2
   i32.const 1
   call $~lib/array/Array<std/array/Ref>#splice
-  local.tee $20
+  local.tee $14
   i32.load offset=12
   if
    i32.const 0
@@ -12825,7 +14064,7 @@
   i32.const 0
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $16
+  local.tee $9
   i32.load offset=4
   local.tee $0
   i32.const 1
@@ -12849,11 +14088,11 @@
   i32.store offset=16
   local.get $2
   call $~lib/rt/pure/__release
-  local.get $16
+  local.get $9
   i32.const 2
   call $~lib/array/Array<std/array/Ref>#splice
   local.set $25
-  local.get $20
+  local.get $14
   call $~lib/rt/pure/__release
   local.get $25
   i32.load offset=12
@@ -12897,7 +14136,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $16
+  local.get $9
   i32.load offset=12
   i32.const 3
   i32.ne
@@ -12909,7 +14148,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $16
+  local.get $9
   i32.const 0
   call $~lib/array/Array<std/array/Ref>#__get
   local.tee $57
@@ -12924,7 +14163,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $16
+  local.get $9
   i32.const 1
   call $~lib/array/Array<std/array/Ref>#__get
   local.tee $58
@@ -12939,7 +14178,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $16
+  local.get $9
   i32.const 2
   call $~lib/array/Array<std/array/Ref>#__get
   local.tee $59
@@ -12960,7 +14199,7 @@
   i32.const 0
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $20
+  local.tee $14
   i32.load offset=4
   local.tee $0
   i32.const 1
@@ -12973,7 +14212,7 @@
   i32.const 2
   call $std/array/Ref#constructor
   i32.store offset=8
-  local.get $20
+  local.get $14
   call $~lib/array/Array<std/array/Ref | null>#splice
   local.tee $30
   i32.load offset=12
@@ -13012,7 +14251,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $20
+  local.get $14
   i32.load offset=12
   i32.const 2
   i32.ne
@@ -13024,7 +14263,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $20
+  local.get $14
   i32.const 0
   call $~lib/array/Array<std/array/Ref | null>#__get
   local.tee $60
@@ -13036,7 +14275,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $20
+  local.get $14
   i32.const 1
   call $~lib/array/Array<std/array/Ref | null>#__get
   local.tee $2
@@ -13069,23 +14308,23 @@
   call $~lib/rt/pure/__release
   local.get $5
   call $~lib/rt/pure/__release
-  local.get $6
-  call $~lib/rt/pure/__release
   local.get $8
   call $~lib/rt/pure/__release
-  local.get $9
+  local.get $7
   call $~lib/rt/pure/__release
-  local.get $11
+  local.get $10
   call $~lib/rt/pure/__release
-  local.get $13
+  local.get $12
+  call $~lib/rt/pure/__release
+  local.get $15
+  call $~lib/rt/pure/__release
+  local.get $16
   call $~lib/rt/pure/__release
   local.get $17
   call $~lib/rt/pure/__release
   local.get $18
   call $~lib/rt/pure/__release
-  local.get $19
-  call $~lib/rt/pure/__release
-  local.get $12
+  local.get $13
   call $~lib/rt/pure/__release
   local.get $21
   call $~lib/rt/pure/__release
@@ -13635,17 +14874,17 @@
    unreachable
   end
   loop $for-loop|0
-   local.get $7
+   local.get $6
    i32.const 100
    i32.lt_s
    if
     global.get $std/array/arr
     call $~lib/array/Array<i32>#pop
     drop
-    local.get $7
+    local.get $6
     i32.const 1
     i32.add
-    local.set $7
+    local.set $6
     br $for-loop|0
    end
   end
@@ -13662,9 +14901,9 @@
   i32.const 3
   call $~lib/array/Array<i32>#push
   i32.const 0
-  local.set $1
+  local.set $2
   global.get $std/array/arr
-  local.tee $2
+  local.tee $1
   i32.load offset=12
   local.tee $3
   i32.const 2
@@ -13676,36 +14915,38 @@
   i32.load offset=4
   local.set $4
   loop $for-loop|043
-   local.get $1
-   local.get $3
    local.get $2
-   i32.load offset=12
-   local.tee $5
    local.get $3
-   local.get $5
+   local.get $1
+   i32.load offset=12
+   local.tee $6
+   local.get $3
+   local.get $6
    i32.lt_s
    select
    i32.lt_s
    if
-    local.get $1
+    local.get $2
     i32.const 2
     i32.shl
-    local.tee $5
-    local.get $2
+    local.tee $6
+    local.get $1
     i32.load offset=4
     i32.add
     i32.load
-    local.set $7
+    local.set $5
+    i32.const 3
+    global.set $~argumentsLength
     local.get $4
-    local.get $5
+    local.get $6
     i32.add
-    local.get $7
+    local.get $5
     f32.convert_i32_s
     f32.store
-    local.get $1
+    local.get $2
     i32.const 1
     i32.add
-    local.set $1
+    local.set $2
     br $for-loop|043
    end
   end
@@ -14249,130 +15490,70 @@
   call $~lib/bindings/Math/random
   i64.reinterpret_f64
   call $~lib/math/NativeMath.seedRandom
+  i32.const 8
+  i32.const 2
+  i32.const 9
+  i32.const 5280
+  call $~lib/rt/__allocArray
+  call $~lib/rt/pure/__retain
+  local.set $1
+  i32.const 0
+  global.set $~argumentsLength
   block $__inlined_func$~lib/array/Array<f32>#sort (result i32)
-   i32.const 8
-   i32.const 2
-   i32.const 9
-   i32.const 5280
-   call $~lib/rt/__allocArray
-   call $~lib/rt/pure/__retain
-   local.tee $3
-   i32.load offset=12
-   local.tee $5
-   i32.const 1
-   i32.le_s
-   if
-    local.get $3
-    call $~lib/rt/pure/__retain
-    br $__inlined_func$~lib/array/Array<f32>#sort
-   end
-   local.get $3
-   i32.load offset=4
-   local.set $4
-   local.get $5
-   i32.const 2
-   i32.eq
-   if
-    local.get $4
-    f32.load offset=4
-    local.tee $14
-    local.get $4
-    f32.load
-    local.tee $34
-    call $~lib/util/sort/COMPARATOR<f32>~anonymous|0
-    i32.const 0
-    i32.lt_s
+   block $folding-inner0
+    local.get $1
+    i32.load offset=12
+    local.tee $2
+    i32.const 1
+    i32.le_s
+    br_if $folding-inner0
+    local.get $1
+    i32.load offset=4
+    local.set $0
+    local.get $2
+    i32.const 2
+    i32.eq
     if
-     local.get $4
+     local.get $0
+     f32.load offset=4
+     local.set $19
+     local.get $0
+     f32.load
+     local.set $34
+     i32.const 2
+     global.set $~argumentsLength
+     local.get $19
      local.get $34
-     f32.store offset=4
-     local.get $4
-     local.get $14
-     f32.store
-    end
-    local.get $3
-    call $~lib/rt/pure/__retain
-    br $__inlined_func$~lib/array/Array<f32>#sort
-   end
-   local.get $5
-   i32.const 256
-   i32.lt_s
-   if
-    i32.const 0
-    local.set $2
-    loop $for-loop|00
-     local.get $2
-     local.get $5
+     call $~lib/util/sort/COMPARATOR<f32>~anonymous|0~nonClosure
+     i32.const 0
      i32.lt_s
      if
-      local.get $4
-      local.get $2
-      i32.const 2
-      i32.shl
-      i32.add
-      f32.load
-      local.set $14
-      local.get $2
-      i32.const 1
-      i32.sub
-      local.set $0
-      loop $while-continue|1
-       local.get $0
-       i32.const 0
-       i32.ge_s
-       if
-        local.get $14
-        local.get $4
-        local.get $0
-        i32.const 2
-        i32.shl
-        i32.add
-        f32.load
-        local.tee $34
-        call $~lib/util/sort/COMPARATOR<f32>~anonymous|0
-        i32.const 0
-        i32.lt_s
-        if
-         local.get $0
-         local.tee $1
-         i32.const 1
-         i32.sub
-         local.set $0
-         local.get $4
-         local.get $1
-         i32.const 1
-         i32.add
-         i32.const 2
-         i32.shl
-         i32.add
-         local.get $34
-         f32.store
-         br $while-continue|1
-        end
-       end
-      end
-      local.get $4
       local.get $0
-      i32.const 1
-      i32.add
-      i32.const 2
-      i32.shl
-      i32.add
-      local.get $14
+      local.get $34
+      f32.store offset=4
+      local.get $0
+      local.get $19
       f32.store
-      local.get $2
-      i32.const 1
-      i32.add
-      local.set $2
-      br $for-loop|00
      end
+     br $folding-inner0
     end
-   else
-    local.get $4
-    local.get $5
-    call $~lib/util/sort/weakHeapSort<f32>
+    local.get $2
+    i32.const 256
+    i32.lt_s
+    if
+     local.get $0
+     local.get $2
+     call $~lib/util/sort/insertionSort<f32>
+    else
+     local.get $0
+     local.get $2
+     call $~lib/util/sort/weakHeapSort<f32>
+    end
+    local.get $1
+    call $~lib/rt/pure/__retain
+    br $__inlined_func$~lib/array/Array<f32>#sort
    end
-   local.get $3
+   local.get $1
    call $~lib/rt/pure/__retain
   end
   call $~lib/rt/pure/__release
@@ -14383,60 +15564,60 @@
    i32.const 5328
    call $~lib/rt/__allocArray
    call $~lib/rt/pure/__retain
-   local.set $7
+   local.set $3
    i32.const 0
-   local.set $1
-   block $folding-inner0
-    local.get $3
+   local.set $0
+   block $folding-inner00
+    local.get $1
     i32.load offset=12
-    local.tee $2
-    local.get $7
+    local.tee $4
+    local.get $3
     i32.load offset=12
     i32.ne
-    br_if $folding-inner0
+    br_if $folding-inner00
     i32.const 1
+    local.get $1
     local.get $3
-    local.get $7
     i32.eq
     br_if $__inlined_func$std/array/isArraysEqual<f32>
     drop
-    loop $for-loop|001
-     local.get $1
-     local.get $2
+    loop $for-loop|00
+     local.get $0
+     local.get $4
      i32.lt_s
      if
-      local.get $3
       local.get $1
+      local.get $0
       call $~lib/array/Array<f32>#__get
-      local.tee $14
-      local.get $14
+      local.tee $19
+      local.get $19
       f32.ne
       if (result i32)
-       local.get $7
-       local.get $1
+       local.get $3
+       local.get $0
        call $~lib/array/Array<f32>#__get
-       local.tee $14
-       local.get $14
+       local.tee $19
+       local.get $19
        f32.ne
       else
        i32.const 0
       end
       i32.eqz
       if
-       local.get $3
        local.get $1
+       local.get $0
        call $~lib/array/Array<f32>#__get
-       local.get $7
-       local.get $1
+       local.get $3
+       local.get $0
        call $~lib/array/Array<f32>#__get
        f32.ne
-       br_if $folding-inner0
+       br_if $folding-inner00
       end
-      local.get $1
+      local.get $0
       i32.const 1
       i32.add
-      local.set $1
-      br $for-loop|001
+      local.set $0
+      br $for-loop|00
      end
     end
     i32.const 1
@@ -14453,130 +15634,70 @@
    call $~lib/builtins/abort
    unreachable
   end
+  i32.const 8
+  i32.const 3
+  i32.const 10
+  i32.const 5376
+  call $~lib/rt/__allocArray
+  call $~lib/rt/pure/__retain
+  local.set $2
+  i32.const 0
+  global.set $~argumentsLength
   block $__inlined_func$~lib/array/Array<f64>#sort (result i32)
-   i32.const 8
-   i32.const 3
-   i32.const 10
-   i32.const 5376
-   call $~lib/rt/__allocArray
-   call $~lib/rt/pure/__retain
-   local.tee $4
-   i32.load offset=12
-   local.tee $6
-   i32.const 1
-   i32.le_s
-   if
+   block $folding-inner01
+    local.get $2
+    i32.load offset=12
+    local.tee $4
+    i32.const 1
+    i32.le_s
+    br_if $folding-inner01
+    local.get $2
+    i32.load offset=4
+    local.set $0
     local.get $4
-    call $~lib/rt/pure/__retain
-    br $__inlined_func$~lib/array/Array<f64>#sort
-   end
-   local.get $4
-   i32.load offset=4
-   local.set $5
-   local.get $6
-   i32.const 2
-   i32.eq
-   if
-    local.get $5
-    f64.load offset=8
-    local.tee $15
-    local.get $5
-    f64.load
-    local.tee $35
-    call $~lib/util/sort/COMPARATOR<f64>~anonymous|0
-    i32.const 0
-    i32.lt_s
+    i32.const 2
+    i32.eq
     if
-     local.get $5
+     local.get $0
+     f64.load offset=8
+     local.set $20
+     local.get $0
+     f64.load
+     local.set $35
+     i32.const 2
+     global.set $~argumentsLength
+     local.get $20
      local.get $35
-     f64.store offset=8
-     local.get $5
-     local.get $15
-     f64.store
-    end
-    local.get $4
-    call $~lib/rt/pure/__retain
-    br $__inlined_func$~lib/array/Array<f64>#sort
-   end
-   local.get $6
-   i32.const 256
-   i32.lt_s
-   if
-    i32.const 0
-    local.set $2
-    loop $for-loop|02
-     local.get $2
-     local.get $6
+     call $~lib/util/sort/COMPARATOR<f64>~anonymous|0~nonClosure
+     i32.const 0
      i32.lt_s
      if
-      local.get $5
-      local.get $2
-      i32.const 3
-      i32.shl
-      i32.add
-      f64.load
-      local.set $15
-      local.get $2
-      i32.const 1
-      i32.sub
-      local.set $0
-      loop $while-continue|13
-       local.get $0
-       i32.const 0
-       i32.ge_s
-       if
-        local.get $15
-        local.get $5
-        local.get $0
-        i32.const 3
-        i32.shl
-        i32.add
-        f64.load
-        local.tee $35
-        call $~lib/util/sort/COMPARATOR<f64>~anonymous|0
-        i32.const 0
-        i32.lt_s
-        if
-         local.get $0
-         local.tee $1
-         i32.const 1
-         i32.sub
-         local.set $0
-         local.get $5
-         local.get $1
-         i32.const 1
-         i32.add
-         i32.const 3
-         i32.shl
-         i32.add
-         local.get $35
-         f64.store
-         br $while-continue|13
-        end
-       end
-      end
-      local.get $5
       local.get $0
-      i32.const 1
-      i32.add
-      i32.const 3
-      i32.shl
-      i32.add
-      local.get $15
+      local.get $35
+      f64.store offset=8
+      local.get $0
+      local.get $20
       f64.store
-      local.get $2
-      i32.const 1
-      i32.add
-      local.set $2
-      br $for-loop|02
      end
+     br $folding-inner01
     end
-   else
-    local.get $5
-    local.get $6
-    call $~lib/util/sort/weakHeapSort<f64>
+    local.get $4
+    i32.const 256
+    i32.lt_s
+    if
+     local.get $0
+     local.get $4
+     call $~lib/util/sort/insertionSort<f64>
+    else
+     local.get $0
+     local.get $4
+     call $~lib/util/sort/weakHeapSort<f64>
+    end
+    local.get $2
+    call $~lib/rt/pure/__retain
+    br $__inlined_func$~lib/array/Array<f64>#sort
    end
-   local.get $4
+   local.get $2
    call $~lib/rt/pure/__retain
   end
   call $~lib/rt/pure/__release
@@ -14587,60 +15708,60 @@
    i32.const 5456
    call $~lib/rt/__allocArray
    call $~lib/rt/pure/__retain
-   local.set $2
+   local.set $4
    i32.const 0
-   local.set $1
-   block $folding-inner01
-    local.get $4
-    i32.load offset=12
-    local.tee $5
+   local.set $0
+   block $folding-inner012
     local.get $2
     i32.load offset=12
+    local.tee $5
+    local.get $4
+    i32.load offset=12
     i32.ne
-    br_if $folding-inner01
+    br_if $folding-inner012
     i32.const 1
     local.get $2
     local.get $4
     i32.eq
     br_if $__inlined_func$std/array/isArraysEqual<f64>
     drop
-    loop $for-loop|025
-     local.get $1
+    loop $for-loop|02
+     local.get $0
      local.get $5
      i32.lt_s
      if
-      local.get $4
-      local.get $1
+      local.get $2
+      local.get $0
       call $~lib/array/Array<f64>#__get
-      local.tee $15
-      local.get $15
+      local.tee $20
+      local.get $20
       f64.ne
       if (result i32)
-       local.get $2
-       local.get $1
+       local.get $4
+       local.get $0
        call $~lib/array/Array<f64>#__get
-       local.tee $15
-       local.get $15
+       local.tee $20
+       local.get $20
        f64.ne
       else
        i32.const 0
       end
       i32.eqz
       if
-       local.get $4
-       local.get $1
-       call $~lib/array/Array<f64>#__get
        local.get $2
-       local.get $1
+       local.get $0
+       call $~lib/array/Array<f64>#__get
+       local.get $4
+       local.get $0
        call $~lib/array/Array<f64>#__get
        f64.ne
-       br_if $folding-inner01
+       br_if $folding-inner012
       end
-      local.get $1
+      local.get $0
       i32.const 1
       i32.add
-      local.set $1
-      br $for-loop|025
+      local.set $0
+      br $for-loop|02
      end
     end
     i32.const 1
@@ -14663,11 +15784,14 @@
   i32.const 5536
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $17
+  local.set $6
+  i32.const 0
+  global.set $~argumentsLength
+  local.get $6
   i32.const 46
   call $~lib/array/Array<i32>#sort
   call $~lib/rt/pure/__release
-  local.get $17
+  local.get $6
   i32.const 5
   i32.const 2
   i32.const 3
@@ -14692,11 +15816,14 @@
   i32.const 5632
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $18
+  local.set $5
+  i32.const 0
+  global.set $~argumentsLength
+  local.get $5
   i32.const 47
   call $~lib/array/Array<i32>#sort
   call $~lib/rt/pure/__release
-  local.get $18
+  local.get $5
   i32.const 5
   i32.const 2
   i32.const 7
@@ -14721,28 +15848,28 @@
   i32.const 5728
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $19
+  local.set $18
   i32.const 1
   i32.const 2
   i32.const 3
   i32.const 5744
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $1
+  local.set $8
   i32.const 2
   i32.const 2
   i32.const 3
   i32.const 5776
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $5
+  local.set $7
   i32.const 4
   i32.const 2
   i32.const 3
   i32.const 5808
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $6
+  local.set $10
   i32.const 4
   i32.const 2
   i32.const 3
@@ -14752,26 +15879,26 @@
   local.set $0
   i32.const 64
   call $std/array/createReverseOrderedArray
-  local.set $8
+  local.set $12
   i32.const 128
   call $std/array/createReverseOrderedArray
-  local.set $9
+  local.set $15
   i32.const 1024
   call $std/array/createReverseOrderedArray
-  local.set $11
+  local.set $16
   i32.const 10000
   call $std/array/createReverseOrderedArray
-  local.set $13
+  local.set $17
   i32.const 512
   call $std/array/createRandomOrderedArray
-  local.set $12
-  local.get $19
+  local.set $13
+  local.get $18
   i32.const 48
   call $std/array/assertSorted<i32>
-  local.get $1
+  local.get $8
   i32.const 48
   call $std/array/assertSorted<i32>
-  local.get $1
+  local.get $8
   i32.const 1
   i32.const 2
   i32.const 3
@@ -14790,10 +15917,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $7
   i32.const 48
   call $std/array/assertSorted<i32>
-  local.get $5
+  local.get $7
   i32.const 2
   i32.const 2
   i32.const 3
@@ -14812,10 +15939,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $6
+  local.get $10
   i32.const 48
   call $std/array/assertSorted<i32>
-  local.get $6
+  local.get $10
   local.get $0
   i32.const 0
   call $std/array/isArraysEqual<u32>
@@ -14828,10 +15955,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $8
+  local.get $12
   i32.const 48
   call $std/array/assertSorted<i32>
-  local.get $8
+  local.get $12
   local.get $0
   i32.const 4
   call $std/array/isArraysEqual<u32>
@@ -14844,10 +15971,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $9
+  local.get $15
   i32.const 48
   call $std/array/assertSorted<i32>
-  local.get $9
+  local.get $15
   local.get $0
   i32.const 4
   call $std/array/isArraysEqual<u32>
@@ -14860,10 +15987,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $11
+  local.get $16
   i32.const 48
   call $std/array/assertSorted<i32>
-  local.get $11
+  local.get $16
   local.get $0
   i32.const 4
   call $std/array/isArraysEqual<u32>
@@ -14876,10 +16003,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $13
+  local.get $17
   i32.const 48
   call $std/array/assertSorted<i32>
-  local.get $13
+  local.get $17
   local.get $0
   i32.const 4
   call $std/array/isArraysEqual<u32>
@@ -14892,44 +16019,44 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $12
+  local.get $13
   i32.const 48
   call $std/array/assertSorted<i32>
+  local.get $1
+  call $~lib/rt/pure/__release
   local.get $3
-  call $~lib/rt/pure/__release
-  local.get $7
-  call $~lib/rt/pure/__release
-  local.get $4
   call $~lib/rt/pure/__release
   local.get $2
   call $~lib/rt/pure/__release
-  local.get $17
-  call $~lib/rt/pure/__release
-  local.get $21
-  call $~lib/rt/pure/__release
-  local.get $18
-  call $~lib/rt/pure/__release
-  local.get $22
-  call $~lib/rt/pure/__release
-  local.get $19
-  call $~lib/rt/pure/__release
-  local.get $1
-  call $~lib/rt/pure/__release
-  local.get $5
+  local.get $4
   call $~lib/rt/pure/__release
   local.get $6
   call $~lib/rt/pure/__release
-  local.get $0
+  local.get $21
+  call $~lib/rt/pure/__release
+  local.get $5
+  call $~lib/rt/pure/__release
+  local.get $22
+  call $~lib/rt/pure/__release
+  local.get $18
   call $~lib/rt/pure/__release
   local.get $8
   call $~lib/rt/pure/__release
-  local.get $9
+  local.get $7
   call $~lib/rt/pure/__release
-  local.get $11
+  local.get $10
   call $~lib/rt/pure/__release
-  local.get $13
+  local.get $0
   call $~lib/rt/pure/__release
   local.get $12
+  call $~lib/rt/pure/__release
+  local.get $15
+  call $~lib/rt/pure/__release
+  local.get $16
+  call $~lib/rt/pure/__release
+  local.get $17
+  call $~lib/rt/pure/__release
+  local.get $13
   call $~lib/rt/pure/__release
   local.get $23
   call $~lib/rt/pure/__release
@@ -14975,64 +16102,37 @@
   i32.const 6080
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $5
+  local.set $6
   i32.const 7
   i32.const 2
   i32.const 15
   i32.const 6128
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $7
-  block $__inlined_func$std/array/isSorted<~lib/string/String | null> (result i32)
-   i32.const 1
-   local.set $1
-   local.get $5
-   i32.const 55
-   call $~lib/array/Array<~lib/array/Array<i32>>#sort
-   local.tee $0
-   local.set $2
-   local.get $0
-   i32.load offset=12
-   local.set $6
-   loop $for-loop|03
-    local.get $1
-    local.get $6
-    i32.lt_s
-    if
-     local.get $2
-     local.get $1
-     i32.const 1
-     i32.sub
-     call $~lib/array/Array<std/array/Ref | null>#__get
-     local.tee $3
-     local.get $2
-     local.get $1
-     call $~lib/array/Array<std/array/Ref | null>#__get
-     local.tee $4
-     call $~lib/util/sort/COMPARATOR<~lib/string/String | null>~anonymous|0
-     i32.const 0
-     i32.gt_s
-     if
-      local.get $3
-      call $~lib/rt/pure/__release
-      local.get $4
-      call $~lib/rt/pure/__release
-      i32.const 0
-      br $__inlined_func$std/array/isSorted<~lib/string/String | null>
-     end
-     local.get $3
-     call $~lib/rt/pure/__release
-     local.get $4
-     call $~lib/rt/pure/__release
-     local.get $1
-     i32.const 1
-     i32.add
-     local.set $1
-     br $for-loop|03
-    end
-   end
-   i32.const 1
-  end
+  local.set $5
+  i32.const 1
+  global.set $~argumentsLength
+  i32.const 55
+  local.set $1
+  i32.const 55
+  local.tee $0
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $0
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $6
+  local.get $0
+  call $~lib/array/Array<~lib/array/Array<i32>>#sort
+  local.tee $2
+  local.get $0
+  call $std/array/isSorted<~lib/string/String | null>
   i32.eqz
   if
    i32.const 0
@@ -15042,58 +16142,80 @@
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $2
+  call $~lib/rt/pure/__release
   local.get $0
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $0
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  call $~lib/rt/pure/__release
+  local.get $1
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
   call $~lib/rt/pure/__release
   block $__inlined_func$std/array/isArraysEqual<~lib/string/String | null> (result i32)
    i32.const 0
-   local.set $1
+   local.set $0
    i32.const 0
-   local.get $5
+   local.get $6
    i32.load offset=12
    local.tee $3
-   local.get $7
+   local.get $5
    i32.load offset=12
    i32.ne
    br_if $__inlined_func$std/array/isArraysEqual<~lib/string/String | null>
    drop
    i32.const 1
    local.get $5
-   local.get $7
+   local.get $6
    i32.eq
    br_if $__inlined_func$std/array/isArraysEqual<~lib/string/String | null>
    drop
-   loop $for-loop|04
-    local.get $1
+   loop $for-loop|03
+    local.get $0
     local.get $3
     i32.lt_s
     if
-     local.get $5
-     local.get $1
+     local.get $6
+     local.get $0
      call $~lib/array/Array<std/array/Ref | null>#__get
-     local.tee $0
-     local.get $7
-     local.get $1
+     local.tee $1
+     local.get $5
+     local.get $0
      call $~lib/array/Array<std/array/Ref | null>#__get
      local.tee $2
      call $~lib/string/String.__eq
      i32.eqz
      if
-      local.get $0
+      local.get $1
       call $~lib/rt/pure/__release
       local.get $2
       call $~lib/rt/pure/__release
       i32.const 0
       br $__inlined_func$std/array/isArraysEqual<~lib/string/String | null>
      end
-     local.get $0
+     local.get $1
      call $~lib/rt/pure/__release
      local.get $2
      call $~lib/rt/pure/__release
-     local.get $1
+     local.get $0
      i32.const 1
      i32.add
-     local.set $1
-     br $for-loop|04
+     local.set $0
+     br $for-loop|03
     end
    end
    i32.const 1
@@ -15108,75 +16230,74 @@
    unreachable
   end
   i32.const 0
-  local.set $1
+  local.set $2
   i32.const 16
   i32.const 16
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
-  local.tee $2
+  local.tee $1
   i32.const 0
   i32.store
-  local.get $2
+  local.get $1
   i32.const 0
   i32.store offset=4
-  local.get $2
+  local.get $1
   i32.const 0
   i32.store offset=8
-  local.get $2
+  local.get $1
   i32.const 0
   i32.store offset=12
   i32.const 1600
   i32.const 0
   call $~lib/rt/tlsf/__alloc
-  local.tee $0
+  local.tee $3
   i32.const 0
   i32.const 1600
   call $~lib/memory/memory.fill
-  local.get $0
-  local.set $3
-  local.get $0
-  local.get $2
+  local.get $3
+  local.tee $0
+  local.get $1
   i32.load
   local.tee $4
   i32.ne
   if
-   local.get $3
+   local.get $0
    call $~lib/rt/pure/__retain
-   local.set $3
+   local.set $0
    local.get $4
    call $~lib/rt/pure/__release
   end
-  local.get $2
-  local.get $3
-  i32.store
-  local.get $2
+  local.get $1
   local.get $0
+  i32.store
+  local.get $1
+  local.get $3
   i32.store offset=4
-  local.get $2
+  local.get $1
   i32.const 1600
   i32.store offset=8
-  local.get $2
+  local.get $1
   i32.const 400
   i32.store offset=12
-  loop $for-loop|09
-   local.get $1
+  loop $for-loop|004
+   local.get $2
    i32.const 400
    i32.lt_s
    if
-    local.get $1
+    local.get $2
     local.set $3
     call $~lib/math/NativeMath.random
     f64.const 32
     f64.mul
     i32.trunc_f64_s
-    local.set $8
+    local.set $7
     i32.const 0
-    local.set $6
+    local.set $8
     i32.const 6064
     local.set $0
     loop $for-loop|01
-     local.get $6
      local.get $8
+     local.get $7
      i32.lt_s
      if
       block $__inlined_func$~lib/string/String#charAt (result i32)
@@ -15188,7 +16309,7 @@
        f64.mul
        f64.floor
        i32.trunc_f64_s
-       local.tee $1
+       local.tee $2
        i32.const 5088
        call $~lib/string/String#get:length
        i32.ge_u
@@ -15198,7 +16319,7 @@
        i32.const 1
        call $~lib/rt/tlsf/__alloc
        local.tee $4
-       local.get $1
+       local.get $2
        i32.const 1
        i32.shl
        i32.const 5088
@@ -15208,13 +16329,13 @@
        local.get $4
        call $~lib/rt/pure/__retain
       end
-      local.set $1
+      local.set $2
       local.get $0
       local.tee $4
       local.get $0
-      local.get $1
+      local.get $2
       call $~lib/string/String.__concat
-      local.tee $9
+      local.tee $10
       local.tee $0
       i32.ne
       if
@@ -15224,18 +16345,18 @@
        local.get $4
        call $~lib/rt/pure/__release
       end
-      local.get $1
+      local.get $2
       call $~lib/rt/pure/__release
-      local.get $9
+      local.get $10
       call $~lib/rt/pure/__release
-      local.get $6
+      local.get $8
       i32.const 1
       i32.add
-      local.set $6
+      local.set $8
       br $for-loop|01
      end
     end
-    local.get $2
+    local.get $1
     local.get $3
     local.get $0
     call $~lib/array/Array<~lib/array/Array<i32>>#__set
@@ -15244,18 +16365,20 @@
     local.get $3
     i32.const 1
     i32.add
-    local.set $1
-    br $for-loop|09
+    local.set $2
+    br $for-loop|004
    end
   end
-  local.get $2
+  i32.const 1
+  global.set $~argumentsLength
+  local.get $1
   i32.const 56
   call $std/array/assertSorted<~lib/array/Array<i32>>
+  local.get $6
+  call $~lib/rt/pure/__release
   local.get $5
   call $~lib/rt/pure/__release
-  local.get $7
-  call $~lib/rt/pure/__release
-  local.get $2
+  local.get $1
   call $~lib/rt/pure/__release
   i32.const 2
   i32.const 0
@@ -15286,10 +16409,10 @@
   i32.const 6384
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $5
+  local.tee $6
   i32.const 6064
   call $~lib/array/Array<i32>#join
-  local.tee $7
+  local.tee $5
   i32.const 6736
   call $~lib/string/String.__eq
   i32.eqz
@@ -15307,10 +16430,10 @@
   i32.const 6768
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $6
+  local.tee $8
   i32.const 6800
   call $~lib/array/Array<u32>#join
-  local.tee $8
+  local.tee $7
   i32.const 6736
   call $~lib/string/String.__eq
   i32.eqz
@@ -15328,10 +16451,10 @@
   i32.const 6832
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $9
+  local.tee $10
   i32.const 6864
   call $~lib/array/Array<i32>#join
-  local.tee $11
+  local.tee $12
   i32.const 6896
   call $~lib/string/String.__eq
   i32.eqz
@@ -15354,7 +16477,7 @@
   local.get $1
   i32.load offset=12
   call $~lib/util/string/joinFloatArray<f64>
-  local.tee $13
+  local.tee $15
   i32.const 8112
   call $~lib/string/String.__eq
   i32.eqz
@@ -15372,10 +16495,10 @@
   i32.const 8240
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $17
+  local.tee $16
   i32.const 6064
   call $~lib/array/Array<~lib/string/String | null>#join
-  local.tee $18
+  local.tee $17
   i32.const 8208
   call $~lib/string/String.__eq
   i32.eqz
@@ -15408,7 +16531,7 @@
   i32.store offset=8
   local.get $2
   call $~lib/array/Array<std/array/Ref | null>#join
-  local.tee $19
+  local.tee $18
   i32.const 8320
   call $~lib/string/String.__eq
   i32.eqz
@@ -15428,17 +16551,17 @@
   call $~lib/rt/pure/__retain
   local.tee $3
   i32.load offset=4
-  local.tee $12
+  local.tee $13
   i32.const 0
   call $std/array/Ref#constructor
   i32.store
-  local.get $12
+  local.get $13
   i32.const 0
   call $std/array/Ref#constructor
   i32.store offset=4
   local.get $3
   call $~lib/array/Array<std/array/Ref | null>#join
-  local.tee $12
+  local.tee $13
   i32.const 8400
   call $~lib/string/String.__eq
   i32.eqz
@@ -15454,33 +16577,33 @@
   call $~lib/rt/pure/__release
   local.get $4
   call $~lib/rt/pure/__release
-  local.get $5
-  call $~lib/rt/pure/__release
-  local.get $7
-  call $~lib/rt/pure/__release
   local.get $6
+  call $~lib/rt/pure/__release
+  local.get $5
   call $~lib/rt/pure/__release
   local.get $8
   call $~lib/rt/pure/__release
-  local.get $9
+  local.get $7
   call $~lib/rt/pure/__release
-  local.get $11
+  local.get $10
+  call $~lib/rt/pure/__release
+  local.get $12
   call $~lib/rt/pure/__release
   local.get $1
   call $~lib/rt/pure/__release
-  local.get $13
+  local.get $15
+  call $~lib/rt/pure/__release
+  local.get $16
   call $~lib/rt/pure/__release
   local.get $17
   call $~lib/rt/pure/__release
-  local.get $18
-  call $~lib/rt/pure/__release
   local.get $2
   call $~lib/rt/pure/__release
-  local.get $19
+  local.get $18
   call $~lib/rt/pure/__release
   local.get $3
   call $~lib/rt/pure/__release
-  local.get $12
+  local.get $13
   call $~lib/rt/pure/__release
   i32.const 0
   i32.const 2
@@ -15502,14 +16625,14 @@
   i32.const 8528
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $5
+  local.set $6
   i32.const 4
   i32.const 2
   i32.const 3
   i32.const 8560
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $7
+  local.set $5
   local.get $3
   i32.const 6304
   call $~lib/array/Array<i32>#join
@@ -15530,7 +16653,7 @@
   i32.const 6304
   call $~lib/array/Array<i32>#join
   local.tee $0
-  local.set $17
+  local.set $16
   local.get $0
   i32.const 8208
   call $~lib/string/String.__eq
@@ -15543,11 +16666,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $6
   i32.const 6304
   call $~lib/array/Array<i32>#join
   local.tee $0
-  local.set $18
+  local.set $17
   local.get $0
   i32.const 8592
   call $~lib/string/String.__eq
@@ -15560,11 +16683,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $7
+  local.get $5
   i32.const 6304
   call $~lib/array/Array<i32>#join
   local.tee $0
-  local.set $19
+  local.set $18
   local.get $0
   i32.const 8624
   call $~lib/string/String.__eq
@@ -15583,13 +16706,13 @@
   i32.const 8656
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $6
+  local.tee $8
   i32.load offset=4
-  local.get $6
+  local.get $8
   i32.load offset=12
   call $~lib/util/string/joinIntegerArray<i8>
   local.tee $0
-  local.set $12
+  local.set $13
   local.get $0
   i32.const 8688
   call $~lib/string/String.__eq
@@ -15608,9 +16731,9 @@
   i32.const 8720
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $8
+  local.tee $7
   i32.load offset=4
-  local.get $8
+  local.get $7
   i32.load offset=12
   call $~lib/util/string/joinIntegerArray<u16>
   local.tee $0
@@ -15633,9 +16756,9 @@
   i32.const 8800
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $9
+  local.tee $10
   i32.load offset=4
-  local.get $9
+  local.get $10
   i32.load offset=12
   call $~lib/util/string/joinIntegerArray<u64>
   local.tee $0
@@ -15658,9 +16781,9 @@
   i32.const 8912
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $11
+  local.tee $12
   i32.load offset=4
-  local.get $11
+  local.get $12
   i32.load offset=12
   call $~lib/util/string/joinIntegerArray<i64>
   local.tee $0
@@ -15857,30 +16980,30 @@
   call $~lib/rt/pure/__release
   local.get $4
   call $~lib/rt/pure/__release
+  local.get $6
+  call $~lib/rt/pure/__release
   local.get $5
   call $~lib/rt/pure/__release
-  local.get $7
   call $~lib/rt/pure/__release
+  local.get $16
   call $~lib/rt/pure/__release
   local.get $17
   call $~lib/rt/pure/__release
   local.get $18
   call $~lib/rt/pure/__release
-  local.get $19
-  call $~lib/rt/pure/__release
-  local.get $6
-  call $~lib/rt/pure/__release
-  local.get $12
-  call $~lib/rt/pure/__release
   local.get $8
+  call $~lib/rt/pure/__release
+  local.get $13
+  call $~lib/rt/pure/__release
+  local.get $7
   call $~lib/rt/pure/__release
   local.get $21
   call $~lib/rt/pure/__release
-  local.get $9
+  local.get $10
   call $~lib/rt/pure/__release
   local.get $22
   call $~lib/rt/pure/__release
-  local.get $11
+  local.get $12
   call $~lib/rt/pure/__release
   local.get $23
   call $~lib/rt/pure/__release
@@ -15906,7 +17029,7 @@
   i32.const 0
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $5
+  local.tee $6
   i32.load offset=4
   local.tee $3
   i32.const 1
@@ -15940,9 +17063,9 @@
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
   i32.store offset=12
-  local.get $5
+  local.get $6
   call $~lib/array/Array<~lib/array/Array<i32>>#flat
-  local.tee $7
+  local.tee $5
   i32.load offset=12
   i32.const 10
   i32.ne
@@ -15955,14 +17078,14 @@
    unreachable
   end
   loop $for-loop|1
-   local.get $10
+   local.get $11
    i32.const 10
    i32.lt_s
    if
-    local.get $7
-    local.get $10
+    local.get $5
+    local.get $11
     call $~lib/array/Array<u32>#__get
-    local.get $10
+    local.get $11
     i32.ne
     if
      i32.const 0
@@ -15972,10 +17095,10 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $10
+    local.get $11
     i32.const 1
     i32.add
-    local.set $10
+    local.set $11
     br $for-loop|1
    end
   end
@@ -15985,7 +17108,7 @@
   i32.const 0
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $6
+  local.tee $8
   i32.load offset=4
   local.tee $3
   i32.const 1
@@ -16019,7 +17142,7 @@
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
   i32.store offset=12
-  local.get $6
+  local.get $8
   call $~lib/array/Array<~lib/array/Array<~lib/string/String | null>>#flat
   local.set $3
   i32.const 8
@@ -16042,21 +17165,21 @@
    unreachable
   end
   i32.const 0
-  local.set $10
+  local.set $11
   loop $for-loop|2
-   local.get $10
+   local.get $11
    local.get $4
    i32.load offset=12
    i32.lt_s
    if
     local.get $3
-    local.get $10
+    local.get $11
     call $~lib/array/Array<std/array/Ref | null>#__get
-    local.tee $8
+    local.tee $7
     local.get $4
-    local.get $10
+    local.get $11
     call $~lib/array/Array<std/array/Ref | null>#__get
-    local.tee $9
+    local.tee $10
     call $~lib/string/String.__eq
     i32.eqz
     if
@@ -16067,14 +17190,14 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $8
-    call $~lib/rt/pure/__release
-    local.get $9
+    local.get $7
     call $~lib/rt/pure/__release
     local.get $10
+    call $~lib/rt/pure/__release
+    local.get $11
     i32.const 1
     i32.add
-    local.set $10
+    local.set $11
     br $for-loop|2
    end
   end
@@ -16084,9 +17207,9 @@
   i32.const 0
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $10
+  local.tee $11
   i32.load offset=4
-  local.tee $8
+  local.tee $7
   i32.const 0
   i32.const 2
   i32.const 3
@@ -16094,7 +17217,7 @@
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
   i32.store
-  local.get $8
+  local.get $7
   i32.const 0
   i32.const 2
   i32.const 3
@@ -16102,9 +17225,9 @@
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
   i32.store offset=4
-  local.get $10
+  local.get $11
   call $~lib/array/Array<~lib/array/Array<i32>>#flat
-  local.tee $8
+  local.tee $7
   i32.load offset=12
   if
    i32.const 0
@@ -16114,15 +17237,15 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $10
+  local.get $11
   call $~lib/rt/pure/__release
-  local.get $8
+  local.get $7
   call $~lib/rt/pure/__release
-  local.get $16
+  local.get $9
   call $~lib/rt/pure/__release
   local.get $25
   call $~lib/rt/pure/__release
-  local.get $20
+  local.get $14
   call $~lib/rt/pure/__release
   local.get $30
   call $~lib/rt/pure/__release
@@ -16132,11 +17255,11 @@
   call $~lib/rt/pure/__release
   local.get $2
   call $~lib/rt/pure/__release
+  local.get $6
+  call $~lib/rt/pure/__release
   local.get $5
   call $~lib/rt/pure/__release
-  local.get $7
-  call $~lib/rt/pure/__release
-  local.get $6
+  local.get $8
   call $~lib/rt/pure/__release
   local.get $3
   call $~lib/rt/pure/__release

--- a/tests/compiler/std/array.untouched.wat
+++ b/tests/compiler/std/array.untouched.wat
@@ -6,11 +6,15 @@
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
  (type $i32_i32_i32_i32_=>_i32 (func (param i32 i32 i32 i32) (result i32)))
  (type $i32_=>_none (func (param i32)))
+ (type $i32_i32_i32_i32_i32_=>_i32 (func (param i32 i32 i32 i32 i32) (result i32)))
  (type $f32_f32_=>_i32 (func (param f32 f32) (result i32)))
  (type $f64_f64_=>_i32 (func (param f64 f64) (result i32)))
+ (type $i32_f32_f32_=>_i32 (func (param i32 f32 f32) (result i32)))
+ (type $i32_f64_f64_=>_i32 (func (param i32 f64 f64) (result i32)))
  (type $none_=>_none (func))
  (type $i64_i32_=>_i32 (func (param i64 i32) (result i32)))
  (type $none_=>_f64 (func (result f64)))
+ (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $i32_i64_i32_=>_none (func (param i32 i64 i32)))
  (type $i32_i32_i64_=>_i32 (func (param i32 i32 i64) (result i32)))
  (type $i32_f32_i32_=>_i32 (func (param i32 f32 i32) (result i32)))
@@ -18,17 +22,16 @@
  (type $i32_i32_=>_f32 (func (param i32 i32) (result f32)))
  (type $i32_i32_i32_=>_f32 (func (param i32 i32 i32) (result f32)))
  (type $i32_i32_=>_f64 (func (param i32 i32) (result f64)))
- (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $i32_i64_i32_i32_=>_none (func (param i32 i64 i32 i32)))
  (type $i64_=>_none (func (param i64)))
  (type $none_=>_i32 (func (result i32)))
- (type $i32_i32_i32_i32_i32_=>_i32 (func (param i32 i32 i32 i32 i32) (result i32)))
  (type $i32_i32_f64_=>_i32 (func (param i32 i32 f64) (result i32)))
  (type $i32_i64_i32_i64_i32_i64_i32_=>_i32 (func (param i32 i64 i32 i64 i32 i64 i32) (result i32)))
  (type $i32_f64_=>_i32 (func (param i32 f64) (result i32)))
  (type $i64_=>_i32 (func (param i64) (result i32)))
  (type $f64_=>_i32 (func (param f64) (result i32)))
  (type $i64_=>_i64 (func (param i64) (result i64)))
+ (type $i32_i32_i32_i32_=>_f32 (func (param i32 i32 i32 i32) (result f32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (import "rtrace" "onalloc" (func $~lib/rt/rtrace/onalloc (param i32)))
  (import "rtrace" "onincrement" (func $~lib/rt/rtrace/onincrement (param i32)))
@@ -237,7 +240,7 @@
  (data (i32.const 10432) "\00\00\00\00\01\00\00\00\00\00\00\00\00\00\00\00")
  (data (i32.const 10448) "\00\00\00\00\01\00\00\00\00\00\00\00\00\00\00\00")
  (table $0 57 funcref)
- (elem (i32.const 1) $start:std/array~anonymous|0 $start:std/array~anonymous|1 $start:std/array~anonymous|2 $start:std/array~anonymous|3 $start:std/array~anonymous|4 $start:std/array~anonymous|5 $start:std/array~anonymous|6 $start:std/array~anonymous|7 $start:std/array~anonymous|8 $start:std/array~anonymous|9 $start:std/array~anonymous|10 $start:std/array~anonymous|11 $start:std/array~anonymous|12 $start:std/array~anonymous|13 $start:std/array~anonymous|14 $start:std/array~anonymous|15 $start:std/array~anonymous|16 $start:std/array~anonymous|17 $start:std/array~anonymous|18 $start:std/array~anonymous|19 $start:std/array~anonymous|20 $start:std/array~anonymous|21 $start:std/array~anonymous|22 $start:std/array~anonymous|23 $start:std/array~anonymous|24 $start:std/array~anonymous|25 $start:std/array~anonymous|26 $start:std/array~anonymous|27 $start:std/array~anonymous|28 $start:std/array~anonymous|29 $start:std/array~anonymous|30 $start:std/array~anonymous|31 $start:std/array~anonymous|32 $start:std/array~anonymous|33 $start:std/array~anonymous|34 $start:std/array~anonymous|35 $start:std/array~anonymous|36 $start:std/array~anonymous|37 $start:std/array~anonymous|38 $start:std/array~anonymous|39 $start:std/array~anonymous|40 $start:std/array~anonymous|41 $start:std/array~anonymous|42 $~lib/util/sort/COMPARATOR<f32>~anonymous|0 $~lib/util/sort/COMPARATOR<f64>~anonymous|0 $~lib/util/sort/COMPARATOR<i32>~anonymous|0 $~lib/util/sort/COMPARATOR<u32>~anonymous|0 $~lib/util/sort/COMPARATOR<i32>~anonymous|1 $start:std/array~anonymous|43 $start:std/array~anonymous|44 $start:std/array~anonymous|45 $start:std/array~anonymous|46 $start:std/array~anonymous|47 $start:std/array~anonymous|48 $~lib/util/sort/COMPARATOR<~lib/string/String | null>~anonymous|0 $~lib/util/sort/COMPARATOR<~lib/string/String>~anonymous|0)
+ (elem (i32.const 1) $start:std/array~anonymous|0~nonClosure $start:std/array~anonymous|1~nonClosure $start:std/array~anonymous|2~nonClosure $start:std/array~anonymous|3~nonClosure $start:std/array~anonymous|4~nonClosure $start:std/array~anonymous|5~nonClosure $start:std/array~anonymous|6~nonClosure $start:std/array~anonymous|7~nonClosure $start:std/array~anonymous|8~nonClosure $start:std/array~anonymous|9~nonClosure $start:std/array~anonymous|10~nonClosure $start:std/array~anonymous|11~nonClosure $start:std/array~anonymous|12~nonClosure $start:std/array~anonymous|13~nonClosure $start:std/array~anonymous|14~nonClosure $start:std/array~anonymous|15~nonClosure $start:std/array~anonymous|16~nonClosure $start:std/array~anonymous|17~nonClosure $start:std/array~anonymous|18~nonClosure $start:std/array~anonymous|19~nonClosure $start:std/array~anonymous|20~nonClosure $start:std/array~anonymous|21~nonClosure $start:std/array~anonymous|22~nonClosure $start:std/array~anonymous|23~nonClosure $start:std/array~anonymous|24~nonClosure $start:std/array~anonymous|25~nonClosure $start:std/array~anonymous|26~nonClosure $start:std/array~anonymous|27~nonClosure $start:std/array~anonymous|28~nonClosure $start:std/array~anonymous|29~nonClosure $start:std/array~anonymous|30~nonClosure $start:std/array~anonymous|31~nonClosure $start:std/array~anonymous|32~nonClosure $start:std/array~anonymous|33~nonClosure $start:std/array~anonymous|34~nonClosure $start:std/array~anonymous|35~nonClosure $start:std/array~anonymous|36~nonClosure $start:std/array~anonymous|37~nonClosure $start:std/array~anonymous|38~nonClosure $start:std/array~anonymous|39~nonClosure $start:std/array~anonymous|40~nonClosure $start:std/array~anonymous|41~nonClosure $start:std/array~anonymous|42~nonClosure $~lib/util/sort/COMPARATOR<f32>~anonymous|0~nonClosure $~lib/util/sort/COMPARATOR<f64>~anonymous|0~nonClosure $~lib/util/sort/COMPARATOR<i32>~anonymous|0~nonClosure $~lib/util/sort/COMPARATOR<u32>~anonymous|0~nonClosure $~lib/util/sort/COMPARATOR<i32>~anonymous|1~nonClosure $start:std/array~anonymous|43~nonClosure $start:std/array~anonymous|44~nonClosure $start:std/array~anonymous|45~nonClosure $start:std/array~anonymous|46~nonClosure $start:std/array~anonymous|47~nonClosure $start:std/array~anonymous|48~nonClosure $~lib/util/sort/COMPARATOR<~lib/string/String | null>~anonymous|0~nonClosure $~lib/util/sort/COMPARATOR<~lib/string/String>~anonymous|0~nonClosure)
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
  (global $~lib/ASC_LOW_MEMORY_LIMIT i32 (i32.const 0))
  (global $~lib/rt/tlsf/collectLock (mut i32) (i32.const 0))
@@ -5697,7 +5700,7 @@
   local.get $2
   call $~lib/array/Array<i32>#__uset
  )
- (func $start:std/array~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|0~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -5715,53 +5718,137 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  i32.const 0
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  local.get $1
   local.set $2
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
+  i32.const 0
+  local.set $3
   local.get $0
   i32.load offset=12
-  local.set $3
+  local.set $4
   loop $for-loop|0
-   local.get $2
    local.get $3
-   local.tee $4
+   local.get $4
+   local.tee $5
    local.get $0
    i32.load offset=12
-   local.tee $5
-   local.get $4
+   local.tee $6
    local.get $5
+   local.get $6
    i32.lt_s
    select
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $5
+   local.get $5
    if
-    local.get $0
-    i32.load offset=4
-    local.get $2
-    i32.const 2
-    i32.shl
-    i32.add
-    i32.load
-    local.get $2
-    local.get $0
-    i32.const 3
-    global.set $~argumentsLength
     local.get $1
-    call_indirect (type $i32_i32_i32_=>_i32)
+    local.set $6
+    local.get $6
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result i32)
+     local.get $6
+     i32.const 4
+     i32.shl
+     local.get $0
+     i32.load offset=4
+     local.get $3
+     i32.const 2
+     i32.shl
+     i32.add
+     i32.load
+     local.get $3
+     local.get $0
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $6
+     i32.const 4
+     i32.shl
+     i32.load
+     call_indirect (type $i32_i32_i32_i32_=>_i32)
+    else
+     local.get $0
+     i32.load offset=4
+     local.get $3
+     i32.const 2
+     i32.shl
+     i32.add
+     i32.load
+     local.get $3
+     local.get $0
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $6
+     call_indirect (type $i32_i32_i32_=>_i32)
+    end
     if
-     local.get $2
+     local.get $3
+     local.set $8
+     local.get $1
+     local.set $7
+     local.get $7
+     i32.const -2147483648
+     i32.and
+     i32.const -2147483648
+     i32.eq
+     if (result i32)
+      local.get $7
+      i32.const 4
+      i32.shl
+     else
+      i32.const 0
+     end
+     call $~lib/rt/pure/__release
+     local.get $8
      return
     end
-    local.get $2
+    local.get $3
     i32.const 1
     i32.add
-    local.set $2
+    local.set $3
     br $for-loop|0
    end
   end
   i32.const -1
+  local.set $3
+  local.get $1
+  local.set $4
+  local.get $4
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $4
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $3
  )
- (func $start:std/array~anonymous|1 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|1~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -5774,7 +5861,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $start:std/array~anonymous|2 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|2~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -5787,7 +5874,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $start:std/array~anonymous|3 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|3~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -5804,7 +5891,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $start:std/array~anonymous|4 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|4~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -5817,7 +5904,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $start:std/array~anonymous|5 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|5~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -5833,7 +5920,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $start:std/array~anonymous|6 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|6~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -5851,54 +5938,138 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  i32.const 0
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  local.get $1
   local.set $2
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
+  i32.const 0
+  local.set $3
   local.get $0
   i32.load offset=12
-  local.set $3
+  local.set $4
   loop $for-loop|0
-   local.get $2
    local.get $3
-   local.tee $4
+   local.get $4
+   local.tee $5
    local.get $0
    i32.load offset=12
-   local.tee $5
-   local.get $4
+   local.tee $6
    local.get $5
+   local.get $6
    i32.lt_s
    select
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $5
+   local.get $5
    if
-    local.get $0
-    i32.load offset=4
-    local.get $2
-    i32.const 2
-    i32.shl
-    i32.add
-    i32.load
-    local.get $2
-    local.get $0
-    i32.const 3
-    global.set $~argumentsLength
     local.get $1
-    call_indirect (type $i32_i32_i32_=>_i32)
+    local.set $6
+    local.get $6
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result i32)
+     local.get $6
+     i32.const 4
+     i32.shl
+     local.get $0
+     i32.load offset=4
+     local.get $3
+     i32.const 2
+     i32.shl
+     i32.add
+     i32.load
+     local.get $3
+     local.get $0
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $6
+     i32.const 4
+     i32.shl
+     i32.load
+     call_indirect (type $i32_i32_i32_i32_=>_i32)
+    else
+     local.get $0
+     i32.load offset=4
+     local.get $3
+     i32.const 2
+     i32.shl
+     i32.add
+     i32.load
+     local.get $3
+     local.get $0
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $6
+     call_indirect (type $i32_i32_i32_=>_i32)
+    end
     i32.eqz
     if
      i32.const 0
+     local.set $8
+     local.get $1
+     local.set $7
+     local.get $7
+     i32.const -2147483648
+     i32.and
+     i32.const -2147483648
+     i32.eq
+     if (result i32)
+      local.get $7
+      i32.const 4
+      i32.shl
+     else
+      i32.const 0
+     end
+     call $~lib/rt/pure/__release
+     local.get $8
      return
     end
-    local.get $2
+    local.get $3
     i32.const 1
     i32.add
-    local.set $2
+    local.set $3
     br $for-loop|0
    end
   end
   i32.const 1
+  local.set $3
+  local.get $1
+  local.set $4
+  local.get $4
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $4
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $3
  )
- (func $start:std/array~anonymous|7 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|7~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -5911,7 +6082,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $start:std/array~anonymous|8 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|8~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -5928,7 +6099,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $start:std/array~anonymous|9 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|9~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -5941,7 +6112,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $start:std/array~anonymous|10 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|10~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -5957,7 +6128,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $start:std/array~anonymous|11 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|11~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -5975,53 +6146,137 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  i32.const 0
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  local.get $1
   local.set $2
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
+  i32.const 0
+  local.set $3
   local.get $0
   i32.load offset=12
-  local.set $3
+  local.set $4
   loop $for-loop|0
-   local.get $2
    local.get $3
-   local.tee $4
+   local.get $4
+   local.tee $5
    local.get $0
    i32.load offset=12
-   local.tee $5
-   local.get $4
+   local.tee $6
    local.get $5
+   local.get $6
    i32.lt_s
    select
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $5
+   local.get $5
    if
-    local.get $0
-    i32.load offset=4
-    local.get $2
-    i32.const 2
-    i32.shl
-    i32.add
-    i32.load
-    local.get $2
-    local.get $0
-    i32.const 3
-    global.set $~argumentsLength
     local.get $1
-    call_indirect (type $i32_i32_i32_=>_i32)
+    local.set $6
+    local.get $6
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result i32)
+     local.get $6
+     i32.const 4
+     i32.shl
+     local.get $0
+     i32.load offset=4
+     local.get $3
+     i32.const 2
+     i32.shl
+     i32.add
+     i32.load
+     local.get $3
+     local.get $0
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $6
+     i32.const 4
+     i32.shl
+     i32.load
+     call_indirect (type $i32_i32_i32_i32_=>_i32)
+    else
+     local.get $0
+     i32.load offset=4
+     local.get $3
+     i32.const 2
+     i32.shl
+     i32.add
+     i32.load
+     local.get $3
+     local.get $0
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $6
+     call_indirect (type $i32_i32_i32_=>_i32)
+    end
     if
      i32.const 1
+     local.set $8
+     local.get $1
+     local.set $7
+     local.get $7
+     i32.const -2147483648
+     i32.and
+     i32.const -2147483648
+     i32.eq
+     if (result i32)
+      local.get $7
+      i32.const 4
+      i32.shl
+     else
+      i32.const 0
+     end
+     call $~lib/rt/pure/__release
+     local.get $8
      return
     end
-    local.get $2
+    local.get $3
     i32.const 1
     i32.add
-    local.set $2
+    local.set $3
     br $for-loop|0
    end
   end
   i32.const 0
+  local.set $3
+  local.get $1
+  local.set $4
+  local.get $4
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $4
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $3
  )
- (func $start:std/array~anonymous|12 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|12~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -6034,7 +6289,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $start:std/array~anonymous|13 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|13~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -6051,7 +6306,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $start:std/array~anonymous|14 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|14~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -6064,7 +6319,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $start:std/array~anonymous|15 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|15~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -6080,7 +6335,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $start:std/array~anonymous|16 (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $start:std/array~anonymous|16~nonClosure (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $2
   call $~lib/rt/pure/__retain
   local.set $2
@@ -6096,48 +6351,111 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  i32.const 0
+  (local $6 i32)
+  local.get $1
   local.set $2
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
+  i32.const 0
+  local.set $3
   local.get $0
   i32.load offset=12
-  local.set $3
+  local.set $4
   loop $for-loop|0
-   local.get $2
    local.get $3
-   local.tee $4
+   local.get $4
+   local.tee $5
    local.get $0
    i32.load offset=12
-   local.tee $5
-   local.get $4
+   local.tee $6
    local.get $5
+   local.get $6
    i32.lt_s
    select
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $5
+   local.get $5
    if
-    local.get $0
-    i32.load offset=4
-    local.get $2
-    i32.const 2
-    i32.shl
-    i32.add
-    i32.load
-    local.get $2
-    local.get $0
-    i32.const 3
-    global.set $~argumentsLength
     local.get $1
-    call_indirect (type $i32_i32_i32_=>_none)
-    local.get $2
+    local.set $6
+    local.get $6
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if
+     local.get $6
+     i32.const 4
+     i32.shl
+     local.get $0
+     i32.load offset=4
+     local.get $3
+     i32.const 2
+     i32.shl
+     i32.add
+     i32.load
+     local.get $3
+     local.get $0
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $6
+     i32.const 4
+     i32.shl
+     i32.load
+     call_indirect (type $i32_i32_i32_i32_=>_none)
+    else
+     local.get $0
+     i32.load offset=4
+     local.get $3
+     i32.const 2
+     i32.shl
+     i32.add
+     i32.load
+     local.get $3
+     local.get $0
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $6
+     call_indirect (type $i32_i32_i32_=>_none)
+    end
+    local.get $3
     i32.const 1
     i32.add
-    local.set $2
+    local.set $3
     br $for-loop|0
    end
   end
+  local.get $1
+  local.set $4
+  local.get $4
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $4
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
  )
- (func $start:std/array~anonymous|17 (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $start:std/array~anonymous|17~nonClosure (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $2
   call $~lib/rt/pure/__retain
   local.set $2
@@ -6152,7 +6470,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $start:std/array~anonymous|18 (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $start:std/array~anonymous|18~nonClosure (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $2
   call $~lib/rt/pure/__retain
   local.set $2
@@ -6163,7 +6481,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $start:std/array~anonymous|19 (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $start:std/array~anonymous|19~nonClosure (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $2
   call $~lib/rt/pure/__retain
   local.set $2
@@ -6177,7 +6495,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $start:std/array~anonymous|20 (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $start:std/array~anonymous|20~nonClosure (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $2
@@ -6290,7 +6608,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $start:std/array~anonymous|21 (param $0 i32) (param $1 i32) (param $2 i32) (result f32)
+ (func $start:std/array~anonymous|21~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result f32)
   (local $3 f32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -6309,68 +6627,133 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 f32)
-  local.get $0
-  i32.load offset=12
+  (local $8 i32)
+  (local $9 f32)
+  local.get $1
   local.set $2
   local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
+  local.get $0
+  i32.load offset=12
+  local.set $3
+  local.get $3
   i32.const 2
   i32.const 9
   i32.const 0
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $3
-  local.get $3
-  i32.load offset=4
   local.set $4
-  i32.const 0
+  local.get $4
+  i32.load offset=4
   local.set $5
+  i32.const 0
+  local.set $6
   loop $for-loop|0
-   local.get $5
-   local.get $2
-   local.tee $6
+   local.get $6
+   local.get $3
+   local.tee $7
    local.get $0
    i32.load offset=12
-   local.tee $7
-   local.get $6
+   local.tee $8
    local.get $7
+   local.get $8
    i32.lt_s
    select
    i32.lt_s
-   local.set $6
-   local.get $6
+   local.set $7
+   local.get $7
    if
-    local.get $0
-    i32.load offset=4
-    local.get $5
-    i32.const 2
-    i32.shl
-    i32.add
-    i32.load
-    local.get $5
-    local.get $0
-    i32.const 3
-    global.set $~argumentsLength
     local.get $1
-    call_indirect (type $i32_i32_i32_=>_f32)
     local.set $8
+    local.get $8
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result f32)
+     local.get $8
+     i32.const 4
+     i32.shl
+     local.get $0
+     i32.load offset=4
+     local.get $6
+     i32.const 2
+     i32.shl
+     i32.add
+     i32.load
+     local.get $6
+     local.get $0
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $8
+     i32.const 4
+     i32.shl
+     i32.load
+     call_indirect (type $i32_i32_i32_i32_=>_f32)
+    else
+     local.get $0
+     i32.load offset=4
+     local.get $6
+     i32.const 2
+     i32.shl
+     i32.add
+     i32.load
+     local.get $6
+     local.get $0
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $8
+     call_indirect (type $i32_i32_i32_=>_f32)
+    end
+    local.set $9
     i32.const 0
     drop
-    local.get $4
     local.get $5
+    local.get $6
     i32.const 2
     i32.shl
     i32.add
-    local.get $8
+    local.get $9
     f32.store
-    local.get $5
+    local.get $6
     i32.const 1
     i32.add
-    local.set $5
+    local.set $6
     br $for-loop|0
    end
   end
-  local.get $3
+  local.get $4
+  local.set $7
+  local.get $1
+  local.set $6
+  local.get $6
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $6
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $7
  )
  (func $~lib/array/Array<f32>#get:length (param $0 i32) (result i32)
   local.get $0
@@ -6407,7 +6790,7 @@
   drop
   local.get $2
  )
- (func $start:std/array~anonymous|22 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|22~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -6433,69 +6816,135 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  local.get $0
-  i32.load offset=12
+  (local $8 i32)
+  (local $9 i32)
+  local.get $1
   local.set $2
   local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
+  local.get $0
+  i32.load offset=12
+  local.set $3
+  local.get $3
   i32.const 2
   i32.const 3
   i32.const 0
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $3
-  local.get $3
-  i32.load offset=4
   local.set $4
-  i32.const 0
+  local.get $4
+  i32.load offset=4
   local.set $5
+  i32.const 0
+  local.set $6
   loop $for-loop|0
-   local.get $5
-   local.get $2
-   local.tee $6
+   local.get $6
+   local.get $3
+   local.tee $7
    local.get $0
    i32.load offset=12
-   local.tee $7
-   local.get $6
+   local.tee $8
    local.get $7
+   local.get $8
    i32.lt_s
    select
    i32.lt_s
-   local.set $6
-   local.get $6
+   local.set $7
+   local.get $7
    if
-    local.get $0
-    i32.load offset=4
-    local.get $5
-    i32.const 2
-    i32.shl
-    i32.add
-    i32.load
-    local.get $5
-    local.get $0
-    i32.const 3
-    global.set $~argumentsLength
     local.get $1
-    call_indirect (type $i32_i32_i32_=>_i32)
-    local.set $7
+    local.set $8
+    local.get $8
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result i32)
+     local.get $8
+     i32.const 4
+     i32.shl
+     local.get $0
+     i32.load offset=4
+     local.get $6
+     i32.const 2
+     i32.shl
+     i32.add
+     i32.load
+     local.get $6
+     local.get $0
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $8
+     i32.const 4
+     i32.shl
+     i32.load
+     call_indirect (type $i32_i32_i32_i32_=>_i32)
+    else
+     local.get $0
+     i32.load offset=4
+     local.get $6
+     i32.const 2
+     i32.shl
+     i32.add
+     i32.load
+     local.get $6
+     local.get $0
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $8
+     call_indirect (type $i32_i32_i32_=>_i32)
+    end
+    local.set $9
     i32.const 0
     drop
-    local.get $4
     local.get $5
+    local.get $6
     i32.const 2
     i32.shl
     i32.add
-    local.get $7
+    local.get $9
     i32.store
-    local.get $5
+    local.get $6
     i32.const 1
     i32.add
-    local.set $5
+    local.set $6
     br $for-loop|0
    end
   end
-  local.get $3
+  local.get $4
+  local.set $7
+  local.get $1
+  local.set $6
+  local.get $6
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $6
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $7
  )
- (func $start:std/array~anonymous|23 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|23~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -6510,7 +6959,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $start:std/array~anonymous|24 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|24~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -6528,7 +6977,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $start:std/array~anonymous|25 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|25~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -6547,64 +6996,124 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  local.get $1
+  local.set $2
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
   i32.const 0
   i32.const 2
   i32.const 3
   i32.const 0
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $2
-  i32.const 0
   local.set $3
+  i32.const 0
+  local.set $4
   local.get $0
   i32.load offset=12
-  local.set $4
+  local.set $5
   loop $for-loop|0
-   local.get $3
    local.get $4
-   local.tee $5
+   local.get $5
+   local.tee $6
    local.get $0
    i32.load offset=12
-   local.tee $6
-   local.get $5
+   local.tee $7
    local.get $6
+   local.get $7
    i32.lt_s
    select
    i32.lt_s
-   local.set $5
-   local.get $5
+   local.set $6
+   local.get $6
    if
     local.get $0
     i32.load offset=4
-    local.get $3
+    local.get $4
     i32.const 2
     i32.shl
     i32.add
     i32.load
-    local.set $6
-    local.get $6
-    local.get $3
-    local.get $0
-    i32.const 3
-    global.set $~argumentsLength
+    local.set $7
     local.get $1
-    call_indirect (type $i32_i32_i32_=>_i32)
+    local.set $8
+    local.get $8
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result i32)
+     local.get $8
+     i32.const 4
+     i32.shl
+     local.get $7
+     local.get $4
+     local.get $0
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $8
+     i32.const 4
+     i32.shl
+     i32.load
+     call_indirect (type $i32_i32_i32_i32_=>_i32)
+    else
+     local.get $7
+     local.get $4
+     local.get $0
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $8
+     call_indirect (type $i32_i32_i32_=>_i32)
+    end
     if
-     local.get $2
-     local.get $6
+     local.get $3
+     local.get $7
      call $~lib/array/Array<i32>#push
      drop
     end
-    local.get $3
+    local.get $4
     i32.const 1
     i32.add
-    local.set $3
+    local.set $4
     br $for-loop|0
    end
   end
-  local.get $2
+  local.get $3
+  local.set $4
+  local.get $1
+  local.set $5
+  local.get $5
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $5
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $4
  )
- (func $start:std/array~anonymous|26 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|26~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -6625,7 +7134,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $start:std/array~anonymous|27 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|27~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -6642,7 +7151,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $start:std/array~anonymous|28 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|28~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -6662,7 +7171,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $start:std/array~anonymous|29 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|29~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -6681,53 +7190,119 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  local.get $2
+  (local $8 i32)
+  local.get $1
   local.set $3
-  i32.const 0
+  local.get $3
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $3
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $3
+  local.set $1
+  local.get $2
   local.set $4
+  i32.const 0
+  local.set $5
   local.get $0
   i32.load offset=12
-  local.set $5
+  local.set $6
   loop $for-loop|0
-   local.get $4
    local.get $5
-   local.tee $6
+   local.get $6
+   local.tee $7
    local.get $0
    i32.load offset=12
-   local.tee $7
-   local.get $6
+   local.tee $8
    local.get $7
+   local.get $8
    i32.lt_s
    select
    i32.lt_s
-   local.set $6
-   local.get $6
+   local.set $7
+   local.get $7
    if
-    local.get $3
-    local.get $0
-    i32.load offset=4
-    local.get $4
-    i32.const 2
-    i32.shl
-    i32.add
-    i32.load
-    local.get $4
-    local.get $0
-    i32.const 4
-    global.set $~argumentsLength
     local.get $1
-    call_indirect (type $i32_i32_i32_i32_=>_i32)
-    local.set $3
-    local.get $4
+    local.set $8
+    local.get $8
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result i32)
+     local.get $8
+     i32.const 4
+     i32.shl
+     local.get $4
+     local.get $0
+     i32.load offset=4
+     local.get $5
+     i32.const 2
+     i32.shl
+     i32.add
+     i32.load
+     local.get $5
+     local.get $0
+     i32.const 4
+     global.set $~argumentsLength
+     local.get $8
+     i32.const 4
+     i32.shl
+     i32.load
+     call_indirect (type $i32_i32_i32_i32_i32_=>_i32)
+    else
+     local.get $4
+     local.get $0
+     i32.load offset=4
+     local.get $5
+     i32.const 2
+     i32.shl
+     i32.add
+     i32.load
+     local.get $5
+     local.get $0
+     i32.const 4
+     global.set $~argumentsLength
+     local.get $8
+     call_indirect (type $i32_i32_i32_i32_=>_i32)
+    end
+    local.set $4
+    local.get $5
     i32.const 1
     i32.add
-    local.set $4
+    local.set $5
     br $for-loop|0
    end
   end
-  local.get $3
+  local.get $4
+  local.set $5
+  local.get $1
+  local.set $6
+  local.get $6
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $6
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $5
  )
- (func $start:std/array~anonymous|30 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|30~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -6740,7 +7315,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $start:std/array~anonymous|31 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|31~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -6764,53 +7339,119 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  local.get $2
+  (local $8 i32)
+  local.get $1
   local.set $3
-  i32.const 0
+  local.get $3
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $3
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $3
+  local.set $1
+  local.get $2
   local.set $4
+  i32.const 0
+  local.set $5
   local.get $0
   i32.load offset=12
-  local.set $5
+  local.set $6
   loop $for-loop|0
-   local.get $4
    local.get $5
-   local.tee $6
+   local.get $6
+   local.tee $7
    local.get $0
    i32.load offset=12
-   local.tee $7
-   local.get $6
+   local.tee $8
    local.get $7
+   local.get $8
    i32.lt_s
    select
    i32.lt_s
-   local.set $6
-   local.get $6
+   local.set $7
+   local.get $7
    if
-    local.get $3
-    local.get $0
-    i32.load offset=4
-    local.get $4
-    i32.const 2
-    i32.shl
-    i32.add
-    i32.load
-    local.get $4
-    local.get $0
-    i32.const 4
-    global.set $~argumentsLength
     local.get $1
-    call_indirect (type $i32_i32_i32_i32_=>_i32)
-    local.set $3
-    local.get $4
+    local.set $8
+    local.get $8
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result i32)
+     local.get $8
+     i32.const 4
+     i32.shl
+     local.get $4
+     local.get $0
+     i32.load offset=4
+     local.get $5
+     i32.const 2
+     i32.shl
+     i32.add
+     i32.load
+     local.get $5
+     local.get $0
+     i32.const 4
+     global.set $~argumentsLength
+     local.get $8
+     i32.const 4
+     i32.shl
+     i32.load
+     call_indirect (type $i32_i32_i32_i32_i32_=>_i32)
+    else
+     local.get $4
+     local.get $0
+     i32.load offset=4
+     local.get $5
+     i32.const 2
+     i32.shl
+     i32.add
+     i32.load
+     local.get $5
+     local.get $0
+     i32.const 4
+     global.set $~argumentsLength
+     local.get $8
+     call_indirect (type $i32_i32_i32_i32_=>_i32)
+    end
+    local.set $4
+    local.get $5
     i32.const 1
     i32.add
-    local.set $4
+    local.set $5
     br $for-loop|0
    end
   end
-  local.get $3
+  local.get $4
+  local.set $5
+  local.get $1
+  local.set $6
+  local.get $6
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $6
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $5
  )
- (func $start:std/array~anonymous|32 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|32~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -6828,7 +7469,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $start:std/array~anonymous|33 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|33~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -6845,7 +7486,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $start:std/array~anonymous|34 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|34~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -6858,7 +7499,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $start:std/array~anonymous|35 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|35~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -6874,7 +7515,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $start:std/array~anonymous|36 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|36~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -6891,45 +7532,112 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  local.get $2
+  (local $6 i32)
+  (local $7 i32)
+  local.get $1
   local.set $3
+  local.get $3
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $3
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $3
+  local.set $1
+  local.get $2
+  local.set $4
   local.get $0
   i32.load offset=12
   i32.const 1
   i32.sub
-  local.set $4
+  local.set $5
   loop $for-loop|0
-   local.get $4
+   local.get $5
    i32.const 0
    i32.ge_s
-   local.set $5
-   local.get $5
+   local.set $6
+   local.get $6
    if
-    local.get $3
-    local.get $0
-    i32.load offset=4
-    local.get $4
-    i32.const 2
-    i32.shl
-    i32.add
-    i32.load
-    local.get $4
-    local.get $0
-    i32.const 4
-    global.set $~argumentsLength
     local.get $1
-    call_indirect (type $i32_i32_i32_i32_=>_i32)
-    local.set $3
-    local.get $4
+    local.set $7
+    local.get $7
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result i32)
+     local.get $7
+     i32.const 4
+     i32.shl
+     local.get $4
+     local.get $0
+     i32.load offset=4
+     local.get $5
+     i32.const 2
+     i32.shl
+     i32.add
+     i32.load
+     local.get $5
+     local.get $0
+     i32.const 4
+     global.set $~argumentsLength
+     local.get $7
+     i32.const 4
+     i32.shl
+     i32.load
+     call_indirect (type $i32_i32_i32_i32_i32_=>_i32)
+    else
+     local.get $4
+     local.get $0
+     i32.load offset=4
+     local.get $5
+     i32.const 2
+     i32.shl
+     i32.add
+     i32.load
+     local.get $5
+     local.get $0
+     i32.const 4
+     global.set $~argumentsLength
+     local.get $7
+     call_indirect (type $i32_i32_i32_i32_=>_i32)
+    end
+    local.set $4
+    local.get $5
     i32.const 1
     i32.sub
-    local.set $4
+    local.set $5
     br $for-loop|0
    end
   end
-  local.get $3
+  local.get $4
+  local.set $6
+  local.get $1
+  local.set $5
+  local.get $5
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $5
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $6
  )
- (func $start:std/array~anonymous|37 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|37~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -6942,7 +7650,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $start:std/array~anonymous|38 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|38~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -6964,45 +7672,112 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  local.get $2
+  (local $6 i32)
+  (local $7 i32)
+  local.get $1
   local.set $3
+  local.get $3
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $3
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $3
+  local.set $1
+  local.get $2
+  local.set $4
   local.get $0
   i32.load offset=12
   i32.const 1
   i32.sub
-  local.set $4
+  local.set $5
   loop $for-loop|0
-   local.get $4
+   local.get $5
    i32.const 0
    i32.ge_s
-   local.set $5
-   local.get $5
+   local.set $6
+   local.get $6
    if
-    local.get $3
-    local.get $0
-    i32.load offset=4
-    local.get $4
-    i32.const 2
-    i32.shl
-    i32.add
-    i32.load
-    local.get $4
-    local.get $0
-    i32.const 4
-    global.set $~argumentsLength
     local.get $1
-    call_indirect (type $i32_i32_i32_i32_=>_i32)
-    local.set $3
-    local.get $4
+    local.set $7
+    local.get $7
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result i32)
+     local.get $7
+     i32.const 4
+     i32.shl
+     local.get $4
+     local.get $0
+     i32.load offset=4
+     local.get $5
+     i32.const 2
+     i32.shl
+     i32.add
+     i32.load
+     local.get $5
+     local.get $0
+     i32.const 4
+     global.set $~argumentsLength
+     local.get $7
+     i32.const 4
+     i32.shl
+     i32.load
+     call_indirect (type $i32_i32_i32_i32_i32_=>_i32)
+    else
+     local.get $4
+     local.get $0
+     i32.load offset=4
+     local.get $5
+     i32.const 2
+     i32.shl
+     i32.add
+     i32.load
+     local.get $5
+     local.get $0
+     i32.const 4
+     global.set $~argumentsLength
+     local.get $7
+     call_indirect (type $i32_i32_i32_i32_=>_i32)
+    end
+    local.set $4
+    local.get $5
     i32.const 1
     i32.sub
-    local.set $4
+    local.set $5
     br $for-loop|0
    end
   end
-  local.get $3
+  local.get $4
+  local.set $6
+  local.get $1
+  local.set $5
+  local.get $5
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $5
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $6
  )
- (func $start:std/array~anonymous|39 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|39~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -7020,7 +7795,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $start:std/array~anonymous|40 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|40~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -7037,7 +7812,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $start:std/array~anonymous|41 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|41~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -7050,7 +7825,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $start:std/array~anonymous|42 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|42~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -7185,68 +7960,110 @@
  (func $~lib/util/sort/insertionSort<f32> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
-  (local $5 f32)
-  (local $6 i32)
+  (local $5 i32)
+  (local $6 f32)
   (local $7 i32)
-  (local $8 f32)
-  (local $9 i32)
-  i32.const 0
+  (local $8 i32)
+  (local $9 f32)
+  (local $10 i32)
+  (local $11 i32)
+  local.get $2
   local.set $3
-  loop $for-loop|0
+  local.get $3
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
    local.get $3
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $3
+  local.set $2
+  i32.const 0
+  local.set $4
+  loop $for-loop|0
+   local.get $4
    local.get $1
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $5
+   local.get $5
    if
     local.get $0
-    local.get $3
+    local.get $4
     i32.const 2
     i32.shl
     i32.add
     f32.load
-    local.set $5
-    local.get $3
+    local.set $6
+    local.get $4
     i32.const 1
     i32.sub
-    local.set $6
+    local.set $7
     block $while-break|1
      loop $while-continue|1
-      local.get $6
+      local.get $7
       i32.const 0
       i32.ge_s
-      local.set $7
-      local.get $7
+      local.set $8
+      local.get $8
       if
        local.get $0
-       local.get $6
+       local.get $7
        i32.const 2
        i32.shl
        i32.add
        f32.load
-       local.set $8
-       local.get $5
-       local.get $8
-       i32.const 2
-       global.set $~argumentsLength
+       local.set $9
        local.get $2
-       call_indirect (type $f32_f32_=>_i32)
+       local.set $10
+       local.get $10
+       i32.const -2147483648
+       i32.and
+       i32.const -2147483648
+       i32.eq
+       if (result i32)
+        local.get $10
+        i32.const 4
+        i32.shl
+        local.get $6
+        local.get $9
+        i32.const 2
+        global.set $~argumentsLength
+        local.get $10
+        i32.const 4
+        i32.shl
+        i32.load
+        call_indirect (type $i32_f32_f32_=>_i32)
+       else
+        local.get $6
+        local.get $9
+        i32.const 2
+        global.set $~argumentsLength
+        local.get $10
+        call_indirect (type $f32_f32_=>_i32)
+       end
        i32.const 0
        i32.lt_s
        if
         local.get $0
-        local.get $6
-        local.tee $9
+        local.get $7
+        local.tee $11
         i32.const 1
         i32.sub
-        local.set $6
-        local.get $9
+        local.set $7
+        local.get $11
         i32.const 1
         i32.add
         i32.const 2
         i32.shl
         i32.add
-        local.get $8
+        local.get $9
         f32.store
        else
         br $while-break|1
@@ -7256,21 +8073,36 @@
      end
     end
     local.get $0
-    local.get $6
+    local.get $7
     i32.const 1
     i32.add
     i32.const 2
     i32.shl
     i32.add
-    local.get $5
+    local.get $6
     f32.store
-    local.get $3
+    local.get $4
     i32.const 1
     i32.add
-    local.set $3
+    local.set $4
     br $for-loop|0
    end
   end
+  local.get $2
+  local.set $4
+  local.get $4
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $4
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
  )
  (func $~lib/rt/tlsf/__free (param $0 i32)
   call $~lib/rt/tlsf/maybeInitialize
@@ -7285,10 +8117,31 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
-  (local $9 f32)
+  (local $9 i32)
   (local $10 f32)
-  (local $11 i32)
-  (local $12 f32)
+  (local $11 f32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 f32)
+  local.get $2
+  local.set $3
+  local.get $3
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $3
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $3
+  local.set $2
   local.get $1
   i32.const 31
   i32.add
@@ -7296,41 +8149,41 @@
   i32.shr_u
   i32.const 2
   i32.shl
-  local.set $3
-  local.get $3
-  i32.const 0
-  call $~lib/rt/tlsf/__alloc
   local.set $4
   local.get $4
   i32.const 0
-  local.get $3
+  call $~lib/rt/tlsf/__alloc
+  local.set $5
+  local.get $5
+  i32.const 0
+  local.get $4
   call $~lib/memory/memory.fill
   local.get $1
   i32.const 1
   i32.sub
-  local.set $5
+  local.set $6
   loop $for-loop|0
-   local.get $5
+   local.get $6
    i32.const 0
    i32.gt_s
-   local.set $6
-   local.get $6
+   local.set $7
+   local.get $7
    if
-    local.get $5
-    local.set $7
+    local.get $6
+    local.set $8
     loop $while-continue|1
-     local.get $7
+     local.get $8
      i32.const 1
      i32.and
-     local.get $4
-     local.get $7
+     local.get $5
+     local.get $8
      i32.const 6
      i32.shr_u
      i32.const 2
      i32.shl
      i32.add
      i32.load
-     local.get $7
+     local.get $8
      i32.const 1
      i32.shr_s
      i32.const 31
@@ -7339,52 +8192,74 @@
      i32.const 1
      i32.and
      i32.eq
-     local.set $8
-     local.get $8
+     local.set $9
+     local.get $9
      if
-      local.get $7
+      local.get $8
       i32.const 1
       i32.shr_s
-      local.set $7
+      local.set $8
       br $while-continue|1
      end
     end
-    local.get $7
+    local.get $8
     i32.const 1
     i32.shr_s
-    local.set $8
-    local.get $0
-    local.get $8
-    i32.const 2
-    i32.shl
-    i32.add
-    f32.load
     local.set $9
     local.get $0
-    local.get $5
+    local.get $9
     i32.const 2
     i32.shl
     i32.add
     f32.load
     local.set $10
-    local.get $9
-    local.get $10
+    local.get $0
+    local.get $6
     i32.const 2
-    global.set $~argumentsLength
+    i32.shl
+    i32.add
+    f32.load
+    local.set $11
     local.get $2
-    call_indirect (type $f32_f32_=>_i32)
+    local.set $12
+    local.get $12
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result i32)
+     local.get $12
+     i32.const 4
+     i32.shl
+     local.get $10
+     local.get $11
+     i32.const 2
+     global.set $~argumentsLength
+     local.get $12
+     i32.const 4
+     i32.shl
+     i32.load
+     call_indirect (type $i32_f32_f32_=>_i32)
+    else
+     local.get $10
+     local.get $11
+     i32.const 2
+     global.set $~argumentsLength
+     local.get $12
+     call_indirect (type $f32_f32_=>_i32)
+    end
     i32.const 0
     i32.lt_s
     if
-     local.get $4
      local.get $5
+     local.get $6
      i32.const 5
      i32.shr_u
      i32.const 2
      i32.shl
      i32.add
-     local.get $4
      local.get $5
+     local.get $6
      i32.const 5
      i32.shr_u
      i32.const 2
@@ -7392,130 +8267,152 @@
      i32.add
      i32.load
      i32.const 1
-     local.get $5
+     local.get $6
      i32.const 31
      i32.and
      i32.shl
      i32.xor
      i32.store
      local.get $0
-     local.get $5
-     i32.const 2
-     i32.shl
-     i32.add
-     local.get $9
-     f32.store
-     local.get $0
-     local.get $8
+     local.get $6
      i32.const 2
      i32.shl
      i32.add
      local.get $10
      f32.store
+     local.get $0
+     local.get $9
+     i32.const 2
+     i32.shl
+     i32.add
+     local.get $11
+     f32.store
     end
-    local.get $5
+    local.get $6
     i32.const 1
     i32.sub
-    local.set $5
+    local.set $6
     br $for-loop|0
    end
   end
   local.get $1
   i32.const 1
   i32.sub
-  local.set $5
+  local.set $6
   loop $for-loop|2
-   local.get $5
+   local.get $6
    i32.const 2
    i32.ge_s
-   local.set $6
-   local.get $6
+   local.set $7
+   local.get $7
    if
     local.get $0
     f32.load
-    local.set $10
+    local.set $11
     local.get $0
     local.get $0
-    local.get $5
+    local.get $6
     i32.const 2
     i32.shl
     i32.add
     f32.load
     f32.store
     local.get $0
-    local.get $5
+    local.get $6
     i32.const 2
     i32.shl
     i32.add
-    local.get $10
+    local.get $11
     f32.store
     i32.const 1
-    local.set $8
+    local.set $9
     loop $while-continue|3
-     local.get $8
+     local.get $9
      i32.const 1
      i32.shl
-     local.get $4
-     local.get $8
+     local.get $5
+     local.get $9
      i32.const 5
      i32.shr_u
      i32.const 2
      i32.shl
      i32.add
      i32.load
-     local.get $8
+     local.get $9
      i32.const 31
      i32.and
      i32.shr_u
      i32.const 1
      i32.and
      i32.add
-     local.tee $7
-     local.get $5
+     local.tee $8
+     local.get $6
      i32.lt_s
-     local.set $11
-     local.get $11
+     local.set $13
+     local.get $13
      if
-      local.get $7
-      local.set $8
+      local.get $8
+      local.set $9
       br $while-continue|3
      end
     end
     loop $while-continue|4
-     local.get $8
+     local.get $9
      i32.const 0
      i32.gt_s
-     local.set $11
-     local.get $11
+     local.set $13
+     local.get $13
      if
       local.get $0
       f32.load
-      local.set $10
+      local.set $11
       local.get $0
-      local.get $8
+      local.get $9
       i32.const 2
       i32.shl
       i32.add
       f32.load
-      local.set $9
-      local.get $10
-      local.get $9
-      i32.const 2
-      global.set $~argumentsLength
+      local.set $10
       local.get $2
-      call_indirect (type $f32_f32_=>_i32)
+      local.set $14
+      local.get $14
+      i32.const -2147483648
+      i32.and
+      i32.const -2147483648
+      i32.eq
+      if (result i32)
+       local.get $14
+       i32.const 4
+       i32.shl
+       local.get $11
+       local.get $10
+       i32.const 2
+       global.set $~argumentsLength
+       local.get $14
+       i32.const 4
+       i32.shl
+       i32.load
+       call_indirect (type $i32_f32_f32_=>_i32)
+      else
+       local.get $11
+       local.get $10
+       i32.const 2
+       global.set $~argumentsLength
+       local.get $14
+       call_indirect (type $f32_f32_=>_i32)
+      end
       i32.const 0
       i32.lt_s
       if
-       local.get $4
-       local.get $8
+       local.get $5
+       local.get $9
        i32.const 5
        i32.shr_u
        i32.const 2
        i32.shl
        i32.add
-       local.get $4
-       local.get $8
+       local.get $5
+       local.get $9
        i32.const 5
        i32.shr_u
        i32.const 2
@@ -7523,128 +8420,271 @@
        i32.add
        i32.load
        i32.const 1
-       local.get $8
+       local.get $9
        i32.const 31
        i32.and
        i32.shl
        i32.xor
        i32.store
        local.get $0
-       local.get $8
+       local.get $9
        i32.const 2
        i32.shl
        i32.add
-       local.get $10
+       local.get $11
        f32.store
        local.get $0
-       local.get $9
+       local.get $10
        f32.store
       end
-      local.get $8
+      local.get $9
       i32.const 1
       i32.shr_s
-      local.set $8
+      local.set $9
       br $while-continue|4
      end
     end
-    local.get $5
+    local.get $6
     i32.const 1
     i32.sub
-    local.set $5
+    local.set $6
     br $for-loop|2
    end
   end
-  local.get $4
+  local.get $5
   call $~lib/rt/tlsf/__free
   local.get $0
   f32.load offset=4
-  local.set $12
+  local.set $15
   local.get $0
   local.get $0
   f32.load
   f32.store offset=4
   local.get $0
-  local.get $12
+  local.get $15
   f32.store
+  local.get $2
+  local.set $6
+  local.get $6
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $6
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
  )
  (func $~lib/array/Array<f32>#sort (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
-  (local $4 f32)
-  (local $5 f32)
+  (local $4 i32)
+  (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  local.get $0
-  i32.load offset=12
+  (local $7 f32)
+  (local $8 f32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  local.get $1
   local.set $2
   local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
+  local.get $0
+  i32.load offset=12
+  local.set $3
+  local.get $3
   i32.const 1
   i32.le_s
   if
    local.get $0
    call $~lib/rt/pure/__retain
+   local.set $5
+   local.get $1
+   local.set $4
+   local.get $4
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $4
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
+   call $~lib/rt/pure/__release
+   local.get $5
    return
   end
   local.get $0
   i32.load offset=4
-  local.set $3
-  local.get $2
+  local.set $6
+  local.get $3
   i32.const 2
   i32.eq
   if
-   local.get $3
+   local.get $6
    f32.load offset=4
-   local.set $4
-   local.get $3
+   local.set $7
+   local.get $6
    f32.load
-   local.set $5
-   local.get $4
-   local.get $5
-   i32.const 2
-   global.set $~argumentsLength
+   local.set $8
    local.get $1
-   call_indirect (type $f32_f32_=>_i32)
+   local.set $5
+   local.get $5
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $5
+    i32.const 4
+    i32.shl
+    local.get $7
+    local.get $8
+    i32.const 2
+    global.set $~argumentsLength
+    local.get $5
+    i32.const 4
+    i32.shl
+    i32.load
+    call_indirect (type $i32_f32_f32_=>_i32)
+   else
+    local.get $7
+    local.get $8
+    i32.const 2
+    global.set $~argumentsLength
+    local.get $5
+    call_indirect (type $f32_f32_=>_i32)
+   end
    i32.const 0
    i32.lt_s
    if
-    local.get $3
-    local.get $5
+    local.get $6
+    local.get $8
     f32.store offset=4
-    local.get $3
-    local.get $4
+    local.get $6
+    local.get $7
     f32.store
    end
    local.get $0
    call $~lib/rt/pure/__retain
+   local.set $10
+   local.get $1
+   local.set $9
+   local.get $9
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $9
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
+   call $~lib/rt/pure/__release
+   local.get $10
    return
   end
+  local.get $6
+  local.set $13
   local.get $3
-  local.set $8
-  local.get $2
-  local.set $7
+  local.set $12
   local.get $1
-  local.set $6
+  local.set $11
+  local.get $11
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $11
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $11
+  local.set $10
   i32.const 0
   drop
-  local.get $7
+  local.get $12
   i32.const 256
   i32.lt_s
   if
-   local.get $8
-   local.get $7
-   local.get $6
+   local.get $13
+   local.get $12
+   local.get $10
    call $~lib/util/sort/insertionSort<f32>
   else
-   local.get $8
-   local.get $7
-   local.get $6
+   local.get $13
+   local.get $12
+   local.get $10
    call $~lib/util/sort/weakHeapSort<f32>
   end
+  local.get $10
+  local.set $14
+  local.get $14
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $14
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__retain
+  local.set $12
+  local.get $1
+  local.set $13
+  local.get $13
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $13
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $12
  )
- (func $~lib/util/sort/COMPARATOR<f32>~anonymous|0 (param $0 f32) (param $1 f32) (result i32)
+ (func $~lib/util/sort/COMPARATOR<f32>~anonymous|0~nonClosure (param $0 f32) (param $1 f32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -7678,6 +8718,10 @@
   i32.sub
  )
  (func $~lib/array/Array<f32>#sort@varargs (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -7696,13 +8740,47 @@
     i32.eq
     drop
     i32.const 44
+    local.set $2
+    local.get $2
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result i32)
+     local.get $2
+     i32.const 4
+     i32.shl
+    else
+     i32.const 0
+    end
+    call $~lib/rt/pure/__retain
+    drop
+    local.get $2
     br $~lib/util/sort/COMPARATOR<f32>|inlined.0
    end
+   local.tee $3
    local.set $1
   end
   local.get $0
   local.get $1
   call $~lib/array/Array<f32>#sort
+  local.set $5
+  local.get $3
+  local.set $4
+  local.get $4
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $4
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $5
  )
  (func $std/array/isArraysEqual<f32> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
@@ -7816,68 +8894,110 @@
  (func $~lib/util/sort/insertionSort<f64> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
-  (local $5 f64)
-  (local $6 i32)
+  (local $5 i32)
+  (local $6 f64)
   (local $7 i32)
-  (local $8 f64)
-  (local $9 i32)
-  i32.const 0
+  (local $8 i32)
+  (local $9 f64)
+  (local $10 i32)
+  (local $11 i32)
+  local.get $2
   local.set $3
-  loop $for-loop|0
+  local.get $3
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
    local.get $3
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $3
+  local.set $2
+  i32.const 0
+  local.set $4
+  loop $for-loop|0
+   local.get $4
    local.get $1
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $5
+   local.get $5
    if
     local.get $0
-    local.get $3
+    local.get $4
     i32.const 3
     i32.shl
     i32.add
     f64.load
-    local.set $5
-    local.get $3
+    local.set $6
+    local.get $4
     i32.const 1
     i32.sub
-    local.set $6
+    local.set $7
     block $while-break|1
      loop $while-continue|1
-      local.get $6
+      local.get $7
       i32.const 0
       i32.ge_s
-      local.set $7
-      local.get $7
+      local.set $8
+      local.get $8
       if
        local.get $0
-       local.get $6
+       local.get $7
        i32.const 3
        i32.shl
        i32.add
        f64.load
-       local.set $8
-       local.get $5
-       local.get $8
-       i32.const 2
-       global.set $~argumentsLength
+       local.set $9
        local.get $2
-       call_indirect (type $f64_f64_=>_i32)
+       local.set $10
+       local.get $10
+       i32.const -2147483648
+       i32.and
+       i32.const -2147483648
+       i32.eq
+       if (result i32)
+        local.get $10
+        i32.const 4
+        i32.shl
+        local.get $6
+        local.get $9
+        i32.const 2
+        global.set $~argumentsLength
+        local.get $10
+        i32.const 4
+        i32.shl
+        i32.load
+        call_indirect (type $i32_f64_f64_=>_i32)
+       else
+        local.get $6
+        local.get $9
+        i32.const 2
+        global.set $~argumentsLength
+        local.get $10
+        call_indirect (type $f64_f64_=>_i32)
+       end
        i32.const 0
        i32.lt_s
        if
         local.get $0
-        local.get $6
-        local.tee $9
+        local.get $7
+        local.tee $11
         i32.const 1
         i32.sub
-        local.set $6
-        local.get $9
+        local.set $7
+        local.get $11
         i32.const 1
         i32.add
         i32.const 3
         i32.shl
         i32.add
-        local.get $8
+        local.get $9
         f64.store
        else
         br $while-break|1
@@ -7887,21 +9007,36 @@
      end
     end
     local.get $0
-    local.get $6
+    local.get $7
     i32.const 1
     i32.add
     i32.const 3
     i32.shl
     i32.add
-    local.get $5
+    local.get $6
     f64.store
-    local.get $3
+    local.get $4
     i32.const 1
     i32.add
-    local.set $3
+    local.set $4
     br $for-loop|0
    end
   end
+  local.get $2
+  local.set $4
+  local.get $4
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $4
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
  )
  (func $~lib/util/sort/weakHeapSort<f64> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
@@ -7910,10 +9045,31 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
-  (local $9 f64)
+  (local $9 i32)
   (local $10 f64)
-  (local $11 i32)
-  (local $12 f64)
+  (local $11 f64)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 f64)
+  local.get $2
+  local.set $3
+  local.get $3
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $3
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $3
+  local.set $2
   local.get $1
   i32.const 31
   i32.add
@@ -7921,41 +9077,41 @@
   i32.shr_u
   i32.const 2
   i32.shl
-  local.set $3
-  local.get $3
-  i32.const 0
-  call $~lib/rt/tlsf/__alloc
   local.set $4
   local.get $4
   i32.const 0
-  local.get $3
+  call $~lib/rt/tlsf/__alloc
+  local.set $5
+  local.get $5
+  i32.const 0
+  local.get $4
   call $~lib/memory/memory.fill
   local.get $1
   i32.const 1
   i32.sub
-  local.set $5
+  local.set $6
   loop $for-loop|0
-   local.get $5
+   local.get $6
    i32.const 0
    i32.gt_s
-   local.set $6
-   local.get $6
+   local.set $7
+   local.get $7
    if
-    local.get $5
-    local.set $7
+    local.get $6
+    local.set $8
     loop $while-continue|1
-     local.get $7
+     local.get $8
      i32.const 1
      i32.and
-     local.get $4
-     local.get $7
+     local.get $5
+     local.get $8
      i32.const 6
      i32.shr_u
      i32.const 2
      i32.shl
      i32.add
      i32.load
-     local.get $7
+     local.get $8
      i32.const 1
      i32.shr_s
      i32.const 31
@@ -7964,52 +9120,74 @@
      i32.const 1
      i32.and
      i32.eq
-     local.set $8
-     local.get $8
+     local.set $9
+     local.get $9
      if
-      local.get $7
+      local.get $8
       i32.const 1
       i32.shr_s
-      local.set $7
+      local.set $8
       br $while-continue|1
      end
     end
-    local.get $7
+    local.get $8
     i32.const 1
     i32.shr_s
-    local.set $8
-    local.get $0
-    local.get $8
-    i32.const 3
-    i32.shl
-    i32.add
-    f64.load
     local.set $9
     local.get $0
-    local.get $5
+    local.get $9
     i32.const 3
     i32.shl
     i32.add
     f64.load
     local.set $10
-    local.get $9
-    local.get $10
-    i32.const 2
-    global.set $~argumentsLength
+    local.get $0
+    local.get $6
+    i32.const 3
+    i32.shl
+    i32.add
+    f64.load
+    local.set $11
     local.get $2
-    call_indirect (type $f64_f64_=>_i32)
+    local.set $12
+    local.get $12
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result i32)
+     local.get $12
+     i32.const 4
+     i32.shl
+     local.get $10
+     local.get $11
+     i32.const 2
+     global.set $~argumentsLength
+     local.get $12
+     i32.const 4
+     i32.shl
+     i32.load
+     call_indirect (type $i32_f64_f64_=>_i32)
+    else
+     local.get $10
+     local.get $11
+     i32.const 2
+     global.set $~argumentsLength
+     local.get $12
+     call_indirect (type $f64_f64_=>_i32)
+    end
     i32.const 0
     i32.lt_s
     if
-     local.get $4
      local.get $5
+     local.get $6
      i32.const 5
      i32.shr_u
      i32.const 2
      i32.shl
      i32.add
-     local.get $4
      local.get $5
+     local.get $6
      i32.const 5
      i32.shr_u
      i32.const 2
@@ -8017,130 +9195,152 @@
      i32.add
      i32.load
      i32.const 1
-     local.get $5
+     local.get $6
      i32.const 31
      i32.and
      i32.shl
      i32.xor
      i32.store
      local.get $0
-     local.get $5
-     i32.const 3
-     i32.shl
-     i32.add
-     local.get $9
-     f64.store
-     local.get $0
-     local.get $8
+     local.get $6
      i32.const 3
      i32.shl
      i32.add
      local.get $10
      f64.store
+     local.get $0
+     local.get $9
+     i32.const 3
+     i32.shl
+     i32.add
+     local.get $11
+     f64.store
     end
-    local.get $5
+    local.get $6
     i32.const 1
     i32.sub
-    local.set $5
+    local.set $6
     br $for-loop|0
    end
   end
   local.get $1
   i32.const 1
   i32.sub
-  local.set $5
+  local.set $6
   loop $for-loop|2
-   local.get $5
+   local.get $6
    i32.const 2
    i32.ge_s
-   local.set $6
-   local.get $6
+   local.set $7
+   local.get $7
    if
     local.get $0
     f64.load
-    local.set $10
+    local.set $11
     local.get $0
     local.get $0
-    local.get $5
+    local.get $6
     i32.const 3
     i32.shl
     i32.add
     f64.load
     f64.store
     local.get $0
-    local.get $5
+    local.get $6
     i32.const 3
     i32.shl
     i32.add
-    local.get $10
+    local.get $11
     f64.store
     i32.const 1
-    local.set $8
+    local.set $9
     loop $while-continue|3
-     local.get $8
+     local.get $9
      i32.const 1
      i32.shl
-     local.get $4
-     local.get $8
+     local.get $5
+     local.get $9
      i32.const 5
      i32.shr_u
      i32.const 2
      i32.shl
      i32.add
      i32.load
-     local.get $8
+     local.get $9
      i32.const 31
      i32.and
      i32.shr_u
      i32.const 1
      i32.and
      i32.add
-     local.tee $7
-     local.get $5
+     local.tee $8
+     local.get $6
      i32.lt_s
-     local.set $11
-     local.get $11
+     local.set $13
+     local.get $13
      if
-      local.get $7
-      local.set $8
+      local.get $8
+      local.set $9
       br $while-continue|3
      end
     end
     loop $while-continue|4
-     local.get $8
+     local.get $9
      i32.const 0
      i32.gt_s
-     local.set $11
-     local.get $11
+     local.set $13
+     local.get $13
      if
       local.get $0
       f64.load
-      local.set $10
+      local.set $11
       local.get $0
-      local.get $8
+      local.get $9
       i32.const 3
       i32.shl
       i32.add
       f64.load
-      local.set $9
-      local.get $10
-      local.get $9
-      i32.const 2
-      global.set $~argumentsLength
+      local.set $10
       local.get $2
-      call_indirect (type $f64_f64_=>_i32)
+      local.set $14
+      local.get $14
+      i32.const -2147483648
+      i32.and
+      i32.const -2147483648
+      i32.eq
+      if (result i32)
+       local.get $14
+       i32.const 4
+       i32.shl
+       local.get $11
+       local.get $10
+       i32.const 2
+       global.set $~argumentsLength
+       local.get $14
+       i32.const 4
+       i32.shl
+       i32.load
+       call_indirect (type $i32_f64_f64_=>_i32)
+      else
+       local.get $11
+       local.get $10
+       i32.const 2
+       global.set $~argumentsLength
+       local.get $14
+       call_indirect (type $f64_f64_=>_i32)
+      end
       i32.const 0
       i32.lt_s
       if
-       local.get $4
-       local.get $8
+       local.get $5
+       local.get $9
        i32.const 5
        i32.shr_u
        i32.const 2
        i32.shl
        i32.add
-       local.get $4
-       local.get $8
+       local.get $5
+       local.get $9
        i32.const 5
        i32.shr_u
        i32.const 2
@@ -8148,128 +9348,271 @@
        i32.add
        i32.load
        i32.const 1
-       local.get $8
+       local.get $9
        i32.const 31
        i32.and
        i32.shl
        i32.xor
        i32.store
        local.get $0
-       local.get $8
+       local.get $9
        i32.const 3
        i32.shl
        i32.add
-       local.get $10
+       local.get $11
        f64.store
        local.get $0
-       local.get $9
+       local.get $10
        f64.store
       end
-      local.get $8
+      local.get $9
       i32.const 1
       i32.shr_s
-      local.set $8
+      local.set $9
       br $while-continue|4
      end
     end
-    local.get $5
+    local.get $6
     i32.const 1
     i32.sub
-    local.set $5
+    local.set $6
     br $for-loop|2
    end
   end
-  local.get $4
+  local.get $5
   call $~lib/rt/tlsf/__free
   local.get $0
   f64.load offset=8
-  local.set $12
+  local.set $15
   local.get $0
   local.get $0
   f64.load
   f64.store offset=8
   local.get $0
-  local.get $12
+  local.get $15
   f64.store
+  local.get $2
+  local.set $6
+  local.get $6
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $6
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
  )
  (func $~lib/array/Array<f64>#sort (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
-  (local $4 f64)
-  (local $5 f64)
+  (local $4 i32)
+  (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  local.get $0
-  i32.load offset=12
+  (local $7 f64)
+  (local $8 f64)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  local.get $1
   local.set $2
   local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
+  local.get $0
+  i32.load offset=12
+  local.set $3
+  local.get $3
   i32.const 1
   i32.le_s
   if
    local.get $0
    call $~lib/rt/pure/__retain
+   local.set $5
+   local.get $1
+   local.set $4
+   local.get $4
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $4
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
+   call $~lib/rt/pure/__release
+   local.get $5
    return
   end
   local.get $0
   i32.load offset=4
-  local.set $3
-  local.get $2
+  local.set $6
+  local.get $3
   i32.const 2
   i32.eq
   if
-   local.get $3
+   local.get $6
    f64.load offset=8
-   local.set $4
-   local.get $3
+   local.set $7
+   local.get $6
    f64.load
-   local.set $5
-   local.get $4
-   local.get $5
-   i32.const 2
-   global.set $~argumentsLength
+   local.set $8
    local.get $1
-   call_indirect (type $f64_f64_=>_i32)
+   local.set $5
+   local.get $5
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $5
+    i32.const 4
+    i32.shl
+    local.get $7
+    local.get $8
+    i32.const 2
+    global.set $~argumentsLength
+    local.get $5
+    i32.const 4
+    i32.shl
+    i32.load
+    call_indirect (type $i32_f64_f64_=>_i32)
+   else
+    local.get $7
+    local.get $8
+    i32.const 2
+    global.set $~argumentsLength
+    local.get $5
+    call_indirect (type $f64_f64_=>_i32)
+   end
    i32.const 0
    i32.lt_s
    if
-    local.get $3
-    local.get $5
+    local.get $6
+    local.get $8
     f64.store offset=8
-    local.get $3
-    local.get $4
+    local.get $6
+    local.get $7
     f64.store
    end
    local.get $0
    call $~lib/rt/pure/__retain
+   local.set $10
+   local.get $1
+   local.set $9
+   local.get $9
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $9
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
+   call $~lib/rt/pure/__release
+   local.get $10
    return
   end
+  local.get $6
+  local.set $13
   local.get $3
-  local.set $8
-  local.get $2
-  local.set $7
+  local.set $12
   local.get $1
-  local.set $6
+  local.set $11
+  local.get $11
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $11
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $11
+  local.set $10
   i32.const 0
   drop
-  local.get $7
+  local.get $12
   i32.const 256
   i32.lt_s
   if
-   local.get $8
-   local.get $7
-   local.get $6
+   local.get $13
+   local.get $12
+   local.get $10
    call $~lib/util/sort/insertionSort<f64>
   else
-   local.get $8
-   local.get $7
-   local.get $6
+   local.get $13
+   local.get $12
+   local.get $10
    call $~lib/util/sort/weakHeapSort<f64>
   end
+  local.get $10
+  local.set $14
+  local.get $14
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $14
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__retain
+  local.set $12
+  local.get $1
+  local.set $13
+  local.get $13
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $13
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $12
  )
- (func $~lib/util/sort/COMPARATOR<f64>~anonymous|0 (param $0 f64) (param $1 f64) (result i32)
+ (func $~lib/util/sort/COMPARATOR<f64>~anonymous|0~nonClosure (param $0 f64) (param $1 f64) (result i32)
   (local $2 i64)
   (local $3 i64)
   local.get $0
@@ -8303,6 +9646,10 @@
   i32.sub
  )
  (func $~lib/array/Array<f64>#sort@varargs (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -8321,13 +9668,47 @@
     i32.eq
     drop
     i32.const 45
+    local.set $2
+    local.get $2
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result i32)
+     local.get $2
+     i32.const 4
+     i32.shl
+    else
+     i32.const 0
+    end
+    call $~lib/rt/pure/__retain
+    drop
+    local.get $2
     br $~lib/util/sort/COMPARATOR<f64>|inlined.0
    end
+   local.tee $3
    local.set $1
   end
   local.get $0
   local.get $1
   call $~lib/array/Array<f64>#sort
+  local.set $5
+  local.get $3
+  local.set $4
+  local.get $4
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $4
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $5
  )
  (func $~lib/array/Array<f64>#get:length (param $0 i32) (result i32)
   local.get $0
@@ -8481,63 +9862,105 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
-  i32.const 0
+  (local $10 i32)
+  (local $11 i32)
+  local.get $2
   local.set $3
-  loop $for-loop|0
+  local.get $3
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
    local.get $3
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $3
+  local.set $2
+  i32.const 0
+  local.set $4
+  loop $for-loop|0
+   local.get $4
    local.get $1
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $5
+   local.get $5
    if
     local.get $0
-    local.get $3
+    local.get $4
     i32.const 2
     i32.shl
     i32.add
     i32.load
-    local.set $5
-    local.get $3
+    local.set $6
+    local.get $4
     i32.const 1
     i32.sub
-    local.set $6
+    local.set $7
     block $while-break|1
      loop $while-continue|1
-      local.get $6
+      local.get $7
       i32.const 0
       i32.ge_s
-      local.set $7
-      local.get $7
+      local.set $8
+      local.get $8
       if
        local.get $0
-       local.get $6
+       local.get $7
        i32.const 2
        i32.shl
        i32.add
        i32.load
-       local.set $8
-       local.get $5
-       local.get $8
-       i32.const 2
-       global.set $~argumentsLength
+       local.set $9
        local.get $2
-       call_indirect (type $i32_i32_=>_i32)
+       local.set $10
+       local.get $10
+       i32.const -2147483648
+       i32.and
+       i32.const -2147483648
+       i32.eq
+       if (result i32)
+        local.get $10
+        i32.const 4
+        i32.shl
+        local.get $6
+        local.get $9
+        i32.const 2
+        global.set $~argumentsLength
+        local.get $10
+        i32.const 4
+        i32.shl
+        i32.load
+        call_indirect (type $i32_i32_i32_=>_i32)
+       else
+        local.get $6
+        local.get $9
+        i32.const 2
+        global.set $~argumentsLength
+        local.get $10
+        call_indirect (type $i32_i32_=>_i32)
+       end
        i32.const 0
        i32.lt_s
        if
         local.get $0
-        local.get $6
-        local.tee $9
+        local.get $7
+        local.tee $11
         i32.const 1
         i32.sub
-        local.set $6
-        local.get $9
+        local.set $7
+        local.get $11
         i32.const 1
         i32.add
         i32.const 2
         i32.shl
         i32.add
-        local.get $8
+        local.get $9
         i32.store
        else
         br $while-break|1
@@ -8547,21 +9970,36 @@
      end
     end
     local.get $0
-    local.get $6
+    local.get $7
     i32.const 1
     i32.add
     i32.const 2
     i32.shl
     i32.add
-    local.get $5
+    local.get $6
     i32.store
-    local.get $3
+    local.get $4
     i32.const 1
     i32.add
-    local.set $3
+    local.set $4
     br $for-loop|0
    end
   end
+  local.get $2
+  local.set $4
+  local.get $4
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $4
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
  )
  (func $~lib/util/sort/weakHeapSort<i32> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
@@ -8574,6 +10012,27 @@
   (local $10 i32)
   (local $11 i32)
   (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  local.get $2
+  local.set $3
+  local.get $3
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $3
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $3
+  local.set $2
   local.get $1
   i32.const 31
   i32.add
@@ -8581,41 +10040,41 @@
   i32.shr_u
   i32.const 2
   i32.shl
-  local.set $3
-  local.get $3
-  i32.const 0
-  call $~lib/rt/tlsf/__alloc
   local.set $4
   local.get $4
   i32.const 0
-  local.get $3
+  call $~lib/rt/tlsf/__alloc
+  local.set $5
+  local.get $5
+  i32.const 0
+  local.get $4
   call $~lib/memory/memory.fill
   local.get $1
   i32.const 1
   i32.sub
-  local.set $5
+  local.set $6
   loop $for-loop|0
-   local.get $5
+   local.get $6
    i32.const 0
    i32.gt_s
-   local.set $6
-   local.get $6
+   local.set $7
+   local.get $7
    if
-    local.get $5
-    local.set $7
+    local.get $6
+    local.set $8
     loop $while-continue|1
-     local.get $7
+     local.get $8
      i32.const 1
      i32.and
-     local.get $4
-     local.get $7
+     local.get $5
+     local.get $8
      i32.const 6
      i32.shr_u
      i32.const 2
      i32.shl
      i32.add
      i32.load
-     local.get $7
+     local.get $8
      i32.const 1
      i32.shr_s
      i32.const 31
@@ -8624,52 +10083,74 @@
      i32.const 1
      i32.and
      i32.eq
-     local.set $8
-     local.get $8
+     local.set $9
+     local.get $9
      if
-      local.get $7
+      local.get $8
       i32.const 1
       i32.shr_s
-      local.set $7
+      local.set $8
       br $while-continue|1
      end
     end
-    local.get $7
+    local.get $8
     i32.const 1
     i32.shr_s
-    local.set $8
-    local.get $0
-    local.get $8
-    i32.const 2
-    i32.shl
-    i32.add
-    i32.load
     local.set $9
     local.get $0
-    local.get $5
+    local.get $9
     i32.const 2
     i32.shl
     i32.add
     i32.load
     local.set $10
-    local.get $9
-    local.get $10
+    local.get $0
+    local.get $6
     i32.const 2
-    global.set $~argumentsLength
+    i32.shl
+    i32.add
+    i32.load
+    local.set $11
     local.get $2
-    call_indirect (type $i32_i32_=>_i32)
+    local.set $12
+    local.get $12
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result i32)
+     local.get $12
+     i32.const 4
+     i32.shl
+     local.get $10
+     local.get $11
+     i32.const 2
+     global.set $~argumentsLength
+     local.get $12
+     i32.const 4
+     i32.shl
+     i32.load
+     call_indirect (type $i32_i32_i32_=>_i32)
+    else
+     local.get $10
+     local.get $11
+     i32.const 2
+     global.set $~argumentsLength
+     local.get $12
+     call_indirect (type $i32_i32_=>_i32)
+    end
     i32.const 0
     i32.lt_s
     if
-     local.get $4
      local.get $5
+     local.get $6
      i32.const 5
      i32.shr_u
      i32.const 2
      i32.shl
      i32.add
-     local.get $4
      local.get $5
+     local.get $6
      i32.const 5
      i32.shr_u
      i32.const 2
@@ -8677,130 +10158,152 @@
      i32.add
      i32.load
      i32.const 1
-     local.get $5
+     local.get $6
      i32.const 31
      i32.and
      i32.shl
      i32.xor
      i32.store
      local.get $0
-     local.get $5
-     i32.const 2
-     i32.shl
-     i32.add
-     local.get $9
-     i32.store
-     local.get $0
-     local.get $8
+     local.get $6
      i32.const 2
      i32.shl
      i32.add
      local.get $10
      i32.store
+     local.get $0
+     local.get $9
+     i32.const 2
+     i32.shl
+     i32.add
+     local.get $11
+     i32.store
     end
-    local.get $5
+    local.get $6
     i32.const 1
     i32.sub
-    local.set $5
+    local.set $6
     br $for-loop|0
    end
   end
   local.get $1
   i32.const 1
   i32.sub
-  local.set $5
+  local.set $6
   loop $for-loop|2
-   local.get $5
+   local.get $6
    i32.const 2
    i32.ge_s
-   local.set $6
-   local.get $6
+   local.set $7
+   local.get $7
    if
     local.get $0
     i32.load
-    local.set $10
+    local.set $11
     local.get $0
     local.get $0
-    local.get $5
+    local.get $6
     i32.const 2
     i32.shl
     i32.add
     i32.load
     i32.store
     local.get $0
-    local.get $5
+    local.get $6
     i32.const 2
     i32.shl
     i32.add
-    local.get $10
+    local.get $11
     i32.store
     i32.const 1
-    local.set $9
+    local.set $10
     loop $while-continue|3
-     local.get $9
+     local.get $10
      i32.const 1
      i32.shl
-     local.get $4
-     local.get $9
+     local.get $5
+     local.get $10
      i32.const 5
      i32.shr_u
      i32.const 2
      i32.shl
      i32.add
      i32.load
-     local.get $9
+     local.get $10
      i32.const 31
      i32.and
      i32.shr_u
      i32.const 1
      i32.and
      i32.add
-     local.tee $8
-     local.get $5
+     local.tee $9
+     local.get $6
      i32.lt_s
-     local.set $7
-     local.get $7
+     local.set $8
+     local.get $8
      if
-      local.get $8
-      local.set $9
+      local.get $9
+      local.set $10
       br $while-continue|3
      end
     end
     loop $while-continue|4
-     local.get $9
+     local.get $10
      i32.const 0
      i32.gt_s
-     local.set $7
-     local.get $7
+     local.set $8
+     local.get $8
      if
       local.get $0
       i32.load
-      local.set $10
+      local.set $11
       local.get $0
-      local.get $9
+      local.get $10
       i32.const 2
       i32.shl
       i32.add
       i32.load
-      local.set $11
-      local.get $10
-      local.get $11
-      i32.const 2
-      global.set $~argumentsLength
+      local.set $13
       local.get $2
-      call_indirect (type $i32_i32_=>_i32)
+      local.set $14
+      local.get $14
+      i32.const -2147483648
+      i32.and
+      i32.const -2147483648
+      i32.eq
+      if (result i32)
+       local.get $14
+       i32.const 4
+       i32.shl
+       local.get $11
+       local.get $13
+       i32.const 2
+       global.set $~argumentsLength
+       local.get $14
+       i32.const 4
+       i32.shl
+       i32.load
+       call_indirect (type $i32_i32_i32_=>_i32)
+      else
+       local.get $11
+       local.get $13
+       i32.const 2
+       global.set $~argumentsLength
+       local.get $14
+       call_indirect (type $i32_i32_=>_i32)
+      end
       i32.const 0
       i32.lt_s
       if
-       local.get $4
-       local.get $9
+       local.get $5
+       local.get $10
        i32.const 5
        i32.shr_u
        i32.const 2
        i32.shl
        i32.add
-       local.get $4
-       local.get $9
+       local.get $5
+       local.get $10
        i32.const 5
        i32.shr_u
        i32.const 2
@@ -8808,49 +10311,64 @@
        i32.add
        i32.load
        i32.const 1
-       local.get $9
+       local.get $10
        i32.const 31
        i32.and
        i32.shl
        i32.xor
        i32.store
        local.get $0
-       local.get $9
+       local.get $10
        i32.const 2
        i32.shl
        i32.add
-       local.get $10
-       i32.store
-       local.get $0
        local.get $11
        i32.store
+       local.get $0
+       local.get $13
+       i32.store
       end
-      local.get $9
+      local.get $10
       i32.const 1
       i32.shr_s
-      local.set $9
+      local.set $10
       br $while-continue|4
      end
     end
-    local.get $5
+    local.get $6
     i32.const 1
     i32.sub
-    local.set $5
+    local.set $6
     br $for-loop|2
    end
   end
-  local.get $4
+  local.get $5
   call $~lib/rt/tlsf/__free
   local.get $0
   i32.load offset=4
-  local.set $12
+  local.set $15
   local.get $0
   local.get $0
   i32.load
   i32.store offset=4
   local.get $0
-  local.get $12
+  local.get $15
   i32.store
+  local.get $2
+  local.set $6
+  local.get $6
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $6
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
  )
  (func $~lib/array/Array<i32>#sort (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
@@ -8858,81 +10376,213 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  local.get $0
-  i32.load offset=12
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  local.get $1
   local.set $2
   local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
+  local.get $0
+  i32.load offset=12
+  local.set $3
+  local.get $3
   i32.const 1
   i32.le_s
   if
    local.get $0
    call $~lib/rt/pure/__retain
+   local.set $5
+   local.get $1
+   local.set $4
+   local.get $4
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $4
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
+   call $~lib/rt/pure/__release
+   local.get $5
    return
   end
   local.get $0
   i32.load offset=4
-  local.set $3
-  local.get $2
+  local.set $6
+  local.get $3
   i32.const 2
   i32.eq
   if
-   local.get $3
+   local.get $6
    i32.load offset=4
-   local.set $4
-   local.get $3
-   i32.load
    local.set $5
-   local.get $4
-   local.get $5
-   i32.const 2
-   global.set $~argumentsLength
+   local.get $6
+   i32.load
+   local.set $7
    local.get $1
-   call_indirect (type $i32_i32_=>_i32)
+   local.set $8
+   local.get $8
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $8
+    i32.const 4
+    i32.shl
+    local.get $5
+    local.get $7
+    i32.const 2
+    global.set $~argumentsLength
+    local.get $8
+    i32.const 4
+    i32.shl
+    i32.load
+    call_indirect (type $i32_i32_i32_=>_i32)
+   else
+    local.get $5
+    local.get $7
+    i32.const 2
+    global.set $~argumentsLength
+    local.get $8
+    call_indirect (type $i32_i32_=>_i32)
+   end
    i32.const 0
    i32.lt_s
    if
-    local.get $3
-    local.get $5
+    local.get $6
+    local.get $7
     i32.store offset=4
-    local.get $3
-    local.get $4
+    local.get $6
+    local.get $5
     i32.store
    end
    local.get $0
    call $~lib/rt/pure/__retain
+   local.set $10
+   local.get $1
+   local.set $9
+   local.get $9
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $9
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
+   call $~lib/rt/pure/__release
+   local.get $10
    return
   end
+  local.get $6
+  local.set $11
   local.get $3
-  local.set $6
-  local.get $2
   local.set $5
   local.get $1
-  local.set $4
+  local.set $7
+  local.get $7
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $7
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $7
+  local.set $10
   i32.const 0
   drop
   local.get $5
   i32.const 256
   i32.lt_s
   if
-   local.get $6
+   local.get $11
    local.get $5
-   local.get $4
+   local.get $10
    call $~lib/util/sort/insertionSort<i32>
   else
-   local.get $6
+   local.get $11
    local.get $5
-   local.get $4
+   local.get $10
    call $~lib/util/sort/weakHeapSort<i32>
   end
+  local.get $10
+  local.set $12
+  local.get $12
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $12
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__retain
+  local.set $5
+  local.get $1
+  local.set $11
+  local.get $11
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $11
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $5
  )
- (func $~lib/util/sort/COMPARATOR<i32>~anonymous|0 (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/sort/COMPARATOR<i32>~anonymous|0~nonClosure (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.sub
  )
  (func $~lib/array/Array<i32>#sort@varargs (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -8954,13 +10604,47 @@
     end
     drop
     i32.const 46
+    local.set $2
+    local.get $2
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result i32)
+     local.get $2
+     i32.const 4
+     i32.shl
+    else
+     i32.const 0
+    end
+    call $~lib/rt/pure/__retain
+    drop
+    local.get $2
     br $~lib/util/sort/COMPARATOR<i32>|inlined.0
    end
+   local.tee $3
    local.set $1
   end
   local.get $0
   local.get $1
   call $~lib/array/Array<i32>#sort
+  local.set $5
+  local.get $3
+  local.set $4
+  local.get $4
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $4
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $5
  )
  (func $~lib/util/sort/insertionSort<u32> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
@@ -8970,63 +10654,105 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
-  i32.const 0
+  (local $10 i32)
+  (local $11 i32)
+  local.get $2
   local.set $3
-  loop $for-loop|0
+  local.get $3
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
    local.get $3
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $3
+  local.set $2
+  i32.const 0
+  local.set $4
+  loop $for-loop|0
+   local.get $4
    local.get $1
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $5
+   local.get $5
    if
     local.get $0
-    local.get $3
+    local.get $4
     i32.const 2
     i32.shl
     i32.add
     i32.load
-    local.set $5
-    local.get $3
+    local.set $6
+    local.get $4
     i32.const 1
     i32.sub
-    local.set $6
+    local.set $7
     block $while-break|1
      loop $while-continue|1
-      local.get $6
+      local.get $7
       i32.const 0
       i32.ge_s
-      local.set $7
-      local.get $7
+      local.set $8
+      local.get $8
       if
        local.get $0
-       local.get $6
+       local.get $7
        i32.const 2
        i32.shl
        i32.add
        i32.load
-       local.set $8
-       local.get $5
-       local.get $8
-       i32.const 2
-       global.set $~argumentsLength
+       local.set $9
        local.get $2
-       call_indirect (type $i32_i32_=>_i32)
+       local.set $10
+       local.get $10
+       i32.const -2147483648
+       i32.and
+       i32.const -2147483648
+       i32.eq
+       if (result i32)
+        local.get $10
+        i32.const 4
+        i32.shl
+        local.get $6
+        local.get $9
+        i32.const 2
+        global.set $~argumentsLength
+        local.get $10
+        i32.const 4
+        i32.shl
+        i32.load
+        call_indirect (type $i32_i32_i32_=>_i32)
+       else
+        local.get $6
+        local.get $9
+        i32.const 2
+        global.set $~argumentsLength
+        local.get $10
+        call_indirect (type $i32_i32_=>_i32)
+       end
        i32.const 0
        i32.lt_s
        if
         local.get $0
-        local.get $6
-        local.tee $9
+        local.get $7
+        local.tee $11
         i32.const 1
         i32.sub
-        local.set $6
-        local.get $9
+        local.set $7
+        local.get $11
         i32.const 1
         i32.add
         i32.const 2
         i32.shl
         i32.add
-        local.get $8
+        local.get $9
         i32.store
        else
         br $while-break|1
@@ -9036,21 +10762,36 @@
      end
     end
     local.get $0
-    local.get $6
+    local.get $7
     i32.const 1
     i32.add
     i32.const 2
     i32.shl
     i32.add
-    local.get $5
+    local.get $6
     i32.store
-    local.get $3
+    local.get $4
     i32.const 1
     i32.add
-    local.set $3
+    local.set $4
     br $for-loop|0
    end
   end
+  local.get $2
+  local.set $4
+  local.get $4
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $4
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
  )
  (func $~lib/util/sort/weakHeapSort<u32> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
@@ -9063,6 +10804,27 @@
   (local $10 i32)
   (local $11 i32)
   (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  local.get $2
+  local.set $3
+  local.get $3
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $3
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $3
+  local.set $2
   local.get $1
   i32.const 31
   i32.add
@@ -9070,41 +10832,41 @@
   i32.shr_u
   i32.const 2
   i32.shl
-  local.set $3
-  local.get $3
-  i32.const 0
-  call $~lib/rt/tlsf/__alloc
   local.set $4
   local.get $4
   i32.const 0
-  local.get $3
+  call $~lib/rt/tlsf/__alloc
+  local.set $5
+  local.get $5
+  i32.const 0
+  local.get $4
   call $~lib/memory/memory.fill
   local.get $1
   i32.const 1
   i32.sub
-  local.set $5
+  local.set $6
   loop $for-loop|0
-   local.get $5
+   local.get $6
    i32.const 0
    i32.gt_s
-   local.set $6
-   local.get $6
+   local.set $7
+   local.get $7
    if
-    local.get $5
-    local.set $7
+    local.get $6
+    local.set $8
     loop $while-continue|1
-     local.get $7
+     local.get $8
      i32.const 1
      i32.and
-     local.get $4
-     local.get $7
+     local.get $5
+     local.get $8
      i32.const 6
      i32.shr_u
      i32.const 2
      i32.shl
      i32.add
      i32.load
-     local.get $7
+     local.get $8
      i32.const 1
      i32.shr_s
      i32.const 31
@@ -9113,52 +10875,74 @@
      i32.const 1
      i32.and
      i32.eq
-     local.set $8
-     local.get $8
+     local.set $9
+     local.get $9
      if
-      local.get $7
+      local.get $8
       i32.const 1
       i32.shr_s
-      local.set $7
+      local.set $8
       br $while-continue|1
      end
     end
-    local.get $7
+    local.get $8
     i32.const 1
     i32.shr_s
-    local.set $8
-    local.get $0
-    local.get $8
-    i32.const 2
-    i32.shl
-    i32.add
-    i32.load
     local.set $9
     local.get $0
-    local.get $5
+    local.get $9
     i32.const 2
     i32.shl
     i32.add
     i32.load
     local.set $10
-    local.get $9
-    local.get $10
+    local.get $0
+    local.get $6
     i32.const 2
-    global.set $~argumentsLength
+    i32.shl
+    i32.add
+    i32.load
+    local.set $11
     local.get $2
-    call_indirect (type $i32_i32_=>_i32)
+    local.set $12
+    local.get $12
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result i32)
+     local.get $12
+     i32.const 4
+     i32.shl
+     local.get $10
+     local.get $11
+     i32.const 2
+     global.set $~argumentsLength
+     local.get $12
+     i32.const 4
+     i32.shl
+     i32.load
+     call_indirect (type $i32_i32_i32_=>_i32)
+    else
+     local.get $10
+     local.get $11
+     i32.const 2
+     global.set $~argumentsLength
+     local.get $12
+     call_indirect (type $i32_i32_=>_i32)
+    end
     i32.const 0
     i32.lt_s
     if
-     local.get $4
      local.get $5
+     local.get $6
      i32.const 5
      i32.shr_u
      i32.const 2
      i32.shl
      i32.add
-     local.get $4
      local.get $5
+     local.get $6
      i32.const 5
      i32.shr_u
      i32.const 2
@@ -9166,130 +10950,152 @@
      i32.add
      i32.load
      i32.const 1
-     local.get $5
+     local.get $6
      i32.const 31
      i32.and
      i32.shl
      i32.xor
      i32.store
      local.get $0
-     local.get $5
-     i32.const 2
-     i32.shl
-     i32.add
-     local.get $9
-     i32.store
-     local.get $0
-     local.get $8
+     local.get $6
      i32.const 2
      i32.shl
      i32.add
      local.get $10
      i32.store
+     local.get $0
+     local.get $9
+     i32.const 2
+     i32.shl
+     i32.add
+     local.get $11
+     i32.store
     end
-    local.get $5
+    local.get $6
     i32.const 1
     i32.sub
-    local.set $5
+    local.set $6
     br $for-loop|0
    end
   end
   local.get $1
   i32.const 1
   i32.sub
-  local.set $5
+  local.set $6
   loop $for-loop|2
-   local.get $5
+   local.get $6
    i32.const 2
    i32.ge_s
-   local.set $6
-   local.get $6
+   local.set $7
+   local.get $7
    if
     local.get $0
     i32.load
-    local.set $10
+    local.set $11
     local.get $0
     local.get $0
-    local.get $5
+    local.get $6
     i32.const 2
     i32.shl
     i32.add
     i32.load
     i32.store
     local.get $0
-    local.get $5
+    local.get $6
     i32.const 2
     i32.shl
     i32.add
-    local.get $10
+    local.get $11
     i32.store
     i32.const 1
-    local.set $9
+    local.set $10
     loop $while-continue|3
-     local.get $9
+     local.get $10
      i32.const 1
      i32.shl
-     local.get $4
-     local.get $9
+     local.get $5
+     local.get $10
      i32.const 5
      i32.shr_u
      i32.const 2
      i32.shl
      i32.add
      i32.load
-     local.get $9
+     local.get $10
      i32.const 31
      i32.and
      i32.shr_u
      i32.const 1
      i32.and
      i32.add
-     local.tee $8
-     local.get $5
+     local.tee $9
+     local.get $6
      i32.lt_s
-     local.set $7
-     local.get $7
+     local.set $8
+     local.get $8
      if
-      local.get $8
-      local.set $9
+      local.get $9
+      local.set $10
       br $while-continue|3
      end
     end
     loop $while-continue|4
-     local.get $9
+     local.get $10
      i32.const 0
      i32.gt_s
-     local.set $7
-     local.get $7
+     local.set $8
+     local.get $8
      if
       local.get $0
       i32.load
-      local.set $10
+      local.set $11
       local.get $0
-      local.get $9
+      local.get $10
       i32.const 2
       i32.shl
       i32.add
       i32.load
-      local.set $11
-      local.get $10
-      local.get $11
-      i32.const 2
-      global.set $~argumentsLength
+      local.set $13
       local.get $2
-      call_indirect (type $i32_i32_=>_i32)
+      local.set $14
+      local.get $14
+      i32.const -2147483648
+      i32.and
+      i32.const -2147483648
+      i32.eq
+      if (result i32)
+       local.get $14
+       i32.const 4
+       i32.shl
+       local.get $11
+       local.get $13
+       i32.const 2
+       global.set $~argumentsLength
+       local.get $14
+       i32.const 4
+       i32.shl
+       i32.load
+       call_indirect (type $i32_i32_i32_=>_i32)
+      else
+       local.get $11
+       local.get $13
+       i32.const 2
+       global.set $~argumentsLength
+       local.get $14
+       call_indirect (type $i32_i32_=>_i32)
+      end
       i32.const 0
       i32.lt_s
       if
-       local.get $4
-       local.get $9
+       local.get $5
+       local.get $10
        i32.const 5
        i32.shr_u
        i32.const 2
        i32.shl
        i32.add
-       local.get $4
-       local.get $9
+       local.get $5
+       local.get $10
        i32.const 5
        i32.shr_u
        i32.const 2
@@ -9297,49 +11103,64 @@
        i32.add
        i32.load
        i32.const 1
-       local.get $9
+       local.get $10
        i32.const 31
        i32.and
        i32.shl
        i32.xor
        i32.store
        local.get $0
-       local.get $9
+       local.get $10
        i32.const 2
        i32.shl
        i32.add
-       local.get $10
-       i32.store
-       local.get $0
        local.get $11
        i32.store
+       local.get $0
+       local.get $13
+       i32.store
       end
-      local.get $9
+      local.get $10
       i32.const 1
       i32.shr_s
-      local.set $9
+      local.set $10
       br $while-continue|4
      end
     end
-    local.get $5
+    local.get $6
     i32.const 1
     i32.sub
-    local.set $5
+    local.set $6
     br $for-loop|2
    end
   end
-  local.get $4
+  local.get $5
   call $~lib/rt/tlsf/__free
   local.get $0
   i32.load offset=4
-  local.set $12
+  local.set $15
   local.get $0
   local.get $0
   i32.load
   i32.store offset=4
   local.get $0
-  local.get $12
+  local.get $15
   i32.store
+  local.get $2
+  local.set $6
+  local.get $6
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $6
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
  )
  (func $~lib/array/Array<u32>#sort (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
@@ -9347,76 +11168,204 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  local.get $0
-  i32.load offset=12
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  local.get $1
   local.set $2
   local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
+  local.get $0
+  i32.load offset=12
+  local.set $3
+  local.get $3
   i32.const 1
   i32.le_s
   if
    local.get $0
    call $~lib/rt/pure/__retain
+   local.set $5
+   local.get $1
+   local.set $4
+   local.get $4
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $4
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
+   call $~lib/rt/pure/__release
+   local.get $5
    return
   end
   local.get $0
   i32.load offset=4
-  local.set $3
-  local.get $2
+  local.set $6
+  local.get $3
   i32.const 2
   i32.eq
   if
-   local.get $3
+   local.get $6
    i32.load offset=4
-   local.set $4
-   local.get $3
-   i32.load
    local.set $5
-   local.get $4
-   local.get $5
-   i32.const 2
-   global.set $~argumentsLength
+   local.get $6
+   i32.load
+   local.set $7
    local.get $1
-   call_indirect (type $i32_i32_=>_i32)
+   local.set $8
+   local.get $8
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $8
+    i32.const 4
+    i32.shl
+    local.get $5
+    local.get $7
+    i32.const 2
+    global.set $~argumentsLength
+    local.get $8
+    i32.const 4
+    i32.shl
+    i32.load
+    call_indirect (type $i32_i32_i32_=>_i32)
+   else
+    local.get $5
+    local.get $7
+    i32.const 2
+    global.set $~argumentsLength
+    local.get $8
+    call_indirect (type $i32_i32_=>_i32)
+   end
    i32.const 0
    i32.lt_s
    if
-    local.get $3
-    local.get $5
+    local.get $6
+    local.get $7
     i32.store offset=4
-    local.get $3
-    local.get $4
+    local.get $6
+    local.get $5
     i32.store
    end
    local.get $0
    call $~lib/rt/pure/__retain
+   local.set $10
+   local.get $1
+   local.set $9
+   local.get $9
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $9
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
+   call $~lib/rt/pure/__release
+   local.get $10
    return
   end
+  local.get $6
+  local.set $11
   local.get $3
-  local.set $6
-  local.get $2
   local.set $5
   local.get $1
-  local.set $4
+  local.set $7
+  local.get $7
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $7
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $7
+  local.set $10
   i32.const 0
   drop
   local.get $5
   i32.const 256
   i32.lt_s
   if
-   local.get $6
+   local.get $11
    local.get $5
-   local.get $4
+   local.get $10
    call $~lib/util/sort/insertionSort<u32>
   else
-   local.get $6
+   local.get $11
    local.get $5
-   local.get $4
+   local.get $10
    call $~lib/util/sort/weakHeapSort<u32>
   end
+  local.get $10
+  local.set $12
+  local.get $12
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $12
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__retain
+  local.set $5
+  local.get $1
+  local.set $11
+  local.get $11
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $11
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $5
  )
- (func $~lib/util/sort/COMPARATOR<u32>~anonymous|0 (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/sort/COMPARATOR<u32>~anonymous|0~nonClosure (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.gt_u
@@ -9426,6 +11375,10 @@
   i32.sub
  )
  (func $~lib/array/Array<u32>#sort@varargs (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -9447,13 +11400,47 @@
     end
     drop
     i32.const 47
+    local.set $2
+    local.get $2
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result i32)
+     local.get $2
+     i32.const 4
+     i32.shl
+    else
+     i32.const 0
+    end
+    call $~lib/rt/pure/__retain
+    drop
+    local.get $2
     br $~lib/util/sort/COMPARATOR<u32>|inlined.0
    end
+   local.tee $3
    local.set $1
   end
   local.get $0
   local.get $1
   call $~lib/array/Array<u32>#sort
+  local.set $5
+  local.get $3
+  local.set $4
+  local.get $4
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $4
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $5
  )
  (func $std/array/createReverseOrderedArray (param $0 i32) (result i32)
   (local $1 i32)
@@ -9575,7 +11562,7 @@
   end
   local.get $1
  )
- (func $~lib/util/sort/COMPARATOR<i32>~anonymous|1 (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/sort/COMPARATOR<i32>~anonymous|1~nonClosure (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.sub
@@ -9585,47 +11572,111 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $0
-  i32.const 1
+  local.get $1
   local.set $2
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
+  i32.const 1
+  local.set $3
   local.get $0
   call $~lib/array/Array<i32>#get:length
-  local.set $3
+  local.set $4
   loop $for-loop|0
-   local.get $2
    local.get $3
-   i32.lt_s
-   local.set $4
    local.get $4
+   i32.lt_s
+   local.set $5
+   local.get $5
    if
-    local.get $0
-    local.get $2
-    i32.const 1
-    i32.sub
-    call $~lib/array/Array<i32>#__get
-    local.get $0
-    local.get $2
-    call $~lib/array/Array<i32>#__get
-    i32.const 2
-    global.set $~argumentsLength
     local.get $1
-    call_indirect (type $i32_i32_=>_i32)
+    local.set $6
+    local.get $6
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result i32)
+     local.get $6
+     i32.const 4
+     i32.shl
+     local.get $0
+     local.get $3
+     i32.const 1
+     i32.sub
+     call $~lib/array/Array<i32>#__get
+     local.get $0
+     local.get $3
+     call $~lib/array/Array<i32>#__get
+     i32.const 2
+     global.set $~argumentsLength
+     local.get $6
+     i32.const 4
+     i32.shl
+     i32.load
+     call_indirect (type $i32_i32_i32_=>_i32)
+    else
+     local.get $0
+     local.get $3
+     i32.const 1
+     i32.sub
+     call $~lib/array/Array<i32>#__get
+     local.get $0
+     local.get $3
+     call $~lib/array/Array<i32>#__get
+     i32.const 2
+     global.set $~argumentsLength
+     local.get $6
+     call_indirect (type $i32_i32_=>_i32)
+    end
     i32.const 0
     i32.gt_s
     if
      i32.const 0
-     local.set $5
+     local.set $8
      local.get $0
      call $~lib/rt/pure/__release
-     local.get $5
+     local.get $1
+     local.set $7
+     local.get $7
+     i32.const -2147483648
+     i32.and
+     i32.const -2147483648
+     i32.eq
+     if (result i32)
+      local.get $7
+      i32.const 4
+      i32.shl
+     else
+      i32.const 0
+     end
+     call $~lib/rt/pure/__release
+     local.get $8
      return
     end
-    local.get $2
+    local.get $3
     i32.const 1
     i32.add
-    local.set $2
+    local.set $3
     br $for-loop|0
    end
   end
@@ -9633,17 +11684,52 @@
   local.set $3
   local.get $0
   call $~lib/rt/pure/__release
+  local.get $1
+  local.set $4
+  local.get $4
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $4
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
   local.get $3
  )
  (func $std/array/assertSorted<i32> (param $0 i32) (param $1 i32)
   (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $0
+  local.get $1
+  local.set $2
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
   local.get $0
   local.get $1
   call $~lib/array/Array<i32>#sort
-  local.tee $2
+  local.tee $3
   local.get $1
   call $std/array/isSorted<i32>
   i32.eqz
@@ -9655,12 +11741,30 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $3
   call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
+  local.get $1
+  local.set $4
+  local.get $4
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $4
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
  )
  (func $std/array/assertSortedDefault<i32> (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $0
@@ -9678,28 +11782,60 @@
    end
    drop
    i32.const 48
+   local.set $1
+   local.get $1
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $1
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
+   call $~lib/rt/pure/__retain
+   drop
+   local.get $1
    br $~lib/util/sort/COMPARATOR<i32>|inlined.1
   end
+  local.tee $2
   call $std/array/assertSorted<i32>
+  local.get $2
+  local.set $3
+  local.get $3
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $3
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $start:std/array~anonymous|43 (param $0 i32) (param $1 i32) (result i32)
+ (func $start:std/array~anonymous|43~nonClosure (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.sub
  )
- (func $start:std/array~anonymous|44 (param $0 i32) (param $1 i32) (result i32)
+ (func $start:std/array~anonymous|44~nonClosure (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.sub
  )
- (func $start:std/array~anonymous|45 (param $0 i32) (param $1 i32) (result i32)
+ (func $start:std/array~anonymous|45~nonClosure (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.sub
  )
- (func $start:std/array~anonymous|46 (param $0 i32) (param $1 i32) (result i32)
+ (func $start:std/array~anonymous|46~nonClosure (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.sub
@@ -9900,7 +12036,7 @@
   end
   local.get $1
  )
- (func $start:std/array~anonymous|47 (param $0 i32) (param $1 i32) (result i32)
+ (func $start:std/array~anonymous|47~nonClosure (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -9930,95 +12066,152 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
-  i32.const 0
+  (local $10 i32)
+  (local $11 i32)
+  local.get $2
   local.set $3
-  loop $for-loop|0
+  local.get $3
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
    local.get $3
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $3
+  local.set $2
+  i32.const 0
+  local.set $4
+  loop $for-loop|0
+   local.get $4
    local.get $1
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $5
+   local.get $5
    if
     local.get $0
-    local.get $3
+    local.get $4
     i32.const 2
     i32.shl
     i32.add
     i32.load
     call $~lib/rt/pure/__retain
-    local.set $5
-    local.get $3
+    local.set $6
+    local.get $4
     i32.const 1
     i32.sub
-    local.set $6
+    local.set $7
     block $while-break|1
      loop $while-continue|1
-      local.get $6
+      local.get $7
       i32.const 0
       i32.ge_s
-      local.set $7
-      local.get $7
+      local.set $8
+      local.get $8
       if
        local.get $0
-       local.get $6
+       local.get $7
        i32.const 2
        i32.shl
        i32.add
        i32.load
        call $~lib/rt/pure/__retain
-       local.set $8
-       local.get $5
-       local.get $8
-       i32.const 2
-       global.set $~argumentsLength
+       local.set $9
        local.get $2
-       call_indirect (type $i32_i32_=>_i32)
+       local.set $10
+       local.get $10
+       i32.const -2147483648
+       i32.and
+       i32.const -2147483648
+       i32.eq
+       if (result i32)
+        local.get $10
+        i32.const 4
+        i32.shl
+        local.get $6
+        local.get $9
+        i32.const 2
+        global.set $~argumentsLength
+        local.get $10
+        i32.const 4
+        i32.shl
+        i32.load
+        call_indirect (type $i32_i32_i32_=>_i32)
+       else
+        local.get $6
+        local.get $9
+        i32.const 2
+        global.set $~argumentsLength
+        local.get $10
+        call_indirect (type $i32_i32_=>_i32)
+       end
        i32.const 0
        i32.lt_s
        if
         local.get $0
-        local.get $6
-        local.tee $9
+        local.get $7
+        local.tee $11
         i32.const 1
         i32.sub
-        local.set $6
-        local.get $9
+        local.set $7
+        local.get $11
         i32.const 1
         i32.add
         i32.const 2
         i32.shl
         i32.add
-        local.get $8
+        local.get $9
         i32.store
        else
-        local.get $8
+        local.get $9
         call $~lib/rt/pure/__release
         br $while-break|1
        end
-       local.get $8
+       local.get $9
        call $~lib/rt/pure/__release
        br $while-continue|1
       end
      end
     end
     local.get $0
-    local.get $6
+    local.get $7
     i32.const 1
     i32.add
     i32.const 2
     i32.shl
     i32.add
-    local.get $5
+    local.get $6
     i32.store
-    local.get $5
+    local.get $6
     call $~lib/rt/pure/__release
-    local.get $3
+    local.get $4
     i32.const 1
     i32.add
-    local.set $3
+    local.set $4
     br $for-loop|0
    end
   end
+  local.get $2
+  local.set $4
+  local.get $4
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $4
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
  )
  (func $~lib/array/Array<~lib/array/Array<i32>>#sort (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
@@ -10026,72 +12219,198 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  local.get $0
-  i32.load offset=12
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  local.get $1
   local.set $2
   local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
+  local.get $0
+  i32.load offset=12
+  local.set $3
+  local.get $3
   i32.const 1
   i32.le_s
   if
    local.get $0
    call $~lib/rt/pure/__retain
+   local.set $5
+   local.get $1
+   local.set $4
+   local.get $4
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $4
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
+   call $~lib/rt/pure/__release
+   local.get $5
    return
   end
   local.get $0
   i32.load offset=4
-  local.set $3
-  local.get $2
+  local.set $6
+  local.get $3
   i32.const 2
   i32.eq
   if
-   local.get $3
+   local.get $6
    i32.load offset=4
    call $~lib/rt/pure/__retain
-   local.set $4
-   local.get $3
+   local.set $5
+   local.get $6
    i32.load
    call $~lib/rt/pure/__retain
-   local.set $5
-   local.get $4
-   local.get $5
-   i32.const 2
-   global.set $~argumentsLength
+   local.set $7
    local.get $1
-   call_indirect (type $i32_i32_=>_i32)
+   local.set $8
+   local.get $8
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $8
+    i32.const 4
+    i32.shl
+    local.get $5
+    local.get $7
+    i32.const 2
+    global.set $~argumentsLength
+    local.get $8
+    i32.const 4
+    i32.shl
+    i32.load
+    call_indirect (type $i32_i32_i32_=>_i32)
+   else
+    local.get $5
+    local.get $7
+    i32.const 2
+    global.set $~argumentsLength
+    local.get $8
+    call_indirect (type $i32_i32_=>_i32)
+   end
    i32.const 0
    i32.lt_s
    if
-    local.get $3
-    local.get $5
+    local.get $6
+    local.get $7
     i32.store offset=4
-    local.get $3
-    local.get $4
+    local.get $6
+    local.get $5
     i32.store
    end
    local.get $0
    call $~lib/rt/pure/__retain
-   local.set $6
-   local.get $4
-   call $~lib/rt/pure/__release
+   local.set $10
    local.get $5
    call $~lib/rt/pure/__release
-   local.get $6
+   local.get $7
+   call $~lib/rt/pure/__release
+   local.get $1
+   local.set $9
+   local.get $9
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $9
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
+   call $~lib/rt/pure/__release
+   local.get $10
    return
   end
+  local.get $6
+  local.set $11
   local.get $3
   local.set $5
-  local.get $2
-  local.set $4
   local.get $1
-  local.set $6
+  local.set $7
+  local.get $7
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $7
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $7
+  local.set $10
   i32.const 1
   drop
+  local.get $11
   local.get $5
-  local.get $4
-  local.get $6
+  local.get $10
   call $~lib/util/sort/insertionSort<~lib/array/Array<i32>>
+  local.get $10
+  local.set $12
+  local.get $12
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $12
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__retain
+  local.set $5
+  local.get $1
+  local.set $11
+  local.get $11
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $11
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $5
  )
  (func $~lib/array/Array<~lib/array/Array<i32>>#get:length (param $0 i32) (result i32)
   local.get $0
@@ -10149,57 +12468,133 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $0
-  i32.const 1
+  local.get $1
   local.set $2
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
+  i32.const 1
+  local.set $3
   local.get $0
   call $~lib/array/Array<~lib/array/Array<i32>>#get:length
-  local.set $3
+  local.set $4
   loop $for-loop|0
-   local.get $2
    local.get $3
-   i32.lt_s
-   local.set $4
    local.get $4
+   i32.lt_s
+   local.set $5
+   local.get $5
    if
-    local.get $0
-    local.get $2
-    i32.const 1
-    i32.sub
-    call $~lib/array/Array<~lib/array/Array<i32>>#__get
-    local.tee $5
-    local.get $0
-    local.get $2
-    call $~lib/array/Array<~lib/array/Array<i32>>#__get
-    local.tee $6
-    i32.const 2
-    global.set $~argumentsLength
     local.get $1
-    call_indirect (type $i32_i32_=>_i32)
+    local.set $6
+    local.get $6
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result i32)
+     local.get $6
+     i32.const 4
+     i32.shl
+     local.get $0
+     local.get $3
+     i32.const 1
+     i32.sub
+     call $~lib/array/Array<~lib/array/Array<i32>>#__get
+     local.tee $7
+     local.get $0
+     local.get $3
+     call $~lib/array/Array<~lib/array/Array<i32>>#__get
+     local.tee $8
+     i32.const 2
+     global.set $~argumentsLength
+     local.get $6
+     i32.const 4
+     i32.shl
+     i32.load
+     call_indirect (type $i32_i32_i32_=>_i32)
+    else
+     local.get $0
+     local.get $3
+     i32.const 1
+     i32.sub
+     call $~lib/array/Array<~lib/array/Array<i32>>#__get
+     local.tee $9
+     local.get $0
+     local.get $3
+     call $~lib/array/Array<~lib/array/Array<i32>>#__get
+     local.tee $10
+     i32.const 2
+     global.set $~argumentsLength
+     local.get $6
+     call_indirect (type $i32_i32_=>_i32)
+    end
     i32.const 0
     i32.gt_s
     if
      i32.const 0
-     local.set $7
+     local.set $12
      local.get $0
      call $~lib/rt/pure/__release
-     local.get $5
-     call $~lib/rt/pure/__release
-     local.get $6
+     local.get $1
+     local.set $11
+     local.get $11
+     i32.const -2147483648
+     i32.and
+     i32.const -2147483648
+     i32.eq
+     if (result i32)
+      local.get $11
+      i32.const 4
+      i32.shl
+     else
+      i32.const 0
+     end
      call $~lib/rt/pure/__release
      local.get $7
+     call $~lib/rt/pure/__release
+     local.get $8
+     call $~lib/rt/pure/__release
+     local.get $9
+     call $~lib/rt/pure/__release
+     local.get $10
+     call $~lib/rt/pure/__release
+     local.get $12
      return
     end
-    local.get $5
+    local.get $7
     call $~lib/rt/pure/__release
-    local.get $6
+    local.get $8
     call $~lib/rt/pure/__release
-    local.get $2
+    local.get $9
+    call $~lib/rt/pure/__release
+    local.get $10
+    call $~lib/rt/pure/__release
+    local.get $3
     i32.const 1
     i32.add
-    local.set $2
+    local.set $3
     br $for-loop|0
    end
   end
@@ -10207,17 +12602,52 @@
   local.set $3
   local.get $0
   call $~lib/rt/pure/__release
+  local.get $1
+  local.set $4
+  local.get $4
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $4
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
   local.get $3
  )
  (func $std/array/assertSorted<~lib/array/Array<i32>> (param $0 i32) (param $1 i32)
   (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $0
+  local.get $1
+  local.set $2
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
   local.get $0
   local.get $1
   call $~lib/array/Array<~lib/array/Array<i32>>#sort
-  local.tee $2
+  local.tee $3
   local.get $1
   call $std/array/isSorted<~lib/array/Array<i32>>
   i32.eqz
@@ -10229,9 +12659,24 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $3
   call $~lib/rt/pure/__release
   local.get $0
+  call $~lib/rt/pure/__release
+  local.get $1
+  local.set $4
+  local.get $4
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $4
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
   call $~lib/rt/pure/__release
  )
  (func $~lib/array/Array<std/array/Proxy<i32>>#constructor (param $0 i32) (param $1 i32) (result i32)
@@ -10440,7 +12885,7 @@
   end
   local.get $1
  )
- (func $start:std/array~anonymous|48 (param $0 i32) (param $1 i32) (result i32)
+ (func $start:std/array~anonymous|48~nonClosure (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -10468,95 +12913,152 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
-  i32.const 0
+  (local $10 i32)
+  (local $11 i32)
+  local.get $2
   local.set $3
-  loop $for-loop|0
+  local.get $3
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
    local.get $3
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $3
+  local.set $2
+  i32.const 0
+  local.set $4
+  loop $for-loop|0
+   local.get $4
    local.get $1
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $5
+   local.get $5
    if
     local.get $0
-    local.get $3
+    local.get $4
     i32.const 2
     i32.shl
     i32.add
     i32.load
     call $~lib/rt/pure/__retain
-    local.set $5
-    local.get $3
+    local.set $6
+    local.get $4
     i32.const 1
     i32.sub
-    local.set $6
+    local.set $7
     block $while-break|1
      loop $while-continue|1
-      local.get $6
+      local.get $7
       i32.const 0
       i32.ge_s
-      local.set $7
-      local.get $7
+      local.set $8
+      local.get $8
       if
        local.get $0
-       local.get $6
+       local.get $7
        i32.const 2
        i32.shl
        i32.add
        i32.load
        call $~lib/rt/pure/__retain
-       local.set $8
-       local.get $5
-       local.get $8
-       i32.const 2
-       global.set $~argumentsLength
+       local.set $9
        local.get $2
-       call_indirect (type $i32_i32_=>_i32)
+       local.set $10
+       local.get $10
+       i32.const -2147483648
+       i32.and
+       i32.const -2147483648
+       i32.eq
+       if (result i32)
+        local.get $10
+        i32.const 4
+        i32.shl
+        local.get $6
+        local.get $9
+        i32.const 2
+        global.set $~argumentsLength
+        local.get $10
+        i32.const 4
+        i32.shl
+        i32.load
+        call_indirect (type $i32_i32_i32_=>_i32)
+       else
+        local.get $6
+        local.get $9
+        i32.const 2
+        global.set $~argumentsLength
+        local.get $10
+        call_indirect (type $i32_i32_=>_i32)
+       end
        i32.const 0
        i32.lt_s
        if
         local.get $0
-        local.get $6
-        local.tee $9
+        local.get $7
+        local.tee $11
         i32.const 1
         i32.sub
-        local.set $6
-        local.get $9
+        local.set $7
+        local.get $11
         i32.const 1
         i32.add
         i32.const 2
         i32.shl
         i32.add
-        local.get $8
+        local.get $9
         i32.store
        else
-        local.get $8
+        local.get $9
         call $~lib/rt/pure/__release
         br $while-break|1
        end
-       local.get $8
+       local.get $9
        call $~lib/rt/pure/__release
        br $while-continue|1
       end
      end
     end
     local.get $0
-    local.get $6
+    local.get $7
     i32.const 1
     i32.add
     i32.const 2
     i32.shl
     i32.add
-    local.get $5
+    local.get $6
     i32.store
-    local.get $5
+    local.get $6
     call $~lib/rt/pure/__release
-    local.get $3
+    local.get $4
     i32.const 1
     i32.add
-    local.set $3
+    local.set $4
     br $for-loop|0
    end
   end
+  local.get $2
+  local.set $4
+  local.get $4
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $4
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
  )
  (func $~lib/array/Array<std/array/Proxy<i32>>#sort (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
@@ -10564,72 +13066,198 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  local.get $0
-  i32.load offset=12
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  local.get $1
   local.set $2
   local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
+  local.get $0
+  i32.load offset=12
+  local.set $3
+  local.get $3
   i32.const 1
   i32.le_s
   if
    local.get $0
    call $~lib/rt/pure/__retain
+   local.set $5
+   local.get $1
+   local.set $4
+   local.get $4
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $4
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
+   call $~lib/rt/pure/__release
+   local.get $5
    return
   end
   local.get $0
   i32.load offset=4
-  local.set $3
-  local.get $2
+  local.set $6
+  local.get $3
   i32.const 2
   i32.eq
   if
-   local.get $3
+   local.get $6
    i32.load offset=4
    call $~lib/rt/pure/__retain
-   local.set $4
-   local.get $3
+   local.set $5
+   local.get $6
    i32.load
    call $~lib/rt/pure/__retain
-   local.set $5
-   local.get $4
-   local.get $5
-   i32.const 2
-   global.set $~argumentsLength
+   local.set $7
    local.get $1
-   call_indirect (type $i32_i32_=>_i32)
+   local.set $8
+   local.get $8
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $8
+    i32.const 4
+    i32.shl
+    local.get $5
+    local.get $7
+    i32.const 2
+    global.set $~argumentsLength
+    local.get $8
+    i32.const 4
+    i32.shl
+    i32.load
+    call_indirect (type $i32_i32_i32_=>_i32)
+   else
+    local.get $5
+    local.get $7
+    i32.const 2
+    global.set $~argumentsLength
+    local.get $8
+    call_indirect (type $i32_i32_=>_i32)
+   end
    i32.const 0
    i32.lt_s
    if
-    local.get $3
-    local.get $5
+    local.get $6
+    local.get $7
     i32.store offset=4
-    local.get $3
-    local.get $4
+    local.get $6
+    local.get $5
     i32.store
    end
    local.get $0
    call $~lib/rt/pure/__retain
-   local.set $6
-   local.get $4
-   call $~lib/rt/pure/__release
+   local.set $10
    local.get $5
    call $~lib/rt/pure/__release
-   local.get $6
+   local.get $7
+   call $~lib/rt/pure/__release
+   local.get $1
+   local.set $9
+   local.get $9
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $9
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
+   call $~lib/rt/pure/__release
+   local.get $10
    return
   end
+  local.get $6
+  local.set $11
   local.get $3
   local.set $5
-  local.get $2
-  local.set $4
   local.get $1
-  local.set $6
+  local.set $7
+  local.get $7
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $7
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $7
+  local.set $10
   i32.const 1
   drop
+  local.get $11
   local.get $5
-  local.get $4
-  local.get $6
+  local.get $10
   call $~lib/util/sort/insertionSort<std/array/Proxy<i32>>
+  local.get $10
+  local.set $12
+  local.get $12
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $12
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__retain
+  local.set $5
+  local.get $1
+  local.set $11
+  local.get $11
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $11
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $5
  )
  (func $~lib/array/Array<std/array/Proxy<i32>>#get:length (param $0 i32) (result i32)
   local.get $0
@@ -10687,57 +13315,133 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $0
-  i32.const 1
+  local.get $1
   local.set $2
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
+  i32.const 1
+  local.set $3
   local.get $0
   call $~lib/array/Array<std/array/Proxy<i32>>#get:length
-  local.set $3
+  local.set $4
   loop $for-loop|0
-   local.get $2
    local.get $3
-   i32.lt_s
-   local.set $4
    local.get $4
+   i32.lt_s
+   local.set $5
+   local.get $5
    if
-    local.get $0
-    local.get $2
-    i32.const 1
-    i32.sub
-    call $~lib/array/Array<std/array/Proxy<i32>>#__get
-    local.tee $5
-    local.get $0
-    local.get $2
-    call $~lib/array/Array<std/array/Proxy<i32>>#__get
-    local.tee $6
-    i32.const 2
-    global.set $~argumentsLength
     local.get $1
-    call_indirect (type $i32_i32_=>_i32)
+    local.set $6
+    local.get $6
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result i32)
+     local.get $6
+     i32.const 4
+     i32.shl
+     local.get $0
+     local.get $3
+     i32.const 1
+     i32.sub
+     call $~lib/array/Array<std/array/Proxy<i32>>#__get
+     local.tee $7
+     local.get $0
+     local.get $3
+     call $~lib/array/Array<std/array/Proxy<i32>>#__get
+     local.tee $8
+     i32.const 2
+     global.set $~argumentsLength
+     local.get $6
+     i32.const 4
+     i32.shl
+     i32.load
+     call_indirect (type $i32_i32_i32_=>_i32)
+    else
+     local.get $0
+     local.get $3
+     i32.const 1
+     i32.sub
+     call $~lib/array/Array<std/array/Proxy<i32>>#__get
+     local.tee $9
+     local.get $0
+     local.get $3
+     call $~lib/array/Array<std/array/Proxy<i32>>#__get
+     local.tee $10
+     i32.const 2
+     global.set $~argumentsLength
+     local.get $6
+     call_indirect (type $i32_i32_=>_i32)
+    end
     i32.const 0
     i32.gt_s
     if
      i32.const 0
-     local.set $7
+     local.set $12
      local.get $0
      call $~lib/rt/pure/__release
-     local.get $5
-     call $~lib/rt/pure/__release
-     local.get $6
+     local.get $1
+     local.set $11
+     local.get $11
+     i32.const -2147483648
+     i32.and
+     i32.const -2147483648
+     i32.eq
+     if (result i32)
+      local.get $11
+      i32.const 4
+      i32.shl
+     else
+      i32.const 0
+     end
      call $~lib/rt/pure/__release
      local.get $7
+     call $~lib/rt/pure/__release
+     local.get $8
+     call $~lib/rt/pure/__release
+     local.get $9
+     call $~lib/rt/pure/__release
+     local.get $10
+     call $~lib/rt/pure/__release
+     local.get $12
      return
     end
-    local.get $5
+    local.get $7
     call $~lib/rt/pure/__release
-    local.get $6
+    local.get $8
     call $~lib/rt/pure/__release
-    local.get $2
+    local.get $9
+    call $~lib/rt/pure/__release
+    local.get $10
+    call $~lib/rt/pure/__release
+    local.get $3
     i32.const 1
     i32.add
-    local.set $2
+    local.set $3
     br $for-loop|0
    end
   end
@@ -10745,17 +13449,52 @@
   local.set $3
   local.get $0
   call $~lib/rt/pure/__release
+  local.get $1
+  local.set $4
+  local.get $4
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $4
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
   local.get $3
  )
  (func $std/array/assertSorted<std/array/Proxy<i32>> (param $0 i32) (param $1 i32)
   (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $0
+  local.get $1
+  local.set $2
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
   local.get $0
   local.get $1
   call $~lib/array/Array<std/array/Proxy<i32>>#sort
-  local.tee $2
+  local.tee $3
   local.get $1
   call $std/array/isSorted<std/array/Proxy<i32>>
   i32.eqz
@@ -10767,9 +13506,24 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $3
   call $~lib/rt/pure/__release
   local.get $0
+  call $~lib/rt/pure/__release
+  local.get $1
+  local.set $4
+  local.get $4
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $4
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
   call $~lib/rt/pure/__release
  )
  (func $~lib/util/sort/insertionSort<~lib/string/String | null> (param $0 i32) (param $1 i32) (param $2 i32)
@@ -10780,95 +13534,152 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
-  i32.const 0
+  (local $10 i32)
+  (local $11 i32)
+  local.get $2
   local.set $3
-  loop $for-loop|0
+  local.get $3
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
    local.get $3
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $3
+  local.set $2
+  i32.const 0
+  local.set $4
+  loop $for-loop|0
+   local.get $4
    local.get $1
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $5
+   local.get $5
    if
     local.get $0
-    local.get $3
+    local.get $4
     i32.const 2
     i32.shl
     i32.add
     i32.load
     call $~lib/rt/pure/__retain
-    local.set $5
-    local.get $3
+    local.set $6
+    local.get $4
     i32.const 1
     i32.sub
-    local.set $6
+    local.set $7
     block $while-break|1
      loop $while-continue|1
-      local.get $6
+      local.get $7
       i32.const 0
       i32.ge_s
-      local.set $7
-      local.get $7
+      local.set $8
+      local.get $8
       if
        local.get $0
-       local.get $6
+       local.get $7
        i32.const 2
        i32.shl
        i32.add
        i32.load
        call $~lib/rt/pure/__retain
-       local.set $8
-       local.get $5
-       local.get $8
-       i32.const 2
-       global.set $~argumentsLength
+       local.set $9
        local.get $2
-       call_indirect (type $i32_i32_=>_i32)
+       local.set $10
+       local.get $10
+       i32.const -2147483648
+       i32.and
+       i32.const -2147483648
+       i32.eq
+       if (result i32)
+        local.get $10
+        i32.const 4
+        i32.shl
+        local.get $6
+        local.get $9
+        i32.const 2
+        global.set $~argumentsLength
+        local.get $10
+        i32.const 4
+        i32.shl
+        i32.load
+        call_indirect (type $i32_i32_i32_=>_i32)
+       else
+        local.get $6
+        local.get $9
+        i32.const 2
+        global.set $~argumentsLength
+        local.get $10
+        call_indirect (type $i32_i32_=>_i32)
+       end
        i32.const 0
        i32.lt_s
        if
         local.get $0
-        local.get $6
-        local.tee $9
+        local.get $7
+        local.tee $11
         i32.const 1
         i32.sub
-        local.set $6
-        local.get $9
+        local.set $7
+        local.get $11
         i32.const 1
         i32.add
         i32.const 2
         i32.shl
         i32.add
-        local.get $8
+        local.get $9
         i32.store
        else
-        local.get $8
+        local.get $9
         call $~lib/rt/pure/__release
         br $while-break|1
        end
-       local.get $8
+       local.get $9
        call $~lib/rt/pure/__release
        br $while-continue|1
       end
      end
     end
     local.get $0
-    local.get $6
+    local.get $7
     i32.const 1
     i32.add
     i32.const 2
     i32.shl
     i32.add
-    local.get $5
+    local.get $6
     i32.store
-    local.get $5
+    local.get $6
     call $~lib/rt/pure/__release
-    local.get $3
+    local.get $4
     i32.const 1
     i32.add
-    local.set $3
+    local.set $4
     br $for-loop|0
    end
   end
+  local.get $2
+  local.set $4
+  local.get $4
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $4
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
  )
  (func $~lib/array/Array<~lib/string/String | null>#sort (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
@@ -10876,72 +13687,198 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  local.get $0
-  i32.load offset=12
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  local.get $1
   local.set $2
   local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
+  local.get $0
+  i32.load offset=12
+  local.set $3
+  local.get $3
   i32.const 1
   i32.le_s
   if
    local.get $0
    call $~lib/rt/pure/__retain
+   local.set $5
+   local.get $1
+   local.set $4
+   local.get $4
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $4
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
+   call $~lib/rt/pure/__release
+   local.get $5
    return
   end
   local.get $0
   i32.load offset=4
-  local.set $3
-  local.get $2
+  local.set $6
+  local.get $3
   i32.const 2
   i32.eq
   if
-   local.get $3
+   local.get $6
    i32.load offset=4
    call $~lib/rt/pure/__retain
-   local.set $4
-   local.get $3
+   local.set $5
+   local.get $6
    i32.load
    call $~lib/rt/pure/__retain
-   local.set $5
-   local.get $4
-   local.get $5
-   i32.const 2
-   global.set $~argumentsLength
+   local.set $7
    local.get $1
-   call_indirect (type $i32_i32_=>_i32)
+   local.set $8
+   local.get $8
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $8
+    i32.const 4
+    i32.shl
+    local.get $5
+    local.get $7
+    i32.const 2
+    global.set $~argumentsLength
+    local.get $8
+    i32.const 4
+    i32.shl
+    i32.load
+    call_indirect (type $i32_i32_i32_=>_i32)
+   else
+    local.get $5
+    local.get $7
+    i32.const 2
+    global.set $~argumentsLength
+    local.get $8
+    call_indirect (type $i32_i32_=>_i32)
+   end
    i32.const 0
    i32.lt_s
    if
-    local.get $3
-    local.get $5
+    local.get $6
+    local.get $7
     i32.store offset=4
-    local.get $3
-    local.get $4
+    local.get $6
+    local.get $5
     i32.store
    end
    local.get $0
    call $~lib/rt/pure/__retain
-   local.set $6
-   local.get $4
-   call $~lib/rt/pure/__release
+   local.set $10
    local.get $5
    call $~lib/rt/pure/__release
-   local.get $6
+   local.get $7
+   call $~lib/rt/pure/__release
+   local.get $1
+   local.set $9
+   local.get $9
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $9
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
+   call $~lib/rt/pure/__release
+   local.get $10
    return
   end
+  local.get $6
+  local.set $11
   local.get $3
   local.set $5
-  local.get $2
-  local.set $4
   local.get $1
-  local.set $6
+  local.set $7
+  local.get $7
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $7
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $7
+  local.set $10
   i32.const 1
   drop
+  local.get $11
   local.get $5
-  local.get $4
-  local.get $6
+  local.get $10
   call $~lib/util/sort/insertionSort<~lib/string/String | null>
+  local.get $10
+  local.set $12
+  local.get $12
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $12
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__retain
+  local.set $5
+  local.get $1
+  local.set $11
+  local.get $11
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $11
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $5
  )
  (func $~lib/array/Array<~lib/string/String | null>#get:length (param $0 i32) (result i32)
   local.get $0
@@ -10989,57 +13926,133 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $0
-  i32.const 1
+  local.get $1
   local.set $2
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
+  i32.const 1
+  local.set $3
   local.get $0
   call $~lib/array/Array<~lib/string/String | null>#get:length
-  local.set $3
+  local.set $4
   loop $for-loop|0
-   local.get $2
    local.get $3
-   i32.lt_s
-   local.set $4
    local.get $4
+   i32.lt_s
+   local.set $5
+   local.get $5
    if
-    local.get $0
-    local.get $2
-    i32.const 1
-    i32.sub
-    call $~lib/array/Array<~lib/string/String | null>#__get
-    local.tee $5
-    local.get $0
-    local.get $2
-    call $~lib/array/Array<~lib/string/String | null>#__get
-    local.tee $6
-    i32.const 2
-    global.set $~argumentsLength
     local.get $1
-    call_indirect (type $i32_i32_=>_i32)
+    local.set $6
+    local.get $6
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result i32)
+     local.get $6
+     i32.const 4
+     i32.shl
+     local.get $0
+     local.get $3
+     i32.const 1
+     i32.sub
+     call $~lib/array/Array<~lib/string/String | null>#__get
+     local.tee $7
+     local.get $0
+     local.get $3
+     call $~lib/array/Array<~lib/string/String | null>#__get
+     local.tee $8
+     i32.const 2
+     global.set $~argumentsLength
+     local.get $6
+     i32.const 4
+     i32.shl
+     i32.load
+     call_indirect (type $i32_i32_i32_=>_i32)
+    else
+     local.get $0
+     local.get $3
+     i32.const 1
+     i32.sub
+     call $~lib/array/Array<~lib/string/String | null>#__get
+     local.tee $9
+     local.get $0
+     local.get $3
+     call $~lib/array/Array<~lib/string/String | null>#__get
+     local.tee $10
+     i32.const 2
+     global.set $~argumentsLength
+     local.get $6
+     call_indirect (type $i32_i32_=>_i32)
+    end
     i32.const 0
     i32.gt_s
     if
      i32.const 0
-     local.set $7
+     local.set $12
      local.get $0
      call $~lib/rt/pure/__release
-     local.get $5
-     call $~lib/rt/pure/__release
-     local.get $6
+     local.get $1
+     local.set $11
+     local.get $11
+     i32.const -2147483648
+     i32.and
+     i32.const -2147483648
+     i32.eq
+     if (result i32)
+      local.get $11
+      i32.const 4
+      i32.shl
+     else
+      i32.const 0
+     end
      call $~lib/rt/pure/__release
      local.get $7
+     call $~lib/rt/pure/__release
+     local.get $8
+     call $~lib/rt/pure/__release
+     local.get $9
+     call $~lib/rt/pure/__release
+     local.get $10
+     call $~lib/rt/pure/__release
+     local.get $12
      return
     end
-    local.get $5
+    local.get $7
     call $~lib/rt/pure/__release
-    local.get $6
+    local.get $8
     call $~lib/rt/pure/__release
-    local.get $2
+    local.get $9
+    call $~lib/rt/pure/__release
+    local.get $10
+    call $~lib/rt/pure/__release
+    local.get $3
     i32.const 1
     i32.add
-    local.set $2
+    local.set $3
     br $for-loop|0
    end
   end
@@ -11047,17 +14060,52 @@
   local.set $3
   local.get $0
   call $~lib/rt/pure/__release
+  local.get $1
+  local.set $4
+  local.get $4
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $4
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
   local.get $3
  )
  (func $std/array/assertSorted<~lib/string/String | null> (param $0 i32) (param $1 i32)
   (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $0
+  local.get $1
+  local.set $2
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
   local.get $0
   local.get $1
   call $~lib/array/Array<~lib/string/String | null>#sort
-  local.tee $2
+  local.tee $3
   local.get $1
   call $std/array/isSorted<~lib/string/String | null>
   i32.eqz
@@ -11069,9 +14117,24 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $3
   call $~lib/rt/pure/__release
   local.get $0
+  call $~lib/rt/pure/__release
+  local.get $1
+  local.set $4
+  local.get $4
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $4
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
   call $~lib/rt/pure/__release
  )
  (func $~lib/string/String#get:length (param $0 i32) (result i32)
@@ -11208,7 +14271,7 @@
   call $~lib/rt/pure/__release
   local.get $7
  )
- (func $~lib/util/sort/COMPARATOR<~lib/string/String | null>~anonymous|0 (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/sort/COMPARATOR<~lib/string/String | null>~anonymous|0~nonClosure (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -11315,6 +14378,9 @@
   local.get $2
  )
  (func $std/array/assertSorted<~lib/string/String | null>@varargs (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -11333,13 +14399,45 @@
     i32.const 1
     drop
     i32.const 55
+    local.set $2
+    local.get $2
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result i32)
+     local.get $2
+     i32.const 4
+     i32.shl
+    else
+     i32.const 0
+    end
+    call $~lib/rt/pure/__retain
+    drop
+    local.get $2
     br $~lib/util/sort/COMPARATOR<~lib/string/String | null>|inlined.0
    end
+   local.tee $3
    local.set $1
   end
   local.get $0
   local.get $1
   call $std/array/assertSorted<~lib/string/String | null>
+  local.get $3
+  local.set $4
+  local.get $4
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $4
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
  )
  (func $~lib/string/String.__eq (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
@@ -11915,95 +15013,152 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
-  i32.const 0
+  (local $10 i32)
+  (local $11 i32)
+  local.get $2
   local.set $3
-  loop $for-loop|0
+  local.get $3
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
    local.get $3
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $3
+  local.set $2
+  i32.const 0
+  local.set $4
+  loop $for-loop|0
+   local.get $4
    local.get $1
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $5
+   local.get $5
    if
     local.get $0
-    local.get $3
+    local.get $4
     i32.const 2
     i32.shl
     i32.add
     i32.load
     call $~lib/rt/pure/__retain
-    local.set $5
-    local.get $3
+    local.set $6
+    local.get $4
     i32.const 1
     i32.sub
-    local.set $6
+    local.set $7
     block $while-break|1
      loop $while-continue|1
-      local.get $6
+      local.get $7
       i32.const 0
       i32.ge_s
-      local.set $7
-      local.get $7
+      local.set $8
+      local.get $8
       if
        local.get $0
-       local.get $6
+       local.get $7
        i32.const 2
        i32.shl
        i32.add
        i32.load
        call $~lib/rt/pure/__retain
-       local.set $8
-       local.get $5
-       local.get $8
-       i32.const 2
-       global.set $~argumentsLength
+       local.set $9
        local.get $2
-       call_indirect (type $i32_i32_=>_i32)
+       local.set $10
+       local.get $10
+       i32.const -2147483648
+       i32.and
+       i32.const -2147483648
+       i32.eq
+       if (result i32)
+        local.get $10
+        i32.const 4
+        i32.shl
+        local.get $6
+        local.get $9
+        i32.const 2
+        global.set $~argumentsLength
+        local.get $10
+        i32.const 4
+        i32.shl
+        i32.load
+        call_indirect (type $i32_i32_i32_=>_i32)
+       else
+        local.get $6
+        local.get $9
+        i32.const 2
+        global.set $~argumentsLength
+        local.get $10
+        call_indirect (type $i32_i32_=>_i32)
+       end
        i32.const 0
        i32.lt_s
        if
         local.get $0
-        local.get $6
-        local.tee $9
+        local.get $7
+        local.tee $11
         i32.const 1
         i32.sub
-        local.set $6
-        local.get $9
+        local.set $7
+        local.get $11
         i32.const 1
         i32.add
         i32.const 2
         i32.shl
         i32.add
-        local.get $8
+        local.get $9
         i32.store
        else
-        local.get $8
+        local.get $9
         call $~lib/rt/pure/__release
         br $while-break|1
        end
-       local.get $8
+       local.get $9
        call $~lib/rt/pure/__release
        br $while-continue|1
       end
      end
     end
     local.get $0
-    local.get $6
+    local.get $7
     i32.const 1
     i32.add
     i32.const 2
     i32.shl
     i32.add
-    local.get $5
+    local.get $6
     i32.store
-    local.get $5
+    local.get $6
     call $~lib/rt/pure/__release
-    local.get $3
+    local.get $4
     i32.const 1
     i32.add
-    local.set $3
+    local.set $4
     br $for-loop|0
    end
   end
+  local.get $2
+  local.set $4
+  local.get $4
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $4
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
  )
  (func $~lib/array/Array<~lib/string/String>#sort (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
@@ -12011,72 +15166,198 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  local.get $0
-  i32.load offset=12
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  local.get $1
   local.set $2
   local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
+  local.get $0
+  i32.load offset=12
+  local.set $3
+  local.get $3
   i32.const 1
   i32.le_s
   if
    local.get $0
    call $~lib/rt/pure/__retain
+   local.set $5
+   local.get $1
+   local.set $4
+   local.get $4
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $4
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
+   call $~lib/rt/pure/__release
+   local.get $5
    return
   end
   local.get $0
   i32.load offset=4
-  local.set $3
-  local.get $2
+  local.set $6
+  local.get $3
   i32.const 2
   i32.eq
   if
-   local.get $3
+   local.get $6
    i32.load offset=4
    call $~lib/rt/pure/__retain
-   local.set $4
-   local.get $3
+   local.set $5
+   local.get $6
    i32.load
    call $~lib/rt/pure/__retain
-   local.set $5
-   local.get $4
-   local.get $5
-   i32.const 2
-   global.set $~argumentsLength
+   local.set $7
    local.get $1
-   call_indirect (type $i32_i32_=>_i32)
+   local.set $8
+   local.get $8
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $8
+    i32.const 4
+    i32.shl
+    local.get $5
+    local.get $7
+    i32.const 2
+    global.set $~argumentsLength
+    local.get $8
+    i32.const 4
+    i32.shl
+    i32.load
+    call_indirect (type $i32_i32_i32_=>_i32)
+   else
+    local.get $5
+    local.get $7
+    i32.const 2
+    global.set $~argumentsLength
+    local.get $8
+    call_indirect (type $i32_i32_=>_i32)
+   end
    i32.const 0
    i32.lt_s
    if
-    local.get $3
-    local.get $5
+    local.get $6
+    local.get $7
     i32.store offset=4
-    local.get $3
-    local.get $4
+    local.get $6
+    local.get $5
     i32.store
    end
    local.get $0
    call $~lib/rt/pure/__retain
-   local.set $6
-   local.get $4
-   call $~lib/rt/pure/__release
+   local.set $10
    local.get $5
    call $~lib/rt/pure/__release
-   local.get $6
+   local.get $7
+   call $~lib/rt/pure/__release
+   local.get $1
+   local.set $9
+   local.get $9
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $9
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
+   call $~lib/rt/pure/__release
+   local.get $10
    return
   end
+  local.get $6
+  local.set $11
   local.get $3
   local.set $5
-  local.get $2
-  local.set $4
   local.get $1
-  local.set $6
+  local.set $7
+  local.get $7
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $7
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $7
+  local.set $10
   i32.const 1
   drop
+  local.get $11
   local.get $5
-  local.get $4
-  local.get $6
+  local.get $10
   call $~lib/util/sort/insertionSort<~lib/string/String>
+  local.get $10
+  local.set $12
+  local.get $12
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $12
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__retain
+  local.set $5
+  local.get $1
+  local.set $11
+  local.get $11
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $11
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $5
  )
  (func $~lib/array/Array<~lib/string/String>#get:length (param $0 i32) (result i32)
   local.get $0
@@ -12134,57 +15415,133 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $0
-  i32.const 1
+  local.get $1
   local.set $2
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
+  i32.const 1
+  local.set $3
   local.get $0
   call $~lib/array/Array<~lib/string/String>#get:length
-  local.set $3
+  local.set $4
   loop $for-loop|0
-   local.get $2
    local.get $3
-   i32.lt_s
-   local.set $4
    local.get $4
+   i32.lt_s
+   local.set $5
+   local.get $5
    if
-    local.get $0
-    local.get $2
-    i32.const 1
-    i32.sub
-    call $~lib/array/Array<~lib/string/String>#__get
-    local.tee $5
-    local.get $0
-    local.get $2
-    call $~lib/array/Array<~lib/string/String>#__get
-    local.tee $6
-    i32.const 2
-    global.set $~argumentsLength
     local.get $1
-    call_indirect (type $i32_i32_=>_i32)
+    local.set $6
+    local.get $6
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result i32)
+     local.get $6
+     i32.const 4
+     i32.shl
+     local.get $0
+     local.get $3
+     i32.const 1
+     i32.sub
+     call $~lib/array/Array<~lib/string/String>#__get
+     local.tee $7
+     local.get $0
+     local.get $3
+     call $~lib/array/Array<~lib/string/String>#__get
+     local.tee $8
+     i32.const 2
+     global.set $~argumentsLength
+     local.get $6
+     i32.const 4
+     i32.shl
+     i32.load
+     call_indirect (type $i32_i32_i32_=>_i32)
+    else
+     local.get $0
+     local.get $3
+     i32.const 1
+     i32.sub
+     call $~lib/array/Array<~lib/string/String>#__get
+     local.tee $9
+     local.get $0
+     local.get $3
+     call $~lib/array/Array<~lib/string/String>#__get
+     local.tee $10
+     i32.const 2
+     global.set $~argumentsLength
+     local.get $6
+     call_indirect (type $i32_i32_=>_i32)
+    end
     i32.const 0
     i32.gt_s
     if
      i32.const 0
-     local.set $7
+     local.set $12
      local.get $0
      call $~lib/rt/pure/__release
-     local.get $5
-     call $~lib/rt/pure/__release
-     local.get $6
+     local.get $1
+     local.set $11
+     local.get $11
+     i32.const -2147483648
+     i32.and
+     i32.const -2147483648
+     i32.eq
+     if (result i32)
+      local.get $11
+      i32.const 4
+      i32.shl
+     else
+      i32.const 0
+     end
      call $~lib/rt/pure/__release
      local.get $7
+     call $~lib/rt/pure/__release
+     local.get $8
+     call $~lib/rt/pure/__release
+     local.get $9
+     call $~lib/rt/pure/__release
+     local.get $10
+     call $~lib/rt/pure/__release
+     local.get $12
      return
     end
-    local.get $5
+    local.get $7
     call $~lib/rt/pure/__release
-    local.get $6
+    local.get $8
     call $~lib/rt/pure/__release
-    local.get $2
+    local.get $9
+    call $~lib/rt/pure/__release
+    local.get $10
+    call $~lib/rt/pure/__release
+    local.get $3
     i32.const 1
     i32.add
-    local.set $2
+    local.set $3
     br $for-loop|0
    end
   end
@@ -12192,17 +15549,52 @@
   local.set $3
   local.get $0
   call $~lib/rt/pure/__release
+  local.get $1
+  local.set $4
+  local.get $4
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $4
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
   local.get $3
  )
  (func $std/array/assertSorted<~lib/string/String> (param $0 i32) (param $1 i32)
   (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $0
+  local.get $1
+  local.set $2
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
   local.get $0
   local.get $1
   call $~lib/array/Array<~lib/string/String>#sort
-  local.tee $2
+  local.tee $3
   local.get $1
   call $std/array/isSorted<~lib/string/String>
   i32.eqz
@@ -12214,12 +15606,27 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $3
   call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
+  local.get $1
+  local.set $4
+  local.get $4
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $4
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
  )
- (func $~lib/util/sort/COMPARATOR<~lib/string/String>~anonymous|0 (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/sort/COMPARATOR<~lib/string/String>~anonymous|0~nonClosure (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -12326,6 +15733,9 @@
   local.get $2
  )
  (func $std/array/assertSorted<~lib/string/String>@varargs (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -12344,13 +15754,45 @@
     i32.const 1
     drop
     i32.const 56
+    local.set $2
+    local.get $2
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result i32)
+     local.get $2
+     i32.const 4
+     i32.shl
+    else
+     i32.const 0
+    end
+    call $~lib/rt/pure/__retain
+    drop
+    local.get $2
     br $~lib/util/sort/COMPARATOR<~lib/string/String>|inlined.0
    end
+   local.tee $3
    local.set $1
   end
   local.get $0
   local.get $1
   call $std/array/assertSorted<~lib/string/String>
+  local.get $3
+  local.set $4
+  local.get $4
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $4
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
  )
  (func $~lib/string/String#substring (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)

--- a/tests/compiler/std/typedarray.optimized.wat
+++ b/tests/compiler/std/typedarray.optimized.wat
@@ -4,13 +4,18 @@
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
  (type $i32_i32_=>_none (func (param i32 i32)))
+ (type $i32_i32_i32_i32_=>_i32 (func (param i32 i32 i32 i32) (result i32)))
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
  (type $i32_=>_none (func (param i32)))
  (type $i64_i32_i32_=>_i32 (func (param i64 i32 i32) (result i32)))
- (type $i32_i32_i32_i32_=>_i32 (func (param i32 i32 i32 i32) (result i32)))
  (type $f32_i32_i32_=>_i32 (func (param f32 i32 i32) (result i32)))
  (type $f64_i32_i32_=>_i32 (func (param f64 i32 i32) (result i32)))
  (type $i32_i32_=>_i64 (func (param i32 i32) (result i64)))
+ (type $i32_i32_i32_i32_i32_=>_i32 (func (param i32 i32 i32 i32 i32) (result i32)))
+ (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
+ (type $i32_i64_i32_i32_=>_i32 (func (param i32 i64 i32 i32) (result i32)))
+ (type $i32_f32_i32_i32_=>_i32 (func (param i32 f32 i32 i32) (result i32)))
+ (type $i32_f64_i32_i32_=>_i32 (func (param i32 f64 i32 i32) (result i32)))
  (type $i64_i64_i32_i32_=>_i64 (func (param i64 i64 i32 i32) (result i64)))
  (type $i32_i32_i64_=>_none (func (param i32 i32 i64)))
  (type $i64_i32_i32_=>_none (func (param i64 i32 i32)))
@@ -19,13 +24,14 @@
  (type $i32_f32_i32_=>_i32 (func (param i32 f32 i32) (result i32)))
  (type $i32_f64_=>_i32 (func (param i32 f64) (result i32)))
  (type $i32_f64_i32_=>_i32 (func (param i32 f64 i32) (result i32)))
+ (type $i32_i64_i64_i32_i32_=>_i64 (func (param i32 i64 i64 i32 i32) (result i64)))
  (type $i32_i32_=>_f32 (func (param i32 i32) (result f32)))
  (type $i32_i32_=>_f64 (func (param i32 i32) (result f64)))
- (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $i32_i32_f32_=>_none (func (param i32 i32 f32)))
  (type $i32_i32_f64_=>_none (func (param i32 i32 f64)))
  (type $i32_i32_f64_f64_f64_f64_f64_=>_none (func (param i32 i32 f64 f64 f64 f64 f64)))
  (type $i32_i64_i32_=>_none (func (param i32 i64 i32)))
+ (type $i32_i64_i32_i32_=>_none (func (param i32 i64 i32 i32)))
  (type $f32_i32_i32_=>_none (func (param f32 i32 i32)))
  (type $f64_i32_i32_=>_none (func (param f64 i32 i32)))
  (type $none_=>_i32 (func (result i32)))
@@ -194,7 +200,7 @@
  (data (i32.const 8560) "\n\00\00\00\01\00\00\00\00\00\00\00\n\00\00\00\00\ff\00\00\00d\n\ff\ff")
  (data (i32.const 8592) "\n\00\00\00\01\00\00\00\00\00\00\00\n\00\00\00\01\ffd\ff\00\00d\n\ff")
  (table $0 123 funcref)
- (elem (i32.const 1) $~lib/util/sort/COMPARATOR<f64>~anonymous|0 $std/typedarray/testReduce<~lib/typedarray/Int8Array,i8>~anonymous|0 $std/typedarray/testReduce<~lib/typedarray/Int8Array,i8>~anonymous|0 $std/typedarray/testReduce<~lib/typedarray/Int8Array,i8>~anonymous|0 $std/typedarray/testReduce<~lib/typedarray/Int8Array,i8>~anonymous|0 $std/typedarray/testReduce<~lib/typedarray/Int8Array,i8>~anonymous|0 $std/typedarray/testReduce<~lib/typedarray/Int8Array,i8>~anonymous|0 $std/typedarray/testReduce<~lib/typedarray/Int8Array,i8>~anonymous|0 $std/typedarray/testReduce<~lib/typedarray/Int64Array,i64>~anonymous|0 $std/typedarray/testReduce<~lib/typedarray/Int64Array,i64>~anonymous|0 $std/typedarray/testReduce<~lib/typedarray/Float32Array,f32>~anonymous|0 $std/typedarray/testReduce<~lib/typedarray/Float64Array,f64>~anonymous|0 $std/typedarray/testReduce<~lib/typedarray/Int8Array,i8>~anonymous|0 $std/typedarray/testReduce<~lib/typedarray/Int8Array,i8>~anonymous|0 $std/typedarray/testReduce<~lib/typedarray/Int8Array,i8>~anonymous|0 $std/typedarray/testReduce<~lib/typedarray/Int8Array,i8>~anonymous|0 $std/typedarray/testReduce<~lib/typedarray/Int8Array,i8>~anonymous|0 $std/typedarray/testReduce<~lib/typedarray/Int8Array,i8>~anonymous|0 $std/typedarray/testReduce<~lib/typedarray/Int8Array,i8>~anonymous|0 $std/typedarray/testReduce<~lib/typedarray/Int64Array,i64>~anonymous|0 $std/typedarray/testReduce<~lib/typedarray/Int64Array,i64>~anonymous|0 $std/typedarray/testReduce<~lib/typedarray/Float32Array,f32>~anonymous|0 $std/typedarray/testReduce<~lib/typedarray/Float64Array,f64>~anonymous|0 $std/typedarray/testArrayMap<~lib/typedarray/Int8Array,i8>~anonymous|0 $std/typedarray/testArrayMap<~lib/typedarray/Int8Array,i8>~anonymous|0 $std/typedarray/testArrayMap<~lib/typedarray/Int8Array,i8>~anonymous|0 $std/typedarray/testArrayMap<~lib/typedarray/Int8Array,i8>~anonymous|0 $std/typedarray/testArrayMap<~lib/typedarray/Int8Array,i8>~anonymous|0 $std/typedarray/testArrayMap<~lib/typedarray/Int8Array,i8>~anonymous|0 $std/typedarray/testArrayMap<~lib/typedarray/Int8Array,i8>~anonymous|0 $std/typedarray/testArrayMap<~lib/typedarray/Int64Array,i64>~anonymous|0 $std/typedarray/testArrayMap<~lib/typedarray/Int64Array,i64>~anonymous|0 $std/typedarray/testArrayMap<~lib/typedarray/Float32Array,f32>~anonymous|0 $std/typedarray/testArrayMap<~lib/typedarray/Float64Array,f64>~anonymous|0 $std/typedarray/testArrayFilter<~lib/typedarray/Int8Array,i8>~anonymous|0 $std/typedarray/testArrayFilter<~lib/typedarray/Uint8Array,u8>~anonymous|0 $std/typedarray/testArrayFilter<~lib/typedarray/Uint8Array,u8>~anonymous|0 $std/typedarray/testArrayFilter<~lib/typedarray/Int16Array,i16>~anonymous|0 $std/typedarray/testArrayFilter<~lib/typedarray/Uint16Array,u16>~anonymous|0 $std/typedarray/testArrayFilter<~lib/typedarray/Int32Array,i32>~anonymous|0 $std/typedarray/testArrayFilter<~lib/typedarray/Uint32Array,u32>~anonymous|0 $std/typedarray/testArrayFilter<~lib/typedarray/Int64Array,i64>~anonymous|0 $std/typedarray/testArrayFilter<~lib/typedarray/Uint64Array,u64>~anonymous|0 $std/typedarray/testArrayFilter<~lib/typedarray/Float32Array,f32>~anonymous|0 $std/typedarray/testArrayFilter<~lib/typedarray/Float64Array,f64>~anonymous|0 $std/typedarray/testArraySome<~lib/typedarray/Int8Array,i8>~anonymous|0 $std/typedarray/testArraySome<~lib/typedarray/Int8Array,i8>~anonymous|1 $std/typedarray/testArraySome<~lib/typedarray/Int8Array,i8>~anonymous|0 $std/typedarray/testArraySome<~lib/typedarray/Int8Array,i8>~anonymous|1 $std/typedarray/testArraySome<~lib/typedarray/Int8Array,i8>~anonymous|0 $std/typedarray/testArraySome<~lib/typedarray/Int8Array,i8>~anonymous|1 $std/typedarray/testArraySome<~lib/typedarray/Int16Array,i16>~anonymous|0 $std/typedarray/testArraySome<~lib/typedarray/Int16Array,i16>~anonymous|1 $std/typedarray/testArraySome<~lib/typedarray/Int16Array,i16>~anonymous|0 $std/typedarray/testArraySome<~lib/typedarray/Int16Array,i16>~anonymous|1 $std/typedarray/testArraySome<~lib/typedarray/Int32Array,i32>~anonymous|0 $std/typedarray/testArraySome<~lib/typedarray/Int32Array,i32>~anonymous|1 $std/typedarray/testArraySome<~lib/typedarray/Int32Array,i32>~anonymous|0 $std/typedarray/testArraySome<~lib/typedarray/Int32Array,i32>~anonymous|1 $std/typedarray/testArraySome<~lib/typedarray/Int64Array,i64>~anonymous|0 $std/typedarray/testArraySome<~lib/typedarray/Int64Array,i64>~anonymous|1 $std/typedarray/testArraySome<~lib/typedarray/Int64Array,i64>~anonymous|0 $std/typedarray/testArraySome<~lib/typedarray/Int64Array,i64>~anonymous|1 $std/typedarray/testArraySome<~lib/typedarray/Float32Array,f32>~anonymous|0 $std/typedarray/testArraySome<~lib/typedarray/Float32Array,f32>~anonymous|1 $std/typedarray/testArraySome<~lib/typedarray/Float64Array,f64>~anonymous|0 $std/typedarray/testArraySome<~lib/typedarray/Float64Array,f64>~anonymous|1 $std/typedarray/testArraySome<~lib/typedarray/Int8Array,i8>~anonymous|0 $std/typedarray/testArrayFindIndex<~lib/typedarray/Int8Array,i8>~anonymous|1 $std/typedarray/testArraySome<~lib/typedarray/Int8Array,i8>~anonymous|0 $std/typedarray/testArrayFindIndex<~lib/typedarray/Int8Array,i8>~anonymous|1 $std/typedarray/testArraySome<~lib/typedarray/Int8Array,i8>~anonymous|0 $std/typedarray/testArrayFindIndex<~lib/typedarray/Int8Array,i8>~anonymous|1 $std/typedarray/testArraySome<~lib/typedarray/Int16Array,i16>~anonymous|0 $std/typedarray/testArrayFindIndex<~lib/typedarray/Int16Array,i16>~anonymous|1 $std/typedarray/testArraySome<~lib/typedarray/Int16Array,i16>~anonymous|0 $std/typedarray/testArrayFindIndex<~lib/typedarray/Int16Array,i16>~anonymous|1 $std/typedarray/testArraySome<~lib/typedarray/Int32Array,i32>~anonymous|0 $std/typedarray/testArrayFindIndex<~lib/typedarray/Int32Array,i32>~anonymous|1 $std/typedarray/testArraySome<~lib/typedarray/Int32Array,i32>~anonymous|0 $std/typedarray/testArrayFindIndex<~lib/typedarray/Int32Array,i32>~anonymous|1 $std/typedarray/testArraySome<~lib/typedarray/Int64Array,i64>~anonymous|0 $std/typedarray/testArrayFindIndex<~lib/typedarray/Int64Array,i64>~anonymous|1 $std/typedarray/testArraySome<~lib/typedarray/Int64Array,i64>~anonymous|0 $std/typedarray/testArrayFindIndex<~lib/typedarray/Int64Array,i64>~anonymous|1 $std/typedarray/testArraySome<~lib/typedarray/Float32Array,f32>~anonymous|0 $std/typedarray/testArrayFindIndex<~lib/typedarray/Float32Array,f32>~anonymous|1 $std/typedarray/testArraySome<~lib/typedarray/Float64Array,f64>~anonymous|0 $std/typedarray/testArrayFindIndex<~lib/typedarray/Float64Array,f64>~anonymous|1 $std/typedarray/testArrayEvery<~lib/typedarray/Int8Array,i8>~anonymous|0 $std/typedarray/testArraySome<~lib/typedarray/Int8Array,i8>~anonymous|0 $std/typedarray/testArrayEvery<~lib/typedarray/Uint8Array,u8>~anonymous|0 $std/typedarray/testArraySome<~lib/typedarray/Int8Array,i8>~anonymous|0 $std/typedarray/testArrayEvery<~lib/typedarray/Uint8Array,u8>~anonymous|0 $std/typedarray/testArraySome<~lib/typedarray/Int8Array,i8>~anonymous|0 $std/typedarray/testArrayEvery<~lib/typedarray/Int16Array,i16>~anonymous|0 $std/typedarray/testArraySome<~lib/typedarray/Int16Array,i16>~anonymous|0 $std/typedarray/testArrayEvery<~lib/typedarray/Uint8Array,u8>~anonymous|0 $std/typedarray/testArraySome<~lib/typedarray/Int16Array,i16>~anonymous|0 $std/typedarray/testArrayEvery<~lib/typedarray/Int32Array,i32>~anonymous|0 $std/typedarray/testArraySome<~lib/typedarray/Int32Array,i32>~anonymous|0 $std/typedarray/testArrayEvery<~lib/typedarray/Uint8Array,u8>~anonymous|0 $std/typedarray/testArraySome<~lib/typedarray/Int32Array,i32>~anonymous|0 $std/typedarray/testArrayEvery<~lib/typedarray/Int64Array,i64>~anonymous|0 $std/typedarray/testArraySome<~lib/typedarray/Int64Array,i64>~anonymous|0 $std/typedarray/testArrayEvery<~lib/typedarray/Uint64Array,u64>~anonymous|0 $std/typedarray/testArraySome<~lib/typedarray/Int64Array,i64>~anonymous|0 $std/typedarray/testArrayEvery<~lib/typedarray/Float32Array,f32>~anonymous|0 $std/typedarray/testArraySome<~lib/typedarray/Float32Array,f32>~anonymous|0 $std/typedarray/testArrayEvery<~lib/typedarray/Float64Array,f64>~anonymous|0 $std/typedarray/testArraySome<~lib/typedarray/Float64Array,f64>~anonymous|0 $std/typedarray/testArrayForEach<~lib/typedarray/Int8Array,i8>~anonymous|0 $std/typedarray/testArrayForEach<~lib/typedarray/Int8Array,i8>~anonymous|0 $std/typedarray/testArrayForEach<~lib/typedarray/Int8Array,i8>~anonymous|0 $std/typedarray/testArrayForEach<~lib/typedarray/Int16Array,i16>~anonymous|0 $std/typedarray/testArrayForEach<~lib/typedarray/Int16Array,i16>~anonymous|0 $std/typedarray/testArrayForEach<~lib/typedarray/Int32Array,i32>~anonymous|0 $std/typedarray/testArrayForEach<~lib/typedarray/Int32Array,i32>~anonymous|0 $std/typedarray/testArrayForEach<~lib/typedarray/Int64Array,i64>~anonymous|0 $std/typedarray/testArrayForEach<~lib/typedarray/Int64Array,i64>~anonymous|0 $std/typedarray/testArrayForEach<~lib/typedarray/Float32Array,f32>~anonymous|0 $std/typedarray/testArrayForEach<~lib/typedarray/Float64Array,f64>~anonymous|0)
+ (elem (i32.const 1) $~lib/util/sort/COMPARATOR<f64>~anonymous|0~nonClosure $std/typedarray/testReduce<~lib/typedarray/Int8Array,i8>~anonymous|0~nonClosure $std/typedarray/testReduce<~lib/typedarray/Int8Array,i8>~anonymous|0~nonClosure $std/typedarray/testReduce<~lib/typedarray/Int8Array,i8>~anonymous|0~nonClosure $std/typedarray/testReduce<~lib/typedarray/Int8Array,i8>~anonymous|0~nonClosure $std/typedarray/testReduce<~lib/typedarray/Int8Array,i8>~anonymous|0~nonClosure $std/typedarray/testReduce<~lib/typedarray/Int8Array,i8>~anonymous|0~nonClosure $std/typedarray/testReduce<~lib/typedarray/Int8Array,i8>~anonymous|0~nonClosure $std/typedarray/testReduce<~lib/typedarray/Int64Array,i64>~anonymous|0~nonClosure $std/typedarray/testReduce<~lib/typedarray/Int64Array,i64>~anonymous|0~nonClosure $std/typedarray/testReduce<~lib/typedarray/Float32Array,f32>~anonymous|0~nonClosure $std/typedarray/testReduce<~lib/typedarray/Float64Array,f64>~anonymous|0~nonClosure $std/typedarray/testReduce<~lib/typedarray/Int8Array,i8>~anonymous|0~nonClosure $std/typedarray/testReduce<~lib/typedarray/Int8Array,i8>~anonymous|0~nonClosure $std/typedarray/testReduce<~lib/typedarray/Int8Array,i8>~anonymous|0~nonClosure $std/typedarray/testReduce<~lib/typedarray/Int8Array,i8>~anonymous|0~nonClosure $std/typedarray/testReduce<~lib/typedarray/Int8Array,i8>~anonymous|0~nonClosure $std/typedarray/testReduce<~lib/typedarray/Int8Array,i8>~anonymous|0~nonClosure $std/typedarray/testReduce<~lib/typedarray/Int8Array,i8>~anonymous|0~nonClosure $std/typedarray/testReduce<~lib/typedarray/Int64Array,i64>~anonymous|0~nonClosure $std/typedarray/testReduce<~lib/typedarray/Int64Array,i64>~anonymous|0~nonClosure $std/typedarray/testReduce<~lib/typedarray/Float32Array,f32>~anonymous|0~nonClosure $std/typedarray/testReduce<~lib/typedarray/Float64Array,f64>~anonymous|0~nonClosure $std/typedarray/testArrayMap<~lib/typedarray/Int8Array,i8>~anonymous|0~nonClosure $std/typedarray/testArrayMap<~lib/typedarray/Int8Array,i8>~anonymous|0~nonClosure $std/typedarray/testArrayMap<~lib/typedarray/Int8Array,i8>~anonymous|0~nonClosure $std/typedarray/testArrayMap<~lib/typedarray/Int8Array,i8>~anonymous|0~nonClosure $std/typedarray/testArrayMap<~lib/typedarray/Int8Array,i8>~anonymous|0~nonClosure $std/typedarray/testArrayMap<~lib/typedarray/Int8Array,i8>~anonymous|0~nonClosure $std/typedarray/testArrayMap<~lib/typedarray/Int8Array,i8>~anonymous|0~nonClosure $std/typedarray/testArrayMap<~lib/typedarray/Int64Array,i64>~anonymous|0~nonClosure $std/typedarray/testArrayMap<~lib/typedarray/Int64Array,i64>~anonymous|0~nonClosure $std/typedarray/testArrayMap<~lib/typedarray/Float32Array,f32>~anonymous|0~nonClosure $std/typedarray/testArrayMap<~lib/typedarray/Float64Array,f64>~anonymous|0~nonClosure $std/typedarray/testArrayFilter<~lib/typedarray/Int8Array,i8>~anonymous|0~nonClosure $std/typedarray/testArrayFilter<~lib/typedarray/Uint8Array,u8>~anonymous|0~nonClosure $std/typedarray/testArrayFilter<~lib/typedarray/Uint8Array,u8>~anonymous|0~nonClosure $std/typedarray/testArrayFilter<~lib/typedarray/Int16Array,i16>~anonymous|0~nonClosure $std/typedarray/testArrayFilter<~lib/typedarray/Uint16Array,u16>~anonymous|0~nonClosure $std/typedarray/testArrayFilter<~lib/typedarray/Int32Array,i32>~anonymous|0~nonClosure $std/typedarray/testArrayFilter<~lib/typedarray/Uint32Array,u32>~anonymous|0~nonClosure $std/typedarray/testArrayFilter<~lib/typedarray/Int64Array,i64>~anonymous|0~nonClosure $std/typedarray/testArrayFilter<~lib/typedarray/Uint64Array,u64>~anonymous|0~nonClosure $std/typedarray/testArrayFilter<~lib/typedarray/Float32Array,f32>~anonymous|0~nonClosure $std/typedarray/testArrayFilter<~lib/typedarray/Float64Array,f64>~anonymous|0~nonClosure $std/typedarray/testArraySome<~lib/typedarray/Int8Array,i8>~anonymous|0~nonClosure $std/typedarray/testArraySome<~lib/typedarray/Int8Array,i8>~anonymous|1~nonClosure $std/typedarray/testArraySome<~lib/typedarray/Int8Array,i8>~anonymous|0~nonClosure $std/typedarray/testArraySome<~lib/typedarray/Int8Array,i8>~anonymous|1~nonClosure $std/typedarray/testArraySome<~lib/typedarray/Int8Array,i8>~anonymous|0~nonClosure $std/typedarray/testArraySome<~lib/typedarray/Int8Array,i8>~anonymous|1~nonClosure $std/typedarray/testArraySome<~lib/typedarray/Int16Array,i16>~anonymous|0~nonClosure $std/typedarray/testArraySome<~lib/typedarray/Int16Array,i16>~anonymous|1~nonClosure $std/typedarray/testArraySome<~lib/typedarray/Int16Array,i16>~anonymous|0~nonClosure $std/typedarray/testArraySome<~lib/typedarray/Int16Array,i16>~anonymous|1~nonClosure $std/typedarray/testArraySome<~lib/typedarray/Int32Array,i32>~anonymous|0~nonClosure $std/typedarray/testArraySome<~lib/typedarray/Int32Array,i32>~anonymous|1~nonClosure $std/typedarray/testArraySome<~lib/typedarray/Int32Array,i32>~anonymous|0~nonClosure $std/typedarray/testArraySome<~lib/typedarray/Int32Array,i32>~anonymous|1~nonClosure $std/typedarray/testArraySome<~lib/typedarray/Int64Array,i64>~anonymous|0~nonClosure $std/typedarray/testArraySome<~lib/typedarray/Int64Array,i64>~anonymous|1~nonClosure $std/typedarray/testArraySome<~lib/typedarray/Int64Array,i64>~anonymous|0~nonClosure $std/typedarray/testArraySome<~lib/typedarray/Int64Array,i64>~anonymous|1~nonClosure $std/typedarray/testArraySome<~lib/typedarray/Float32Array,f32>~anonymous|0~nonClosure $std/typedarray/testArraySome<~lib/typedarray/Float32Array,f32>~anonymous|1~nonClosure $std/typedarray/testArraySome<~lib/typedarray/Float64Array,f64>~anonymous|0~nonClosure $std/typedarray/testArraySome<~lib/typedarray/Float64Array,f64>~anonymous|1~nonClosure $std/typedarray/testArraySome<~lib/typedarray/Int8Array,i8>~anonymous|0~nonClosure $std/typedarray/testArrayFindIndex<~lib/typedarray/Int8Array,i8>~anonymous|1~nonClosure $std/typedarray/testArraySome<~lib/typedarray/Int8Array,i8>~anonymous|0~nonClosure $std/typedarray/testArrayFindIndex<~lib/typedarray/Int8Array,i8>~anonymous|1~nonClosure $std/typedarray/testArraySome<~lib/typedarray/Int8Array,i8>~anonymous|0~nonClosure $std/typedarray/testArrayFindIndex<~lib/typedarray/Int8Array,i8>~anonymous|1~nonClosure $std/typedarray/testArraySome<~lib/typedarray/Int16Array,i16>~anonymous|0~nonClosure $std/typedarray/testArrayFindIndex<~lib/typedarray/Int16Array,i16>~anonymous|1~nonClosure $std/typedarray/testArraySome<~lib/typedarray/Int16Array,i16>~anonymous|0~nonClosure $std/typedarray/testArrayFindIndex<~lib/typedarray/Int16Array,i16>~anonymous|1~nonClosure $std/typedarray/testArraySome<~lib/typedarray/Int32Array,i32>~anonymous|0~nonClosure $std/typedarray/testArrayFindIndex<~lib/typedarray/Int32Array,i32>~anonymous|1~nonClosure $std/typedarray/testArraySome<~lib/typedarray/Int32Array,i32>~anonymous|0~nonClosure $std/typedarray/testArrayFindIndex<~lib/typedarray/Int32Array,i32>~anonymous|1~nonClosure $std/typedarray/testArraySome<~lib/typedarray/Int64Array,i64>~anonymous|0~nonClosure $std/typedarray/testArrayFindIndex<~lib/typedarray/Int64Array,i64>~anonymous|1~nonClosure $std/typedarray/testArraySome<~lib/typedarray/Int64Array,i64>~anonymous|0~nonClosure $std/typedarray/testArrayFindIndex<~lib/typedarray/Int64Array,i64>~anonymous|1~nonClosure $std/typedarray/testArraySome<~lib/typedarray/Float32Array,f32>~anonymous|0~nonClosure $std/typedarray/testArrayFindIndex<~lib/typedarray/Float32Array,f32>~anonymous|1~nonClosure $std/typedarray/testArraySome<~lib/typedarray/Float64Array,f64>~anonymous|0~nonClosure $std/typedarray/testArrayFindIndex<~lib/typedarray/Float64Array,f64>~anonymous|1~nonClosure $std/typedarray/testArrayEvery<~lib/typedarray/Int8Array,i8>~anonymous|0~nonClosure $std/typedarray/testArraySome<~lib/typedarray/Int8Array,i8>~anonymous|0~nonClosure $std/typedarray/testArrayEvery<~lib/typedarray/Uint8Array,u8>~anonymous|0~nonClosure $std/typedarray/testArraySome<~lib/typedarray/Int8Array,i8>~anonymous|0~nonClosure $std/typedarray/testArrayEvery<~lib/typedarray/Uint8Array,u8>~anonymous|0~nonClosure $std/typedarray/testArraySome<~lib/typedarray/Int8Array,i8>~anonymous|0~nonClosure $std/typedarray/testArrayEvery<~lib/typedarray/Int16Array,i16>~anonymous|0~nonClosure $std/typedarray/testArraySome<~lib/typedarray/Int16Array,i16>~anonymous|0~nonClosure $std/typedarray/testArrayEvery<~lib/typedarray/Uint8Array,u8>~anonymous|0~nonClosure $std/typedarray/testArraySome<~lib/typedarray/Int16Array,i16>~anonymous|0~nonClosure $std/typedarray/testArrayEvery<~lib/typedarray/Int32Array,i32>~anonymous|0~nonClosure $std/typedarray/testArraySome<~lib/typedarray/Int32Array,i32>~anonymous|0~nonClosure $std/typedarray/testArrayEvery<~lib/typedarray/Uint8Array,u8>~anonymous|0~nonClosure $std/typedarray/testArraySome<~lib/typedarray/Int32Array,i32>~anonymous|0~nonClosure $std/typedarray/testArrayEvery<~lib/typedarray/Int64Array,i64>~anonymous|0~nonClosure $std/typedarray/testArraySome<~lib/typedarray/Int64Array,i64>~anonymous|0~nonClosure $std/typedarray/testArrayEvery<~lib/typedarray/Uint64Array,u64>~anonymous|0~nonClosure $std/typedarray/testArraySome<~lib/typedarray/Int64Array,i64>~anonymous|0~nonClosure $std/typedarray/testArrayEvery<~lib/typedarray/Float32Array,f32>~anonymous|0~nonClosure $std/typedarray/testArraySome<~lib/typedarray/Float32Array,f32>~anonymous|0~nonClosure $std/typedarray/testArrayEvery<~lib/typedarray/Float64Array,f64>~anonymous|0~nonClosure $std/typedarray/testArraySome<~lib/typedarray/Float64Array,f64>~anonymous|0~nonClosure $std/typedarray/testArrayForEach<~lib/typedarray/Int8Array,i8>~anonymous|0~nonClosure $std/typedarray/testArrayForEach<~lib/typedarray/Int8Array,i8>~anonymous|0~nonClosure $std/typedarray/testArrayForEach<~lib/typedarray/Int8Array,i8>~anonymous|0~nonClosure $std/typedarray/testArrayForEach<~lib/typedarray/Int16Array,i16>~anonymous|0~nonClosure $std/typedarray/testArrayForEach<~lib/typedarray/Int16Array,i16>~anonymous|0~nonClosure $std/typedarray/testArrayForEach<~lib/typedarray/Int32Array,i32>~anonymous|0~nonClosure $std/typedarray/testArrayForEach<~lib/typedarray/Int32Array,i32>~anonymous|0~nonClosure $std/typedarray/testArrayForEach<~lib/typedarray/Int64Array,i64>~anonymous|0~nonClosure $std/typedarray/testArrayForEach<~lib/typedarray/Int64Array,i64>~anonymous|0~nonClosure $std/typedarray/testArrayForEach<~lib/typedarray/Float32Array,f32>~anonymous|0~nonClosure $std/typedarray/testArrayForEach<~lib/typedarray/Float64Array,f64>~anonymous|0~nonClosure)
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/collectLock (mut i32) (i32.const 0))
  (global $~argumentsLength (mut i32) (i32.const 0))
@@ -2378,7 +2384,7 @@
        global.set $~argumentsLength
        local.get $5
        local.get $4
-       call $~lib/util/sort/COMPARATOR<f64>~anonymous|0
+       call $~lib/util/sort/COMPARATOR<f64>~anonymous|0~nonClosure
        i32.const 0
        i32.ge_s
        br_if $while-break|1
@@ -2554,7 +2560,7 @@
     global.set $~argumentsLength
     local.get $4
     local.get $6
-    call $~lib/util/sort/COMPARATOR<f64>~anonymous|0
+    call $~lib/util/sort/COMPARATOR<f64>~anonymous|0~nonClosure
     i32.const 0
     i32.lt_s
     if
@@ -2670,7 +2676,7 @@
       global.set $~argumentsLength
       local.get $4
       local.get $6
-      call $~lib/util/sort/COMPARATOR<f64>~anonymous|0
+      call $~lib/util/sort/COMPARATOR<f64>~anonymous|0~nonClosure
       i32.const 0
       i32.lt_s
       if
@@ -2731,7 +2737,7 @@
   local.get $4
   f64.store
  )
- (func $~lib/util/sort/COMPARATOR<f64>~anonymous|0 (param $0 f64) (param $1 f64) (result i32)
+ (func $~lib/util/sort/COMPARATOR<f64>~anonymous|0~nonClosure (param $0 f64) (param $1 f64) (result i32)
   (local $2 i64)
   (local $3 i64)
   local.get $0
@@ -3627,7 +3633,7 @@
   call $~lib/memory/memory.copy
   local.get $5
  )
- (func $std/typedarray/testReduce<~lib/typedarray/Int8Array,i8>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduce<~lib/typedarray/Int8Array,i8>~anonymous|0~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   local.get $0
   local.get $1
   i32.add
@@ -3658,31 +3664,74 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  local.get $1
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  local.tee $3
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $3
+  call $~lib/rt/pure/__retain
+  drop
   local.get $0
   i32.load offset=4
-  local.set $4
+  local.set $3
   local.get $0
   i32.load offset=8
-  local.set $5
+  local.set $6
   loop $for-loop|0
    local.get $2
-   local.get $5
+   local.get $6
    i32.lt_s
    if
-    local.get $2
-    local.get $4
-    i32.add
-    i32.load8_u
-    local.set $6
-    i32.const 4
-    global.set $~argumentsLength
-    local.get $3
-    local.get $6
-    local.get $2
-    local.get $0
     local.get $1
-    call_indirect (type $i32_i32_i32_i32_=>_i32)
-    local.set $3
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result i32)
+     local.get $2
+     local.get $3
+     i32.add
+     i32.load8_u
+     local.set $4
+     i32.const 4
+     global.set $~argumentsLength
+     local.get $1
+     i32.const 4
+     i32.shl
+     local.tee $7
+     local.get $5
+     local.get $4
+     local.get $2
+     local.get $0
+     local.get $7
+     i32.load
+     call_indirect (type $i32_i32_i32_i32_i32_=>_i32)
+    else
+     local.get $2
+     local.get $3
+     i32.add
+     i32.load8_u
+     local.set $4
+     i32.const 4
+     global.set $~argumentsLength
+     local.get $5
+     local.get $4
+     local.get $2
+     local.get $0
+     local.get $1
+     call_indirect (type $i32_i32_i32_i32_=>_i32)
+    end
+    local.set $5
     local.get $2
     i32.const 1
     i32.add
@@ -3690,7 +3739,28 @@
     br $for-loop|0
    end
   end
-  local.get $3
+  local.get $1
+  i32.const 4
+  i32.shl
+  local.tee $0
+  i32.const 0
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  call $~lib/rt/pure/__release
+  local.get $0
+  i32.const 0
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  call $~lib/rt/pure/__release
+  local.get $5
  )
  (func $~lib/typedarray/Int16Array#__set (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $1
@@ -3746,35 +3816,80 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  local.get $1
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  local.tee $3
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $3
+  call $~lib/rt/pure/__retain
+  drop
   local.get $0
   i32.load offset=4
-  local.set $4
+  local.set $3
   local.get $0
   i32.load offset=8
   i32.const 2
   i32.shr_u
-  local.set $5
+  local.set $6
   loop $for-loop|0
    local.get $2
-   local.get $5
+   local.get $6
    i32.lt_s
    if
-    local.get $4
-    local.get $2
-    i32.const 2
-    i32.shl
-    i32.add
-    i32.load
-    local.set $6
-    i32.const 4
-    global.set $~argumentsLength
-    local.get $3
-    local.get $6
-    local.get $2
-    local.get $0
     local.get $1
-    call_indirect (type $i32_i32_i32_i32_=>_i32)
-    local.set $3
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result i32)
+     local.get $3
+     local.get $2
+     i32.const 2
+     i32.shl
+     i32.add
+     i32.load
+     local.set $4
+     i32.const 4
+     global.set $~argumentsLength
+     local.get $1
+     i32.const 4
+     i32.shl
+     local.tee $7
+     local.get $5
+     local.get $4
+     local.get $2
+     local.get $0
+     local.get $7
+     i32.load
+     call_indirect (type $i32_i32_i32_i32_i32_=>_i32)
+    else
+     local.get $3
+     local.get $2
+     i32.const 2
+     i32.shl
+     i32.add
+     i32.load
+     local.set $4
+     i32.const 4
+     global.set $~argumentsLength
+     local.get $5
+     local.get $4
+     local.get $2
+     local.get $0
+     local.get $1
+     call_indirect (type $i32_i32_i32_i32_=>_i32)
+    end
+    local.set $5
     local.get $2
     i32.const 1
     i32.add
@@ -3782,7 +3897,28 @@
     br $for-loop|0
    end
   end
-  local.get $3
+  local.get $1
+  i32.const 4
+  i32.shl
+  local.tee $0
+  i32.const 0
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  call $~lib/rt/pure/__release
+  local.get $0
+  i32.const 0
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  call $~lib/rt/pure/__release
+  local.get $5
  )
  (func $~lib/typedarray/Uint32Array#__set (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $1
@@ -3832,46 +3968,91 @@
   local.get $2
   i64.store
  )
- (func $std/typedarray/testReduce<~lib/typedarray/Int64Array,i64>~anonymous|0 (param $0 i64) (param $1 i64) (param $2 i32) (param $3 i32) (result i64)
+ (func $std/typedarray/testReduce<~lib/typedarray/Int64Array,i64>~anonymous|0~nonClosure (param $0 i64) (param $1 i64) (param $2 i32) (param $3 i32) (result i64)
   local.get $0
   local.get $1
   i64.add
  )
  (func $~lib/typedarray/Int64Array#reduce<i64> (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
-  (local $3 i64)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i64)
+  (local $3 i32)
+  (local $4 i64)
+  (local $5 i64)
+  (local $6 i32)
+  (local $7 i32)
+  local.get $1
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  local.tee $3
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $3
+  call $~lib/rt/pure/__retain
+  drop
   local.get $0
   i32.load offset=4
-  local.set $4
+  local.set $3
   local.get $0
   i32.load offset=8
   i32.const 3
   i32.shr_u
-  local.set $5
+  local.set $6
   loop $for-loop|0
    local.get $2
-   local.get $5
+   local.get $6
    i32.lt_s
    if
-    local.get $4
-    local.get $2
-    i32.const 3
-    i32.shl
-    i32.add
-    i64.load
-    local.set $6
-    i32.const 4
-    global.set $~argumentsLength
-    local.get $3
-    local.get $6
-    local.get $2
-    local.get $0
     local.get $1
-    call_indirect (type $i64_i64_i32_i32_=>_i64)
-    local.set $3
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result i64)
+     local.get $3
+     local.get $2
+     i32.const 3
+     i32.shl
+     i32.add
+     i64.load
+     local.set $4
+     i32.const 4
+     global.set $~argumentsLength
+     local.get $1
+     i32.const 4
+     i32.shl
+     local.tee $7
+     local.get $5
+     local.get $4
+     local.get $2
+     local.get $0
+     local.get $7
+     i32.load
+     call_indirect (type $i32_i64_i64_i32_i32_=>_i64)
+    else
+     local.get $3
+     local.get $2
+     i32.const 3
+     i32.shl
+     i32.add
+     i64.load
+     local.set $4
+     i32.const 4
+     global.set $~argumentsLength
+     local.get $5
+     local.get $4
+     local.get $2
+     local.get $0
+     local.get $1
+     call_indirect (type $i64_i64_i32_i32_=>_i64)
+    end
+    local.set $5
     local.get $2
     i32.const 1
     i32.add
@@ -3879,7 +4060,28 @@
     br $for-loop|0
    end
   end
-  local.get $3
+  local.get $1
+  i32.const 4
+  i32.shl
+  local.tee $0
+  i32.const 0
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  call $~lib/rt/pure/__release
+  local.get $0
+  i32.const 0
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  call $~lib/rt/pure/__release
+  local.get $5
  )
  (func $~lib/typedarray/Uint64Array#__set (param $0 i32) (param $1 i32) (param $2 i64)
   local.get $1
@@ -3929,12 +4131,12 @@
   local.get $2
   f32.store
  )
- (func $std/typedarray/testReduce<~lib/typedarray/Float32Array,f32>~anonymous|0 (param $0 f32) (param $1 f32) (param $2 i32) (param $3 i32) (result f32)
+ (func $std/typedarray/testReduce<~lib/typedarray/Float32Array,f32>~anonymous|0~nonClosure (param $0 f32) (param $1 f32) (param $2 i32) (param $3 i32) (result f32)
   local.get $0
   local.get $1
   f32.add
  )
- (func $std/typedarray/testReduce<~lib/typedarray/Float64Array,f64>~anonymous|0 (param $0 f64) (param $1 f64) (param $2 i32) (param $3 i32) (result f64)
+ (func $std/typedarray/testReduce<~lib/typedarray/Float64Array,f64>~anonymous|0~nonClosure (param $0 f64) (param $1 f64) (param $2 i32) (param $3 i32) (result f64)
   local.get $0
   local.get $1
   f64.add
@@ -3944,9 +4146,26 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  local.get $1
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  local.tee $2
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  call $~lib/rt/pure/__retain
+  drop
   local.get $0
   i32.load offset=4
-  local.set $4
+  local.set $5
   local.get $0
   i32.load offset=8
   i32.const 1
@@ -3957,20 +4176,46 @@
    i32.const 0
    i32.ge_s
    if
-    local.get $2
-    local.get $4
-    i32.add
-    i32.load8_u
-    local.set $5
-    i32.const 4
-    global.set $~argumentsLength
-    local.get $3
-    local.get $5
-    local.get $2
-    local.get $0
     local.get $1
-    call_indirect (type $i32_i32_i32_i32_=>_i32)
-    local.set $3
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result i32)
+     local.get $2
+     local.get $5
+     i32.add
+     i32.load8_u
+     local.set $3
+     i32.const 4
+     global.set $~argumentsLength
+     local.get $1
+     i32.const 4
+     i32.shl
+     local.tee $6
+     local.get $4
+     local.get $3
+     local.get $2
+     local.get $0
+     local.get $6
+     i32.load
+     call_indirect (type $i32_i32_i32_i32_i32_=>_i32)
+    else
+     local.get $2
+     local.get $5
+     i32.add
+     i32.load8_u
+     local.set $3
+     i32.const 4
+     global.set $~argumentsLength
+     local.get $4
+     local.get $3
+     local.get $2
+     local.get $0
+     local.get $1
+     call_indirect (type $i32_i32_i32_i32_=>_i32)
+    end
+    local.set $4
     local.get $2
     i32.const 1
     i32.sub
@@ -3978,16 +4223,54 @@
     br $for-loop|0
    end
   end
-  local.get $3
+  local.get $1
+  i32.const 4
+  i32.shl
+  local.tee $0
+  i32.const 0
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  call $~lib/rt/pure/__release
+  local.get $0
+  i32.const 0
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  call $~lib/rt/pure/__release
+  local.get $4
  )
  (func $~lib/typedarray/Int32Array#reduceRight<i32> (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  local.get $1
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  local.tee $2
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  call $~lib/rt/pure/__retain
+  drop
   local.get $0
   i32.load offset=4
-  local.set $4
+  local.set $5
   local.get $0
   i32.load offset=8
   i32.const 2
@@ -4000,22 +4283,50 @@
    i32.const 0
    i32.ge_s
    if
-    local.get $4
-    local.get $2
-    i32.const 2
-    i32.shl
-    i32.add
-    i32.load
-    local.set $5
-    i32.const 4
-    global.set $~argumentsLength
-    local.get $3
-    local.get $5
-    local.get $2
-    local.get $0
     local.get $1
-    call_indirect (type $i32_i32_i32_i32_=>_i32)
-    local.set $3
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result i32)
+     local.get $5
+     local.get $2
+     i32.const 2
+     i32.shl
+     i32.add
+     i32.load
+     local.set $3
+     i32.const 4
+     global.set $~argumentsLength
+     local.get $1
+     i32.const 4
+     i32.shl
+     local.tee $6
+     local.get $4
+     local.get $3
+     local.get $2
+     local.get $0
+     local.get $6
+     i32.load
+     call_indirect (type $i32_i32_i32_i32_i32_=>_i32)
+    else
+     local.get $5
+     local.get $2
+     i32.const 2
+     i32.shl
+     i32.add
+     i32.load
+     local.set $3
+     i32.const 4
+     global.set $~argumentsLength
+     local.get $4
+     local.get $3
+     local.get $2
+     local.get $0
+     local.get $1
+     call_indirect (type $i32_i32_i32_i32_=>_i32)
+    end
+    local.set $4
     local.get $2
     i32.const 1
     i32.sub
@@ -4023,16 +4334,54 @@
     br $for-loop|0
    end
   end
-  local.get $3
+  local.get $1
+  i32.const 4
+  i32.shl
+  local.tee $0
+  i32.const 0
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  call $~lib/rt/pure/__release
+  local.get $0
+  i32.const 0
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  call $~lib/rt/pure/__release
+  local.get $4
  )
  (func $~lib/typedarray/Int64Array#reduceRight<i64> (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local $3 i64)
-  (local $4 i32)
-  (local $5 i64)
+  (local $4 i64)
+  (local $5 i32)
+  (local $6 i32)
+  local.get $1
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  local.tee $2
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  call $~lib/rt/pure/__retain
+  drop
   local.get $0
   i32.load offset=4
-  local.set $4
+  local.set $5
   local.get $0
   i32.load offset=8
   i32.const 3
@@ -4045,22 +4394,50 @@
    i32.const 0
    i32.ge_s
    if
-    local.get $4
-    local.get $2
-    i32.const 3
-    i32.shl
-    i32.add
-    i64.load
-    local.set $5
-    i32.const 4
-    global.set $~argumentsLength
-    local.get $3
-    local.get $5
-    local.get $2
-    local.get $0
     local.get $1
-    call_indirect (type $i64_i64_i32_i32_=>_i64)
-    local.set $3
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result i64)
+     local.get $5
+     local.get $2
+     i32.const 3
+     i32.shl
+     i32.add
+     i64.load
+     local.set $3
+     i32.const 4
+     global.set $~argumentsLength
+     local.get $1
+     i32.const 4
+     i32.shl
+     local.tee $6
+     local.get $4
+     local.get $3
+     local.get $2
+     local.get $0
+     local.get $6
+     i32.load
+     call_indirect (type $i32_i64_i64_i32_i32_=>_i64)
+    else
+     local.get $5
+     local.get $2
+     i32.const 3
+     i32.shl
+     i32.add
+     i64.load
+     local.set $3
+     i32.const 4
+     global.set $~argumentsLength
+     local.get $4
+     local.get $3
+     local.get $2
+     local.get $0
+     local.get $1
+     call_indirect (type $i64_i64_i32_i32_=>_i64)
+    end
+    local.set $4
     local.get $2
     i32.const 1
     i32.sub
@@ -4068,9 +4445,30 @@
     br $for-loop|0
    end
   end
-  local.get $3
+  local.get $1
+  i32.const 4
+  i32.shl
+  local.tee $0
+  i32.const 0
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  call $~lib/rt/pure/__release
+  local.get $0
+  i32.const 0
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  call $~lib/rt/pure/__release
+  local.get $4
  )
- (func $std/typedarray/testArrayMap<~lib/typedarray/Int8Array,i8>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Int8Array,i8>~anonymous|0~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   local.get $0
   i32.mul
@@ -4163,7 +4561,7 @@
   i32.add
   i32.load
  )
- (func $std/typedarray/testArrayMap<~lib/typedarray/Int64Array,i64>~anonymous|0 (param $0 i64) (param $1 i32) (param $2 i32) (result i64)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Int64Array,i64>~anonymous|0~nonClosure (param $0 i64) (param $1 i32) (param $2 i32) (result i64)
   local.get $0
   local.get $0
   i64.mul
@@ -4214,7 +4612,7 @@
   i32.add
   i64.load
  )
- (func $std/typedarray/testArrayMap<~lib/typedarray/Float32Array,f32>~anonymous|0 (param $0 f32) (param $1 i32) (param $2 i32) (result f32)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Float32Array,f32>~anonymous|0~nonClosure (param $0 f32) (param $1 i32) (param $2 i32) (result f32)
   local.get $0
   local.get $0
   f32.mul
@@ -4242,12 +4640,12 @@
   i32.add
   f32.load
  )
- (func $std/typedarray/testArrayMap<~lib/typedarray/Float64Array,f64>~anonymous|0 (param $0 f64) (param $1 i32) (param $2 i32) (result f64)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Float64Array,f64>~anonymous|0~nonClosure (param $0 f64) (param $1 i32) (param $2 i32) (result f64)
   local.get $0
   local.get $0
   f64.mul
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Int8Array,i8>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Int8Array,i8>~anonymous|0~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 24
   i32.shl
@@ -4428,7 +4826,7 @@
     local.get $7
     local.get $3
     local.get $1
-    call $std/typedarray/testArrayFilter<~lib/typedarray/Int8Array,i8>~anonymous|0
+    call $std/typedarray/testArrayFilter<~lib/typedarray/Int8Array,i8>~anonymous|0~nonClosure
     if
      local.get $2
      local.get $6
@@ -4528,7 +4926,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint8Array,u8>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint8Array,u8>~anonymous|0~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 255
   i32.and
@@ -4595,7 +4993,7 @@
     local.get $7
     local.get $3
     local.get $1
-    call $std/typedarray/testArrayFilter<~lib/typedarray/Uint8Array,u8>~anonymous|0
+    call $std/typedarray/testArrayFilter<~lib/typedarray/Uint8Array,u8>~anonymous|0~nonClosure
     if
      local.get $2
      local.get $6
@@ -4755,7 +5153,7 @@
     local.get $7
     local.get $3
     local.get $1
-    call $std/typedarray/testArrayFilter<~lib/typedarray/Uint8Array,u8>~anonymous|0
+    call $std/typedarray/testArrayFilter<~lib/typedarray/Uint8Array,u8>~anonymous|0~nonClosure
     if
      local.get $2
      local.get $6
@@ -4855,7 +5253,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Int16Array,i16>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Int16Array,i16>~anonymous|0~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 16
   i32.shl
@@ -4907,7 +5305,7 @@
     local.get $6
     local.get $3
     local.get $0
-    call $std/typedarray/testArrayFilter<~lib/typedarray/Int16Array,i16>~anonymous|0
+    call $std/typedarray/testArrayFilter<~lib/typedarray/Int16Array,i16>~anonymous|0~nonClosure
     if
      local.get $5
      local.get $4
@@ -4946,6 +5344,7 @@
   i32.store offset=4
   local.get $2
   call $~lib/rt/pure/__retain
+  local.tee $0
  )
  (func $std/typedarray/testArrayFilter<~lib/typedarray/Int16Array,i16>
   (local $0 i32)
@@ -5042,7 +5441,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint16Array,u16>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint16Array,u16>~anonymous|0~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 65535
   i32.and
@@ -5092,7 +5491,7 @@
     local.get $6
     local.get $3
     local.get $0
-    call $std/typedarray/testArrayFilter<~lib/typedarray/Uint16Array,u16>~anonymous|0
+    call $std/typedarray/testArrayFilter<~lib/typedarray/Uint16Array,u16>~anonymous|0~nonClosure
     if
      local.get $5
      local.get $4
@@ -5131,6 +5530,7 @@
   i32.store offset=4
   local.get $2
   call $~lib/rt/pure/__retain
+  local.tee $0
  )
  (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint16Array,u16>
   (local $0 i32)
@@ -5227,7 +5627,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Int32Array,i32>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Int32Array,i32>~anonymous|0~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 2
   i32.gt_s
@@ -5312,6 +5712,7 @@
   i32.store offset=4
   local.get $2
   call $~lib/rt/pure/__retain
+  local.tee $0
  )
  (func $std/typedarray/testArrayFilter<~lib/typedarray/Int32Array,i32>
   (local $0 i32)
@@ -5408,7 +5809,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint32Array,u32>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint32Array,u32>~anonymous|0~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 2
   i32.gt_u
@@ -5493,6 +5894,7 @@
   i32.store offset=4
   local.get $2
   call $~lib/rt/pure/__retain
+  local.tee $0
  )
  (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint32Array,u32>
   (local $0 i32)
@@ -5589,7 +5991,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Int64Array,i64>~anonymous|0 (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Int64Array,i64>~anonymous|0~nonClosure (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i64.const 2
   i64.gt_s
@@ -5674,6 +6076,7 @@
   i32.store offset=4
   local.get $2
   call $~lib/rt/pure/__retain
+  local.tee $0
  )
  (func $std/typedarray/testArrayFilter<~lib/typedarray/Int64Array,i64>
   (local $0 i32)
@@ -5770,7 +6173,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint64Array,u64>~anonymous|0 (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint64Array,u64>~anonymous|0~nonClosure (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i64.const 2
   i64.gt_u
@@ -5855,6 +6258,7 @@
   i32.store offset=4
   local.get $2
   call $~lib/rt/pure/__retain
+  local.tee $0
  )
  (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint64Array,u64>
   (local $0 i32)
@@ -5951,7 +6355,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Float32Array,f32>~anonymous|0 (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Float32Array,f32>~anonymous|0~nonClosure (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   f32.const 2
   f32.gt
@@ -6036,6 +6440,7 @@
   i32.store offset=4
   local.get $2
   call $~lib/rt/pure/__retain
+  local.tee $0
  )
  (func $std/typedarray/testArrayFilter<~lib/typedarray/Float32Array,f32>
   (local $0 i32)
@@ -6132,7 +6537,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Float64Array,f64>~anonymous|0 (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Float64Array,f64>~anonymous|0~nonClosure (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   f64.const 2
   f64.gt
@@ -6217,6 +6622,7 @@
   i32.store offset=4
   local.get $2
   call $~lib/rt/pure/__retain
+  local.tee $0
  )
  (func $std/typedarray/testArrayFilter<~lib/typedarray/Float64Array,f64>
   (local $0 i32)
@@ -6313,7 +6719,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Int8Array,i8>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Int8Array,i8>~anonymous|0~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 255
   i32.and
@@ -6326,44 +6732,123 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  local.get $1
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  local.tee $4
+  call $~lib/rt/pure/__retain
+  drop
   local.get $0
+  local.set $2
+  local.get $1
+  local.set $0
+  local.get $4
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
   i32.load offset=4
-  local.set $3
-  local.get $0
-  i32.load offset=8
   local.set $4
-  loop $for-loop|0
-   local.get $2
-   local.get $4
-   i32.lt_s
-   if
-    block $~lib/typedarray/SOME<~lib/typedarray/Int8Array,i8>|inlined.0
-     local.get $2
-     local.get $3
-     i32.add
-     i32.load8_s
-     i32.const 3
-     global.set $~argumentsLength
-     local.get $2
+  local.get $2
+  i32.load offset=8
+  local.set $5
+  block $~lib/typedarray/SOME<~lib/typedarray/Int8Array,i8>|inlined.0
+   loop $for-loop|0
+    local.get $3
+    local.get $5
+    i32.lt_s
+    if
      local.get $0
-     local.get $1
-     call_indirect (type $i32_i32_i32_=>_i32)
+     i32.const -2147483648
+     i32.and
+     i32.const -2147483648
+     i32.eq
+     if (result i32)
+      local.get $3
+      local.get $4
+      i32.add
+      i32.load8_s
+      local.set $1
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $0
+      i32.const 4
+      i32.shl
+      local.tee $6
+      local.get $1
+      local.get $3
+      local.get $2
+      local.get $6
+      i32.load
+      call_indirect (type $i32_i32_i32_i32_=>_i32)
+     else
+      local.get $3
+      local.get $4
+      i32.add
+      i32.load8_s
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $3
+      local.get $2
+      local.get $0
+      call_indirect (type $i32_i32_i32_=>_i32)
+     end
      if
+      local.get $0
+      i32.const 4
+      i32.shl
+      i32.const 0
+      local.get $0
+      i32.const -2147483648
+      i32.and
+      i32.const -2147483648
+      i32.eq
+      select
+      call $~lib/rt/pure/__release
       i32.const 1
-      local.set $6
+      local.set $7
       br $~lib/typedarray/SOME<~lib/typedarray/Int8Array,i8>|inlined.0
      end
-     local.get $2
+     local.get $3
      i32.const 1
      i32.add
-     local.set $2
+     local.set $3
      br $for-loop|0
     end
    end
+   local.get $0
+   i32.const 4
+   i32.shl
+   i32.const 0
+   local.get $0
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   select
+   call $~lib/rt/pure/__release
   end
-  local.get $6
+  local.get $0
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $0
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  call $~lib/rt/pure/__release
+  local.get $7
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Int8Array,i8>~anonymous|1 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Int8Array,i8>~anonymous|1~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 255
   i32.and
@@ -6375,44 +6860,123 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  local.get $1
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  local.tee $4
+  call $~lib/rt/pure/__retain
+  drop
   local.get $0
+  local.set $2
+  local.get $1
+  local.set $0
+  local.get $4
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
   i32.load offset=4
-  local.set $3
-  local.get $0
-  i32.load offset=8
   local.set $4
-  loop $for-loop|0
-   local.get $2
-   local.get $4
-   i32.lt_s
-   if
-    block $~lib/typedarray/SOME<~lib/typedarray/Uint8Array,u8>|inlined.0
-     local.get $2
-     local.get $3
-     i32.add
-     i32.load8_u
-     i32.const 3
-     global.set $~argumentsLength
-     local.get $2
+  local.get $2
+  i32.load offset=8
+  local.set $5
+  block $~lib/typedarray/SOME<~lib/typedarray/Uint8Array,u8>|inlined.0
+   loop $for-loop|0
+    local.get $3
+    local.get $5
+    i32.lt_s
+    if
      local.get $0
-     local.get $1
-     call_indirect (type $i32_i32_i32_=>_i32)
+     i32.const -2147483648
+     i32.and
+     i32.const -2147483648
+     i32.eq
+     if (result i32)
+      local.get $3
+      local.get $4
+      i32.add
+      i32.load8_u
+      local.set $1
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $0
+      i32.const 4
+      i32.shl
+      local.tee $6
+      local.get $1
+      local.get $3
+      local.get $2
+      local.get $6
+      i32.load
+      call_indirect (type $i32_i32_i32_i32_=>_i32)
+     else
+      local.get $3
+      local.get $4
+      i32.add
+      i32.load8_u
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $3
+      local.get $2
+      local.get $0
+      call_indirect (type $i32_i32_i32_=>_i32)
+     end
      if
+      local.get $0
+      i32.const 4
+      i32.shl
+      i32.const 0
+      local.get $0
+      i32.const -2147483648
+      i32.and
+      i32.const -2147483648
+      i32.eq
+      select
+      call $~lib/rt/pure/__release
       i32.const 1
-      local.set $6
+      local.set $7
       br $~lib/typedarray/SOME<~lib/typedarray/Uint8Array,u8>|inlined.0
      end
-     local.get $2
+     local.get $3
      i32.const 1
      i32.add
-     local.set $2
+     local.set $3
      br $for-loop|0
     end
    end
+   local.get $0
+   i32.const 4
+   i32.shl
+   i32.const 0
+   local.get $0
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   select
+   call $~lib/rt/pure/__release
   end
-  local.get $6
+  local.get $0
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $0
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  call $~lib/rt/pure/__release
+  local.get $7
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Int16Array,i16>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Int16Array,i16>~anonymous|0~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 65535
   i32.and
@@ -6425,48 +6989,129 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  local.get $1
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  local.tee $4
+  call $~lib/rt/pure/__retain
+  drop
   local.get $0
+  local.set $2
+  local.get $1
+  local.set $0
+  local.get $4
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
   i32.load offset=4
-  local.set $3
-  local.get $0
+  local.set $4
+  local.get $2
   i32.load offset=8
   i32.const 1
   i32.shr_u
-  local.set $4
-  loop $for-loop|0
-   local.get $2
-   local.get $4
-   i32.lt_s
-   if
-    block $~lib/typedarray/SOME<~lib/typedarray/Int16Array,i16>|inlined.0
-     local.get $3
-     local.get $2
-     i32.const 1
-     i32.shl
-     i32.add
-     i32.load16_s
-     i32.const 3
-     global.set $~argumentsLength
-     local.get $2
+  local.set $5
+  block $~lib/typedarray/SOME<~lib/typedarray/Int16Array,i16>|inlined.0
+   loop $for-loop|0
+    local.get $3
+    local.get $5
+    i32.lt_s
+    if
      local.get $0
-     local.get $1
-     call_indirect (type $i32_i32_i32_=>_i32)
-     if
+     i32.const -2147483648
+     i32.and
+     i32.const -2147483648
+     i32.eq
+     if (result i32)
+      local.get $4
+      local.get $3
       i32.const 1
-      local.set $6
+      i32.shl
+      i32.add
+      i32.load16_s
+      local.set $1
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $0
+      i32.const 4
+      i32.shl
+      local.tee $6
+      local.get $1
+      local.get $3
+      local.get $2
+      local.get $6
+      i32.load
+      call_indirect (type $i32_i32_i32_i32_=>_i32)
+     else
+      local.get $4
+      local.get $3
+      i32.const 1
+      i32.shl
+      i32.add
+      i32.load16_s
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $3
+      local.get $2
+      local.get $0
+      call_indirect (type $i32_i32_i32_=>_i32)
+     end
+     if
+      local.get $0
+      i32.const 4
+      i32.shl
+      i32.const 0
+      local.get $0
+      i32.const -2147483648
+      i32.and
+      i32.const -2147483648
+      i32.eq
+      select
+      call $~lib/rt/pure/__release
+      i32.const 1
+      local.set $7
       br $~lib/typedarray/SOME<~lib/typedarray/Int16Array,i16>|inlined.0
      end
-     local.get $2
+     local.get $3
      i32.const 1
      i32.add
-     local.set $2
+     local.set $3
      br $for-loop|0
     end
    end
+   local.get $0
+   i32.const 4
+   i32.shl
+   i32.const 0
+   local.get $0
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   select
+   call $~lib/rt/pure/__release
   end
-  local.get $6
+  local.get $0
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $0
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  call $~lib/rt/pure/__release
+  local.get $7
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Int16Array,i16>~anonymous|1 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Int16Array,i16>~anonymous|1~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 65535
   i32.and
@@ -6478,48 +7123,129 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  local.get $1
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  local.tee $4
+  call $~lib/rt/pure/__retain
+  drop
   local.get $0
+  local.set $2
+  local.get $1
+  local.set $0
+  local.get $4
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
   i32.load offset=4
-  local.set $3
-  local.get $0
+  local.set $4
+  local.get $2
   i32.load offset=8
   i32.const 1
   i32.shr_u
-  local.set $4
-  loop $for-loop|0
-   local.get $2
-   local.get $4
-   i32.lt_s
-   if
-    block $~lib/typedarray/SOME<~lib/typedarray/Uint16Array,u16>|inlined.0
-     local.get $3
-     local.get $2
-     i32.const 1
-     i32.shl
-     i32.add
-     i32.load16_u
-     i32.const 3
-     global.set $~argumentsLength
-     local.get $2
+  local.set $5
+  block $~lib/typedarray/SOME<~lib/typedarray/Uint16Array,u16>|inlined.0
+   loop $for-loop|0
+    local.get $3
+    local.get $5
+    i32.lt_s
+    if
      local.get $0
-     local.get $1
-     call_indirect (type $i32_i32_i32_=>_i32)
-     if
+     i32.const -2147483648
+     i32.and
+     i32.const -2147483648
+     i32.eq
+     if (result i32)
+      local.get $4
+      local.get $3
       i32.const 1
-      local.set $6
+      i32.shl
+      i32.add
+      i32.load16_u
+      local.set $1
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $0
+      i32.const 4
+      i32.shl
+      local.tee $6
+      local.get $1
+      local.get $3
+      local.get $2
+      local.get $6
+      i32.load
+      call_indirect (type $i32_i32_i32_i32_=>_i32)
+     else
+      local.get $4
+      local.get $3
+      i32.const 1
+      i32.shl
+      i32.add
+      i32.load16_u
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $3
+      local.get $2
+      local.get $0
+      call_indirect (type $i32_i32_i32_=>_i32)
+     end
+     if
+      local.get $0
+      i32.const 4
+      i32.shl
+      i32.const 0
+      local.get $0
+      i32.const -2147483648
+      i32.and
+      i32.const -2147483648
+      i32.eq
+      select
+      call $~lib/rt/pure/__release
+      i32.const 1
+      local.set $7
       br $~lib/typedarray/SOME<~lib/typedarray/Uint16Array,u16>|inlined.0
      end
-     local.get $2
+     local.get $3
      i32.const 1
      i32.add
-     local.set $2
+     local.set $3
      br $for-loop|0
     end
    end
+   local.get $0
+   i32.const 4
+   i32.shl
+   i32.const 0
+   local.get $0
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   select
+   call $~lib/rt/pure/__release
   end
-  local.get $6
+  local.get $0
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $0
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  call $~lib/rt/pure/__release
+  local.get $7
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Int32Array,i32>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Int32Array,i32>~anonymous|0~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 2
   i32.eq
@@ -6530,52 +7256,133 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  local.get $1
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  local.tee $4
+  call $~lib/rt/pure/__retain
+  drop
   local.get $0
+  local.set $2
+  local.get $1
+  local.set $0
+  local.get $4
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
   i32.load offset=4
-  local.set $3
-  local.get $0
+  local.set $4
+  local.get $2
   i32.load offset=8
   i32.const 2
   i32.shr_u
-  local.set $4
-  loop $for-loop|0
-   local.get $2
-   local.get $4
-   i32.lt_s
-   if
-    block $~lib/typedarray/SOME<~lib/typedarray/Int32Array,i32>|inlined.0
-     local.get $3
-     local.get $2
-     i32.const 2
-     i32.shl
-     i32.add
-     i32.load
-     i32.const 3
-     global.set $~argumentsLength
-     local.get $2
+  local.set $5
+  block $~lib/typedarray/SOME<~lib/typedarray/Int32Array,i32>|inlined.0
+   loop $for-loop|0
+    local.get $3
+    local.get $5
+    i32.lt_s
+    if
      local.get $0
-     local.get $1
-     call_indirect (type $i32_i32_i32_=>_i32)
+     i32.const -2147483648
+     i32.and
+     i32.const -2147483648
+     i32.eq
+     if (result i32)
+      local.get $4
+      local.get $3
+      i32.const 2
+      i32.shl
+      i32.add
+      i32.load
+      local.set $1
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $0
+      i32.const 4
+      i32.shl
+      local.tee $6
+      local.get $1
+      local.get $3
+      local.get $2
+      local.get $6
+      i32.load
+      call_indirect (type $i32_i32_i32_i32_=>_i32)
+     else
+      local.get $4
+      local.get $3
+      i32.const 2
+      i32.shl
+      i32.add
+      i32.load
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $3
+      local.get $2
+      local.get $0
+      call_indirect (type $i32_i32_i32_=>_i32)
+     end
      if
+      local.get $0
+      i32.const 4
+      i32.shl
+      i32.const 0
+      local.get $0
+      i32.const -2147483648
+      i32.and
+      i32.const -2147483648
+      i32.eq
+      select
+      call $~lib/rt/pure/__release
       i32.const 1
-      local.set $6
+      local.set $7
       br $~lib/typedarray/SOME<~lib/typedarray/Int32Array,i32>|inlined.0
      end
-     local.get $2
+     local.get $3
      i32.const 1
      i32.add
-     local.set $2
+     local.set $3
      br $for-loop|0
     end
    end
+   local.get $0
+   i32.const 4
+   i32.shl
+   i32.const 0
+   local.get $0
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   select
+   call $~lib/rt/pure/__release
   end
-  local.get $6
+  local.get $0
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $0
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  call $~lib/rt/pure/__release
+  local.get $7
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Int32Array,i32>~anonymous|1 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Int32Array,i32>~anonymous|1~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.eqz
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Int64Array,i64>~anonymous|0 (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Int64Array,i64>~anonymous|0~nonClosure (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i64.const 2
   i64.eq
@@ -6586,52 +7393,133 @@
   (local $4 i32)
   (local $5 i64)
   (local $6 i32)
+  (local $7 i32)
+  local.get $1
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  local.tee $4
+  call $~lib/rt/pure/__retain
+  drop
   local.get $0
+  local.set $2
+  local.get $1
+  local.set $0
+  local.get $4
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
   i32.load offset=4
-  local.set $3
-  local.get $0
+  local.set $4
+  local.get $2
   i32.load offset=8
   i32.const 3
   i32.shr_u
-  local.set $4
-  loop $for-loop|0
-   local.get $2
-   local.get $4
-   i32.lt_s
-   if
-    block $~lib/typedarray/SOME<~lib/typedarray/Int64Array,i64>|inlined.0
-     local.get $3
-     local.get $2
-     i32.const 3
-     i32.shl
-     i32.add
-     i64.load
-     i32.const 3
-     global.set $~argumentsLength
-     local.get $2
+  local.set $1
+  block $~lib/typedarray/SOME<~lib/typedarray/Int64Array,i64>|inlined.0
+   loop $for-loop|0
+    local.get $3
+    local.get $1
+    i32.lt_s
+    if
      local.get $0
-     local.get $1
-     call_indirect (type $i64_i32_i32_=>_i32)
+     i32.const -2147483648
+     i32.and
+     i32.const -2147483648
+     i32.eq
+     if (result i32)
+      local.get $4
+      local.get $3
+      i32.const 3
+      i32.shl
+      i32.add
+      i64.load
+      local.set $5
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $0
+      i32.const 4
+      i32.shl
+      local.tee $6
+      local.get $5
+      local.get $3
+      local.get $2
+      local.get $6
+      i32.load
+      call_indirect (type $i32_i64_i32_i32_=>_i32)
+     else
+      local.get $4
+      local.get $3
+      i32.const 3
+      i32.shl
+      i32.add
+      i64.load
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $3
+      local.get $2
+      local.get $0
+      call_indirect (type $i64_i32_i32_=>_i32)
+     end
      if
+      local.get $0
+      i32.const 4
+      i32.shl
+      i32.const 0
+      local.get $0
+      i32.const -2147483648
+      i32.and
+      i32.const -2147483648
+      i32.eq
+      select
+      call $~lib/rt/pure/__release
       i32.const 1
-      local.set $6
+      local.set $7
       br $~lib/typedarray/SOME<~lib/typedarray/Int64Array,i64>|inlined.0
      end
-     local.get $2
+     local.get $3
      i32.const 1
      i32.add
-     local.set $2
+     local.set $3
      br $for-loop|0
     end
    end
+   local.get $0
+   i32.const 4
+   i32.shl
+   i32.const 0
+   local.get $0
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   select
+   call $~lib/rt/pure/__release
   end
-  local.get $6
+  local.get $0
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $0
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  call $~lib/rt/pure/__release
+  local.get $7
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Int64Array,i64>~anonymous|1 (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Int64Array,i64>~anonymous|1~nonClosure (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i64.eqz
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Float32Array,f32>~anonymous|0 (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Float32Array,f32>~anonymous|0~nonClosure (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   f32.const 2
   f32.eq
@@ -6642,53 +7530,134 @@
   (local $4 i32)
   (local $5 f32)
   (local $6 i32)
+  (local $7 i32)
+  local.get $1
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  local.tee $4
+  call $~lib/rt/pure/__retain
+  drop
   local.get $0
+  local.set $2
+  local.get $1
+  local.set $0
+  local.get $4
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
   i32.load offset=4
-  local.set $3
-  local.get $0
+  local.set $4
+  local.get $2
   i32.load offset=8
   i32.const 2
   i32.shr_u
-  local.set $4
-  loop $for-loop|0
-   local.get $2
-   local.get $4
-   i32.lt_s
-   if
-    block $~lib/typedarray/SOME<~lib/typedarray/Float32Array,f32>|inlined.0
-     local.get $3
-     local.get $2
-     i32.const 2
-     i32.shl
-     i32.add
-     f32.load
-     i32.const 3
-     global.set $~argumentsLength
-     local.get $2
+  local.set $1
+  block $~lib/typedarray/SOME<~lib/typedarray/Float32Array,f32>|inlined.0
+   loop $for-loop|0
+    local.get $3
+    local.get $1
+    i32.lt_s
+    if
      local.get $0
-     local.get $1
-     call_indirect (type $f32_i32_i32_=>_i32)
+     i32.const -2147483648
+     i32.and
+     i32.const -2147483648
+     i32.eq
+     if (result i32)
+      local.get $4
+      local.get $3
+      i32.const 2
+      i32.shl
+      i32.add
+      f32.load
+      local.set $5
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $0
+      i32.const 4
+      i32.shl
+      local.tee $6
+      local.get $5
+      local.get $3
+      local.get $2
+      local.get $6
+      i32.load
+      call_indirect (type $i32_f32_i32_i32_=>_i32)
+     else
+      local.get $4
+      local.get $3
+      i32.const 2
+      i32.shl
+      i32.add
+      f32.load
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $3
+      local.get $2
+      local.get $0
+      call_indirect (type $f32_i32_i32_=>_i32)
+     end
      if
+      local.get $0
+      i32.const 4
+      i32.shl
+      i32.const 0
+      local.get $0
+      i32.const -2147483648
+      i32.and
+      i32.const -2147483648
+      i32.eq
+      select
+      call $~lib/rt/pure/__release
       i32.const 1
-      local.set $6
+      local.set $7
       br $~lib/typedarray/SOME<~lib/typedarray/Float32Array,f32>|inlined.0
      end
-     local.get $2
+     local.get $3
      i32.const 1
      i32.add
-     local.set $2
+     local.set $3
      br $for-loop|0
     end
    end
+   local.get $0
+   i32.const 4
+   i32.shl
+   i32.const 0
+   local.get $0
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   select
+   call $~lib/rt/pure/__release
   end
-  local.get $6
+  local.get $0
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $0
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  call $~lib/rt/pure/__release
+  local.get $7
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Float32Array,f32>~anonymous|1 (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Float32Array,f32>~anonymous|1~nonClosure (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   f32.const 0
   f32.eq
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Float64Array,f64>~anonymous|0 (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Float64Array,f64>~anonymous|0~nonClosure (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   f64.const 2
   f64.eq
@@ -6699,48 +7668,129 @@
   (local $4 i32)
   (local $5 f64)
   (local $6 i32)
+  (local $7 i32)
+  local.get $1
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  local.tee $4
+  call $~lib/rt/pure/__retain
+  drop
   local.get $0
+  local.set $2
+  local.get $1
+  local.set $0
+  local.get $4
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
   i32.load offset=4
-  local.set $3
-  local.get $0
+  local.set $4
+  local.get $2
   i32.load offset=8
   i32.const 3
   i32.shr_u
-  local.set $4
-  loop $for-loop|0
-   local.get $2
-   local.get $4
-   i32.lt_s
-   if
-    block $~lib/typedarray/SOME<~lib/typedarray/Float64Array,f64>|inlined.0
-     local.get $3
-     local.get $2
-     i32.const 3
-     i32.shl
-     i32.add
-     f64.load
-     i32.const 3
-     global.set $~argumentsLength
-     local.get $2
+  local.set $1
+  block $~lib/typedarray/SOME<~lib/typedarray/Float64Array,f64>|inlined.0
+   loop $for-loop|0
+    local.get $3
+    local.get $1
+    i32.lt_s
+    if
      local.get $0
-     local.get $1
-     call_indirect (type $f64_i32_i32_=>_i32)
+     i32.const -2147483648
+     i32.and
+     i32.const -2147483648
+     i32.eq
+     if (result i32)
+      local.get $4
+      local.get $3
+      i32.const 3
+      i32.shl
+      i32.add
+      f64.load
+      local.set $5
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $0
+      i32.const 4
+      i32.shl
+      local.tee $6
+      local.get $5
+      local.get $3
+      local.get $2
+      local.get $6
+      i32.load
+      call_indirect (type $i32_f64_i32_i32_=>_i32)
+     else
+      local.get $4
+      local.get $3
+      i32.const 3
+      i32.shl
+      i32.add
+      f64.load
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $3
+      local.get $2
+      local.get $0
+      call_indirect (type $f64_i32_i32_=>_i32)
+     end
      if
+      local.get $0
+      i32.const 4
+      i32.shl
+      i32.const 0
+      local.get $0
+      i32.const -2147483648
+      i32.and
+      i32.const -2147483648
+      i32.eq
+      select
+      call $~lib/rt/pure/__release
       i32.const 1
-      local.set $6
+      local.set $7
       br $~lib/typedarray/SOME<~lib/typedarray/Float64Array,f64>|inlined.0
      end
-     local.get $2
+     local.get $3
      i32.const 1
      i32.add
-     local.set $2
+     local.set $3
      br $for-loop|0
     end
    end
+   local.get $0
+   i32.const 4
+   i32.shl
+   i32.const 0
+   local.get $0
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   select
+   call $~lib/rt/pure/__release
   end
-  local.get $6
+  local.get $0
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $0
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  call $~lib/rt/pure/__release
+  local.get $7
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Float64Array,f64>~anonymous|1 (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Float64Array,f64>~anonymous|1~nonClosure (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   f64.const 0
   f64.eq
@@ -6750,42 +7800,122 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  local.get $1
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  local.tee $4
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $1
   local.get $0
+  local.set $1
+  local.set $0
+  local.get $4
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $1
   i32.load offset=4
-  local.set $3
-  local.get $0
-  i32.load offset=8
   local.set $4
-  block $~lib/typedarray/FIND_INDEX<~lib/typedarray/Int8Array,i8>|inlined.0
+  local.get $1
+  i32.load offset=8
+  local.set $5
+  block $~lib/typedarray/FIND_INDEX<~lib/typedarray/Int8Array,i8>|inlined.0 (result i32)
    loop $for-loop|0
-    local.get $2
-    local.get $4
+    local.get $3
+    local.get $5
     i32.lt_s
     if
-     local.get $2
-     local.get $3
-     i32.add
-     i32.load8_s
-     i32.const 3
-     global.set $~argumentsLength
-     local.get $2
      local.get $0
-     local.get $1
-     call_indirect (type $i32_i32_i32_=>_i32)
-     br_if $~lib/typedarray/FIND_INDEX<~lib/typedarray/Int8Array,i8>|inlined.0
-     local.get $2
+     i32.const -2147483648
+     i32.and
+     i32.const -2147483648
+     i32.eq
+     if (result i32)
+      local.get $3
+      local.get $4
+      i32.add
+      i32.load8_s
+      local.set $2
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $0
+      i32.const 4
+      i32.shl
+      local.tee $6
+      local.get $2
+      local.get $3
+      local.get $1
+      local.get $6
+      i32.load
+      call_indirect (type $i32_i32_i32_i32_=>_i32)
+     else
+      local.get $3
+      local.get $4
+      i32.add
+      i32.load8_s
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $3
+      local.get $1
+      local.get $0
+      call_indirect (type $i32_i32_i32_=>_i32)
+     end
+     if
+      local.get $0
+      i32.const 4
+      i32.shl
+      i32.const 0
+      local.get $0
+      i32.const -2147483648
+      i32.and
+      i32.const -2147483648
+      i32.eq
+      select
+      call $~lib/rt/pure/__release
+      local.get $3
+      br $~lib/typedarray/FIND_INDEX<~lib/typedarray/Int8Array,i8>|inlined.0
+     end
+     local.get $3
      i32.const 1
      i32.add
-     local.set $2
+     local.set $3
      br $for-loop|0
     end
    end
+   local.get $0
+   i32.const 4
+   i32.shl
+   i32.const 0
+   local.get $0
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   select
+   call $~lib/rt/pure/__release
    i32.const -1
-   local.set $2
   end
-  local.get $2
+  local.get $0
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $0
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int8Array,i8>~anonymous|1 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int8Array,i8>~anonymous|1~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 255
   i32.and
@@ -6797,86 +7927,248 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  local.get $1
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  local.tee $4
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $1
   local.get $0
+  local.set $1
+  local.set $0
+  local.get $4
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $1
   i32.load offset=4
-  local.set $3
-  local.get $0
-  i32.load offset=8
   local.set $4
-  block $~lib/typedarray/FIND_INDEX<~lib/typedarray/Uint8Array,u8>|inlined.0
+  local.get $1
+  i32.load offset=8
+  local.set $5
+  block $~lib/typedarray/FIND_INDEX<~lib/typedarray/Uint8Array,u8>|inlined.0 (result i32)
    loop $for-loop|0
-    local.get $2
-    local.get $4
+    local.get $3
+    local.get $5
     i32.lt_s
     if
-     local.get $2
-     local.get $3
-     i32.add
-     i32.load8_u
-     i32.const 3
-     global.set $~argumentsLength
-     local.get $2
      local.get $0
-     local.get $1
-     call_indirect (type $i32_i32_i32_=>_i32)
-     br_if $~lib/typedarray/FIND_INDEX<~lib/typedarray/Uint8Array,u8>|inlined.0
-     local.get $2
+     i32.const -2147483648
+     i32.and
+     i32.const -2147483648
+     i32.eq
+     if (result i32)
+      local.get $3
+      local.get $4
+      i32.add
+      i32.load8_u
+      local.set $2
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $0
+      i32.const 4
+      i32.shl
+      local.tee $6
+      local.get $2
+      local.get $3
+      local.get $1
+      local.get $6
+      i32.load
+      call_indirect (type $i32_i32_i32_i32_=>_i32)
+     else
+      local.get $3
+      local.get $4
+      i32.add
+      i32.load8_u
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $3
+      local.get $1
+      local.get $0
+      call_indirect (type $i32_i32_i32_=>_i32)
+     end
+     if
+      local.get $0
+      i32.const 4
+      i32.shl
+      i32.const 0
+      local.get $0
+      i32.const -2147483648
+      i32.and
+      i32.const -2147483648
+      i32.eq
+      select
+      call $~lib/rt/pure/__release
+      local.get $3
+      br $~lib/typedarray/FIND_INDEX<~lib/typedarray/Uint8Array,u8>|inlined.0
+     end
+     local.get $3
      i32.const 1
      i32.add
-     local.set $2
+     local.set $3
      br $for-loop|0
     end
    end
+   local.get $0
+   i32.const 4
+   i32.shl
+   i32.const 0
+   local.get $0
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   select
+   call $~lib/rt/pure/__release
    i32.const -1
-   local.set $2
   end
-  local.get $2
+  local.get $0
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $0
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  call $~lib/rt/pure/__release
  )
  (func $~lib/typedarray/Int16Array#findIndex (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  local.get $1
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  local.tee $4
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $1
   local.get $0
+  local.set $1
+  local.set $0
+  local.get $4
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $1
   i32.load offset=4
-  local.set $3
-  local.get $0
+  local.set $4
+  local.get $1
   i32.load offset=8
   i32.const 1
   i32.shr_u
-  local.set $4
-  block $~lib/typedarray/FIND_INDEX<~lib/typedarray/Int16Array,i16>|inlined.0
+  local.set $5
+  block $~lib/typedarray/FIND_INDEX<~lib/typedarray/Int16Array,i16>|inlined.0 (result i32)
    loop $for-loop|0
-    local.get $2
-    local.get $4
+    local.get $3
+    local.get $5
     i32.lt_s
     if
-     local.get $3
-     local.get $2
-     i32.const 1
-     i32.shl
-     i32.add
-     i32.load16_s
-     i32.const 3
-     global.set $~argumentsLength
-     local.get $2
      local.get $0
-     local.get $1
-     call_indirect (type $i32_i32_i32_=>_i32)
-     br_if $~lib/typedarray/FIND_INDEX<~lib/typedarray/Int16Array,i16>|inlined.0
-     local.get $2
+     i32.const -2147483648
+     i32.and
+     i32.const -2147483648
+     i32.eq
+     if (result i32)
+      local.get $4
+      local.get $3
+      i32.const 1
+      i32.shl
+      i32.add
+      i32.load16_s
+      local.set $2
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $0
+      i32.const 4
+      i32.shl
+      local.tee $6
+      local.get $2
+      local.get $3
+      local.get $1
+      local.get $6
+      i32.load
+      call_indirect (type $i32_i32_i32_i32_=>_i32)
+     else
+      local.get $4
+      local.get $3
+      i32.const 1
+      i32.shl
+      i32.add
+      i32.load16_s
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $3
+      local.get $1
+      local.get $0
+      call_indirect (type $i32_i32_i32_=>_i32)
+     end
+     if
+      local.get $0
+      i32.const 4
+      i32.shl
+      i32.const 0
+      local.get $0
+      i32.const -2147483648
+      i32.and
+      i32.const -2147483648
+      i32.eq
+      select
+      call $~lib/rt/pure/__release
+      local.get $3
+      br $~lib/typedarray/FIND_INDEX<~lib/typedarray/Int16Array,i16>|inlined.0
+     end
+     local.get $3
      i32.const 1
      i32.add
-     local.set $2
+     local.set $3
      br $for-loop|0
     end
    end
+   local.get $0
+   i32.const 4
+   i32.shl
+   i32.const 0
+   local.get $0
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   select
+   call $~lib/rt/pure/__release
    i32.const -1
-   local.set $2
   end
-  local.get $2
+  local.get $0
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $0
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int16Array,i16>~anonymous|1 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int16Array,i16>~anonymous|1~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 65535
   i32.and
@@ -6888,90 +8180,254 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  local.get $1
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  local.tee $4
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $1
   local.get $0
+  local.set $1
+  local.set $0
+  local.get $4
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $1
   i32.load offset=4
-  local.set $3
-  local.get $0
+  local.set $4
+  local.get $1
   i32.load offset=8
   i32.const 1
   i32.shr_u
-  local.set $4
-  block $~lib/typedarray/FIND_INDEX<~lib/typedarray/Uint16Array,u16>|inlined.0
+  local.set $5
+  block $~lib/typedarray/FIND_INDEX<~lib/typedarray/Uint16Array,u16>|inlined.0 (result i32)
    loop $for-loop|0
-    local.get $2
-    local.get $4
+    local.get $3
+    local.get $5
     i32.lt_s
     if
-     local.get $3
-     local.get $2
-     i32.const 1
-     i32.shl
-     i32.add
-     i32.load16_u
-     i32.const 3
-     global.set $~argumentsLength
-     local.get $2
      local.get $0
-     local.get $1
-     call_indirect (type $i32_i32_i32_=>_i32)
-     br_if $~lib/typedarray/FIND_INDEX<~lib/typedarray/Uint16Array,u16>|inlined.0
-     local.get $2
+     i32.const -2147483648
+     i32.and
+     i32.const -2147483648
+     i32.eq
+     if (result i32)
+      local.get $4
+      local.get $3
+      i32.const 1
+      i32.shl
+      i32.add
+      i32.load16_u
+      local.set $2
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $0
+      i32.const 4
+      i32.shl
+      local.tee $6
+      local.get $2
+      local.get $3
+      local.get $1
+      local.get $6
+      i32.load
+      call_indirect (type $i32_i32_i32_i32_=>_i32)
+     else
+      local.get $4
+      local.get $3
+      i32.const 1
+      i32.shl
+      i32.add
+      i32.load16_u
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $3
+      local.get $1
+      local.get $0
+      call_indirect (type $i32_i32_i32_=>_i32)
+     end
+     if
+      local.get $0
+      i32.const 4
+      i32.shl
+      i32.const 0
+      local.get $0
+      i32.const -2147483648
+      i32.and
+      i32.const -2147483648
+      i32.eq
+      select
+      call $~lib/rt/pure/__release
+      local.get $3
+      br $~lib/typedarray/FIND_INDEX<~lib/typedarray/Uint16Array,u16>|inlined.0
+     end
+     local.get $3
      i32.const 1
      i32.add
-     local.set $2
+     local.set $3
      br $for-loop|0
     end
    end
+   local.get $0
+   i32.const 4
+   i32.shl
+   i32.const 0
+   local.get $0
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   select
+   call $~lib/rt/pure/__release
    i32.const -1
-   local.set $2
   end
-  local.get $2
+  local.get $0
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $0
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  call $~lib/rt/pure/__release
  )
  (func $~lib/typedarray/Int32Array#findIndex (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  local.get $1
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  local.tee $4
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $1
   local.get $0
+  local.set $1
+  local.set $0
+  local.get $4
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $1
   i32.load offset=4
-  local.set $3
-  local.get $0
+  local.set $4
+  local.get $1
   i32.load offset=8
   i32.const 2
   i32.shr_u
-  local.set $4
-  block $~lib/typedarray/FIND_INDEX<~lib/typedarray/Int32Array,i32>|inlined.0
+  local.set $5
+  block $~lib/typedarray/FIND_INDEX<~lib/typedarray/Int32Array,i32>|inlined.0 (result i32)
    loop $for-loop|0
-    local.get $2
-    local.get $4
+    local.get $3
+    local.get $5
     i32.lt_s
     if
-     local.get $3
-     local.get $2
-     i32.const 2
-     i32.shl
-     i32.add
-     i32.load
-     i32.const 3
-     global.set $~argumentsLength
-     local.get $2
      local.get $0
-     local.get $1
-     call_indirect (type $i32_i32_i32_=>_i32)
-     br_if $~lib/typedarray/FIND_INDEX<~lib/typedarray/Int32Array,i32>|inlined.0
-     local.get $2
+     i32.const -2147483648
+     i32.and
+     i32.const -2147483648
+     i32.eq
+     if (result i32)
+      local.get $4
+      local.get $3
+      i32.const 2
+      i32.shl
+      i32.add
+      i32.load
+      local.set $2
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $0
+      i32.const 4
+      i32.shl
+      local.tee $6
+      local.get $2
+      local.get $3
+      local.get $1
+      local.get $6
+      i32.load
+      call_indirect (type $i32_i32_i32_i32_=>_i32)
+     else
+      local.get $4
+      local.get $3
+      i32.const 2
+      i32.shl
+      i32.add
+      i32.load
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $3
+      local.get $1
+      local.get $0
+      call_indirect (type $i32_i32_i32_=>_i32)
+     end
+     if
+      local.get $0
+      i32.const 4
+      i32.shl
+      i32.const 0
+      local.get $0
+      i32.const -2147483648
+      i32.and
+      i32.const -2147483648
+      i32.eq
+      select
+      call $~lib/rt/pure/__release
+      local.get $3
+      br $~lib/typedarray/FIND_INDEX<~lib/typedarray/Int32Array,i32>|inlined.0
+     end
+     local.get $3
      i32.const 1
      i32.add
-     local.set $2
+     local.set $3
      br $for-loop|0
     end
    end
+   local.get $0
+   i32.const 4
+   i32.shl
+   i32.const 0
+   local.get $0
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   select
+   call $~lib/rt/pure/__release
    i32.const -1
-   local.set $2
   end
-  local.get $2
+  local.get $0
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $0
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int32Array,i32>~anonymous|1 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int32Array,i32>~anonymous|1~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 4
   i32.eq
@@ -6981,46 +8437,128 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i64)
+  (local $6 i32)
+  local.get $1
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  local.tee $4
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $1
   local.get $0
+  local.set $1
+  local.set $0
+  local.get $4
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $1
   i32.load offset=4
-  local.set $3
-  local.get $0
+  local.set $4
+  local.get $1
   i32.load offset=8
   i32.const 3
   i32.shr_u
-  local.set $4
-  block $~lib/typedarray/FIND_INDEX<~lib/typedarray/Int64Array,i64>|inlined.0
+  local.set $2
+  block $~lib/typedarray/FIND_INDEX<~lib/typedarray/Int64Array,i64>|inlined.0 (result i32)
    loop $for-loop|0
+    local.get $3
     local.get $2
-    local.get $4
     i32.lt_s
     if
-     local.get $3
-     local.get $2
-     i32.const 3
-     i32.shl
-     i32.add
-     i64.load
-     i32.const 3
-     global.set $~argumentsLength
-     local.get $2
      local.get $0
-     local.get $1
-     call_indirect (type $i64_i32_i32_=>_i32)
-     br_if $~lib/typedarray/FIND_INDEX<~lib/typedarray/Int64Array,i64>|inlined.0
-     local.get $2
+     i32.const -2147483648
+     i32.and
+     i32.const -2147483648
+     i32.eq
+     if (result i32)
+      local.get $4
+      local.get $3
+      i32.const 3
+      i32.shl
+      i32.add
+      i64.load
+      local.set $5
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $0
+      i32.const 4
+      i32.shl
+      local.tee $6
+      local.get $5
+      local.get $3
+      local.get $1
+      local.get $6
+      i32.load
+      call_indirect (type $i32_i64_i32_i32_=>_i32)
+     else
+      local.get $4
+      local.get $3
+      i32.const 3
+      i32.shl
+      i32.add
+      i64.load
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $3
+      local.get $1
+      local.get $0
+      call_indirect (type $i64_i32_i32_=>_i32)
+     end
+     if
+      local.get $0
+      i32.const 4
+      i32.shl
+      i32.const 0
+      local.get $0
+      i32.const -2147483648
+      i32.and
+      i32.const -2147483648
+      i32.eq
+      select
+      call $~lib/rt/pure/__release
+      local.get $3
+      br $~lib/typedarray/FIND_INDEX<~lib/typedarray/Int64Array,i64>|inlined.0
+     end
+     local.get $3
      i32.const 1
      i32.add
-     local.set $2
+     local.set $3
      br $for-loop|0
     end
    end
+   local.get $0
+   i32.const 4
+   i32.shl
+   i32.const 0
+   local.get $0
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   select
+   call $~lib/rt/pure/__release
    i32.const -1
-   local.set $2
   end
-  local.get $2
+  local.get $0
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $0
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int64Array,i64>~anonymous|1 (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int64Array,i64>~anonymous|1~nonClosure (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i64.const 4
   i64.eq
@@ -7030,46 +8568,128 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 f32)
+  (local $6 i32)
+  local.get $1
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  local.tee $4
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $1
   local.get $0
+  local.set $1
+  local.set $0
+  local.get $4
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $1
   i32.load offset=4
-  local.set $3
-  local.get $0
+  local.set $4
+  local.get $1
   i32.load offset=8
   i32.const 2
   i32.shr_u
-  local.set $4
-  block $~lib/typedarray/FIND_INDEX<~lib/typedarray/Float32Array,f32>|inlined.0
+  local.set $2
+  block $~lib/typedarray/FIND_INDEX<~lib/typedarray/Float32Array,f32>|inlined.0 (result i32)
    loop $for-loop|0
+    local.get $3
     local.get $2
-    local.get $4
     i32.lt_s
     if
-     local.get $3
-     local.get $2
-     i32.const 2
-     i32.shl
-     i32.add
-     f32.load
-     i32.const 3
-     global.set $~argumentsLength
-     local.get $2
      local.get $0
-     local.get $1
-     call_indirect (type $f32_i32_i32_=>_i32)
-     br_if $~lib/typedarray/FIND_INDEX<~lib/typedarray/Float32Array,f32>|inlined.0
-     local.get $2
+     i32.const -2147483648
+     i32.and
+     i32.const -2147483648
+     i32.eq
+     if (result i32)
+      local.get $4
+      local.get $3
+      i32.const 2
+      i32.shl
+      i32.add
+      f32.load
+      local.set $5
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $0
+      i32.const 4
+      i32.shl
+      local.tee $6
+      local.get $5
+      local.get $3
+      local.get $1
+      local.get $6
+      i32.load
+      call_indirect (type $i32_f32_i32_i32_=>_i32)
+     else
+      local.get $4
+      local.get $3
+      i32.const 2
+      i32.shl
+      i32.add
+      f32.load
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $3
+      local.get $1
+      local.get $0
+      call_indirect (type $f32_i32_i32_=>_i32)
+     end
+     if
+      local.get $0
+      i32.const 4
+      i32.shl
+      i32.const 0
+      local.get $0
+      i32.const -2147483648
+      i32.and
+      i32.const -2147483648
+      i32.eq
+      select
+      call $~lib/rt/pure/__release
+      local.get $3
+      br $~lib/typedarray/FIND_INDEX<~lib/typedarray/Float32Array,f32>|inlined.0
+     end
+     local.get $3
      i32.const 1
      i32.add
-     local.set $2
+     local.set $3
      br $for-loop|0
     end
    end
+   local.get $0
+   i32.const 4
+   i32.shl
+   i32.const 0
+   local.get $0
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   select
+   call $~lib/rt/pure/__release
    i32.const -1
-   local.set $2
   end
-  local.get $2
+  local.get $0
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $0
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Float32Array,f32>~anonymous|1 (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Float32Array,f32>~anonymous|1~nonClosure (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   f32.const 4
   f32.eq
@@ -7079,51 +8699,133 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 f64)
+  (local $6 i32)
+  local.get $1
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  local.tee $4
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $1
   local.get $0
+  local.set $1
+  local.set $0
+  local.get $4
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $1
   i32.load offset=4
-  local.set $3
-  local.get $0
+  local.set $4
+  local.get $1
   i32.load offset=8
   i32.const 3
   i32.shr_u
-  local.set $4
-  block $~lib/typedarray/FIND_INDEX<~lib/typedarray/Float64Array,f64>|inlined.0
+  local.set $2
+  block $~lib/typedarray/FIND_INDEX<~lib/typedarray/Float64Array,f64>|inlined.0 (result i32)
    loop $for-loop|0
+    local.get $3
     local.get $2
-    local.get $4
     i32.lt_s
     if
-     local.get $3
-     local.get $2
-     i32.const 3
-     i32.shl
-     i32.add
-     f64.load
-     i32.const 3
-     global.set $~argumentsLength
-     local.get $2
      local.get $0
-     local.get $1
-     call_indirect (type $f64_i32_i32_=>_i32)
-     br_if $~lib/typedarray/FIND_INDEX<~lib/typedarray/Float64Array,f64>|inlined.0
-     local.get $2
+     i32.const -2147483648
+     i32.and
+     i32.const -2147483648
+     i32.eq
+     if (result i32)
+      local.get $4
+      local.get $3
+      i32.const 3
+      i32.shl
+      i32.add
+      f64.load
+      local.set $5
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $0
+      i32.const 4
+      i32.shl
+      local.tee $6
+      local.get $5
+      local.get $3
+      local.get $1
+      local.get $6
+      i32.load
+      call_indirect (type $i32_f64_i32_i32_=>_i32)
+     else
+      local.get $4
+      local.get $3
+      i32.const 3
+      i32.shl
+      i32.add
+      f64.load
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $3
+      local.get $1
+      local.get $0
+      call_indirect (type $f64_i32_i32_=>_i32)
+     end
+     if
+      local.get $0
+      i32.const 4
+      i32.shl
+      i32.const 0
+      local.get $0
+      i32.const -2147483648
+      i32.and
+      i32.const -2147483648
+      i32.eq
+      select
+      call $~lib/rt/pure/__release
+      local.get $3
+      br $~lib/typedarray/FIND_INDEX<~lib/typedarray/Float64Array,f64>|inlined.0
+     end
+     local.get $3
      i32.const 1
      i32.add
-     local.set $2
+     local.set $3
      br $for-loop|0
     end
    end
+   local.get $0
+   i32.const 4
+   i32.shl
+   i32.const 0
+   local.get $0
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   select
+   call $~lib/rt/pure/__release
    i32.const -1
-   local.set $2
   end
-  local.get $2
+  local.get $0
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $0
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Float64Array,f64>~anonymous|1 (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Float64Array,f64>~anonymous|1~nonClosure (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   f64.const 4
   f64.eq
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Int8Array,i8>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Int8Array,i8>~anonymous|0~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 24
   i32.shl
@@ -7139,43 +8841,124 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  local.get $1
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  local.tee $4
+  call $~lib/rt/pure/__retain
+  drop
   local.get $0
+  local.set $2
+  local.get $1
+  local.set $0
+  local.get $4
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
   i32.load offset=4
-  local.set $3
-  local.get $0
-  i32.load offset=8
   local.set $4
+  local.get $2
+  i32.load offset=8
+  local.set $5
   block $~lib/typedarray/EVERY<~lib/typedarray/Int8Array,i8>|inlined.0
    loop $for-loop|0
-    local.get $2
-    local.get $4
+    local.get $3
+    local.get $5
     i32.lt_s
     if
-     local.get $2
-     local.get $3
-     i32.add
-     i32.load8_s
-     i32.const 3
-     global.set $~argumentsLength
-     local.get $2
      local.get $0
-     local.get $1
-     call_indirect (type $i32_i32_i32_=>_i32)
+     i32.const -2147483648
+     i32.and
+     i32.const -2147483648
+     i32.eq
+     if (result i32)
+      local.get $3
+      local.get $4
+      i32.add
+      i32.load8_s
+      local.set $1
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $0
+      i32.const 4
+      i32.shl
+      local.tee $6
+      local.get $1
+      local.get $3
+      local.get $2
+      local.get $6
+      i32.load
+      call_indirect (type $i32_i32_i32_i32_=>_i32)
+     else
+      local.get $3
+      local.get $4
+      i32.add
+      i32.load8_s
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $3
+      local.get $2
+      local.get $0
+      call_indirect (type $i32_i32_i32_=>_i32)
+     end
      i32.eqz
-     br_if $~lib/typedarray/EVERY<~lib/typedarray/Int8Array,i8>|inlined.0
-     local.get $2
+     if
+      local.get $0
+      i32.const 4
+      i32.shl
+      i32.const 0
+      local.get $0
+      i32.const -2147483648
+      i32.and
+      i32.const -2147483648
+      i32.eq
+      select
+      call $~lib/rt/pure/__release
+      br $~lib/typedarray/EVERY<~lib/typedarray/Int8Array,i8>|inlined.0
+     end
+     local.get $3
      i32.const 1
      i32.add
-     local.set $2
+     local.set $3
      br $for-loop|0
     end
    end
+   local.get $0
+   i32.const 4
+   i32.shl
+   i32.const 0
+   local.get $0
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   select
+   call $~lib/rt/pure/__release
    i32.const 1
-   local.set $6
+   local.set $7
   end
-  local.get $6
+  local.get $0
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $0
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  call $~lib/rt/pure/__release
+  local.get $7
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint8Array,u8>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint8Array,u8>~anonymous|0~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 1
   i32.and
@@ -7187,43 +8970,124 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  local.get $1
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  local.tee $4
+  call $~lib/rt/pure/__retain
+  drop
   local.get $0
+  local.set $2
+  local.get $1
+  local.set $0
+  local.get $4
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
   i32.load offset=4
-  local.set $3
-  local.get $0
-  i32.load offset=8
   local.set $4
+  local.get $2
+  i32.load offset=8
+  local.set $5
   block $~lib/typedarray/EVERY<~lib/typedarray/Uint8Array,u8>|inlined.0
    loop $for-loop|0
-    local.get $2
-    local.get $4
+    local.get $3
+    local.get $5
     i32.lt_s
     if
-     local.get $2
-     local.get $3
-     i32.add
-     i32.load8_u
-     i32.const 3
-     global.set $~argumentsLength
-     local.get $2
      local.get $0
-     local.get $1
-     call_indirect (type $i32_i32_i32_=>_i32)
+     i32.const -2147483648
+     i32.and
+     i32.const -2147483648
+     i32.eq
+     if (result i32)
+      local.get $3
+      local.get $4
+      i32.add
+      i32.load8_u
+      local.set $1
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $0
+      i32.const 4
+      i32.shl
+      local.tee $6
+      local.get $1
+      local.get $3
+      local.get $2
+      local.get $6
+      i32.load
+      call_indirect (type $i32_i32_i32_i32_=>_i32)
+     else
+      local.get $3
+      local.get $4
+      i32.add
+      i32.load8_u
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $3
+      local.get $2
+      local.get $0
+      call_indirect (type $i32_i32_i32_=>_i32)
+     end
      i32.eqz
-     br_if $~lib/typedarray/EVERY<~lib/typedarray/Uint8Array,u8>|inlined.0
-     local.get $2
+     if
+      local.get $0
+      i32.const 4
+      i32.shl
+      i32.const 0
+      local.get $0
+      i32.const -2147483648
+      i32.and
+      i32.const -2147483648
+      i32.eq
+      select
+      call $~lib/rt/pure/__release
+      br $~lib/typedarray/EVERY<~lib/typedarray/Uint8Array,u8>|inlined.0
+     end
+     local.get $3
      i32.const 1
      i32.add
-     local.set $2
+     local.set $3
      br $for-loop|0
     end
    end
+   local.get $0
+   i32.const 4
+   i32.shl
+   i32.const 0
+   local.get $0
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   select
+   call $~lib/rt/pure/__release
    i32.const 1
-   local.set $6
+   local.set $7
   end
-  local.get $6
+  local.get $0
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $0
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  call $~lib/rt/pure/__release
+  local.get $7
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Int16Array,i16>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Int16Array,i16>~anonymous|0~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 16
   i32.shl
@@ -7239,45 +9103,128 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  local.get $1
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  local.tee $4
+  call $~lib/rt/pure/__retain
+  drop
   local.get $0
+  local.set $2
+  local.get $1
+  local.set $0
+  local.get $4
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
   i32.load offset=4
-  local.set $3
-  local.get $0
+  local.set $4
+  local.get $2
   i32.load offset=8
   i32.const 1
   i32.shr_u
-  local.set $4
+  local.set $5
   block $~lib/typedarray/EVERY<~lib/typedarray/Int16Array,i16>|inlined.0
    loop $for-loop|0
-    local.get $2
-    local.get $4
+    local.get $3
+    local.get $5
     i32.lt_s
     if
-     local.get $3
-     local.get $2
-     i32.const 1
-     i32.shl
-     i32.add
-     i32.load16_s
-     i32.const 3
-     global.set $~argumentsLength
-     local.get $2
      local.get $0
-     local.get $1
-     call_indirect (type $i32_i32_i32_=>_i32)
+     i32.const -2147483648
+     i32.and
+     i32.const -2147483648
+     i32.eq
+     if (result i32)
+      local.get $4
+      local.get $3
+      i32.const 1
+      i32.shl
+      i32.add
+      i32.load16_s
+      local.set $1
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $0
+      i32.const 4
+      i32.shl
+      local.tee $6
+      local.get $1
+      local.get $3
+      local.get $2
+      local.get $6
+      i32.load
+      call_indirect (type $i32_i32_i32_i32_=>_i32)
+     else
+      local.get $4
+      local.get $3
+      i32.const 1
+      i32.shl
+      i32.add
+      i32.load16_s
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $3
+      local.get $2
+      local.get $0
+      call_indirect (type $i32_i32_i32_=>_i32)
+     end
      i32.eqz
-     br_if $~lib/typedarray/EVERY<~lib/typedarray/Int16Array,i16>|inlined.0
-     local.get $2
+     if
+      local.get $0
+      i32.const 4
+      i32.shl
+      i32.const 0
+      local.get $0
+      i32.const -2147483648
+      i32.and
+      i32.const -2147483648
+      i32.eq
+      select
+      call $~lib/rt/pure/__release
+      br $~lib/typedarray/EVERY<~lib/typedarray/Int16Array,i16>|inlined.0
+     end
+     local.get $3
      i32.const 1
      i32.add
-     local.set $2
+     local.set $3
      br $for-loop|0
     end
    end
+   local.get $0
+   i32.const 4
+   i32.shl
+   i32.const 0
+   local.get $0
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   select
+   call $~lib/rt/pure/__release
    i32.const 1
-   local.set $6
+   local.set $7
   end
-  local.get $6
+  local.get $0
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $0
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  call $~lib/rt/pure/__release
+  local.get $7
  )
  (func $~lib/typedarray/Uint16Array#every (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
@@ -7285,47 +9232,130 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  local.get $1
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  local.tee $4
+  call $~lib/rt/pure/__retain
+  drop
   local.get $0
+  local.set $2
+  local.get $1
+  local.set $0
+  local.get $4
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
   i32.load offset=4
-  local.set $3
-  local.get $0
+  local.set $4
+  local.get $2
   i32.load offset=8
   i32.const 1
   i32.shr_u
-  local.set $4
+  local.set $5
   block $~lib/typedarray/EVERY<~lib/typedarray/Uint16Array,u16>|inlined.0
    loop $for-loop|0
-    local.get $2
-    local.get $4
+    local.get $3
+    local.get $5
     i32.lt_s
     if
-     local.get $3
-     local.get $2
-     i32.const 1
-     i32.shl
-     i32.add
-     i32.load16_u
-     i32.const 3
-     global.set $~argumentsLength
-     local.get $2
      local.get $0
-     local.get $1
-     call_indirect (type $i32_i32_i32_=>_i32)
+     i32.const -2147483648
+     i32.and
+     i32.const -2147483648
+     i32.eq
+     if (result i32)
+      local.get $4
+      local.get $3
+      i32.const 1
+      i32.shl
+      i32.add
+      i32.load16_u
+      local.set $1
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $0
+      i32.const 4
+      i32.shl
+      local.tee $6
+      local.get $1
+      local.get $3
+      local.get $2
+      local.get $6
+      i32.load
+      call_indirect (type $i32_i32_i32_i32_=>_i32)
+     else
+      local.get $4
+      local.get $3
+      i32.const 1
+      i32.shl
+      i32.add
+      i32.load16_u
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $3
+      local.get $2
+      local.get $0
+      call_indirect (type $i32_i32_i32_=>_i32)
+     end
      i32.eqz
-     br_if $~lib/typedarray/EVERY<~lib/typedarray/Uint16Array,u16>|inlined.0
-     local.get $2
+     if
+      local.get $0
+      i32.const 4
+      i32.shl
+      i32.const 0
+      local.get $0
+      i32.const -2147483648
+      i32.and
+      i32.const -2147483648
+      i32.eq
+      select
+      call $~lib/rt/pure/__release
+      br $~lib/typedarray/EVERY<~lib/typedarray/Uint16Array,u16>|inlined.0
+     end
+     local.get $3
      i32.const 1
      i32.add
-     local.set $2
+     local.set $3
      br $for-loop|0
     end
    end
+   local.get $0
+   i32.const 4
+   i32.shl
+   i32.const 0
+   local.get $0
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   select
+   call $~lib/rt/pure/__release
    i32.const 1
-   local.set $6
+   local.set $7
   end
-  local.get $6
+  local.get $0
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $0
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  call $~lib/rt/pure/__release
+  local.get $7
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Int32Array,i32>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Int32Array,i32>~anonymous|0~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 2
   i32.rem_s
@@ -7337,47 +9367,130 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  local.get $1
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  local.tee $4
+  call $~lib/rt/pure/__retain
+  drop
   local.get $0
+  local.set $2
+  local.get $1
+  local.set $0
+  local.get $4
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
   i32.load offset=4
-  local.set $3
-  local.get $0
+  local.set $4
+  local.get $2
   i32.load offset=8
   i32.const 2
   i32.shr_u
-  local.set $4
+  local.set $5
   block $~lib/typedarray/EVERY<~lib/typedarray/Int32Array,i32>|inlined.0
    loop $for-loop|0
-    local.get $2
-    local.get $4
+    local.get $3
+    local.get $5
     i32.lt_s
     if
-     local.get $3
-     local.get $2
-     i32.const 2
-     i32.shl
-     i32.add
-     i32.load
-     i32.const 3
-     global.set $~argumentsLength
-     local.get $2
      local.get $0
-     local.get $1
-     call_indirect (type $i32_i32_i32_=>_i32)
+     i32.const -2147483648
+     i32.and
+     i32.const -2147483648
+     i32.eq
+     if (result i32)
+      local.get $4
+      local.get $3
+      i32.const 2
+      i32.shl
+      i32.add
+      i32.load
+      local.set $1
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $0
+      i32.const 4
+      i32.shl
+      local.tee $6
+      local.get $1
+      local.get $3
+      local.get $2
+      local.get $6
+      i32.load
+      call_indirect (type $i32_i32_i32_i32_=>_i32)
+     else
+      local.get $4
+      local.get $3
+      i32.const 2
+      i32.shl
+      i32.add
+      i32.load
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $3
+      local.get $2
+      local.get $0
+      call_indirect (type $i32_i32_i32_=>_i32)
+     end
      i32.eqz
-     br_if $~lib/typedarray/EVERY<~lib/typedarray/Int32Array,i32>|inlined.0
-     local.get $2
+     if
+      local.get $0
+      i32.const 4
+      i32.shl
+      i32.const 0
+      local.get $0
+      i32.const -2147483648
+      i32.and
+      i32.const -2147483648
+      i32.eq
+      select
+      call $~lib/rt/pure/__release
+      br $~lib/typedarray/EVERY<~lib/typedarray/Int32Array,i32>|inlined.0
+     end
+     local.get $3
      i32.const 1
      i32.add
-     local.set $2
+     local.set $3
      br $for-loop|0
     end
    end
+   local.get $0
+   i32.const 4
+   i32.shl
+   i32.const 0
+   local.get $0
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   select
+   call $~lib/rt/pure/__release
    i32.const 1
-   local.set $6
+   local.set $7
   end
-  local.get $6
+  local.get $0
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $0
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  call $~lib/rt/pure/__release
+  local.get $7
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Int64Array,i64>~anonymous|0 (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Int64Array,i64>~anonymous|0~nonClosure (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i64.const 2
   i64.rem_s
@@ -7389,47 +9502,130 @@
   (local $4 i32)
   (local $5 i64)
   (local $6 i32)
+  (local $7 i32)
+  local.get $1
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  local.tee $4
+  call $~lib/rt/pure/__retain
+  drop
   local.get $0
+  local.set $2
+  local.get $1
+  local.set $0
+  local.get $4
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
   i32.load offset=4
-  local.set $3
-  local.get $0
+  local.set $4
+  local.get $2
   i32.load offset=8
   i32.const 3
   i32.shr_u
-  local.set $4
+  local.set $1
   block $~lib/typedarray/EVERY<~lib/typedarray/Int64Array,i64>|inlined.0
    loop $for-loop|0
-    local.get $2
-    local.get $4
+    local.get $3
+    local.get $1
     i32.lt_s
     if
-     local.get $3
-     local.get $2
-     i32.const 3
-     i32.shl
-     i32.add
-     i64.load
-     i32.const 3
-     global.set $~argumentsLength
-     local.get $2
      local.get $0
-     local.get $1
-     call_indirect (type $i64_i32_i32_=>_i32)
+     i32.const -2147483648
+     i32.and
+     i32.const -2147483648
+     i32.eq
+     if (result i32)
+      local.get $4
+      local.get $3
+      i32.const 3
+      i32.shl
+      i32.add
+      i64.load
+      local.set $5
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $0
+      i32.const 4
+      i32.shl
+      local.tee $6
+      local.get $5
+      local.get $3
+      local.get $2
+      local.get $6
+      i32.load
+      call_indirect (type $i32_i64_i32_i32_=>_i32)
+     else
+      local.get $4
+      local.get $3
+      i32.const 3
+      i32.shl
+      i32.add
+      i64.load
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $3
+      local.get $2
+      local.get $0
+      call_indirect (type $i64_i32_i32_=>_i32)
+     end
      i32.eqz
-     br_if $~lib/typedarray/EVERY<~lib/typedarray/Int64Array,i64>|inlined.0
-     local.get $2
+     if
+      local.get $0
+      i32.const 4
+      i32.shl
+      i32.const 0
+      local.get $0
+      i32.const -2147483648
+      i32.and
+      i32.const -2147483648
+      i32.eq
+      select
+      call $~lib/rt/pure/__release
+      br $~lib/typedarray/EVERY<~lib/typedarray/Int64Array,i64>|inlined.0
+     end
+     local.get $3
      i32.const 1
      i32.add
-     local.set $2
+     local.set $3
      br $for-loop|0
     end
    end
+   local.get $0
+   i32.const 4
+   i32.shl
+   i32.const 0
+   local.get $0
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   select
+   call $~lib/rt/pure/__release
    i32.const 1
-   local.set $6
+   local.set $7
   end
-  local.get $6
+  local.get $0
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $0
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  call $~lib/rt/pure/__release
+  local.get $7
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint64Array,u64>~anonymous|0 (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint64Array,u64>~anonymous|0~nonClosure (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i64.const 2
   i64.rem_u
@@ -7582,7 +9778,7 @@
   local.get $0
   f32.mul
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Float32Array,f32>~anonymous|0 (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Float32Array,f32>~anonymous|0~nonClosure (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.mod
   f32.const 0
@@ -7594,45 +9790,128 @@
   (local $4 i32)
   (local $5 f32)
   (local $6 i32)
+  (local $7 i32)
+  local.get $1
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  local.tee $4
+  call $~lib/rt/pure/__retain
+  drop
   local.get $0
+  local.set $2
+  local.get $1
+  local.set $0
+  local.get $4
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
   i32.load offset=4
-  local.set $3
-  local.get $0
+  local.set $4
+  local.get $2
   i32.load offset=8
   i32.const 2
   i32.shr_u
-  local.set $4
+  local.set $1
   block $~lib/typedarray/EVERY<~lib/typedarray/Float32Array,f32>|inlined.0
    loop $for-loop|0
-    local.get $2
-    local.get $4
+    local.get $3
+    local.get $1
     i32.lt_s
     if
-     local.get $3
-     local.get $2
-     i32.const 2
-     i32.shl
-     i32.add
-     f32.load
-     i32.const 3
-     global.set $~argumentsLength
-     local.get $2
      local.get $0
-     local.get $1
-     call_indirect (type $f32_i32_i32_=>_i32)
+     i32.const -2147483648
+     i32.and
+     i32.const -2147483648
+     i32.eq
+     if (result i32)
+      local.get $4
+      local.get $3
+      i32.const 2
+      i32.shl
+      i32.add
+      f32.load
+      local.set $5
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $0
+      i32.const 4
+      i32.shl
+      local.tee $6
+      local.get $5
+      local.get $3
+      local.get $2
+      local.get $6
+      i32.load
+      call_indirect (type $i32_f32_i32_i32_=>_i32)
+     else
+      local.get $4
+      local.get $3
+      i32.const 2
+      i32.shl
+      i32.add
+      f32.load
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $3
+      local.get $2
+      local.get $0
+      call_indirect (type $f32_i32_i32_=>_i32)
+     end
      i32.eqz
-     br_if $~lib/typedarray/EVERY<~lib/typedarray/Float32Array,f32>|inlined.0
-     local.get $2
+     if
+      local.get $0
+      i32.const 4
+      i32.shl
+      i32.const 0
+      local.get $0
+      i32.const -2147483648
+      i32.and
+      i32.const -2147483648
+      i32.eq
+      select
+      call $~lib/rt/pure/__release
+      br $~lib/typedarray/EVERY<~lib/typedarray/Float32Array,f32>|inlined.0
+     end
+     local.get $3
      i32.const 1
      i32.add
-     local.set $2
+     local.set $3
      br $for-loop|0
     end
    end
+   local.get $0
+   i32.const 4
+   i32.shl
+   i32.const 0
+   local.get $0
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   select
+   call $~lib/rt/pure/__release
    i32.const 1
-   local.set $6
+   local.set $7
   end
-  local.get $6
+  local.get $0
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $0
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  call $~lib/rt/pure/__release
+  local.get $7
  )
  (func $~lib/math/NativeMath.mod (param $0 f64) (result f64)
   (local $1 i64)
@@ -7788,7 +10067,7 @@
   local.get $0
   f64.mul
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Float64Array,f64>~anonymous|0 (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Float64Array,f64>~anonymous|0~nonClosure (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMath.mod
   f64.const 0
@@ -7800,47 +10079,130 @@
   (local $4 i32)
   (local $5 f64)
   (local $6 i32)
+  (local $7 i32)
+  local.get $1
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  local.tee $4
+  call $~lib/rt/pure/__retain
+  drop
   local.get $0
+  local.set $2
+  local.get $1
+  local.set $0
+  local.get $4
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
   i32.load offset=4
-  local.set $3
-  local.get $0
+  local.set $4
+  local.get $2
   i32.load offset=8
   i32.const 3
   i32.shr_u
-  local.set $4
+  local.set $1
   block $~lib/typedarray/EVERY<~lib/typedarray/Float64Array,f64>|inlined.0
    loop $for-loop|0
-    local.get $2
-    local.get $4
+    local.get $3
+    local.get $1
     i32.lt_s
     if
-     local.get $3
-     local.get $2
-     i32.const 3
-     i32.shl
-     i32.add
-     f64.load
-     i32.const 3
-     global.set $~argumentsLength
-     local.get $2
      local.get $0
-     local.get $1
-     call_indirect (type $f64_i32_i32_=>_i32)
+     i32.const -2147483648
+     i32.and
+     i32.const -2147483648
+     i32.eq
+     if (result i32)
+      local.get $4
+      local.get $3
+      i32.const 3
+      i32.shl
+      i32.add
+      f64.load
+      local.set $5
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $0
+      i32.const 4
+      i32.shl
+      local.tee $6
+      local.get $5
+      local.get $3
+      local.get $2
+      local.get $6
+      i32.load
+      call_indirect (type $i32_f64_i32_i32_=>_i32)
+     else
+      local.get $4
+      local.get $3
+      i32.const 3
+      i32.shl
+      i32.add
+      f64.load
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $3
+      local.get $2
+      local.get $0
+      call_indirect (type $f64_i32_i32_=>_i32)
+     end
      i32.eqz
-     br_if $~lib/typedarray/EVERY<~lib/typedarray/Float64Array,f64>|inlined.0
-     local.get $2
+     if
+      local.get $0
+      i32.const 4
+      i32.shl
+      i32.const 0
+      local.get $0
+      i32.const -2147483648
+      i32.and
+      i32.const -2147483648
+      i32.eq
+      select
+      call $~lib/rt/pure/__release
+      br $~lib/typedarray/EVERY<~lib/typedarray/Float64Array,f64>|inlined.0
+     end
+     local.get $3
      i32.const 1
      i32.add
-     local.set $2
+     local.set $3
      br $for-loop|0
     end
    end
+   local.get $0
+   i32.const 4
+   i32.shl
+   i32.const 0
+   local.get $0
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   select
+   call $~lib/rt/pure/__release
    i32.const 1
-   local.set $6
+   local.set $7
   end
-  local.get $6
+  local.get $0
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $0
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  call $~lib/rt/pure/__release
+  local.get $7
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Int8Array,i8>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Int8Array,i8>~anonymous|0~nonClosure (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $0
   i32.const 255
   i32.and
@@ -7890,36 +10252,104 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  local.get $1
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  local.tee $4
+  call $~lib/rt/pure/__retain
+  drop
   local.get $0
+  local.set $2
+  local.get $1
+  local.set $0
+  local.get $4
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
   i32.load offset=4
-  local.set $3
-  local.get $0
-  i32.load offset=8
   local.set $4
+  local.get $2
+  i32.load offset=8
+  local.set $5
   loop $for-loop|0
-   local.get $2
-   local.get $4
+   local.get $3
+   local.get $5
    i32.lt_s
    if
-    local.get $2
-    local.get $3
-    i32.add
-    i32.load8_u
-    i32.const 3
-    global.set $~argumentsLength
-    local.get $2
     local.get $0
-    local.get $1
-    call_indirect (type $i32_i32_i32_=>_none)
-    local.get $2
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if
+     local.get $3
+     local.get $4
+     i32.add
+     i32.load8_u
+     local.set $1
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $0
+     i32.const 4
+     i32.shl
+     local.tee $6
+     local.get $1
+     local.get $3
+     local.get $2
+     local.get $6
+     i32.load
+     call_indirect (type $i32_i32_i32_i32_=>_none)
+    else
+     local.get $3
+     local.get $4
+     i32.add
+     i32.load8_u
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $3
+     local.get $2
+     local.get $0
+     call_indirect (type $i32_i32_i32_=>_none)
+    end
+    local.get $3
     i32.const 1
     i32.add
-    local.set $2
+    local.set $3
     br $for-loop|0
    end
   end
+  local.get $0
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $0
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  call $~lib/rt/pure/__release
+  local.get $0
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $0
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Int16Array,i16>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Int16Array,i16>~anonymous|0~nonClosure (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $0
   i32.const 65535
   i32.and
@@ -7964,7 +10394,7 @@
   i32.add
   global.set $std/typedarray/forEachCallCount
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Int32Array,i32>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Int32Array,i32>~anonymous|0~nonClosure (param $0 i32) (param $1 i32) (param $2 i32)
   i32.const 2704
   local.get $1
   call $~lib/array/Array<i32>#__get
@@ -8010,40 +10440,110 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  local.get $1
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  local.tee $4
+  call $~lib/rt/pure/__retain
+  drop
   local.get $0
+  local.set $2
+  local.get $1
+  local.set $0
+  local.get $4
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
   i32.load offset=4
-  local.set $3
-  local.get $0
+  local.set $4
+  local.get $2
   i32.load offset=8
   i32.const 2
   i32.shr_u
-  local.set $4
+  local.set $5
   loop $for-loop|0
-   local.get $2
-   local.get $4
+   local.get $3
+   local.get $5
    i32.lt_s
    if
-    local.get $3
-    local.get $2
-    i32.const 2
-    i32.shl
-    i32.add
-    i32.load
-    i32.const 3
-    global.set $~argumentsLength
-    local.get $2
     local.get $0
-    local.get $1
-    call_indirect (type $i32_i32_i32_=>_none)
-    local.get $2
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if
+     local.get $4
+     local.get $3
+     i32.const 2
+     i32.shl
+     i32.add
+     i32.load
+     local.set $1
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $0
+     i32.const 4
+     i32.shl
+     local.tee $6
+     local.get $1
+     local.get $3
+     local.get $2
+     local.get $6
+     i32.load
+     call_indirect (type $i32_i32_i32_i32_=>_none)
+    else
+     local.get $4
+     local.get $3
+     i32.const 2
+     i32.shl
+     i32.add
+     i32.load
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $3
+     local.get $2
+     local.get $0
+     call_indirect (type $i32_i32_i32_=>_none)
+    end
+    local.get $3
     i32.const 1
     i32.add
-    local.set $2
+    local.set $3
     br $for-loop|0
    end
   end
+  local.get $0
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $0
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  call $~lib/rt/pure/__release
+  local.get $0
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $0
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Int64Array,i64>~anonymous|0 (param $0 i64) (param $1 i32) (param $2 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Int64Array,i64>~anonymous|0~nonClosure (param $0 i64) (param $1 i32) (param $2 i32)
   local.get $0
   i32.const 2704
   local.get $1
@@ -8090,40 +10590,110 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i64)
+  (local $6 i32)
+  local.get $1
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  local.tee $4
+  call $~lib/rt/pure/__retain
+  drop
   local.get $0
+  local.set $2
+  local.get $1
+  local.set $0
+  local.get $4
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
   i32.load offset=4
-  local.set $3
-  local.get $0
+  local.set $4
+  local.get $2
   i32.load offset=8
   i32.const 3
   i32.shr_u
-  local.set $4
+  local.set $1
   loop $for-loop|0
-   local.get $2
-   local.get $4
+   local.get $3
+   local.get $1
    i32.lt_s
    if
-    local.get $3
-    local.get $2
-    i32.const 3
-    i32.shl
-    i32.add
-    i64.load
-    i32.const 3
-    global.set $~argumentsLength
-    local.get $2
     local.get $0
-    local.get $1
-    call_indirect (type $i64_i32_i32_=>_none)
-    local.get $2
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if
+     local.get $4
+     local.get $3
+     i32.const 3
+     i32.shl
+     i32.add
+     i64.load
+     local.set $5
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $0
+     i32.const 4
+     i32.shl
+     local.tee $6
+     local.get $5
+     local.get $3
+     local.get $2
+     local.get $6
+     i32.load
+     call_indirect (type $i32_i64_i32_i32_=>_none)
+    else
+     local.get $4
+     local.get $3
+     i32.const 3
+     i32.shl
+     i32.add
+     i64.load
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $3
+     local.get $2
+     local.get $0
+     call_indirect (type $i64_i32_i32_=>_none)
+    end
+    local.get $3
     i32.const 1
     i32.add
-    local.set $2
+    local.set $3
     br $for-loop|0
    end
   end
+  local.get $0
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $0
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  call $~lib/rt/pure/__release
+  local.get $0
+  i32.const 4
+  i32.shl
+  i32.const 0
+  local.get $0
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  select
+  call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Float32Array,f32>~anonymous|0 (param $0 f32) (param $1 i32) (param $2 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Float32Array,f32>~anonymous|0~nonClosure (param $0 f32) (param $1 i32) (param $2 i32)
   local.get $0
   i32.const 2704
   local.get $1
@@ -8165,7 +10735,7 @@
   i32.add
   global.set $std/typedarray/forEachCallCount
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Float64Array,f64>~anonymous|0 (param $0 f64) (param $1 i32) (param $2 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Float64Array,f64>~anonymous|0~nonClosure (param $0 f64) (param $1 i32) (param $2 i32)
   local.get $0
   i32.const 2704
   local.get $1
@@ -25913,21 +28483,22 @@
   (local $13 i32)
   (local $14 i32)
   (local $15 i32)
-  (local $16 f32)
-  (local $17 i32)
+  (local $16 f64)
+  (local $17 f32)
   (local $18 i32)
   (local $19 i32)
-  (local $20 i64)
-  (local $21 f64)
-  (local $22 f32)
+  (local $20 i32)
+  (local $21 i64)
+  (local $22 f64)
   (local $23 f64)
-  (local $24 i32)
+  (local $24 f32)
   (local $25 i32)
   (local $26 i32)
   (local $27 i32)
   (local $28 i32)
   (local $29 i32)
   (local $30 i32)
+  (local $31 i32)
   i32.const 0
   call $std/typedarray/testInstantiate
   i32.const 5
@@ -26165,58 +28736,58 @@
   block $~lib/typedarray/SORT<~lib/typedarray/Float64Array,f64>|inlined.0
    local.get $0
    call $~lib/rt/pure/__retain
-   local.tee $29
+   local.tee $30
    i32.load offset=8
    i32.const 3
    i32.shr_u
-   local.tee $30
+   local.tee $31
    i32.const 1
    i32.le_s
    br_if $~lib/typedarray/SORT<~lib/typedarray/Float64Array,f64>|inlined.0
-   local.get $29
+   local.get $30
    i32.load offset=4
    local.set $1
-   local.get $30
+   local.get $31
    i32.const 2
    i32.eq
    if
     local.get $1
     f64.load offset=8
-    local.set $23
+    local.set $22
     local.get $1
     f64.load
-    local.set $21
+    local.set $16
     i32.const 2
     global.set $~argumentsLength
-    local.get $23
-    local.get $21
-    call $~lib/util/sort/COMPARATOR<f64>~anonymous|0
+    local.get $22
+    local.get $16
+    call $~lib/util/sort/COMPARATOR<f64>~anonymous|0~nonClosure
     i32.const 0
     i32.lt_s
     if
      local.get $1
-     local.get $21
+     local.get $16
      f64.store offset=8
      local.get $1
-     local.get $23
+     local.get $22
      f64.store
     end
     br $~lib/typedarray/SORT<~lib/typedarray/Float64Array,f64>|inlined.0
    end
-   local.get $30
+   local.get $31
    i32.const 256
    i32.lt_s
    if
     local.get $1
-    local.get $30
+    local.get $31
     call $~lib/util/sort/insertionSort<f64>
    else
     local.get $1
-    local.get $30
+    local.get $31
     call $~lib/util/sort/weakHeapSort<f64>
    end
   end
-  local.get $29
+  local.get $30
   call $~lib/rt/pure/__release
   local.get $0
   i32.const 0
@@ -26349,7 +28920,7 @@
   i32.const 1504
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $30
+  local.tee $31
   call $std/typedarray/isInt8ArrayEqual
   i32.eqz
   if
@@ -26373,7 +28944,7 @@
   i32.const 1584
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $29
+  local.tee $30
   call $std/typedarray/isInt8ArrayEqual
   i32.eqz
   if
@@ -26397,7 +28968,7 @@
   i32.const 1616
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $28
+  local.tee $29
   call $std/typedarray/isInt8ArrayEqual
   i32.eqz
   if
@@ -26421,7 +28992,7 @@
   i32.const 1648
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $27
+  local.tee $28
   call $std/typedarray/isInt8ArrayEqual
   i32.eqz
   if
@@ -26445,7 +29016,7 @@
   i32.const 1680
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $26
+  local.tee $27
   call $std/typedarray/isInt8ArrayEqual
   i32.eqz
   if
@@ -26509,7 +29080,7 @@
   i32.const 1712
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $25
+  local.tee $26
   call $std/typedarray/isInt8ArrayEqual
   i32.eqz
   if
@@ -26527,7 +29098,7 @@
   i32.const 1744
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $24
+  local.tee $25
   call $std/typedarray/isInt8ArrayEqual
   i32.eqz
   if
@@ -26540,6 +29111,8 @@
   end
   local.get $1
   call $~lib/rt/pure/__release
+  local.get $31
+  call $~lib/rt/pure/__release
   local.get $30
   call $~lib/rt/pure/__release
   local.get $29
@@ -26548,13 +29121,11 @@
   call $~lib/rt/pure/__release
   local.get $27
   call $~lib/rt/pure/__release
-  local.get $26
-  call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
-  local.get $25
+  local.get $26
   call $~lib/rt/pure/__release
-  local.get $24
+  local.get $25
   call $~lib/rt/pure/__release
   i32.const 5
   call $~lib/typedarray/Int32Array#constructor
@@ -26591,7 +29162,7 @@
   i32.const 1776
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $30
+  local.tee $31
   call $std/typedarray/isInt32ArrayEqual
   i32.eqz
   if
@@ -26615,7 +29186,7 @@
   i32.const 1824
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $29
+  local.tee $30
   call $std/typedarray/isInt32ArrayEqual
   i32.eqz
   if
@@ -26639,7 +29210,7 @@
   i32.const 1872
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $28
+  local.tee $29
   call $std/typedarray/isInt32ArrayEqual
   i32.eqz
   if
@@ -26663,7 +29234,7 @@
   i32.const 1920
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $27
+  local.tee $28
   call $std/typedarray/isInt32ArrayEqual
   i32.eqz
   if
@@ -26687,7 +29258,7 @@
   i32.const 1968
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $26
+  local.tee $27
   call $std/typedarray/isInt32ArrayEqual
   i32.eqz
   if
@@ -26753,7 +29324,7 @@
   i32.const 2016
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $25
+  local.tee $26
   call $std/typedarray/isInt32ArrayEqual
   i32.eqz
   if
@@ -26771,7 +29342,7 @@
   i32.const 2048
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $24
+  local.tee $25
   call $std/typedarray/isInt32ArrayEqual
   i32.eqz
   if
@@ -26784,6 +29355,8 @@
   end
   local.get $1
   call $~lib/rt/pure/__release
+  local.get $31
+  call $~lib/rt/pure/__release
   local.get $30
   call $~lib/rt/pure/__release
   local.get $29
@@ -26792,13 +29365,11 @@
   call $~lib/rt/pure/__release
   local.get $27
   call $~lib/rt/pure/__release
-  local.get $26
-  call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
-  local.get $25
+  local.get $26
   call $~lib/rt/pure/__release
-  local.get $24
+  local.get $25
   call $~lib/rt/pure/__release
   i32.const 6
   call $~lib/typedarray/Int8Array#constructor
@@ -26883,7 +29454,7 @@
   i32.const 1
   i32.const 5
   call $~lib/typedarray/Int8Array#subarray
-  local.tee $30
+  local.tee $31
   i32.const 0
   call $~lib/typedarray/Int8Array#__get
   i32.const 3
@@ -26896,7 +29467,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $30
+  local.get $31
   i32.load offset=8
   i32.const 4
   i32.ne
@@ -26908,7 +29479,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $30
+  local.get $31
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
   i32.const 2
   i32.ne
@@ -26920,7 +29491,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $30
+  local.get $31
   i32.load offset=8
   i32.const 4
   i32.ne
@@ -26932,11 +29503,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $30
+  local.get $31
   i32.const 1
   i32.const 4
   call $~lib/typedarray/Int8Array#subarray
-  local.tee $29
+  local.tee $30
   i32.const 0
   call $~lib/typedarray/Int8Array#__get
   i32.const 4
@@ -26949,7 +29520,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $29
+  local.get $30
   i32.load offset=8
   i32.const 3
   i32.ne
@@ -26961,7 +29532,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $29
+  local.get $30
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
   i32.const 3
   i32.ne
@@ -26973,7 +29544,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $29
+  local.get $30
   i32.load offset=8
   i32.const 3
   i32.ne
@@ -26989,9 +29560,9 @@
   call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
-  local.get $30
+  local.get $31
   call $~lib/rt/pure/__release
-  local.get $29
+  local.get $30
   call $~lib/rt/pure/__release
   i32.const 5
   call $~lib/typedarray/Int32Array#constructor
@@ -27019,20 +29590,20 @@
   i32.const 0
   i32.const 2147483647
   call $~lib/typedarray/Int32Array#slice
-  local.set $30
+  local.set $31
   local.get $1
   i32.const 0
   i32.const 3
   i32.const 2147483647
   call $~lib/typedarray/Int32Array#copyWithin
-  local.tee $28
+  local.tee $29
   i32.const 5
   i32.const 2
   i32.const 15
   i32.const 2096
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $27
+  local.tee $28
   call $std/typedarray/isInt32ArrayEqual
   i32.eqz
   if
@@ -27043,7 +29614,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $30
+  local.get $31
   i32.const 0
   i32.const 2147483647
   call $~lib/typedarray/Int32Array#slice
@@ -27055,14 +29626,14 @@
   i32.const 3
   i32.const 2147483647
   call $~lib/typedarray/Int32Array#copyWithin
-  local.tee $26
+  local.tee $27
   i32.const 5
   i32.const 2
   i32.const 15
   i32.const 2144
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $25
+  local.tee $26
   call $std/typedarray/isInt32ArrayEqual
   i32.eqz
   if
@@ -27073,26 +29644,26 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $30
+  local.get $31
   i32.const 0
   i32.const 2147483647
   call $~lib/typedarray/Int32Array#slice
-  local.set $29
+  local.set $30
   local.get $0
   call $~lib/rt/pure/__release
-  local.get $29
+  local.get $30
   i32.const 1
   i32.const 2
   i32.const 2147483647
   call $~lib/typedarray/Int32Array#copyWithin
-  local.tee $24
+  local.tee $25
   i32.const 5
   i32.const 2
   i32.const 15
   i32.const 2192
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $19
+  local.tee $20
   call $std/typedarray/isInt32ArrayEqual
   i32.eqz
   if
@@ -27103,25 +29674,25 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $30
+  local.get $31
   i32.const 0
   i32.const 2147483647
   call $~lib/typedarray/Int32Array#slice
-  local.get $29
+  local.get $30
   call $~lib/rt/pure/__release
   local.tee $0
   i32.const 2
   i32.const 2
   i32.const 2147483647
   call $~lib/typedarray/Int32Array#copyWithin
-  local.tee $29
+  local.tee $30
   i32.const 5
   i32.const 2
   i32.const 15
   i32.const 2240
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $18
+  local.tee $19
   call $std/typedarray/isInt32ArrayEqual
   i32.eqz
   if
@@ -27132,7 +29703,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $30
+  local.get $31
   i32.const 0
   i32.const 2147483647
   call $~lib/typedarray/Int32Array#slice
@@ -27143,7 +29714,7 @@
   i32.const 3
   i32.const 4
   call $~lib/typedarray/Int32Array#copyWithin
-  local.tee $17
+  local.tee $18
   i32.const 5
   i32.const 2
   i32.const 15
@@ -27161,7 +29732,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $30
+  local.get $31
   i32.const 0
   i32.const 2147483647
   call $~lib/typedarray/Int32Array#slice
@@ -27190,7 +29761,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $30
+  local.get $31
   i32.const 0
   i32.const 2147483647
   call $~lib/typedarray/Int32Array#slice
@@ -27219,7 +29790,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $30
+  local.get $31
   i32.const 0
   i32.const 2147483647
   call $~lib/typedarray/Int32Array#slice
@@ -27248,7 +29819,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $30
+  local.get $31
   i32.const 0
   i32.const 2147483647
   call $~lib/typedarray/Int32Array#slice
@@ -27277,13 +29848,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $30
+  local.get $31
   i32.const 0
   i32.const 2147483647
   call $~lib/typedarray/Int32Array#slice
+  local.set $1
   local.get $0
   call $~lib/rt/pure/__release
-  local.tee $0
+  local.get $1
   i32.const -4
   i32.const -3
   i32.const -2
@@ -27306,13 +29878,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $30
+  local.get $31
   i32.const 0
   i32.const 2147483647
   call $~lib/typedarray/Int32Array#slice
-  local.get $0
+  local.set $0
+  local.get $1
   call $~lib/rt/pure/__release
-  local.tee $0
+  local.get $0
   i32.const -4
   i32.const -3
   i32.const -1
@@ -27335,7 +29908,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $30
+  local.get $31
   i32.const 0
   i32.const 2147483647
   call $~lib/typedarray/Int32Array#slice
@@ -27367,7 +29940,9 @@
   end
   local.get $1
   call $~lib/rt/pure/__release
-  local.get $30
+  local.get $31
+  call $~lib/rt/pure/__release
+  local.get $29
   call $~lib/rt/pure/__release
   local.get $28
   call $~lib/rt/pure/__release
@@ -27377,15 +29952,13 @@
   call $~lib/rt/pure/__release
   local.get $25
   call $~lib/rt/pure/__release
-  local.get $24
+  local.get $20
+  call $~lib/rt/pure/__release
+  local.get $30
   call $~lib/rt/pure/__release
   local.get $19
   call $~lib/rt/pure/__release
-  local.get $29
-  call $~lib/rt/pure/__release
   local.get $18
-  call $~lib/rt/pure/__release
-  local.get $17
   call $~lib/rt/pure/__release
   local.get $15
   call $~lib/rt/pure/__release
@@ -27443,7 +30016,7 @@
   i32.const 1
   i32.const 4
   call $~lib/typedarray/Int32Array#subarray
-  local.tee $30
+  local.tee $31
   i32.load offset=8
   i32.const 2
   i32.shr_u
@@ -27457,7 +30030,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $30
+  local.get $31
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
   i32.const 4
   i32.ne
@@ -27469,7 +30042,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $30
+  local.get $31
   i32.load offset=8
   i32.const 12
   i32.ne
@@ -27547,11 +30120,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $30
+  local.get $31
   i32.const 1
   i32.const 2
   call $~lib/typedarray/Int32Array#slice
-  local.tee $29
+  local.tee $30
   i32.const 0
   call $~lib/typedarray/Int32Array#__get
   i32.const 3
@@ -27564,7 +30137,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $29
+  local.get $30
   i32.load offset=8
   i32.const 2
   i32.shr_u
@@ -27578,7 +30151,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $29
+  local.get $30
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
   if
    i32.const 0
@@ -27588,7 +30161,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $29
+  local.get $30
   i32.load offset=8
   i32.const 4
   i32.ne
@@ -27605,7 +30178,7 @@
   i32.const 0
   i32.const 2147483647
   call $~lib/typedarray/Int32Array#slice
-  local.tee $28
+  local.tee $29
   i32.eq
   if
    i32.const 0
@@ -27615,7 +30188,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $28
+  local.get $29
   i32.load offset=8
   i32.const 2
   i32.shr_u
@@ -27632,7 +30205,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $28
+  local.get $29
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
   local.get $1
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
@@ -27645,7 +30218,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $28
+  local.get $29
   i32.load offset=8
   local.get $1
   i32.load offset=8
@@ -27660,58 +30233,58 @@
   end
   local.get $1
   call $~lib/rt/pure/__release
-  local.get $30
+  local.get $31
   call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
-  local.get $29
+  local.get $30
   call $~lib/rt/pure/__release
-  local.get $28
+  local.get $29
   call $~lib/rt/pure/__release
   i32.const 3
   call $~lib/typedarray/Int8Array#constructor
-  local.tee $30
+  local.tee $31
   i32.const 0
   i32.const 1
   call $~lib/typedarray/Int8Array#__set
-  local.get $30
+  local.get $31
   i32.const 1
   i32.const 2
   call $~lib/typedarray/Int8Array#__set
-  local.get $30
+  local.get $31
   i32.const 2
   i32.const 3
   call $~lib/typedarray/Int8Array#__set
   i32.const 0
-  local.set $0
-  i32.const 0
   local.set $1
-  local.get $30
+  i32.const 0
+  local.set $0
+  local.get $31
   i32.load offset=4
-  local.set $29
-  local.get $30
+  local.set $30
+  local.get $31
   i32.load offset=8
-  local.set $28
+  local.set $29
   loop $for-loop|0
-   local.get $0
-   local.get $28
+   local.get $1
+   local.get $29
    i32.lt_s
    if
-    local.get $0
-    local.get $29
+    local.get $1
+    local.get $30
     i32.add
     i32.load8_s
-    local.set $27
+    local.set $28
     i32.const 4
     global.set $~argumentsLength
-    local.get $1
-    local.get $27
-    i32.add
-    local.set $1
     local.get $0
-    i32.const 1
+    local.get $28
     i32.add
     local.set $0
+    local.get $1
+    i32.const 1
+    i32.add
+    local.set $1
     br $for-loop|0
    end
   end
@@ -27732,13 +30305,13 @@
                 block $folding-inner4
                  block $folding-inner3
                   block $folding-inner2
-                   local.get $1
+                   local.get $0
                    i32.const 255
                    i32.and
                    i32.const 6
                    i32.ne
                    br_if $folding-inner2
-                   local.get $30
+                   local.get $31
                    call $~lib/rt/pure/__release
                    i32.const 3
                    call $~lib/typedarray/Uint8Array#constructor
@@ -27790,121 +30363,121 @@
                    call $~lib/rt/pure/__release
                    i32.const 3
                    call $~lib/typedarray/Int16Array#constructor
-                   local.tee $30
+                   local.tee $31
                    i32.const 0
                    i32.const 1
                    call $~lib/typedarray/Int16Array#__set
-                   local.get $30
+                   local.get $31
                    i32.const 1
                    i32.const 2
                    call $~lib/typedarray/Int16Array#__set
-                   local.get $30
+                   local.get $31
                    i32.const 2
                    i32.const 3
                    call $~lib/typedarray/Int16Array#__set
                    i32.const 0
-                   local.set $0
-                   i32.const 0
                    local.set $1
-                   local.get $30
+                   i32.const 0
+                   local.set $0
+                   local.get $31
                    i32.load offset=4
-                   local.set $29
-                   local.get $30
+                   local.set $30
+                   local.get $31
                    i32.load offset=8
                    i32.const 1
                    i32.shr_u
-                   local.set $28
+                   local.set $29
                    loop $for-loop|00
-                    local.get $0
-                    local.get $28
+                    local.get $1
+                    local.get $29
                     i32.lt_s
                     if
-                     local.get $29
-                     local.get $0
+                     local.get $30
+                     local.get $1
                      i32.const 1
                      i32.shl
                      i32.add
                      i32.load16_s
-                     local.set $27
+                     local.set $28
                      i32.const 4
                      global.set $~argumentsLength
-                     local.get $1
-                     local.get $27
-                     i32.add
-                     local.set $1
                      local.get $0
-                     i32.const 1
+                     local.get $28
                      i32.add
                      local.set $0
+                     local.get $1
+                     i32.const 1
+                     i32.add
+                     local.set $1
                      br $for-loop|00
                     end
                    end
-                   local.get $1
+                   local.get $0
                    i32.const 65535
                    i32.and
                    i32.const 6
                    i32.ne
                    br_if $folding-inner2
-                   local.get $30
+                   local.get $31
                    call $~lib/rt/pure/__release
                    i32.const 3
                    call $~lib/typedarray/Uint16Array#constructor
-                   local.tee $30
+                   local.tee $31
                    i32.const 0
                    i32.const 1
                    call $~lib/typedarray/Uint16Array#__set
-                   local.get $30
+                   local.get $31
                    i32.const 1
                    i32.const 2
                    call $~lib/typedarray/Uint16Array#__set
-                   local.get $30
+                   local.get $31
                    i32.const 2
                    i32.const 3
                    call $~lib/typedarray/Uint16Array#__set
                    i32.const 0
-                   local.set $0
-                   i32.const 0
                    local.set $1
-                   local.get $30
+                   i32.const 0
+                   local.set $0
+                   local.get $31
                    i32.load offset=4
-                   local.set $29
-                   local.get $30
+                   local.set $30
+                   local.get $31
                    i32.load offset=8
                    i32.const 1
                    i32.shr_u
-                   local.set $28
+                   local.set $29
                    loop $for-loop|01
-                    local.get $0
-                    local.get $28
+                    local.get $1
+                    local.get $29
                     i32.lt_s
                     if
-                     local.get $29
-                     local.get $0
+                     local.get $30
+                     local.get $1
                      i32.const 1
                      i32.shl
                      i32.add
                      i32.load16_u
-                     local.set $27
+                     local.set $28
                      i32.const 4
                      global.set $~argumentsLength
-                     local.get $1
-                     local.get $27
-                     i32.add
-                     local.set $1
                      local.get $0
-                     i32.const 1
+                     local.get $28
                      i32.add
                      local.set $0
+                     local.get $1
+                     i32.const 1
+                     i32.add
+                     local.set $1
                      br $for-loop|01
                     end
                    end
-                   local.get $1
+                   local.get $0
                    i32.const 65535
                    i32.and
                    i32.const 6
                    i32.ne
                    br_if $folding-inner2
-                   local.get $30
+                   local.get $31
                    call $~lib/rt/pure/__release
                    i32.const 3
                    call $~lib/typedarray/Int32Array#constructor
@@ -27996,107 +30569,105 @@
                    call $~lib/rt/pure/__release
                    i32.const 3
                    call $~lib/typedarray/Float32Array#constructor
-                   local.tee $1
+                   local.tee $0
                    i32.const 0
                    f32.const 1
                    call $~lib/typedarray/Float32Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 1
                    f32.const 2
                    call $~lib/typedarray/Float32Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 2
                    f32.const 3
                    call $~lib/typedarray/Float32Array#__set
                    i32.const 0
-                   local.set $0
-                   local.get $1
+                   local.set $1
+                   local.get $0
                    i32.load offset=4
-                   local.set $30
-                   local.get $1
+                   local.set $31
+                   local.get $0
                    i32.load offset=8
                    i32.const 2
                    i32.shr_u
-                   local.set $29
+                   local.set $30
                    loop $for-loop|02
-                    local.get $0
-                    local.get $29
+                    local.get $1
+                    local.get $30
                     i32.lt_s
                     if
-                     local.get $30
-                     local.get $0
+                     local.get $31
+                     local.get $1
                      i32.const 2
                      i32.shl
                      i32.add
                      f32.load
-                     local.set $16
+                     local.set $17
                      i32.const 4
                      global.set $~argumentsLength
-                     local.get $22
-                     local.get $16
+                     local.get $24
+                     local.get $17
                      f32.add
-                     local.set $22
-                     local.get $0
+                     local.set $24
+                     local.get $1
                      i32.const 1
                      i32.add
-                     local.set $0
+                     local.set $1
                      br $for-loop|02
                     end
                    end
-                   local.get $22
+                   local.get $24
                    f32.const 6
                    f32.ne
                    br_if $folding-inner2
-                   local.get $1
+                   local.get $0
                    call $~lib/rt/pure/__release
                    i32.const 3
                    call $~lib/typedarray/Float64Array#constructor
-                   local.tee $1
+                   local.tee $0
                    i32.const 0
                    f64.const 1
                    call $~lib/typedarray/Float64Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 1
                    f64.const 2
                    call $~lib/typedarray/Float64Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 2
                    f64.const 3
                    call $~lib/typedarray/Float64Array#__set
                    i32.const 0
-                   local.set $0
-                   f64.const 0
-                   local.set $23
-                   local.get $1
+                   local.set $1
+                   local.get $0
                    i32.load offset=4
-                   local.set $30
-                   local.get $1
+                   local.set $31
+                   local.get $0
                    i32.load offset=8
                    i32.const 3
                    i32.shr_u
-                   local.set $29
+                   local.set $30
                    loop $for-loop|03
-                    local.get $0
-                    local.get $29
+                    local.get $1
+                    local.get $30
                     i32.lt_s
                     if
-                     local.get $30
-                     local.get $0
+                     local.get $31
+                     local.get $1
                      i32.const 3
                      i32.shl
                      i32.add
                      f64.load
-                     local.set $21
+                     local.set $22
                      i32.const 4
                      global.set $~argumentsLength
                      local.get $23
-                     local.get $21
+                     local.get $22
                      f64.add
                      local.set $23
-                     local.get $0
+                     local.get $1
                      i32.const 1
                      i32.add
-                     local.set $0
+                     local.set $1
                      br $for-loop|03
                     end
                    end
@@ -28104,62 +30675,62 @@
                    f64.const 6
                    f64.ne
                    br_if $folding-inner2
-                   local.get $1
+                   local.get $0
                    call $~lib/rt/pure/__release
                    i32.const 3
                    call $~lib/typedarray/Int8Array#constructor
-                   local.tee $30
+                   local.tee $31
                    i32.const 0
                    i32.const 1
                    call $~lib/typedarray/Int8Array#__set
-                   local.get $30
+                   local.get $31
                    i32.const 1
                    i32.const 2
                    call $~lib/typedarray/Int8Array#__set
-                   local.get $30
+                   local.get $31
                    i32.const 2
                    i32.const 3
                    call $~lib/typedarray/Int8Array#__set
                    i32.const 0
-                   local.set $0
-                   local.get $30
+                   local.set $1
+                   local.get $31
                    i32.load offset=4
-                   local.set $29
-                   local.get $30
+                   local.set $30
+                   local.get $31
                    i32.load offset=8
                    i32.const 1
                    i32.sub
-                   local.set $1
+                   local.set $0
                    loop $for-loop|04
-                    local.get $1
+                    local.get $0
                     i32.const 0
                     i32.ge_s
                     if
+                     local.get $0
+                     local.get $30
+                     i32.add
+                     i32.load8_s
+                     local.set $29
+                     i32.const 4
+                     global.set $~argumentsLength
                      local.get $1
                      local.get $29
                      i32.add
-                     i32.load8_s
-                     local.set $28
-                     i32.const 4
-                     global.set $~argumentsLength
+                     local.set $1
                      local.get $0
-                     local.get $28
-                     i32.add
-                     local.set $0
-                     local.get $1
                      i32.const 1
                      i32.sub
-                     local.set $1
+                     local.set $0
                      br $for-loop|04
                     end
                    end
-                   local.get $0
+                   local.get $1
                    i32.const 255
                    i32.and
                    i32.const 6
                    i32.ne
                    br_if $folding-inner3
-                   local.get $30
+                   local.get $31
                    call $~lib/rt/pure/__release
                    i32.const 3
                    call $~lib/typedarray/Uint8Array#constructor
@@ -28211,121 +30782,121 @@
                    call $~lib/rt/pure/__release
                    i32.const 3
                    call $~lib/typedarray/Int16Array#constructor
-                   local.tee $30
+                   local.tee $31
                    i32.const 0
                    i32.const 1
                    call $~lib/typedarray/Int16Array#__set
-                   local.get $30
+                   local.get $31
                    i32.const 1
                    i32.const 2
                    call $~lib/typedarray/Int16Array#__set
-                   local.get $30
+                   local.get $31
                    i32.const 2
                    i32.const 3
                    call $~lib/typedarray/Int16Array#__set
                    i32.const 0
-                   local.set $0
-                   local.get $30
+                   local.set $1
+                   local.get $31
                    i32.load offset=4
-                   local.set $29
-                   local.get $30
+                   local.set $30
+                   local.get $31
                    i32.load offset=8
                    i32.const 1
                    i32.shr_u
                    i32.const 1
                    i32.sub
-                   local.set $1
+                   local.set $0
                    loop $for-loop|05
-                    local.get $1
+                    local.get $0
                     i32.const 0
                     i32.ge_s
                     if
-                     local.get $29
-                     local.get $1
+                     local.get $30
+                     local.get $0
                      i32.const 1
                      i32.shl
                      i32.add
                      i32.load16_s
-                     local.set $28
+                     local.set $29
                      i32.const 4
                      global.set $~argumentsLength
-                     local.get $0
-                     local.get $28
-                     i32.add
-                     local.set $0
                      local.get $1
+                     local.get $29
+                     i32.add
+                     local.set $1
+                     local.get $0
                      i32.const 1
                      i32.sub
-                     local.set $1
+                     local.set $0
                      br $for-loop|05
                     end
                    end
-                   local.get $0
+                   local.get $1
                    i32.const 65535
                    i32.and
                    i32.const 6
                    i32.ne
                    br_if $folding-inner3
-                   local.get $30
+                   local.get $31
                    call $~lib/rt/pure/__release
                    i32.const 3
                    call $~lib/typedarray/Uint16Array#constructor
-                   local.tee $30
+                   local.tee $31
                    i32.const 0
                    i32.const 1
                    call $~lib/typedarray/Uint16Array#__set
-                   local.get $30
+                   local.get $31
                    i32.const 1
                    i32.const 2
                    call $~lib/typedarray/Uint16Array#__set
-                   local.get $30
+                   local.get $31
                    i32.const 2
                    i32.const 3
                    call $~lib/typedarray/Uint16Array#__set
                    i32.const 0
-                   local.set $0
-                   local.get $30
+                   local.set $1
+                   local.get $31
                    i32.load offset=4
-                   local.set $29
-                   local.get $30
+                   local.set $30
+                   local.get $31
                    i32.load offset=8
                    i32.const 1
                    i32.shr_u
                    i32.const 1
                    i32.sub
-                   local.set $1
+                   local.set $0
                    loop $for-loop|06
-                    local.get $1
+                    local.get $0
                     i32.const 0
                     i32.ge_s
                     if
-                     local.get $29
-                     local.get $1
+                     local.get $30
+                     local.get $0
                      i32.const 1
                      i32.shl
                      i32.add
                      i32.load16_u
-                     local.set $28
+                     local.set $29
                      i32.const 4
                      global.set $~argumentsLength
-                     local.get $0
-                     local.get $28
-                     i32.add
-                     local.set $0
                      local.get $1
+                     local.get $29
+                     i32.add
+                     local.set $1
+                     local.get $0
                      i32.const 1
                      i32.sub
-                     local.set $1
+                     local.set $0
                      br $for-loop|06
                     end
                    end
-                   local.get $0
+                   local.get $1
                    i32.const 65535
                    i32.and
                    i32.const 6
                    i32.ne
                    br_if $folding-inner3
-                   local.get $30
+                   local.get $31
                    call $~lib/rt/pure/__release
                    i32.const 3
                    call $~lib/typedarray/Int32Array#constructor
@@ -28418,109 +30989,109 @@
                     call $~lib/rt/pure/__release
                     i32.const 3
                     call $~lib/typedarray/Float32Array#constructor
-                    local.tee $0
+                    local.tee $1
                     i32.const 0
                     f32.const 1
                     call $~lib/typedarray/Float32Array#__set
-                    local.get $0
+                    local.get $1
                     i32.const 1
                     f32.const 2
                     call $~lib/typedarray/Float32Array#__set
-                    local.get $0
+                    local.get $1
                     i32.const 2
                     f32.const 3
                     call $~lib/typedarray/Float32Array#__set
                     f32.const 0
-                    local.set $22
-                    local.get $0
+                    local.set $24
+                    local.get $1
                     i32.load offset=4
-                    local.set $30
-                    local.get $0
+                    local.set $31
+                    local.get $1
                     i32.load offset=8
                     i32.const 2
                     i32.shr_u
                     i32.const 1
                     i32.sub
-                    local.set $1
+                    local.set $0
                     loop $for-loop|07
-                     local.get $1
+                     local.get $0
                      i32.const 0
                      i32.ge_s
                      if
-                      local.get $30
-                      local.get $1
+                      local.get $31
+                      local.get $0
                       i32.const 2
                       i32.shl
                       i32.add
                       f32.load
-                      local.set $16
+                      local.set $17
                       i32.const 4
                       global.set $~argumentsLength
-                      local.get $22
-                      local.get $16
+                      local.get $24
+                      local.get $17
                       f32.add
-                      local.set $22
-                      local.get $1
+                      local.set $24
+                      local.get $0
                       i32.const 1
                       i32.sub
-                      local.set $1
+                      local.set $0
                       br $for-loop|07
                      end
                     end
-                    local.get $22
+                    local.get $24
                     f32.const 6
                     f32.ne
                     br_if $folding-inner1
-                    local.get $0
+                    local.get $1
                     call $~lib/rt/pure/__release
                     i32.const 3
                     call $~lib/typedarray/Float64Array#constructor
-                    local.tee $0
+                    local.tee $1
                     i32.const 0
                     f64.const 1
                     call $~lib/typedarray/Float64Array#__set
-                    local.get $0
+                    local.get $1
                     i32.const 1
                     f64.const 2
                     call $~lib/typedarray/Float64Array#__set
-                    local.get $0
+                    local.get $1
                     i32.const 2
                     f64.const 3
                     call $~lib/typedarray/Float64Array#__set
                     f64.const 0
                     local.set $23
-                    local.get $0
+                    local.get $1
                     i32.load offset=4
-                    local.set $30
-                    local.get $0
+                    local.set $31
+                    local.get $1
                     i32.load offset=8
                     i32.const 3
                     i32.shr_u
                     i32.const 1
                     i32.sub
-                    local.set $1
+                    local.set $0
                     loop $for-loop|08
-                     local.get $1
+                     local.get $0
                      i32.const 0
                      i32.ge_s
                      if
-                      local.get $30
-                      local.get $1
+                      local.get $31
+                      local.get $0
                       i32.const 3
                       i32.shl
                       i32.add
                       f64.load
-                      local.set $21
+                      local.set $22
                       i32.const 4
                       global.set $~argumentsLength
                       local.get $23
-                      local.get $21
+                      local.get $22
                       f64.add
                       local.set $23
-                      local.get $1
+                      local.get $0
                       i32.const 1
                       i32.sub
-                      local.set $1
+                      local.set $0
                       br $for-loop|08
                      end
                     end
@@ -28528,7 +31099,7 @@
                     f64.const 6
                     f64.ne
                     br_if $folding-inner1
-                    local.get $0
+                    local.get $1
                     call $~lib/rt/pure/__release
                     i32.const 3
                     call $~lib/typedarray/Int8Array#constructor
@@ -28548,35 +31119,35 @@
                     local.set $1
                     local.get $0
                     i32.load offset=8
-                    local.set $29
+                    local.set $30
                     local.get $0
                     i32.load offset=4
-                    local.set $26
+                    local.set $27
                     i32.const 12
                     i32.const 3
                     call $~lib/rt/tlsf/__alloc
-                    local.set $30
-                    local.get $29
+                    local.set $31
+                    local.get $30
                     i32.const 0
                     call $~lib/rt/tlsf/__alloc
-                    local.set $28
+                    local.set $29
                     loop $for-loop|09
                      local.get $1
-                     local.get $29
+                     local.get $30
                      i32.lt_s
                      if
                       local.get $1
-                      local.get $26
+                      local.get $27
                       i32.add
                       i32.load8_s
-                      local.set $27
+                      local.set $28
                       i32.const 3
                       global.set $~argumentsLength
                       local.get $1
-                      local.get $28
+                      local.get $29
                       i32.add
-                      local.get $27
-                      local.get $27
+                      local.get $28
+                      local.get $28
                       i32.mul
                       i32.store8
                       local.get $1
@@ -28586,17 +31157,17 @@
                       br $for-loop|09
                      end
                     end
-                    local.get $30
-                    local.get $28
+                    local.get $31
+                    local.get $29
                     call $~lib/rt/pure/__retain
                     i32.store
-                    local.get $30
-                    local.get $28
-                    i32.store offset=4
-                    local.get $30
+                    local.get $31
                     local.get $29
-                    i32.store offset=8
+                    i32.store offset=4
+                    local.get $31
                     local.get $30
+                    i32.store offset=8
+                    local.get $31
                     call $~lib/rt/pure/__retain
                     local.tee $1
                     i32.const 0
@@ -28638,35 +31209,35 @@
                     local.set $1
                     local.get $0
                     i32.load offset=8
-                    local.set $29
+                    local.set $30
                     local.get $0
                     i32.load offset=4
-                    local.set $26
+                    local.set $27
                     i32.const 12
                     i32.const 4
                     call $~lib/rt/tlsf/__alloc
-                    local.set $30
-                    local.get $29
+                    local.set $31
+                    local.get $30
                     i32.const 0
                     call $~lib/rt/tlsf/__alloc
-                    local.set $28
+                    local.set $29
                     loop $for-loop|010
                      local.get $1
-                     local.get $29
+                     local.get $30
                      i32.lt_s
                      if
                       local.get $1
-                      local.get $26
+                      local.get $27
                       i32.add
                       i32.load8_u
-                      local.set $27
+                      local.set $28
                       i32.const 3
                       global.set $~argumentsLength
                       local.get $1
-                      local.get $28
+                      local.get $29
                       i32.add
-                      local.get $27
-                      local.get $27
+                      local.get $28
+                      local.get $28
                       i32.mul
                       i32.store8
                       local.get $1
@@ -28676,17 +31247,17 @@
                       br $for-loop|010
                      end
                     end
-                    local.get $30
-                    local.get $28
+                    local.get $31
+                    local.get $29
                     call $~lib/rt/pure/__retain
                     i32.store
-                    local.get $30
-                    local.get $28
-                    i32.store offset=4
-                    local.get $30
+                    local.get $31
                     local.get $29
-                    i32.store offset=8
+                    i32.store offset=4
+                    local.get $31
                     local.get $30
+                    i32.store offset=8
+                    local.get $31
                     call $~lib/rt/pure/__retain
                     local.tee $1
                     i32.const 0
@@ -28728,35 +31299,35 @@
                     local.set $1
                     local.get $0
                     i32.load offset=8
-                    local.set $29
+                    local.set $30
                     local.get $0
                     i32.load offset=4
-                    local.set $26
+                    local.set $27
                     i32.const 12
                     i32.const 5
                     call $~lib/rt/tlsf/__alloc
-                    local.set $30
-                    local.get $29
+                    local.set $31
+                    local.get $30
                     i32.const 0
                     call $~lib/rt/tlsf/__alloc
-                    local.set $28
+                    local.set $29
                     loop $for-loop|011
                      local.get $1
-                     local.get $29
+                     local.get $30
                      i32.lt_s
                      if
                       local.get $1
-                      local.get $26
+                      local.get $27
                       i32.add
                       i32.load8_u
-                      local.set $27
+                      local.set $28
                       i32.const 3
                       global.set $~argumentsLength
                       local.get $1
-                      local.get $28
+                      local.get $29
                       i32.add
-                      local.get $27
-                      local.get $27
+                      local.get $28
+                      local.get $28
                       i32.mul
                       i32.store8
                       local.get $1
@@ -28766,17 +31337,17 @@
                       br $for-loop|011
                      end
                     end
-                    local.get $30
-                    local.get $28
+                    local.get $31
+                    local.get $29
                     call $~lib/rt/pure/__retain
                     i32.store
-                    local.get $30
-                    local.get $28
-                    i32.store offset=4
-                    local.get $30
+                    local.get $31
                     local.get $29
-                    i32.store offset=8
+                    i32.store offset=4
+                    local.get $31
                     local.get $30
+                    i32.store offset=8
+                    local.get $31
                     call $~lib/rt/pure/__retain
                     local.tee $1
                     i32.const 0
@@ -28802,787 +31373,787 @@
                     call $~lib/rt/pure/__release
                     i32.const 3
                     call $~lib/typedarray/Int16Array#constructor
-                    local.tee $0
+                    local.tee $1
                     i32.const 0
                     i32.const 1
                     call $~lib/typedarray/Int16Array#__set
-                    local.get $0
+                    local.get $1
                     i32.const 1
                     i32.const 2
                     call $~lib/typedarray/Int16Array#__set
-                    local.get $0
+                    local.get $1
                     i32.const 2
                     i32.const 3
                     call $~lib/typedarray/Int16Array#__set
                     i32.const 0
-                    local.set $1
-                    local.get $0
+                    local.set $0
+                    local.get $1
                     i32.load offset=8
                     i32.const 1
                     i32.shr_u
-                    local.set $28
-                    local.get $0
+                    local.set $29
+                    local.get $1
                     i32.load offset=4
-                    local.set $26
+                    local.set $27
                     i32.const 12
                     i32.const 6
                     call $~lib/rt/tlsf/__alloc
-                    local.set $30
-                    local.get $28
+                    local.set $31
+                    local.get $29
                     i32.const 1
                     i32.shl
-                    local.tee $25
+                    local.tee $26
                     i32.const 0
                     call $~lib/rt/tlsf/__alloc
-                    local.set $29
+                    local.set $30
                     loop $for-loop|012
-                     local.get $1
-                     local.get $28
+                     local.get $0
+                     local.get $29
                      i32.lt_s
                      if
-                      local.get $26
-                      local.get $1
+                      local.get $27
+                      local.get $0
                       i32.const 1
                       i32.shl
-                      local.tee $24
+                      local.tee $25
                       i32.add
                       i32.load16_s
-                      local.set $27
+                      local.set $28
                       i32.const 3
                       global.set $~argumentsLength
-                      local.get $24
-                      local.get $29
+                      local.get $25
+                      local.get $30
                       i32.add
-                      local.get $27
-                      local.get $27
+                      local.get $28
+                      local.get $28
                       i32.mul
                       i32.store16
-                      local.get $1
+                      local.get $0
                       i32.const 1
                       i32.add
-                      local.set $1
+                      local.set $0
                       br $for-loop|012
                      end
                     end
+                    local.get $31
                     local.get $30
-                    local.get $29
                     call $~lib/rt/pure/__retain
                     i32.store
+                    local.get $31
                     local.get $30
-                    local.get $29
                     i32.store offset=4
-                    local.get $30
-                    local.get $25
+                    local.get $31
+                    local.get $26
                     i32.store offset=8
-                    local.get $30
+                    local.get $31
                     call $~lib/rt/pure/__retain
-                    local.tee $1
+                    local.tee $0
                     i32.const 0
                     call $~lib/typedarray/Int16Array#__get
                     i32.const 1
                     i32.ne
                     br_if $folding-inner4
-                    local.get $1
+                    local.get $0
                     i32.const 1
                     call $~lib/typedarray/Int16Array#__get
                     i32.const 4
                     i32.ne
                     br_if $folding-inner5
-                    local.get $1
+                    local.get $0
                     i32.const 2
                     call $~lib/typedarray/Int16Array#__get
                     i32.const 9
                     i32.ne
                     br_if $folding-inner6
-                    local.get $0
-                    call $~lib/rt/pure/__release
                     local.get $1
+                    call $~lib/rt/pure/__release
+                    local.get $0
                     call $~lib/rt/pure/__release
                     i32.const 3
                     call $~lib/typedarray/Uint16Array#constructor
-                    local.tee $0
+                    local.tee $1
                     i32.const 0
                     i32.const 1
                     call $~lib/typedarray/Uint16Array#__set
-                    local.get $0
+                    local.get $1
                     i32.const 1
                     i32.const 2
                     call $~lib/typedarray/Uint16Array#__set
-                    local.get $0
+                    local.get $1
                     i32.const 2
                     i32.const 3
                     call $~lib/typedarray/Uint16Array#__set
                     i32.const 0
-                    local.set $1
-                    local.get $0
+                    local.set $0
+                    local.get $1
                     i32.load offset=8
                     i32.const 1
                     i32.shr_u
-                    local.set $28
-                    local.get $0
+                    local.set $29
+                    local.get $1
                     i32.load offset=4
-                    local.set $26
+                    local.set $27
                     i32.const 12
                     i32.const 7
                     call $~lib/rt/tlsf/__alloc
-                    local.set $30
-                    local.get $28
+                    local.set $31
+                    local.get $29
                     i32.const 1
                     i32.shl
-                    local.tee $25
+                    local.tee $26
                     i32.const 0
                     call $~lib/rt/tlsf/__alloc
-                    local.set $29
+                    local.set $30
                     loop $for-loop|013
-                     local.get $1
-                     local.get $28
+                     local.get $0
+                     local.get $29
                      i32.lt_s
                      if
-                      local.get $26
-                      local.get $1
+                      local.get $27
+                      local.get $0
                       i32.const 1
                       i32.shl
-                      local.tee $24
+                      local.tee $25
                       i32.add
                       i32.load16_u
-                      local.set $27
+                      local.set $28
                       i32.const 3
                       global.set $~argumentsLength
-                      local.get $24
-                      local.get $29
+                      local.get $25
+                      local.get $30
                       i32.add
-                      local.get $27
-                      local.get $27
+                      local.get $28
+                      local.get $28
                       i32.mul
                       i32.store16
-                      local.get $1
+                      local.get $0
                       i32.const 1
                       i32.add
-                      local.set $1
+                      local.set $0
                       br $for-loop|013
                      end
                     end
+                    local.get $31
                     local.get $30
-                    local.get $29
                     call $~lib/rt/pure/__retain
                     i32.store
+                    local.get $31
                     local.get $30
-                    local.get $29
                     i32.store offset=4
-                    local.get $30
-                    local.get $25
+                    local.get $31
+                    local.get $26
                     i32.store offset=8
-                    local.get $30
+                    local.get $31
                     call $~lib/rt/pure/__retain
-                    local.tee $1
+                    local.tee $0
                     i32.const 0
                     call $~lib/typedarray/Uint16Array#__get
                     i32.const 1
                     i32.ne
                     br_if $folding-inner4
-                    local.get $1
+                    local.get $0
                     i32.const 1
                     call $~lib/typedarray/Uint16Array#__get
                     i32.const 4
                     i32.ne
                     br_if $folding-inner5
-                    local.get $1
+                    local.get $0
                     i32.const 2
                     call $~lib/typedarray/Uint16Array#__get
                     i32.const 9
                     i32.ne
                     br_if $folding-inner6
-                    local.get $0
-                    call $~lib/rt/pure/__release
                     local.get $1
+                    call $~lib/rt/pure/__release
+                    local.get $0
                     call $~lib/rt/pure/__release
                     i32.const 3
                     call $~lib/typedarray/Int32Array#constructor
-                    local.tee $0
+                    local.tee $1
                     i32.const 0
                     i32.const 1
                     call $~lib/typedarray/Int32Array#__set
-                    local.get $0
+                    local.get $1
                     i32.const 1
                     i32.const 2
                     call $~lib/typedarray/Int32Array#__set
-                    local.get $0
+                    local.get $1
                     i32.const 2
                     i32.const 3
                     call $~lib/typedarray/Int32Array#__set
                     i32.const 0
-                    local.set $1
-                    local.get $0
+                    local.set $0
+                    local.get $1
                     i32.load offset=8
                     i32.const 2
                     i32.shr_u
-                    local.set $28
-                    local.get $0
+                    local.set $29
+                    local.get $1
                     i32.load offset=4
-                    local.set $26
+                    local.set $27
                     i32.const 12
                     i32.const 8
                     call $~lib/rt/tlsf/__alloc
-                    local.set $30
-                    local.get $28
+                    local.set $31
+                    local.get $29
                     i32.const 2
                     i32.shl
-                    local.tee $25
+                    local.tee $26
                     i32.const 0
                     call $~lib/rt/tlsf/__alloc
-                    local.set $29
+                    local.set $30
                     loop $for-loop|014
-                     local.get $1
-                     local.get $28
+                     local.get $0
+                     local.get $29
                      i32.lt_s
                      if
-                      local.get $26
-                      local.get $1
+                      local.get $27
+                      local.get $0
                       i32.const 2
                       i32.shl
-                      local.tee $24
+                      local.tee $25
                       i32.add
                       i32.load
-                      local.set $27
+                      local.set $28
                       i32.const 3
                       global.set $~argumentsLength
-                      local.get $24
-                      local.get $29
+                      local.get $25
+                      local.get $30
                       i32.add
-                      local.get $27
-                      local.get $27
+                      local.get $28
+                      local.get $28
                       i32.mul
                       i32.store
-                      local.get $1
+                      local.get $0
                       i32.const 1
                       i32.add
-                      local.set $1
+                      local.set $0
                       br $for-loop|014
                      end
                     end
+                    local.get $31
                     local.get $30
-                    local.get $29
                     call $~lib/rt/pure/__retain
                     i32.store
+                    local.get $31
                     local.get $30
-                    local.get $29
                     i32.store offset=4
-                    local.get $30
-                    local.get $25
+                    local.get $31
+                    local.get $26
                     i32.store offset=8
-                    local.get $30
+                    local.get $31
                     call $~lib/rt/pure/__retain
-                    local.tee $1
+                    local.tee $0
                     i32.const 0
                     call $~lib/typedarray/Int32Array#__get
                     i32.const 1
                     i32.ne
                     br_if $folding-inner4
-                    local.get $1
+                    local.get $0
                     i32.const 1
                     call $~lib/typedarray/Int32Array#__get
                     i32.const 4
                     i32.ne
                     br_if $folding-inner5
-                    local.get $1
+                    local.get $0
                     i32.const 2
                     call $~lib/typedarray/Int32Array#__get
                     i32.const 9
                     i32.ne
                     br_if $folding-inner6
-                    local.get $0
-                    call $~lib/rt/pure/__release
                     local.get $1
+                    call $~lib/rt/pure/__release
+                    local.get $0
                     call $~lib/rt/pure/__release
                     i32.const 3
                     call $~lib/typedarray/Uint32Array#constructor
-                    local.tee $0
+                    local.tee $1
                     i32.const 0
                     i32.const 1
                     call $~lib/typedarray/Uint32Array#__set
-                    local.get $0
+                    local.get $1
                     i32.const 1
                     i32.const 2
                     call $~lib/typedarray/Uint32Array#__set
-                    local.get $0
+                    local.get $1
                     i32.const 2
                     i32.const 3
                     call $~lib/typedarray/Uint32Array#__set
                     i32.const 0
-                    local.set $1
-                    local.get $0
+                    local.set $0
+                    local.get $1
                     i32.load offset=8
                     i32.const 2
                     i32.shr_u
-                    local.set $28
-                    local.get $0
+                    local.set $29
+                    local.get $1
                     i32.load offset=4
-                    local.set $26
+                    local.set $27
                     i32.const 12
                     i32.const 9
                     call $~lib/rt/tlsf/__alloc
-                    local.set $30
-                    local.get $28
+                    local.set $31
+                    local.get $29
                     i32.const 2
                     i32.shl
-                    local.tee $25
+                    local.tee $26
                     i32.const 0
                     call $~lib/rt/tlsf/__alloc
-                    local.set $29
+                    local.set $30
                     loop $for-loop|015
-                     local.get $1
-                     local.get $28
+                     local.get $0
+                     local.get $29
                      i32.lt_s
                      if
-                      local.get $26
-                      local.get $1
+                      local.get $27
+                      local.get $0
                       i32.const 2
                       i32.shl
-                      local.tee $24
+                      local.tee $25
                       i32.add
                       i32.load
-                      local.set $27
+                      local.set $28
                       i32.const 3
                       global.set $~argumentsLength
-                      local.get $24
-                      local.get $29
+                      local.get $25
+                      local.get $30
                       i32.add
-                      local.get $27
-                      local.get $27
+                      local.get $28
+                      local.get $28
                       i32.mul
                       i32.store
-                      local.get $1
+                      local.get $0
                       i32.const 1
                       i32.add
-                      local.set $1
+                      local.set $0
                       br $for-loop|015
                      end
                     end
+                    local.get $31
                     local.get $30
-                    local.get $29
                     call $~lib/rt/pure/__retain
                     i32.store
+                    local.get $31
                     local.get $30
-                    local.get $29
                     i32.store offset=4
-                    local.get $30
-                    local.get $25
+                    local.get $31
+                    local.get $26
                     i32.store offset=8
-                    local.get $30
+                    local.get $31
                     call $~lib/rt/pure/__retain
-                    local.tee $1
+                    local.tee $0
                     i32.const 0
                     call $~lib/typedarray/Uint32Array#__get
                     i32.const 1
                     i32.ne
                     br_if $folding-inner4
-                    local.get $1
+                    local.get $0
                     i32.const 1
                     call $~lib/typedarray/Uint32Array#__get
                     i32.const 4
                     i32.ne
                     br_if $folding-inner5
-                    local.get $1
+                    local.get $0
                     i32.const 2
                     call $~lib/typedarray/Uint32Array#__get
                     i32.const 9
                     i32.ne
                     br_if $folding-inner6
-                    local.get $0
-                    call $~lib/rt/pure/__release
                     local.get $1
+                    call $~lib/rt/pure/__release
+                    local.get $0
                     call $~lib/rt/pure/__release
                     i32.const 3
                     call $~lib/typedarray/Int64Array#constructor
-                    local.tee $0
+                    local.tee $1
                     i32.const 0
                     i64.const 1
                     call $~lib/typedarray/Int64Array#__set
-                    local.get $0
+                    local.get $1
                     i32.const 1
                     i64.const 2
                     call $~lib/typedarray/Int64Array#__set
-                    local.get $0
+                    local.get $1
                     i32.const 2
                     i64.const 3
                     call $~lib/typedarray/Int64Array#__set
                     i32.const 0
-                    local.set $1
-                    local.get $0
+                    local.set $0
+                    local.get $1
                     i32.load offset=8
                     i32.const 3
                     i32.shr_u
-                    local.set $28
-                    local.get $0
+                    local.set $29
+                    local.get $1
                     i32.load offset=4
-                    local.set $27
+                    local.set $28
                     i32.const 12
                     i32.const 10
                     call $~lib/rt/tlsf/__alloc
-                    local.set $30
-                    local.get $28
+                    local.set $31
+                    local.get $29
                     i32.const 3
                     i32.shl
-                    local.tee $26
+                    local.tee $27
                     i32.const 0
                     call $~lib/rt/tlsf/__alloc
-                    local.set $29
+                    local.set $30
                     loop $for-loop|016
-                     local.get $1
-                     local.get $28
+                     local.get $0
+                     local.get $29
                      i32.lt_s
                      if
-                      local.get $27
-                      local.get $1
+                      local.get $28
+                      local.get $0
                       i32.const 3
                       i32.shl
-                      local.tee $25
+                      local.tee $26
                       i32.add
                       i64.load
-                      local.set $20
+                      local.set $21
                       i32.const 3
                       global.set $~argumentsLength
-                      local.get $25
-                      local.get $29
+                      local.get $26
+                      local.get $30
                       i32.add
-                      local.get $20
-                      local.get $20
+                      local.get $21
+                      local.get $21
                       i64.mul
                       i64.store
-                      local.get $1
+                      local.get $0
                       i32.const 1
                       i32.add
-                      local.set $1
+                      local.set $0
                       br $for-loop|016
                      end
                     end
+                    local.get $31
                     local.get $30
-                    local.get $29
                     call $~lib/rt/pure/__retain
                     i32.store
+                    local.get $31
                     local.get $30
-                    local.get $29
                     i32.store offset=4
-                    local.get $30
-                    local.get $26
+                    local.get $31
+                    local.get $27
                     i32.store offset=8
-                    local.get $30
+                    local.get $31
                     call $~lib/rt/pure/__retain
-                    local.tee $1
+                    local.tee $0
                     i32.const 0
                     call $~lib/typedarray/Int64Array#__get
                     i64.const 1
                     i64.ne
                     br_if $folding-inner4
-                    local.get $1
+                    local.get $0
                     i32.const 1
                     call $~lib/typedarray/Int64Array#__get
                     i64.const 4
                     i64.ne
                     br_if $folding-inner5
-                    local.get $1
+                    local.get $0
                     i32.const 2
                     call $~lib/typedarray/Int64Array#__get
                     i64.const 9
                     i64.ne
                     br_if $folding-inner6
-                    local.get $0
-                    call $~lib/rt/pure/__release
                     local.get $1
+                    call $~lib/rt/pure/__release
+                    local.get $0
                     call $~lib/rt/pure/__release
                     i32.const 3
                     call $~lib/typedarray/Uint64Array#constructor
-                    local.tee $0
+                    local.tee $1
                     i32.const 0
                     i64.const 1
                     call $~lib/typedarray/Uint64Array#__set
-                    local.get $0
+                    local.get $1
                     i32.const 1
                     i64.const 2
                     call $~lib/typedarray/Uint64Array#__set
-                    local.get $0
+                    local.get $1
                     i32.const 2
                     i64.const 3
                     call $~lib/typedarray/Uint64Array#__set
                     i32.const 0
-                    local.set $1
-                    local.get $0
+                    local.set $0
+                    local.get $1
                     i32.load offset=8
                     i32.const 3
                     i32.shr_u
-                    local.set $28
-                    local.get $0
+                    local.set $29
+                    local.get $1
                     i32.load offset=4
-                    local.set $27
+                    local.set $28
                     i32.const 12
                     i32.const 11
                     call $~lib/rt/tlsf/__alloc
-                    local.set $30
-                    local.get $28
+                    local.set $31
+                    local.get $29
                     i32.const 3
                     i32.shl
-                    local.tee $26
+                    local.tee $27
                     i32.const 0
                     call $~lib/rt/tlsf/__alloc
-                    local.set $29
+                    local.set $30
                     loop $for-loop|017
-                     local.get $1
-                     local.get $28
+                     local.get $0
+                     local.get $29
                      i32.lt_s
                      if
-                      local.get $27
-                      local.get $1
+                      local.get $28
+                      local.get $0
                       i32.const 3
                       i32.shl
-                      local.tee $25
+                      local.tee $26
                       i32.add
                       i64.load
-                      local.set $20
+                      local.set $21
                       i32.const 3
                       global.set $~argumentsLength
-                      local.get $25
-                      local.get $29
+                      local.get $26
+                      local.get $30
                       i32.add
-                      local.get $20
-                      local.get $20
+                      local.get $21
+                      local.get $21
                       i64.mul
                       i64.store
-                      local.get $1
+                      local.get $0
                       i32.const 1
                       i32.add
-                      local.set $1
+                      local.set $0
                       br $for-loop|017
                      end
                     end
+                    local.get $31
                     local.get $30
-                    local.get $29
                     call $~lib/rt/pure/__retain
                     i32.store
+                    local.get $31
                     local.get $30
-                    local.get $29
                     i32.store offset=4
-                    local.get $30
-                    local.get $26
+                    local.get $31
+                    local.get $27
                     i32.store offset=8
-                    local.get $30
+                    local.get $31
                     call $~lib/rt/pure/__retain
-                    local.tee $1
+                    local.tee $0
                     i32.const 0
                     call $~lib/typedarray/Uint64Array#__get
                     i64.const 1
                     i64.ne
                     br_if $folding-inner4
-                    local.get $1
+                    local.get $0
                     i32.const 1
                     call $~lib/typedarray/Uint64Array#__get
                     i64.const 4
                     i64.ne
                     br_if $folding-inner5
-                    local.get $1
+                    local.get $0
                     i32.const 2
                     call $~lib/typedarray/Uint64Array#__get
                     i64.const 9
                     i64.ne
                     br_if $folding-inner6
-                    local.get $0
-                    call $~lib/rt/pure/__release
                     local.get $1
+                    call $~lib/rt/pure/__release
+                    local.get $0
                     call $~lib/rt/pure/__release
                     i32.const 3
                     call $~lib/typedarray/Float32Array#constructor
-                    local.tee $0
+                    local.tee $1
                     i32.const 0
                     f32.const 1
                     call $~lib/typedarray/Float32Array#__set
-                    local.get $0
+                    local.get $1
                     i32.const 1
                     f32.const 2
                     call $~lib/typedarray/Float32Array#__set
-                    local.get $0
+                    local.get $1
                     i32.const 2
                     f32.const 3
                     call $~lib/typedarray/Float32Array#__set
                     i32.const 0
-                    local.set $1
-                    local.get $0
+                    local.set $0
+                    local.get $1
                     i32.load offset=8
                     i32.const 2
                     i32.shr_u
-                    local.set $28
-                    local.get $0
+                    local.set $29
+                    local.get $1
                     i32.load offset=4
-                    local.set $27
+                    local.set $28
                     i32.const 12
                     i32.const 12
                     call $~lib/rt/tlsf/__alloc
-                    local.set $30
-                    local.get $28
+                    local.set $31
+                    local.get $29
                     i32.const 2
                     i32.shl
-                    local.tee $26
+                    local.tee $27
                     i32.const 0
                     call $~lib/rt/tlsf/__alloc
-                    local.set $29
+                    local.set $30
                     loop $for-loop|018
-                     local.get $1
-                     local.get $28
+                     local.get $0
+                     local.get $29
                      i32.lt_s
                      if
-                      local.get $27
-                      local.get $1
+                      local.get $28
+                      local.get $0
                       i32.const 2
                       i32.shl
-                      local.tee $25
+                      local.tee $26
                       i32.add
                       f32.load
-                      local.set $22
+                      local.set $24
                       i32.const 3
                       global.set $~argumentsLength
-                      local.get $25
-                      local.get $29
+                      local.get $26
+                      local.get $30
                       i32.add
-                      local.get $22
-                      local.get $22
+                      local.get $24
+                      local.get $24
                       f32.mul
                       f32.store
-                      local.get $1
+                      local.get $0
                       i32.const 1
                       i32.add
-                      local.set $1
+                      local.set $0
                       br $for-loop|018
                      end
                     end
+                    local.get $31
                     local.get $30
-                    local.get $29
                     call $~lib/rt/pure/__retain
                     i32.store
+                    local.get $31
                     local.get $30
-                    local.get $29
                     i32.store offset=4
-                    local.get $30
-                    local.get $26
+                    local.get $31
+                    local.get $27
                     i32.store offset=8
-                    local.get $30
+                    local.get $31
                     call $~lib/rt/pure/__retain
-                    local.tee $1
+                    local.tee $0
                     i32.const 0
                     call $~lib/typedarray/Float32Array#__get
                     f32.const 1
                     f32.ne
                     br_if $folding-inner4
-                    local.get $1
+                    local.get $0
                     i32.const 1
                     call $~lib/typedarray/Float32Array#__get
                     f32.const 4
                     f32.ne
                     br_if $folding-inner5
-                    local.get $1
+                    local.get $0
                     i32.const 2
                     call $~lib/typedarray/Float32Array#__get
                     f32.const 9
                     f32.ne
                     br_if $folding-inner6
-                    local.get $0
-                    call $~lib/rt/pure/__release
                     local.get $1
+                    call $~lib/rt/pure/__release
+                    local.get $0
                     call $~lib/rt/pure/__release
                     i32.const 3
                     call $~lib/typedarray/Float64Array#constructor
-                    local.tee $0
+                    local.tee $1
                     i32.const 0
                     f64.const 1
                     call $~lib/typedarray/Float64Array#__set
-                    local.get $0
+                    local.get $1
                     i32.const 1
                     f64.const 2
                     call $~lib/typedarray/Float64Array#__set
-                    local.get $0
+                    local.get $1
                     i32.const 2
                     f64.const 3
                     call $~lib/typedarray/Float64Array#__set
                     i32.const 0
-                    local.set $1
-                    local.get $0
+                    local.set $0
+                    local.get $1
                     i32.load offset=8
                     i32.const 3
                     i32.shr_u
-                    local.set $28
-                    local.get $0
+                    local.set $29
+                    local.get $1
                     i32.load offset=4
-                    local.set $27
+                    local.set $28
                     i32.const 12
                     i32.const 13
                     call $~lib/rt/tlsf/__alloc
-                    local.set $30
-                    local.get $28
+                    local.set $31
+                    local.get $29
                     i32.const 3
                     i32.shl
-                    local.tee $26
+                    local.tee $27
                     i32.const 0
                     call $~lib/rt/tlsf/__alloc
-                    local.set $29
+                    local.set $30
                     loop $for-loop|019
-                     local.get $1
-                     local.get $28
+                     local.get $0
+                     local.get $29
                      i32.lt_s
                      if
-                      local.get $27
-                      local.get $1
+                      local.get $28
+                      local.get $0
                       i32.const 3
                       i32.shl
-                      local.tee $25
+                      local.tee $26
                       i32.add
                       f64.load
                       local.set $23
                       i32.const 3
                       global.set $~argumentsLength
-                      local.get $25
-                      local.get $29
+                      local.get $26
+                      local.get $30
                       i32.add
                       local.get $23
                       local.get $23
                       f64.mul
                       f64.store
-                      local.get $1
+                      local.get $0
                       i32.const 1
                       i32.add
-                      local.set $1
+                      local.set $0
                       br $for-loop|019
                      end
                     end
+                    local.get $31
                     local.get $30
-                    local.get $29
                     call $~lib/rt/pure/__retain
                     i32.store
+                    local.get $31
                     local.get $30
-                    local.get $29
                     i32.store offset=4
-                    local.get $30
-                    local.get $26
+                    local.get $31
+                    local.get $27
                     i32.store offset=8
-                    local.get $30
+                    local.get $31
                     call $~lib/rt/pure/__retain
-                    local.tee $1
+                    local.tee $0
                     i32.const 0
                     call $~lib/typedarray/Float64Array#__get
                     f64.const 1
                     f64.ne
                     br_if $folding-inner4
-                    local.get $1
+                    local.get $0
                     i32.const 1
                     call $~lib/typedarray/Float64Array#__get
                     f64.const 4
                     f64.ne
                     br_if $folding-inner5
-                    local.get $1
+                    local.get $0
                     i32.const 2
                     call $~lib/typedarray/Float64Array#__get
                     f64.const 9
                     f64.ne
                     br_if $folding-inner6
-                    local.get $0
-                    call $~lib/rt/pure/__release
                     local.get $1
+                    call $~lib/rt/pure/__release
+                    local.get $0
                     call $~lib/rt/pure/__release
                     call $std/typedarray/testArrayFilter<~lib/typedarray/Int8Array,i8>
                     call $std/typedarray/testArrayFilter<~lib/typedarray/Uint8Array,u8>
@@ -30457,9 +33028,9 @@
                     global.set $std/typedarray/forEachCallCount
                     i32.const 3
                     call $~lib/typedarray/Int8Array#constructor
-                    local.tee $0
+                    local.tee $1
                     global.set $std/typedarray/forEachSelf
-                    local.get $0
+                    local.get $1
                     i32.const 0
                     i32.const 2704
                     i32.const 0
@@ -30469,7 +33040,7 @@
                     i32.const 24
                     i32.shr_s
                     call $~lib/typedarray/Int8Array#__set
-                    local.get $0
+                    local.get $1
                     i32.const 1
                     i32.const 2704
                     i32.const 1
@@ -30479,7 +33050,7 @@
                     i32.const 24
                     i32.shr_s
                     call $~lib/typedarray/Int8Array#__set
-                    local.get $0
+                    local.get $1
                     i32.const 2
                     i32.const 2704
                     i32.const 2
@@ -30490,39 +33061,39 @@
                     i32.shr_s
                     call $~lib/typedarray/Int8Array#__set
                     i32.const 0
-                    local.set $1
-                    local.get $0
+                    local.set $0
+                    local.get $1
                     i32.load offset=4
-                    local.set $30
-                    local.get $0
+                    local.set $31
+                    local.get $1
                     i32.load offset=8
-                    local.set $29
-                    loop $for-loop|020
-                     local.get $1
-                     local.get $29
+                    local.set $30
+                    loop $for-loop|0912
+                     local.get $0
+                     local.get $30
                      i32.lt_s
                      if
-                      local.get $1
-                      local.get $30
+                      local.get $0
+                      local.get $31
                       i32.add
                       i32.load8_s
                       i32.const 3
                       global.set $~argumentsLength
-                      local.get $1
                       local.get $0
-                      call $std/typedarray/testArrayForEach<~lib/typedarray/Int8Array,i8>~anonymous|0
                       local.get $1
+                      call $std/typedarray/testArrayForEach<~lib/typedarray/Int8Array,i8>~anonymous|0~nonClosure
+                      local.get $0
                       i32.const 1
                       i32.add
-                      local.set $1
-                      br $for-loop|020
+                      local.set $0
+                      br $for-loop|0912
                      end
                     end
                     global.get $std/typedarray/forEachCallCount
                     i32.const 3
                     i32.ne
                     br_if $folding-inner13
-                    local.get $0
+                    local.get $1
                     call $~lib/rt/pure/__release
                     i32.const 0
                     global.set $std/typedarray/forEachCallCount
@@ -30606,9 +33177,9 @@
                     global.set $std/typedarray/forEachCallCount
                     i32.const 3
                     call $~lib/typedarray/Int16Array#constructor
-                    local.tee $0
+                    local.tee $1
                     global.set $std/typedarray/forEachSelf
-                    local.get $0
+                    local.get $1
                     i32.const 0
                     i32.const 2704
                     i32.const 0
@@ -30618,7 +33189,7 @@
                     i32.const 16
                     i32.shr_s
                     call $~lib/typedarray/Int16Array#__set
-                    local.get $0
+                    local.get $1
                     i32.const 1
                     i32.const 2704
                     i32.const 1
@@ -30628,7 +33199,7 @@
                     i32.const 16
                     i32.shr_s
                     call $~lib/typedarray/Int16Array#__set
-                    local.get $0
+                    local.get $1
                     i32.const 2
                     i32.const 2704
                     i32.const 2
@@ -30639,51 +33210,51 @@
                     i32.shr_s
                     call $~lib/typedarray/Int16Array#__set
                     i32.const 0
-                    local.set $1
-                    local.get $0
+                    local.set $0
+                    local.get $1
                     i32.load offset=4
-                    local.set $30
-                    local.get $0
+                    local.set $31
+                    local.get $1
                     i32.load offset=8
                     i32.const 1
                     i32.shr_u
-                    local.set $29
-                    loop $for-loop|021
-                     local.get $1
-                     local.get $29
+                    local.set $30
+                    loop $for-loop|01013
+                     local.get $0
+                     local.get $30
                      i32.lt_s
                      if
-                      local.get $30
-                      local.get $1
+                      local.get $31
+                      local.get $0
                       i32.const 1
                       i32.shl
                       i32.add
                       i32.load16_s
                       i32.const 3
                       global.set $~argumentsLength
-                      local.get $1
                       local.get $0
-                      call $std/typedarray/testArrayForEach<~lib/typedarray/Int16Array,i16>~anonymous|0
                       local.get $1
+                      call $std/typedarray/testArrayForEach<~lib/typedarray/Int16Array,i16>~anonymous|0~nonClosure
+                      local.get $0
                       i32.const 1
                       i32.add
-                      local.set $1
-                      br $for-loop|021
+                      local.set $0
+                      br $for-loop|01013
                      end
                     end
                     global.get $std/typedarray/forEachCallCount
                     i32.const 3
                     i32.ne
                     br_if $folding-inner13
-                    local.get $0
+                    local.get $1
                     call $~lib/rt/pure/__release
                     i32.const 0
                     global.set $std/typedarray/forEachCallCount
                     i32.const 3
                     call $~lib/typedarray/Uint16Array#constructor
-                    local.tee $0
+                    local.tee $1
                     global.set $std/typedarray/forEachSelf
-                    local.get $0
+                    local.get $1
                     i32.const 0
                     i32.const 2704
                     i32.const 0
@@ -30691,7 +33262,7 @@
                     i32.const 65535
                     i32.and
                     call $~lib/typedarray/Uint16Array#__set
-                    local.get $0
+                    local.get $1
                     i32.const 1
                     i32.const 2704
                     i32.const 1
@@ -30699,7 +33270,7 @@
                     i32.const 65535
                     i32.and
                     call $~lib/typedarray/Uint16Array#__set
-                    local.get $0
+                    local.get $1
                     i32.const 2
                     i32.const 2704
                     i32.const 2
@@ -30708,43 +33279,43 @@
                     i32.and
                     call $~lib/typedarray/Uint16Array#__set
                     i32.const 0
-                    local.set $1
-                    local.get $0
+                    local.set $0
+                    local.get $1
                     i32.load offset=4
-                    local.set $30
-                    local.get $0
+                    local.set $31
+                    local.get $1
                     i32.load offset=8
                     i32.const 1
                     i32.shr_u
-                    local.set $29
-                    loop $for-loop|022
-                     local.get $1
-                     local.get $29
+                    local.set $30
+                    loop $for-loop|01114
+                     local.get $0
+                     local.get $30
                      i32.lt_s
                      if
-                      local.get $30
-                      local.get $1
+                      local.get $31
+                      local.get $0
                       i32.const 1
                       i32.shl
                       i32.add
                       i32.load16_u
                       i32.const 3
                       global.set $~argumentsLength
-                      local.get $1
                       local.get $0
-                      call $std/typedarray/testArrayForEach<~lib/typedarray/Int16Array,i16>~anonymous|0
                       local.get $1
+                      call $std/typedarray/testArrayForEach<~lib/typedarray/Int16Array,i16>~anonymous|0~nonClosure
+                      local.get $0
                       i32.const 1
                       i32.add
-                      local.set $1
-                      br $for-loop|022
+                      local.set $0
+                      br $for-loop|01114
                      end
                     end
                     global.get $std/typedarray/forEachCallCount
                     i32.const 3
                     i32.ne
                     br_if $folding-inner13
-                    local.get $0
+                    local.get $1
                     call $~lib/rt/pure/__release
                     i32.const 0
                     global.set $std/typedarray/forEachCallCount
@@ -30888,23 +33459,23 @@
                     global.set $std/typedarray/forEachCallCount
                     i32.const 3
                     call $~lib/typedarray/Float32Array#constructor
-                    local.tee $1
+                    local.tee $0
                     global.set $std/typedarray/forEachSelf
-                    local.get $1
+                    local.get $0
                     i32.const 0
                     i32.const 2704
                     i32.const 0
                     call $~lib/array/Array<i32>#__get
                     f32.convert_i32_s
                     call $~lib/typedarray/Float32Array#__set
-                    local.get $1
+                    local.get $0
                     i32.const 1
                     i32.const 2704
                     i32.const 1
                     call $~lib/array/Array<i32>#__get
                     f32.convert_i32_s
                     call $~lib/typedarray/Float32Array#__set
-                    local.get $1
+                    local.get $0
                     i32.const 2
                     i32.const 2704
                     i32.const 2
@@ -30912,65 +33483,65 @@
                     f32.convert_i32_s
                     call $~lib/typedarray/Float32Array#__set
                     i32.const 0
-                    local.set $0
-                    local.get $1
+                    local.set $1
+                    local.get $0
                     i32.load offset=4
-                    local.set $30
-                    local.get $1
+                    local.set $31
+                    local.get $0
                     i32.load offset=8
                     i32.const 2
                     i32.shr_u
-                    local.set $29
-                    loop $for-loop|023
-                     local.get $0
-                     local.get $29
+                    local.set $30
+                    loop $for-loop|01220
+                     local.get $1
+                     local.get $30
                      i32.lt_s
                      if
-                      local.get $30
-                      local.get $0
+                      local.get $31
+                      local.get $1
                       i32.const 2
                       i32.shl
                       i32.add
                       f32.load
                       i32.const 3
                       global.set $~argumentsLength
-                      local.get $0
                       local.get $1
-                      call $std/typedarray/testArrayForEach<~lib/typedarray/Float32Array,f32>~anonymous|0
                       local.get $0
+                      call $std/typedarray/testArrayForEach<~lib/typedarray/Float32Array,f32>~anonymous|0~nonClosure
+                      local.get $1
                       i32.const 1
                       i32.add
-                      local.set $0
-                      br $for-loop|023
+                      local.set $1
+                      br $for-loop|01220
                      end
                     end
                     global.get $std/typedarray/forEachCallCount
                     i32.const 3
                     i32.ne
                     br_if $folding-inner13
-                    local.get $1
+                    local.get $0
                     call $~lib/rt/pure/__release
                     i32.const 0
                     global.set $std/typedarray/forEachCallCount
                     i32.const 3
                     call $~lib/typedarray/Float64Array#constructor
-                    local.tee $1
+                    local.tee $0
                     global.set $std/typedarray/forEachSelf
-                    local.get $1
+                    local.get $0
                     i32.const 0
                     i32.const 2704
                     i32.const 0
                     call $~lib/array/Array<i32>#__get
                     f64.convert_i32_s
                     call $~lib/typedarray/Float64Array#__set
-                    local.get $1
+                    local.get $0
                     i32.const 1
                     i32.const 2704
                     i32.const 1
                     call $~lib/array/Array<i32>#__get
                     f64.convert_i32_s
                     call $~lib/typedarray/Float64Array#__set
-                    local.get $1
+                    local.get $0
                     i32.const 2
                     i32.const 2704
                     i32.const 2
@@ -30978,43 +33549,43 @@
                     f64.convert_i32_s
                     call $~lib/typedarray/Float64Array#__set
                     i32.const 0
-                    local.set $0
-                    local.get $1
+                    local.set $1
+                    local.get $0
                     i32.load offset=4
-                    local.set $30
-                    local.get $1
+                    local.set $31
+                    local.get $0
                     i32.load offset=8
                     i32.const 3
                     i32.shr_u
-                    local.set $29
-                    loop $for-loop|024
-                     local.get $0
-                     local.get $29
+                    local.set $30
+                    loop $for-loop|01321
+                     local.get $1
+                     local.get $30
                      i32.lt_s
                      if
-                      local.get $30
-                      local.get $0
+                      local.get $31
+                      local.get $1
                       i32.const 3
                       i32.shl
                       i32.add
                       f64.load
                       i32.const 3
                       global.set $~argumentsLength
-                      local.get $0
                       local.get $1
-                      call $std/typedarray/testArrayForEach<~lib/typedarray/Float64Array,f64>~anonymous|0
                       local.get $0
+                      call $std/typedarray/testArrayForEach<~lib/typedarray/Float64Array,f64>~anonymous|0~nonClosure
+                      local.get $1
                       i32.const 1
                       i32.add
-                      local.set $0
-                      br $for-loop|024
+                      local.set $1
+                      br $for-loop|01321
                      end
                     end
                     global.get $std/typedarray/forEachCallCount
                     i32.const 3
                     i32.ne
                     br_if $folding-inner13
-                    local.get $1
+                    local.get $0
                     call $~lib/rt/pure/__release
                     call $std/typedarray/testArrayReverse<~lib/typedarray/Int8Array,i8>
                     call $std/typedarray/testArrayReverse<~lib/typedarray/Uint8Array,u8>
@@ -31040,11 +33611,11 @@
                     call $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Float64Array,f64>
                     i32.const 1
                     call $~lib/typedarray/Float64Array#constructor
-                    local.tee $30
+                    local.tee $31
                     i32.const 0
                     f64.const nan:0x8000000000000
                     call $~lib/typedarray/Float64Array#__set
-                    local.get $30
+                    local.get $31
                     f64.const nan:0x8000000000000
                     i32.const 0
                     call $~lib/typedarray/Float64Array#indexOf
@@ -31059,33 +33630,33 @@
                      unreachable
                     end
                     i32.const 0
-                    local.set $0
-                    i32.const 0
                     local.set $1
+                    i32.const 0
+                    local.set $0
                     block $~lib/typedarray/INCLUDES<~lib/typedarray/Float64Array,f64>|inlined.0
-                     local.get $30
+                     local.get $31
                      i32.load offset=8
                      i32.const 3
                      i32.shr_u
-                     local.tee $29
+                     local.tee $30
                      if (result i32)
                       i32.const 0
-                      local.get $29
+                      local.get $30
                       i32.ge_s
                      else
                       i32.const 1
                      end
                      br_if $~lib/typedarray/INCLUDES<~lib/typedarray/Float64Array,f64>|inlined.0
-                     local.get $30
+                     local.get $31
                      i32.load offset=4
-                     local.set $27
+                     local.set $28
                      loop $while-continue|0
-                      local.get $0
-                      local.get $29
+                      local.get $1
+                      local.get $30
                       i32.lt_s
                       if
-                       local.get $27
-                       local.get $0
+                       local.get $28
+                       local.get $1
                        i32.const 3
                        i32.shl
                        i32.add
@@ -31102,18 +33673,18 @@
                        end
                        if
                         i32.const 1
-                        local.set $1
+                        local.set $0
                         br $~lib/typedarray/INCLUDES<~lib/typedarray/Float64Array,f64>|inlined.0
                        end
-                       local.get $0
+                       local.get $1
                        i32.const 1
                        i32.add
-                       local.set $0
+                       local.set $1
                        br $while-continue|0
                       end
                      end
                     end
-                    local.get $1
+                    local.get $0
                     i32.const 0
                     i32.ne
                     i32.const 1
@@ -31128,11 +33699,11 @@
                     end
                     i32.const 1
                     call $~lib/typedarray/Float32Array#constructor
-                    local.tee $29
+                    local.tee $0
                     i32.const 0
                     f32.const nan:0x400000
                     call $~lib/typedarray/Float32Array#__set
-                    local.get $29
+                    local.get $0
                     f32.const nan:0x400000
                     i32.const 0
                     call $~lib/typedarray/Float32Array#indexOf
@@ -31147,61 +33718,61 @@
                      unreachable
                     end
                     i32.const 0
-                    local.set $1
+                    local.set $30
                     i32.const 0
-                    local.set $0
+                    local.set $1
                     block $~lib/typedarray/INCLUDES<~lib/typedarray/Float32Array,f32>|inlined.0
-                     local.get $29
+                     local.get $0
                      i32.load offset=8
                      i32.const 2
                      i32.shr_u
-                     local.tee $28
+                     local.tee $29
                      if (result i32)
                       i32.const 0
-                      local.get $28
+                      local.get $29
                       i32.ge_s
                      else
                       i32.const 1
                      end
                      br_if $~lib/typedarray/INCLUDES<~lib/typedarray/Float32Array,f32>|inlined.0
-                     local.get $29
+                     local.get $0
                      i32.load offset=4
-                     local.set $26
-                     loop $while-continue|025
-                      local.get $1
-                      local.get $28
+                     local.set $27
+                     loop $while-continue|014
+                      local.get $30
+                      local.get $29
                       i32.lt_s
                       if
-                       local.get $26
-                       local.get $1
+                       local.get $27
+                       local.get $30
                        i32.const 2
                        i32.shl
                        i32.add
                        f32.load
-                       local.tee $22
+                       local.tee $24
                        f32.const nan:0x400000
                        f32.eq
                        if (result i32)
                         i32.const 1
                        else
-                        local.get $22
-                        local.get $22
+                        local.get $24
+                        local.get $24
                         f32.ne
                        end
                        if
                         i32.const 1
-                        local.set $0
+                        local.set $1
                         br $~lib/typedarray/INCLUDES<~lib/typedarray/Float32Array,f32>|inlined.0
                        end
-                       local.get $1
+                       local.get $30
                        i32.const 1
                        i32.add
-                       local.set $1
-                       br $while-continue|025
+                       local.set $30
+                       br $while-continue|014
                       end
                      end
                     end
-                    local.get $0
+                    local.get $1
                     i32.const 0
                     i32.ne
                     i32.const 1
@@ -31214,9 +33785,9 @@
                      call $~lib/builtins/abort
                      unreachable
                     end
-                    local.get $30
+                    local.get $31
                     call $~lib/rt/pure/__release
-                    local.get $29
+                    local.get $0
                     call $~lib/rt/pure/__release
                     i32.const 5
                     call $~lib/typedarray/Int8Array#constructor
@@ -31249,21 +33820,20 @@
                     br_if $folding-inner0
                     local.get $1
                     call $~lib/typedarray/Int8Array#join
-                    local.tee $30
+                    local.tee $31
                     i32.const 3296
                     call $~lib/string/String.__eq
                     i32.eqz
                     br_if $folding-inner18
                     local.get $0
                     call $~lib/rt/pure/__release
-                    local.get $30
+                    local.get $31
                     call $~lib/rt/pure/__release
                     local.get $1
                     call $~lib/rt/pure/__release
                     i32.const 5
                     call $~lib/typedarray/Uint8Array#constructor
                     local.tee $1
-                    local.get $1
                     i32.const 0
                     i32.const 1
                     call $~lib/typedarray/Uint8Array#__set
@@ -31285,27 +33855,27 @@
                     call $~lib/typedarray/Uint8Array#__set
                     local.get $1
                     call $~lib/typedarray/Uint8Array#join
-                    local.tee $30
+                    local.tee $0
                     i32.const 3296
                     call $~lib/string/String.__eq
                     i32.eqz
                     br_if $folding-inner0
+                    local.get $1
                     call $~lib/typedarray/Uint8Array#join
-                    local.tee $0
-                    local.get $0
+                    local.tee $31
                     i32.const 3296
                     call $~lib/string/String.__eq
                     i32.eqz
                     br_if $folding-inner18
-                    local.get $30
+                    local.get $0
                     call $~lib/rt/pure/__release
+                    local.get $31
                     call $~lib/rt/pure/__release
                     local.get $1
                     call $~lib/rt/pure/__release
                     i32.const 5
                     call $~lib/typedarray/Uint8ClampedArray#constructor
                     local.tee $1
-                    local.get $1
                     i32.const 0
                     i32.const 1
                     call $~lib/typedarray/Uint8ClampedArray#__set
@@ -31327,20 +33897,21 @@
                     call $~lib/typedarray/Uint8ClampedArray#__set
                     local.get $1
                     call $~lib/typedarray/Uint8Array#join
-                    local.tee $30
+                    local.tee $0
                     i32.const 3296
                     call $~lib/string/String.__eq
                     i32.eqz
                     br_if $folding-inner0
+                    local.get $1
                     call $~lib/typedarray/Uint8Array#join
-                    local.tee $0
-                    local.get $0
+                    local.tee $31
                     i32.const 3296
                     call $~lib/string/String.__eq
                     i32.eqz
                     br_if $folding-inner18
-                    local.get $30
+                    local.get $0
                     call $~lib/rt/pure/__release
+                    local.get $31
                     call $~lib/rt/pure/__release
                     local.get $1
                     call $~lib/rt/pure/__release
@@ -31375,14 +33946,14 @@
                     br_if $folding-inner0
                     local.get $1
                     call $~lib/typedarray/Int16Array#join
-                    local.tee $30
+                    local.tee $31
                     i32.const 3296
                     call $~lib/string/String.__eq
                     i32.eqz
                     br_if $folding-inner18
                     local.get $0
                     call $~lib/rt/pure/__release
-                    local.get $30
+                    local.get $31
                     call $~lib/rt/pure/__release
                     local.get $1
                     call $~lib/rt/pure/__release
@@ -31417,14 +33988,14 @@
                     br_if $folding-inner0
                     local.get $1
                     call $~lib/typedarray/Uint16Array#join
-                    local.tee $30
+                    local.tee $31
                     i32.const 3296
                     call $~lib/string/String.__eq
                     i32.eqz
                     br_if $folding-inner18
                     local.get $0
                     call $~lib/rt/pure/__release
-                    local.get $30
+                    local.get $31
                     call $~lib/rt/pure/__release
                     local.get $1
                     call $~lib/rt/pure/__release
@@ -31459,14 +34030,14 @@
                     br_if $folding-inner0
                     local.get $1
                     call $~lib/typedarray/Int32Array#join
-                    local.tee $30
+                    local.tee $31
                     i32.const 3296
                     call $~lib/string/String.__eq
                     i32.eqz
                     br_if $folding-inner18
                     local.get $0
                     call $~lib/rt/pure/__release
-                    local.get $30
+                    local.get $31
                     call $~lib/rt/pure/__release
                     local.get $1
                     call $~lib/rt/pure/__release
@@ -31501,14 +34072,14 @@
                     br_if $folding-inner0
                     local.get $1
                     call $~lib/typedarray/Uint32Array#join
-                    local.tee $30
+                    local.tee $31
                     i32.const 3296
                     call $~lib/string/String.__eq
                     i32.eqz
                     br_if $folding-inner18
                     local.get $0
                     call $~lib/rt/pure/__release
-                    local.get $30
+                    local.get $31
                     call $~lib/rt/pure/__release
                     local.get $1
                     call $~lib/rt/pure/__release
@@ -31543,14 +34114,14 @@
                     br_if $folding-inner0
                     local.get $1
                     call $~lib/typedarray/Int64Array#join
-                    local.tee $30
+                    local.tee $31
                     i32.const 3296
                     call $~lib/string/String.__eq
                     i32.eqz
                     br_if $folding-inner18
                     local.get $0
                     call $~lib/rt/pure/__release
-                    local.get $30
+                    local.get $31
                     call $~lib/rt/pure/__release
                     local.get $1
                     call $~lib/rt/pure/__release
@@ -31585,14 +34156,14 @@
                     br_if $folding-inner0
                     local.get $1
                     call $~lib/typedarray/Uint64Array#join
-                    local.tee $30
+                    local.tee $31
                     i32.const 3296
                     call $~lib/string/String.__eq
                     i32.eqz
                     br_if $folding-inner18
                     local.get $0
                     call $~lib/rt/pure/__release
-                    local.get $30
+                    local.get $31
                     call $~lib/rt/pure/__release
                     local.get $1
                     call $~lib/rt/pure/__release
@@ -31627,14 +34198,14 @@
                     br_if $folding-inner16
                     local.get $1
                     call $~lib/typedarray/Float32Array#join
-                    local.tee $30
+                    local.tee $31
                     i32.const 4400
                     call $~lib/string/String.__eq
                     i32.eqz
                     br_if $folding-inner17
                     local.get $0
                     call $~lib/rt/pure/__release
-                    local.get $30
+                    local.get $31
                     call $~lib/rt/pure/__release
                     local.get $1
                     call $~lib/rt/pure/__release
@@ -31669,14 +34240,14 @@
                     br_if $folding-inner16
                     local.get $1
                     call $~lib/typedarray/Float64Array#join
-                    local.tee $30
+                    local.tee $31
                     i32.const 4400
                     call $~lib/string/String.__eq
                     i32.eqz
                     br_if $folding-inner17
                     local.get $0
                     call $~lib/rt/pure/__release
-                    local.get $30
+                    local.get $31
                     call $~lib/rt/pure/__release
                     local.get $1
                     call $~lib/rt/pure/__release
@@ -31688,7 +34259,7 @@
                     local.get $1
                     i32.const 0
                     call $~lib/typedarray/Uint8Array.wrap@varargs
-                    local.tee $30
+                    local.tee $31
                     i32.load offset=8
                     if
                      i32.const 0
@@ -31709,7 +34280,7 @@
                     i32.const 2
                     call $~lib/typedarray/Uint8Array.wrap@varargs
                     local.set $1
-                    local.get $30
+                    local.get $31
                     call $~lib/rt/pure/__release
                     local.get $1
                     i32.load offset=8
@@ -31752,49 +34323,49 @@
                     local.set $0
                     i32.const 3
                     call $~lib/typedarray/Float32Array#constructor
-                    local.tee $30
+                    local.tee $31
                     i32.const 0
                     f32.const 400
                     call $~lib/typedarray/Float32Array#__set
-                    local.get $30
+                    local.get $31
                     i32.const 1
                     f32.const nan:0x400000
                     call $~lib/typedarray/Float32Array#__set
-                    local.get $30
+                    local.get $31
                     i32.const 2
                     f32.const inf
                     call $~lib/typedarray/Float32Array#__set
                     i32.const 4
                     call $~lib/typedarray/Int64Array#constructor
-                    local.tee $29
+                    local.tee $30
                     i32.const 0
                     i64.const -10
                     call $~lib/typedarray/Int64Array#__set
-                    local.get $29
+                    local.get $30
                     i32.const 1
                     i64.const 100
                     call $~lib/typedarray/Int64Array#__set
-                    local.get $29
+                    local.get $30
                     i32.const 2
                     i64.const 10
                     call $~lib/typedarray/Int64Array#__set
-                    local.get $29
+                    local.get $30
                     i32.const 3
                     i64.const 300
                     call $~lib/typedarray/Int64Array#__set
                     i32.const 2
                     call $~lib/typedarray/Int32Array#constructor
-                    local.tee $28
+                    local.tee $29
                     i32.const 0
                     i32.const 300
                     call $~lib/typedarray/Int32Array#__set
-                    local.get $28
+                    local.get $29
                     i32.const 1
                     i32.const -1
                     call $~lib/typedarray/Int32Array#__set
                     i32.const 0
                     local.set $1
-                    local.get $30
+                    local.get $31
                     i32.load offset=8
                     i32.const 2
                     i32.shr_u
@@ -31808,38 +34379,38 @@
                     i32.load offset=4
                     i32.const 1
                     i32.add
-                    local.set $26
-                    local.get $30
+                    local.set $27
+                    local.get $31
                     i32.load offset=4
-                    local.set $25
-                    local.get $30
+                    local.set $26
+                    local.get $31
                     i32.load offset=8
                     i32.const 2
                     i32.shr_u
-                    local.set $24
-                    loop $for-loop|026
+                    local.set $25
+                    loop $for-loop|01522
                      local.get $1
-                     local.get $24
+                     local.get $25
                      i32.lt_s
                      if
                       local.get $1
-                      local.get $26
+                      local.get $27
                       i32.add
-                      local.get $25
+                      local.get $26
                       local.get $1
                       i32.const 2
                       i32.shl
                       i32.add
                       f32.load
-                      local.tee $22
-                      local.get $22
+                      local.tee $24
+                      local.get $24
                       f32.sub
                       f32.const 0
                       f32.eq
                       if (result i32)
                        f32.const 0
                        f32.const 255
-                       local.get $22
+                       local.get $24
                        f32.min
                        f32.max
                        i32.trunc_f32_u
@@ -31851,16 +34422,16 @@
                       i32.const 1
                       i32.add
                       local.set $1
-                      br $for-loop|026
+                      br $for-loop|01522
                      end
                     end
                     local.get $0
-                    local.get $29
+                    local.get $30
                     i32.const 4
                     call $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Int64Array>
                     i32.const 0
                     local.set $1
-                    local.get $28
+                    local.get $29
                     i32.load offset=8
                     i32.const 2
                     i32.shr_u
@@ -31874,37 +34445,37 @@
                     i32.load offset=4
                     i32.const 8
                     i32.add
-                    local.set $26
-                    local.get $28
+                    local.set $27
+                    local.get $29
                     i32.load offset=4
-                    local.set $25
-                    local.get $28
+                    local.set $26
+                    local.get $29
                     i32.load offset=8
                     i32.const 2
                     i32.shr_u
-                    local.set $24
-                    loop $for-loop|027
+                    local.set $25
+                    loop $for-loop|01623
                      local.get $1
-                     local.get $24
+                     local.get $25
                      i32.lt_s
                      if
                       local.get $1
-                      local.get $26
+                      local.get $27
                       i32.add
-                      local.get $25
+                      local.get $26
                       local.get $1
                       i32.const 2
                       i32.shl
                       i32.add
                       i32.load
-                      local.tee $27
+                      local.tee $28
                       i32.const 31
                       i32.shr_s
                       i32.const -1
                       i32.xor
-                      local.get $27
+                      local.get $28
                       i32.const 255
-                      local.get $27
+                      local.get $28
                       i32.sub
                       i32.const 31
                       i32.shr_s
@@ -31915,7 +34486,7 @@
                       i32.const 1
                       i32.add
                       local.set $1
-                      br $for-loop|027
+                      br $for-loop|01623
                      end
                     end
                     local.get $0
@@ -31925,7 +34496,7 @@
                     i32.const 8576
                     call $~lib/rt/__allocArray
                     call $~lib/rt/pure/__retain
-                    local.tee $25
+                    local.tee $26
                     call $std/typedarray/valuesEqual<~lib/typedarray/Uint8ClampedArray>
                     i32.const 4
                     call $~lib/typedarray/Uint32Array#constructor
@@ -31947,24 +34518,24 @@
                     call $~lib/typedarray/Uint32Array#__set
                     i32.const 4
                     call $~lib/typedarray/Int16Array#constructor
-                    local.tee $27
+                    local.tee $28
                     i32.const 0
                     i32.const -10
                     call $~lib/typedarray/Int16Array#__set
-                    local.get $27
+                    local.get $28
                     i32.const 1
                     i32.const 100
                     call $~lib/typedarray/Int16Array#__set
-                    local.get $27
+                    local.get $28
                     i32.const 2
                     i32.const 10
                     call $~lib/typedarray/Int16Array#__set
-                    local.get $27
+                    local.get $28
                     i32.const 3
                     i32.const 300
                     call $~lib/typedarray/Int16Array#__set
                     i32.const 0
-                    local.set $26
+                    local.set $27
                     local.get $1
                     i32.load offset=8
                     i32.const 2
@@ -31975,45 +34546,45 @@
                     br_if $folding-inner19
                     local.get $0
                     i32.load offset=4
-                    local.set $24
+                    local.set $25
                     local.get $1
                     i32.load offset=4
-                    local.set $19
+                    local.set $20
                     local.get $1
                     i32.load offset=8
                     i32.const 2
                     i32.shr_u
-                    local.set $18
-                    loop $for-loop|028
-                     local.get $26
-                     local.get $18
+                    local.set $19
+                    loop $for-loop|01724
+                     local.get $27
+                     local.get $19
                      i32.lt_s
                      if
-                      local.get $24
-                      local.get $26
+                      local.get $25
+                      local.get $27
                       i32.add
                       i32.const 255
-                      local.get $19
-                      local.get $26
+                      local.get $20
+                      local.get $27
                       i32.const 2
                       i32.shl
                       i32.add
                       i32.load
-                      local.tee $17
+                      local.tee $18
                       i32.const 255
-                      local.get $17
+                      local.get $18
                       i32.lt_u
                       select
                       i32.store8
-                      local.get $26
+                      local.get $27
                       i32.const 1
                       i32.add
-                      local.set $26
-                      br $for-loop|028
+                      local.set $27
+                      br $for-loop|01724
                      end
                     end
                     local.get $0
-                    local.get $27
+                    local.get $28
                     i32.const 5
                     call $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Int16Array>
                     local.get $0
@@ -32023,23 +34594,23 @@
                     i32.const 8608
                     call $~lib/rt/__allocArray
                     call $~lib/rt/pure/__retain
-                    local.tee $26
+                    local.tee $27
                     call $std/typedarray/valuesEqual<~lib/typedarray/Uint8ClampedArray>
                     local.get $0
+                    call $~lib/rt/pure/__release
+                    local.get $31
                     call $~lib/rt/pure/__release
                     local.get $30
                     call $~lib/rt/pure/__release
                     local.get $29
                     call $~lib/rt/pure/__release
-                    local.get $28
-                    call $~lib/rt/pure/__release
-                    local.get $25
+                    local.get $26
                     call $~lib/rt/pure/__release
                     local.get $1
                     call $~lib/rt/pure/__release
-                    local.get $27
+                    local.get $28
                     call $~lib/rt/pure/__release
-                    local.get $26
+                    local.get $27
                     call $~lib/rt/pure/__release
                     return
                    end

--- a/tests/compiler/std/typedarray.untouched.wat
+++ b/tests/compiler/std/typedarray.untouched.wat
@@ -3,24 +3,32 @@
  (type $none_=>_none (func))
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
+ (type $i32_i32_i32_i32_=>_i32 (func (param i32 i32 i32 i32) (result i32)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
  (type $i32_i32_=>_none (func (param i32 i32)))
- (type $i32_i32_i32_i32_=>_i32 (func (param i32 i32 i32 i32) (result i32)))
  (type $i64_i32_i32_=>_i32 (func (param i64 i32 i32) (result i32)))
+ (type $i32_i32_i32_i32_i32_=>_i32 (func (param i32 i32 i32 i32 i32) (result i32)))
  (type $f32_i32_i32_=>_i32 (func (param f32 i32 i32) (result i32)))
  (type $f64_i32_i32_=>_i32 (func (param f64 i32 i32) (result i32)))
  (type $i32_=>_none (func (param i32)))
+ (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
+ (type $i32_i64_i32_i32_=>_i32 (func (param i32 i64 i32 i32) (result i32)))
  (type $i64_i64_i32_i32_=>_i64 (func (param i64 i64 i32 i32) (result i64)))
  (type $i32_i64_i32_=>_i32 (func (param i32 i64 i32) (result i32)))
  (type $i32_i32_=>_i64 (func (param i32 i32) (result i64)))
  (type $f64_f64_=>_i32 (func (param f64 f64) (result i32)))
  (type $i64_i32_i32_=>_none (func (param i64 i32 i32)))
  (type $i32_f32_i32_=>_i32 (func (param i32 f32 i32) (result i32)))
+ (type $i32_f32_i32_i32_=>_i32 (func (param i32 f32 i32 i32) (result i32)))
  (type $i32_f64_i32_=>_i32 (func (param i32 f64 i32) (result i32)))
+ (type $i32_f64_i32_i32_=>_i32 (func (param i32 f64 i32 i32) (result i32)))
+ (type $i32_f64_f64_=>_i32 (func (param i32 f64 f64) (result i32)))
  (type $i32_i32_i64_=>_i64 (func (param i32 i32 i64) (result i64)))
+ (type $i32_i64_i64_i32_i32_=>_i64 (func (param i32 i64 i64 i32 i32) (result i64)))
  (type $i64_i32_i32_=>_i64 (func (param i64 i32 i32) (result i64)))
  (type $f32_f32_i32_i32_=>_f32 (func (param f32 f32 i32 i32) (result f32)))
  (type $f64_f64_i32_i32_=>_f64 (func (param f64 f64 i32 i32) (result f64)))
+ (type $i32_i64_i32_i32_=>_none (func (param i32 i64 i32 i32)))
  (type $i64_i32_=>_i32 (func (param i64 i32) (result i32)))
  (type $i32_i32_=>_f32 (func (param i32 i32) (result f32)))
  (type $i32_i32_=>_f64 (func (param i32 i32) (result f64)))
@@ -29,23 +37,27 @@
  (type $f32_i32_i32_=>_none (func (param f32 i32 i32)))
  (type $f64_i32_i32_=>_none (func (param f64 i32 i32)))
  (type $i32_i32_i64_=>_i32 (func (param i32 i32 i64) (result i32)))
+ (type $i32_i64_i32_i32_=>_i64 (func (param i32 i64 i32 i32) (result i64)))
  (type $i32_i32_f32_=>_f32 (func (param i32 i32 f32) (result f32)))
+ (type $i32_f32_f32_i32_i32_=>_f32 (func (param i32 f32 f32 i32 i32) (result f32)))
  (type $f32_i32_i32_=>_f32 (func (param f32 i32 i32) (result f32)))
  (type $i32_i32_f64_=>_f64 (func (param i32 i32 f64) (result f64)))
+ (type $i32_f64_f64_i32_i32_=>_f64 (func (param i32 f64 f64 i32 i32) (result f64)))
  (type $f64_i32_i32_=>_f64 (func (param f64 i32 i32) (result f64)))
- (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $i32_i32_f32_=>_none (func (param i32 i32 f32)))
  (type $i32_i32_f64_=>_none (func (param i32 i32 f64)))
  (type $i32_i32_f64_f64_f64_f64_f64_=>_none (func (param i32 i32 f64 f64 f64 f64 f64)))
- (type $i32_i64_i32_i32_=>_none (func (param i32 i64 i32 i32)))
+ (type $i32_f32_i32_i32_=>_none (func (param i32 f32 i32 i32)))
+ (type $i32_f64_i32_i32_=>_none (func (param i32 f64 i32 i32)))
  (type $none_=>_i32 (func (result i32)))
- (type $i32_i32_i32_i32_i32_=>_i32 (func (param i32 i32 i32 i32 i32) (result i32)))
  (type $i32_i32_f64_=>_i32 (func (param i32 i32 f64) (result i32)))
  (type $i32_i64_i32_i64_i32_i64_i32_=>_i32 (func (param i32 i64 i32 i64 i32 i64 i32) (result i32)))
  (type $i32_f64_=>_i32 (func (param i32 f64) (result i32)))
  (type $i64_=>_i32 (func (param i64) (result i32)))
  (type $f64_=>_i32 (func (param f64) (result i32)))
+ (type $i32_f32_i32_i32_=>_f32 (func (param i32 f32 i32 i32) (result f32)))
  (type $f32_f32_=>_f32 (func (param f32 f32) (result f32)))
+ (type $i32_f64_i32_i32_=>_f64 (func (param i32 f64 i32 i32) (result f64)))
  (type $f64_f64_=>_f64 (func (param f64 f64) (result f64)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (import "rtrace" "onalloc" (func $~lib/rt/rtrace/onalloc (param i32)))
@@ -190,7 +202,7 @@
  (data (i32.const 8992) "\n\00\00\00\01\00\00\00\00\00\00\00\n\00\00\00\00\ff\00\00\00d\n\ff\ff\00")
  (data (i32.const 9024) "\n\00\00\00\01\00\00\00\00\00\00\00\n\00\00\00\01\ffd\ff\00\00d\n\ff\00")
  (table $0 123 funcref)
- (elem (i32.const 1) $~lib/util/sort/COMPARATOR<f64>~anonymous|0 $std/typedarray/testReduce<~lib/typedarray/Int8Array,i8>~anonymous|0 $std/typedarray/testReduce<~lib/typedarray/Uint8Array,u8>~anonymous|0 $std/typedarray/testReduce<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|0 $std/typedarray/testReduce<~lib/typedarray/Int16Array,i16>~anonymous|0 $std/typedarray/testReduce<~lib/typedarray/Uint16Array,u16>~anonymous|0 $std/typedarray/testReduce<~lib/typedarray/Int32Array,i32>~anonymous|0 $std/typedarray/testReduce<~lib/typedarray/Uint32Array,u32>~anonymous|0 $std/typedarray/testReduce<~lib/typedarray/Int64Array,i64>~anonymous|0 $std/typedarray/testReduce<~lib/typedarray/Uint64Array,u64>~anonymous|0 $std/typedarray/testReduce<~lib/typedarray/Float32Array,f32>~anonymous|0 $std/typedarray/testReduce<~lib/typedarray/Float64Array,f64>~anonymous|0 $std/typedarray/testReduceRight<~lib/typedarray/Int8Array,i8>~anonymous|0 $std/typedarray/testReduceRight<~lib/typedarray/Uint8Array,u8>~anonymous|0 $std/typedarray/testReduceRight<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|0 $std/typedarray/testReduceRight<~lib/typedarray/Int16Array,i16>~anonymous|0 $std/typedarray/testReduceRight<~lib/typedarray/Uint16Array,u16>~anonymous|0 $std/typedarray/testReduceRight<~lib/typedarray/Int32Array,i32>~anonymous|0 $std/typedarray/testReduceRight<~lib/typedarray/Uint32Array,u32>~anonymous|0 $std/typedarray/testReduceRight<~lib/typedarray/Int64Array,i64>~anonymous|0 $std/typedarray/testReduceRight<~lib/typedarray/Uint64Array,u64>~anonymous|0 $std/typedarray/testReduceRight<~lib/typedarray/Float32Array,f32>~anonymous|0 $std/typedarray/testReduceRight<~lib/typedarray/Float64Array,f64>~anonymous|0 $std/typedarray/testArrayMap<~lib/typedarray/Int8Array,i8>~anonymous|0 $std/typedarray/testArrayMap<~lib/typedarray/Uint8Array,u8>~anonymous|0 $std/typedarray/testArrayMap<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|0 $std/typedarray/testArrayMap<~lib/typedarray/Int16Array,i16>~anonymous|0 $std/typedarray/testArrayMap<~lib/typedarray/Uint16Array,u16>~anonymous|0 $std/typedarray/testArrayMap<~lib/typedarray/Int32Array,i32>~anonymous|0 $std/typedarray/testArrayMap<~lib/typedarray/Uint32Array,u32>~anonymous|0 $std/typedarray/testArrayMap<~lib/typedarray/Int64Array,i64>~anonymous|0 $std/typedarray/testArrayMap<~lib/typedarray/Uint64Array,u64>~anonymous|0 $std/typedarray/testArrayMap<~lib/typedarray/Float32Array,f32>~anonymous|0 $std/typedarray/testArrayMap<~lib/typedarray/Float64Array,f64>~anonymous|0 $std/typedarray/testArrayFilter<~lib/typedarray/Int8Array,i8>~anonymous|0 $std/typedarray/testArrayFilter<~lib/typedarray/Uint8Array,u8>~anonymous|0 $std/typedarray/testArrayFilter<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|0 $std/typedarray/testArrayFilter<~lib/typedarray/Int16Array,i16>~anonymous|0 $std/typedarray/testArrayFilter<~lib/typedarray/Uint16Array,u16>~anonymous|0 $std/typedarray/testArrayFilter<~lib/typedarray/Int32Array,i32>~anonymous|0 $std/typedarray/testArrayFilter<~lib/typedarray/Uint32Array,u32>~anonymous|0 $std/typedarray/testArrayFilter<~lib/typedarray/Int64Array,i64>~anonymous|0 $std/typedarray/testArrayFilter<~lib/typedarray/Uint64Array,u64>~anonymous|0 $std/typedarray/testArrayFilter<~lib/typedarray/Float32Array,f32>~anonymous|0 $std/typedarray/testArrayFilter<~lib/typedarray/Float64Array,f64>~anonymous|0 $std/typedarray/testArraySome<~lib/typedarray/Int8Array,i8>~anonymous|0 $std/typedarray/testArraySome<~lib/typedarray/Int8Array,i8>~anonymous|1 $std/typedarray/testArraySome<~lib/typedarray/Uint8Array,u8>~anonymous|0 $std/typedarray/testArraySome<~lib/typedarray/Uint8Array,u8>~anonymous|1 $std/typedarray/testArraySome<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|0 $std/typedarray/testArraySome<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|1 $std/typedarray/testArraySome<~lib/typedarray/Int16Array,i16>~anonymous|0 $std/typedarray/testArraySome<~lib/typedarray/Int16Array,i16>~anonymous|1 $std/typedarray/testArraySome<~lib/typedarray/Uint16Array,u16>~anonymous|0 $std/typedarray/testArraySome<~lib/typedarray/Uint16Array,u16>~anonymous|1 $std/typedarray/testArraySome<~lib/typedarray/Int32Array,i32>~anonymous|0 $std/typedarray/testArraySome<~lib/typedarray/Int32Array,i32>~anonymous|1 $std/typedarray/testArraySome<~lib/typedarray/Uint32Array,u32>~anonymous|0 $std/typedarray/testArraySome<~lib/typedarray/Uint32Array,u32>~anonymous|1 $std/typedarray/testArraySome<~lib/typedarray/Int64Array,i64>~anonymous|0 $std/typedarray/testArraySome<~lib/typedarray/Int64Array,i64>~anonymous|1 $std/typedarray/testArraySome<~lib/typedarray/Uint64Array,u64>~anonymous|0 $std/typedarray/testArraySome<~lib/typedarray/Uint64Array,u64>~anonymous|1 $std/typedarray/testArraySome<~lib/typedarray/Float32Array,f32>~anonymous|0 $std/typedarray/testArraySome<~lib/typedarray/Float32Array,f32>~anonymous|1 $std/typedarray/testArraySome<~lib/typedarray/Float64Array,f64>~anonymous|0 $std/typedarray/testArraySome<~lib/typedarray/Float64Array,f64>~anonymous|1 $std/typedarray/testArrayFindIndex<~lib/typedarray/Int8Array,i8>~anonymous|0 $std/typedarray/testArrayFindIndex<~lib/typedarray/Int8Array,i8>~anonymous|1 $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint8Array,u8>~anonymous|0 $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint8Array,u8>~anonymous|1 $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|0 $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|1 $std/typedarray/testArrayFindIndex<~lib/typedarray/Int16Array,i16>~anonymous|0 $std/typedarray/testArrayFindIndex<~lib/typedarray/Int16Array,i16>~anonymous|1 $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint16Array,u16>~anonymous|0 $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint16Array,u16>~anonymous|1 $std/typedarray/testArrayFindIndex<~lib/typedarray/Int32Array,i32>~anonymous|0 $std/typedarray/testArrayFindIndex<~lib/typedarray/Int32Array,i32>~anonymous|1 $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint32Array,u32>~anonymous|0 $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint32Array,u32>~anonymous|1 $std/typedarray/testArrayFindIndex<~lib/typedarray/Int64Array,i64>~anonymous|0 $std/typedarray/testArrayFindIndex<~lib/typedarray/Int64Array,i64>~anonymous|1 $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint64Array,u64>~anonymous|0 $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint64Array,u64>~anonymous|1 $std/typedarray/testArrayFindIndex<~lib/typedarray/Float32Array,f32>~anonymous|0 $std/typedarray/testArrayFindIndex<~lib/typedarray/Float32Array,f32>~anonymous|1 $std/typedarray/testArrayFindIndex<~lib/typedarray/Float64Array,f64>~anonymous|0 $std/typedarray/testArrayFindIndex<~lib/typedarray/Float64Array,f64>~anonymous|1 $std/typedarray/testArrayEvery<~lib/typedarray/Int8Array,i8>~anonymous|0 $std/typedarray/testArrayEvery<~lib/typedarray/Int8Array,i8>~anonymous|1 $std/typedarray/testArrayEvery<~lib/typedarray/Uint8Array,u8>~anonymous|0 $std/typedarray/testArrayEvery<~lib/typedarray/Uint8Array,u8>~anonymous|1 $std/typedarray/testArrayEvery<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|0 $std/typedarray/testArrayEvery<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|1 $std/typedarray/testArrayEvery<~lib/typedarray/Int16Array,i16>~anonymous|0 $std/typedarray/testArrayEvery<~lib/typedarray/Int16Array,i16>~anonymous|1 $std/typedarray/testArrayEvery<~lib/typedarray/Uint16Array,u16>~anonymous|0 $std/typedarray/testArrayEvery<~lib/typedarray/Uint16Array,u16>~anonymous|1 $std/typedarray/testArrayEvery<~lib/typedarray/Int32Array,i32>~anonymous|0 $std/typedarray/testArrayEvery<~lib/typedarray/Int32Array,i32>~anonymous|1 $std/typedarray/testArrayEvery<~lib/typedarray/Uint32Array,u32>~anonymous|0 $std/typedarray/testArrayEvery<~lib/typedarray/Uint32Array,u32>~anonymous|1 $std/typedarray/testArrayEvery<~lib/typedarray/Int64Array,i64>~anonymous|0 $std/typedarray/testArrayEvery<~lib/typedarray/Int64Array,i64>~anonymous|1 $std/typedarray/testArrayEvery<~lib/typedarray/Uint64Array,u64>~anonymous|0 $std/typedarray/testArrayEvery<~lib/typedarray/Uint64Array,u64>~anonymous|1 $std/typedarray/testArrayEvery<~lib/typedarray/Float32Array,f32>~anonymous|0 $std/typedarray/testArrayEvery<~lib/typedarray/Float32Array,f32>~anonymous|1 $std/typedarray/testArrayEvery<~lib/typedarray/Float64Array,f64>~anonymous|0 $std/typedarray/testArrayEvery<~lib/typedarray/Float64Array,f64>~anonymous|1 $std/typedarray/testArrayForEach<~lib/typedarray/Int8Array,i8>~anonymous|0 $std/typedarray/testArrayForEach<~lib/typedarray/Uint8Array,u8>~anonymous|0 $std/typedarray/testArrayForEach<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|0 $std/typedarray/testArrayForEach<~lib/typedarray/Int16Array,i16>~anonymous|0 $std/typedarray/testArrayForEach<~lib/typedarray/Uint16Array,u16>~anonymous|0 $std/typedarray/testArrayForEach<~lib/typedarray/Int32Array,i32>~anonymous|0 $std/typedarray/testArrayForEach<~lib/typedarray/Uint32Array,u32>~anonymous|0 $std/typedarray/testArrayForEach<~lib/typedarray/Int64Array,i64>~anonymous|0 $std/typedarray/testArrayForEach<~lib/typedarray/Uint64Array,u64>~anonymous|0 $std/typedarray/testArrayForEach<~lib/typedarray/Float32Array,f32>~anonymous|0 $std/typedarray/testArrayForEach<~lib/typedarray/Float64Array,f64>~anonymous|0)
+ (elem (i32.const 1) $~lib/util/sort/COMPARATOR<f64>~anonymous|0~nonClosure $std/typedarray/testReduce<~lib/typedarray/Int8Array,i8>~anonymous|0~nonClosure $std/typedarray/testReduce<~lib/typedarray/Uint8Array,u8>~anonymous|0~nonClosure $std/typedarray/testReduce<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|0~nonClosure $std/typedarray/testReduce<~lib/typedarray/Int16Array,i16>~anonymous|0~nonClosure $std/typedarray/testReduce<~lib/typedarray/Uint16Array,u16>~anonymous|0~nonClosure $std/typedarray/testReduce<~lib/typedarray/Int32Array,i32>~anonymous|0~nonClosure $std/typedarray/testReduce<~lib/typedarray/Uint32Array,u32>~anonymous|0~nonClosure $std/typedarray/testReduce<~lib/typedarray/Int64Array,i64>~anonymous|0~nonClosure $std/typedarray/testReduce<~lib/typedarray/Uint64Array,u64>~anonymous|0~nonClosure $std/typedarray/testReduce<~lib/typedarray/Float32Array,f32>~anonymous|0~nonClosure $std/typedarray/testReduce<~lib/typedarray/Float64Array,f64>~anonymous|0~nonClosure $std/typedarray/testReduceRight<~lib/typedarray/Int8Array,i8>~anonymous|0~nonClosure $std/typedarray/testReduceRight<~lib/typedarray/Uint8Array,u8>~anonymous|0~nonClosure $std/typedarray/testReduceRight<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|0~nonClosure $std/typedarray/testReduceRight<~lib/typedarray/Int16Array,i16>~anonymous|0~nonClosure $std/typedarray/testReduceRight<~lib/typedarray/Uint16Array,u16>~anonymous|0~nonClosure $std/typedarray/testReduceRight<~lib/typedarray/Int32Array,i32>~anonymous|0~nonClosure $std/typedarray/testReduceRight<~lib/typedarray/Uint32Array,u32>~anonymous|0~nonClosure $std/typedarray/testReduceRight<~lib/typedarray/Int64Array,i64>~anonymous|0~nonClosure $std/typedarray/testReduceRight<~lib/typedarray/Uint64Array,u64>~anonymous|0~nonClosure $std/typedarray/testReduceRight<~lib/typedarray/Float32Array,f32>~anonymous|0~nonClosure $std/typedarray/testReduceRight<~lib/typedarray/Float64Array,f64>~anonymous|0~nonClosure $std/typedarray/testArrayMap<~lib/typedarray/Int8Array,i8>~anonymous|0~nonClosure $std/typedarray/testArrayMap<~lib/typedarray/Uint8Array,u8>~anonymous|0~nonClosure $std/typedarray/testArrayMap<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|0~nonClosure $std/typedarray/testArrayMap<~lib/typedarray/Int16Array,i16>~anonymous|0~nonClosure $std/typedarray/testArrayMap<~lib/typedarray/Uint16Array,u16>~anonymous|0~nonClosure $std/typedarray/testArrayMap<~lib/typedarray/Int32Array,i32>~anonymous|0~nonClosure $std/typedarray/testArrayMap<~lib/typedarray/Uint32Array,u32>~anonymous|0~nonClosure $std/typedarray/testArrayMap<~lib/typedarray/Int64Array,i64>~anonymous|0~nonClosure $std/typedarray/testArrayMap<~lib/typedarray/Uint64Array,u64>~anonymous|0~nonClosure $std/typedarray/testArrayMap<~lib/typedarray/Float32Array,f32>~anonymous|0~nonClosure $std/typedarray/testArrayMap<~lib/typedarray/Float64Array,f64>~anonymous|0~nonClosure $std/typedarray/testArrayFilter<~lib/typedarray/Int8Array,i8>~anonymous|0~nonClosure $std/typedarray/testArrayFilter<~lib/typedarray/Uint8Array,u8>~anonymous|0~nonClosure $std/typedarray/testArrayFilter<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|0~nonClosure $std/typedarray/testArrayFilter<~lib/typedarray/Int16Array,i16>~anonymous|0~nonClosure $std/typedarray/testArrayFilter<~lib/typedarray/Uint16Array,u16>~anonymous|0~nonClosure $std/typedarray/testArrayFilter<~lib/typedarray/Int32Array,i32>~anonymous|0~nonClosure $std/typedarray/testArrayFilter<~lib/typedarray/Uint32Array,u32>~anonymous|0~nonClosure $std/typedarray/testArrayFilter<~lib/typedarray/Int64Array,i64>~anonymous|0~nonClosure $std/typedarray/testArrayFilter<~lib/typedarray/Uint64Array,u64>~anonymous|0~nonClosure $std/typedarray/testArrayFilter<~lib/typedarray/Float32Array,f32>~anonymous|0~nonClosure $std/typedarray/testArrayFilter<~lib/typedarray/Float64Array,f64>~anonymous|0~nonClosure $std/typedarray/testArraySome<~lib/typedarray/Int8Array,i8>~anonymous|0~nonClosure $std/typedarray/testArraySome<~lib/typedarray/Int8Array,i8>~anonymous|1~nonClosure $std/typedarray/testArraySome<~lib/typedarray/Uint8Array,u8>~anonymous|0~nonClosure $std/typedarray/testArraySome<~lib/typedarray/Uint8Array,u8>~anonymous|1~nonClosure $std/typedarray/testArraySome<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|0~nonClosure $std/typedarray/testArraySome<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|1~nonClosure $std/typedarray/testArraySome<~lib/typedarray/Int16Array,i16>~anonymous|0~nonClosure $std/typedarray/testArraySome<~lib/typedarray/Int16Array,i16>~anonymous|1~nonClosure $std/typedarray/testArraySome<~lib/typedarray/Uint16Array,u16>~anonymous|0~nonClosure $std/typedarray/testArraySome<~lib/typedarray/Uint16Array,u16>~anonymous|1~nonClosure $std/typedarray/testArraySome<~lib/typedarray/Int32Array,i32>~anonymous|0~nonClosure $std/typedarray/testArraySome<~lib/typedarray/Int32Array,i32>~anonymous|1~nonClosure $std/typedarray/testArraySome<~lib/typedarray/Uint32Array,u32>~anonymous|0~nonClosure $std/typedarray/testArraySome<~lib/typedarray/Uint32Array,u32>~anonymous|1~nonClosure $std/typedarray/testArraySome<~lib/typedarray/Int64Array,i64>~anonymous|0~nonClosure $std/typedarray/testArraySome<~lib/typedarray/Int64Array,i64>~anonymous|1~nonClosure $std/typedarray/testArraySome<~lib/typedarray/Uint64Array,u64>~anonymous|0~nonClosure $std/typedarray/testArraySome<~lib/typedarray/Uint64Array,u64>~anonymous|1~nonClosure $std/typedarray/testArraySome<~lib/typedarray/Float32Array,f32>~anonymous|0~nonClosure $std/typedarray/testArraySome<~lib/typedarray/Float32Array,f32>~anonymous|1~nonClosure $std/typedarray/testArraySome<~lib/typedarray/Float64Array,f64>~anonymous|0~nonClosure $std/typedarray/testArraySome<~lib/typedarray/Float64Array,f64>~anonymous|1~nonClosure $std/typedarray/testArrayFindIndex<~lib/typedarray/Int8Array,i8>~anonymous|0~nonClosure $std/typedarray/testArrayFindIndex<~lib/typedarray/Int8Array,i8>~anonymous|1~nonClosure $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint8Array,u8>~anonymous|0~nonClosure $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint8Array,u8>~anonymous|1~nonClosure $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|0~nonClosure $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|1~nonClosure $std/typedarray/testArrayFindIndex<~lib/typedarray/Int16Array,i16>~anonymous|0~nonClosure $std/typedarray/testArrayFindIndex<~lib/typedarray/Int16Array,i16>~anonymous|1~nonClosure $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint16Array,u16>~anonymous|0~nonClosure $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint16Array,u16>~anonymous|1~nonClosure $std/typedarray/testArrayFindIndex<~lib/typedarray/Int32Array,i32>~anonymous|0~nonClosure $std/typedarray/testArrayFindIndex<~lib/typedarray/Int32Array,i32>~anonymous|1~nonClosure $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint32Array,u32>~anonymous|0~nonClosure $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint32Array,u32>~anonymous|1~nonClosure $std/typedarray/testArrayFindIndex<~lib/typedarray/Int64Array,i64>~anonymous|0~nonClosure $std/typedarray/testArrayFindIndex<~lib/typedarray/Int64Array,i64>~anonymous|1~nonClosure $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint64Array,u64>~anonymous|0~nonClosure $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint64Array,u64>~anonymous|1~nonClosure $std/typedarray/testArrayFindIndex<~lib/typedarray/Float32Array,f32>~anonymous|0~nonClosure $std/typedarray/testArrayFindIndex<~lib/typedarray/Float32Array,f32>~anonymous|1~nonClosure $std/typedarray/testArrayFindIndex<~lib/typedarray/Float64Array,f64>~anonymous|0~nonClosure $std/typedarray/testArrayFindIndex<~lib/typedarray/Float64Array,f64>~anonymous|1~nonClosure $std/typedarray/testArrayEvery<~lib/typedarray/Int8Array,i8>~anonymous|0~nonClosure $std/typedarray/testArrayEvery<~lib/typedarray/Int8Array,i8>~anonymous|1~nonClosure $std/typedarray/testArrayEvery<~lib/typedarray/Uint8Array,u8>~anonymous|0~nonClosure $std/typedarray/testArrayEvery<~lib/typedarray/Uint8Array,u8>~anonymous|1~nonClosure $std/typedarray/testArrayEvery<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|0~nonClosure $std/typedarray/testArrayEvery<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|1~nonClosure $std/typedarray/testArrayEvery<~lib/typedarray/Int16Array,i16>~anonymous|0~nonClosure $std/typedarray/testArrayEvery<~lib/typedarray/Int16Array,i16>~anonymous|1~nonClosure $std/typedarray/testArrayEvery<~lib/typedarray/Uint16Array,u16>~anonymous|0~nonClosure $std/typedarray/testArrayEvery<~lib/typedarray/Uint16Array,u16>~anonymous|1~nonClosure $std/typedarray/testArrayEvery<~lib/typedarray/Int32Array,i32>~anonymous|0~nonClosure $std/typedarray/testArrayEvery<~lib/typedarray/Int32Array,i32>~anonymous|1~nonClosure $std/typedarray/testArrayEvery<~lib/typedarray/Uint32Array,u32>~anonymous|0~nonClosure $std/typedarray/testArrayEvery<~lib/typedarray/Uint32Array,u32>~anonymous|1~nonClosure $std/typedarray/testArrayEvery<~lib/typedarray/Int64Array,i64>~anonymous|0~nonClosure $std/typedarray/testArrayEvery<~lib/typedarray/Int64Array,i64>~anonymous|1~nonClosure $std/typedarray/testArrayEvery<~lib/typedarray/Uint64Array,u64>~anonymous|0~nonClosure $std/typedarray/testArrayEvery<~lib/typedarray/Uint64Array,u64>~anonymous|1~nonClosure $std/typedarray/testArrayEvery<~lib/typedarray/Float32Array,f32>~anonymous|0~nonClosure $std/typedarray/testArrayEvery<~lib/typedarray/Float32Array,f32>~anonymous|1~nonClosure $std/typedarray/testArrayEvery<~lib/typedarray/Float64Array,f64>~anonymous|0~nonClosure $std/typedarray/testArrayEvery<~lib/typedarray/Float64Array,f64>~anonymous|1~nonClosure $std/typedarray/testArrayForEach<~lib/typedarray/Int8Array,i8>~anonymous|0~nonClosure $std/typedarray/testArrayForEach<~lib/typedarray/Uint8Array,u8>~anonymous|0~nonClosure $std/typedarray/testArrayForEach<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|0~nonClosure $std/typedarray/testArrayForEach<~lib/typedarray/Int16Array,i16>~anonymous|0~nonClosure $std/typedarray/testArrayForEach<~lib/typedarray/Uint16Array,u16>~anonymous|0~nonClosure $std/typedarray/testArrayForEach<~lib/typedarray/Int32Array,i32>~anonymous|0~nonClosure $std/typedarray/testArrayForEach<~lib/typedarray/Uint32Array,u32>~anonymous|0~nonClosure $std/typedarray/testArrayForEach<~lib/typedarray/Int64Array,i64>~anonymous|0~nonClosure $std/typedarray/testArrayForEach<~lib/typedarray/Uint64Array,u64>~anonymous|0~nonClosure $std/typedarray/testArrayForEach<~lib/typedarray/Float32Array,f32>~anonymous|0~nonClosure $std/typedarray/testArrayForEach<~lib/typedarray/Float64Array,f64>~anonymous|0~nonClosure)
  (global $~lib/typedarray/Int8Array.BYTES_PER_ELEMENT i32 (i32.const 1))
  (global $~lib/typedarray/Uint8Array.BYTES_PER_ELEMENT i32 (i32.const 1))
  (global $~lib/typedarray/Uint8ClampedArray.BYTES_PER_ELEMENT i32 (i32.const 1))
@@ -3091,68 +3103,110 @@
  (func $~lib/util/sort/insertionSort<f64> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
-  (local $5 f64)
-  (local $6 i32)
+  (local $5 i32)
+  (local $6 f64)
   (local $7 i32)
-  (local $8 f64)
-  (local $9 i32)
-  i32.const 0
+  (local $8 i32)
+  (local $9 f64)
+  (local $10 i32)
+  (local $11 i32)
+  local.get $2
   local.set $3
-  loop $for-loop|0
+  local.get $3
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
    local.get $3
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $3
+  local.set $2
+  i32.const 0
+  local.set $4
+  loop $for-loop|0
+   local.get $4
    local.get $1
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $5
+   local.get $5
    if
     local.get $0
-    local.get $3
+    local.get $4
     i32.const 3
     i32.shl
     i32.add
     f64.load
-    local.set $5
-    local.get $3
+    local.set $6
+    local.get $4
     i32.const 1
     i32.sub
-    local.set $6
+    local.set $7
     block $while-break|1
      loop $while-continue|1
-      local.get $6
+      local.get $7
       i32.const 0
       i32.ge_s
-      local.set $7
-      local.get $7
+      local.set $8
+      local.get $8
       if
        local.get $0
-       local.get $6
+       local.get $7
        i32.const 3
        i32.shl
        i32.add
        f64.load
-       local.set $8
-       local.get $5
-       local.get $8
-       i32.const 2
-       global.set $~argumentsLength
+       local.set $9
        local.get $2
-       call_indirect (type $f64_f64_=>_i32)
+       local.set $10
+       local.get $10
+       i32.const -2147483648
+       i32.and
+       i32.const -2147483648
+       i32.eq
+       if (result i32)
+        local.get $10
+        i32.const 4
+        i32.shl
+        local.get $6
+        local.get $9
+        i32.const 2
+        global.set $~argumentsLength
+        local.get $10
+        i32.const 4
+        i32.shl
+        i32.load
+        call_indirect (type $i32_f64_f64_=>_i32)
+       else
+        local.get $6
+        local.get $9
+        i32.const 2
+        global.set $~argumentsLength
+        local.get $10
+        call_indirect (type $f64_f64_=>_i32)
+       end
        i32.const 0
        i32.lt_s
        if
         local.get $0
-        local.get $6
-        local.tee $9
+        local.get $7
+        local.tee $11
         i32.const 1
         i32.sub
-        local.set $6
-        local.get $9
+        local.set $7
+        local.get $11
         i32.const 1
         i32.add
         i32.const 3
         i32.shl
         i32.add
-        local.get $8
+        local.get $9
         f64.store
        else
         br $while-break|1
@@ -3162,21 +3216,36 @@
      end
     end
     local.get $0
-    local.get $6
+    local.get $7
     i32.const 1
     i32.add
     i32.const 3
     i32.shl
     i32.add
-    local.get $5
+    local.get $6
     f64.store
-    local.get $3
+    local.get $4
     i32.const 1
     i32.add
-    local.set $3
+    local.set $4
     br $for-loop|0
    end
   end
+  local.get $2
+  local.set $4
+  local.get $4
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $4
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
  )
  (func $~lib/rt/tlsf/checkUsedBlock (param $0 i32) (result i32)
   (local $1 i32)
@@ -3257,10 +3326,31 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
-  (local $9 f64)
+  (local $9 i32)
   (local $10 f64)
-  (local $11 i32)
-  (local $12 f64)
+  (local $11 f64)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 f64)
+  local.get $2
+  local.set $3
+  local.get $3
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $3
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $3
+  local.set $2
   local.get $1
   i32.const 31
   i32.add
@@ -3268,41 +3358,41 @@
   i32.shr_u
   i32.const 2
   i32.shl
-  local.set $3
-  local.get $3
-  i32.const 0
-  call $~lib/rt/tlsf/__alloc
   local.set $4
   local.get $4
   i32.const 0
-  local.get $3
+  call $~lib/rt/tlsf/__alloc
+  local.set $5
+  local.get $5
+  i32.const 0
+  local.get $4
   call $~lib/memory/memory.fill
   local.get $1
   i32.const 1
   i32.sub
-  local.set $5
+  local.set $6
   loop $for-loop|0
-   local.get $5
+   local.get $6
    i32.const 0
    i32.gt_s
-   local.set $6
-   local.get $6
+   local.set $7
+   local.get $7
    if
-    local.get $5
-    local.set $7
+    local.get $6
+    local.set $8
     loop $while-continue|1
-     local.get $7
+     local.get $8
      i32.const 1
      i32.and
-     local.get $4
-     local.get $7
+     local.get $5
+     local.get $8
      i32.const 6
      i32.shr_u
      i32.const 2
      i32.shl
      i32.add
      i32.load
-     local.get $7
+     local.get $8
      i32.const 1
      i32.shr_s
      i32.const 31
@@ -3311,52 +3401,74 @@
      i32.const 1
      i32.and
      i32.eq
-     local.set $8
-     local.get $8
+     local.set $9
+     local.get $9
      if
-      local.get $7
+      local.get $8
       i32.const 1
       i32.shr_s
-      local.set $7
+      local.set $8
       br $while-continue|1
      end
     end
-    local.get $7
+    local.get $8
     i32.const 1
     i32.shr_s
-    local.set $8
-    local.get $0
-    local.get $8
-    i32.const 3
-    i32.shl
-    i32.add
-    f64.load
     local.set $9
     local.get $0
-    local.get $5
+    local.get $9
     i32.const 3
     i32.shl
     i32.add
     f64.load
     local.set $10
-    local.get $9
-    local.get $10
-    i32.const 2
-    global.set $~argumentsLength
+    local.get $0
+    local.get $6
+    i32.const 3
+    i32.shl
+    i32.add
+    f64.load
+    local.set $11
     local.get $2
-    call_indirect (type $f64_f64_=>_i32)
+    local.set $12
+    local.get $12
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result i32)
+     local.get $12
+     i32.const 4
+     i32.shl
+     local.get $10
+     local.get $11
+     i32.const 2
+     global.set $~argumentsLength
+     local.get $12
+     i32.const 4
+     i32.shl
+     i32.load
+     call_indirect (type $i32_f64_f64_=>_i32)
+    else
+     local.get $10
+     local.get $11
+     i32.const 2
+     global.set $~argumentsLength
+     local.get $12
+     call_indirect (type $f64_f64_=>_i32)
+    end
     i32.const 0
     i32.lt_s
     if
-     local.get $4
      local.get $5
+     local.get $6
      i32.const 5
      i32.shr_u
      i32.const 2
      i32.shl
      i32.add
-     local.get $4
      local.get $5
+     local.get $6
      i32.const 5
      i32.shr_u
      i32.const 2
@@ -3364,130 +3476,152 @@
      i32.add
      i32.load
      i32.const 1
-     local.get $5
+     local.get $6
      i32.const 31
      i32.and
      i32.shl
      i32.xor
      i32.store
      local.get $0
-     local.get $5
-     i32.const 3
-     i32.shl
-     i32.add
-     local.get $9
-     f64.store
-     local.get $0
-     local.get $8
+     local.get $6
      i32.const 3
      i32.shl
      i32.add
      local.get $10
      f64.store
+     local.get $0
+     local.get $9
+     i32.const 3
+     i32.shl
+     i32.add
+     local.get $11
+     f64.store
     end
-    local.get $5
+    local.get $6
     i32.const 1
     i32.sub
-    local.set $5
+    local.set $6
     br $for-loop|0
    end
   end
   local.get $1
   i32.const 1
   i32.sub
-  local.set $5
+  local.set $6
   loop $for-loop|2
-   local.get $5
+   local.get $6
    i32.const 2
    i32.ge_s
-   local.set $6
-   local.get $6
+   local.set $7
+   local.get $7
    if
     local.get $0
     f64.load
-    local.set $10
+    local.set $11
     local.get $0
     local.get $0
-    local.get $5
+    local.get $6
     i32.const 3
     i32.shl
     i32.add
     f64.load
     f64.store
     local.get $0
-    local.get $5
+    local.get $6
     i32.const 3
     i32.shl
     i32.add
-    local.get $10
+    local.get $11
     f64.store
     i32.const 1
-    local.set $8
+    local.set $9
     loop $while-continue|3
-     local.get $8
+     local.get $9
      i32.const 1
      i32.shl
-     local.get $4
-     local.get $8
+     local.get $5
+     local.get $9
      i32.const 5
      i32.shr_u
      i32.const 2
      i32.shl
      i32.add
      i32.load
-     local.get $8
+     local.get $9
      i32.const 31
      i32.and
      i32.shr_u
      i32.const 1
      i32.and
      i32.add
-     local.tee $7
-     local.get $5
+     local.tee $8
+     local.get $6
      i32.lt_s
-     local.set $11
-     local.get $11
+     local.set $13
+     local.get $13
      if
-      local.get $7
-      local.set $8
+      local.get $8
+      local.set $9
       br $while-continue|3
      end
     end
     loop $while-continue|4
-     local.get $8
+     local.get $9
      i32.const 0
      i32.gt_s
-     local.set $11
-     local.get $11
+     local.set $13
+     local.get $13
      if
       local.get $0
       f64.load
-      local.set $10
+      local.set $11
       local.get $0
-      local.get $8
+      local.get $9
       i32.const 3
       i32.shl
       i32.add
       f64.load
-      local.set $9
-      local.get $10
-      local.get $9
-      i32.const 2
-      global.set $~argumentsLength
+      local.set $10
       local.get $2
-      call_indirect (type $f64_f64_=>_i32)
+      local.set $14
+      local.get $14
+      i32.const -2147483648
+      i32.and
+      i32.const -2147483648
+      i32.eq
+      if (result i32)
+       local.get $14
+       i32.const 4
+       i32.shl
+       local.get $11
+       local.get $10
+       i32.const 2
+       global.set $~argumentsLength
+       local.get $14
+       i32.const 4
+       i32.shl
+       i32.load
+       call_indirect (type $i32_f64_f64_=>_i32)
+      else
+       local.get $11
+       local.get $10
+       i32.const 2
+       global.set $~argumentsLength
+       local.get $14
+       call_indirect (type $f64_f64_=>_i32)
+      end
       i32.const 0
       i32.lt_s
       if
-       local.get $4
-       local.get $8
+       local.get $5
+       local.get $9
        i32.const 5
        i32.shr_u
        i32.const 2
        i32.shl
        i32.add
-       local.get $4
-       local.get $8
+       local.get $5
+       local.get $9
        i32.const 5
        i32.shr_u
        i32.const 2
@@ -3495,134 +3629,311 @@
        i32.add
        i32.load
        i32.const 1
-       local.get $8
+       local.get $9
        i32.const 31
        i32.and
        i32.shl
        i32.xor
        i32.store
        local.get $0
-       local.get $8
+       local.get $9
        i32.const 3
        i32.shl
        i32.add
-       local.get $10
+       local.get $11
        f64.store
        local.get $0
-       local.get $9
+       local.get $10
        f64.store
       end
-      local.get $8
+      local.get $9
       i32.const 1
       i32.shr_s
-      local.set $8
+      local.set $9
       br $while-continue|4
      end
     end
-    local.get $5
+    local.get $6
     i32.const 1
     i32.sub
-    local.set $5
+    local.set $6
     br $for-loop|2
    end
   end
-  local.get $4
+  local.get $5
   call $~lib/rt/tlsf/__free
   local.get $0
   f64.load offset=8
-  local.set $12
+  local.set $15
   local.get $0
   local.get $0
   f64.load
   f64.store offset=8
   local.get $0
-  local.get $12
+  local.get $15
   f64.store
+  local.get $2
+  local.set $6
+  local.get $6
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $6
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
  )
  (func $~lib/typedarray/Float64Array#sort (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  (local $6 f64)
-  (local $7 f64)
+  (local $6 i32)
+  (local $7 i32)
   (local $8 i32)
-  (local $9 i32)
-  (local $10 i32)
+  (local $9 f64)
+  (local $10 f64)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  local.get $1
+  local.set $2
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
   block $~lib/typedarray/SORT<~lib/typedarray/Float64Array,f64>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
-   local.set $3
+   local.set $5
    local.get $1
-   local.set $2
-   local.get $3
-   call $~lib/typedarray/Float64Array#get:length
    local.set $4
    local.get $4
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $4
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
+   call $~lib/rt/pure/__retain
+   drop
+   local.get $4
+   local.set $3
+   local.get $5
+   call $~lib/typedarray/Float64Array#get:length
+   local.set $6
+   local.get $6
    i32.const 1
    i32.le_s
    if
+    local.get $5
+    local.set $8
     local.get $3
-    br $~lib/typedarray/SORT<~lib/typedarray/Float64Array,f64>|inlined.0
-   end
-   local.get $3
-   i32.load offset=4
-   local.set $5
-   local.get $4
-   i32.const 2
-   i32.eq
-   if
-    local.get $5
-    f64.load offset=8
-    local.set $6
-    local.get $5
-    f64.load
     local.set $7
-    local.get $6
     local.get $7
-    i32.const 2
-    global.set $~argumentsLength
-    local.get $2
-    call_indirect (type $f64_f64_=>_i32)
-    i32.const 0
-    i32.lt_s
-    if
-     local.get $5
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result i32)
      local.get $7
-     f64.store offset=8
-     local.get $5
-     local.get $6
-     f64.store
+     i32.const 4
+     i32.shl
+    else
+     i32.const 0
     end
-    local.get $3
+    call $~lib/rt/pure/__release
+    local.get $8
     br $~lib/typedarray/SORT<~lib/typedarray/Float64Array,f64>|inlined.0
    end
    local.get $5
-   local.set $10
-   local.get $4
-   local.set $9
-   local.get $2
+   i32.load offset=4
    local.set $8
+   local.get $6
+   i32.const 2
+   i32.eq
+   if
+    local.get $8
+    f64.load offset=8
+    local.set $9
+    local.get $8
+    f64.load
+    local.set $10
+    local.get $3
+    local.set $11
+    local.get $11
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result i32)
+     local.get $11
+     i32.const 4
+     i32.shl
+     local.get $9
+     local.get $10
+     i32.const 2
+     global.set $~argumentsLength
+     local.get $11
+     i32.const 4
+     i32.shl
+     i32.load
+     call_indirect (type $i32_f64_f64_=>_i32)
+    else
+     local.get $9
+     local.get $10
+     i32.const 2
+     global.set $~argumentsLength
+     local.get $11
+     call_indirect (type $f64_f64_=>_i32)
+    end
+    i32.const 0
+    i32.lt_s
+    if
+     local.get $8
+     local.get $10
+     f64.store offset=8
+     local.get $8
+     local.get $9
+     f64.store
+    end
+    local.get $5
+    local.set $13
+    local.get $3
+    local.set $12
+    local.get $12
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result i32)
+     local.get $12
+     i32.const 4
+     i32.shl
+    else
+     i32.const 0
+    end
+    call $~lib/rt/pure/__release
+    local.get $13
+    br $~lib/typedarray/SORT<~lib/typedarray/Float64Array,f64>|inlined.0
+   end
+   local.get $8
+   local.set $16
+   local.get $6
+   local.set $15
+   local.get $3
+   local.set $14
+   local.get $14
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $14
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
+   call $~lib/rt/pure/__retain
+   drop
+   local.get $14
+   local.set $13
    i32.const 0
    drop
-   local.get $9
+   local.get $15
    i32.const 256
    i32.lt_s
    if
-    local.get $10
-    local.get $9
-    local.get $8
+    local.get $16
+    local.get $15
+    local.get $13
     call $~lib/util/sort/insertionSort<f64>
    else
-    local.get $10
-    local.get $9
-    local.get $8
+    local.get $16
+    local.get $15
+    local.get $13
     call $~lib/util/sort/weakHeapSort<f64>
    end
+   local.get $13
+   local.set $17
+   local.get $17
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $17
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
+   call $~lib/rt/pure/__release
+   local.get $5
+   local.set $15
    local.get $3
+   local.set $16
+   local.get $16
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $16
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
+   call $~lib/rt/pure/__release
+   local.get $15
   end
+  local.set $6
+  local.get $1
+  local.set $8
+  local.get $8
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $8
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $6
  )
- (func $~lib/util/sort/COMPARATOR<f64>~anonymous|0 (param $0 f64) (param $1 f64) (result i32)
+ (func $~lib/util/sort/COMPARATOR<f64>~anonymous|0~nonClosure (param $0 f64) (param $1 f64) (result i32)
   (local $2 i64)
   (local $3 i64)
   local.get $0
@@ -3656,6 +3967,10 @@
   i32.sub
  )
  (func $~lib/typedarray/Float64Array#sort@varargs (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -3674,13 +3989,47 @@
     i32.eq
     drop
     i32.const 1
+    local.set $2
+    local.get $2
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result i32)
+     local.get $2
+     i32.const 4
+     i32.shl
+    else
+     i32.const 0
+    end
+    call $~lib/rt/pure/__retain
+    drop
+    local.get $2
     br $~lib/util/sort/COMPARATOR<f64>|inlined.0
    end
+   local.tee $3
    local.set $1
   end
   local.get $0
   local.get $1
   call $~lib/typedarray/Float64Array#sort
+  local.set $5
+  local.get $3
+  local.set $4
+  local.get $4
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $4
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $5
  )
  (func $~lib/typedarray/Float64Array#__get (param $0 i32) (param $1 i32) (result f64)
   local.get $1
@@ -5854,7 +6203,7 @@
   call $~lib/memory/memory.copy
   local.get $7
  )
- (func $std/typedarray/testReduce<~lib/typedarray/Int8Array,i8>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduce<~lib/typedarray/Int8Array,i8>~anonymous|0~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -5875,54 +6224,152 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  local.get $1
+  local.set $3
+  local.get $3
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $3
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $3
+  local.set $1
   local.get $0
   call $~lib/rt/pure/__retain
-  local.set $5
-  local.get $1
-  local.set $4
-  local.get $2
-  local.set $3
-  local.get $5
-  i32.load offset=4
-  local.set $6
-  i32.const 0
   local.set $7
-  local.get $5
-  call $~lib/typedarray/Int8Array#get:length
+  local.get $1
+  local.set $6
+  local.get $6
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $6
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $6
+  local.set $5
+  local.get $2
+  local.set $4
+  local.get $7
+  i32.load offset=4
   local.set $8
+  i32.const 0
+  local.set $9
+  local.get $7
+  call $~lib/typedarray/Int8Array#get:length
+  local.set $10
   loop $for-loop|0
-   local.get $7
-   local.get $8
-   i32.lt_s
-   local.set $9
    local.get $9
+   local.get $10
+   i32.lt_s
+   local.set $11
+   local.get $11
    if
-    local.get $3
-    local.get $6
-    local.get $7
-    i32.const 0
-    i32.shl
-    i32.add
-    i32.load8_s
-    local.get $7
     local.get $5
-    i32.const 4
-    global.set $~argumentsLength
-    local.get $4
-    call_indirect (type $i32_i32_i32_i32_=>_i32)
-    local.set $3
-    local.get $7
+    local.set $12
+    local.get $12
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result i32)
+     local.get $12
+     i32.const 4
+     i32.shl
+     local.get $4
+     local.get $8
+     local.get $9
+     i32.const 0
+     i32.shl
+     i32.add
+     i32.load8_s
+     local.get $9
+     local.get $7
+     i32.const 4
+     global.set $~argumentsLength
+     local.get $12
+     i32.const 4
+     i32.shl
+     i32.load
+     call_indirect (type $i32_i32_i32_i32_i32_=>_i32)
+    else
+     local.get $4
+     local.get $8
+     local.get $9
+     i32.const 0
+     i32.shl
+     i32.add
+     i32.load8_s
+     local.get $9
+     local.get $7
+     i32.const 4
+     global.set $~argumentsLength
+     local.get $12
+     call_indirect (type $i32_i32_i32_i32_=>_i32)
+    end
+    local.set $4
+    local.get $9
     i32.const 1
     i32.add
-    local.set $7
+    local.set $9
     br $for-loop|0
    end
   end
-  local.get $3
-  local.set $8
+  local.get $4
+  local.set $9
   local.get $5
+  local.set $10
+  local.get $10
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $10
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
   call $~lib/rt/pure/__release
+  local.get $7
+  call $~lib/rt/pure/__release
+  local.get $9
+  local.set $7
+  local.get $1
+  local.set $8
   local.get $8
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $8
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $7
  )
  (func $std/typedarray/testReduce<~lib/typedarray/Int8Array,i8>
   (local $0 i32)
@@ -5992,7 +6439,7 @@
   local.get $2
   i32.store8
  )
- (func $std/typedarray/testReduce<~lib/typedarray/Uint8Array,u8>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduce<~lib/typedarray/Uint8Array,u8>~anonymous|0~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -6013,54 +6460,152 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  local.get $1
+  local.set $3
+  local.get $3
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $3
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $3
+  local.set $1
   local.get $0
   call $~lib/rt/pure/__retain
-  local.set $5
-  local.get $1
-  local.set $4
-  local.get $2
-  local.set $3
-  local.get $5
-  i32.load offset=4
-  local.set $6
-  i32.const 0
   local.set $7
-  local.get $5
-  call $~lib/typedarray/Uint8Array#get:length
+  local.get $1
+  local.set $6
+  local.get $6
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $6
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $6
+  local.set $5
+  local.get $2
+  local.set $4
+  local.get $7
+  i32.load offset=4
   local.set $8
+  i32.const 0
+  local.set $9
+  local.get $7
+  call $~lib/typedarray/Uint8Array#get:length
+  local.set $10
   loop $for-loop|0
-   local.get $7
-   local.get $8
-   i32.lt_s
-   local.set $9
    local.get $9
+   local.get $10
+   i32.lt_s
+   local.set $11
+   local.get $11
    if
-    local.get $3
-    local.get $6
-    local.get $7
-    i32.const 0
-    i32.shl
-    i32.add
-    i32.load8_u
-    local.get $7
     local.get $5
-    i32.const 4
-    global.set $~argumentsLength
-    local.get $4
-    call_indirect (type $i32_i32_i32_i32_=>_i32)
-    local.set $3
-    local.get $7
+    local.set $12
+    local.get $12
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result i32)
+     local.get $12
+     i32.const 4
+     i32.shl
+     local.get $4
+     local.get $8
+     local.get $9
+     i32.const 0
+     i32.shl
+     i32.add
+     i32.load8_u
+     local.get $9
+     local.get $7
+     i32.const 4
+     global.set $~argumentsLength
+     local.get $12
+     i32.const 4
+     i32.shl
+     i32.load
+     call_indirect (type $i32_i32_i32_i32_i32_=>_i32)
+    else
+     local.get $4
+     local.get $8
+     local.get $9
+     i32.const 0
+     i32.shl
+     i32.add
+     i32.load8_u
+     local.get $9
+     local.get $7
+     i32.const 4
+     global.set $~argumentsLength
+     local.get $12
+     call_indirect (type $i32_i32_i32_i32_=>_i32)
+    end
+    local.set $4
+    local.get $9
     i32.const 1
     i32.add
-    local.set $7
+    local.set $9
     br $for-loop|0
    end
   end
-  local.get $3
-  local.set $8
+  local.get $4
+  local.set $9
   local.get $5
+  local.set $10
+  local.get $10
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $10
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
   call $~lib/rt/pure/__release
+  local.get $7
+  call $~lib/rt/pure/__release
+  local.get $9
+  local.set $7
+  local.get $1
+  local.set $8
   local.get $8
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $8
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $7
  )
  (func $std/typedarray/testReduce<~lib/typedarray/Uint8Array,u8>
   (local $0 i32)
@@ -6108,7 +6653,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testReduce<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduce<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|0~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -6129,54 +6674,152 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  local.get $1
+  local.set $3
+  local.get $3
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $3
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $3
+  local.set $1
   local.get $0
   call $~lib/rt/pure/__retain
-  local.set $5
-  local.get $1
-  local.set $4
-  local.get $2
-  local.set $3
-  local.get $5
-  i32.load offset=4
-  local.set $6
-  i32.const 0
   local.set $7
-  local.get $5
-  call $~lib/typedarray/Uint8ClampedArray#get:length
+  local.get $1
+  local.set $6
+  local.get $6
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $6
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $6
+  local.set $5
+  local.get $2
+  local.set $4
+  local.get $7
+  i32.load offset=4
   local.set $8
+  i32.const 0
+  local.set $9
+  local.get $7
+  call $~lib/typedarray/Uint8ClampedArray#get:length
+  local.set $10
   loop $for-loop|0
-   local.get $7
-   local.get $8
-   i32.lt_s
-   local.set $9
    local.get $9
+   local.get $10
+   i32.lt_s
+   local.set $11
+   local.get $11
    if
-    local.get $3
-    local.get $6
-    local.get $7
-    i32.const 0
-    i32.shl
-    i32.add
-    i32.load8_u
-    local.get $7
     local.get $5
-    i32.const 4
-    global.set $~argumentsLength
-    local.get $4
-    call_indirect (type $i32_i32_i32_i32_=>_i32)
-    local.set $3
-    local.get $7
+    local.set $12
+    local.get $12
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result i32)
+     local.get $12
+     i32.const 4
+     i32.shl
+     local.get $4
+     local.get $8
+     local.get $9
+     i32.const 0
+     i32.shl
+     i32.add
+     i32.load8_u
+     local.get $9
+     local.get $7
+     i32.const 4
+     global.set $~argumentsLength
+     local.get $12
+     i32.const 4
+     i32.shl
+     i32.load
+     call_indirect (type $i32_i32_i32_i32_i32_=>_i32)
+    else
+     local.get $4
+     local.get $8
+     local.get $9
+     i32.const 0
+     i32.shl
+     i32.add
+     i32.load8_u
+     local.get $9
+     local.get $7
+     i32.const 4
+     global.set $~argumentsLength
+     local.get $12
+     call_indirect (type $i32_i32_i32_i32_=>_i32)
+    end
+    local.set $4
+    local.get $9
     i32.const 1
     i32.add
-    local.set $7
+    local.set $9
     br $for-loop|0
    end
   end
-  local.get $3
-  local.set $8
+  local.get $4
+  local.set $9
   local.get $5
+  local.set $10
+  local.get $10
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $10
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
   call $~lib/rt/pure/__release
+  local.get $7
+  call $~lib/rt/pure/__release
+  local.get $9
+  local.set $7
+  local.get $1
+  local.set $8
   local.get $8
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $8
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $7
  )
  (func $std/typedarray/testReduce<~lib/typedarray/Uint8ClampedArray,u8>
   (local $0 i32)
@@ -6248,7 +6891,7 @@
   local.get $2
   i32.store16
  )
- (func $std/typedarray/testReduce<~lib/typedarray/Int16Array,i16>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduce<~lib/typedarray/Int16Array,i16>~anonymous|0~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -6269,54 +6912,152 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  local.get $1
+  local.set $3
+  local.get $3
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $3
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $3
+  local.set $1
   local.get $0
   call $~lib/rt/pure/__retain
-  local.set $5
-  local.get $1
-  local.set $4
-  local.get $2
-  local.set $3
-  local.get $5
-  i32.load offset=4
-  local.set $6
-  i32.const 0
   local.set $7
-  local.get $5
-  call $~lib/typedarray/Int16Array#get:length
+  local.get $1
+  local.set $6
+  local.get $6
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $6
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $6
+  local.set $5
+  local.get $2
+  local.set $4
+  local.get $7
+  i32.load offset=4
   local.set $8
+  i32.const 0
+  local.set $9
+  local.get $7
+  call $~lib/typedarray/Int16Array#get:length
+  local.set $10
   loop $for-loop|0
-   local.get $7
-   local.get $8
-   i32.lt_s
-   local.set $9
    local.get $9
+   local.get $10
+   i32.lt_s
+   local.set $11
+   local.get $11
    if
-    local.get $3
-    local.get $6
-    local.get $7
-    i32.const 1
-    i32.shl
-    i32.add
-    i32.load16_s
-    local.get $7
     local.get $5
-    i32.const 4
-    global.set $~argumentsLength
-    local.get $4
-    call_indirect (type $i32_i32_i32_i32_=>_i32)
-    local.set $3
-    local.get $7
+    local.set $12
+    local.get $12
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result i32)
+     local.get $12
+     i32.const 4
+     i32.shl
+     local.get $4
+     local.get $8
+     local.get $9
+     i32.const 1
+     i32.shl
+     i32.add
+     i32.load16_s
+     local.get $9
+     local.get $7
+     i32.const 4
+     global.set $~argumentsLength
+     local.get $12
+     i32.const 4
+     i32.shl
+     i32.load
+     call_indirect (type $i32_i32_i32_i32_i32_=>_i32)
+    else
+     local.get $4
+     local.get $8
+     local.get $9
+     i32.const 1
+     i32.shl
+     i32.add
+     i32.load16_s
+     local.get $9
+     local.get $7
+     i32.const 4
+     global.set $~argumentsLength
+     local.get $12
+     call_indirect (type $i32_i32_i32_i32_=>_i32)
+    end
+    local.set $4
+    local.get $9
     i32.const 1
     i32.add
-    local.set $7
+    local.set $9
     br $for-loop|0
    end
   end
-  local.get $3
-  local.set $8
+  local.get $4
+  local.set $9
   local.get $5
+  local.set $10
+  local.get $10
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $10
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
   call $~lib/rt/pure/__release
+  local.get $7
+  call $~lib/rt/pure/__release
+  local.get $9
+  local.set $7
+  local.get $1
+  local.set $8
   local.get $8
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $8
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $7
  )
  (func $std/typedarray/testReduce<~lib/typedarray/Int16Array,i16>
   (local $0 i32)
@@ -6390,7 +7131,7 @@
   local.get $2
   i32.store16
  )
- (func $std/typedarray/testReduce<~lib/typedarray/Uint16Array,u16>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduce<~lib/typedarray/Uint16Array,u16>~anonymous|0~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -6411,54 +7152,152 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  local.get $1
+  local.set $3
+  local.get $3
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $3
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $3
+  local.set $1
   local.get $0
   call $~lib/rt/pure/__retain
-  local.set $5
-  local.get $1
-  local.set $4
-  local.get $2
-  local.set $3
-  local.get $5
-  i32.load offset=4
-  local.set $6
-  i32.const 0
   local.set $7
-  local.get $5
-  call $~lib/typedarray/Uint16Array#get:length
+  local.get $1
+  local.set $6
+  local.get $6
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $6
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $6
+  local.set $5
+  local.get $2
+  local.set $4
+  local.get $7
+  i32.load offset=4
   local.set $8
+  i32.const 0
+  local.set $9
+  local.get $7
+  call $~lib/typedarray/Uint16Array#get:length
+  local.set $10
   loop $for-loop|0
-   local.get $7
-   local.get $8
-   i32.lt_s
-   local.set $9
    local.get $9
+   local.get $10
+   i32.lt_s
+   local.set $11
+   local.get $11
    if
-    local.get $3
-    local.get $6
-    local.get $7
-    i32.const 1
-    i32.shl
-    i32.add
-    i32.load16_u
-    local.get $7
     local.get $5
-    i32.const 4
-    global.set $~argumentsLength
-    local.get $4
-    call_indirect (type $i32_i32_i32_i32_=>_i32)
-    local.set $3
-    local.get $7
+    local.set $12
+    local.get $12
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result i32)
+     local.get $12
+     i32.const 4
+     i32.shl
+     local.get $4
+     local.get $8
+     local.get $9
+     i32.const 1
+     i32.shl
+     i32.add
+     i32.load16_u
+     local.get $9
+     local.get $7
+     i32.const 4
+     global.set $~argumentsLength
+     local.get $12
+     i32.const 4
+     i32.shl
+     i32.load
+     call_indirect (type $i32_i32_i32_i32_i32_=>_i32)
+    else
+     local.get $4
+     local.get $8
+     local.get $9
+     i32.const 1
+     i32.shl
+     i32.add
+     i32.load16_u
+     local.get $9
+     local.get $7
+     i32.const 4
+     global.set $~argumentsLength
+     local.get $12
+     call_indirect (type $i32_i32_i32_i32_=>_i32)
+    end
+    local.set $4
+    local.get $9
     i32.const 1
     i32.add
-    local.set $7
+    local.set $9
     br $for-loop|0
    end
   end
-  local.get $3
-  local.set $8
+  local.get $4
+  local.set $9
   local.get $5
+  local.set $10
+  local.get $10
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $10
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
   call $~lib/rt/pure/__release
+  local.get $7
+  call $~lib/rt/pure/__release
+  local.get $9
+  local.set $7
+  local.get $1
+  local.set $8
   local.get $8
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $8
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $7
  )
  (func $std/typedarray/testReduce<~lib/typedarray/Uint16Array,u16>
   (local $0 i32)
@@ -6506,7 +7345,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testReduce<~lib/typedarray/Int32Array,i32>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduce<~lib/typedarray/Int32Array,i32>~anonymous|0~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -6527,54 +7366,152 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  local.get $1
+  local.set $3
+  local.get $3
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $3
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $3
+  local.set $1
   local.get $0
   call $~lib/rt/pure/__retain
-  local.set $5
-  local.get $1
-  local.set $4
-  local.get $2
-  local.set $3
-  local.get $5
-  i32.load offset=4
-  local.set $6
-  i32.const 0
   local.set $7
-  local.get $5
-  call $~lib/typedarray/Int32Array#get:length
+  local.get $1
+  local.set $6
+  local.get $6
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $6
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $6
+  local.set $5
+  local.get $2
+  local.set $4
+  local.get $7
+  i32.load offset=4
   local.set $8
+  i32.const 0
+  local.set $9
+  local.get $7
+  call $~lib/typedarray/Int32Array#get:length
+  local.set $10
   loop $for-loop|0
-   local.get $7
-   local.get $8
-   i32.lt_s
-   local.set $9
    local.get $9
+   local.get $10
+   i32.lt_s
+   local.set $11
+   local.get $11
    if
-    local.get $3
-    local.get $6
-    local.get $7
-    i32.const 2
-    i32.shl
-    i32.add
-    i32.load
-    local.get $7
     local.get $5
-    i32.const 4
-    global.set $~argumentsLength
-    local.get $4
-    call_indirect (type $i32_i32_i32_i32_=>_i32)
-    local.set $3
-    local.get $7
+    local.set $12
+    local.get $12
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result i32)
+     local.get $12
+     i32.const 4
+     i32.shl
+     local.get $4
+     local.get $8
+     local.get $9
+     i32.const 2
+     i32.shl
+     i32.add
+     i32.load
+     local.get $9
+     local.get $7
+     i32.const 4
+     global.set $~argumentsLength
+     local.get $12
+     i32.const 4
+     i32.shl
+     i32.load
+     call_indirect (type $i32_i32_i32_i32_i32_=>_i32)
+    else
+     local.get $4
+     local.get $8
+     local.get $9
+     i32.const 2
+     i32.shl
+     i32.add
+     i32.load
+     local.get $9
+     local.get $7
+     i32.const 4
+     global.set $~argumentsLength
+     local.get $12
+     call_indirect (type $i32_i32_i32_i32_=>_i32)
+    end
+    local.set $4
+    local.get $9
     i32.const 1
     i32.add
-    local.set $7
+    local.set $9
     br $for-loop|0
    end
   end
-  local.get $3
-  local.set $8
+  local.get $4
+  local.set $9
   local.get $5
+  local.set $10
+  local.get $10
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $10
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
   call $~lib/rt/pure/__release
+  local.get $7
+  call $~lib/rt/pure/__release
+  local.get $9
+  local.set $7
+  local.get $1
+  local.set $8
   local.get $8
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $8
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $7
  )
  (func $std/typedarray/testReduce<~lib/typedarray/Int32Array,i32>
   (local $0 i32)
@@ -6644,7 +7581,7 @@
   local.get $2
   i32.store
  )
- (func $std/typedarray/testReduce<~lib/typedarray/Uint32Array,u32>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduce<~lib/typedarray/Uint32Array,u32>~anonymous|0~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -6665,54 +7602,152 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  local.get $1
+  local.set $3
+  local.get $3
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $3
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $3
+  local.set $1
   local.get $0
   call $~lib/rt/pure/__retain
-  local.set $5
-  local.get $1
-  local.set $4
-  local.get $2
-  local.set $3
-  local.get $5
-  i32.load offset=4
-  local.set $6
-  i32.const 0
   local.set $7
-  local.get $5
-  call $~lib/typedarray/Uint32Array#get:length
+  local.get $1
+  local.set $6
+  local.get $6
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $6
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $6
+  local.set $5
+  local.get $2
+  local.set $4
+  local.get $7
+  i32.load offset=4
   local.set $8
+  i32.const 0
+  local.set $9
+  local.get $7
+  call $~lib/typedarray/Uint32Array#get:length
+  local.set $10
   loop $for-loop|0
-   local.get $7
-   local.get $8
-   i32.lt_s
-   local.set $9
    local.get $9
+   local.get $10
+   i32.lt_s
+   local.set $11
+   local.get $11
    if
-    local.get $3
-    local.get $6
-    local.get $7
-    i32.const 2
-    i32.shl
-    i32.add
-    i32.load
-    local.get $7
     local.get $5
-    i32.const 4
-    global.set $~argumentsLength
-    local.get $4
-    call_indirect (type $i32_i32_i32_i32_=>_i32)
-    local.set $3
-    local.get $7
+    local.set $12
+    local.get $12
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result i32)
+     local.get $12
+     i32.const 4
+     i32.shl
+     local.get $4
+     local.get $8
+     local.get $9
+     i32.const 2
+     i32.shl
+     i32.add
+     i32.load
+     local.get $9
+     local.get $7
+     i32.const 4
+     global.set $~argumentsLength
+     local.get $12
+     i32.const 4
+     i32.shl
+     i32.load
+     call_indirect (type $i32_i32_i32_i32_i32_=>_i32)
+    else
+     local.get $4
+     local.get $8
+     local.get $9
+     i32.const 2
+     i32.shl
+     i32.add
+     i32.load
+     local.get $9
+     local.get $7
+     i32.const 4
+     global.set $~argumentsLength
+     local.get $12
+     call_indirect (type $i32_i32_i32_i32_=>_i32)
+    end
+    local.set $4
+    local.get $9
     i32.const 1
     i32.add
-    local.set $7
+    local.set $9
     br $for-loop|0
    end
   end
-  local.get $3
-  local.set $8
+  local.get $4
+  local.set $9
   local.get $5
+  local.set $10
+  local.get $10
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $10
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
   call $~lib/rt/pure/__release
+  local.get $7
+  call $~lib/rt/pure/__release
+  local.get $9
+  local.set $7
+  local.get $1
+  local.set $8
   local.get $8
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $8
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $7
  )
  (func $std/typedarray/testReduce<~lib/typedarray/Uint32Array,u32>
   (local $0 i32)
@@ -6782,7 +7817,7 @@
   local.get $2
   i64.store
  )
- (func $std/typedarray/testReduce<~lib/typedarray/Int64Array,i64>~anonymous|0 (param $0 i64) (param $1 i64) (param $2 i32) (param $3 i32) (result i64)
+ (func $std/typedarray/testReduce<~lib/typedarray/Int64Array,i64>~anonymous|0~nonClosure (param $0 i64) (param $1 i64) (param $2 i32) (param $3 i32) (result i64)
   (local $4 i64)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -6796,62 +7831,160 @@
   local.get $4
  )
  (func $~lib/typedarray/Int64Array#reduce<i64> (param $0 i32) (param $1 i32) (param $2 i64) (result i64)
-  (local $3 i64)
-  (local $4 i32)
+  (local $3 i32)
+  (local $4 i64)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
-  (local $10 i64)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i64)
+  local.get $1
+  local.set $3
+  local.get $3
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $3
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $3
+  local.set $1
   local.get $0
   call $~lib/rt/pure/__retain
-  local.set $5
-  local.get $1
-  local.set $4
-  local.get $2
-  local.set $3
-  local.get $5
-  i32.load offset=4
-  local.set $6
-  i32.const 0
   local.set $7
-  local.get $5
-  call $~lib/typedarray/Int64Array#get:length
+  local.get $1
+  local.set $6
+  local.get $6
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $6
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $6
+  local.set $5
+  local.get $2
+  local.set $4
+  local.get $7
+  i32.load offset=4
   local.set $8
+  i32.const 0
+  local.set $9
+  local.get $7
+  call $~lib/typedarray/Int64Array#get:length
+  local.set $10
   loop $for-loop|0
-   local.get $7
-   local.get $8
-   i32.lt_s
-   local.set $9
    local.get $9
+   local.get $10
+   i32.lt_s
+   local.set $11
+   local.get $11
    if
-    local.get $3
-    local.get $6
-    local.get $7
-    i32.const 3
-    i32.shl
-    i32.add
-    i64.load
-    local.get $7
     local.get $5
-    i32.const 4
-    global.set $~argumentsLength
-    local.get $4
-    call_indirect (type $i64_i64_i32_i32_=>_i64)
-    local.set $3
-    local.get $7
+    local.set $12
+    local.get $12
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result i64)
+     local.get $12
+     i32.const 4
+     i32.shl
+     local.get $4
+     local.get $8
+     local.get $9
+     i32.const 3
+     i32.shl
+     i32.add
+     i64.load
+     local.get $9
+     local.get $7
+     i32.const 4
+     global.set $~argumentsLength
+     local.get $12
+     i32.const 4
+     i32.shl
+     i32.load
+     call_indirect (type $i32_i64_i64_i32_i32_=>_i64)
+    else
+     local.get $4
+     local.get $8
+     local.get $9
+     i32.const 3
+     i32.shl
+     i32.add
+     i64.load
+     local.get $9
+     local.get $7
+     i32.const 4
+     global.set $~argumentsLength
+     local.get $12
+     call_indirect (type $i64_i64_i32_i32_=>_i64)
+    end
+    local.set $4
+    local.get $9
     i32.const 1
     i32.add
-    local.set $7
+    local.set $9
     br $for-loop|0
    end
   end
-  local.get $3
-  local.set $10
+  local.get $4
+  local.set $13
   local.get $5
-  call $~lib/rt/pure/__release
+  local.set $10
   local.get $10
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $10
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $7
+  call $~lib/rt/pure/__release
+  local.get $13
+  local.set $4
+  local.get $1
+  local.set $8
+  local.get $8
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $8
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $4
  )
  (func $std/typedarray/testReduce<~lib/typedarray/Int64Array,i64>
   (local $0 i32)
@@ -6921,7 +8054,7 @@
   local.get $2
   i64.store
  )
- (func $std/typedarray/testReduce<~lib/typedarray/Uint64Array,u64>~anonymous|0 (param $0 i64) (param $1 i64) (param $2 i32) (param $3 i32) (result i64)
+ (func $std/typedarray/testReduce<~lib/typedarray/Uint64Array,u64>~anonymous|0~nonClosure (param $0 i64) (param $1 i64) (param $2 i32) (param $3 i32) (result i64)
   (local $4 i64)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -6935,62 +8068,160 @@
   local.get $4
  )
  (func $~lib/typedarray/Uint64Array#reduce<u64> (param $0 i32) (param $1 i32) (param $2 i64) (result i64)
-  (local $3 i64)
-  (local $4 i32)
+  (local $3 i32)
+  (local $4 i64)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
-  (local $10 i64)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i64)
+  local.get $1
+  local.set $3
+  local.get $3
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $3
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $3
+  local.set $1
   local.get $0
   call $~lib/rt/pure/__retain
-  local.set $5
-  local.get $1
-  local.set $4
-  local.get $2
-  local.set $3
-  local.get $5
-  i32.load offset=4
-  local.set $6
-  i32.const 0
   local.set $7
-  local.get $5
-  call $~lib/typedarray/Uint64Array#get:length
+  local.get $1
+  local.set $6
+  local.get $6
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $6
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $6
+  local.set $5
+  local.get $2
+  local.set $4
+  local.get $7
+  i32.load offset=4
   local.set $8
+  i32.const 0
+  local.set $9
+  local.get $7
+  call $~lib/typedarray/Uint64Array#get:length
+  local.set $10
   loop $for-loop|0
-   local.get $7
-   local.get $8
-   i32.lt_s
-   local.set $9
    local.get $9
+   local.get $10
+   i32.lt_s
+   local.set $11
+   local.get $11
    if
-    local.get $3
-    local.get $6
-    local.get $7
-    i32.const 3
-    i32.shl
-    i32.add
-    i64.load
-    local.get $7
     local.get $5
-    i32.const 4
-    global.set $~argumentsLength
-    local.get $4
-    call_indirect (type $i64_i64_i32_i32_=>_i64)
-    local.set $3
-    local.get $7
+    local.set $12
+    local.get $12
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result i64)
+     local.get $12
+     i32.const 4
+     i32.shl
+     local.get $4
+     local.get $8
+     local.get $9
+     i32.const 3
+     i32.shl
+     i32.add
+     i64.load
+     local.get $9
+     local.get $7
+     i32.const 4
+     global.set $~argumentsLength
+     local.get $12
+     i32.const 4
+     i32.shl
+     i32.load
+     call_indirect (type $i32_i64_i64_i32_i32_=>_i64)
+    else
+     local.get $4
+     local.get $8
+     local.get $9
+     i32.const 3
+     i32.shl
+     i32.add
+     i64.load
+     local.get $9
+     local.get $7
+     i32.const 4
+     global.set $~argumentsLength
+     local.get $12
+     call_indirect (type $i64_i64_i32_i32_=>_i64)
+    end
+    local.set $4
+    local.get $9
     i32.const 1
     i32.add
-    local.set $7
+    local.set $9
     br $for-loop|0
    end
   end
-  local.get $3
-  local.set $10
+  local.get $4
+  local.set $13
   local.get $5
-  call $~lib/rt/pure/__release
+  local.set $10
   local.get $10
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $10
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $7
+  call $~lib/rt/pure/__release
+  local.get $13
+  local.set $4
+  local.get $1
+  local.set $8
+  local.get $8
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $8
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $4
  )
  (func $std/typedarray/testReduce<~lib/typedarray/Uint64Array,u64>
   (local $0 i32)
@@ -7060,7 +8291,7 @@
   local.get $2
   f32.store
  )
- (func $std/typedarray/testReduce<~lib/typedarray/Float32Array,f32>~anonymous|0 (param $0 f32) (param $1 f32) (param $2 i32) (param $3 i32) (result f32)
+ (func $std/typedarray/testReduce<~lib/typedarray/Float32Array,f32>~anonymous|0~nonClosure (param $0 f32) (param $1 f32) (param $2 i32) (param $3 i32) (result f32)
   (local $4 f32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -7074,62 +8305,160 @@
   local.get $4
  )
  (func $~lib/typedarray/Float32Array#reduce<f32> (param $0 i32) (param $1 i32) (param $2 f32) (result f32)
-  (local $3 f32)
-  (local $4 i32)
+  (local $3 i32)
+  (local $4 f32)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
-  (local $10 f32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 f32)
+  local.get $1
+  local.set $3
+  local.get $3
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $3
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $3
+  local.set $1
   local.get $0
   call $~lib/rt/pure/__retain
-  local.set $5
-  local.get $1
-  local.set $4
-  local.get $2
-  local.set $3
-  local.get $5
-  i32.load offset=4
-  local.set $6
-  i32.const 0
   local.set $7
-  local.get $5
-  call $~lib/typedarray/Float32Array#get:length
+  local.get $1
+  local.set $6
+  local.get $6
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $6
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $6
+  local.set $5
+  local.get $2
+  local.set $4
+  local.get $7
+  i32.load offset=4
   local.set $8
+  i32.const 0
+  local.set $9
+  local.get $7
+  call $~lib/typedarray/Float32Array#get:length
+  local.set $10
   loop $for-loop|0
-   local.get $7
-   local.get $8
-   i32.lt_s
-   local.set $9
    local.get $9
+   local.get $10
+   i32.lt_s
+   local.set $11
+   local.get $11
    if
-    local.get $3
-    local.get $6
-    local.get $7
-    i32.const 2
-    i32.shl
-    i32.add
-    f32.load
-    local.get $7
     local.get $5
-    i32.const 4
-    global.set $~argumentsLength
-    local.get $4
-    call_indirect (type $f32_f32_i32_i32_=>_f32)
-    local.set $3
-    local.get $7
+    local.set $12
+    local.get $12
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result f32)
+     local.get $12
+     i32.const 4
+     i32.shl
+     local.get $4
+     local.get $8
+     local.get $9
+     i32.const 2
+     i32.shl
+     i32.add
+     f32.load
+     local.get $9
+     local.get $7
+     i32.const 4
+     global.set $~argumentsLength
+     local.get $12
+     i32.const 4
+     i32.shl
+     i32.load
+     call_indirect (type $i32_f32_f32_i32_i32_=>_f32)
+    else
+     local.get $4
+     local.get $8
+     local.get $9
+     i32.const 2
+     i32.shl
+     i32.add
+     f32.load
+     local.get $9
+     local.get $7
+     i32.const 4
+     global.set $~argumentsLength
+     local.get $12
+     call_indirect (type $f32_f32_i32_i32_=>_f32)
+    end
+    local.set $4
+    local.get $9
     i32.const 1
     i32.add
-    local.set $7
+    local.set $9
     br $for-loop|0
    end
   end
-  local.get $3
-  local.set $10
+  local.get $4
+  local.set $13
   local.get $5
-  call $~lib/rt/pure/__release
+  local.set $10
   local.get $10
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $10
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $7
+  call $~lib/rt/pure/__release
+  local.get $13
+  local.set $4
+  local.get $1
+  local.set $8
+  local.get $8
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $8
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $4
  )
  (func $std/typedarray/testReduce<~lib/typedarray/Float32Array,f32>
   (local $0 i32)
@@ -7175,7 +8504,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testReduce<~lib/typedarray/Float64Array,f64>~anonymous|0 (param $0 f64) (param $1 f64) (param $2 i32) (param $3 i32) (result f64)
+ (func $std/typedarray/testReduce<~lib/typedarray/Float64Array,f64>~anonymous|0~nonClosure (param $0 f64) (param $1 f64) (param $2 i32) (param $3 i32) (result f64)
   (local $4 f64)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -7189,62 +8518,160 @@
   local.get $4
  )
  (func $~lib/typedarray/Float64Array#reduce<f64> (param $0 i32) (param $1 i32) (param $2 f64) (result f64)
-  (local $3 f64)
-  (local $4 i32)
+  (local $3 i32)
+  (local $4 f64)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
-  (local $10 f64)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 f64)
+  local.get $1
+  local.set $3
+  local.get $3
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $3
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $3
+  local.set $1
   local.get $0
   call $~lib/rt/pure/__retain
-  local.set $5
-  local.get $1
-  local.set $4
-  local.get $2
-  local.set $3
-  local.get $5
-  i32.load offset=4
-  local.set $6
-  i32.const 0
   local.set $7
-  local.get $5
-  call $~lib/typedarray/Float64Array#get:length
+  local.get $1
+  local.set $6
+  local.get $6
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $6
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $6
+  local.set $5
+  local.get $2
+  local.set $4
+  local.get $7
+  i32.load offset=4
   local.set $8
+  i32.const 0
+  local.set $9
+  local.get $7
+  call $~lib/typedarray/Float64Array#get:length
+  local.set $10
   loop $for-loop|0
-   local.get $7
-   local.get $8
-   i32.lt_s
-   local.set $9
    local.get $9
+   local.get $10
+   i32.lt_s
+   local.set $11
+   local.get $11
    if
-    local.get $3
-    local.get $6
-    local.get $7
-    i32.const 3
-    i32.shl
-    i32.add
-    f64.load
-    local.get $7
     local.get $5
-    i32.const 4
-    global.set $~argumentsLength
-    local.get $4
-    call_indirect (type $f64_f64_i32_i32_=>_f64)
-    local.set $3
-    local.get $7
+    local.set $12
+    local.get $12
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result f64)
+     local.get $12
+     i32.const 4
+     i32.shl
+     local.get $4
+     local.get $8
+     local.get $9
+     i32.const 3
+     i32.shl
+     i32.add
+     f64.load
+     local.get $9
+     local.get $7
+     i32.const 4
+     global.set $~argumentsLength
+     local.get $12
+     i32.const 4
+     i32.shl
+     i32.load
+     call_indirect (type $i32_f64_f64_i32_i32_=>_f64)
+    else
+     local.get $4
+     local.get $8
+     local.get $9
+     i32.const 3
+     i32.shl
+     i32.add
+     f64.load
+     local.get $9
+     local.get $7
+     i32.const 4
+     global.set $~argumentsLength
+     local.get $12
+     call_indirect (type $f64_f64_i32_i32_=>_f64)
+    end
+    local.set $4
+    local.get $9
     i32.const 1
     i32.add
-    local.set $7
+    local.set $9
     br $for-loop|0
    end
   end
-  local.get $3
-  local.set $10
+  local.get $4
+  local.set $13
   local.get $5
-  call $~lib/rt/pure/__release
+  local.set $10
   local.get $10
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $10
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $7
+  call $~lib/rt/pure/__release
+  local.get $13
+  local.set $4
+  local.get $1
+  local.set $8
+  local.get $8
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $8
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $4
  )
  (func $std/typedarray/testReduce<~lib/typedarray/Float64Array,f64>
   (local $0 i32)
@@ -7290,7 +8717,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testReduceRight<~lib/typedarray/Int8Array,i8>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Int8Array,i8>~anonymous|0~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -7310,52 +8737,150 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  local.get $1
+  local.set $3
+  local.get $3
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $3
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $3
+  local.set $1
   local.get $0
   call $~lib/rt/pure/__retain
-  local.set $5
+  local.set $7
   local.get $1
-  local.set $4
-  local.get $2
-  local.set $3
-  local.get $5
-  i32.load offset=4
   local.set $6
-  local.get $5
+  local.get $6
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $6
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $6
+  local.set $5
+  local.get $2
+  local.set $4
+  local.get $7
+  i32.load offset=4
+  local.set $8
+  local.get $7
   call $~lib/typedarray/Int8Array#get:length
   i32.const 1
   i32.sub
-  local.set $7
+  local.set $9
   loop $for-loop|0
-   local.get $7
+   local.get $9
    i32.const 0
    i32.ge_s
-   local.set $8
-   local.get $8
+   local.set $10
+   local.get $10
    if
-    local.get $3
-    local.get $6
-    local.get $7
-    i32.const 0
-    i32.shl
-    i32.add
-    i32.load8_s
-    local.get $7
     local.get $5
-    i32.const 4
-    global.set $~argumentsLength
-    local.get $4
-    call_indirect (type $i32_i32_i32_i32_=>_i32)
-    local.set $3
-    local.get $7
+    local.set $11
+    local.get $11
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result i32)
+     local.get $11
+     i32.const 4
+     i32.shl
+     local.get $4
+     local.get $8
+     local.get $9
+     i32.const 0
+     i32.shl
+     i32.add
+     i32.load8_s
+     local.get $9
+     local.get $7
+     i32.const 4
+     global.set $~argumentsLength
+     local.get $11
+     i32.const 4
+     i32.shl
+     i32.load
+     call_indirect (type $i32_i32_i32_i32_i32_=>_i32)
+    else
+     local.get $4
+     local.get $8
+     local.get $9
+     i32.const 0
+     i32.shl
+     i32.add
+     i32.load8_s
+     local.get $9
+     local.get $7
+     i32.const 4
+     global.set $~argumentsLength
+     local.get $11
+     call_indirect (type $i32_i32_i32_i32_=>_i32)
+    end
+    local.set $4
+    local.get $9
     i32.const 1
     i32.sub
-    local.set $7
+    local.set $9
     br $for-loop|0
    end
   end
-  local.get $3
-  local.set $7
+  local.get $4
+  local.set $10
   local.get $5
+  local.set $9
+  local.get $9
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $9
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $7
+  call $~lib/rt/pure/__release
+  local.get $10
+  local.set $7
+  local.get $1
+  local.set $8
+  local.get $8
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $8
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
   call $~lib/rt/pure/__release
   local.get $7
  )
@@ -7407,7 +8932,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testReduceRight<~lib/typedarray/Uint8Array,u8>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Uint8Array,u8>~anonymous|0~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -7427,52 +8952,150 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  local.get $1
+  local.set $3
+  local.get $3
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $3
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $3
+  local.set $1
   local.get $0
   call $~lib/rt/pure/__retain
-  local.set $5
+  local.set $7
   local.get $1
-  local.set $4
-  local.get $2
-  local.set $3
-  local.get $5
-  i32.load offset=4
   local.set $6
-  local.get $5
+  local.get $6
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $6
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $6
+  local.set $5
+  local.get $2
+  local.set $4
+  local.get $7
+  i32.load offset=4
+  local.set $8
+  local.get $7
   call $~lib/typedarray/Uint8Array#get:length
   i32.const 1
   i32.sub
-  local.set $7
+  local.set $9
   loop $for-loop|0
-   local.get $7
+   local.get $9
    i32.const 0
    i32.ge_s
-   local.set $8
-   local.get $8
+   local.set $10
+   local.get $10
    if
-    local.get $3
-    local.get $6
-    local.get $7
-    i32.const 0
-    i32.shl
-    i32.add
-    i32.load8_u
-    local.get $7
     local.get $5
-    i32.const 4
-    global.set $~argumentsLength
-    local.get $4
-    call_indirect (type $i32_i32_i32_i32_=>_i32)
-    local.set $3
-    local.get $7
+    local.set $11
+    local.get $11
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result i32)
+     local.get $11
+     i32.const 4
+     i32.shl
+     local.get $4
+     local.get $8
+     local.get $9
+     i32.const 0
+     i32.shl
+     i32.add
+     i32.load8_u
+     local.get $9
+     local.get $7
+     i32.const 4
+     global.set $~argumentsLength
+     local.get $11
+     i32.const 4
+     i32.shl
+     i32.load
+     call_indirect (type $i32_i32_i32_i32_i32_=>_i32)
+    else
+     local.get $4
+     local.get $8
+     local.get $9
+     i32.const 0
+     i32.shl
+     i32.add
+     i32.load8_u
+     local.get $9
+     local.get $7
+     i32.const 4
+     global.set $~argumentsLength
+     local.get $11
+     call_indirect (type $i32_i32_i32_i32_=>_i32)
+    end
+    local.set $4
+    local.get $9
     i32.const 1
     i32.sub
-    local.set $7
+    local.set $9
     br $for-loop|0
    end
   end
-  local.get $3
-  local.set $7
+  local.get $4
+  local.set $10
   local.get $5
+  local.set $9
+  local.get $9
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $9
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $7
+  call $~lib/rt/pure/__release
+  local.get $10
+  local.set $7
+  local.get $1
+  local.set $8
+  local.get $8
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $8
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
   call $~lib/rt/pure/__release
   local.get $7
  )
@@ -7522,7 +9145,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testReduceRight<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|0~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -7542,52 +9165,150 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  local.get $1
+  local.set $3
+  local.get $3
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $3
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $3
+  local.set $1
   local.get $0
   call $~lib/rt/pure/__retain
-  local.set $5
+  local.set $7
   local.get $1
-  local.set $4
-  local.get $2
-  local.set $3
-  local.get $5
-  i32.load offset=4
   local.set $6
-  local.get $5
+  local.get $6
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $6
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $6
+  local.set $5
+  local.get $2
+  local.set $4
+  local.get $7
+  i32.load offset=4
+  local.set $8
+  local.get $7
   call $~lib/typedarray/Uint8ClampedArray#get:length
   i32.const 1
   i32.sub
-  local.set $7
+  local.set $9
   loop $for-loop|0
-   local.get $7
+   local.get $9
    i32.const 0
    i32.ge_s
-   local.set $8
-   local.get $8
+   local.set $10
+   local.get $10
    if
-    local.get $3
-    local.get $6
-    local.get $7
-    i32.const 0
-    i32.shl
-    i32.add
-    i32.load8_u
-    local.get $7
     local.get $5
-    i32.const 4
-    global.set $~argumentsLength
-    local.get $4
-    call_indirect (type $i32_i32_i32_i32_=>_i32)
-    local.set $3
-    local.get $7
+    local.set $11
+    local.get $11
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result i32)
+     local.get $11
+     i32.const 4
+     i32.shl
+     local.get $4
+     local.get $8
+     local.get $9
+     i32.const 0
+     i32.shl
+     i32.add
+     i32.load8_u
+     local.get $9
+     local.get $7
+     i32.const 4
+     global.set $~argumentsLength
+     local.get $11
+     i32.const 4
+     i32.shl
+     i32.load
+     call_indirect (type $i32_i32_i32_i32_i32_=>_i32)
+    else
+     local.get $4
+     local.get $8
+     local.get $9
+     i32.const 0
+     i32.shl
+     i32.add
+     i32.load8_u
+     local.get $9
+     local.get $7
+     i32.const 4
+     global.set $~argumentsLength
+     local.get $11
+     call_indirect (type $i32_i32_i32_i32_=>_i32)
+    end
+    local.set $4
+    local.get $9
     i32.const 1
     i32.sub
-    local.set $7
+    local.set $9
     br $for-loop|0
    end
   end
-  local.get $3
-  local.set $7
+  local.get $4
+  local.set $10
   local.get $5
+  local.set $9
+  local.get $9
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $9
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $7
+  call $~lib/rt/pure/__release
+  local.get $10
+  local.set $7
+  local.get $1
+  local.set $8
+  local.get $8
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $8
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
   call $~lib/rt/pure/__release
   local.get $7
  )
@@ -7637,7 +9358,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testReduceRight<~lib/typedarray/Int16Array,i16>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Int16Array,i16>~anonymous|0~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -7657,52 +9378,150 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  local.get $1
+  local.set $3
+  local.get $3
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $3
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $3
+  local.set $1
   local.get $0
   call $~lib/rt/pure/__retain
-  local.set $5
+  local.set $7
   local.get $1
-  local.set $4
-  local.get $2
-  local.set $3
-  local.get $5
-  i32.load offset=4
   local.set $6
-  local.get $5
+  local.get $6
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $6
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $6
+  local.set $5
+  local.get $2
+  local.set $4
+  local.get $7
+  i32.load offset=4
+  local.set $8
+  local.get $7
   call $~lib/typedarray/Int16Array#get:length
   i32.const 1
   i32.sub
-  local.set $7
+  local.set $9
   loop $for-loop|0
-   local.get $7
+   local.get $9
    i32.const 0
    i32.ge_s
-   local.set $8
-   local.get $8
+   local.set $10
+   local.get $10
    if
-    local.get $3
-    local.get $6
-    local.get $7
-    i32.const 1
-    i32.shl
-    i32.add
-    i32.load16_s
-    local.get $7
     local.get $5
-    i32.const 4
-    global.set $~argumentsLength
-    local.get $4
-    call_indirect (type $i32_i32_i32_i32_=>_i32)
-    local.set $3
-    local.get $7
+    local.set $11
+    local.get $11
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result i32)
+     local.get $11
+     i32.const 4
+     i32.shl
+     local.get $4
+     local.get $8
+     local.get $9
+     i32.const 1
+     i32.shl
+     i32.add
+     i32.load16_s
+     local.get $9
+     local.get $7
+     i32.const 4
+     global.set $~argumentsLength
+     local.get $11
+     i32.const 4
+     i32.shl
+     i32.load
+     call_indirect (type $i32_i32_i32_i32_i32_=>_i32)
+    else
+     local.get $4
+     local.get $8
+     local.get $9
+     i32.const 1
+     i32.shl
+     i32.add
+     i32.load16_s
+     local.get $9
+     local.get $7
+     i32.const 4
+     global.set $~argumentsLength
+     local.get $11
+     call_indirect (type $i32_i32_i32_i32_=>_i32)
+    end
+    local.set $4
+    local.get $9
     i32.const 1
     i32.sub
-    local.set $7
+    local.set $9
     br $for-loop|0
    end
   end
-  local.get $3
-  local.set $7
+  local.get $4
+  local.set $10
   local.get $5
+  local.set $9
+  local.get $9
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $9
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $7
+  call $~lib/rt/pure/__release
+  local.get $10
+  local.set $7
+  local.get $1
+  local.set $8
+  local.get $8
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $8
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
   call $~lib/rt/pure/__release
   local.get $7
  )
@@ -7754,7 +9573,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testReduceRight<~lib/typedarray/Uint16Array,u16>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Uint16Array,u16>~anonymous|0~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -7774,52 +9593,150 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  local.get $1
+  local.set $3
+  local.get $3
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $3
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $3
+  local.set $1
   local.get $0
   call $~lib/rt/pure/__retain
-  local.set $5
+  local.set $7
   local.get $1
-  local.set $4
-  local.get $2
-  local.set $3
-  local.get $5
-  i32.load offset=4
   local.set $6
-  local.get $5
+  local.get $6
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $6
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $6
+  local.set $5
+  local.get $2
+  local.set $4
+  local.get $7
+  i32.load offset=4
+  local.set $8
+  local.get $7
   call $~lib/typedarray/Uint16Array#get:length
   i32.const 1
   i32.sub
-  local.set $7
+  local.set $9
   loop $for-loop|0
-   local.get $7
+   local.get $9
    i32.const 0
    i32.ge_s
-   local.set $8
-   local.get $8
+   local.set $10
+   local.get $10
    if
-    local.get $3
-    local.get $6
-    local.get $7
-    i32.const 1
-    i32.shl
-    i32.add
-    i32.load16_u
-    local.get $7
     local.get $5
-    i32.const 4
-    global.set $~argumentsLength
-    local.get $4
-    call_indirect (type $i32_i32_i32_i32_=>_i32)
-    local.set $3
-    local.get $7
+    local.set $11
+    local.get $11
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result i32)
+     local.get $11
+     i32.const 4
+     i32.shl
+     local.get $4
+     local.get $8
+     local.get $9
+     i32.const 1
+     i32.shl
+     i32.add
+     i32.load16_u
+     local.get $9
+     local.get $7
+     i32.const 4
+     global.set $~argumentsLength
+     local.get $11
+     i32.const 4
+     i32.shl
+     i32.load
+     call_indirect (type $i32_i32_i32_i32_i32_=>_i32)
+    else
+     local.get $4
+     local.get $8
+     local.get $9
+     i32.const 1
+     i32.shl
+     i32.add
+     i32.load16_u
+     local.get $9
+     local.get $7
+     i32.const 4
+     global.set $~argumentsLength
+     local.get $11
+     call_indirect (type $i32_i32_i32_i32_=>_i32)
+    end
+    local.set $4
+    local.get $9
     i32.const 1
     i32.sub
-    local.set $7
+    local.set $9
     br $for-loop|0
    end
   end
-  local.get $3
-  local.set $7
+  local.get $4
+  local.set $10
   local.get $5
+  local.set $9
+  local.get $9
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $9
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $7
+  call $~lib/rt/pure/__release
+  local.get $10
+  local.set $7
+  local.get $1
+  local.set $8
+  local.get $8
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $8
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
   call $~lib/rt/pure/__release
   local.get $7
  )
@@ -7869,7 +9786,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testReduceRight<~lib/typedarray/Int32Array,i32>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Int32Array,i32>~anonymous|0~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -7889,52 +9806,150 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  local.get $1
+  local.set $3
+  local.get $3
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $3
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $3
+  local.set $1
   local.get $0
   call $~lib/rt/pure/__retain
-  local.set $5
+  local.set $7
   local.get $1
-  local.set $4
-  local.get $2
-  local.set $3
-  local.get $5
-  i32.load offset=4
   local.set $6
-  local.get $5
+  local.get $6
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $6
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $6
+  local.set $5
+  local.get $2
+  local.set $4
+  local.get $7
+  i32.load offset=4
+  local.set $8
+  local.get $7
   call $~lib/typedarray/Int32Array#get:length
   i32.const 1
   i32.sub
-  local.set $7
+  local.set $9
   loop $for-loop|0
-   local.get $7
+   local.get $9
    i32.const 0
    i32.ge_s
-   local.set $8
-   local.get $8
+   local.set $10
+   local.get $10
    if
-    local.get $3
-    local.get $6
-    local.get $7
-    i32.const 2
-    i32.shl
-    i32.add
-    i32.load
-    local.get $7
     local.get $5
-    i32.const 4
-    global.set $~argumentsLength
-    local.get $4
-    call_indirect (type $i32_i32_i32_i32_=>_i32)
-    local.set $3
-    local.get $7
+    local.set $11
+    local.get $11
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result i32)
+     local.get $11
+     i32.const 4
+     i32.shl
+     local.get $4
+     local.get $8
+     local.get $9
+     i32.const 2
+     i32.shl
+     i32.add
+     i32.load
+     local.get $9
+     local.get $7
+     i32.const 4
+     global.set $~argumentsLength
+     local.get $11
+     i32.const 4
+     i32.shl
+     i32.load
+     call_indirect (type $i32_i32_i32_i32_i32_=>_i32)
+    else
+     local.get $4
+     local.get $8
+     local.get $9
+     i32.const 2
+     i32.shl
+     i32.add
+     i32.load
+     local.get $9
+     local.get $7
+     i32.const 4
+     global.set $~argumentsLength
+     local.get $11
+     call_indirect (type $i32_i32_i32_i32_=>_i32)
+    end
+    local.set $4
+    local.get $9
     i32.const 1
     i32.sub
-    local.set $7
+    local.set $9
     br $for-loop|0
    end
   end
-  local.get $3
-  local.set $7
+  local.get $4
+  local.set $10
   local.get $5
+  local.set $9
+  local.get $9
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $9
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $7
+  call $~lib/rt/pure/__release
+  local.get $10
+  local.set $7
+  local.get $1
+  local.set $8
+  local.get $8
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $8
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
   call $~lib/rt/pure/__release
   local.get $7
  )
@@ -7982,7 +9997,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testReduceRight<~lib/typedarray/Uint32Array,u32>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Uint32Array,u32>~anonymous|0~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -8002,52 +10017,150 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  local.get $1
+  local.set $3
+  local.get $3
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $3
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $3
+  local.set $1
   local.get $0
   call $~lib/rt/pure/__retain
-  local.set $5
+  local.set $7
   local.get $1
-  local.set $4
-  local.get $2
-  local.set $3
-  local.get $5
-  i32.load offset=4
   local.set $6
-  local.get $5
+  local.get $6
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $6
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $6
+  local.set $5
+  local.get $2
+  local.set $4
+  local.get $7
+  i32.load offset=4
+  local.set $8
+  local.get $7
   call $~lib/typedarray/Uint32Array#get:length
   i32.const 1
   i32.sub
-  local.set $7
+  local.set $9
   loop $for-loop|0
-   local.get $7
+   local.get $9
    i32.const 0
    i32.ge_s
-   local.set $8
-   local.get $8
+   local.set $10
+   local.get $10
    if
-    local.get $3
-    local.get $6
-    local.get $7
-    i32.const 2
-    i32.shl
-    i32.add
-    i32.load
-    local.get $7
     local.get $5
-    i32.const 4
-    global.set $~argumentsLength
-    local.get $4
-    call_indirect (type $i32_i32_i32_i32_=>_i32)
-    local.set $3
-    local.get $7
+    local.set $11
+    local.get $11
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result i32)
+     local.get $11
+     i32.const 4
+     i32.shl
+     local.get $4
+     local.get $8
+     local.get $9
+     i32.const 2
+     i32.shl
+     i32.add
+     i32.load
+     local.get $9
+     local.get $7
+     i32.const 4
+     global.set $~argumentsLength
+     local.get $11
+     i32.const 4
+     i32.shl
+     i32.load
+     call_indirect (type $i32_i32_i32_i32_i32_=>_i32)
+    else
+     local.get $4
+     local.get $8
+     local.get $9
+     i32.const 2
+     i32.shl
+     i32.add
+     i32.load
+     local.get $9
+     local.get $7
+     i32.const 4
+     global.set $~argumentsLength
+     local.get $11
+     call_indirect (type $i32_i32_i32_i32_=>_i32)
+    end
+    local.set $4
+    local.get $9
     i32.const 1
     i32.sub
-    local.set $7
+    local.set $9
     br $for-loop|0
    end
   end
-  local.get $3
-  local.set $7
+  local.get $4
+  local.set $10
   local.get $5
+  local.set $9
+  local.get $9
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $9
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $7
+  call $~lib/rt/pure/__release
+  local.get $10
+  local.set $7
+  local.get $1
+  local.set $8
+  local.get $8
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $8
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
   call $~lib/rt/pure/__release
   local.get $7
  )
@@ -8095,7 +10208,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testReduceRight<~lib/typedarray/Int64Array,i64>~anonymous|0 (param $0 i64) (param $1 i64) (param $2 i32) (param $3 i32) (result i64)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Int64Array,i64>~anonymous|0~nonClosure (param $0 i64) (param $1 i64) (param $2 i32) (param $3 i32) (result i64)
   (local $4 i64)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -8109,61 +10222,159 @@
   local.get $4
  )
  (func $~lib/typedarray/Int64Array#reduceRight<i64> (param $0 i32) (param $1 i32) (param $2 i64) (result i64)
-  (local $3 i64)
-  (local $4 i32)
+  (local $3 i32)
+  (local $4 i64)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
-  (local $9 i64)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i64)
+  local.get $1
+  local.set $3
+  local.get $3
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $3
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $3
+  local.set $1
   local.get $0
   call $~lib/rt/pure/__retain
-  local.set $5
+  local.set $7
   local.get $1
-  local.set $4
-  local.get $2
-  local.set $3
-  local.get $5
-  i32.load offset=4
   local.set $6
-  local.get $5
+  local.get $6
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $6
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $6
+  local.set $5
+  local.get $2
+  local.set $4
+  local.get $7
+  i32.load offset=4
+  local.set $8
+  local.get $7
   call $~lib/typedarray/Int64Array#get:length
   i32.const 1
   i32.sub
-  local.set $7
+  local.set $9
   loop $for-loop|0
-   local.get $7
+   local.get $9
    i32.const 0
    i32.ge_s
-   local.set $8
-   local.get $8
+   local.set $10
+   local.get $10
    if
-    local.get $3
-    local.get $6
-    local.get $7
-    i32.const 3
-    i32.shl
-    i32.add
-    i64.load
-    local.get $7
     local.get $5
-    i32.const 4
-    global.set $~argumentsLength
-    local.get $4
-    call_indirect (type $i64_i64_i32_i32_=>_i64)
-    local.set $3
-    local.get $7
+    local.set $11
+    local.get $11
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result i64)
+     local.get $11
+     i32.const 4
+     i32.shl
+     local.get $4
+     local.get $8
+     local.get $9
+     i32.const 3
+     i32.shl
+     i32.add
+     i64.load
+     local.get $9
+     local.get $7
+     i32.const 4
+     global.set $~argumentsLength
+     local.get $11
+     i32.const 4
+     i32.shl
+     i32.load
+     call_indirect (type $i32_i64_i64_i32_i32_=>_i64)
+    else
+     local.get $4
+     local.get $8
+     local.get $9
+     i32.const 3
+     i32.shl
+     i32.add
+     i64.load
+     local.get $9
+     local.get $7
+     i32.const 4
+     global.set $~argumentsLength
+     local.get $11
+     call_indirect (type $i64_i64_i32_i32_=>_i64)
+    end
+    local.set $4
+    local.get $9
     i32.const 1
     i32.sub
-    local.set $7
+    local.set $9
     br $for-loop|0
    end
   end
-  local.get $3
-  local.set $9
+  local.get $4
+  local.set $12
   local.get $5
-  call $~lib/rt/pure/__release
+  local.set $9
   local.get $9
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $9
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $7
+  call $~lib/rt/pure/__release
+  local.get $12
+  local.set $4
+  local.get $1
+  local.set $8
+  local.get $8
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $8
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $4
  )
  (func $std/typedarray/testReduceRight<~lib/typedarray/Int64Array,i64>
   (local $0 i32)
@@ -8209,7 +10420,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testReduceRight<~lib/typedarray/Uint64Array,u64>~anonymous|0 (param $0 i64) (param $1 i64) (param $2 i32) (param $3 i32) (result i64)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Uint64Array,u64>~anonymous|0~nonClosure (param $0 i64) (param $1 i64) (param $2 i32) (param $3 i32) (result i64)
   (local $4 i64)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -8223,61 +10434,159 @@
   local.get $4
  )
  (func $~lib/typedarray/Uint64Array#reduceRight<u64> (param $0 i32) (param $1 i32) (param $2 i64) (result i64)
-  (local $3 i64)
-  (local $4 i32)
+  (local $3 i32)
+  (local $4 i64)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
-  (local $9 i64)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i64)
+  local.get $1
+  local.set $3
+  local.get $3
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $3
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $3
+  local.set $1
   local.get $0
   call $~lib/rt/pure/__retain
-  local.set $5
+  local.set $7
   local.get $1
-  local.set $4
-  local.get $2
-  local.set $3
-  local.get $5
-  i32.load offset=4
   local.set $6
-  local.get $5
+  local.get $6
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $6
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $6
+  local.set $5
+  local.get $2
+  local.set $4
+  local.get $7
+  i32.load offset=4
+  local.set $8
+  local.get $7
   call $~lib/typedarray/Uint64Array#get:length
   i32.const 1
   i32.sub
-  local.set $7
+  local.set $9
   loop $for-loop|0
-   local.get $7
+   local.get $9
    i32.const 0
    i32.ge_s
-   local.set $8
-   local.get $8
+   local.set $10
+   local.get $10
    if
-    local.get $3
-    local.get $6
-    local.get $7
-    i32.const 3
-    i32.shl
-    i32.add
-    i64.load
-    local.get $7
     local.get $5
-    i32.const 4
-    global.set $~argumentsLength
-    local.get $4
-    call_indirect (type $i64_i64_i32_i32_=>_i64)
-    local.set $3
-    local.get $7
+    local.set $11
+    local.get $11
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result i64)
+     local.get $11
+     i32.const 4
+     i32.shl
+     local.get $4
+     local.get $8
+     local.get $9
+     i32.const 3
+     i32.shl
+     i32.add
+     i64.load
+     local.get $9
+     local.get $7
+     i32.const 4
+     global.set $~argumentsLength
+     local.get $11
+     i32.const 4
+     i32.shl
+     i32.load
+     call_indirect (type $i32_i64_i64_i32_i32_=>_i64)
+    else
+     local.get $4
+     local.get $8
+     local.get $9
+     i32.const 3
+     i32.shl
+     i32.add
+     i64.load
+     local.get $9
+     local.get $7
+     i32.const 4
+     global.set $~argumentsLength
+     local.get $11
+     call_indirect (type $i64_i64_i32_i32_=>_i64)
+    end
+    local.set $4
+    local.get $9
     i32.const 1
     i32.sub
-    local.set $7
+    local.set $9
     br $for-loop|0
    end
   end
-  local.get $3
-  local.set $9
+  local.get $4
+  local.set $12
   local.get $5
-  call $~lib/rt/pure/__release
+  local.set $9
   local.get $9
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $9
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $7
+  call $~lib/rt/pure/__release
+  local.get $12
+  local.set $4
+  local.get $1
+  local.set $8
+  local.get $8
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $8
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $4
  )
  (func $std/typedarray/testReduceRight<~lib/typedarray/Uint64Array,u64>
   (local $0 i32)
@@ -8323,7 +10632,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testReduceRight<~lib/typedarray/Float32Array,f32>~anonymous|0 (param $0 f32) (param $1 f32) (param $2 i32) (param $3 i32) (result f32)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Float32Array,f32>~anonymous|0~nonClosure (param $0 f32) (param $1 f32) (param $2 i32) (param $3 i32) (result f32)
   (local $4 f32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -8337,61 +10646,159 @@
   local.get $4
  )
  (func $~lib/typedarray/Float32Array#reduceRight<f32> (param $0 i32) (param $1 i32) (param $2 f32) (result f32)
-  (local $3 f32)
-  (local $4 i32)
+  (local $3 i32)
+  (local $4 f32)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
-  (local $9 f32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 f32)
+  local.get $1
+  local.set $3
+  local.get $3
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $3
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $3
+  local.set $1
   local.get $0
   call $~lib/rt/pure/__retain
-  local.set $5
+  local.set $7
   local.get $1
-  local.set $4
-  local.get $2
-  local.set $3
-  local.get $5
-  i32.load offset=4
   local.set $6
-  local.get $5
+  local.get $6
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $6
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $6
+  local.set $5
+  local.get $2
+  local.set $4
+  local.get $7
+  i32.load offset=4
+  local.set $8
+  local.get $7
   call $~lib/typedarray/Float32Array#get:length
   i32.const 1
   i32.sub
-  local.set $7
+  local.set $9
   loop $for-loop|0
-   local.get $7
+   local.get $9
    i32.const 0
    i32.ge_s
-   local.set $8
-   local.get $8
+   local.set $10
+   local.get $10
    if
-    local.get $3
-    local.get $6
-    local.get $7
-    i32.const 2
-    i32.shl
-    i32.add
-    f32.load
-    local.get $7
     local.get $5
-    i32.const 4
-    global.set $~argumentsLength
-    local.get $4
-    call_indirect (type $f32_f32_i32_i32_=>_f32)
-    local.set $3
-    local.get $7
+    local.set $11
+    local.get $11
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result f32)
+     local.get $11
+     i32.const 4
+     i32.shl
+     local.get $4
+     local.get $8
+     local.get $9
+     i32.const 2
+     i32.shl
+     i32.add
+     f32.load
+     local.get $9
+     local.get $7
+     i32.const 4
+     global.set $~argumentsLength
+     local.get $11
+     i32.const 4
+     i32.shl
+     i32.load
+     call_indirect (type $i32_f32_f32_i32_i32_=>_f32)
+    else
+     local.get $4
+     local.get $8
+     local.get $9
+     i32.const 2
+     i32.shl
+     i32.add
+     f32.load
+     local.get $9
+     local.get $7
+     i32.const 4
+     global.set $~argumentsLength
+     local.get $11
+     call_indirect (type $f32_f32_i32_i32_=>_f32)
+    end
+    local.set $4
+    local.get $9
     i32.const 1
     i32.sub
-    local.set $7
+    local.set $9
     br $for-loop|0
    end
   end
-  local.get $3
-  local.set $9
+  local.get $4
+  local.set $12
   local.get $5
-  call $~lib/rt/pure/__release
+  local.set $9
   local.get $9
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $9
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $7
+  call $~lib/rt/pure/__release
+  local.get $12
+  local.set $4
+  local.get $1
+  local.set $8
+  local.get $8
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $8
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $4
  )
  (func $std/typedarray/testReduceRight<~lib/typedarray/Float32Array,f32>
   (local $0 i32)
@@ -8437,7 +10844,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testReduceRight<~lib/typedarray/Float64Array,f64>~anonymous|0 (param $0 f64) (param $1 f64) (param $2 i32) (param $3 i32) (result f64)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Float64Array,f64>~anonymous|0~nonClosure (param $0 f64) (param $1 f64) (param $2 i32) (param $3 i32) (result f64)
   (local $4 f64)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -8451,61 +10858,159 @@
   local.get $4
  )
  (func $~lib/typedarray/Float64Array#reduceRight<f64> (param $0 i32) (param $1 i32) (param $2 f64) (result f64)
-  (local $3 f64)
-  (local $4 i32)
+  (local $3 i32)
+  (local $4 f64)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
-  (local $9 f64)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 f64)
+  local.get $1
+  local.set $3
+  local.get $3
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $3
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $3
+  local.set $1
   local.get $0
   call $~lib/rt/pure/__retain
-  local.set $5
+  local.set $7
   local.get $1
-  local.set $4
-  local.get $2
-  local.set $3
-  local.get $5
-  i32.load offset=4
   local.set $6
-  local.get $5
+  local.get $6
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $6
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $6
+  local.set $5
+  local.get $2
+  local.set $4
+  local.get $7
+  i32.load offset=4
+  local.set $8
+  local.get $7
   call $~lib/typedarray/Float64Array#get:length
   i32.const 1
   i32.sub
-  local.set $7
+  local.set $9
   loop $for-loop|0
-   local.get $7
+   local.get $9
    i32.const 0
    i32.ge_s
-   local.set $8
-   local.get $8
+   local.set $10
+   local.get $10
    if
-    local.get $3
-    local.get $6
-    local.get $7
-    i32.const 3
-    i32.shl
-    i32.add
-    f64.load
-    local.get $7
     local.get $5
-    i32.const 4
-    global.set $~argumentsLength
-    local.get $4
-    call_indirect (type $f64_f64_i32_i32_=>_f64)
-    local.set $3
-    local.get $7
+    local.set $11
+    local.get $11
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result f64)
+     local.get $11
+     i32.const 4
+     i32.shl
+     local.get $4
+     local.get $8
+     local.get $9
+     i32.const 3
+     i32.shl
+     i32.add
+     f64.load
+     local.get $9
+     local.get $7
+     i32.const 4
+     global.set $~argumentsLength
+     local.get $11
+     i32.const 4
+     i32.shl
+     i32.load
+     call_indirect (type $i32_f64_f64_i32_i32_=>_f64)
+    else
+     local.get $4
+     local.get $8
+     local.get $9
+     i32.const 3
+     i32.shl
+     i32.add
+     f64.load
+     local.get $9
+     local.get $7
+     i32.const 4
+     global.set $~argumentsLength
+     local.get $11
+     call_indirect (type $f64_f64_i32_i32_=>_f64)
+    end
+    local.set $4
+    local.get $9
     i32.const 1
     i32.sub
-    local.set $7
+    local.set $9
     br $for-loop|0
    end
   end
-  local.get $3
-  local.set $9
+  local.get $4
+  local.set $12
   local.get $5
-  call $~lib/rt/pure/__release
+  local.set $9
   local.get $9
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $9
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $7
+  call $~lib/rt/pure/__release
+  local.get $12
+  local.set $4
+  local.get $1
+  local.set $8
+  local.get $8
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $8
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $4
  )
  (func $std/typedarray/testReduceRight<~lib/typedarray/Float64Array,f64>
   (local $0 i32)
@@ -8551,7 +11056,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayMap<~lib/typedarray/Int8Array,i8>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Int8Array,i8>~anonymous|0~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -8574,77 +11079,174 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
-  local.get $0
-  call $~lib/rt/pure/__retain
-  local.set $3
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
   local.get $1
   local.set $2
-  local.get $3
-  call $~lib/typedarray/Int8Array#get:length
-  local.set $4
-  local.get $3
-  i32.load offset=4
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
+  local.get $0
+  call $~lib/rt/pure/__retain
   local.set $5
+  local.get $1
+  local.set $4
   local.get $4
-  i32.const 0
-  i32.shl
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $4
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $4
+  local.set $3
+  local.get $5
+  call $~lib/typedarray/Int8Array#get:length
   local.set $6
-  i32.const 12
-  i32.const 3
-  call $~lib/rt/tlsf/__alloc
+  local.get $5
+  i32.load offset=4
   local.set $7
   local.get $6
   i32.const 0
-  call $~lib/rt/tlsf/__alloc
+  i32.shl
   local.set $8
-  i32.const 0
+  i32.const 12
+  i32.const 3
+  call $~lib/rt/tlsf/__alloc
   local.set $9
+  local.get $8
+  i32.const 0
+  call $~lib/rt/tlsf/__alloc
+  local.set $10
+  i32.const 0
+  local.set $11
   loop $for-loop|0
-   local.get $9
-   local.get $4
+   local.get $11
+   local.get $6
    i32.lt_s
-   local.set $10
-   local.get $10
+   local.set $12
+   local.get $12
    if
-    local.get $8
-    local.get $9
+    local.get $10
+    local.get $11
     i32.const 0
     i32.shl
     i32.add
-    local.get $5
-    local.get $9
-    i32.const 0
-    i32.shl
-    i32.add
-    i32.load8_s
-    local.get $9
     local.get $3
-    i32.const 3
-    global.set $~argumentsLength
-    local.get $2
-    call_indirect (type $i32_i32_i32_=>_i32)
+    local.set $13
+    local.get $13
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result i32)
+     local.get $13
+     i32.const 4
+     i32.shl
+     local.get $7
+     local.get $11
+     i32.const 0
+     i32.shl
+     i32.add
+     i32.load8_s
+     local.get $11
+     local.get $5
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $13
+     i32.const 4
+     i32.shl
+     i32.load
+     call_indirect (type $i32_i32_i32_i32_=>_i32)
+    else
+     local.get $7
+     local.get $11
+     i32.const 0
+     i32.shl
+     i32.add
+     i32.load8_s
+     local.get $11
+     local.get $5
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $13
+     call_indirect (type $i32_i32_i32_=>_i32)
+    end
     i32.store8
-    local.get $9
+    local.get $11
     i32.const 1
     i32.add
-    local.set $9
+    local.set $11
     br $for-loop|0
    end
   end
-  local.get $7
-  local.get $8
+  local.get $9
+  local.get $10
   call $~lib/rt/pure/__retain
   i32.store
-  local.get $7
-  local.get $8
+  local.get $9
+  local.get $10
   i32.store offset=4
-  local.get $7
-  local.get $6
+  local.get $9
+  local.get $8
   i32.store offset=8
-  local.get $7
+  local.get $9
   call $~lib/rt/pure/__retain
-  local.set $9
+  local.set $12
   local.get $3
+  local.set $11
+  local.get $11
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $11
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $5
+  call $~lib/rt/pure/__release
+  local.get $12
+  local.set $9
+  local.get $1
+  local.set $10
+  local.get $10
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $10
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
   call $~lib/rt/pure/__release
   local.get $9
  )
@@ -8723,7 +11325,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayMap<~lib/typedarray/Uint8Array,u8>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Uint8Array,u8>~anonymous|0~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -8746,77 +11348,174 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
-  local.get $0
-  call $~lib/rt/pure/__retain
-  local.set $3
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
   local.get $1
   local.set $2
-  local.get $3
-  call $~lib/typedarray/Uint8Array#get:length
-  local.set $4
-  local.get $3
-  i32.load offset=4
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
+  local.get $0
+  call $~lib/rt/pure/__retain
   local.set $5
+  local.get $1
+  local.set $4
   local.get $4
-  i32.const 0
-  i32.shl
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $4
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $4
+  local.set $3
+  local.get $5
+  call $~lib/typedarray/Uint8Array#get:length
   local.set $6
-  i32.const 12
-  i32.const 4
-  call $~lib/rt/tlsf/__alloc
+  local.get $5
+  i32.load offset=4
   local.set $7
   local.get $6
   i32.const 0
-  call $~lib/rt/tlsf/__alloc
+  i32.shl
   local.set $8
-  i32.const 0
+  i32.const 12
+  i32.const 4
+  call $~lib/rt/tlsf/__alloc
   local.set $9
+  local.get $8
+  i32.const 0
+  call $~lib/rt/tlsf/__alloc
+  local.set $10
+  i32.const 0
+  local.set $11
   loop $for-loop|0
-   local.get $9
-   local.get $4
+   local.get $11
+   local.get $6
    i32.lt_s
-   local.set $10
-   local.get $10
+   local.set $12
+   local.get $12
    if
-    local.get $8
-    local.get $9
+    local.get $10
+    local.get $11
     i32.const 0
     i32.shl
     i32.add
-    local.get $5
-    local.get $9
-    i32.const 0
-    i32.shl
-    i32.add
-    i32.load8_u
-    local.get $9
     local.get $3
-    i32.const 3
-    global.set $~argumentsLength
-    local.get $2
-    call_indirect (type $i32_i32_i32_=>_i32)
+    local.set $13
+    local.get $13
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result i32)
+     local.get $13
+     i32.const 4
+     i32.shl
+     local.get $7
+     local.get $11
+     i32.const 0
+     i32.shl
+     i32.add
+     i32.load8_u
+     local.get $11
+     local.get $5
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $13
+     i32.const 4
+     i32.shl
+     i32.load
+     call_indirect (type $i32_i32_i32_i32_=>_i32)
+    else
+     local.get $7
+     local.get $11
+     i32.const 0
+     i32.shl
+     i32.add
+     i32.load8_u
+     local.get $11
+     local.get $5
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $13
+     call_indirect (type $i32_i32_i32_=>_i32)
+    end
     i32.store8
-    local.get $9
+    local.get $11
     i32.const 1
     i32.add
-    local.set $9
+    local.set $11
     br $for-loop|0
    end
   end
-  local.get $7
-  local.get $8
+  local.get $9
+  local.get $10
   call $~lib/rt/pure/__retain
   i32.store
-  local.get $7
-  local.get $8
+  local.get $9
+  local.get $10
   i32.store offset=4
-  local.get $7
-  local.get $6
+  local.get $9
+  local.get $8
   i32.store offset=8
-  local.get $7
+  local.get $9
   call $~lib/rt/pure/__retain
-  local.set $9
+  local.set $12
   local.get $3
+  local.set $11
+  local.get $11
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $11
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $5
+  call $~lib/rt/pure/__release
+  local.get $12
+  local.set $9
+  local.get $1
+  local.set $10
+  local.get $10
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $10
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
   call $~lib/rt/pure/__release
   local.get $9
  )
@@ -8914,7 +11613,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayMap<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|0~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -8937,77 +11636,174 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
-  local.get $0
-  call $~lib/rt/pure/__retain
-  local.set $3
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
   local.get $1
   local.set $2
-  local.get $3
-  call $~lib/typedarray/Uint8ClampedArray#get:length
-  local.set $4
-  local.get $3
-  i32.load offset=4
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
+  local.get $0
+  call $~lib/rt/pure/__retain
   local.set $5
+  local.get $1
+  local.set $4
   local.get $4
-  i32.const 0
-  i32.shl
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $4
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $4
+  local.set $3
+  local.get $5
+  call $~lib/typedarray/Uint8ClampedArray#get:length
   local.set $6
-  i32.const 12
-  i32.const 5
-  call $~lib/rt/tlsf/__alloc
+  local.get $5
+  i32.load offset=4
   local.set $7
   local.get $6
   i32.const 0
-  call $~lib/rt/tlsf/__alloc
+  i32.shl
   local.set $8
-  i32.const 0
+  i32.const 12
+  i32.const 5
+  call $~lib/rt/tlsf/__alloc
   local.set $9
+  local.get $8
+  i32.const 0
+  call $~lib/rt/tlsf/__alloc
+  local.set $10
+  i32.const 0
+  local.set $11
   loop $for-loop|0
-   local.get $9
-   local.get $4
+   local.get $11
+   local.get $6
    i32.lt_s
-   local.set $10
-   local.get $10
+   local.set $12
+   local.get $12
    if
-    local.get $8
-    local.get $9
+    local.get $10
+    local.get $11
     i32.const 0
     i32.shl
     i32.add
-    local.get $5
-    local.get $9
-    i32.const 0
-    i32.shl
-    i32.add
-    i32.load8_u
-    local.get $9
     local.get $3
-    i32.const 3
-    global.set $~argumentsLength
-    local.get $2
-    call_indirect (type $i32_i32_i32_=>_i32)
+    local.set $13
+    local.get $13
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result i32)
+     local.get $13
+     i32.const 4
+     i32.shl
+     local.get $7
+     local.get $11
+     i32.const 0
+     i32.shl
+     i32.add
+     i32.load8_u
+     local.get $11
+     local.get $5
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $13
+     i32.const 4
+     i32.shl
+     i32.load
+     call_indirect (type $i32_i32_i32_i32_=>_i32)
+    else
+     local.get $7
+     local.get $11
+     i32.const 0
+     i32.shl
+     i32.add
+     i32.load8_u
+     local.get $11
+     local.get $5
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $13
+     call_indirect (type $i32_i32_i32_=>_i32)
+    end
     i32.store8
-    local.get $9
+    local.get $11
     i32.const 1
     i32.add
-    local.set $9
+    local.set $11
     br $for-loop|0
    end
   end
-  local.get $7
-  local.get $8
+  local.get $9
+  local.get $10
   call $~lib/rt/pure/__retain
   i32.store
-  local.get $7
-  local.get $8
+  local.get $9
+  local.get $10
   i32.store offset=4
-  local.get $7
-  local.get $6
+  local.get $9
+  local.get $8
   i32.store offset=8
-  local.get $7
+  local.get $9
   call $~lib/rt/pure/__retain
-  local.set $9
+  local.set $12
   local.get $3
+  local.set $11
+  local.get $11
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $11
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $5
+  call $~lib/rt/pure/__release
+  local.get $12
+  local.set $9
+  local.get $1
+  local.set $10
+  local.get $10
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $10
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
   call $~lib/rt/pure/__release
   local.get $9
  )
@@ -9086,7 +11882,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayMap<~lib/typedarray/Int16Array,i16>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Int16Array,i16>~anonymous|0~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -9109,77 +11905,174 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
-  local.get $0
-  call $~lib/rt/pure/__retain
-  local.set $3
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
   local.get $1
   local.set $2
-  local.get $3
-  call $~lib/typedarray/Int16Array#get:length
-  local.set $4
-  local.get $3
-  i32.load offset=4
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
+  local.get $0
+  call $~lib/rt/pure/__retain
   local.set $5
+  local.get $1
+  local.set $4
   local.get $4
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $4
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $4
+  local.set $3
+  local.get $5
+  call $~lib/typedarray/Int16Array#get:length
+  local.set $6
+  local.get $5
+  i32.load offset=4
+  local.set $7
+  local.get $6
   i32.const 1
   i32.shl
-  local.set $6
+  local.set $8
   i32.const 12
   i32.const 6
   call $~lib/rt/tlsf/__alloc
-  local.set $7
-  local.get $6
+  local.set $9
+  local.get $8
   i32.const 0
   call $~lib/rt/tlsf/__alloc
-  local.set $8
+  local.set $10
   i32.const 0
-  local.set $9
+  local.set $11
   loop $for-loop|0
-   local.get $9
-   local.get $4
+   local.get $11
+   local.get $6
    i32.lt_s
-   local.set $10
-   local.get $10
+   local.set $12
+   local.get $12
    if
-    local.get $8
-    local.get $9
+    local.get $10
+    local.get $11
     i32.const 1
     i32.shl
     i32.add
-    local.get $5
-    local.get $9
-    i32.const 1
-    i32.shl
-    i32.add
-    i32.load16_s
-    local.get $9
     local.get $3
-    i32.const 3
-    global.set $~argumentsLength
-    local.get $2
-    call_indirect (type $i32_i32_i32_=>_i32)
+    local.set $13
+    local.get $13
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result i32)
+     local.get $13
+     i32.const 4
+     i32.shl
+     local.get $7
+     local.get $11
+     i32.const 1
+     i32.shl
+     i32.add
+     i32.load16_s
+     local.get $11
+     local.get $5
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $13
+     i32.const 4
+     i32.shl
+     i32.load
+     call_indirect (type $i32_i32_i32_i32_=>_i32)
+    else
+     local.get $7
+     local.get $11
+     i32.const 1
+     i32.shl
+     i32.add
+     i32.load16_s
+     local.get $11
+     local.get $5
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $13
+     call_indirect (type $i32_i32_i32_=>_i32)
+    end
     i32.store16
-    local.get $9
+    local.get $11
     i32.const 1
     i32.add
-    local.set $9
+    local.set $11
     br $for-loop|0
    end
   end
-  local.get $7
-  local.get $8
+  local.get $9
+  local.get $10
   call $~lib/rt/pure/__retain
   i32.store
-  local.get $7
-  local.get $8
+  local.get $9
+  local.get $10
   i32.store offset=4
-  local.get $7
-  local.get $6
+  local.get $9
+  local.get $8
   i32.store offset=8
-  local.get $7
+  local.get $9
   call $~lib/rt/pure/__retain
-  local.set $9
+  local.set $12
   local.get $3
+  local.set $11
+  local.get $11
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $11
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $5
+  call $~lib/rt/pure/__release
+  local.get $12
+  local.set $9
+  local.get $1
+  local.set $10
+  local.get $10
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $10
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
   call $~lib/rt/pure/__release
   local.get $9
  )
@@ -9281,7 +12174,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayMap<~lib/typedarray/Uint16Array,u16>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Uint16Array,u16>~anonymous|0~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -9304,77 +12197,174 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
-  local.get $0
-  call $~lib/rt/pure/__retain
-  local.set $3
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
   local.get $1
   local.set $2
-  local.get $3
-  call $~lib/typedarray/Uint16Array#get:length
-  local.set $4
-  local.get $3
-  i32.load offset=4
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
+  local.get $0
+  call $~lib/rt/pure/__retain
   local.set $5
+  local.get $1
+  local.set $4
   local.get $4
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $4
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $4
+  local.set $3
+  local.get $5
+  call $~lib/typedarray/Uint16Array#get:length
+  local.set $6
+  local.get $5
+  i32.load offset=4
+  local.set $7
+  local.get $6
   i32.const 1
   i32.shl
-  local.set $6
+  local.set $8
   i32.const 12
   i32.const 7
   call $~lib/rt/tlsf/__alloc
-  local.set $7
-  local.get $6
+  local.set $9
+  local.get $8
   i32.const 0
   call $~lib/rt/tlsf/__alloc
-  local.set $8
+  local.set $10
   i32.const 0
-  local.set $9
+  local.set $11
   loop $for-loop|0
-   local.get $9
-   local.get $4
+   local.get $11
+   local.get $6
    i32.lt_s
-   local.set $10
-   local.get $10
+   local.set $12
+   local.get $12
    if
-    local.get $8
-    local.get $9
+    local.get $10
+    local.get $11
     i32.const 1
     i32.shl
     i32.add
-    local.get $5
-    local.get $9
-    i32.const 1
-    i32.shl
-    i32.add
-    i32.load16_u
-    local.get $9
     local.get $3
-    i32.const 3
-    global.set $~argumentsLength
-    local.get $2
-    call_indirect (type $i32_i32_i32_=>_i32)
+    local.set $13
+    local.get $13
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result i32)
+     local.get $13
+     i32.const 4
+     i32.shl
+     local.get $7
+     local.get $11
+     i32.const 1
+     i32.shl
+     i32.add
+     i32.load16_u
+     local.get $11
+     local.get $5
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $13
+     i32.const 4
+     i32.shl
+     i32.load
+     call_indirect (type $i32_i32_i32_i32_=>_i32)
+    else
+     local.get $7
+     local.get $11
+     i32.const 1
+     i32.shl
+     i32.add
+     i32.load16_u
+     local.get $11
+     local.get $5
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $13
+     call_indirect (type $i32_i32_i32_=>_i32)
+    end
     i32.store16
-    local.get $9
+    local.get $11
     i32.const 1
     i32.add
-    local.set $9
+    local.set $11
     br $for-loop|0
    end
   end
-  local.get $7
-  local.get $8
+  local.get $9
+  local.get $10
   call $~lib/rt/pure/__retain
   i32.store
-  local.get $7
-  local.get $8
+  local.get $9
+  local.get $10
   i32.store offset=4
-  local.get $7
-  local.get $6
+  local.get $9
+  local.get $8
   i32.store offset=8
-  local.get $7
+  local.get $9
   call $~lib/rt/pure/__retain
-  local.set $9
+  local.set $12
   local.get $3
+  local.set $11
+  local.get $11
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $11
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $5
+  call $~lib/rt/pure/__release
+  local.get $12
+  local.set $9
+  local.get $1
+  local.set $10
+  local.get $10
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $10
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
   call $~lib/rt/pure/__release
   local.get $9
  )
@@ -9476,7 +12466,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayMap<~lib/typedarray/Int32Array,i32>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Int32Array,i32>~anonymous|0~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -9499,77 +12489,174 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
-  local.get $0
-  call $~lib/rt/pure/__retain
-  local.set $3
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
   local.get $1
   local.set $2
-  local.get $3
-  call $~lib/typedarray/Int32Array#get:length
-  local.set $4
-  local.get $3
-  i32.load offset=4
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
+  local.get $0
+  call $~lib/rt/pure/__retain
   local.set $5
+  local.get $1
+  local.set $4
   local.get $4
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $4
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $4
+  local.set $3
+  local.get $5
+  call $~lib/typedarray/Int32Array#get:length
+  local.set $6
+  local.get $5
+  i32.load offset=4
+  local.set $7
+  local.get $6
   i32.const 2
   i32.shl
-  local.set $6
+  local.set $8
   i32.const 12
   i32.const 8
   call $~lib/rt/tlsf/__alloc
-  local.set $7
-  local.get $6
+  local.set $9
+  local.get $8
   i32.const 0
   call $~lib/rt/tlsf/__alloc
-  local.set $8
+  local.set $10
   i32.const 0
-  local.set $9
+  local.set $11
   loop $for-loop|0
-   local.get $9
-   local.get $4
+   local.get $11
+   local.get $6
    i32.lt_s
-   local.set $10
-   local.get $10
+   local.set $12
+   local.get $12
    if
-    local.get $8
-    local.get $9
+    local.get $10
+    local.get $11
     i32.const 2
     i32.shl
     i32.add
-    local.get $5
-    local.get $9
-    i32.const 2
-    i32.shl
-    i32.add
-    i32.load
-    local.get $9
     local.get $3
-    i32.const 3
-    global.set $~argumentsLength
-    local.get $2
-    call_indirect (type $i32_i32_i32_=>_i32)
+    local.set $13
+    local.get $13
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result i32)
+     local.get $13
+     i32.const 4
+     i32.shl
+     local.get $7
+     local.get $11
+     i32.const 2
+     i32.shl
+     i32.add
+     i32.load
+     local.get $11
+     local.get $5
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $13
+     i32.const 4
+     i32.shl
+     i32.load
+     call_indirect (type $i32_i32_i32_i32_=>_i32)
+    else
+     local.get $7
+     local.get $11
+     i32.const 2
+     i32.shl
+     i32.add
+     i32.load
+     local.get $11
+     local.get $5
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $13
+     call_indirect (type $i32_i32_i32_=>_i32)
+    end
     i32.store
-    local.get $9
+    local.get $11
     i32.const 1
     i32.add
-    local.set $9
+    local.set $11
     br $for-loop|0
    end
   end
-  local.get $7
-  local.get $8
+  local.get $9
+  local.get $10
   call $~lib/rt/pure/__retain
   i32.store
-  local.get $7
-  local.get $8
+  local.get $9
+  local.get $10
   i32.store offset=4
-  local.get $7
-  local.get $6
+  local.get $9
+  local.get $8
   i32.store offset=8
-  local.get $7
+  local.get $9
   call $~lib/rt/pure/__retain
-  local.set $9
+  local.set $12
   local.get $3
+  local.set $11
+  local.get $11
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $11
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $5
+  call $~lib/rt/pure/__release
+  local.get $12
+  local.set $9
+  local.get $1
+  local.set $10
+  local.get $10
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $10
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
   call $~lib/rt/pure/__release
   local.get $9
  )
@@ -9648,7 +12735,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayMap<~lib/typedarray/Uint32Array,u32>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Uint32Array,u32>~anonymous|0~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -9671,77 +12758,174 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
-  local.get $0
-  call $~lib/rt/pure/__retain
-  local.set $3
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
   local.get $1
   local.set $2
-  local.get $3
-  call $~lib/typedarray/Uint32Array#get:length
-  local.set $4
-  local.get $3
-  i32.load offset=4
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
+  local.get $0
+  call $~lib/rt/pure/__retain
   local.set $5
+  local.get $1
+  local.set $4
   local.get $4
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $4
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $4
+  local.set $3
+  local.get $5
+  call $~lib/typedarray/Uint32Array#get:length
+  local.set $6
+  local.get $5
+  i32.load offset=4
+  local.set $7
+  local.get $6
   i32.const 2
   i32.shl
-  local.set $6
+  local.set $8
   i32.const 12
   i32.const 9
   call $~lib/rt/tlsf/__alloc
-  local.set $7
-  local.get $6
+  local.set $9
+  local.get $8
   i32.const 0
   call $~lib/rt/tlsf/__alloc
-  local.set $8
+  local.set $10
   i32.const 0
-  local.set $9
+  local.set $11
   loop $for-loop|0
-   local.get $9
-   local.get $4
+   local.get $11
+   local.get $6
    i32.lt_s
-   local.set $10
-   local.get $10
+   local.set $12
+   local.get $12
    if
-    local.get $8
-    local.get $9
+    local.get $10
+    local.get $11
     i32.const 2
     i32.shl
     i32.add
-    local.get $5
-    local.get $9
-    i32.const 2
-    i32.shl
-    i32.add
-    i32.load
-    local.get $9
     local.get $3
-    i32.const 3
-    global.set $~argumentsLength
-    local.get $2
-    call_indirect (type $i32_i32_i32_=>_i32)
+    local.set $13
+    local.get $13
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result i32)
+     local.get $13
+     i32.const 4
+     i32.shl
+     local.get $7
+     local.get $11
+     i32.const 2
+     i32.shl
+     i32.add
+     i32.load
+     local.get $11
+     local.get $5
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $13
+     i32.const 4
+     i32.shl
+     i32.load
+     call_indirect (type $i32_i32_i32_i32_=>_i32)
+    else
+     local.get $7
+     local.get $11
+     i32.const 2
+     i32.shl
+     i32.add
+     i32.load
+     local.get $11
+     local.get $5
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $13
+     call_indirect (type $i32_i32_i32_=>_i32)
+    end
     i32.store
-    local.get $9
+    local.get $11
     i32.const 1
     i32.add
-    local.set $9
+    local.set $11
     br $for-loop|0
    end
   end
-  local.get $7
-  local.get $8
+  local.get $9
+  local.get $10
   call $~lib/rt/pure/__retain
   i32.store
-  local.get $7
-  local.get $8
+  local.get $9
+  local.get $10
   i32.store offset=4
-  local.get $7
-  local.get $6
+  local.get $9
+  local.get $8
   i32.store offset=8
-  local.get $7
+  local.get $9
   call $~lib/rt/pure/__retain
-  local.set $9
+  local.set $12
   local.get $3
+  local.set $11
+  local.get $11
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $11
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $5
+  call $~lib/rt/pure/__release
+  local.get $12
+  local.set $9
+  local.get $1
+  local.set $10
+  local.get $10
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $10
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
   call $~lib/rt/pure/__release
   local.get $9
  )
@@ -9843,7 +13027,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayMap<~lib/typedarray/Int64Array,i64>~anonymous|0 (param $0 i64) (param $1 i32) (param $2 i32) (result i64)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Int64Array,i64>~anonymous|0~nonClosure (param $0 i64) (param $1 i32) (param $2 i32) (result i64)
   (local $3 i64)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -9866,77 +13050,174 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
-  local.get $0
-  call $~lib/rt/pure/__retain
-  local.set $3
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
   local.get $1
   local.set $2
-  local.get $3
-  call $~lib/typedarray/Int64Array#get:length
-  local.set $4
-  local.get $3
-  i32.load offset=4
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
+  local.get $0
+  call $~lib/rt/pure/__retain
   local.set $5
+  local.get $1
+  local.set $4
   local.get $4
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $4
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $4
+  local.set $3
+  local.get $5
+  call $~lib/typedarray/Int64Array#get:length
+  local.set $6
+  local.get $5
+  i32.load offset=4
+  local.set $7
+  local.get $6
   i32.const 3
   i32.shl
-  local.set $6
+  local.set $8
   i32.const 12
   i32.const 10
   call $~lib/rt/tlsf/__alloc
-  local.set $7
-  local.get $6
+  local.set $9
+  local.get $8
   i32.const 0
   call $~lib/rt/tlsf/__alloc
-  local.set $8
+  local.set $10
   i32.const 0
-  local.set $9
+  local.set $11
   loop $for-loop|0
-   local.get $9
-   local.get $4
+   local.get $11
+   local.get $6
    i32.lt_s
-   local.set $10
-   local.get $10
+   local.set $12
+   local.get $12
    if
-    local.get $8
-    local.get $9
+    local.get $10
+    local.get $11
     i32.const 3
     i32.shl
     i32.add
-    local.get $5
-    local.get $9
-    i32.const 3
-    i32.shl
-    i32.add
-    i64.load
-    local.get $9
     local.get $3
-    i32.const 3
-    global.set $~argumentsLength
-    local.get $2
-    call_indirect (type $i64_i32_i32_=>_i64)
+    local.set $13
+    local.get $13
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result i64)
+     local.get $13
+     i32.const 4
+     i32.shl
+     local.get $7
+     local.get $11
+     i32.const 3
+     i32.shl
+     i32.add
+     i64.load
+     local.get $11
+     local.get $5
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $13
+     i32.const 4
+     i32.shl
+     i32.load
+     call_indirect (type $i32_i64_i32_i32_=>_i64)
+    else
+     local.get $7
+     local.get $11
+     i32.const 3
+     i32.shl
+     i32.add
+     i64.load
+     local.get $11
+     local.get $5
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $13
+     call_indirect (type $i64_i32_i32_=>_i64)
+    end
     i64.store
-    local.get $9
+    local.get $11
     i32.const 1
     i32.add
-    local.set $9
+    local.set $11
     br $for-loop|0
    end
   end
-  local.get $7
-  local.get $8
+  local.get $9
+  local.get $10
   call $~lib/rt/pure/__retain
   i32.store
-  local.get $7
-  local.get $8
+  local.get $9
+  local.get $10
   i32.store offset=4
-  local.get $7
-  local.get $6
+  local.get $9
+  local.get $8
   i32.store offset=8
-  local.get $7
+  local.get $9
   call $~lib/rt/pure/__retain
-  local.set $9
+  local.set $12
   local.get $3
+  local.set $11
+  local.get $11
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $11
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $5
+  call $~lib/rt/pure/__release
+  local.get $12
+  local.set $9
+  local.get $1
+  local.set $10
+  local.get $10
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $10
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
   call $~lib/rt/pure/__release
   local.get $9
  )
@@ -10038,7 +13319,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayMap<~lib/typedarray/Uint64Array,u64>~anonymous|0 (param $0 i64) (param $1 i32) (param $2 i32) (result i64)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Uint64Array,u64>~anonymous|0~nonClosure (param $0 i64) (param $1 i32) (param $2 i32) (result i64)
   (local $3 i64)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -10061,77 +13342,174 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
-  local.get $0
-  call $~lib/rt/pure/__retain
-  local.set $3
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
   local.get $1
   local.set $2
-  local.get $3
-  call $~lib/typedarray/Uint64Array#get:length
-  local.set $4
-  local.get $3
-  i32.load offset=4
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
+  local.get $0
+  call $~lib/rt/pure/__retain
   local.set $5
+  local.get $1
+  local.set $4
   local.get $4
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $4
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $4
+  local.set $3
+  local.get $5
+  call $~lib/typedarray/Uint64Array#get:length
+  local.set $6
+  local.get $5
+  i32.load offset=4
+  local.set $7
+  local.get $6
   i32.const 3
   i32.shl
-  local.set $6
+  local.set $8
   i32.const 12
   i32.const 11
   call $~lib/rt/tlsf/__alloc
-  local.set $7
-  local.get $6
+  local.set $9
+  local.get $8
   i32.const 0
   call $~lib/rt/tlsf/__alloc
-  local.set $8
+  local.set $10
   i32.const 0
-  local.set $9
+  local.set $11
   loop $for-loop|0
-   local.get $9
-   local.get $4
+   local.get $11
+   local.get $6
    i32.lt_s
-   local.set $10
-   local.get $10
+   local.set $12
+   local.get $12
    if
-    local.get $8
-    local.get $9
+    local.get $10
+    local.get $11
     i32.const 3
     i32.shl
     i32.add
-    local.get $5
-    local.get $9
-    i32.const 3
-    i32.shl
-    i32.add
-    i64.load
-    local.get $9
     local.get $3
-    i32.const 3
-    global.set $~argumentsLength
-    local.get $2
-    call_indirect (type $i64_i32_i32_=>_i64)
+    local.set $13
+    local.get $13
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result i64)
+     local.get $13
+     i32.const 4
+     i32.shl
+     local.get $7
+     local.get $11
+     i32.const 3
+     i32.shl
+     i32.add
+     i64.load
+     local.get $11
+     local.get $5
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $13
+     i32.const 4
+     i32.shl
+     i32.load
+     call_indirect (type $i32_i64_i32_i32_=>_i64)
+    else
+     local.get $7
+     local.get $11
+     i32.const 3
+     i32.shl
+     i32.add
+     i64.load
+     local.get $11
+     local.get $5
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $13
+     call_indirect (type $i64_i32_i32_=>_i64)
+    end
     i64.store
-    local.get $9
+    local.get $11
     i32.const 1
     i32.add
-    local.set $9
+    local.set $11
     br $for-loop|0
    end
   end
-  local.get $7
-  local.get $8
+  local.get $9
+  local.get $10
   call $~lib/rt/pure/__retain
   i32.store
-  local.get $7
-  local.get $8
+  local.get $9
+  local.get $10
   i32.store offset=4
-  local.get $7
-  local.get $6
+  local.get $9
+  local.get $8
   i32.store offset=8
-  local.get $7
+  local.get $9
   call $~lib/rt/pure/__retain
-  local.set $9
+  local.set $12
   local.get $3
+  local.set $11
+  local.get $11
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $11
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $5
+  call $~lib/rt/pure/__release
+  local.get $12
+  local.set $9
+  local.get $1
+  local.set $10
+  local.get $10
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $10
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
   call $~lib/rt/pure/__release
   local.get $9
  )
@@ -10233,7 +13611,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayMap<~lib/typedarray/Float32Array,f32>~anonymous|0 (param $0 f32) (param $1 i32) (param $2 i32) (result f32)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Float32Array,f32>~anonymous|0~nonClosure (param $0 f32) (param $1 i32) (param $2 i32) (result f32)
   (local $3 f32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -10256,77 +13634,174 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
-  local.get $0
-  call $~lib/rt/pure/__retain
-  local.set $3
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
   local.get $1
   local.set $2
-  local.get $3
-  call $~lib/typedarray/Float32Array#get:length
-  local.set $4
-  local.get $3
-  i32.load offset=4
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
+  local.get $0
+  call $~lib/rt/pure/__retain
   local.set $5
+  local.get $1
+  local.set $4
   local.get $4
-  i32.const 2
-  i32.shl
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $4
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $4
+  local.set $3
+  local.get $5
+  call $~lib/typedarray/Float32Array#get:length
   local.set $6
-  i32.const 12
-  i32.const 12
-  call $~lib/rt/tlsf/__alloc
+  local.get $5
+  i32.load offset=4
   local.set $7
   local.get $6
+  i32.const 2
+  i32.shl
+  local.set $8
+  i32.const 12
+  i32.const 12
+  call $~lib/rt/tlsf/__alloc
+  local.set $9
+  local.get $8
   i32.const 0
   call $~lib/rt/tlsf/__alloc
-  local.set $8
+  local.set $10
   i32.const 0
-  local.set $9
+  local.set $11
   loop $for-loop|0
-   local.get $9
-   local.get $4
+   local.get $11
+   local.get $6
    i32.lt_s
-   local.set $10
-   local.get $10
+   local.set $12
+   local.get $12
    if
-    local.get $8
-    local.get $9
+    local.get $10
+    local.get $11
     i32.const 2
     i32.shl
     i32.add
-    local.get $5
-    local.get $9
-    i32.const 2
-    i32.shl
-    i32.add
-    f32.load
-    local.get $9
     local.get $3
-    i32.const 3
-    global.set $~argumentsLength
-    local.get $2
-    call_indirect (type $f32_i32_i32_=>_f32)
+    local.set $13
+    local.get $13
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result f32)
+     local.get $13
+     i32.const 4
+     i32.shl
+     local.get $7
+     local.get $11
+     i32.const 2
+     i32.shl
+     i32.add
+     f32.load
+     local.get $11
+     local.get $5
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $13
+     i32.const 4
+     i32.shl
+     i32.load
+     call_indirect (type $i32_f32_i32_i32_=>_f32)
+    else
+     local.get $7
+     local.get $11
+     i32.const 2
+     i32.shl
+     i32.add
+     f32.load
+     local.get $11
+     local.get $5
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $13
+     call_indirect (type $f32_i32_i32_=>_f32)
+    end
     f32.store
-    local.get $9
+    local.get $11
     i32.const 1
     i32.add
-    local.set $9
+    local.set $11
     br $for-loop|0
    end
   end
-  local.get $7
-  local.get $8
+  local.get $9
+  local.get $10
   call $~lib/rt/pure/__retain
   i32.store
-  local.get $7
-  local.get $8
+  local.get $9
+  local.get $10
   i32.store offset=4
-  local.get $7
-  local.get $6
+  local.get $9
+  local.get $8
   i32.store offset=8
-  local.get $7
+  local.get $9
   call $~lib/rt/pure/__retain
-  local.set $9
+  local.set $12
   local.get $3
+  local.set $11
+  local.get $11
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $11
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $5
+  call $~lib/rt/pure/__release
+  local.get $12
+  local.set $9
+  local.get $1
+  local.set $10
+  local.get $10
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $10
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
   call $~lib/rt/pure/__release
   local.get $9
  )
@@ -10428,7 +13903,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayMap<~lib/typedarray/Float64Array,f64>~anonymous|0 (param $0 f64) (param $1 i32) (param $2 i32) (result f64)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Float64Array,f64>~anonymous|0~nonClosure (param $0 f64) (param $1 i32) (param $2 i32) (result f64)
   (local $3 f64)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -10451,77 +13926,174 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
-  local.get $0
-  call $~lib/rt/pure/__retain
-  local.set $3
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
   local.get $1
   local.set $2
-  local.get $3
-  call $~lib/typedarray/Float64Array#get:length
-  local.set $4
-  local.get $3
-  i32.load offset=4
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
+  local.get $0
+  call $~lib/rt/pure/__retain
   local.set $5
+  local.get $1
+  local.set $4
   local.get $4
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $4
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $4
+  local.set $3
+  local.get $5
+  call $~lib/typedarray/Float64Array#get:length
+  local.set $6
+  local.get $5
+  i32.load offset=4
+  local.set $7
+  local.get $6
   i32.const 3
   i32.shl
-  local.set $6
+  local.set $8
   i32.const 12
   i32.const 13
   call $~lib/rt/tlsf/__alloc
-  local.set $7
-  local.get $6
+  local.set $9
+  local.get $8
   i32.const 0
   call $~lib/rt/tlsf/__alloc
-  local.set $8
+  local.set $10
   i32.const 0
-  local.set $9
+  local.set $11
   loop $for-loop|0
-   local.get $9
-   local.get $4
+   local.get $11
+   local.get $6
    i32.lt_s
-   local.set $10
-   local.get $10
+   local.set $12
+   local.get $12
    if
-    local.get $8
-    local.get $9
+    local.get $10
+    local.get $11
     i32.const 3
     i32.shl
     i32.add
-    local.get $5
-    local.get $9
-    i32.const 3
-    i32.shl
-    i32.add
-    f64.load
-    local.get $9
     local.get $3
-    i32.const 3
-    global.set $~argumentsLength
-    local.get $2
-    call_indirect (type $f64_i32_i32_=>_f64)
+    local.set $13
+    local.get $13
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result f64)
+     local.get $13
+     i32.const 4
+     i32.shl
+     local.get $7
+     local.get $11
+     i32.const 3
+     i32.shl
+     i32.add
+     f64.load
+     local.get $11
+     local.get $5
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $13
+     i32.const 4
+     i32.shl
+     i32.load
+     call_indirect (type $i32_f64_i32_i32_=>_f64)
+    else
+     local.get $7
+     local.get $11
+     i32.const 3
+     i32.shl
+     i32.add
+     f64.load
+     local.get $11
+     local.get $5
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $13
+     call_indirect (type $f64_i32_i32_=>_f64)
+    end
     f64.store
-    local.get $9
+    local.get $11
     i32.const 1
     i32.add
-    local.set $9
+    local.set $11
     br $for-loop|0
    end
   end
-  local.get $7
-  local.get $8
+  local.get $9
+  local.get $10
   call $~lib/rt/pure/__retain
   i32.store
-  local.get $7
-  local.get $8
+  local.get $9
+  local.get $10
   i32.store offset=4
-  local.get $7
-  local.get $6
+  local.get $9
+  local.get $8
   i32.store offset=8
-  local.get $7
+  local.get $9
   call $~lib/rt/pure/__retain
-  local.set $9
+  local.set $12
   local.get $3
+  local.set $11
+  local.get $11
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $11
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $5
+  call $~lib/rt/pure/__release
+  local.get $12
+  local.set $9
+  local.get $1
+  local.set $10
+  local.get $10
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $10
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
   call $~lib/rt/pure/__release
   local.get $9
  )
@@ -10600,7 +14172,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Int8Array,i8>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Int8Array,i8>~anonymous|0~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -10761,95 +14333,187 @@
   (local $10 i32)
   (local $11 i32)
   (local $12 i32)
-  local.get $0
-  call $~lib/rt/pure/__retain
-  local.set $3
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
   local.get $1
   local.set $2
-  local.get $3
-  call $~lib/typedarray/Int8Array#get:length
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $5
+  local.get $1
   local.set $4
+  local.get $4
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $4
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $4
+  local.set $3
+  local.get $5
+  call $~lib/typedarray/Int8Array#get:length
+  local.set $6
   i32.const 12
   i32.const 3
   call $~lib/rt/tlsf/__alloc
-  local.set $5
-  local.get $4
+  local.set $7
+  local.get $6
   i32.const 0
   i32.shl
   i32.const 0
   call $~lib/rt/tlsf/__alloc
-  local.set $6
-  local.get $3
-  i32.load offset=4
-  local.set $7
-  i32.const 0
   local.set $8
-  i32.const 0
+  local.get $5
+  i32.load offset=4
   local.set $9
+  i32.const 0
+  local.set $10
+  i32.const 0
+  local.set $11
   loop $for-loop|0
-   local.get $9
-   local.get $4
+   local.get $11
+   local.get $6
    i32.lt_s
-   local.set $10
-   local.get $10
+   local.set $12
+   local.get $12
    if
-    local.get $7
     local.get $9
+    local.get $11
     i32.const 0
     i32.shl
     i32.add
     i32.load8_s
-    local.set $11
-    local.get $11
-    local.get $9
+    local.set $13
     local.get $3
-    i32.const 3
-    global.set $~argumentsLength
-    local.get $2
-    call_indirect (type $i32_i32_i32_=>_i32)
+    local.set $14
+    local.get $14
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result i32)
+     local.get $14
+     i32.const 4
+     i32.shl
+     local.get $13
+     local.get $11
+     local.get $5
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $14
+     i32.const 4
+     i32.shl
+     i32.load
+     call_indirect (type $i32_i32_i32_i32_=>_i32)
+    else
+     local.get $13
+     local.get $11
+     local.get $5
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $14
+     call_indirect (type $i32_i32_i32_=>_i32)
+    end
     if
-     local.get $6
      local.get $8
-     local.tee $12
+     local.get $10
+     local.tee $15
      i32.const 1
      i32.add
-     local.set $8
-     local.get $12
+     local.set $10
+     local.get $15
      i32.const 0
      i32.shl
      i32.add
-     local.get $11
+     local.get $13
      i32.store8
     end
-    local.get $9
+    local.get $11
     i32.const 1
     i32.add
-    local.set $9
+    local.set $11
     br $for-loop|0
    end
   end
-  local.get $8
+  local.get $10
   i32.const 0
   i32.shl
-  local.set $9
-  local.get $6
-  local.get $9
+  local.set $11
+  local.get $8
+  local.get $11
   call $~lib/rt/tlsf/__realloc
-  local.set $10
-  local.get $5
-  local.get $10
+  local.set $12
+  local.get $7
+  local.get $12
   call $~lib/rt/pure/__retain
   i32.store
-  local.get $5
-  local.get $9
+  local.get $7
+  local.get $11
   i32.store offset=8
-  local.get $5
-  local.get $10
+  local.get $7
+  local.get $12
   i32.store offset=4
-  local.get $5
+  local.get $7
   call $~lib/rt/pure/__retain
-  local.set $11
+  local.set $15
   local.get $3
+  local.set $13
+  local.get $13
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $13
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $5
+  call $~lib/rt/pure/__release
+  local.get $15
+  local.set $11
+  local.get $1
+  local.set $12
+  local.get $12
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $12
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
   call $~lib/rt/pure/__release
   local.get $11
  )
@@ -10962,7 +14626,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint8Array,u8>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint8Array,u8>~anonymous|0~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -10989,95 +14653,187 @@
   (local $10 i32)
   (local $11 i32)
   (local $12 i32)
-  local.get $0
-  call $~lib/rt/pure/__retain
-  local.set $3
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
   local.get $1
   local.set $2
-  local.get $3
-  call $~lib/typedarray/Uint8Array#get:length
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $5
+  local.get $1
   local.set $4
+  local.get $4
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $4
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $4
+  local.set $3
+  local.get $5
+  call $~lib/typedarray/Uint8Array#get:length
+  local.set $6
   i32.const 12
   i32.const 4
   call $~lib/rt/tlsf/__alloc
-  local.set $5
-  local.get $4
+  local.set $7
+  local.get $6
   i32.const 0
   i32.shl
   i32.const 0
   call $~lib/rt/tlsf/__alloc
-  local.set $6
-  local.get $3
-  i32.load offset=4
-  local.set $7
-  i32.const 0
   local.set $8
-  i32.const 0
+  local.get $5
+  i32.load offset=4
   local.set $9
+  i32.const 0
+  local.set $10
+  i32.const 0
+  local.set $11
   loop $for-loop|0
-   local.get $9
-   local.get $4
+   local.get $11
+   local.get $6
    i32.lt_s
-   local.set $10
-   local.get $10
+   local.set $12
+   local.get $12
    if
-    local.get $7
     local.get $9
+    local.get $11
     i32.const 0
     i32.shl
     i32.add
     i32.load8_u
-    local.set $11
-    local.get $11
-    local.get $9
+    local.set $13
     local.get $3
-    i32.const 3
-    global.set $~argumentsLength
-    local.get $2
-    call_indirect (type $i32_i32_i32_=>_i32)
+    local.set $14
+    local.get $14
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result i32)
+     local.get $14
+     i32.const 4
+     i32.shl
+     local.get $13
+     local.get $11
+     local.get $5
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $14
+     i32.const 4
+     i32.shl
+     i32.load
+     call_indirect (type $i32_i32_i32_i32_=>_i32)
+    else
+     local.get $13
+     local.get $11
+     local.get $5
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $14
+     call_indirect (type $i32_i32_i32_=>_i32)
+    end
     if
-     local.get $6
      local.get $8
-     local.tee $12
+     local.get $10
+     local.tee $15
      i32.const 1
      i32.add
-     local.set $8
-     local.get $12
+     local.set $10
+     local.get $15
      i32.const 0
      i32.shl
      i32.add
-     local.get $11
+     local.get $13
      i32.store8
     end
-    local.get $9
+    local.get $11
     i32.const 1
     i32.add
-    local.set $9
+    local.set $11
     br $for-loop|0
    end
   end
-  local.get $8
+  local.get $10
   i32.const 0
   i32.shl
-  local.set $9
-  local.get $6
-  local.get $9
+  local.set $11
+  local.get $8
+  local.get $11
   call $~lib/rt/tlsf/__realloc
-  local.set $10
-  local.get $5
-  local.get $10
+  local.set $12
+  local.get $7
+  local.get $12
   call $~lib/rt/pure/__retain
   i32.store
-  local.get $5
-  local.get $9
+  local.get $7
+  local.get $11
   i32.store offset=8
-  local.get $5
-  local.get $10
+  local.get $7
+  local.get $12
   i32.store offset=4
-  local.get $5
+  local.get $7
   call $~lib/rt/pure/__retain
-  local.set $11
+  local.set $15
   local.get $3
+  local.set $13
+  local.get $13
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $13
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $5
+  call $~lib/rt/pure/__release
+  local.get $15
+  local.set $11
+  local.get $1
+  local.set $12
+  local.get $12
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $12
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
   call $~lib/rt/pure/__release
   local.get $11
  )
@@ -11190,7 +14946,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|0~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -11217,95 +14973,187 @@
   (local $10 i32)
   (local $11 i32)
   (local $12 i32)
-  local.get $0
-  call $~lib/rt/pure/__retain
-  local.set $3
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
   local.get $1
   local.set $2
-  local.get $3
-  call $~lib/typedarray/Uint8ClampedArray#get:length
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $5
+  local.get $1
   local.set $4
+  local.get $4
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $4
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $4
+  local.set $3
+  local.get $5
+  call $~lib/typedarray/Uint8ClampedArray#get:length
+  local.set $6
   i32.const 12
   i32.const 5
   call $~lib/rt/tlsf/__alloc
-  local.set $5
-  local.get $4
+  local.set $7
+  local.get $6
   i32.const 0
   i32.shl
   i32.const 0
   call $~lib/rt/tlsf/__alloc
-  local.set $6
-  local.get $3
-  i32.load offset=4
-  local.set $7
-  i32.const 0
   local.set $8
-  i32.const 0
+  local.get $5
+  i32.load offset=4
   local.set $9
+  i32.const 0
+  local.set $10
+  i32.const 0
+  local.set $11
   loop $for-loop|0
-   local.get $9
-   local.get $4
+   local.get $11
+   local.get $6
    i32.lt_s
-   local.set $10
-   local.get $10
+   local.set $12
+   local.get $12
    if
-    local.get $7
     local.get $9
+    local.get $11
     i32.const 0
     i32.shl
     i32.add
     i32.load8_u
-    local.set $11
-    local.get $11
-    local.get $9
+    local.set $13
     local.get $3
-    i32.const 3
-    global.set $~argumentsLength
-    local.get $2
-    call_indirect (type $i32_i32_i32_=>_i32)
+    local.set $14
+    local.get $14
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result i32)
+     local.get $14
+     i32.const 4
+     i32.shl
+     local.get $13
+     local.get $11
+     local.get $5
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $14
+     i32.const 4
+     i32.shl
+     i32.load
+     call_indirect (type $i32_i32_i32_i32_=>_i32)
+    else
+     local.get $13
+     local.get $11
+     local.get $5
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $14
+     call_indirect (type $i32_i32_i32_=>_i32)
+    end
     if
-     local.get $6
      local.get $8
-     local.tee $12
+     local.get $10
+     local.tee $15
      i32.const 1
      i32.add
-     local.set $8
-     local.get $12
+     local.set $10
+     local.get $15
      i32.const 0
      i32.shl
      i32.add
-     local.get $11
+     local.get $13
      i32.store8
     end
-    local.get $9
+    local.get $11
     i32.const 1
     i32.add
-    local.set $9
+    local.set $11
     br $for-loop|0
    end
   end
-  local.get $8
+  local.get $10
   i32.const 0
   i32.shl
-  local.set $9
-  local.get $6
-  local.get $9
+  local.set $11
+  local.get $8
+  local.get $11
   call $~lib/rt/tlsf/__realloc
-  local.set $10
-  local.get $5
-  local.get $10
+  local.set $12
+  local.get $7
+  local.get $12
   call $~lib/rt/pure/__retain
   i32.store
-  local.get $5
-  local.get $9
+  local.get $7
+  local.get $11
   i32.store offset=8
-  local.get $5
-  local.get $10
+  local.get $7
+  local.get $12
   i32.store offset=4
-  local.get $5
+  local.get $7
   call $~lib/rt/pure/__retain
-  local.set $11
+  local.set $15
   local.get $3
+  local.set $13
+  local.get $13
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $13
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $5
+  call $~lib/rt/pure/__release
+  local.get $15
+  local.set $11
+  local.get $1
+  local.set $12
+  local.get $12
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $12
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
   call $~lib/rt/pure/__release
   local.get $11
  )
@@ -11418,7 +15266,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Int16Array,i16>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Int16Array,i16>~anonymous|0~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -11447,95 +15295,187 @@
   (local $10 i32)
   (local $11 i32)
   (local $12 i32)
-  local.get $0
-  call $~lib/rt/pure/__retain
-  local.set $3
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
   local.get $1
   local.set $2
-  local.get $3
-  call $~lib/typedarray/Int16Array#get:length
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $5
+  local.get $1
   local.set $4
+  local.get $4
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $4
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $4
+  local.set $3
+  local.get $5
+  call $~lib/typedarray/Int16Array#get:length
+  local.set $6
   i32.const 12
   i32.const 6
   call $~lib/rt/tlsf/__alloc
-  local.set $5
-  local.get $4
+  local.set $7
+  local.get $6
   i32.const 1
   i32.shl
   i32.const 0
   call $~lib/rt/tlsf/__alloc
-  local.set $6
-  local.get $3
-  i32.load offset=4
-  local.set $7
-  i32.const 0
   local.set $8
-  i32.const 0
+  local.get $5
+  i32.load offset=4
   local.set $9
+  i32.const 0
+  local.set $10
+  i32.const 0
+  local.set $11
   loop $for-loop|0
-   local.get $9
-   local.get $4
+   local.get $11
+   local.get $6
    i32.lt_s
-   local.set $10
-   local.get $10
+   local.set $12
+   local.get $12
    if
-    local.get $7
     local.get $9
+    local.get $11
     i32.const 1
     i32.shl
     i32.add
     i32.load16_s
-    local.set $11
-    local.get $11
-    local.get $9
+    local.set $13
     local.get $3
-    i32.const 3
-    global.set $~argumentsLength
-    local.get $2
-    call_indirect (type $i32_i32_i32_=>_i32)
+    local.set $14
+    local.get $14
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result i32)
+     local.get $14
+     i32.const 4
+     i32.shl
+     local.get $13
+     local.get $11
+     local.get $5
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $14
+     i32.const 4
+     i32.shl
+     i32.load
+     call_indirect (type $i32_i32_i32_i32_=>_i32)
+    else
+     local.get $13
+     local.get $11
+     local.get $5
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $14
+     call_indirect (type $i32_i32_i32_=>_i32)
+    end
     if
-     local.get $6
      local.get $8
-     local.tee $12
+     local.get $10
+     local.tee $15
      i32.const 1
      i32.add
-     local.set $8
-     local.get $12
+     local.set $10
+     local.get $15
      i32.const 1
      i32.shl
      i32.add
-     local.get $11
+     local.get $13
      i32.store16
     end
-    local.get $9
+    local.get $11
     i32.const 1
     i32.add
-    local.set $9
+    local.set $11
     br $for-loop|0
    end
   end
-  local.get $8
+  local.get $10
   i32.const 1
   i32.shl
-  local.set $9
-  local.get $6
-  local.get $9
+  local.set $11
+  local.get $8
+  local.get $11
   call $~lib/rt/tlsf/__realloc
-  local.set $10
-  local.get $5
-  local.get $10
+  local.set $12
+  local.get $7
+  local.get $12
   call $~lib/rt/pure/__retain
   i32.store
-  local.get $5
-  local.get $9
+  local.get $7
+  local.get $11
   i32.store offset=8
-  local.get $5
-  local.get $10
+  local.get $7
+  local.get $12
   i32.store offset=4
-  local.get $5
+  local.get $7
   call $~lib/rt/pure/__retain
-  local.set $11
+  local.set $15
   local.get $3
+  local.set $13
+  local.get $13
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $13
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $5
+  call $~lib/rt/pure/__release
+  local.get $15
+  local.set $11
+  local.get $1
+  local.set $12
+  local.get $12
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $12
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
   call $~lib/rt/pure/__release
   local.get $11
  )
@@ -11648,7 +15588,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint16Array,u16>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint16Array,u16>~anonymous|0~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -11675,95 +15615,187 @@
   (local $10 i32)
   (local $11 i32)
   (local $12 i32)
-  local.get $0
-  call $~lib/rt/pure/__retain
-  local.set $3
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
   local.get $1
   local.set $2
-  local.get $3
-  call $~lib/typedarray/Uint16Array#get:length
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $5
+  local.get $1
   local.set $4
+  local.get $4
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $4
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $4
+  local.set $3
+  local.get $5
+  call $~lib/typedarray/Uint16Array#get:length
+  local.set $6
   i32.const 12
   i32.const 7
   call $~lib/rt/tlsf/__alloc
-  local.set $5
-  local.get $4
+  local.set $7
+  local.get $6
   i32.const 1
   i32.shl
   i32.const 0
   call $~lib/rt/tlsf/__alloc
-  local.set $6
-  local.get $3
-  i32.load offset=4
-  local.set $7
-  i32.const 0
   local.set $8
-  i32.const 0
+  local.get $5
+  i32.load offset=4
   local.set $9
+  i32.const 0
+  local.set $10
+  i32.const 0
+  local.set $11
   loop $for-loop|0
-   local.get $9
-   local.get $4
+   local.get $11
+   local.get $6
    i32.lt_s
-   local.set $10
-   local.get $10
+   local.set $12
+   local.get $12
    if
-    local.get $7
     local.get $9
+    local.get $11
     i32.const 1
     i32.shl
     i32.add
     i32.load16_u
-    local.set $11
-    local.get $11
-    local.get $9
+    local.set $13
     local.get $3
-    i32.const 3
-    global.set $~argumentsLength
-    local.get $2
-    call_indirect (type $i32_i32_i32_=>_i32)
+    local.set $14
+    local.get $14
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result i32)
+     local.get $14
+     i32.const 4
+     i32.shl
+     local.get $13
+     local.get $11
+     local.get $5
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $14
+     i32.const 4
+     i32.shl
+     i32.load
+     call_indirect (type $i32_i32_i32_i32_=>_i32)
+    else
+     local.get $13
+     local.get $11
+     local.get $5
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $14
+     call_indirect (type $i32_i32_i32_=>_i32)
+    end
     if
-     local.get $6
      local.get $8
-     local.tee $12
+     local.get $10
+     local.tee $15
      i32.const 1
      i32.add
-     local.set $8
-     local.get $12
+     local.set $10
+     local.get $15
      i32.const 1
      i32.shl
      i32.add
-     local.get $11
+     local.get $13
      i32.store16
     end
-    local.get $9
+    local.get $11
     i32.const 1
     i32.add
-    local.set $9
+    local.set $11
     br $for-loop|0
    end
   end
-  local.get $8
+  local.get $10
   i32.const 1
   i32.shl
-  local.set $9
-  local.get $6
-  local.get $9
+  local.set $11
+  local.get $8
+  local.get $11
   call $~lib/rt/tlsf/__realloc
-  local.set $10
-  local.get $5
-  local.get $10
+  local.set $12
+  local.get $7
+  local.get $12
   call $~lib/rt/pure/__retain
   i32.store
-  local.get $5
-  local.get $9
+  local.get $7
+  local.get $11
   i32.store offset=8
-  local.get $5
-  local.get $10
+  local.get $7
+  local.get $12
   i32.store offset=4
-  local.get $5
+  local.get $7
   call $~lib/rt/pure/__retain
-  local.set $11
+  local.set $15
   local.get $3
+  local.set $13
+  local.get $13
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $13
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $5
+  call $~lib/rt/pure/__release
+  local.get $15
+  local.set $11
+  local.get $1
+  local.set $12
+  local.get $12
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $12
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
   call $~lib/rt/pure/__release
   local.get $11
  )
@@ -11876,7 +15908,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Int32Array,i32>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Int32Array,i32>~anonymous|0~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -11901,95 +15933,187 @@
   (local $10 i32)
   (local $11 i32)
   (local $12 i32)
-  local.get $0
-  call $~lib/rt/pure/__retain
-  local.set $3
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
   local.get $1
   local.set $2
-  local.get $3
-  call $~lib/typedarray/Int32Array#get:length
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $5
+  local.get $1
   local.set $4
+  local.get $4
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $4
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $4
+  local.set $3
+  local.get $5
+  call $~lib/typedarray/Int32Array#get:length
+  local.set $6
   i32.const 12
   i32.const 8
   call $~lib/rt/tlsf/__alloc
-  local.set $5
-  local.get $4
+  local.set $7
+  local.get $6
   i32.const 2
   i32.shl
   i32.const 0
   call $~lib/rt/tlsf/__alloc
-  local.set $6
-  local.get $3
-  i32.load offset=4
-  local.set $7
-  i32.const 0
   local.set $8
-  i32.const 0
+  local.get $5
+  i32.load offset=4
   local.set $9
+  i32.const 0
+  local.set $10
+  i32.const 0
+  local.set $11
   loop $for-loop|0
-   local.get $9
-   local.get $4
+   local.get $11
+   local.get $6
    i32.lt_s
-   local.set $10
-   local.get $10
+   local.set $12
+   local.get $12
    if
-    local.get $7
     local.get $9
+    local.get $11
     i32.const 2
     i32.shl
     i32.add
     i32.load
-    local.set $11
-    local.get $11
-    local.get $9
+    local.set $13
     local.get $3
-    i32.const 3
-    global.set $~argumentsLength
-    local.get $2
-    call_indirect (type $i32_i32_i32_=>_i32)
+    local.set $14
+    local.get $14
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result i32)
+     local.get $14
+     i32.const 4
+     i32.shl
+     local.get $13
+     local.get $11
+     local.get $5
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $14
+     i32.const 4
+     i32.shl
+     i32.load
+     call_indirect (type $i32_i32_i32_i32_=>_i32)
+    else
+     local.get $13
+     local.get $11
+     local.get $5
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $14
+     call_indirect (type $i32_i32_i32_=>_i32)
+    end
     if
-     local.get $6
      local.get $8
-     local.tee $12
+     local.get $10
+     local.tee $15
      i32.const 1
      i32.add
-     local.set $8
-     local.get $12
+     local.set $10
+     local.get $15
      i32.const 2
      i32.shl
      i32.add
-     local.get $11
+     local.get $13
      i32.store
     end
-    local.get $9
+    local.get $11
     i32.const 1
     i32.add
-    local.set $9
+    local.set $11
     br $for-loop|0
    end
   end
-  local.get $8
+  local.get $10
   i32.const 2
   i32.shl
-  local.set $9
-  local.get $6
-  local.get $9
+  local.set $11
+  local.get $8
+  local.get $11
   call $~lib/rt/tlsf/__realloc
-  local.set $10
-  local.get $5
-  local.get $10
+  local.set $12
+  local.get $7
+  local.get $12
   call $~lib/rt/pure/__retain
   i32.store
-  local.get $5
-  local.get $9
+  local.get $7
+  local.get $11
   i32.store offset=8
-  local.get $5
-  local.get $10
+  local.get $7
+  local.get $12
   i32.store offset=4
-  local.get $5
+  local.get $7
   call $~lib/rt/pure/__retain
-  local.set $11
+  local.set $15
   local.get $3
+  local.set $13
+  local.get $13
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $13
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $5
+  call $~lib/rt/pure/__release
+  local.get $15
+  local.set $11
+  local.get $1
+  local.set $12
+  local.get $12
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $12
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
   call $~lib/rt/pure/__release
   local.get $11
  )
@@ -12102,7 +16226,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint32Array,u32>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint32Array,u32>~anonymous|0~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -12127,95 +16251,187 @@
   (local $10 i32)
   (local $11 i32)
   (local $12 i32)
-  local.get $0
-  call $~lib/rt/pure/__retain
-  local.set $3
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
   local.get $1
   local.set $2
-  local.get $3
-  call $~lib/typedarray/Uint32Array#get:length
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $5
+  local.get $1
   local.set $4
+  local.get $4
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $4
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $4
+  local.set $3
+  local.get $5
+  call $~lib/typedarray/Uint32Array#get:length
+  local.set $6
   i32.const 12
   i32.const 9
   call $~lib/rt/tlsf/__alloc
-  local.set $5
-  local.get $4
+  local.set $7
+  local.get $6
   i32.const 2
   i32.shl
   i32.const 0
   call $~lib/rt/tlsf/__alloc
-  local.set $6
-  local.get $3
-  i32.load offset=4
-  local.set $7
-  i32.const 0
   local.set $8
-  i32.const 0
+  local.get $5
+  i32.load offset=4
   local.set $9
+  i32.const 0
+  local.set $10
+  i32.const 0
+  local.set $11
   loop $for-loop|0
-   local.get $9
-   local.get $4
+   local.get $11
+   local.get $6
    i32.lt_s
-   local.set $10
-   local.get $10
+   local.set $12
+   local.get $12
    if
-    local.get $7
     local.get $9
+    local.get $11
     i32.const 2
     i32.shl
     i32.add
     i32.load
-    local.set $11
-    local.get $11
-    local.get $9
+    local.set $13
     local.get $3
-    i32.const 3
-    global.set $~argumentsLength
-    local.get $2
-    call_indirect (type $i32_i32_i32_=>_i32)
+    local.set $14
+    local.get $14
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result i32)
+     local.get $14
+     i32.const 4
+     i32.shl
+     local.get $13
+     local.get $11
+     local.get $5
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $14
+     i32.const 4
+     i32.shl
+     i32.load
+     call_indirect (type $i32_i32_i32_i32_=>_i32)
+    else
+     local.get $13
+     local.get $11
+     local.get $5
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $14
+     call_indirect (type $i32_i32_i32_=>_i32)
+    end
     if
-     local.get $6
      local.get $8
-     local.tee $12
+     local.get $10
+     local.tee $15
      i32.const 1
      i32.add
-     local.set $8
-     local.get $12
+     local.set $10
+     local.get $15
      i32.const 2
      i32.shl
      i32.add
-     local.get $11
+     local.get $13
      i32.store
     end
-    local.get $9
+    local.get $11
     i32.const 1
     i32.add
-    local.set $9
+    local.set $11
     br $for-loop|0
    end
   end
-  local.get $8
+  local.get $10
   i32.const 2
   i32.shl
-  local.set $9
-  local.get $6
-  local.get $9
+  local.set $11
+  local.get $8
+  local.get $11
   call $~lib/rt/tlsf/__realloc
-  local.set $10
-  local.get $5
-  local.get $10
+  local.set $12
+  local.get $7
+  local.get $12
   call $~lib/rt/pure/__retain
   i32.store
-  local.get $5
-  local.get $9
+  local.get $7
+  local.get $11
   i32.store offset=8
-  local.get $5
-  local.get $10
+  local.get $7
+  local.get $12
   i32.store offset=4
-  local.get $5
+  local.get $7
   call $~lib/rt/pure/__retain
-  local.set $11
+  local.set $15
   local.get $3
+  local.set $13
+  local.get $13
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $13
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $5
+  call $~lib/rt/pure/__release
+  local.get $15
+  local.set $11
+  local.get $1
+  local.set $12
+  local.get $12
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $12
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
   call $~lib/rt/pure/__release
   local.get $11
  )
@@ -12328,7 +16544,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Int64Array,i64>~anonymous|0 (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Int64Array,i64>~anonymous|0~nonClosure (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -12351,99 +16567,192 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
-  (local $11 i64)
+  (local $11 i32)
   (local $12 i32)
-  local.get $0
-  call $~lib/rt/pure/__retain
-  local.set $3
+  (local $13 i64)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
   local.get $1
   local.set $2
-  local.get $3
-  call $~lib/typedarray/Int64Array#get:length
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $5
+  local.get $1
   local.set $4
+  local.get $4
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $4
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $4
+  local.set $3
+  local.get $5
+  call $~lib/typedarray/Int64Array#get:length
+  local.set $6
   i32.const 12
   i32.const 10
   call $~lib/rt/tlsf/__alloc
-  local.set $5
-  local.get $4
+  local.set $7
+  local.get $6
   i32.const 3
   i32.shl
   i32.const 0
   call $~lib/rt/tlsf/__alloc
-  local.set $6
-  local.get $3
-  i32.load offset=4
-  local.set $7
-  i32.const 0
   local.set $8
-  i32.const 0
+  local.get $5
+  i32.load offset=4
   local.set $9
+  i32.const 0
+  local.set $10
+  i32.const 0
+  local.set $11
   loop $for-loop|0
-   local.get $9
-   local.get $4
+   local.get $11
+   local.get $6
    i32.lt_s
-   local.set $10
-   local.get $10
+   local.set $12
+   local.get $12
    if
-    local.get $7
     local.get $9
+    local.get $11
     i32.const 3
     i32.shl
     i32.add
     i64.load
-    local.set $11
-    local.get $11
-    local.get $9
+    local.set $13
     local.get $3
-    i32.const 3
-    global.set $~argumentsLength
-    local.get $2
-    call_indirect (type $i64_i32_i32_=>_i32)
+    local.set $14
+    local.get $14
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result i32)
+     local.get $14
+     i32.const 4
+     i32.shl
+     local.get $13
+     local.get $11
+     local.get $5
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $14
+     i32.const 4
+     i32.shl
+     i32.load
+     call_indirect (type $i32_i64_i32_i32_=>_i32)
+    else
+     local.get $13
+     local.get $11
+     local.get $5
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $14
+     call_indirect (type $i64_i32_i32_=>_i32)
+    end
     if
-     local.get $6
      local.get $8
-     local.tee $12
+     local.get $10
+     local.tee $15
      i32.const 1
      i32.add
-     local.set $8
-     local.get $12
+     local.set $10
+     local.get $15
      i32.const 3
      i32.shl
      i32.add
-     local.get $11
+     local.get $13
      i64.store
     end
-    local.get $9
+    local.get $11
     i32.const 1
     i32.add
-    local.set $9
+    local.set $11
     br $for-loop|0
    end
   end
-  local.get $8
+  local.get $10
   i32.const 3
   i32.shl
-  local.set $9
-  local.get $6
-  local.get $9
+  local.set $11
+  local.get $8
+  local.get $11
   call $~lib/rt/tlsf/__realloc
-  local.set $10
-  local.get $5
-  local.get $10
+  local.set $12
+  local.get $7
+  local.get $12
   call $~lib/rt/pure/__retain
   i32.store
-  local.get $5
-  local.get $9
+  local.get $7
+  local.get $11
   i32.store offset=8
-  local.get $5
-  local.get $10
-  i32.store offset=4
-  local.get $5
-  call $~lib/rt/pure/__retain
-  local.set $12
-  local.get $3
-  call $~lib/rt/pure/__release
+  local.get $7
   local.get $12
+  i32.store offset=4
+  local.get $7
+  call $~lib/rt/pure/__retain
+  local.set $16
+  local.get $3
+  local.set $15
+  local.get $15
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $15
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $5
+  call $~lib/rt/pure/__release
+  local.get $16
+  local.set $11
+  local.get $1
+  local.set $12
+  local.get $12
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $12
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $11
  )
  (func $std/typedarray/testArrayFilter<~lib/typedarray/Int64Array,i64>
   (local $0 i32)
@@ -12554,7 +16863,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint64Array,u64>~anonymous|0 (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint64Array,u64>~anonymous|0~nonClosure (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -12577,99 +16886,192 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
-  (local $11 i64)
+  (local $11 i32)
   (local $12 i32)
-  local.get $0
-  call $~lib/rt/pure/__retain
-  local.set $3
+  (local $13 i64)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
   local.get $1
   local.set $2
-  local.get $3
-  call $~lib/typedarray/Uint64Array#get:length
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $5
+  local.get $1
   local.set $4
+  local.get $4
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $4
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $4
+  local.set $3
+  local.get $5
+  call $~lib/typedarray/Uint64Array#get:length
+  local.set $6
   i32.const 12
   i32.const 11
   call $~lib/rt/tlsf/__alloc
-  local.set $5
-  local.get $4
+  local.set $7
+  local.get $6
   i32.const 3
   i32.shl
   i32.const 0
   call $~lib/rt/tlsf/__alloc
-  local.set $6
-  local.get $3
-  i32.load offset=4
-  local.set $7
-  i32.const 0
   local.set $8
-  i32.const 0
+  local.get $5
+  i32.load offset=4
   local.set $9
+  i32.const 0
+  local.set $10
+  i32.const 0
+  local.set $11
   loop $for-loop|0
-   local.get $9
-   local.get $4
+   local.get $11
+   local.get $6
    i32.lt_s
-   local.set $10
-   local.get $10
+   local.set $12
+   local.get $12
    if
-    local.get $7
     local.get $9
+    local.get $11
     i32.const 3
     i32.shl
     i32.add
     i64.load
-    local.set $11
-    local.get $11
-    local.get $9
+    local.set $13
     local.get $3
-    i32.const 3
-    global.set $~argumentsLength
-    local.get $2
-    call_indirect (type $i64_i32_i32_=>_i32)
+    local.set $14
+    local.get $14
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result i32)
+     local.get $14
+     i32.const 4
+     i32.shl
+     local.get $13
+     local.get $11
+     local.get $5
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $14
+     i32.const 4
+     i32.shl
+     i32.load
+     call_indirect (type $i32_i64_i32_i32_=>_i32)
+    else
+     local.get $13
+     local.get $11
+     local.get $5
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $14
+     call_indirect (type $i64_i32_i32_=>_i32)
+    end
     if
-     local.get $6
      local.get $8
-     local.tee $12
+     local.get $10
+     local.tee $15
      i32.const 1
      i32.add
-     local.set $8
-     local.get $12
+     local.set $10
+     local.get $15
      i32.const 3
      i32.shl
      i32.add
-     local.get $11
+     local.get $13
      i64.store
     end
-    local.get $9
+    local.get $11
     i32.const 1
     i32.add
-    local.set $9
+    local.set $11
     br $for-loop|0
    end
   end
-  local.get $8
+  local.get $10
   i32.const 3
   i32.shl
-  local.set $9
-  local.get $6
-  local.get $9
+  local.set $11
+  local.get $8
+  local.get $11
   call $~lib/rt/tlsf/__realloc
-  local.set $10
-  local.get $5
-  local.get $10
+  local.set $12
+  local.get $7
+  local.get $12
   call $~lib/rt/pure/__retain
   i32.store
-  local.get $5
-  local.get $9
+  local.get $7
+  local.get $11
   i32.store offset=8
-  local.get $5
-  local.get $10
-  i32.store offset=4
-  local.get $5
-  call $~lib/rt/pure/__retain
-  local.set $12
-  local.get $3
-  call $~lib/rt/pure/__release
+  local.get $7
   local.get $12
+  i32.store offset=4
+  local.get $7
+  call $~lib/rt/pure/__retain
+  local.set $16
+  local.get $3
+  local.set $15
+  local.get $15
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $15
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $5
+  call $~lib/rt/pure/__release
+  local.get $16
+  local.set $11
+  local.get $1
+  local.set $12
+  local.get $12
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $12
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $11
  )
  (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint64Array,u64>
   (local $0 i32)
@@ -12780,7 +17182,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Float32Array,f32>~anonymous|0 (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Float32Array,f32>~anonymous|0~nonClosure (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -12803,99 +17205,192 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
-  (local $11 f32)
+  (local $11 i32)
   (local $12 i32)
-  local.get $0
-  call $~lib/rt/pure/__retain
-  local.set $3
+  (local $13 f32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
   local.get $1
   local.set $2
-  local.get $3
-  call $~lib/typedarray/Float32Array#get:length
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $5
+  local.get $1
   local.set $4
+  local.get $4
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $4
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $4
+  local.set $3
+  local.get $5
+  call $~lib/typedarray/Float32Array#get:length
+  local.set $6
   i32.const 12
   i32.const 12
   call $~lib/rt/tlsf/__alloc
-  local.set $5
-  local.get $4
+  local.set $7
+  local.get $6
   i32.const 2
   i32.shl
   i32.const 0
   call $~lib/rt/tlsf/__alloc
-  local.set $6
-  local.get $3
-  i32.load offset=4
-  local.set $7
-  i32.const 0
   local.set $8
-  i32.const 0
+  local.get $5
+  i32.load offset=4
   local.set $9
+  i32.const 0
+  local.set $10
+  i32.const 0
+  local.set $11
   loop $for-loop|0
-   local.get $9
-   local.get $4
+   local.get $11
+   local.get $6
    i32.lt_s
-   local.set $10
-   local.get $10
+   local.set $12
+   local.get $12
    if
-    local.get $7
     local.get $9
+    local.get $11
     i32.const 2
     i32.shl
     i32.add
     f32.load
-    local.set $11
-    local.get $11
-    local.get $9
+    local.set $13
     local.get $3
-    i32.const 3
-    global.set $~argumentsLength
-    local.get $2
-    call_indirect (type $f32_i32_i32_=>_i32)
+    local.set $14
+    local.get $14
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result i32)
+     local.get $14
+     i32.const 4
+     i32.shl
+     local.get $13
+     local.get $11
+     local.get $5
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $14
+     i32.const 4
+     i32.shl
+     i32.load
+     call_indirect (type $i32_f32_i32_i32_=>_i32)
+    else
+     local.get $13
+     local.get $11
+     local.get $5
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $14
+     call_indirect (type $f32_i32_i32_=>_i32)
+    end
     if
-     local.get $6
      local.get $8
-     local.tee $12
+     local.get $10
+     local.tee $15
      i32.const 1
      i32.add
-     local.set $8
-     local.get $12
+     local.set $10
+     local.get $15
      i32.const 2
      i32.shl
      i32.add
-     local.get $11
+     local.get $13
      f32.store
     end
-    local.get $9
+    local.get $11
     i32.const 1
     i32.add
-    local.set $9
+    local.set $11
     br $for-loop|0
    end
   end
-  local.get $8
+  local.get $10
   i32.const 2
   i32.shl
-  local.set $9
-  local.get $6
-  local.get $9
+  local.set $11
+  local.get $8
+  local.get $11
   call $~lib/rt/tlsf/__realloc
-  local.set $10
-  local.get $5
-  local.get $10
+  local.set $12
+  local.get $7
+  local.get $12
   call $~lib/rt/pure/__retain
   i32.store
-  local.get $5
-  local.get $9
+  local.get $7
+  local.get $11
   i32.store offset=8
-  local.get $5
-  local.get $10
-  i32.store offset=4
-  local.get $5
-  call $~lib/rt/pure/__retain
-  local.set $12
-  local.get $3
-  call $~lib/rt/pure/__release
+  local.get $7
   local.get $12
+  i32.store offset=4
+  local.get $7
+  call $~lib/rt/pure/__retain
+  local.set $16
+  local.get $3
+  local.set $15
+  local.get $15
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $15
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $5
+  call $~lib/rt/pure/__release
+  local.get $16
+  local.set $11
+  local.get $1
+  local.set $12
+  local.get $12
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $12
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $11
  )
  (func $std/typedarray/testArrayFilter<~lib/typedarray/Float32Array,f32>
   (local $0 i32)
@@ -13006,7 +17501,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Float64Array,f64>~anonymous|0 (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Float64Array,f64>~anonymous|0~nonClosure (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -13029,99 +17524,192 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
-  (local $11 f64)
+  (local $11 i32)
   (local $12 i32)
-  local.get $0
-  call $~lib/rt/pure/__retain
-  local.set $3
+  (local $13 f64)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
   local.get $1
   local.set $2
-  local.get $3
-  call $~lib/typedarray/Float64Array#get:length
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $5
+  local.get $1
   local.set $4
+  local.get $4
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $4
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $4
+  local.set $3
+  local.get $5
+  call $~lib/typedarray/Float64Array#get:length
+  local.set $6
   i32.const 12
   i32.const 13
   call $~lib/rt/tlsf/__alloc
-  local.set $5
-  local.get $4
+  local.set $7
+  local.get $6
   i32.const 3
   i32.shl
   i32.const 0
   call $~lib/rt/tlsf/__alloc
-  local.set $6
-  local.get $3
-  i32.load offset=4
-  local.set $7
-  i32.const 0
   local.set $8
-  i32.const 0
+  local.get $5
+  i32.load offset=4
   local.set $9
+  i32.const 0
+  local.set $10
+  i32.const 0
+  local.set $11
   loop $for-loop|0
-   local.get $9
-   local.get $4
+   local.get $11
+   local.get $6
    i32.lt_s
-   local.set $10
-   local.get $10
+   local.set $12
+   local.get $12
    if
-    local.get $7
     local.get $9
+    local.get $11
     i32.const 3
     i32.shl
     i32.add
     f64.load
-    local.set $11
-    local.get $11
-    local.get $9
+    local.set $13
     local.get $3
-    i32.const 3
-    global.set $~argumentsLength
-    local.get $2
-    call_indirect (type $f64_i32_i32_=>_i32)
+    local.set $14
+    local.get $14
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if (result i32)
+     local.get $14
+     i32.const 4
+     i32.shl
+     local.get $13
+     local.get $11
+     local.get $5
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $14
+     i32.const 4
+     i32.shl
+     i32.load
+     call_indirect (type $i32_f64_i32_i32_=>_i32)
+    else
+     local.get $13
+     local.get $11
+     local.get $5
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $14
+     call_indirect (type $f64_i32_i32_=>_i32)
+    end
     if
-     local.get $6
      local.get $8
-     local.tee $12
+     local.get $10
+     local.tee $15
      i32.const 1
      i32.add
-     local.set $8
-     local.get $12
+     local.set $10
+     local.get $15
      i32.const 3
      i32.shl
      i32.add
-     local.get $11
+     local.get $13
      f64.store
     end
-    local.get $9
+    local.get $11
     i32.const 1
     i32.add
-    local.set $9
+    local.set $11
     br $for-loop|0
    end
   end
-  local.get $8
+  local.get $10
   i32.const 3
   i32.shl
-  local.set $9
-  local.get $6
-  local.get $9
+  local.set $11
+  local.get $8
+  local.get $11
   call $~lib/rt/tlsf/__realloc
-  local.set $10
-  local.get $5
-  local.get $10
+  local.set $12
+  local.get $7
+  local.get $12
   call $~lib/rt/pure/__retain
   i32.store
-  local.get $5
-  local.get $9
+  local.get $7
+  local.get $11
   i32.store offset=8
-  local.get $5
-  local.get $10
-  i32.store offset=4
-  local.get $5
-  call $~lib/rt/pure/__retain
-  local.set $12
-  local.get $3
-  call $~lib/rt/pure/__release
+  local.get $7
   local.get $12
+  i32.store offset=4
+  local.get $7
+  call $~lib/rt/pure/__retain
+  local.set $16
+  local.get $3
+  local.set $15
+  local.get $15
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $15
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $5
+  call $~lib/rt/pure/__release
+  local.get $16
+  local.set $11
+  local.get $1
+  local.set $12
+  local.get $12
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $12
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $11
  )
  (func $std/typedarray/testArrayFilter<~lib/typedarray/Float64Array,f64>
   (local $0 i32)
@@ -13232,7 +17820,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Int8Array,i8>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Int8Array,i8>~anonymous|0~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -13257,62 +17845,175 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  local.get $1
+  local.set $2
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
   block $~lib/typedarray/SOME<~lib/typedarray/Int8Array,i8>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
-   local.set $3
-   local.get $1
-   local.set $2
-   local.get $3
-   i32.load offset=4
-   local.set $4
-   i32.const 0
    local.set $5
-   local.get $3
-   call $~lib/typedarray/Int8Array#get:length
+   local.get $1
+   local.set $4
+   local.get $4
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $4
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
+   call $~lib/rt/pure/__retain
+   drop
+   local.get $4
+   local.set $3
+   local.get $5
+   i32.load offset=4
    local.set $6
+   i32.const 0
+   local.set $7
+   local.get $5
+   call $~lib/typedarray/Int8Array#get:length
+   local.set $8
    loop $for-loop|0
-    local.get $5
-    local.get $6
-    i32.lt_s
-    local.set $7
     local.get $7
+    local.get $8
+    i32.lt_s
+    local.set $9
+    local.get $9
     if
-     local.get $4
-     local.get $5
-     i32.const 0
-     i32.shl
-     i32.add
-     i32.load8_s
-     local.get $5
      local.get $3
-     i32.const 3
-     global.set $~argumentsLength
-     local.get $2
-     call_indirect (type $i32_i32_i32_=>_i32)
+     local.set $10
+     local.get $10
+     i32.const -2147483648
+     i32.and
+     i32.const -2147483648
+     i32.eq
+     if (result i32)
+      local.get $10
+      i32.const 4
+      i32.shl
+      local.get $6
+      local.get $7
+      i32.const 0
+      i32.shl
+      i32.add
+      i32.load8_s
+      local.get $7
+      local.get $5
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $10
+      i32.const 4
+      i32.shl
+      i32.load
+      call_indirect (type $i32_i32_i32_i32_=>_i32)
+     else
+      local.get $6
+      local.get $7
+      i32.const 0
+      i32.shl
+      i32.add
+      i32.load8_s
+      local.get $7
+      local.get $5
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $10
+      call_indirect (type $i32_i32_i32_=>_i32)
+     end
      if
       i32.const 1
-      local.set $8
+      local.set $12
       local.get $3
+      local.set $11
+      local.get $11
+      i32.const -2147483648
+      i32.and
+      i32.const -2147483648
+      i32.eq
+      if (result i32)
+       local.get $11
+       i32.const 4
+       i32.shl
+      else
+       i32.const 0
+      end
       call $~lib/rt/pure/__release
-      local.get $8
+      local.get $5
+      call $~lib/rt/pure/__release
+      local.get $12
       br $~lib/typedarray/SOME<~lib/typedarray/Int8Array,i8>|inlined.0
      end
-     local.get $5
+     local.get $7
      i32.const 1
      i32.add
-     local.set $5
+     local.set $7
      br $for-loop|0
     end
    end
    i32.const 0
-   local.set $6
+   local.set $7
    local.get $3
+   local.set $8
+   local.get $8
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $8
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
    call $~lib/rt/pure/__release
-   local.get $6
+   local.get $5
+   call $~lib/rt/pure/__release
+   local.get $7
   end
+  local.set $5
+  local.get $1
+  local.set $6
+  local.get $6
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $6
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $5
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Int8Array,i8>~anonymous|1 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Int8Array,i8>~anonymous|1~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -13388,7 +18089,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Uint8Array,u8>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Uint8Array,u8>~anonymous|0~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -13411,62 +18112,175 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  local.get $1
+  local.set $2
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
   block $~lib/typedarray/SOME<~lib/typedarray/Uint8Array,u8>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
-   local.set $3
-   local.get $1
-   local.set $2
-   local.get $3
-   i32.load offset=4
-   local.set $4
-   i32.const 0
    local.set $5
-   local.get $3
-   call $~lib/typedarray/Uint8Array#get:length
+   local.get $1
+   local.set $4
+   local.get $4
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $4
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
+   call $~lib/rt/pure/__retain
+   drop
+   local.get $4
+   local.set $3
+   local.get $5
+   i32.load offset=4
    local.set $6
+   i32.const 0
+   local.set $7
+   local.get $5
+   call $~lib/typedarray/Uint8Array#get:length
+   local.set $8
    loop $for-loop|0
-    local.get $5
-    local.get $6
-    i32.lt_s
-    local.set $7
     local.get $7
+    local.get $8
+    i32.lt_s
+    local.set $9
+    local.get $9
     if
-     local.get $4
-     local.get $5
-     i32.const 0
-     i32.shl
-     i32.add
-     i32.load8_u
-     local.get $5
      local.get $3
-     i32.const 3
-     global.set $~argumentsLength
-     local.get $2
-     call_indirect (type $i32_i32_i32_=>_i32)
+     local.set $10
+     local.get $10
+     i32.const -2147483648
+     i32.and
+     i32.const -2147483648
+     i32.eq
+     if (result i32)
+      local.get $10
+      i32.const 4
+      i32.shl
+      local.get $6
+      local.get $7
+      i32.const 0
+      i32.shl
+      i32.add
+      i32.load8_u
+      local.get $7
+      local.get $5
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $10
+      i32.const 4
+      i32.shl
+      i32.load
+      call_indirect (type $i32_i32_i32_i32_=>_i32)
+     else
+      local.get $6
+      local.get $7
+      i32.const 0
+      i32.shl
+      i32.add
+      i32.load8_u
+      local.get $7
+      local.get $5
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $10
+      call_indirect (type $i32_i32_i32_=>_i32)
+     end
      if
       i32.const 1
-      local.set $8
+      local.set $12
       local.get $3
+      local.set $11
+      local.get $11
+      i32.const -2147483648
+      i32.and
+      i32.const -2147483648
+      i32.eq
+      if (result i32)
+       local.get $11
+       i32.const 4
+       i32.shl
+      else
+       i32.const 0
+      end
       call $~lib/rt/pure/__release
-      local.get $8
+      local.get $5
+      call $~lib/rt/pure/__release
+      local.get $12
       br $~lib/typedarray/SOME<~lib/typedarray/Uint8Array,u8>|inlined.0
      end
-     local.get $5
+     local.get $7
      i32.const 1
      i32.add
-     local.set $5
+     local.set $7
      br $for-loop|0
     end
    end
    i32.const 0
-   local.set $6
+   local.set $7
    local.get $3
+   local.set $8
+   local.get $8
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $8
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
    call $~lib/rt/pure/__release
-   local.get $6
+   local.get $5
+   call $~lib/rt/pure/__release
+   local.get $7
   end
+  local.set $5
+  local.get $1
+  local.set $6
+  local.get $6
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $6
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $5
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Uint8Array,u8>~anonymous|1 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Uint8Array,u8>~anonymous|1~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -13540,7 +18354,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|0~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -13563,62 +18377,175 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  local.get $1
+  local.set $2
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
   block $~lib/typedarray/SOME<~lib/typedarray/Uint8ClampedArray,u8>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
-   local.set $3
-   local.get $1
-   local.set $2
-   local.get $3
-   i32.load offset=4
-   local.set $4
-   i32.const 0
    local.set $5
-   local.get $3
-   call $~lib/typedarray/Uint8ClampedArray#get:length
+   local.get $1
+   local.set $4
+   local.get $4
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $4
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
+   call $~lib/rt/pure/__retain
+   drop
+   local.get $4
+   local.set $3
+   local.get $5
+   i32.load offset=4
    local.set $6
+   i32.const 0
+   local.set $7
+   local.get $5
+   call $~lib/typedarray/Uint8ClampedArray#get:length
+   local.set $8
    loop $for-loop|0
-    local.get $5
-    local.get $6
-    i32.lt_s
-    local.set $7
     local.get $7
+    local.get $8
+    i32.lt_s
+    local.set $9
+    local.get $9
     if
-     local.get $4
-     local.get $5
-     i32.const 0
-     i32.shl
-     i32.add
-     i32.load8_u
-     local.get $5
      local.get $3
-     i32.const 3
-     global.set $~argumentsLength
-     local.get $2
-     call_indirect (type $i32_i32_i32_=>_i32)
+     local.set $10
+     local.get $10
+     i32.const -2147483648
+     i32.and
+     i32.const -2147483648
+     i32.eq
+     if (result i32)
+      local.get $10
+      i32.const 4
+      i32.shl
+      local.get $6
+      local.get $7
+      i32.const 0
+      i32.shl
+      i32.add
+      i32.load8_u
+      local.get $7
+      local.get $5
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $10
+      i32.const 4
+      i32.shl
+      i32.load
+      call_indirect (type $i32_i32_i32_i32_=>_i32)
+     else
+      local.get $6
+      local.get $7
+      i32.const 0
+      i32.shl
+      i32.add
+      i32.load8_u
+      local.get $7
+      local.get $5
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $10
+      call_indirect (type $i32_i32_i32_=>_i32)
+     end
      if
       i32.const 1
-      local.set $8
+      local.set $12
       local.get $3
+      local.set $11
+      local.get $11
+      i32.const -2147483648
+      i32.and
+      i32.const -2147483648
+      i32.eq
+      if (result i32)
+       local.get $11
+       i32.const 4
+       i32.shl
+      else
+       i32.const 0
+      end
       call $~lib/rt/pure/__release
-      local.get $8
+      local.get $5
+      call $~lib/rt/pure/__release
+      local.get $12
       br $~lib/typedarray/SOME<~lib/typedarray/Uint8ClampedArray,u8>|inlined.0
      end
-     local.get $5
+     local.get $7
      i32.const 1
      i32.add
-     local.set $5
+     local.set $7
      br $for-loop|0
     end
    end
    i32.const 0
-   local.set $6
+   local.set $7
    local.get $3
+   local.set $8
+   local.get $8
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $8
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
    call $~lib/rt/pure/__release
-   local.get $6
+   local.get $5
+   call $~lib/rt/pure/__release
+   local.get $7
   end
+  local.set $5
+  local.get $1
+  local.set $6
+  local.get $6
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $6
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $5
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|1 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|1~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -13692,7 +18619,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Int16Array,i16>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Int16Array,i16>~anonymous|0~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -13717,62 +18644,175 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  local.get $1
+  local.set $2
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
   block $~lib/typedarray/SOME<~lib/typedarray/Int16Array,i16>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
-   local.set $3
-   local.get $1
-   local.set $2
-   local.get $3
-   i32.load offset=4
-   local.set $4
-   i32.const 0
    local.set $5
-   local.get $3
-   call $~lib/typedarray/Int16Array#get:length
+   local.get $1
+   local.set $4
+   local.get $4
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $4
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
+   call $~lib/rt/pure/__retain
+   drop
+   local.get $4
+   local.set $3
+   local.get $5
+   i32.load offset=4
    local.set $6
+   i32.const 0
+   local.set $7
+   local.get $5
+   call $~lib/typedarray/Int16Array#get:length
+   local.set $8
    loop $for-loop|0
-    local.get $5
-    local.get $6
-    i32.lt_s
-    local.set $7
     local.get $7
+    local.get $8
+    i32.lt_s
+    local.set $9
+    local.get $9
     if
-     local.get $4
-     local.get $5
-     i32.const 1
-     i32.shl
-     i32.add
-     i32.load16_s
-     local.get $5
      local.get $3
-     i32.const 3
-     global.set $~argumentsLength
-     local.get $2
-     call_indirect (type $i32_i32_i32_=>_i32)
+     local.set $10
+     local.get $10
+     i32.const -2147483648
+     i32.and
+     i32.const -2147483648
+     i32.eq
+     if (result i32)
+      local.get $10
+      i32.const 4
+      i32.shl
+      local.get $6
+      local.get $7
+      i32.const 1
+      i32.shl
+      i32.add
+      i32.load16_s
+      local.get $7
+      local.get $5
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $10
+      i32.const 4
+      i32.shl
+      i32.load
+      call_indirect (type $i32_i32_i32_i32_=>_i32)
+     else
+      local.get $6
+      local.get $7
+      i32.const 1
+      i32.shl
+      i32.add
+      i32.load16_s
+      local.get $7
+      local.get $5
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $10
+      call_indirect (type $i32_i32_i32_=>_i32)
+     end
      if
       i32.const 1
-      local.set $8
+      local.set $12
       local.get $3
+      local.set $11
+      local.get $11
+      i32.const -2147483648
+      i32.and
+      i32.const -2147483648
+      i32.eq
+      if (result i32)
+       local.get $11
+       i32.const 4
+       i32.shl
+      else
+       i32.const 0
+      end
       call $~lib/rt/pure/__release
-      local.get $8
+      local.get $5
+      call $~lib/rt/pure/__release
+      local.get $12
       br $~lib/typedarray/SOME<~lib/typedarray/Int16Array,i16>|inlined.0
      end
-     local.get $5
+     local.get $7
      i32.const 1
      i32.add
-     local.set $5
+     local.set $7
      br $for-loop|0
     end
    end
    i32.const 0
-   local.set $6
+   local.set $7
    local.get $3
+   local.set $8
+   local.get $8
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $8
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
    call $~lib/rt/pure/__release
-   local.get $6
+   local.get $5
+   call $~lib/rt/pure/__release
+   local.get $7
   end
+  local.set $5
+  local.get $1
+  local.set $6
+  local.get $6
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $6
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $5
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Int16Array,i16>~anonymous|1 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Int16Array,i16>~anonymous|1~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -13848,7 +18888,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Uint16Array,u16>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Uint16Array,u16>~anonymous|0~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -13871,62 +18911,175 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  local.get $1
+  local.set $2
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
   block $~lib/typedarray/SOME<~lib/typedarray/Uint16Array,u16>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
-   local.set $3
-   local.get $1
-   local.set $2
-   local.get $3
-   i32.load offset=4
-   local.set $4
-   i32.const 0
    local.set $5
-   local.get $3
-   call $~lib/typedarray/Uint16Array#get:length
+   local.get $1
+   local.set $4
+   local.get $4
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $4
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
+   call $~lib/rt/pure/__retain
+   drop
+   local.get $4
+   local.set $3
+   local.get $5
+   i32.load offset=4
    local.set $6
+   i32.const 0
+   local.set $7
+   local.get $5
+   call $~lib/typedarray/Uint16Array#get:length
+   local.set $8
    loop $for-loop|0
-    local.get $5
-    local.get $6
-    i32.lt_s
-    local.set $7
     local.get $7
+    local.get $8
+    i32.lt_s
+    local.set $9
+    local.get $9
     if
-     local.get $4
-     local.get $5
-     i32.const 1
-     i32.shl
-     i32.add
-     i32.load16_u
-     local.get $5
      local.get $3
-     i32.const 3
-     global.set $~argumentsLength
-     local.get $2
-     call_indirect (type $i32_i32_i32_=>_i32)
+     local.set $10
+     local.get $10
+     i32.const -2147483648
+     i32.and
+     i32.const -2147483648
+     i32.eq
+     if (result i32)
+      local.get $10
+      i32.const 4
+      i32.shl
+      local.get $6
+      local.get $7
+      i32.const 1
+      i32.shl
+      i32.add
+      i32.load16_u
+      local.get $7
+      local.get $5
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $10
+      i32.const 4
+      i32.shl
+      i32.load
+      call_indirect (type $i32_i32_i32_i32_=>_i32)
+     else
+      local.get $6
+      local.get $7
+      i32.const 1
+      i32.shl
+      i32.add
+      i32.load16_u
+      local.get $7
+      local.get $5
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $10
+      call_indirect (type $i32_i32_i32_=>_i32)
+     end
      if
       i32.const 1
-      local.set $8
+      local.set $12
       local.get $3
+      local.set $11
+      local.get $11
+      i32.const -2147483648
+      i32.and
+      i32.const -2147483648
+      i32.eq
+      if (result i32)
+       local.get $11
+       i32.const 4
+       i32.shl
+      else
+       i32.const 0
+      end
       call $~lib/rt/pure/__release
-      local.get $8
+      local.get $5
+      call $~lib/rt/pure/__release
+      local.get $12
       br $~lib/typedarray/SOME<~lib/typedarray/Uint16Array,u16>|inlined.0
      end
-     local.get $5
+     local.get $7
      i32.const 1
      i32.add
-     local.set $5
+     local.set $7
      br $for-loop|0
     end
    end
    i32.const 0
-   local.set $6
+   local.set $7
    local.get $3
+   local.set $8
+   local.get $8
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $8
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
    call $~lib/rt/pure/__release
-   local.get $6
+   local.get $5
+   call $~lib/rt/pure/__release
+   local.get $7
   end
+  local.set $5
+  local.get $1
+  local.set $6
+  local.get $6
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $6
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $5
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Uint16Array,u16>~anonymous|1 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Uint16Array,u16>~anonymous|1~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -14000,7 +19153,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Int32Array,i32>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Int32Array,i32>~anonymous|0~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -14021,62 +19174,175 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  local.get $1
+  local.set $2
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
   block $~lib/typedarray/SOME<~lib/typedarray/Int32Array,i32>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
-   local.set $3
-   local.get $1
-   local.set $2
-   local.get $3
-   i32.load offset=4
-   local.set $4
-   i32.const 0
    local.set $5
-   local.get $3
-   call $~lib/typedarray/Int32Array#get:length
+   local.get $1
+   local.set $4
+   local.get $4
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $4
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
+   call $~lib/rt/pure/__retain
+   drop
+   local.get $4
+   local.set $3
+   local.get $5
+   i32.load offset=4
    local.set $6
+   i32.const 0
+   local.set $7
+   local.get $5
+   call $~lib/typedarray/Int32Array#get:length
+   local.set $8
    loop $for-loop|0
-    local.get $5
-    local.get $6
-    i32.lt_s
-    local.set $7
     local.get $7
+    local.get $8
+    i32.lt_s
+    local.set $9
+    local.get $9
     if
-     local.get $4
-     local.get $5
-     i32.const 2
-     i32.shl
-     i32.add
-     i32.load
-     local.get $5
      local.get $3
-     i32.const 3
-     global.set $~argumentsLength
-     local.get $2
-     call_indirect (type $i32_i32_i32_=>_i32)
+     local.set $10
+     local.get $10
+     i32.const -2147483648
+     i32.and
+     i32.const -2147483648
+     i32.eq
+     if (result i32)
+      local.get $10
+      i32.const 4
+      i32.shl
+      local.get $6
+      local.get $7
+      i32.const 2
+      i32.shl
+      i32.add
+      i32.load
+      local.get $7
+      local.get $5
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $10
+      i32.const 4
+      i32.shl
+      i32.load
+      call_indirect (type $i32_i32_i32_i32_=>_i32)
+     else
+      local.get $6
+      local.get $7
+      i32.const 2
+      i32.shl
+      i32.add
+      i32.load
+      local.get $7
+      local.get $5
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $10
+      call_indirect (type $i32_i32_i32_=>_i32)
+     end
      if
       i32.const 1
-      local.set $8
+      local.set $12
       local.get $3
+      local.set $11
+      local.get $11
+      i32.const -2147483648
+      i32.and
+      i32.const -2147483648
+      i32.eq
+      if (result i32)
+       local.get $11
+       i32.const 4
+       i32.shl
+      else
+       i32.const 0
+      end
       call $~lib/rt/pure/__release
-      local.get $8
+      local.get $5
+      call $~lib/rt/pure/__release
+      local.get $12
       br $~lib/typedarray/SOME<~lib/typedarray/Int32Array,i32>|inlined.0
      end
-     local.get $5
+     local.get $7
      i32.const 1
      i32.add
-     local.set $5
+     local.set $7
      br $for-loop|0
     end
    end
    i32.const 0
-   local.set $6
+   local.set $7
    local.get $3
+   local.set $8
+   local.get $8
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $8
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
    call $~lib/rt/pure/__release
-   local.get $6
+   local.get $5
+   call $~lib/rt/pure/__release
+   local.get $7
   end
+  local.set $5
+  local.get $1
+  local.set $6
+  local.get $6
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $6
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $5
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Int32Array,i32>~anonymous|1 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Int32Array,i32>~anonymous|1~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -14148,7 +19414,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Uint32Array,u32>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Uint32Array,u32>~anonymous|0~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -14169,62 +19435,175 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  local.get $1
+  local.set $2
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
   block $~lib/typedarray/SOME<~lib/typedarray/Uint32Array,u32>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
-   local.set $3
-   local.get $1
-   local.set $2
-   local.get $3
-   i32.load offset=4
-   local.set $4
-   i32.const 0
    local.set $5
-   local.get $3
-   call $~lib/typedarray/Uint32Array#get:length
+   local.get $1
+   local.set $4
+   local.get $4
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $4
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
+   call $~lib/rt/pure/__retain
+   drop
+   local.get $4
+   local.set $3
+   local.get $5
+   i32.load offset=4
    local.set $6
+   i32.const 0
+   local.set $7
+   local.get $5
+   call $~lib/typedarray/Uint32Array#get:length
+   local.set $8
    loop $for-loop|0
-    local.get $5
-    local.get $6
-    i32.lt_s
-    local.set $7
     local.get $7
+    local.get $8
+    i32.lt_s
+    local.set $9
+    local.get $9
     if
-     local.get $4
-     local.get $5
-     i32.const 2
-     i32.shl
-     i32.add
-     i32.load
-     local.get $5
      local.get $3
-     i32.const 3
-     global.set $~argumentsLength
-     local.get $2
-     call_indirect (type $i32_i32_i32_=>_i32)
+     local.set $10
+     local.get $10
+     i32.const -2147483648
+     i32.and
+     i32.const -2147483648
+     i32.eq
+     if (result i32)
+      local.get $10
+      i32.const 4
+      i32.shl
+      local.get $6
+      local.get $7
+      i32.const 2
+      i32.shl
+      i32.add
+      i32.load
+      local.get $7
+      local.get $5
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $10
+      i32.const 4
+      i32.shl
+      i32.load
+      call_indirect (type $i32_i32_i32_i32_=>_i32)
+     else
+      local.get $6
+      local.get $7
+      i32.const 2
+      i32.shl
+      i32.add
+      i32.load
+      local.get $7
+      local.get $5
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $10
+      call_indirect (type $i32_i32_i32_=>_i32)
+     end
      if
       i32.const 1
-      local.set $8
+      local.set $12
       local.get $3
+      local.set $11
+      local.get $11
+      i32.const -2147483648
+      i32.and
+      i32.const -2147483648
+      i32.eq
+      if (result i32)
+       local.get $11
+       i32.const 4
+       i32.shl
+      else
+       i32.const 0
+      end
       call $~lib/rt/pure/__release
-      local.get $8
+      local.get $5
+      call $~lib/rt/pure/__release
+      local.get $12
       br $~lib/typedarray/SOME<~lib/typedarray/Uint32Array,u32>|inlined.0
      end
-     local.get $5
+     local.get $7
      i32.const 1
      i32.add
-     local.set $5
+     local.set $7
      br $for-loop|0
     end
    end
    i32.const 0
-   local.set $6
+   local.set $7
    local.get $3
+   local.set $8
+   local.get $8
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $8
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
    call $~lib/rt/pure/__release
-   local.get $6
+   local.get $5
+   call $~lib/rt/pure/__release
+   local.get $7
   end
+  local.set $5
+  local.get $1
+  local.set $6
+  local.get $6
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $6
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $5
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Uint32Array,u32>~anonymous|1 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Uint32Array,u32>~anonymous|1~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -14296,7 +19675,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Int64Array,i64>~anonymous|0 (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Int64Array,i64>~anonymous|0~nonClosure (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -14317,62 +19696,175 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  local.get $1
+  local.set $2
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
   block $~lib/typedarray/SOME<~lib/typedarray/Int64Array,i64>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
-   local.set $3
-   local.get $1
-   local.set $2
-   local.get $3
-   i32.load offset=4
-   local.set $4
-   i32.const 0
    local.set $5
-   local.get $3
-   call $~lib/typedarray/Int64Array#get:length
+   local.get $1
+   local.set $4
+   local.get $4
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $4
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
+   call $~lib/rt/pure/__retain
+   drop
+   local.get $4
+   local.set $3
+   local.get $5
+   i32.load offset=4
    local.set $6
+   i32.const 0
+   local.set $7
+   local.get $5
+   call $~lib/typedarray/Int64Array#get:length
+   local.set $8
    loop $for-loop|0
-    local.get $5
-    local.get $6
-    i32.lt_s
-    local.set $7
     local.get $7
+    local.get $8
+    i32.lt_s
+    local.set $9
+    local.get $9
     if
-     local.get $4
-     local.get $5
-     i32.const 3
-     i32.shl
-     i32.add
-     i64.load
-     local.get $5
      local.get $3
-     i32.const 3
-     global.set $~argumentsLength
-     local.get $2
-     call_indirect (type $i64_i32_i32_=>_i32)
+     local.set $10
+     local.get $10
+     i32.const -2147483648
+     i32.and
+     i32.const -2147483648
+     i32.eq
+     if (result i32)
+      local.get $10
+      i32.const 4
+      i32.shl
+      local.get $6
+      local.get $7
+      i32.const 3
+      i32.shl
+      i32.add
+      i64.load
+      local.get $7
+      local.get $5
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $10
+      i32.const 4
+      i32.shl
+      i32.load
+      call_indirect (type $i32_i64_i32_i32_=>_i32)
+     else
+      local.get $6
+      local.get $7
+      i32.const 3
+      i32.shl
+      i32.add
+      i64.load
+      local.get $7
+      local.get $5
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $10
+      call_indirect (type $i64_i32_i32_=>_i32)
+     end
      if
       i32.const 1
-      local.set $8
+      local.set $12
       local.get $3
+      local.set $11
+      local.get $11
+      i32.const -2147483648
+      i32.and
+      i32.const -2147483648
+      i32.eq
+      if (result i32)
+       local.get $11
+       i32.const 4
+       i32.shl
+      else
+       i32.const 0
+      end
       call $~lib/rt/pure/__release
-      local.get $8
+      local.get $5
+      call $~lib/rt/pure/__release
+      local.get $12
       br $~lib/typedarray/SOME<~lib/typedarray/Int64Array,i64>|inlined.0
      end
-     local.get $5
+     local.get $7
      i32.const 1
      i32.add
-     local.set $5
+     local.set $7
      br $for-loop|0
     end
    end
    i32.const 0
-   local.set $6
+   local.set $7
    local.get $3
+   local.set $8
+   local.get $8
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $8
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
    call $~lib/rt/pure/__release
-   local.get $6
+   local.get $5
+   call $~lib/rt/pure/__release
+   local.get $7
   end
+  local.set $5
+  local.get $1
+  local.set $6
+  local.get $6
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $6
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $5
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Int64Array,i64>~anonymous|1 (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Int64Array,i64>~anonymous|1~nonClosure (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -14444,7 +19936,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Uint64Array,u64>~anonymous|0 (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Uint64Array,u64>~anonymous|0~nonClosure (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -14465,62 +19957,175 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  local.get $1
+  local.set $2
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
   block $~lib/typedarray/SOME<~lib/typedarray/Uint64Array,u64>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
-   local.set $3
-   local.get $1
-   local.set $2
-   local.get $3
-   i32.load offset=4
-   local.set $4
-   i32.const 0
    local.set $5
-   local.get $3
-   call $~lib/typedarray/Uint64Array#get:length
+   local.get $1
+   local.set $4
+   local.get $4
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $4
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
+   call $~lib/rt/pure/__retain
+   drop
+   local.get $4
+   local.set $3
+   local.get $5
+   i32.load offset=4
    local.set $6
+   i32.const 0
+   local.set $7
+   local.get $5
+   call $~lib/typedarray/Uint64Array#get:length
+   local.set $8
    loop $for-loop|0
-    local.get $5
-    local.get $6
-    i32.lt_s
-    local.set $7
     local.get $7
+    local.get $8
+    i32.lt_s
+    local.set $9
+    local.get $9
     if
-     local.get $4
-     local.get $5
-     i32.const 3
-     i32.shl
-     i32.add
-     i64.load
-     local.get $5
      local.get $3
-     i32.const 3
-     global.set $~argumentsLength
-     local.get $2
-     call_indirect (type $i64_i32_i32_=>_i32)
+     local.set $10
+     local.get $10
+     i32.const -2147483648
+     i32.and
+     i32.const -2147483648
+     i32.eq
+     if (result i32)
+      local.get $10
+      i32.const 4
+      i32.shl
+      local.get $6
+      local.get $7
+      i32.const 3
+      i32.shl
+      i32.add
+      i64.load
+      local.get $7
+      local.get $5
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $10
+      i32.const 4
+      i32.shl
+      i32.load
+      call_indirect (type $i32_i64_i32_i32_=>_i32)
+     else
+      local.get $6
+      local.get $7
+      i32.const 3
+      i32.shl
+      i32.add
+      i64.load
+      local.get $7
+      local.get $5
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $10
+      call_indirect (type $i64_i32_i32_=>_i32)
+     end
      if
       i32.const 1
-      local.set $8
+      local.set $12
       local.get $3
+      local.set $11
+      local.get $11
+      i32.const -2147483648
+      i32.and
+      i32.const -2147483648
+      i32.eq
+      if (result i32)
+       local.get $11
+       i32.const 4
+       i32.shl
+      else
+       i32.const 0
+      end
       call $~lib/rt/pure/__release
-      local.get $8
+      local.get $5
+      call $~lib/rt/pure/__release
+      local.get $12
       br $~lib/typedarray/SOME<~lib/typedarray/Uint64Array,u64>|inlined.0
      end
-     local.get $5
+     local.get $7
      i32.const 1
      i32.add
-     local.set $5
+     local.set $7
      br $for-loop|0
     end
    end
    i32.const 0
-   local.set $6
+   local.set $7
    local.get $3
+   local.set $8
+   local.get $8
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $8
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
    call $~lib/rt/pure/__release
-   local.get $6
+   local.get $5
+   call $~lib/rt/pure/__release
+   local.get $7
   end
+  local.set $5
+  local.get $1
+  local.set $6
+  local.get $6
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $6
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $5
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Uint64Array,u64>~anonymous|1 (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Uint64Array,u64>~anonymous|1~nonClosure (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -14592,7 +20197,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Float32Array,f32>~anonymous|0 (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Float32Array,f32>~anonymous|0~nonClosure (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -14613,62 +20218,175 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  local.get $1
+  local.set $2
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
   block $~lib/typedarray/SOME<~lib/typedarray/Float32Array,f32>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
-   local.set $3
-   local.get $1
-   local.set $2
-   local.get $3
-   i32.load offset=4
-   local.set $4
-   i32.const 0
    local.set $5
-   local.get $3
-   call $~lib/typedarray/Float32Array#get:length
+   local.get $1
+   local.set $4
+   local.get $4
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $4
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
+   call $~lib/rt/pure/__retain
+   drop
+   local.get $4
+   local.set $3
+   local.get $5
+   i32.load offset=4
    local.set $6
+   i32.const 0
+   local.set $7
+   local.get $5
+   call $~lib/typedarray/Float32Array#get:length
+   local.set $8
    loop $for-loop|0
-    local.get $5
-    local.get $6
-    i32.lt_s
-    local.set $7
     local.get $7
+    local.get $8
+    i32.lt_s
+    local.set $9
+    local.get $9
     if
-     local.get $4
-     local.get $5
-     i32.const 2
-     i32.shl
-     i32.add
-     f32.load
-     local.get $5
      local.get $3
-     i32.const 3
-     global.set $~argumentsLength
-     local.get $2
-     call_indirect (type $f32_i32_i32_=>_i32)
+     local.set $10
+     local.get $10
+     i32.const -2147483648
+     i32.and
+     i32.const -2147483648
+     i32.eq
+     if (result i32)
+      local.get $10
+      i32.const 4
+      i32.shl
+      local.get $6
+      local.get $7
+      i32.const 2
+      i32.shl
+      i32.add
+      f32.load
+      local.get $7
+      local.get $5
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $10
+      i32.const 4
+      i32.shl
+      i32.load
+      call_indirect (type $i32_f32_i32_i32_=>_i32)
+     else
+      local.get $6
+      local.get $7
+      i32.const 2
+      i32.shl
+      i32.add
+      f32.load
+      local.get $7
+      local.get $5
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $10
+      call_indirect (type $f32_i32_i32_=>_i32)
+     end
      if
       i32.const 1
-      local.set $8
+      local.set $12
       local.get $3
+      local.set $11
+      local.get $11
+      i32.const -2147483648
+      i32.and
+      i32.const -2147483648
+      i32.eq
+      if (result i32)
+       local.get $11
+       i32.const 4
+       i32.shl
+      else
+       i32.const 0
+      end
       call $~lib/rt/pure/__release
-      local.get $8
+      local.get $5
+      call $~lib/rt/pure/__release
+      local.get $12
       br $~lib/typedarray/SOME<~lib/typedarray/Float32Array,f32>|inlined.0
      end
-     local.get $5
+     local.get $7
      i32.const 1
      i32.add
-     local.set $5
+     local.set $7
      br $for-loop|0
     end
    end
    i32.const 0
-   local.set $6
+   local.set $7
    local.get $3
+   local.set $8
+   local.get $8
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $8
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
    call $~lib/rt/pure/__release
-   local.get $6
+   local.get $5
+   call $~lib/rt/pure/__release
+   local.get $7
   end
+  local.set $5
+  local.get $1
+  local.set $6
+  local.get $6
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $6
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $5
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Float32Array,f32>~anonymous|1 (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Float32Array,f32>~anonymous|1~nonClosure (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -14740,7 +20458,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Float64Array,f64>~anonymous|0 (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Float64Array,f64>~anonymous|0~nonClosure (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -14761,62 +20479,175 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  local.get $1
+  local.set $2
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
   block $~lib/typedarray/SOME<~lib/typedarray/Float64Array,f64>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
-   local.set $3
-   local.get $1
-   local.set $2
-   local.get $3
-   i32.load offset=4
-   local.set $4
-   i32.const 0
    local.set $5
-   local.get $3
-   call $~lib/typedarray/Float64Array#get:length
+   local.get $1
+   local.set $4
+   local.get $4
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $4
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
+   call $~lib/rt/pure/__retain
+   drop
+   local.get $4
+   local.set $3
+   local.get $5
+   i32.load offset=4
    local.set $6
+   i32.const 0
+   local.set $7
+   local.get $5
+   call $~lib/typedarray/Float64Array#get:length
+   local.set $8
    loop $for-loop|0
-    local.get $5
-    local.get $6
-    i32.lt_s
-    local.set $7
     local.get $7
+    local.get $8
+    i32.lt_s
+    local.set $9
+    local.get $9
     if
-     local.get $4
-     local.get $5
-     i32.const 3
-     i32.shl
-     i32.add
-     f64.load
-     local.get $5
      local.get $3
-     i32.const 3
-     global.set $~argumentsLength
-     local.get $2
-     call_indirect (type $f64_i32_i32_=>_i32)
+     local.set $10
+     local.get $10
+     i32.const -2147483648
+     i32.and
+     i32.const -2147483648
+     i32.eq
+     if (result i32)
+      local.get $10
+      i32.const 4
+      i32.shl
+      local.get $6
+      local.get $7
+      i32.const 3
+      i32.shl
+      i32.add
+      f64.load
+      local.get $7
+      local.get $5
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $10
+      i32.const 4
+      i32.shl
+      i32.load
+      call_indirect (type $i32_f64_i32_i32_=>_i32)
+     else
+      local.get $6
+      local.get $7
+      i32.const 3
+      i32.shl
+      i32.add
+      f64.load
+      local.get $7
+      local.get $5
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $10
+      call_indirect (type $f64_i32_i32_=>_i32)
+     end
      if
       i32.const 1
-      local.set $8
+      local.set $12
       local.get $3
+      local.set $11
+      local.get $11
+      i32.const -2147483648
+      i32.and
+      i32.const -2147483648
+      i32.eq
+      if (result i32)
+       local.get $11
+       i32.const 4
+       i32.shl
+      else
+       i32.const 0
+      end
       call $~lib/rt/pure/__release
-      local.get $8
+      local.get $5
+      call $~lib/rt/pure/__release
+      local.get $12
       br $~lib/typedarray/SOME<~lib/typedarray/Float64Array,f64>|inlined.0
      end
-     local.get $5
+     local.get $7
      i32.const 1
      i32.add
-     local.set $5
+     local.set $7
      br $for-loop|0
     end
    end
    i32.const 0
-   local.set $6
+   local.set $7
    local.get $3
+   local.set $8
+   local.get $8
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $8
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
    call $~lib/rt/pure/__release
-   local.get $6
+   local.get $5
+   call $~lib/rt/pure/__release
+   local.get $7
   end
+  local.set $5
+  local.get $1
+  local.set $6
+  local.get $6
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $6
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $5
  )
- (func $std/typedarray/testArraySome<~lib/typedarray/Float64Array,f64>~anonymous|1 (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Float64Array,f64>~anonymous|1~nonClosure (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -14888,7 +20719,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int8Array,i8>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int8Array,i8>~anonymous|0~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -14913,62 +20744,175 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  local.get $1
+  local.set $2
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
   block $~lib/typedarray/FIND_INDEX<~lib/typedarray/Int8Array,i8>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
-   local.set $3
-   local.get $1
-   local.set $2
-   local.get $3
-   i32.load offset=4
-   local.set $4
-   i32.const 0
    local.set $5
-   local.get $3
-   call $~lib/typedarray/Int8Array#get:length
+   local.get $1
+   local.set $4
+   local.get $4
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $4
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
+   call $~lib/rt/pure/__retain
+   drop
+   local.get $4
+   local.set $3
+   local.get $5
+   i32.load offset=4
    local.set $6
+   i32.const 0
+   local.set $7
+   local.get $5
+   call $~lib/typedarray/Int8Array#get:length
+   local.set $8
    loop $for-loop|0
-    local.get $5
-    local.get $6
-    i32.lt_s
-    local.set $7
     local.get $7
+    local.get $8
+    i32.lt_s
+    local.set $9
+    local.get $9
     if
-     local.get $4
-     local.get $5
-     i32.const 0
-     i32.shl
-     i32.add
-     i32.load8_s
-     local.get $5
      local.get $3
-     i32.const 3
-     global.set $~argumentsLength
-     local.get $2
-     call_indirect (type $i32_i32_i32_=>_i32)
-     if
+     local.set $10
+     local.get $10
+     i32.const -2147483648
+     i32.and
+     i32.const -2147483648
+     i32.eq
+     if (result i32)
+      local.get $10
+      i32.const 4
+      i32.shl
+      local.get $6
+      local.get $7
+      i32.const 0
+      i32.shl
+      i32.add
+      i32.load8_s
+      local.get $7
       local.get $5
-      local.set $8
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $10
+      i32.const 4
+      i32.shl
+      i32.load
+      call_indirect (type $i32_i32_i32_i32_=>_i32)
+     else
+      local.get $6
+      local.get $7
+      i32.const 0
+      i32.shl
+      i32.add
+      i32.load8_s
+      local.get $7
+      local.get $5
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $10
+      call_indirect (type $i32_i32_i32_=>_i32)
+     end
+     if
+      local.get $7
+      local.set $12
       local.get $3
+      local.set $11
+      local.get $11
+      i32.const -2147483648
+      i32.and
+      i32.const -2147483648
+      i32.eq
+      if (result i32)
+       local.get $11
+       i32.const 4
+       i32.shl
+      else
+       i32.const 0
+      end
       call $~lib/rt/pure/__release
-      local.get $8
+      local.get $5
+      call $~lib/rt/pure/__release
+      local.get $12
       br $~lib/typedarray/FIND_INDEX<~lib/typedarray/Int8Array,i8>|inlined.0
      end
-     local.get $5
+     local.get $7
      i32.const 1
      i32.add
-     local.set $5
+     local.set $7
      br $for-loop|0
     end
    end
    i32.const -1
-   local.set $6
+   local.set $7
    local.get $3
+   local.set $8
+   local.get $8
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $8
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
    call $~lib/rt/pure/__release
-   local.get $6
+   local.get $5
+   call $~lib/rt/pure/__release
+   local.get $7
   end
+  local.set $5
+  local.get $1
+  local.set $6
+  local.get $6
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $6
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $5
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int8Array,i8>~anonymous|1 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int8Array,i8>~anonymous|1~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -15045,7 +20989,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint8Array,u8>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint8Array,u8>~anonymous|0~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -15068,62 +21012,175 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  local.get $1
+  local.set $2
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
   block $~lib/typedarray/FIND_INDEX<~lib/typedarray/Uint8Array,u8>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
-   local.set $3
-   local.get $1
-   local.set $2
-   local.get $3
-   i32.load offset=4
-   local.set $4
-   i32.const 0
    local.set $5
-   local.get $3
-   call $~lib/typedarray/Uint8Array#get:length
+   local.get $1
+   local.set $4
+   local.get $4
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $4
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
+   call $~lib/rt/pure/__retain
+   drop
+   local.get $4
+   local.set $3
+   local.get $5
+   i32.load offset=4
    local.set $6
+   i32.const 0
+   local.set $7
+   local.get $5
+   call $~lib/typedarray/Uint8Array#get:length
+   local.set $8
    loop $for-loop|0
-    local.get $5
-    local.get $6
-    i32.lt_s
-    local.set $7
     local.get $7
+    local.get $8
+    i32.lt_s
+    local.set $9
+    local.get $9
     if
-     local.get $4
-     local.get $5
-     i32.const 0
-     i32.shl
-     i32.add
-     i32.load8_u
-     local.get $5
      local.get $3
-     i32.const 3
-     global.set $~argumentsLength
-     local.get $2
-     call_indirect (type $i32_i32_i32_=>_i32)
-     if
+     local.set $10
+     local.get $10
+     i32.const -2147483648
+     i32.and
+     i32.const -2147483648
+     i32.eq
+     if (result i32)
+      local.get $10
+      i32.const 4
+      i32.shl
+      local.get $6
+      local.get $7
+      i32.const 0
+      i32.shl
+      i32.add
+      i32.load8_u
+      local.get $7
       local.get $5
-      local.set $8
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $10
+      i32.const 4
+      i32.shl
+      i32.load
+      call_indirect (type $i32_i32_i32_i32_=>_i32)
+     else
+      local.get $6
+      local.get $7
+      i32.const 0
+      i32.shl
+      i32.add
+      i32.load8_u
+      local.get $7
+      local.get $5
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $10
+      call_indirect (type $i32_i32_i32_=>_i32)
+     end
+     if
+      local.get $7
+      local.set $12
       local.get $3
+      local.set $11
+      local.get $11
+      i32.const -2147483648
+      i32.and
+      i32.const -2147483648
+      i32.eq
+      if (result i32)
+       local.get $11
+       i32.const 4
+       i32.shl
+      else
+       i32.const 0
+      end
       call $~lib/rt/pure/__release
-      local.get $8
+      local.get $5
+      call $~lib/rt/pure/__release
+      local.get $12
       br $~lib/typedarray/FIND_INDEX<~lib/typedarray/Uint8Array,u8>|inlined.0
      end
-     local.get $5
+     local.get $7
      i32.const 1
      i32.add
-     local.set $5
+     local.set $7
      br $for-loop|0
     end
    end
    i32.const -1
-   local.set $6
+   local.set $7
    local.get $3
+   local.set $8
+   local.get $8
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $8
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
    call $~lib/rt/pure/__release
-   local.get $6
+   local.get $5
+   call $~lib/rt/pure/__release
+   local.get $7
   end
+  local.set $5
+  local.get $1
+  local.set $6
+  local.get $6
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $6
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $5
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint8Array,u8>~anonymous|1 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint8Array,u8>~anonymous|1~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -15198,7 +21255,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|0~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -15221,62 +21278,175 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  local.get $1
+  local.set $2
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
   block $~lib/typedarray/FIND_INDEX<~lib/typedarray/Uint8ClampedArray,u8>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
-   local.set $3
-   local.get $1
-   local.set $2
-   local.get $3
-   i32.load offset=4
-   local.set $4
-   i32.const 0
    local.set $5
-   local.get $3
-   call $~lib/typedarray/Uint8ClampedArray#get:length
+   local.get $1
+   local.set $4
+   local.get $4
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $4
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
+   call $~lib/rt/pure/__retain
+   drop
+   local.get $4
+   local.set $3
+   local.get $5
+   i32.load offset=4
    local.set $6
+   i32.const 0
+   local.set $7
+   local.get $5
+   call $~lib/typedarray/Uint8ClampedArray#get:length
+   local.set $8
    loop $for-loop|0
-    local.get $5
-    local.get $6
-    i32.lt_s
-    local.set $7
     local.get $7
+    local.get $8
+    i32.lt_s
+    local.set $9
+    local.get $9
     if
-     local.get $4
-     local.get $5
-     i32.const 0
-     i32.shl
-     i32.add
-     i32.load8_u
-     local.get $5
      local.get $3
-     i32.const 3
-     global.set $~argumentsLength
-     local.get $2
-     call_indirect (type $i32_i32_i32_=>_i32)
-     if
+     local.set $10
+     local.get $10
+     i32.const -2147483648
+     i32.and
+     i32.const -2147483648
+     i32.eq
+     if (result i32)
+      local.get $10
+      i32.const 4
+      i32.shl
+      local.get $6
+      local.get $7
+      i32.const 0
+      i32.shl
+      i32.add
+      i32.load8_u
+      local.get $7
       local.get $5
-      local.set $8
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $10
+      i32.const 4
+      i32.shl
+      i32.load
+      call_indirect (type $i32_i32_i32_i32_=>_i32)
+     else
+      local.get $6
+      local.get $7
+      i32.const 0
+      i32.shl
+      i32.add
+      i32.load8_u
+      local.get $7
+      local.get $5
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $10
+      call_indirect (type $i32_i32_i32_=>_i32)
+     end
+     if
+      local.get $7
+      local.set $12
       local.get $3
+      local.set $11
+      local.get $11
+      i32.const -2147483648
+      i32.and
+      i32.const -2147483648
+      i32.eq
+      if (result i32)
+       local.get $11
+       i32.const 4
+       i32.shl
+      else
+       i32.const 0
+      end
       call $~lib/rt/pure/__release
-      local.get $8
+      local.get $5
+      call $~lib/rt/pure/__release
+      local.get $12
       br $~lib/typedarray/FIND_INDEX<~lib/typedarray/Uint8ClampedArray,u8>|inlined.0
      end
-     local.get $5
+     local.get $7
      i32.const 1
      i32.add
-     local.set $5
+     local.set $7
      br $for-loop|0
     end
    end
    i32.const -1
-   local.set $6
+   local.set $7
    local.get $3
+   local.set $8
+   local.get $8
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $8
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
    call $~lib/rt/pure/__release
-   local.get $6
+   local.get $5
+   call $~lib/rt/pure/__release
+   local.get $7
   end
+  local.set $5
+  local.get $1
+  local.set $6
+  local.get $6
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $6
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $5
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|1 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|1~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -15351,7 +21521,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int16Array,i16>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int16Array,i16>~anonymous|0~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -15376,62 +21546,175 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  local.get $1
+  local.set $2
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
   block $~lib/typedarray/FIND_INDEX<~lib/typedarray/Int16Array,i16>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
-   local.set $3
-   local.get $1
-   local.set $2
-   local.get $3
-   i32.load offset=4
-   local.set $4
-   i32.const 0
    local.set $5
-   local.get $3
-   call $~lib/typedarray/Int16Array#get:length
+   local.get $1
+   local.set $4
+   local.get $4
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $4
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
+   call $~lib/rt/pure/__retain
+   drop
+   local.get $4
+   local.set $3
+   local.get $5
+   i32.load offset=4
    local.set $6
+   i32.const 0
+   local.set $7
+   local.get $5
+   call $~lib/typedarray/Int16Array#get:length
+   local.set $8
    loop $for-loop|0
-    local.get $5
-    local.get $6
-    i32.lt_s
-    local.set $7
     local.get $7
+    local.get $8
+    i32.lt_s
+    local.set $9
+    local.get $9
     if
-     local.get $4
-     local.get $5
-     i32.const 1
-     i32.shl
-     i32.add
-     i32.load16_s
-     local.get $5
      local.get $3
-     i32.const 3
-     global.set $~argumentsLength
-     local.get $2
-     call_indirect (type $i32_i32_i32_=>_i32)
-     if
+     local.set $10
+     local.get $10
+     i32.const -2147483648
+     i32.and
+     i32.const -2147483648
+     i32.eq
+     if (result i32)
+      local.get $10
+      i32.const 4
+      i32.shl
+      local.get $6
+      local.get $7
+      i32.const 1
+      i32.shl
+      i32.add
+      i32.load16_s
+      local.get $7
       local.get $5
-      local.set $8
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $10
+      i32.const 4
+      i32.shl
+      i32.load
+      call_indirect (type $i32_i32_i32_i32_=>_i32)
+     else
+      local.get $6
+      local.get $7
+      i32.const 1
+      i32.shl
+      i32.add
+      i32.load16_s
+      local.get $7
+      local.get $5
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $10
+      call_indirect (type $i32_i32_i32_=>_i32)
+     end
+     if
+      local.get $7
+      local.set $12
       local.get $3
+      local.set $11
+      local.get $11
+      i32.const -2147483648
+      i32.and
+      i32.const -2147483648
+      i32.eq
+      if (result i32)
+       local.get $11
+       i32.const 4
+       i32.shl
+      else
+       i32.const 0
+      end
       call $~lib/rt/pure/__release
-      local.get $8
+      local.get $5
+      call $~lib/rt/pure/__release
+      local.get $12
       br $~lib/typedarray/FIND_INDEX<~lib/typedarray/Int16Array,i16>|inlined.0
      end
-     local.get $5
+     local.get $7
      i32.const 1
      i32.add
-     local.set $5
+     local.set $7
      br $for-loop|0
     end
    end
    i32.const -1
-   local.set $6
+   local.set $7
    local.get $3
+   local.set $8
+   local.get $8
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $8
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
    call $~lib/rt/pure/__release
-   local.get $6
+   local.get $5
+   call $~lib/rt/pure/__release
+   local.get $7
   end
+  local.set $5
+  local.get $1
+  local.set $6
+  local.get $6
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $6
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $5
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int16Array,i16>~anonymous|1 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int16Array,i16>~anonymous|1~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -15508,7 +21791,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint16Array,u16>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint16Array,u16>~anonymous|0~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -15531,62 +21814,175 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  local.get $1
+  local.set $2
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
   block $~lib/typedarray/FIND_INDEX<~lib/typedarray/Uint16Array,u16>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
-   local.set $3
-   local.get $1
-   local.set $2
-   local.get $3
-   i32.load offset=4
-   local.set $4
-   i32.const 0
    local.set $5
-   local.get $3
-   call $~lib/typedarray/Uint16Array#get:length
+   local.get $1
+   local.set $4
+   local.get $4
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $4
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
+   call $~lib/rt/pure/__retain
+   drop
+   local.get $4
+   local.set $3
+   local.get $5
+   i32.load offset=4
    local.set $6
+   i32.const 0
+   local.set $7
+   local.get $5
+   call $~lib/typedarray/Uint16Array#get:length
+   local.set $8
    loop $for-loop|0
-    local.get $5
-    local.get $6
-    i32.lt_s
-    local.set $7
     local.get $7
+    local.get $8
+    i32.lt_s
+    local.set $9
+    local.get $9
     if
-     local.get $4
-     local.get $5
-     i32.const 1
-     i32.shl
-     i32.add
-     i32.load16_u
-     local.get $5
      local.get $3
-     i32.const 3
-     global.set $~argumentsLength
-     local.get $2
-     call_indirect (type $i32_i32_i32_=>_i32)
-     if
+     local.set $10
+     local.get $10
+     i32.const -2147483648
+     i32.and
+     i32.const -2147483648
+     i32.eq
+     if (result i32)
+      local.get $10
+      i32.const 4
+      i32.shl
+      local.get $6
+      local.get $7
+      i32.const 1
+      i32.shl
+      i32.add
+      i32.load16_u
+      local.get $7
       local.get $5
-      local.set $8
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $10
+      i32.const 4
+      i32.shl
+      i32.load
+      call_indirect (type $i32_i32_i32_i32_=>_i32)
+     else
+      local.get $6
+      local.get $7
+      i32.const 1
+      i32.shl
+      i32.add
+      i32.load16_u
+      local.get $7
+      local.get $5
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $10
+      call_indirect (type $i32_i32_i32_=>_i32)
+     end
+     if
+      local.get $7
+      local.set $12
       local.get $3
+      local.set $11
+      local.get $11
+      i32.const -2147483648
+      i32.and
+      i32.const -2147483648
+      i32.eq
+      if (result i32)
+       local.get $11
+       i32.const 4
+       i32.shl
+      else
+       i32.const 0
+      end
       call $~lib/rt/pure/__release
-      local.get $8
+      local.get $5
+      call $~lib/rt/pure/__release
+      local.get $12
       br $~lib/typedarray/FIND_INDEX<~lib/typedarray/Uint16Array,u16>|inlined.0
      end
-     local.get $5
+     local.get $7
      i32.const 1
      i32.add
-     local.set $5
+     local.set $7
      br $for-loop|0
     end
    end
    i32.const -1
-   local.set $6
+   local.set $7
    local.get $3
+   local.set $8
+   local.get $8
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $8
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
    call $~lib/rt/pure/__release
-   local.get $6
+   local.get $5
+   call $~lib/rt/pure/__release
+   local.get $7
   end
+  local.set $5
+  local.get $1
+  local.set $6
+  local.get $6
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $6
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $5
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint16Array,u16>~anonymous|1 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint16Array,u16>~anonymous|1~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -15661,7 +22057,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int32Array,i32>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int32Array,i32>~anonymous|0~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -15682,62 +22078,175 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  local.get $1
+  local.set $2
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
   block $~lib/typedarray/FIND_INDEX<~lib/typedarray/Int32Array,i32>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
-   local.set $3
-   local.get $1
-   local.set $2
-   local.get $3
-   i32.load offset=4
-   local.set $4
-   i32.const 0
    local.set $5
-   local.get $3
-   call $~lib/typedarray/Int32Array#get:length
+   local.get $1
+   local.set $4
+   local.get $4
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $4
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
+   call $~lib/rt/pure/__retain
+   drop
+   local.get $4
+   local.set $3
+   local.get $5
+   i32.load offset=4
    local.set $6
+   i32.const 0
+   local.set $7
+   local.get $5
+   call $~lib/typedarray/Int32Array#get:length
+   local.set $8
    loop $for-loop|0
-    local.get $5
-    local.get $6
-    i32.lt_s
-    local.set $7
     local.get $7
+    local.get $8
+    i32.lt_s
+    local.set $9
+    local.get $9
     if
-     local.get $4
-     local.get $5
-     i32.const 2
-     i32.shl
-     i32.add
-     i32.load
-     local.get $5
      local.get $3
-     i32.const 3
-     global.set $~argumentsLength
-     local.get $2
-     call_indirect (type $i32_i32_i32_=>_i32)
-     if
+     local.set $10
+     local.get $10
+     i32.const -2147483648
+     i32.and
+     i32.const -2147483648
+     i32.eq
+     if (result i32)
+      local.get $10
+      i32.const 4
+      i32.shl
+      local.get $6
+      local.get $7
+      i32.const 2
+      i32.shl
+      i32.add
+      i32.load
+      local.get $7
       local.get $5
-      local.set $8
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $10
+      i32.const 4
+      i32.shl
+      i32.load
+      call_indirect (type $i32_i32_i32_i32_=>_i32)
+     else
+      local.get $6
+      local.get $7
+      i32.const 2
+      i32.shl
+      i32.add
+      i32.load
+      local.get $7
+      local.get $5
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $10
+      call_indirect (type $i32_i32_i32_=>_i32)
+     end
+     if
+      local.get $7
+      local.set $12
       local.get $3
+      local.set $11
+      local.get $11
+      i32.const -2147483648
+      i32.and
+      i32.const -2147483648
+      i32.eq
+      if (result i32)
+       local.get $11
+       i32.const 4
+       i32.shl
+      else
+       i32.const 0
+      end
       call $~lib/rt/pure/__release
-      local.get $8
+      local.get $5
+      call $~lib/rt/pure/__release
+      local.get $12
       br $~lib/typedarray/FIND_INDEX<~lib/typedarray/Int32Array,i32>|inlined.0
      end
-     local.get $5
+     local.get $7
      i32.const 1
      i32.add
-     local.set $5
+     local.set $7
      br $for-loop|0
     end
    end
    i32.const -1
-   local.set $6
+   local.set $7
    local.get $3
+   local.set $8
+   local.get $8
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $8
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
    call $~lib/rt/pure/__release
-   local.get $6
+   local.get $5
+   call $~lib/rt/pure/__release
+   local.get $7
   end
+  local.set $5
+  local.get $1
+  local.set $6
+  local.get $6
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $6
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $5
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int32Array,i32>~anonymous|1 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int32Array,i32>~anonymous|1~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -15810,7 +22319,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint32Array,u32>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint32Array,u32>~anonymous|0~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -15831,62 +22340,175 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  local.get $1
+  local.set $2
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
   block $~lib/typedarray/FIND_INDEX<~lib/typedarray/Uint32Array,u32>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
-   local.set $3
-   local.get $1
-   local.set $2
-   local.get $3
-   i32.load offset=4
-   local.set $4
-   i32.const 0
    local.set $5
-   local.get $3
-   call $~lib/typedarray/Uint32Array#get:length
+   local.get $1
+   local.set $4
+   local.get $4
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $4
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
+   call $~lib/rt/pure/__retain
+   drop
+   local.get $4
+   local.set $3
+   local.get $5
+   i32.load offset=4
    local.set $6
+   i32.const 0
+   local.set $7
+   local.get $5
+   call $~lib/typedarray/Uint32Array#get:length
+   local.set $8
    loop $for-loop|0
-    local.get $5
-    local.get $6
-    i32.lt_s
-    local.set $7
     local.get $7
+    local.get $8
+    i32.lt_s
+    local.set $9
+    local.get $9
     if
-     local.get $4
-     local.get $5
-     i32.const 2
-     i32.shl
-     i32.add
-     i32.load
-     local.get $5
      local.get $3
-     i32.const 3
-     global.set $~argumentsLength
-     local.get $2
-     call_indirect (type $i32_i32_i32_=>_i32)
-     if
+     local.set $10
+     local.get $10
+     i32.const -2147483648
+     i32.and
+     i32.const -2147483648
+     i32.eq
+     if (result i32)
+      local.get $10
+      i32.const 4
+      i32.shl
+      local.get $6
+      local.get $7
+      i32.const 2
+      i32.shl
+      i32.add
+      i32.load
+      local.get $7
       local.get $5
-      local.set $8
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $10
+      i32.const 4
+      i32.shl
+      i32.load
+      call_indirect (type $i32_i32_i32_i32_=>_i32)
+     else
+      local.get $6
+      local.get $7
+      i32.const 2
+      i32.shl
+      i32.add
+      i32.load
+      local.get $7
+      local.get $5
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $10
+      call_indirect (type $i32_i32_i32_=>_i32)
+     end
+     if
+      local.get $7
+      local.set $12
       local.get $3
+      local.set $11
+      local.get $11
+      i32.const -2147483648
+      i32.and
+      i32.const -2147483648
+      i32.eq
+      if (result i32)
+       local.get $11
+       i32.const 4
+       i32.shl
+      else
+       i32.const 0
+      end
       call $~lib/rt/pure/__release
-      local.get $8
+      local.get $5
+      call $~lib/rt/pure/__release
+      local.get $12
       br $~lib/typedarray/FIND_INDEX<~lib/typedarray/Uint32Array,u32>|inlined.0
      end
-     local.get $5
+     local.get $7
      i32.const 1
      i32.add
-     local.set $5
+     local.set $7
      br $for-loop|0
     end
    end
    i32.const -1
-   local.set $6
+   local.set $7
    local.get $3
+   local.set $8
+   local.get $8
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $8
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
    call $~lib/rt/pure/__release
-   local.get $6
+   local.get $5
+   call $~lib/rt/pure/__release
+   local.get $7
   end
+  local.set $5
+  local.get $1
+  local.set $6
+  local.get $6
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $6
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $5
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint32Array,u32>~anonymous|1 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint32Array,u32>~anonymous|1~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -15959,7 +22581,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int64Array,i64>~anonymous|0 (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int64Array,i64>~anonymous|0~nonClosure (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -15980,62 +22602,175 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  local.get $1
+  local.set $2
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
   block $~lib/typedarray/FIND_INDEX<~lib/typedarray/Int64Array,i64>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
-   local.set $3
-   local.get $1
-   local.set $2
-   local.get $3
-   i32.load offset=4
-   local.set $4
-   i32.const 0
    local.set $5
-   local.get $3
-   call $~lib/typedarray/Int64Array#get:length
+   local.get $1
+   local.set $4
+   local.get $4
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $4
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
+   call $~lib/rt/pure/__retain
+   drop
+   local.get $4
+   local.set $3
+   local.get $5
+   i32.load offset=4
    local.set $6
+   i32.const 0
+   local.set $7
+   local.get $5
+   call $~lib/typedarray/Int64Array#get:length
+   local.set $8
    loop $for-loop|0
-    local.get $5
-    local.get $6
-    i32.lt_s
-    local.set $7
     local.get $7
+    local.get $8
+    i32.lt_s
+    local.set $9
+    local.get $9
     if
-     local.get $4
-     local.get $5
-     i32.const 3
-     i32.shl
-     i32.add
-     i64.load
-     local.get $5
      local.get $3
-     i32.const 3
-     global.set $~argumentsLength
-     local.get $2
-     call_indirect (type $i64_i32_i32_=>_i32)
-     if
+     local.set $10
+     local.get $10
+     i32.const -2147483648
+     i32.and
+     i32.const -2147483648
+     i32.eq
+     if (result i32)
+      local.get $10
+      i32.const 4
+      i32.shl
+      local.get $6
+      local.get $7
+      i32.const 3
+      i32.shl
+      i32.add
+      i64.load
+      local.get $7
       local.get $5
-      local.set $8
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $10
+      i32.const 4
+      i32.shl
+      i32.load
+      call_indirect (type $i32_i64_i32_i32_=>_i32)
+     else
+      local.get $6
+      local.get $7
+      i32.const 3
+      i32.shl
+      i32.add
+      i64.load
+      local.get $7
+      local.get $5
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $10
+      call_indirect (type $i64_i32_i32_=>_i32)
+     end
+     if
+      local.get $7
+      local.set $12
       local.get $3
+      local.set $11
+      local.get $11
+      i32.const -2147483648
+      i32.and
+      i32.const -2147483648
+      i32.eq
+      if (result i32)
+       local.get $11
+       i32.const 4
+       i32.shl
+      else
+       i32.const 0
+      end
       call $~lib/rt/pure/__release
-      local.get $8
+      local.get $5
+      call $~lib/rt/pure/__release
+      local.get $12
       br $~lib/typedarray/FIND_INDEX<~lib/typedarray/Int64Array,i64>|inlined.0
      end
-     local.get $5
+     local.get $7
      i32.const 1
      i32.add
-     local.set $5
+     local.set $7
      br $for-loop|0
     end
    end
    i32.const -1
-   local.set $6
+   local.set $7
    local.get $3
+   local.set $8
+   local.get $8
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $8
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
    call $~lib/rt/pure/__release
-   local.get $6
+   local.get $5
+   call $~lib/rt/pure/__release
+   local.get $7
   end
+  local.set $5
+  local.get $1
+  local.set $6
+  local.get $6
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $6
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $5
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int64Array,i64>~anonymous|1 (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int64Array,i64>~anonymous|1~nonClosure (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -16108,7 +22843,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint64Array,u64>~anonymous|0 (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint64Array,u64>~anonymous|0~nonClosure (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -16129,62 +22864,175 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  local.get $1
+  local.set $2
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
   block $~lib/typedarray/FIND_INDEX<~lib/typedarray/Uint64Array,u64>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
-   local.set $3
-   local.get $1
-   local.set $2
-   local.get $3
-   i32.load offset=4
-   local.set $4
-   i32.const 0
    local.set $5
-   local.get $3
-   call $~lib/typedarray/Uint64Array#get:length
+   local.get $1
+   local.set $4
+   local.get $4
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $4
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
+   call $~lib/rt/pure/__retain
+   drop
+   local.get $4
+   local.set $3
+   local.get $5
+   i32.load offset=4
    local.set $6
+   i32.const 0
+   local.set $7
+   local.get $5
+   call $~lib/typedarray/Uint64Array#get:length
+   local.set $8
    loop $for-loop|0
-    local.get $5
-    local.get $6
-    i32.lt_s
-    local.set $7
     local.get $7
+    local.get $8
+    i32.lt_s
+    local.set $9
+    local.get $9
     if
-     local.get $4
-     local.get $5
-     i32.const 3
-     i32.shl
-     i32.add
-     i64.load
-     local.get $5
      local.get $3
-     i32.const 3
-     global.set $~argumentsLength
-     local.get $2
-     call_indirect (type $i64_i32_i32_=>_i32)
-     if
+     local.set $10
+     local.get $10
+     i32.const -2147483648
+     i32.and
+     i32.const -2147483648
+     i32.eq
+     if (result i32)
+      local.get $10
+      i32.const 4
+      i32.shl
+      local.get $6
+      local.get $7
+      i32.const 3
+      i32.shl
+      i32.add
+      i64.load
+      local.get $7
       local.get $5
-      local.set $8
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $10
+      i32.const 4
+      i32.shl
+      i32.load
+      call_indirect (type $i32_i64_i32_i32_=>_i32)
+     else
+      local.get $6
+      local.get $7
+      i32.const 3
+      i32.shl
+      i32.add
+      i64.load
+      local.get $7
+      local.get $5
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $10
+      call_indirect (type $i64_i32_i32_=>_i32)
+     end
+     if
+      local.get $7
+      local.set $12
       local.get $3
+      local.set $11
+      local.get $11
+      i32.const -2147483648
+      i32.and
+      i32.const -2147483648
+      i32.eq
+      if (result i32)
+       local.get $11
+       i32.const 4
+       i32.shl
+      else
+       i32.const 0
+      end
       call $~lib/rt/pure/__release
-      local.get $8
+      local.get $5
+      call $~lib/rt/pure/__release
+      local.get $12
       br $~lib/typedarray/FIND_INDEX<~lib/typedarray/Uint64Array,u64>|inlined.0
      end
-     local.get $5
+     local.get $7
      i32.const 1
      i32.add
-     local.set $5
+     local.set $7
      br $for-loop|0
     end
    end
    i32.const -1
-   local.set $6
+   local.set $7
    local.get $3
+   local.set $8
+   local.get $8
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $8
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
    call $~lib/rt/pure/__release
-   local.get $6
+   local.get $5
+   call $~lib/rt/pure/__release
+   local.get $7
   end
+  local.set $5
+  local.get $1
+  local.set $6
+  local.get $6
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $6
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $5
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint64Array,u64>~anonymous|1 (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint64Array,u64>~anonymous|1~nonClosure (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -16257,7 +23105,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Float32Array,f32>~anonymous|0 (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Float32Array,f32>~anonymous|0~nonClosure (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -16278,62 +23126,175 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  local.get $1
+  local.set $2
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
   block $~lib/typedarray/FIND_INDEX<~lib/typedarray/Float32Array,f32>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
-   local.set $3
-   local.get $1
-   local.set $2
-   local.get $3
-   i32.load offset=4
-   local.set $4
-   i32.const 0
    local.set $5
-   local.get $3
-   call $~lib/typedarray/Float32Array#get:length
+   local.get $1
+   local.set $4
+   local.get $4
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $4
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
+   call $~lib/rt/pure/__retain
+   drop
+   local.get $4
+   local.set $3
+   local.get $5
+   i32.load offset=4
    local.set $6
+   i32.const 0
+   local.set $7
+   local.get $5
+   call $~lib/typedarray/Float32Array#get:length
+   local.set $8
    loop $for-loop|0
-    local.get $5
-    local.get $6
-    i32.lt_s
-    local.set $7
     local.get $7
+    local.get $8
+    i32.lt_s
+    local.set $9
+    local.get $9
     if
-     local.get $4
-     local.get $5
-     i32.const 2
-     i32.shl
-     i32.add
-     f32.load
-     local.get $5
      local.get $3
-     i32.const 3
-     global.set $~argumentsLength
-     local.get $2
-     call_indirect (type $f32_i32_i32_=>_i32)
-     if
+     local.set $10
+     local.get $10
+     i32.const -2147483648
+     i32.and
+     i32.const -2147483648
+     i32.eq
+     if (result i32)
+      local.get $10
+      i32.const 4
+      i32.shl
+      local.get $6
+      local.get $7
+      i32.const 2
+      i32.shl
+      i32.add
+      f32.load
+      local.get $7
       local.get $5
-      local.set $8
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $10
+      i32.const 4
+      i32.shl
+      i32.load
+      call_indirect (type $i32_f32_i32_i32_=>_i32)
+     else
+      local.get $6
+      local.get $7
+      i32.const 2
+      i32.shl
+      i32.add
+      f32.load
+      local.get $7
+      local.get $5
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $10
+      call_indirect (type $f32_i32_i32_=>_i32)
+     end
+     if
+      local.get $7
+      local.set $12
       local.get $3
+      local.set $11
+      local.get $11
+      i32.const -2147483648
+      i32.and
+      i32.const -2147483648
+      i32.eq
+      if (result i32)
+       local.get $11
+       i32.const 4
+       i32.shl
+      else
+       i32.const 0
+      end
       call $~lib/rt/pure/__release
-      local.get $8
+      local.get $5
+      call $~lib/rt/pure/__release
+      local.get $12
       br $~lib/typedarray/FIND_INDEX<~lib/typedarray/Float32Array,f32>|inlined.0
      end
-     local.get $5
+     local.get $7
      i32.const 1
      i32.add
-     local.set $5
+     local.set $7
      br $for-loop|0
     end
    end
    i32.const -1
-   local.set $6
+   local.set $7
    local.get $3
+   local.set $8
+   local.get $8
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $8
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
    call $~lib/rt/pure/__release
-   local.get $6
+   local.get $5
+   call $~lib/rt/pure/__release
+   local.get $7
   end
+  local.set $5
+  local.get $1
+  local.set $6
+  local.get $6
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $6
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $5
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Float32Array,f32>~anonymous|1 (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Float32Array,f32>~anonymous|1~nonClosure (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -16406,7 +23367,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Float64Array,f64>~anonymous|0 (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Float64Array,f64>~anonymous|0~nonClosure (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -16427,62 +23388,175 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  local.get $1
+  local.set $2
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
   block $~lib/typedarray/FIND_INDEX<~lib/typedarray/Float64Array,f64>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
-   local.set $3
-   local.get $1
-   local.set $2
-   local.get $3
-   i32.load offset=4
-   local.set $4
-   i32.const 0
    local.set $5
-   local.get $3
-   call $~lib/typedarray/Float64Array#get:length
+   local.get $1
+   local.set $4
+   local.get $4
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $4
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
+   call $~lib/rt/pure/__retain
+   drop
+   local.get $4
+   local.set $3
+   local.get $5
+   i32.load offset=4
    local.set $6
+   i32.const 0
+   local.set $7
+   local.get $5
+   call $~lib/typedarray/Float64Array#get:length
+   local.set $8
    loop $for-loop|0
-    local.get $5
-    local.get $6
-    i32.lt_s
-    local.set $7
     local.get $7
+    local.get $8
+    i32.lt_s
+    local.set $9
+    local.get $9
     if
-     local.get $4
-     local.get $5
-     i32.const 3
-     i32.shl
-     i32.add
-     f64.load
-     local.get $5
      local.get $3
-     i32.const 3
-     global.set $~argumentsLength
-     local.get $2
-     call_indirect (type $f64_i32_i32_=>_i32)
-     if
+     local.set $10
+     local.get $10
+     i32.const -2147483648
+     i32.and
+     i32.const -2147483648
+     i32.eq
+     if (result i32)
+      local.get $10
+      i32.const 4
+      i32.shl
+      local.get $6
+      local.get $7
+      i32.const 3
+      i32.shl
+      i32.add
+      f64.load
+      local.get $7
       local.get $5
-      local.set $8
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $10
+      i32.const 4
+      i32.shl
+      i32.load
+      call_indirect (type $i32_f64_i32_i32_=>_i32)
+     else
+      local.get $6
+      local.get $7
+      i32.const 3
+      i32.shl
+      i32.add
+      f64.load
+      local.get $7
+      local.get $5
+      i32.const 3
+      global.set $~argumentsLength
+      local.get $10
+      call_indirect (type $f64_i32_i32_=>_i32)
+     end
+     if
+      local.get $7
+      local.set $12
       local.get $3
+      local.set $11
+      local.get $11
+      i32.const -2147483648
+      i32.and
+      i32.const -2147483648
+      i32.eq
+      if (result i32)
+       local.get $11
+       i32.const 4
+       i32.shl
+      else
+       i32.const 0
+      end
       call $~lib/rt/pure/__release
-      local.get $8
+      local.get $5
+      call $~lib/rt/pure/__release
+      local.get $12
       br $~lib/typedarray/FIND_INDEX<~lib/typedarray/Float64Array,f64>|inlined.0
      end
-     local.get $5
+     local.get $7
      i32.const 1
      i32.add
-     local.set $5
+     local.set $7
      br $for-loop|0
     end
    end
    i32.const -1
-   local.set $6
+   local.set $7
    local.get $3
+   local.set $8
+   local.get $8
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $8
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
    call $~lib/rt/pure/__release
-   local.get $6
+   local.get $5
+   call $~lib/rt/pure/__release
+   local.get $7
   end
+  local.set $5
+  local.get $1
+  local.set $6
+  local.get $6
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $6
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $5
  )
- (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Float64Array,f64>~anonymous|1 (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Float64Array,f64>~anonymous|1~nonClosure (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -16555,7 +23629,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Int8Array,i8>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Int8Array,i8>~anonymous|0~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -16582,65 +23656,178 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  local.get $1
+  local.set $2
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
   block $~lib/typedarray/EVERY<~lib/typedarray/Int8Array,i8>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
-   local.set $3
-   local.get $1
-   local.set $2
-   local.get $3
-   i32.load offset=4
-   local.set $4
-   i32.const 0
    local.set $5
-   local.get $3
-   call $~lib/typedarray/Int8Array#get:length
+   local.get $1
+   local.set $4
+   local.get $4
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $4
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
+   call $~lib/rt/pure/__retain
+   drop
+   local.get $4
+   local.set $3
+   local.get $5
+   i32.load offset=4
    local.set $6
+   i32.const 0
+   local.set $7
+   local.get $5
+   call $~lib/typedarray/Int8Array#get:length
+   local.set $8
    loop $for-loop|0
-    local.get $5
-    local.get $6
-    i32.lt_s
-    local.set $7
     local.get $7
+    local.get $8
+    i32.lt_s
+    local.set $9
+    local.get $9
     if
      block $for-continue|0
-      local.get $4
-      local.get $5
-      i32.const 0
-      i32.shl
-      i32.add
-      i32.load8_s
-      local.get $5
       local.get $3
-      i32.const 3
-      global.set $~argumentsLength
-      local.get $2
-      call_indirect (type $i32_i32_i32_=>_i32)
+      local.set $10
+      local.get $10
+      i32.const -2147483648
+      i32.and
+      i32.const -2147483648
+      i32.eq
+      if (result i32)
+       local.get $10
+       i32.const 4
+       i32.shl
+       local.get $6
+       local.get $7
+       i32.const 0
+       i32.shl
+       i32.add
+       i32.load8_s
+       local.get $7
+       local.get $5
+       i32.const 3
+       global.set $~argumentsLength
+       local.get $10
+       i32.const 4
+       i32.shl
+       i32.load
+       call_indirect (type $i32_i32_i32_i32_=>_i32)
+      else
+       local.get $6
+       local.get $7
+       i32.const 0
+       i32.shl
+       i32.add
+       i32.load8_s
+       local.get $7
+       local.get $5
+       i32.const 3
+       global.set $~argumentsLength
+       local.get $10
+       call_indirect (type $i32_i32_i32_=>_i32)
+      end
       if
        br $for-continue|0
       end
       i32.const 0
-      local.set $8
+      local.set $12
       local.get $3
+      local.set $11
+      local.get $11
+      i32.const -2147483648
+      i32.and
+      i32.const -2147483648
+      i32.eq
+      if (result i32)
+       local.get $11
+       i32.const 4
+       i32.shl
+      else
+       i32.const 0
+      end
       call $~lib/rt/pure/__release
-      local.get $8
+      local.get $5
+      call $~lib/rt/pure/__release
+      local.get $12
       br $~lib/typedarray/EVERY<~lib/typedarray/Int8Array,i8>|inlined.0
      end
-     local.get $5
+     local.get $7
      i32.const 1
      i32.add
-     local.set $5
+     local.set $7
      br $for-loop|0
     end
    end
    i32.const 1
-   local.set $6
+   local.set $7
    local.get $3
+   local.set $8
+   local.get $8
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $8
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
    call $~lib/rt/pure/__release
-   local.get $6
+   local.get $5
+   call $~lib/rt/pure/__release
+   local.get $7
   end
+  local.set $5
+  local.get $1
+  local.set $6
+  local.get $6
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $6
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $5
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Int8Array,i8>~anonymous|1 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Int8Array,i8>~anonymous|1~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -16716,7 +23903,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint8Array,u8>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint8Array,u8>~anonymous|0~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -16741,65 +23928,178 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  local.get $1
+  local.set $2
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
   block $~lib/typedarray/EVERY<~lib/typedarray/Uint8Array,u8>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
-   local.set $3
-   local.get $1
-   local.set $2
-   local.get $3
-   i32.load offset=4
-   local.set $4
-   i32.const 0
    local.set $5
-   local.get $3
-   call $~lib/typedarray/Uint8Array#get:length
+   local.get $1
+   local.set $4
+   local.get $4
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $4
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
+   call $~lib/rt/pure/__retain
+   drop
+   local.get $4
+   local.set $3
+   local.get $5
+   i32.load offset=4
    local.set $6
+   i32.const 0
+   local.set $7
+   local.get $5
+   call $~lib/typedarray/Uint8Array#get:length
+   local.set $8
    loop $for-loop|0
-    local.get $5
-    local.get $6
-    i32.lt_s
-    local.set $7
     local.get $7
+    local.get $8
+    i32.lt_s
+    local.set $9
+    local.get $9
     if
      block $for-continue|0
-      local.get $4
-      local.get $5
-      i32.const 0
-      i32.shl
-      i32.add
-      i32.load8_u
-      local.get $5
       local.get $3
-      i32.const 3
-      global.set $~argumentsLength
-      local.get $2
-      call_indirect (type $i32_i32_i32_=>_i32)
+      local.set $10
+      local.get $10
+      i32.const -2147483648
+      i32.and
+      i32.const -2147483648
+      i32.eq
+      if (result i32)
+       local.get $10
+       i32.const 4
+       i32.shl
+       local.get $6
+       local.get $7
+       i32.const 0
+       i32.shl
+       i32.add
+       i32.load8_u
+       local.get $7
+       local.get $5
+       i32.const 3
+       global.set $~argumentsLength
+       local.get $10
+       i32.const 4
+       i32.shl
+       i32.load
+       call_indirect (type $i32_i32_i32_i32_=>_i32)
+      else
+       local.get $6
+       local.get $7
+       i32.const 0
+       i32.shl
+       i32.add
+       i32.load8_u
+       local.get $7
+       local.get $5
+       i32.const 3
+       global.set $~argumentsLength
+       local.get $10
+       call_indirect (type $i32_i32_i32_=>_i32)
+      end
       if
        br $for-continue|0
       end
       i32.const 0
-      local.set $8
+      local.set $12
       local.get $3
+      local.set $11
+      local.get $11
+      i32.const -2147483648
+      i32.and
+      i32.const -2147483648
+      i32.eq
+      if (result i32)
+       local.get $11
+       i32.const 4
+       i32.shl
+      else
+       i32.const 0
+      end
       call $~lib/rt/pure/__release
-      local.get $8
+      local.get $5
+      call $~lib/rt/pure/__release
+      local.get $12
       br $~lib/typedarray/EVERY<~lib/typedarray/Uint8Array,u8>|inlined.0
      end
-     local.get $5
+     local.get $7
      i32.const 1
      i32.add
-     local.set $5
+     local.set $7
      br $for-loop|0
     end
    end
    i32.const 1
-   local.set $6
+   local.set $7
    local.get $3
+   local.set $8
+   local.get $8
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $8
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
    call $~lib/rt/pure/__release
-   local.get $6
+   local.get $5
+   call $~lib/rt/pure/__release
+   local.get $7
   end
+  local.set $5
+  local.get $1
+  local.set $6
+  local.get $6
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $6
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $5
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint8Array,u8>~anonymous|1 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint8Array,u8>~anonymous|1~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -16873,7 +24173,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|0~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -16898,65 +24198,178 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  local.get $1
+  local.set $2
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
   block $~lib/typedarray/EVERY<~lib/typedarray/Uint8ClampedArray,u8>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
-   local.set $3
-   local.get $1
-   local.set $2
-   local.get $3
-   i32.load offset=4
-   local.set $4
-   i32.const 0
    local.set $5
-   local.get $3
-   call $~lib/typedarray/Uint8ClampedArray#get:length
+   local.get $1
+   local.set $4
+   local.get $4
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $4
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
+   call $~lib/rt/pure/__retain
+   drop
+   local.get $4
+   local.set $3
+   local.get $5
+   i32.load offset=4
    local.set $6
+   i32.const 0
+   local.set $7
+   local.get $5
+   call $~lib/typedarray/Uint8ClampedArray#get:length
+   local.set $8
    loop $for-loop|0
-    local.get $5
-    local.get $6
-    i32.lt_s
-    local.set $7
     local.get $7
+    local.get $8
+    i32.lt_s
+    local.set $9
+    local.get $9
     if
      block $for-continue|0
-      local.get $4
-      local.get $5
-      i32.const 0
-      i32.shl
-      i32.add
-      i32.load8_u
-      local.get $5
       local.get $3
-      i32.const 3
-      global.set $~argumentsLength
-      local.get $2
-      call_indirect (type $i32_i32_i32_=>_i32)
+      local.set $10
+      local.get $10
+      i32.const -2147483648
+      i32.and
+      i32.const -2147483648
+      i32.eq
+      if (result i32)
+       local.get $10
+       i32.const 4
+       i32.shl
+       local.get $6
+       local.get $7
+       i32.const 0
+       i32.shl
+       i32.add
+       i32.load8_u
+       local.get $7
+       local.get $5
+       i32.const 3
+       global.set $~argumentsLength
+       local.get $10
+       i32.const 4
+       i32.shl
+       i32.load
+       call_indirect (type $i32_i32_i32_i32_=>_i32)
+      else
+       local.get $6
+       local.get $7
+       i32.const 0
+       i32.shl
+       i32.add
+       i32.load8_u
+       local.get $7
+       local.get $5
+       i32.const 3
+       global.set $~argumentsLength
+       local.get $10
+       call_indirect (type $i32_i32_i32_=>_i32)
+      end
       if
        br $for-continue|0
       end
       i32.const 0
-      local.set $8
+      local.set $12
       local.get $3
+      local.set $11
+      local.get $11
+      i32.const -2147483648
+      i32.and
+      i32.const -2147483648
+      i32.eq
+      if (result i32)
+       local.get $11
+       i32.const 4
+       i32.shl
+      else
+       i32.const 0
+      end
       call $~lib/rt/pure/__release
-      local.get $8
+      local.get $5
+      call $~lib/rt/pure/__release
+      local.get $12
       br $~lib/typedarray/EVERY<~lib/typedarray/Uint8ClampedArray,u8>|inlined.0
      end
-     local.get $5
+     local.get $7
      i32.const 1
      i32.add
-     local.set $5
+     local.set $7
      br $for-loop|0
     end
    end
    i32.const 1
-   local.set $6
+   local.set $7
    local.get $3
+   local.set $8
+   local.get $8
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $8
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
    call $~lib/rt/pure/__release
-   local.get $6
+   local.get $5
+   call $~lib/rt/pure/__release
+   local.get $7
   end
+  local.set $5
+  local.get $1
+  local.set $6
+  local.get $6
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $6
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $5
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|1 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|1~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -17030,7 +24443,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Int16Array,i16>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Int16Array,i16>~anonymous|0~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -17057,65 +24470,178 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  local.get $1
+  local.set $2
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
   block $~lib/typedarray/EVERY<~lib/typedarray/Int16Array,i16>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
-   local.set $3
-   local.get $1
-   local.set $2
-   local.get $3
-   i32.load offset=4
-   local.set $4
-   i32.const 0
    local.set $5
-   local.get $3
-   call $~lib/typedarray/Int16Array#get:length
+   local.get $1
+   local.set $4
+   local.get $4
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $4
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
+   call $~lib/rt/pure/__retain
+   drop
+   local.get $4
+   local.set $3
+   local.get $5
+   i32.load offset=4
    local.set $6
+   i32.const 0
+   local.set $7
+   local.get $5
+   call $~lib/typedarray/Int16Array#get:length
+   local.set $8
    loop $for-loop|0
-    local.get $5
-    local.get $6
-    i32.lt_s
-    local.set $7
     local.get $7
+    local.get $8
+    i32.lt_s
+    local.set $9
+    local.get $9
     if
      block $for-continue|0
-      local.get $4
-      local.get $5
-      i32.const 1
-      i32.shl
-      i32.add
-      i32.load16_s
-      local.get $5
       local.get $3
-      i32.const 3
-      global.set $~argumentsLength
-      local.get $2
-      call_indirect (type $i32_i32_i32_=>_i32)
+      local.set $10
+      local.get $10
+      i32.const -2147483648
+      i32.and
+      i32.const -2147483648
+      i32.eq
+      if (result i32)
+       local.get $10
+       i32.const 4
+       i32.shl
+       local.get $6
+       local.get $7
+       i32.const 1
+       i32.shl
+       i32.add
+       i32.load16_s
+       local.get $7
+       local.get $5
+       i32.const 3
+       global.set $~argumentsLength
+       local.get $10
+       i32.const 4
+       i32.shl
+       i32.load
+       call_indirect (type $i32_i32_i32_i32_=>_i32)
+      else
+       local.get $6
+       local.get $7
+       i32.const 1
+       i32.shl
+       i32.add
+       i32.load16_s
+       local.get $7
+       local.get $5
+       i32.const 3
+       global.set $~argumentsLength
+       local.get $10
+       call_indirect (type $i32_i32_i32_=>_i32)
+      end
       if
        br $for-continue|0
       end
       i32.const 0
-      local.set $8
+      local.set $12
       local.get $3
+      local.set $11
+      local.get $11
+      i32.const -2147483648
+      i32.and
+      i32.const -2147483648
+      i32.eq
+      if (result i32)
+       local.get $11
+       i32.const 4
+       i32.shl
+      else
+       i32.const 0
+      end
       call $~lib/rt/pure/__release
-      local.get $8
+      local.get $5
+      call $~lib/rt/pure/__release
+      local.get $12
       br $~lib/typedarray/EVERY<~lib/typedarray/Int16Array,i16>|inlined.0
      end
-     local.get $5
+     local.get $7
      i32.const 1
      i32.add
-     local.set $5
+     local.set $7
      br $for-loop|0
     end
    end
    i32.const 1
-   local.set $6
+   local.set $7
    local.get $3
+   local.set $8
+   local.get $8
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $8
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
    call $~lib/rt/pure/__release
-   local.get $6
+   local.get $5
+   call $~lib/rt/pure/__release
+   local.get $7
   end
+  local.set $5
+  local.get $1
+  local.set $6
+  local.get $6
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $6
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $5
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Int16Array,i16>~anonymous|1 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Int16Array,i16>~anonymous|1~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -17191,7 +24717,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint16Array,u16>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint16Array,u16>~anonymous|0~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -17216,65 +24742,178 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  local.get $1
+  local.set $2
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
   block $~lib/typedarray/EVERY<~lib/typedarray/Uint16Array,u16>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
-   local.set $3
-   local.get $1
-   local.set $2
-   local.get $3
-   i32.load offset=4
-   local.set $4
-   i32.const 0
    local.set $5
-   local.get $3
-   call $~lib/typedarray/Uint16Array#get:length
+   local.get $1
+   local.set $4
+   local.get $4
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $4
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
+   call $~lib/rt/pure/__retain
+   drop
+   local.get $4
+   local.set $3
+   local.get $5
+   i32.load offset=4
    local.set $6
+   i32.const 0
+   local.set $7
+   local.get $5
+   call $~lib/typedarray/Uint16Array#get:length
+   local.set $8
    loop $for-loop|0
-    local.get $5
-    local.get $6
-    i32.lt_s
-    local.set $7
     local.get $7
+    local.get $8
+    i32.lt_s
+    local.set $9
+    local.get $9
     if
      block $for-continue|0
-      local.get $4
-      local.get $5
-      i32.const 1
-      i32.shl
-      i32.add
-      i32.load16_u
-      local.get $5
       local.get $3
-      i32.const 3
-      global.set $~argumentsLength
-      local.get $2
-      call_indirect (type $i32_i32_i32_=>_i32)
+      local.set $10
+      local.get $10
+      i32.const -2147483648
+      i32.and
+      i32.const -2147483648
+      i32.eq
+      if (result i32)
+       local.get $10
+       i32.const 4
+       i32.shl
+       local.get $6
+       local.get $7
+       i32.const 1
+       i32.shl
+       i32.add
+       i32.load16_u
+       local.get $7
+       local.get $5
+       i32.const 3
+       global.set $~argumentsLength
+       local.get $10
+       i32.const 4
+       i32.shl
+       i32.load
+       call_indirect (type $i32_i32_i32_i32_=>_i32)
+      else
+       local.get $6
+       local.get $7
+       i32.const 1
+       i32.shl
+       i32.add
+       i32.load16_u
+       local.get $7
+       local.get $5
+       i32.const 3
+       global.set $~argumentsLength
+       local.get $10
+       call_indirect (type $i32_i32_i32_=>_i32)
+      end
       if
        br $for-continue|0
       end
       i32.const 0
-      local.set $8
+      local.set $12
       local.get $3
+      local.set $11
+      local.get $11
+      i32.const -2147483648
+      i32.and
+      i32.const -2147483648
+      i32.eq
+      if (result i32)
+       local.get $11
+       i32.const 4
+       i32.shl
+      else
+       i32.const 0
+      end
       call $~lib/rt/pure/__release
-      local.get $8
+      local.get $5
+      call $~lib/rt/pure/__release
+      local.get $12
       br $~lib/typedarray/EVERY<~lib/typedarray/Uint16Array,u16>|inlined.0
      end
-     local.get $5
+     local.get $7
      i32.const 1
      i32.add
-     local.set $5
+     local.set $7
      br $for-loop|0
     end
    end
    i32.const 1
-   local.set $6
+   local.set $7
    local.get $3
+   local.set $8
+   local.get $8
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $8
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
    call $~lib/rt/pure/__release
-   local.get $6
+   local.get $5
+   call $~lib/rt/pure/__release
+   local.get $7
   end
+  local.set $5
+  local.get $1
+  local.set $6
+  local.get $6
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $6
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $5
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint16Array,u16>~anonymous|1 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint16Array,u16>~anonymous|1~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -17348,7 +24987,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Int32Array,i32>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Int32Array,i32>~anonymous|0~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -17371,65 +25010,178 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  local.get $1
+  local.set $2
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
   block $~lib/typedarray/EVERY<~lib/typedarray/Int32Array,i32>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
-   local.set $3
-   local.get $1
-   local.set $2
-   local.get $3
-   i32.load offset=4
-   local.set $4
-   i32.const 0
    local.set $5
-   local.get $3
-   call $~lib/typedarray/Int32Array#get:length
+   local.get $1
+   local.set $4
+   local.get $4
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $4
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
+   call $~lib/rt/pure/__retain
+   drop
+   local.get $4
+   local.set $3
+   local.get $5
+   i32.load offset=4
    local.set $6
+   i32.const 0
+   local.set $7
+   local.get $5
+   call $~lib/typedarray/Int32Array#get:length
+   local.set $8
    loop $for-loop|0
-    local.get $5
-    local.get $6
-    i32.lt_s
-    local.set $7
     local.get $7
+    local.get $8
+    i32.lt_s
+    local.set $9
+    local.get $9
     if
      block $for-continue|0
-      local.get $4
-      local.get $5
-      i32.const 2
-      i32.shl
-      i32.add
-      i32.load
-      local.get $5
       local.get $3
-      i32.const 3
-      global.set $~argumentsLength
-      local.get $2
-      call_indirect (type $i32_i32_i32_=>_i32)
+      local.set $10
+      local.get $10
+      i32.const -2147483648
+      i32.and
+      i32.const -2147483648
+      i32.eq
+      if (result i32)
+       local.get $10
+       i32.const 4
+       i32.shl
+       local.get $6
+       local.get $7
+       i32.const 2
+       i32.shl
+       i32.add
+       i32.load
+       local.get $7
+       local.get $5
+       i32.const 3
+       global.set $~argumentsLength
+       local.get $10
+       i32.const 4
+       i32.shl
+       i32.load
+       call_indirect (type $i32_i32_i32_i32_=>_i32)
+      else
+       local.get $6
+       local.get $7
+       i32.const 2
+       i32.shl
+       i32.add
+       i32.load
+       local.get $7
+       local.get $5
+       i32.const 3
+       global.set $~argumentsLength
+       local.get $10
+       call_indirect (type $i32_i32_i32_=>_i32)
+      end
       if
        br $for-continue|0
       end
       i32.const 0
-      local.set $8
+      local.set $12
       local.get $3
+      local.set $11
+      local.get $11
+      i32.const -2147483648
+      i32.and
+      i32.const -2147483648
+      i32.eq
+      if (result i32)
+       local.get $11
+       i32.const 4
+       i32.shl
+      else
+       i32.const 0
+      end
       call $~lib/rt/pure/__release
-      local.get $8
+      local.get $5
+      call $~lib/rt/pure/__release
+      local.get $12
       br $~lib/typedarray/EVERY<~lib/typedarray/Int32Array,i32>|inlined.0
      end
-     local.get $5
+     local.get $7
      i32.const 1
      i32.add
-     local.set $5
+     local.set $7
      br $for-loop|0
     end
    end
    i32.const 1
-   local.set $6
+   local.set $7
    local.get $3
+   local.set $8
+   local.get $8
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $8
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
    call $~lib/rt/pure/__release
-   local.get $6
+   local.get $5
+   call $~lib/rt/pure/__release
+   local.get $7
   end
+  local.set $5
+  local.get $1
+  local.set $6
+  local.get $6
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $6
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $5
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Int32Array,i32>~anonymous|1 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Int32Array,i32>~anonymous|1~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -17501,7 +25253,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint32Array,u32>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint32Array,u32>~anonymous|0~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -17524,65 +25276,178 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  local.get $1
+  local.set $2
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
   block $~lib/typedarray/EVERY<~lib/typedarray/Uint32Array,u32>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
-   local.set $3
-   local.get $1
-   local.set $2
-   local.get $3
-   i32.load offset=4
-   local.set $4
-   i32.const 0
    local.set $5
-   local.get $3
-   call $~lib/typedarray/Uint32Array#get:length
+   local.get $1
+   local.set $4
+   local.get $4
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $4
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
+   call $~lib/rt/pure/__retain
+   drop
+   local.get $4
+   local.set $3
+   local.get $5
+   i32.load offset=4
    local.set $6
+   i32.const 0
+   local.set $7
+   local.get $5
+   call $~lib/typedarray/Uint32Array#get:length
+   local.set $8
    loop $for-loop|0
-    local.get $5
-    local.get $6
-    i32.lt_s
-    local.set $7
     local.get $7
+    local.get $8
+    i32.lt_s
+    local.set $9
+    local.get $9
     if
      block $for-continue|0
-      local.get $4
-      local.get $5
-      i32.const 2
-      i32.shl
-      i32.add
-      i32.load
-      local.get $5
       local.get $3
-      i32.const 3
-      global.set $~argumentsLength
-      local.get $2
-      call_indirect (type $i32_i32_i32_=>_i32)
+      local.set $10
+      local.get $10
+      i32.const -2147483648
+      i32.and
+      i32.const -2147483648
+      i32.eq
+      if (result i32)
+       local.get $10
+       i32.const 4
+       i32.shl
+       local.get $6
+       local.get $7
+       i32.const 2
+       i32.shl
+       i32.add
+       i32.load
+       local.get $7
+       local.get $5
+       i32.const 3
+       global.set $~argumentsLength
+       local.get $10
+       i32.const 4
+       i32.shl
+       i32.load
+       call_indirect (type $i32_i32_i32_i32_=>_i32)
+      else
+       local.get $6
+       local.get $7
+       i32.const 2
+       i32.shl
+       i32.add
+       i32.load
+       local.get $7
+       local.get $5
+       i32.const 3
+       global.set $~argumentsLength
+       local.get $10
+       call_indirect (type $i32_i32_i32_=>_i32)
+      end
       if
        br $for-continue|0
       end
       i32.const 0
-      local.set $8
+      local.set $12
       local.get $3
+      local.set $11
+      local.get $11
+      i32.const -2147483648
+      i32.and
+      i32.const -2147483648
+      i32.eq
+      if (result i32)
+       local.get $11
+       i32.const 4
+       i32.shl
+      else
+       i32.const 0
+      end
       call $~lib/rt/pure/__release
-      local.get $8
+      local.get $5
+      call $~lib/rt/pure/__release
+      local.get $12
       br $~lib/typedarray/EVERY<~lib/typedarray/Uint32Array,u32>|inlined.0
      end
-     local.get $5
+     local.get $7
      i32.const 1
      i32.add
-     local.set $5
+     local.set $7
      br $for-loop|0
     end
    end
    i32.const 1
-   local.set $6
+   local.set $7
    local.get $3
+   local.set $8
+   local.get $8
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $8
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
    call $~lib/rt/pure/__release
-   local.get $6
+   local.get $5
+   call $~lib/rt/pure/__release
+   local.get $7
   end
+  local.set $5
+  local.get $1
+  local.set $6
+  local.get $6
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $6
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $5
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint32Array,u32>~anonymous|1 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint32Array,u32>~anonymous|1~nonClosure (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -17654,7 +25519,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Int64Array,i64>~anonymous|0 (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Int64Array,i64>~anonymous|0~nonClosure (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -17677,65 +25542,178 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  local.get $1
+  local.set $2
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
   block $~lib/typedarray/EVERY<~lib/typedarray/Int64Array,i64>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
-   local.set $3
-   local.get $1
-   local.set $2
-   local.get $3
-   i32.load offset=4
-   local.set $4
-   i32.const 0
    local.set $5
-   local.get $3
-   call $~lib/typedarray/Int64Array#get:length
+   local.get $1
+   local.set $4
+   local.get $4
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $4
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
+   call $~lib/rt/pure/__retain
+   drop
+   local.get $4
+   local.set $3
+   local.get $5
+   i32.load offset=4
    local.set $6
+   i32.const 0
+   local.set $7
+   local.get $5
+   call $~lib/typedarray/Int64Array#get:length
+   local.set $8
    loop $for-loop|0
-    local.get $5
-    local.get $6
-    i32.lt_s
-    local.set $7
     local.get $7
+    local.get $8
+    i32.lt_s
+    local.set $9
+    local.get $9
     if
      block $for-continue|0
-      local.get $4
-      local.get $5
-      i32.const 3
-      i32.shl
-      i32.add
-      i64.load
-      local.get $5
       local.get $3
-      i32.const 3
-      global.set $~argumentsLength
-      local.get $2
-      call_indirect (type $i64_i32_i32_=>_i32)
+      local.set $10
+      local.get $10
+      i32.const -2147483648
+      i32.and
+      i32.const -2147483648
+      i32.eq
+      if (result i32)
+       local.get $10
+       i32.const 4
+       i32.shl
+       local.get $6
+       local.get $7
+       i32.const 3
+       i32.shl
+       i32.add
+       i64.load
+       local.get $7
+       local.get $5
+       i32.const 3
+       global.set $~argumentsLength
+       local.get $10
+       i32.const 4
+       i32.shl
+       i32.load
+       call_indirect (type $i32_i64_i32_i32_=>_i32)
+      else
+       local.get $6
+       local.get $7
+       i32.const 3
+       i32.shl
+       i32.add
+       i64.load
+       local.get $7
+       local.get $5
+       i32.const 3
+       global.set $~argumentsLength
+       local.get $10
+       call_indirect (type $i64_i32_i32_=>_i32)
+      end
       if
        br $for-continue|0
       end
       i32.const 0
-      local.set $8
+      local.set $12
       local.get $3
+      local.set $11
+      local.get $11
+      i32.const -2147483648
+      i32.and
+      i32.const -2147483648
+      i32.eq
+      if (result i32)
+       local.get $11
+       i32.const 4
+       i32.shl
+      else
+       i32.const 0
+      end
       call $~lib/rt/pure/__release
-      local.get $8
+      local.get $5
+      call $~lib/rt/pure/__release
+      local.get $12
       br $~lib/typedarray/EVERY<~lib/typedarray/Int64Array,i64>|inlined.0
      end
-     local.get $5
+     local.get $7
      i32.const 1
      i32.add
-     local.set $5
+     local.set $7
      br $for-loop|0
     end
    end
    i32.const 1
-   local.set $6
+   local.set $7
    local.get $3
+   local.set $8
+   local.get $8
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $8
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
    call $~lib/rt/pure/__release
-   local.get $6
+   local.get $5
+   call $~lib/rt/pure/__release
+   local.get $7
   end
+  local.set $5
+  local.get $1
+  local.set $6
+  local.get $6
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $6
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $5
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Int64Array,i64>~anonymous|1 (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Int64Array,i64>~anonymous|1~nonClosure (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -17807,7 +25785,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint64Array,u64>~anonymous|0 (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint64Array,u64>~anonymous|0~nonClosure (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -17830,65 +25808,178 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  local.get $1
+  local.set $2
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
   block $~lib/typedarray/EVERY<~lib/typedarray/Uint64Array,u64>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
-   local.set $3
-   local.get $1
-   local.set $2
-   local.get $3
-   i32.load offset=4
-   local.set $4
-   i32.const 0
    local.set $5
-   local.get $3
-   call $~lib/typedarray/Uint64Array#get:length
+   local.get $1
+   local.set $4
+   local.get $4
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $4
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
+   call $~lib/rt/pure/__retain
+   drop
+   local.get $4
+   local.set $3
+   local.get $5
+   i32.load offset=4
    local.set $6
+   i32.const 0
+   local.set $7
+   local.get $5
+   call $~lib/typedarray/Uint64Array#get:length
+   local.set $8
    loop $for-loop|0
-    local.get $5
-    local.get $6
-    i32.lt_s
-    local.set $7
     local.get $7
+    local.get $8
+    i32.lt_s
+    local.set $9
+    local.get $9
     if
      block $for-continue|0
-      local.get $4
-      local.get $5
-      i32.const 3
-      i32.shl
-      i32.add
-      i64.load
-      local.get $5
       local.get $3
-      i32.const 3
-      global.set $~argumentsLength
-      local.get $2
-      call_indirect (type $i64_i32_i32_=>_i32)
+      local.set $10
+      local.get $10
+      i32.const -2147483648
+      i32.and
+      i32.const -2147483648
+      i32.eq
+      if (result i32)
+       local.get $10
+       i32.const 4
+       i32.shl
+       local.get $6
+       local.get $7
+       i32.const 3
+       i32.shl
+       i32.add
+       i64.load
+       local.get $7
+       local.get $5
+       i32.const 3
+       global.set $~argumentsLength
+       local.get $10
+       i32.const 4
+       i32.shl
+       i32.load
+       call_indirect (type $i32_i64_i32_i32_=>_i32)
+      else
+       local.get $6
+       local.get $7
+       i32.const 3
+       i32.shl
+       i32.add
+       i64.load
+       local.get $7
+       local.get $5
+       i32.const 3
+       global.set $~argumentsLength
+       local.get $10
+       call_indirect (type $i64_i32_i32_=>_i32)
+      end
       if
        br $for-continue|0
       end
       i32.const 0
-      local.set $8
+      local.set $12
       local.get $3
+      local.set $11
+      local.get $11
+      i32.const -2147483648
+      i32.and
+      i32.const -2147483648
+      i32.eq
+      if (result i32)
+       local.get $11
+       i32.const 4
+       i32.shl
+      else
+       i32.const 0
+      end
       call $~lib/rt/pure/__release
-      local.get $8
+      local.get $5
+      call $~lib/rt/pure/__release
+      local.get $12
       br $~lib/typedarray/EVERY<~lib/typedarray/Uint64Array,u64>|inlined.0
      end
-     local.get $5
+     local.get $7
      i32.const 1
      i32.add
-     local.set $5
+     local.set $7
      br $for-loop|0
     end
    end
    i32.const 1
-   local.set $6
+   local.set $7
    local.get $3
+   local.set $8
+   local.get $8
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $8
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
    call $~lib/rt/pure/__release
-   local.get $6
+   local.get $5
+   call $~lib/rt/pure/__release
+   local.get $7
   end
+  local.set $5
+  local.get $1
+  local.set $6
+  local.get $6
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $6
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $5
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint64Array,u64>~anonymous|1 (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint64Array,u64>~anonymous|1~nonClosure (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -18208,7 +26299,7 @@
   local.get $2
   f32.reinterpret_i32
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Float32Array,f32>~anonymous|0 (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Float32Array,f32>~anonymous|0~nonClosure (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -18231,65 +26322,178 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  local.get $1
+  local.set $2
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
   block $~lib/typedarray/EVERY<~lib/typedarray/Float32Array,f32>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
-   local.set $3
-   local.get $1
-   local.set $2
-   local.get $3
-   i32.load offset=4
-   local.set $4
-   i32.const 0
    local.set $5
-   local.get $3
-   call $~lib/typedarray/Float32Array#get:length
+   local.get $1
+   local.set $4
+   local.get $4
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $4
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
+   call $~lib/rt/pure/__retain
+   drop
+   local.get $4
+   local.set $3
+   local.get $5
+   i32.load offset=4
    local.set $6
+   i32.const 0
+   local.set $7
+   local.get $5
+   call $~lib/typedarray/Float32Array#get:length
+   local.set $8
    loop $for-loop|0
-    local.get $5
-    local.get $6
-    i32.lt_s
-    local.set $7
     local.get $7
+    local.get $8
+    i32.lt_s
+    local.set $9
+    local.get $9
     if
      block $for-continue|0
-      local.get $4
-      local.get $5
-      i32.const 2
-      i32.shl
-      i32.add
-      f32.load
-      local.get $5
       local.get $3
-      i32.const 3
-      global.set $~argumentsLength
-      local.get $2
-      call_indirect (type $f32_i32_i32_=>_i32)
+      local.set $10
+      local.get $10
+      i32.const -2147483648
+      i32.and
+      i32.const -2147483648
+      i32.eq
+      if (result i32)
+       local.get $10
+       i32.const 4
+       i32.shl
+       local.get $6
+       local.get $7
+       i32.const 2
+       i32.shl
+       i32.add
+       f32.load
+       local.get $7
+       local.get $5
+       i32.const 3
+       global.set $~argumentsLength
+       local.get $10
+       i32.const 4
+       i32.shl
+       i32.load
+       call_indirect (type $i32_f32_i32_i32_=>_i32)
+      else
+       local.get $6
+       local.get $7
+       i32.const 2
+       i32.shl
+       i32.add
+       f32.load
+       local.get $7
+       local.get $5
+       i32.const 3
+       global.set $~argumentsLength
+       local.get $10
+       call_indirect (type $f32_i32_i32_=>_i32)
+      end
       if
        br $for-continue|0
       end
       i32.const 0
-      local.set $8
+      local.set $12
       local.get $3
+      local.set $11
+      local.get $11
+      i32.const -2147483648
+      i32.and
+      i32.const -2147483648
+      i32.eq
+      if (result i32)
+       local.get $11
+       i32.const 4
+       i32.shl
+      else
+       i32.const 0
+      end
       call $~lib/rt/pure/__release
-      local.get $8
+      local.get $5
+      call $~lib/rt/pure/__release
+      local.get $12
       br $~lib/typedarray/EVERY<~lib/typedarray/Float32Array,f32>|inlined.0
      end
-     local.get $5
+     local.get $7
      i32.const 1
      i32.add
-     local.set $5
+     local.set $7
      br $for-loop|0
     end
    end
    i32.const 1
-   local.set $6
+   local.set $7
    local.get $3
+   local.set $8
+   local.get $8
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $8
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
    call $~lib/rt/pure/__release
-   local.get $6
+   local.get $5
+   call $~lib/rt/pure/__release
+   local.get $7
   end
+  local.set $5
+  local.get $1
+  local.set $6
+  local.get $6
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $6
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $5
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Float32Array,f32>~anonymous|1 (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Float32Array,f32>~anonymous|1~nonClosure (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -18615,7 +26819,7 @@
   local.get $2
   f64.reinterpret_i64
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Float64Array,f64>~anonymous|0 (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Float64Array,f64>~anonymous|0~nonClosure (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -18638,65 +26842,178 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  local.get $1
+  local.set $2
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
   block $~lib/typedarray/EVERY<~lib/typedarray/Float64Array,f64>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
-   local.set $3
-   local.get $1
-   local.set $2
-   local.get $3
-   i32.load offset=4
-   local.set $4
-   i32.const 0
    local.set $5
-   local.get $3
-   call $~lib/typedarray/Float64Array#get:length
+   local.get $1
+   local.set $4
+   local.get $4
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $4
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
+   call $~lib/rt/pure/__retain
+   drop
+   local.get $4
+   local.set $3
+   local.get $5
+   i32.load offset=4
    local.set $6
+   i32.const 0
+   local.set $7
+   local.get $5
+   call $~lib/typedarray/Float64Array#get:length
+   local.set $8
    loop $for-loop|0
-    local.get $5
-    local.get $6
-    i32.lt_s
-    local.set $7
     local.get $7
+    local.get $8
+    i32.lt_s
+    local.set $9
+    local.get $9
     if
      block $for-continue|0
-      local.get $4
-      local.get $5
-      i32.const 3
-      i32.shl
-      i32.add
-      f64.load
-      local.get $5
       local.get $3
-      i32.const 3
-      global.set $~argumentsLength
-      local.get $2
-      call_indirect (type $f64_i32_i32_=>_i32)
+      local.set $10
+      local.get $10
+      i32.const -2147483648
+      i32.and
+      i32.const -2147483648
+      i32.eq
+      if (result i32)
+       local.get $10
+       i32.const 4
+       i32.shl
+       local.get $6
+       local.get $7
+       i32.const 3
+       i32.shl
+       i32.add
+       f64.load
+       local.get $7
+       local.get $5
+       i32.const 3
+       global.set $~argumentsLength
+       local.get $10
+       i32.const 4
+       i32.shl
+       i32.load
+       call_indirect (type $i32_f64_i32_i32_=>_i32)
+      else
+       local.get $6
+       local.get $7
+       i32.const 3
+       i32.shl
+       i32.add
+       f64.load
+       local.get $7
+       local.get $5
+       i32.const 3
+       global.set $~argumentsLength
+       local.get $10
+       call_indirect (type $f64_i32_i32_=>_i32)
+      end
       if
        br $for-continue|0
       end
       i32.const 0
-      local.set $8
+      local.set $12
       local.get $3
+      local.set $11
+      local.get $11
+      i32.const -2147483648
+      i32.and
+      i32.const -2147483648
+      i32.eq
+      if (result i32)
+       local.get $11
+       i32.const 4
+       i32.shl
+      else
+       i32.const 0
+      end
       call $~lib/rt/pure/__release
-      local.get $8
+      local.get $5
+      call $~lib/rt/pure/__release
+      local.get $12
       br $~lib/typedarray/EVERY<~lib/typedarray/Float64Array,f64>|inlined.0
      end
-     local.get $5
+     local.get $7
      i32.const 1
      i32.add
-     local.set $5
+     local.set $7
      br $for-loop|0
     end
    end
    i32.const 1
-   local.set $6
+   local.set $7
    local.get $3
+   local.set $8
+   local.get $8
+   i32.const -2147483648
+   i32.and
+   i32.const -2147483648
+   i32.eq
+   if (result i32)
+    local.get $8
+    i32.const 4
+    i32.shl
+   else
+    i32.const 0
+   end
    call $~lib/rt/pure/__release
-   local.get $6
+   local.get $5
+   call $~lib/rt/pure/__release
+   local.get $7
   end
+  local.set $5
+  local.get $1
+  local.set $6
+  local.get $6
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $6
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $5
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Float64Array,f64>~anonymous|1 (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Float64Array,f64>~anonymous|1~nonClosure (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -18768,7 +27085,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Int8Array,i8>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Int8Array,i8>~anonymous|0~nonClosure (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -18835,46 +27152,141 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  local.get $0
-  call $~lib/rt/pure/__retain
-  local.set $3
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
   local.get $1
   local.set $2
-  local.get $3
-  i32.load offset=4
-  local.set $4
-  i32.const 0
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
+  local.get $0
+  call $~lib/rt/pure/__retain
   local.set $5
-  local.get $3
-  call $~lib/typedarray/Int8Array#get:length
+  local.get $1
+  local.set $4
+  local.get $4
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $4
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $4
+  local.set $3
+  local.get $5
+  i32.load offset=4
   local.set $6
+  i32.const 0
+  local.set $7
+  local.get $5
+  call $~lib/typedarray/Int8Array#get:length
+  local.set $8
   loop $for-loop|0
-   local.get $5
-   local.get $6
-   i32.lt_s
-   local.set $7
    local.get $7
+   local.get $8
+   i32.lt_s
+   local.set $9
+   local.get $9
    if
-    local.get $4
-    local.get $5
-    i32.const 0
-    i32.shl
-    i32.add
-    i32.load8_s
-    local.get $5
     local.get $3
-    i32.const 3
-    global.set $~argumentsLength
-    local.get $2
-    call_indirect (type $i32_i32_i32_=>_none)
-    local.get $5
+    local.set $10
+    local.get $10
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if
+     local.get $10
+     i32.const 4
+     i32.shl
+     local.get $6
+     local.get $7
+     i32.const 0
+     i32.shl
+     i32.add
+     i32.load8_s
+     local.get $7
+     local.get $5
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $10
+     i32.const 4
+     i32.shl
+     i32.load
+     call_indirect (type $i32_i32_i32_i32_=>_none)
+    else
+     local.get $6
+     local.get $7
+     i32.const 0
+     i32.shl
+     i32.add
+     i32.load8_s
+     local.get $7
+     local.get $5
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $10
+     call_indirect (type $i32_i32_i32_=>_none)
+    end
+    local.get $7
     i32.const 1
     i32.add
-    local.set $5
+    local.set $7
     br $for-loop|0
    end
   end
   local.get $3
+  local.set $8
+  local.get $8
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $8
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $5
+  call $~lib/rt/pure/__release
+  local.get $1
+  local.set $6
+  local.get $6
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $6
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
   call $~lib/rt/pure/__release
  )
  (func $std/typedarray/testArrayForEach<~lib/typedarray/Int8Array,i8>
@@ -18940,7 +27352,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint8Array,u8>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint8Array,u8>~anonymous|0~nonClosure (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -19003,46 +27415,141 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  local.get $0
-  call $~lib/rt/pure/__retain
-  local.set $3
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
   local.get $1
   local.set $2
-  local.get $3
-  i32.load offset=4
-  local.set $4
-  i32.const 0
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
+  local.get $0
+  call $~lib/rt/pure/__retain
   local.set $5
-  local.get $3
-  call $~lib/typedarray/Uint8Array#get:length
+  local.get $1
+  local.set $4
+  local.get $4
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $4
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $4
+  local.set $3
+  local.get $5
+  i32.load offset=4
   local.set $6
+  i32.const 0
+  local.set $7
+  local.get $5
+  call $~lib/typedarray/Uint8Array#get:length
+  local.set $8
   loop $for-loop|0
-   local.get $5
-   local.get $6
-   i32.lt_s
-   local.set $7
    local.get $7
+   local.get $8
+   i32.lt_s
+   local.set $9
+   local.get $9
    if
-    local.get $4
-    local.get $5
-    i32.const 0
-    i32.shl
-    i32.add
-    i32.load8_u
-    local.get $5
     local.get $3
-    i32.const 3
-    global.set $~argumentsLength
-    local.get $2
-    call_indirect (type $i32_i32_i32_=>_none)
-    local.get $5
+    local.set $10
+    local.get $10
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if
+     local.get $10
+     i32.const 4
+     i32.shl
+     local.get $6
+     local.get $7
+     i32.const 0
+     i32.shl
+     i32.add
+     i32.load8_u
+     local.get $7
+     local.get $5
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $10
+     i32.const 4
+     i32.shl
+     i32.load
+     call_indirect (type $i32_i32_i32_i32_=>_none)
+    else
+     local.get $6
+     local.get $7
+     i32.const 0
+     i32.shl
+     i32.add
+     i32.load8_u
+     local.get $7
+     local.get $5
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $10
+     call_indirect (type $i32_i32_i32_=>_none)
+    end
+    local.get $7
     i32.const 1
     i32.add
-    local.set $5
+    local.set $7
     br $for-loop|0
    end
   end
   local.get $3
+  local.set $8
+  local.get $8
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $8
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $5
+  call $~lib/rt/pure/__release
+  local.get $1
+  local.set $6
+  local.get $6
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $6
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
   call $~lib/rt/pure/__release
  )
  (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint8Array,u8>
@@ -19102,7 +27609,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|0~nonClosure (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -19165,46 +27672,141 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  local.get $0
-  call $~lib/rt/pure/__retain
-  local.set $3
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
   local.get $1
   local.set $2
-  local.get $3
-  i32.load offset=4
-  local.set $4
-  i32.const 0
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
+  local.get $0
+  call $~lib/rt/pure/__retain
   local.set $5
-  local.get $3
-  call $~lib/typedarray/Uint8ClampedArray#get:length
+  local.get $1
+  local.set $4
+  local.get $4
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $4
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $4
+  local.set $3
+  local.get $5
+  i32.load offset=4
   local.set $6
+  i32.const 0
+  local.set $7
+  local.get $5
+  call $~lib/typedarray/Uint8ClampedArray#get:length
+  local.set $8
   loop $for-loop|0
-   local.get $5
-   local.get $6
-   i32.lt_s
-   local.set $7
    local.get $7
+   local.get $8
+   i32.lt_s
+   local.set $9
+   local.get $9
    if
-    local.get $4
-    local.get $5
-    i32.const 0
-    i32.shl
-    i32.add
-    i32.load8_u
-    local.get $5
     local.get $3
-    i32.const 3
-    global.set $~argumentsLength
-    local.get $2
-    call_indirect (type $i32_i32_i32_=>_none)
-    local.get $5
+    local.set $10
+    local.get $10
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if
+     local.get $10
+     i32.const 4
+     i32.shl
+     local.get $6
+     local.get $7
+     i32.const 0
+     i32.shl
+     i32.add
+     i32.load8_u
+     local.get $7
+     local.get $5
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $10
+     i32.const 4
+     i32.shl
+     i32.load
+     call_indirect (type $i32_i32_i32_i32_=>_none)
+    else
+     local.get $6
+     local.get $7
+     i32.const 0
+     i32.shl
+     i32.add
+     i32.load8_u
+     local.get $7
+     local.get $5
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $10
+     call_indirect (type $i32_i32_i32_=>_none)
+    end
+    local.get $7
     i32.const 1
     i32.add
-    local.set $5
+    local.set $7
     br $for-loop|0
    end
   end
   local.get $3
+  local.set $8
+  local.get $8
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $8
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $5
+  call $~lib/rt/pure/__release
+  local.get $1
+  local.set $6
+  local.get $6
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $6
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
   call $~lib/rt/pure/__release
  )
  (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint8ClampedArray,u8>
@@ -19264,7 +27866,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Int16Array,i16>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Int16Array,i16>~anonymous|0~nonClosure (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -19331,46 +27933,141 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  local.get $0
-  call $~lib/rt/pure/__retain
-  local.set $3
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
   local.get $1
   local.set $2
-  local.get $3
-  i32.load offset=4
-  local.set $4
-  i32.const 0
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
+  local.get $0
+  call $~lib/rt/pure/__retain
   local.set $5
-  local.get $3
-  call $~lib/typedarray/Int16Array#get:length
+  local.get $1
+  local.set $4
+  local.get $4
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $4
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $4
+  local.set $3
+  local.get $5
+  i32.load offset=4
   local.set $6
+  i32.const 0
+  local.set $7
+  local.get $5
+  call $~lib/typedarray/Int16Array#get:length
+  local.set $8
   loop $for-loop|0
-   local.get $5
-   local.get $6
-   i32.lt_s
-   local.set $7
    local.get $7
+   local.get $8
+   i32.lt_s
+   local.set $9
+   local.get $9
    if
-    local.get $4
-    local.get $5
-    i32.const 1
-    i32.shl
-    i32.add
-    i32.load16_s
-    local.get $5
     local.get $3
-    i32.const 3
-    global.set $~argumentsLength
-    local.get $2
-    call_indirect (type $i32_i32_i32_=>_none)
-    local.get $5
+    local.set $10
+    local.get $10
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if
+     local.get $10
+     i32.const 4
+     i32.shl
+     local.get $6
+     local.get $7
+     i32.const 1
+     i32.shl
+     i32.add
+     i32.load16_s
+     local.get $7
+     local.get $5
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $10
+     i32.const 4
+     i32.shl
+     i32.load
+     call_indirect (type $i32_i32_i32_i32_=>_none)
+    else
+     local.get $6
+     local.get $7
+     i32.const 1
+     i32.shl
+     i32.add
+     i32.load16_s
+     local.get $7
+     local.get $5
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $10
+     call_indirect (type $i32_i32_i32_=>_none)
+    end
+    local.get $7
     i32.const 1
     i32.add
-    local.set $5
+    local.set $7
     br $for-loop|0
    end
   end
   local.get $3
+  local.set $8
+  local.get $8
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $8
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $5
+  call $~lib/rt/pure/__release
+  local.get $1
+  local.set $6
+  local.get $6
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $6
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
   call $~lib/rt/pure/__release
  )
  (func $std/typedarray/testArrayForEach<~lib/typedarray/Int16Array,i16>
@@ -19436,7 +28133,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint16Array,u16>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint16Array,u16>~anonymous|0~nonClosure (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -19499,46 +28196,141 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  local.get $0
-  call $~lib/rt/pure/__retain
-  local.set $3
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
   local.get $1
   local.set $2
-  local.get $3
-  i32.load offset=4
-  local.set $4
-  i32.const 0
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
+  local.get $0
+  call $~lib/rt/pure/__retain
   local.set $5
-  local.get $3
-  call $~lib/typedarray/Uint16Array#get:length
+  local.get $1
+  local.set $4
+  local.get $4
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $4
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $4
+  local.set $3
+  local.get $5
+  i32.load offset=4
   local.set $6
+  i32.const 0
+  local.set $7
+  local.get $5
+  call $~lib/typedarray/Uint16Array#get:length
+  local.set $8
   loop $for-loop|0
-   local.get $5
-   local.get $6
-   i32.lt_s
-   local.set $7
    local.get $7
+   local.get $8
+   i32.lt_s
+   local.set $9
+   local.get $9
    if
-    local.get $4
-    local.get $5
-    i32.const 1
-    i32.shl
-    i32.add
-    i32.load16_u
-    local.get $5
     local.get $3
-    i32.const 3
-    global.set $~argumentsLength
-    local.get $2
-    call_indirect (type $i32_i32_i32_=>_none)
-    local.get $5
+    local.set $10
+    local.get $10
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if
+     local.get $10
+     i32.const 4
+     i32.shl
+     local.get $6
+     local.get $7
+     i32.const 1
+     i32.shl
+     i32.add
+     i32.load16_u
+     local.get $7
+     local.get $5
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $10
+     i32.const 4
+     i32.shl
+     i32.load
+     call_indirect (type $i32_i32_i32_i32_=>_none)
+    else
+     local.get $6
+     local.get $7
+     i32.const 1
+     i32.shl
+     i32.add
+     i32.load16_u
+     local.get $7
+     local.get $5
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $10
+     call_indirect (type $i32_i32_i32_=>_none)
+    end
+    local.get $7
     i32.const 1
     i32.add
-    local.set $5
+    local.set $7
     br $for-loop|0
    end
   end
   local.get $3
+  local.set $8
+  local.get $8
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $8
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $5
+  call $~lib/rt/pure/__release
+  local.get $1
+  local.set $6
+  local.get $6
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $6
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
   call $~lib/rt/pure/__release
  )
  (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint16Array,u16>
@@ -19598,7 +28390,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Int32Array,i32>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Int32Array,i32>~anonymous|0~nonClosure (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -19657,46 +28449,141 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  local.get $0
-  call $~lib/rt/pure/__retain
-  local.set $3
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
   local.get $1
   local.set $2
-  local.get $3
-  i32.load offset=4
-  local.set $4
-  i32.const 0
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
+  local.get $0
+  call $~lib/rt/pure/__retain
   local.set $5
-  local.get $3
-  call $~lib/typedarray/Int32Array#get:length
+  local.get $1
+  local.set $4
+  local.get $4
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $4
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $4
+  local.set $3
+  local.get $5
+  i32.load offset=4
   local.set $6
+  i32.const 0
+  local.set $7
+  local.get $5
+  call $~lib/typedarray/Int32Array#get:length
+  local.set $8
   loop $for-loop|0
-   local.get $5
-   local.get $6
-   i32.lt_s
-   local.set $7
    local.get $7
+   local.get $8
+   i32.lt_s
+   local.set $9
+   local.get $9
    if
-    local.get $4
-    local.get $5
-    i32.const 2
-    i32.shl
-    i32.add
-    i32.load
-    local.get $5
     local.get $3
-    i32.const 3
-    global.set $~argumentsLength
-    local.get $2
-    call_indirect (type $i32_i32_i32_=>_none)
-    local.get $5
+    local.set $10
+    local.get $10
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if
+     local.get $10
+     i32.const 4
+     i32.shl
+     local.get $6
+     local.get $7
+     i32.const 2
+     i32.shl
+     i32.add
+     i32.load
+     local.get $7
+     local.get $5
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $10
+     i32.const 4
+     i32.shl
+     i32.load
+     call_indirect (type $i32_i32_i32_i32_=>_none)
+    else
+     local.get $6
+     local.get $7
+     i32.const 2
+     i32.shl
+     i32.add
+     i32.load
+     local.get $7
+     local.get $5
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $10
+     call_indirect (type $i32_i32_i32_=>_none)
+    end
+    local.get $7
     i32.const 1
     i32.add
-    local.set $5
+    local.set $7
     br $for-loop|0
    end
   end
   local.get $3
+  local.set $8
+  local.get $8
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $8
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $5
+  call $~lib/rt/pure/__release
+  local.get $1
+  local.set $6
+  local.get $6
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $6
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
   call $~lib/rt/pure/__release
  )
  (func $std/typedarray/testArrayForEach<~lib/typedarray/Int32Array,i32>
@@ -19750,7 +28637,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint32Array,u32>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint32Array,u32>~anonymous|0~nonClosure (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -19809,46 +28696,141 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  local.get $0
-  call $~lib/rt/pure/__retain
-  local.set $3
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
   local.get $1
   local.set $2
-  local.get $3
-  i32.load offset=4
-  local.set $4
-  i32.const 0
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
+  local.get $0
+  call $~lib/rt/pure/__retain
   local.set $5
-  local.get $3
-  call $~lib/typedarray/Uint32Array#get:length
+  local.get $1
+  local.set $4
+  local.get $4
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $4
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $4
+  local.set $3
+  local.get $5
+  i32.load offset=4
   local.set $6
+  i32.const 0
+  local.set $7
+  local.get $5
+  call $~lib/typedarray/Uint32Array#get:length
+  local.set $8
   loop $for-loop|0
-   local.get $5
-   local.get $6
-   i32.lt_s
-   local.set $7
    local.get $7
+   local.get $8
+   i32.lt_s
+   local.set $9
+   local.get $9
    if
-    local.get $4
-    local.get $5
-    i32.const 2
-    i32.shl
-    i32.add
-    i32.load
-    local.get $5
     local.get $3
-    i32.const 3
-    global.set $~argumentsLength
-    local.get $2
-    call_indirect (type $i32_i32_i32_=>_none)
-    local.get $5
+    local.set $10
+    local.get $10
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if
+     local.get $10
+     i32.const 4
+     i32.shl
+     local.get $6
+     local.get $7
+     i32.const 2
+     i32.shl
+     i32.add
+     i32.load
+     local.get $7
+     local.get $5
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $10
+     i32.const 4
+     i32.shl
+     i32.load
+     call_indirect (type $i32_i32_i32_i32_=>_none)
+    else
+     local.get $6
+     local.get $7
+     i32.const 2
+     i32.shl
+     i32.add
+     i32.load
+     local.get $7
+     local.get $5
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $10
+     call_indirect (type $i32_i32_i32_=>_none)
+    end
+    local.get $7
     i32.const 1
     i32.add
-    local.set $5
+    local.set $7
     br $for-loop|0
    end
   end
   local.get $3
+  local.set $8
+  local.get $8
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $8
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $5
+  call $~lib/rt/pure/__release
+  local.get $1
+  local.set $6
+  local.get $6
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $6
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
   call $~lib/rt/pure/__release
  )
  (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint32Array,u32>
@@ -19902,7 +28884,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Int64Array,i64>~anonymous|0 (param $0 i64) (param $1 i32) (param $2 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Int64Array,i64>~anonymous|0~nonClosure (param $0 i64) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -19962,46 +28944,141 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  local.get $0
-  call $~lib/rt/pure/__retain
-  local.set $3
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
   local.get $1
   local.set $2
-  local.get $3
-  i32.load offset=4
-  local.set $4
-  i32.const 0
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
+  local.get $0
+  call $~lib/rt/pure/__retain
   local.set $5
-  local.get $3
-  call $~lib/typedarray/Int64Array#get:length
+  local.get $1
+  local.set $4
+  local.get $4
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $4
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $4
+  local.set $3
+  local.get $5
+  i32.load offset=4
   local.set $6
+  i32.const 0
+  local.set $7
+  local.get $5
+  call $~lib/typedarray/Int64Array#get:length
+  local.set $8
   loop $for-loop|0
-   local.get $5
-   local.get $6
-   i32.lt_s
-   local.set $7
    local.get $7
+   local.get $8
+   i32.lt_s
+   local.set $9
+   local.get $9
    if
-    local.get $4
-    local.get $5
-    i32.const 3
-    i32.shl
-    i32.add
-    i64.load
-    local.get $5
     local.get $3
-    i32.const 3
-    global.set $~argumentsLength
-    local.get $2
-    call_indirect (type $i64_i32_i32_=>_none)
-    local.get $5
+    local.set $10
+    local.get $10
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if
+     local.get $10
+     i32.const 4
+     i32.shl
+     local.get $6
+     local.get $7
+     i32.const 3
+     i32.shl
+     i32.add
+     i64.load
+     local.get $7
+     local.get $5
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $10
+     i32.const 4
+     i32.shl
+     i32.load
+     call_indirect (type $i32_i64_i32_i32_=>_none)
+    else
+     local.get $6
+     local.get $7
+     i32.const 3
+     i32.shl
+     i32.add
+     i64.load
+     local.get $7
+     local.get $5
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $10
+     call_indirect (type $i64_i32_i32_=>_none)
+    end
+    local.get $7
     i32.const 1
     i32.add
-    local.set $5
+    local.set $7
     br $for-loop|0
    end
   end
   local.get $3
+  local.set $8
+  local.get $8
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $8
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $5
+  call $~lib/rt/pure/__release
+  local.get $1
+  local.set $6
+  local.get $6
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $6
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
   call $~lib/rt/pure/__release
  )
  (func $std/typedarray/testArrayForEach<~lib/typedarray/Int64Array,i64>
@@ -20058,7 +29135,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint64Array,u64>~anonymous|0 (param $0 i64) (param $1 i32) (param $2 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint64Array,u64>~anonymous|0~nonClosure (param $0 i64) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -20118,46 +29195,141 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  local.get $0
-  call $~lib/rt/pure/__retain
-  local.set $3
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
   local.get $1
   local.set $2
-  local.get $3
-  i32.load offset=4
-  local.set $4
-  i32.const 0
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
+  local.get $0
+  call $~lib/rt/pure/__retain
   local.set $5
-  local.get $3
-  call $~lib/typedarray/Uint64Array#get:length
+  local.get $1
+  local.set $4
+  local.get $4
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $4
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $4
+  local.set $3
+  local.get $5
+  i32.load offset=4
   local.set $6
+  i32.const 0
+  local.set $7
+  local.get $5
+  call $~lib/typedarray/Uint64Array#get:length
+  local.set $8
   loop $for-loop|0
-   local.get $5
-   local.get $6
-   i32.lt_s
-   local.set $7
    local.get $7
+   local.get $8
+   i32.lt_s
+   local.set $9
+   local.get $9
    if
-    local.get $4
-    local.get $5
-    i32.const 3
-    i32.shl
-    i32.add
-    i64.load
-    local.get $5
     local.get $3
-    i32.const 3
-    global.set $~argumentsLength
-    local.get $2
-    call_indirect (type $i64_i32_i32_=>_none)
-    local.get $5
+    local.set $10
+    local.get $10
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if
+     local.get $10
+     i32.const 4
+     i32.shl
+     local.get $6
+     local.get $7
+     i32.const 3
+     i32.shl
+     i32.add
+     i64.load
+     local.get $7
+     local.get $5
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $10
+     i32.const 4
+     i32.shl
+     i32.load
+     call_indirect (type $i32_i64_i32_i32_=>_none)
+    else
+     local.get $6
+     local.get $7
+     i32.const 3
+     i32.shl
+     i32.add
+     i64.load
+     local.get $7
+     local.get $5
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $10
+     call_indirect (type $i64_i32_i32_=>_none)
+    end
+    local.get $7
     i32.const 1
     i32.add
-    local.set $5
+    local.set $7
     br $for-loop|0
    end
   end
   local.get $3
+  local.set $8
+  local.get $8
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $8
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $5
+  call $~lib/rt/pure/__release
+  local.get $1
+  local.set $6
+  local.get $6
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $6
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
   call $~lib/rt/pure/__release
  )
  (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint64Array,u64>
@@ -20214,7 +29386,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Float32Array,f32>~anonymous|0 (param $0 f32) (param $1 i32) (param $2 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Float32Array,f32>~anonymous|0~nonClosure (param $0 f32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -20274,46 +29446,141 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  local.get $0
-  call $~lib/rt/pure/__retain
-  local.set $3
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
   local.get $1
   local.set $2
-  local.get $3
-  i32.load offset=4
-  local.set $4
-  i32.const 0
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
+  local.get $0
+  call $~lib/rt/pure/__retain
   local.set $5
-  local.get $3
-  call $~lib/typedarray/Float32Array#get:length
+  local.get $1
+  local.set $4
+  local.get $4
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $4
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $4
+  local.set $3
+  local.get $5
+  i32.load offset=4
   local.set $6
+  i32.const 0
+  local.set $7
+  local.get $5
+  call $~lib/typedarray/Float32Array#get:length
+  local.set $8
   loop $for-loop|0
-   local.get $5
-   local.get $6
-   i32.lt_s
-   local.set $7
    local.get $7
+   local.get $8
+   i32.lt_s
+   local.set $9
+   local.get $9
    if
-    local.get $4
-    local.get $5
-    i32.const 2
-    i32.shl
-    i32.add
-    f32.load
-    local.get $5
     local.get $3
-    i32.const 3
-    global.set $~argumentsLength
-    local.get $2
-    call_indirect (type $f32_i32_i32_=>_none)
-    local.get $5
+    local.set $10
+    local.get $10
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if
+     local.get $10
+     i32.const 4
+     i32.shl
+     local.get $6
+     local.get $7
+     i32.const 2
+     i32.shl
+     i32.add
+     f32.load
+     local.get $7
+     local.get $5
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $10
+     i32.const 4
+     i32.shl
+     i32.load
+     call_indirect (type $i32_f32_i32_i32_=>_none)
+    else
+     local.get $6
+     local.get $7
+     i32.const 2
+     i32.shl
+     i32.add
+     f32.load
+     local.get $7
+     local.get $5
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $10
+     call_indirect (type $f32_i32_i32_=>_none)
+    end
+    local.get $7
     i32.const 1
     i32.add
-    local.set $5
+    local.set $7
     br $for-loop|0
    end
   end
   local.get $3
+  local.set $8
+  local.get $8
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $8
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $5
+  call $~lib/rt/pure/__release
+  local.get $1
+  local.set $6
+  local.get $6
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $6
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
   call $~lib/rt/pure/__release
  )
  (func $std/typedarray/testArrayForEach<~lib/typedarray/Float32Array,f32>
@@ -20370,7 +29637,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Float64Array,f64>~anonymous|0 (param $0 f64) (param $1 i32) (param $2 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Float64Array,f64>~anonymous|0~nonClosure (param $0 f64) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -20430,46 +29697,141 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  local.get $0
-  call $~lib/rt/pure/__retain
-  local.set $3
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
   local.get $1
   local.set $2
-  local.get $3
-  i32.load offset=4
-  local.set $4
-  i32.const 0
+  local.get $2
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $2
+  local.set $1
+  local.get $0
+  call $~lib/rt/pure/__retain
   local.set $5
-  local.get $3
-  call $~lib/typedarray/Float64Array#get:length
+  local.get $1
+  local.set $4
+  local.get $4
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $4
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $4
+  local.set $3
+  local.get $5
+  i32.load offset=4
   local.set $6
+  i32.const 0
+  local.set $7
+  local.get $5
+  call $~lib/typedarray/Float64Array#get:length
+  local.set $8
   loop $for-loop|0
-   local.get $5
-   local.get $6
-   i32.lt_s
-   local.set $7
    local.get $7
+   local.get $8
+   i32.lt_s
+   local.set $9
+   local.get $9
    if
-    local.get $4
-    local.get $5
-    i32.const 3
-    i32.shl
-    i32.add
-    f64.load
-    local.get $5
     local.get $3
-    i32.const 3
-    global.set $~argumentsLength
-    local.get $2
-    call_indirect (type $f64_i32_i32_=>_none)
-    local.get $5
+    local.set $10
+    local.get $10
+    i32.const -2147483648
+    i32.and
+    i32.const -2147483648
+    i32.eq
+    if
+     local.get $10
+     i32.const 4
+     i32.shl
+     local.get $6
+     local.get $7
+     i32.const 3
+     i32.shl
+     i32.add
+     f64.load
+     local.get $7
+     local.get $5
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $10
+     i32.const 4
+     i32.shl
+     i32.load
+     call_indirect (type $i32_f64_i32_i32_=>_none)
+    else
+     local.get $6
+     local.get $7
+     i32.const 3
+     i32.shl
+     i32.add
+     f64.load
+     local.get $7
+     local.get $5
+     i32.const 3
+     global.set $~argumentsLength
+     local.get $10
+     call_indirect (type $f64_i32_i32_=>_none)
+    end
+    local.get $7
     i32.const 1
     i32.add
-    local.set $5
+    local.set $7
     br $for-loop|0
    end
   end
   local.get $3
+  local.set $8
+  local.get $8
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $8
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
+  call $~lib/rt/pure/__release
+  local.get $5
+  call $~lib/rt/pure/__release
+  local.get $1
+  local.set $6
+  local.get $6
+  i32.const -2147483648
+  i32.and
+  i32.const -2147483648
+  i32.eq
+  if (result i32)
+   local.get $6
+   i32.const 4
+   i32.shl
+  else
+   i32.const 0
+  end
   call $~lib/rt/pure/__release
  )
  (func $std/typedarray/testArrayForEach<~lib/typedarray/Float64Array,f64>

--- a/tests/compiler/typeof.untouched.wat
+++ b/tests/compiler/typeof.untouched.wat
@@ -16,7 +16,7 @@
  (data (i32.const 224) "\0c\00\00\00\01\00\00\00\01\00\00\00\0c\00\00\00s\00t\00r\00i\00n\00g\00")
  (data (i32.const 256) "\12\00\00\00\01\00\00\00\01\00\00\00\12\00\00\00u\00n\00d\00e\00f\00i\00n\00e\00d\00")
  (table $0 2 funcref)
- (elem (i32.const 1) $start:typeof~anonymous|0)
+ (elem (i32.const 1) $start:typeof~anonymous|0~nonClosure)
  (global $typeof/SomeNamespace.a i32 (i32.const 1))
  (global $~lib/ASC_SHRINK_LEVEL i32 (i32.const 0))
  (global $typeof/b (mut i32) (i32.const 1))
@@ -246,7 +246,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $start:typeof~anonymous|0
+ (func $start:typeof~anonymous|0~nonClosure
   nop
  )
  (func $~lib/rt/stub/maybeGrowMemory (param $0 i32)


### PR DESCRIPTION
A Closure implementation which works as follows:
- Closures get an extra context argument appended to them
- While compiling a closure, we point to offsets from that context pointer in linear memory to access closed over variables
- After compiling a closure, we generate a class for that closure of this form:
```typescript
class Closure|X { // X is unique per closure 
  fn: usize // holds function ptr
  x: i32 // outside lexical scope which is referenced from the closure
  ...
}
```
- The object which is returned from defining a closure is an instantiation of the above object that was generated
- When this object is called in scope:
  - We copy in the values of the local scope into the `Closure|X` class instance
  - We load the closure context argument, followed by the rest of the normal arguments
  - We call the anonymous method
- When this object is converted into a function type (a type only signified by a type signature). This typically occurs because we're returning it from a function or passing it as an argument to a function
  - We copy in the values of the local scope into the `Closure|X` class instance one more time
  - We right-shift the bits of the address by 4, removing the 0s that result from 16-bit address alignment
  - We set the MSB
- When an anonymous function is called
  - We check to see if the MSB is set, that implies that it's a closure
  - Apply the same procedure as when it's called in scope, except without copying in local values (since we don't have access to them here)

There are still some improvements to be made, but I think we're in a pretty stable state and things seem to all be working.

cc @willemneal

## CURRENT LIMITATIONS
In the interest of time, I'm leaving in some limitations intentionally. They should be represented in the tests closure-limitations and closure-limitations-runtime. Here's a list for reference:
- writing to a closed value
- creating a closure within an anonymous function
- returning a closure from an exported function
- Calling a closure in the same scope it was defined in within a function, i.e.:
```typescript
class Foo {
  field: i32;
}
var compClosuresSameScope = (): void => {
  var foo: Foo = {
    field: 8
  }
  var withFoo1 = (): void => {
    foo.field += 1;
  }
  var withFoo2 = (): void => {
    withFoo1();
  }
}
```