### PR TITLE
Fix converge option

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -1629,7 +1629,7 @@ export class Module {
     binaryen._BinaryenModuleInterpret(this.ref);
   }
 
-  toBinary(sourceMapUrl: string | null): BinaryModule {
+  toBinary(sourceMapUrl: string | null = null): BinaryModule {
     var out = this.lit; // safe to reuse as long as..
     assert(binaryen._BinaryenSizeofLiteral() >= 12);
     var cStr = allocString(sourceMapUrl);
@@ -1642,7 +1642,7 @@ export class Module {
     var ret = new BinaryModule();
     ret.output = readBuffer(binaryPtr, binaryLen);
     ret.sourceMap = readString(sourceMapPtr);
-    binaryen._free(cStr);
+    if (cStr) binaryen._free(cStr);
     binaryen._free(binaryPtr);
     if (sourceMapPtr) binaryen._free(sourceMapPtr);
     return ret;
@@ -2329,7 +2329,7 @@ function stringLengthUTF8(str: string): usize {
 }
 
 function allocString(str: string | null): usize {
-  if (str === null) return 0;
+  if (str == null) return 0;
   var ptr = binaryen._malloc(stringLengthUTF8(str) + 1);
   // the following is based on Emscripten's stringToUTF8Array
   var idx = ptr;

--- a/src/module.ts
+++ b/src/module.ts
@@ -2329,7 +2329,7 @@ function stringLengthUTF8(str: string): usize {
 }
 
 function allocString(str: string | null): usize {
-  if (str == null) return 0;
+  if (str === null) return 0;
   var ptr = binaryen._malloc(stringLengthUTF8(str) + 1);
   // the following is based on Emscripten's stringToUTF8Array
   var idx = ptr;

--- a/tests/compiler/converge.json
+++ b/tests/compiler/converge.json
@@ -1,0 +1,6 @@
+{
+  "asc_flags": [
+    "--runtime none",
+    "--converge"
+  ]
+}

--- a/tests/compiler/converge.optimized.wat
+++ b/tests/compiler/converge.optimized.wat
@@ -1,0 +1,9 @@
+(module
+ (type $none_=>_none (func))
+ (memory $0 0)
+ (export "memory" (memory $0))
+ (export "test" (func $converge/test))
+ (func $converge/test
+  nop
+ )
+)

--- a/tests/compiler/converge.ts
+++ b/tests/compiler/converge.ts
@@ -1,0 +1,1 @@
+export function test(): void {}

--- a/tests/compiler/converge.untouched.wat
+++ b/tests/compiler/converge.untouched.wat
@@ -1,0 +1,10 @@
+(module
+ (type $none_=>_none (func))
+ (memory $0 0)
+ (table $0 1 funcref)
+ (export "memory" (memory $0))
+ (export "test" (func $converge/test))
+ (func $converge/test
+  nop
+ )
+)


### PR DESCRIPTION
fixes https://github.com/AssemblyScript/assemblyscript/issues/1248

During converge we call `Module#toBinary` with no arguments since the source map is irrelevant to determine just binary size, with the implicit `undefined` resulting in the issue in portable code.