### PR TITLE
Fix identifier handling on export { default as ... }

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -2473,7 +2473,7 @@ export class Parser extends DiagnosticEmitter {
 
     // before: Identifier ('as' Identifier)?
 
-    if (tn.skipIdentifier()) {
+    if (tn.skipIdentifier(IdentifierHandling.ALWAYS)) {
       let identifier = Node.createIdentifierExpression(tn.readIdentifier(), tn.range());
       let asIdentifier: IdentifierExpression | null = null;
       if (tn.skip(Token.AS)) {

--- a/tests/compiler/reexport.optimized.wat
+++ b/tests/compiler/reexport.optimized.wat
@@ -25,6 +25,8 @@
  (export "exportstar.renamed_c" (global $export/c))
  (export "exportstar.ns.two" (func $export/ns.one))
  (export "exportstar.default.two" (func $export/ns.one))
+ (export "default" (func $export/ns.one))
+ (export "renamed_default" (func $export/ns.one))
  (func $export/add (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1

--- a/tests/compiler/reexport.ts
+++ b/tests/compiler/reexport.ts
@@ -27,3 +27,6 @@ export { ns as renamed_ns } from "./export";
 
 import * as exportstar from "./exportstar";
 export { exportstar };
+
+export { default } from "./export-default";
+export { default as renamed_default } from "./export-default";

--- a/tests/compiler/reexport.untouched.wat
+++ b/tests/compiler/reexport.untouched.wat
@@ -26,6 +26,8 @@
  (export "exportstar.renamed_c" (global $export/c))
  (export "exportstar.ns.two" (func $export/ns.two))
  (export "exportstar.default.two" (func $export/ns.two))
+ (export "default" (func $export-default/theDefault))
+ (export "renamed_default" (func $export-default/theDefault))
  (start $~start)
  (func $export/add (param $0 i32) (param $1 i32) (result i32)
   local.get $0
@@ -56,6 +58,9 @@
   nop
  )
  (func $export/ns.two
+  nop
+ )
+ (func $export-default/theDefault
   nop
  )
  (func $~start

--- a/tests/compiler/rereexport.optimized.wat
+++ b/tests/compiler/rereexport.optimized.wat
@@ -1,4 +1,5 @@
 (module
+ (type $none_=>_none (func))
  (memory $0 0)
  (global $export/a i32 (i32.const 1))
  (global $export/b i32 (i32.const 2))
@@ -7,4 +8,9 @@
  (export "renamed_a" (global $export/a))
  (export "renamed_b" (global $export/b))
  (export "renamed_renamed_b" (global $export/b))
+ (export "default" (func $export-default/theDefault))
+ (export "renamed_default" (func $export-default/theDefault))
+ (func $export-default/theDefault
+  nop
+ )
 )

--- a/tests/compiler/rereexport.ts
+++ b/tests/compiler/rereexport.ts
@@ -2,5 +2,7 @@ export {
   a,
   a as renamed_a,
   renamed_b,
-  renamed_b as renamed_renamed_b
+  renamed_b as renamed_renamed_b,
+  default,
+  default as renamed_default
 } from "./reexport";

--- a/tests/compiler/rereexport.untouched.wat
+++ b/tests/compiler/rereexport.untouched.wat
@@ -11,6 +11,8 @@
  (export "renamed_a" (global $export/a))
  (export "renamed_b" (global $export/b))
  (export "renamed_renamed_b" (global $export/b))
+ (export "default" (func $export-default/theDefault))
+ (export "renamed_default" (func $export-default/theDefault))
  (start $~start)
  (func $export/add (param $0 i32) (param $1 i32) (result i32)
   local.get $0
@@ -34,6 +36,9 @@
  )
  (func $start:rereexport
   call $start:reexport
+ )
+ (func $export-default/theDefault
+  nop
  )
  (func $~start
   call $start:rereexport

--- a/tests/compiler/wildcard-export.optimized.wat
+++ b/tests/compiler/wildcard-export.optimized.wat
@@ -1,4 +1,5 @@
 (module
+ (type $none_=>_none (func))
  (memory $0 0)
  (global $export/a i32 (i32.const 1))
  (global $export/b i32 (i32.const 2))
@@ -7,4 +8,9 @@
  (export "renamed_a" (global $export/a))
  (export "renamed_b" (global $export/b))
  (export "renamed_renamed_b" (global $export/b))
+ (export "default" (func $export-default/theDefault))
+ (export "renamed_default" (func $export-default/theDefault))
+ (func $export-default/theDefault
+  nop
+ )
 )

--- a/tests/compiler/wildcard-export.untouched.wat
+++ b/tests/compiler/wildcard-export.untouched.wat
@@ -11,6 +11,8 @@
  (export "renamed_a" (global $export/a))
  (export "renamed_b" (global $export/b))
  (export "renamed_renamed_b" (global $export/b))
+ (export "default" (func $export-default/theDefault))
+ (export "renamed_default" (func $export-default/theDefault))
  (start $~start)
  (func $export/add (param $0 i32) (param $1 i32) (result i32)
   local.get $0
@@ -37,6 +39,9 @@
  )
  (func $start:wildcard-export
   call $start:rereexport
+ )
+ (func $export-default/theDefault
+  nop
  )
  (func $~start
   call $start:wildcard-export


### PR DESCRIPTION
Fixes the parser bailing on `default` in

```ts
export { default as something } from "./something";
```

due to identifier handling.

Related: https://github.com/AssemblyScript/assemblyscript/issues/98