### PR TITLE
Validate modules by default

### DIFF
--- a/bin/asinit
+++ b/bin/asinit
@@ -249,8 +249,8 @@ function ensureGitignore() {
 function ensurePackageJson() {
   console.log("- Making sure that 'package.json' contains the build commands...")
   const entryPath = path.relative(projectDir, entryFile).replace(/\\/g, "/");
-  const buildUntouched = "asc " + entryPath + " -b build/untouched.wasm -t build/untouched.wat --validate --sourceMap --debug";
-  const buildOptimized = "asc " + entryPath + " -b build/optimized.wasm -t build/optimized.wat --validate --sourceMap --optimize";
+  const buildUntouched = "asc " + entryPath + " -b build/untouched.wasm -t build/untouched.wat --sourceMap --debug";
+  const buildOptimized = "asc " + entryPath + " -b build/optimized.wasm -t build/optimized.wat --sourceMap --optimize";
   const buildAll = "npm run asbuild:untouched && npm run asbuild:optimized";
   if (!fs.existsSync(packageFile)) {
     fs.writeFileSync(packageFile, JSON.stringify({

--- a/cli/asc.d.ts
+++ b/cli/asc.d.ts
@@ -69,8 +69,6 @@ interface CompilerOptions {
   shrinkLevel?: number;
   /** Re-optimizes until no further improvements can be made. */
   converge?: boolean;
-  /** Validates the module using Binaryen. Exits if invalid. */
-  validate?: boolean;
   /** Specifies the base directory of input and output files. */
   baseDir?: string;
   /** Specifies the output file. File extension indicates format. */
@@ -119,6 +117,8 @@ interface CompilerOptions {
   trapMode?: "allow" | "clamp" | "js";
   /** Specifies additional Binaryen passes to run. */
   runPasses?: string | string[];
+  /** Skips validating the module using Binaryen. */
+  noValidate?: boolean;
   /** Enables WebAssembly features that are disabled by default. */
   enable?: string | string[];
   /** Disables WebAssembly features that are enabled by default. */

--- a/cli/asc.js
+++ b/cli/asc.js
@@ -638,7 +638,7 @@ exports.main = function main(argv, options, callback) {
   }
 
   // Validate the module if requested
-  if (args.validate) {
+  if (!args.noValidate) {
     stats.validateCount++;
     stats.validateTime += measure(() => {
       if (!module.validate()) {

--- a/cli/asc.json
+++ b/cli/asc.json
@@ -218,13 +218,6 @@
     "type": "S"
   },
 
-  "validate": {
-    "category": "Binaryen",
-    "description": "Validates the module using Binaryen. Exits if invalid.",
-    "type": "b",
-    "alias": "c",
-    "default": false
-  },
   "trapMode": {
     "category": "Binaryen",
     "description": [
@@ -245,6 +238,13 @@
       "optimizations, if any. See: Binaryen/src/passes/pass.cpp"
     ],
     "type": "s"
+  },
+  "noValidate": {
+    "category": "Binaryen",
+    "description": "Skips validating the module using Binaryen.",
+    "type": "b",
+    "alias": "c",
+    "default": false
   },
 
   "baseDir": {

--- a/lib/parse/package.json
+++ b/lib/parse/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "types": "index.d.ts",
   "scripts": {
-    "asbuild": "asc assembly/index.ts -O3 -b build/index.wasm -t build/index.wat --importMemory --runtime none --sourceMap --validate",
+    "asbuild": "asc assembly/index.ts -O3 -b build/index.wasm -t build/index.wat --importMemory --runtime none --sourceMap",
     "build": "npm run asbuild && webpack --mode production --display-modules",
     "test": "ts-node tests/"
   },

--- a/lib/webpack/index.js
+++ b/lib/webpack/index.js
@@ -23,7 +23,6 @@ function compile() {
     "--baseDir", path.dirname(this.resourcePath),
     "--binaryFile", basePath + ".wasm",
     "--textFile", basePath + ".wat",
-    "--validate",
     "--optimize"
   ];
   if (this.sourceMap)

--- a/package.json
+++ b/package.json
@@ -66,8 +66,8 @@
     "prepublishOnly": "node scripts/prepublish",
     "postpublish": "node scripts/postpublish",
     "asbuild": "npm run asbuild:untouched && npm run asbuild:optimized",
-    "asbuild:untouched": "node bin/asc src/glue/wasm/index.ts src/index.ts -t out/assemblyscript.untouched.wat -b out/assemblyscript.untouched.wasm -d out/assemblyscript.d.ts --validate --debug --measure --runtime stub",
-    "asbuild:optimized": "node bin/asc src/glue/wasm/index.ts src/index.ts -t out/assemblyscript.optimized.wat -b out/assemblyscript.optimized.wasm -O3 --validate --measure --runtime stub",
+    "asbuild:untouched": "node bin/asc src/glue/wasm/index.ts src/index.ts -t out/assemblyscript.untouched.wat -b out/assemblyscript.untouched.wasm -d out/assemblyscript.d.ts --debug --measure --runtime stub",
+    "asbuild:optimized": "node bin/asc src/glue/wasm/index.ts src/index.ts -t out/assemblyscript.optimized.wat -b out/assemblyscript.optimized.wasm -O3 --measure --runtime stub",
     "astest": "ts-node tests/bootstrap"
   },
   "releaseFiles": [

--- a/tests/allocators/buddy/package.json
+++ b/tests/allocators/buddy/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "scripts": {
     "build": "npm run build:untouched && npm run build:optimized",
-    "build:untouched": "node ../../../bin/asc assembly/index.ts -t untouched.wat -b untouched.wasm --runtime none --validate --sourceMap --measure",
-    "build:optimized": "node ../../../bin/asc assembly/index.ts -t optimized.wat -b optimized.wasm --runtime none --validate --sourceMap --measure --noAssert --optimize"
+    "build:untouched": "node ../../../bin/asc assembly/index.ts -t untouched.wat -b untouched.wasm --runtime none --sourceMap --measure",
+    "build:optimized": "node ../../../bin/asc assembly/index.ts -t optimized.wat -b optimized.wasm --runtime none --sourceMap --measure --noAssert --optimize"
   }
 }

--- a/tests/allocators/rt-full/package.json
+++ b/tests/allocators/rt-full/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "scripts": {
     "build": "npm run build:untouched && npm run build:optimized",
-    "build:untouched": "node ../../../bin/asc assembly/index.ts -t untouched.wat -b untouched.wasm --runtime full --validate --sourceMap --measure",
-    "build:optimized": "node ../../../bin/asc assembly/index.ts -t optimized.wat -b optimized.wasm --runtime full --validate --sourceMap --measure --noAssert --optimize"
+    "build:untouched": "node ../../../bin/asc assembly/index.ts -t untouched.wat -b untouched.wasm --runtime full --sourceMap --measure",
+    "build:optimized": "node ../../../bin/asc assembly/index.ts -t optimized.wat -b optimized.wasm --runtime full --sourceMap --measure --noAssert --optimize"
   }
 }

--- a/tests/allocators/rt-stub/package.json
+++ b/tests/allocators/rt-stub/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "scripts": {
     "build": "npm run build:untouched && npm run build:optimized",
-    "build:untouched": "node ../../../bin/asc assembly/index.ts -t untouched.wat -b untouched.wasm --runtime stub --validate --sourceMap --measure",
-    "build:optimized": "node ../../../bin/asc assembly/index.ts -t optimized.wat -b optimized.wasm --runtime stub --validate --sourceMap --measure --noAssert --optimize"
+    "build:untouched": "node ../../../bin/asc assembly/index.ts -t untouched.wat -b untouched.wasm --runtime stub --sourceMap --measure",
+    "build:optimized": "node ../../../bin/asc assembly/index.ts -t optimized.wat -b optimized.wasm --runtime stub --sourceMap --measure --noAssert --optimize"
   }
 }

--- a/tests/compiler.js
+++ b/tests/compiler.js
@@ -145,7 +145,6 @@ function runTest(basename) {
   var cmd = [
     basename + ".ts",
     "--baseDir", basedir,
-    "--validate",
     "--measure",
     "--debug",
     "--pedantic",
@@ -224,7 +223,6 @@ function runTest(basename) {
     var cmd = [
       basename + ".ts",
       "--baseDir", basedir,
-      "--validate",
       "--measure",
       "--pedantic",
       "--binaryFile", // -> stdout

--- a/tests/compiler/features/simd.ts
+++ b/tests/compiler/features/simd.ts
@@ -1,4 +1,4 @@
-// hint: asc tests/compiler/simd --enable simd --validate
+// hint: asc tests/compiler/simd --enable simd
 
 function test_v128(): void {
   // equality and inequality

--- a/tests/compiler/std/simd.ts
+++ b/tests/compiler/std/simd.ts
@@ -1,4 +1,4 @@
-// hint: asc tests/compiler/std/simd --enable simd --validate
+// hint: asc tests/compiler/std/simd --enable simd
 
 @final
 class I8x16 {

--- a/tests/packages/package.json
+++ b/tests/packages/package.json
@@ -1,15 +1,15 @@
 {
   "scripts": {
     "test": "npm run a && npm run b && npm run c && npm run d && npm run e && npm run f && npm run g && npm run as && npm run h",
-    "a": "cd ./packages/a && node ../../../../bin/asc assembly/index.ts --noEmit --runtime stub --validate",
-    "as": "cd ./packages/as && node ../../../../bin/asc as/index.ts --noEmit --runtime stub --validate",
+    "a": "cd ./packages/a && node ../../../../bin/asc assembly/index.ts --noEmit --runtime stub",
+    "as": "cd ./packages/as && node ../../../../bin/asc as/index.ts --noEmit --runtime stub",
     "b": "cd ./packages/b && node ../../../../bin/asc assembly/index.ts --noEmit --runtime stub && node ../../../../bin/asc assembly/index.ts --noEmit --runtime stub --listFiles",
-    "c": "cd ./packages/c && node ../../../../bin/asc assembly/index.ts --noEmit --runtime stub --validate",
-    "d": "cd ./packages/d && node ../../../../bin/asc assembly/index.ts --path packages --noEmit --runtime stub --validate --traceResolution",
-    "e": "cd ./packages/d/packages/e && node ../../../../../../bin/asc assembly/index.ts --noEmit --runtime stub --validate",
-    "f": "cd ./packages/d/packages/e/packages/f && node ../../../../../../../../bin/asc assembly/index.ts --noEmit --runtime stub --validate",
+    "c": "cd ./packages/c && node ../../../../bin/asc assembly/index.ts --noEmit --runtime stub",
+    "d": "cd ./packages/d && node ../../../../bin/asc assembly/index.ts --path packages --noEmit --runtime stub --traceResolution",
+    "e": "cd ./packages/d/packages/e && node ../../../../../../bin/asc assembly/index.ts --noEmit --runtime stub",
+    "f": "cd ./packages/d/packages/e/packages/f && node ../../../../../../../../bin/asc assembly/index.ts --noEmit --runtime stub",
     "g": "cd ./packages/g && node test.js",
-    "h": "cd ./packages/h && node ../../../../bin/asc assembly/index.ts --noEmit --runtime none --validate --traceResolution"
+    "h": "cd ./packages/h && node ../../../../bin/asc assembly/index.ts --noEmit --runtime none --traceResolution"
   },
   "author": "Willem Wyndham",
   "license": "Apache-2.0"

--- a/tests/packages/packages/g/test.js
+++ b/tests/packages/packages/g/test.js
@@ -5,7 +5,6 @@ let argv = [
   "assembly/index.ts",
   "--noEmit",
   "--runtime", "stub",
-  "--validate",
   "--traceResolution"
 ];
 

--- a/tests/runtime/package.json
+++ b/tests/runtime/package.json
@@ -3,8 +3,8 @@
   "scripts": {
     "server": "http-server . -o -c-1",
     "build": "npm run build:untouched && npm run build:optimized",
-    "build:untouched": "node ../../bin/asc assembly/index.ts -t untouched.wat -b untouched.wasm --runtime full --validate --sourceMap --measure",
-    "build:optimized": "node ../../bin/asc assembly/index.ts -t optimized.wat -b optimized.wasm --runtime full --validate --sourceMap --measure --noAssert --optimize"
+    "build:untouched": "node ../../bin/asc assembly/index.ts -t untouched.wat -b untouched.wasm --runtime full --sourceMap --measure",
+    "build:optimized": "node ../../bin/asc assembly/index.ts -t optimized.wat -b optimized.wasm --runtime full --sourceMap --measure --noAssert --optimize"
   },
   "devDependencies": {
     "http-server": "^0.11.1"


### PR DESCRIPTION
Validation isn't that costly, and always good to do, and typically added to the command line to be sure. Hence this PR changes the `--validate` option to be enabled by default, making it opt-out with `--noValidate`.