### PR TITLE
Refactor static properties / use correct this arguments

### DIFF
--- a/cli/asc.json
+++ b/cli/asc.json
@@ -243,7 +243,6 @@
     "category": "Binaryen",
     "description": "Skips validating the module using Binaryen.",
     "type": "b",
-    "alias": "c",
     "default": false
   },
 

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -122,7 +122,10 @@ export abstract class ExportsWalker {
         break;
       }
       case ElementKind.PROPERTY_PROTOTYPE: {
-        this.visitPropertyInstances(name, <PropertyPrototype>element);
+        let propertyInstance = (<PropertyPrototype>element).instance;
+        if (!propertyInstance) break;
+        element = propertyInstance;
+        // fall-through
         break;
       }
       case ElementKind.PROPERTY: {
@@ -162,16 +165,6 @@ export abstract class ExportsWalker {
         if (instance.is(CommonFlags.COMPILED)) this.visitClass(name, instance);
       }
     }
-  }
-
-  private visitPropertyInstances(name: string, element: PropertyPrototype): void {
-    // var instances = element.instances;
-    // if (instances) {
-    //   for (let instance of instances.values()) {
-    //     if (instance.is(CommonFlags.COMPILED)) this.visitProperty(instance);
-    //   }
-    // }
-    assert(false);
   }
 
   abstract visitGlobal(name: string, element: Global): void;

--- a/src/flow.ts
+++ b/src/flow.ts
@@ -412,9 +412,10 @@ export class Flow {
 
   /** Adds a new scoped alias for the specified local. For example `super` aliased to the `this` local. */
   addScopedAlias(name: string, type: Type, index: i32, reportNode: Node | null = null): Local {
-    if (!this.scopedLocals) this.scopedLocals = new Map();
+    var scopedLocals = this.scopedLocals;
+    if (!scopedLocals) this.scopedLocals = scopedLocals = new Map();
     else {
-      let existingLocal = this.scopedLocals.get(name);
+      let existingLocal = scopedLocals.get(name);
       if (existingLocal) {
         if (reportNode) {
           if (!existingLocal.declaration.range.source.isNative) {
@@ -437,7 +438,7 @@ export class Flow {
     assert(index < this.parentFunction.localsByIndex.length);
     var scopedAlias = new Local(name, index, type, this.parentFunction);
     // not flagged as SCOPED as it must not be free'd when the flow is finalized
-    this.scopedLocals.set(name, scopedAlias);
+    scopedLocals.set(name, scopedAlias);
     return scopedAlias;
   }
 

--- a/src/program.ts
+++ b/src/program.ts
@@ -3210,7 +3210,10 @@ export class FunctionPrototype extends DeclaredElement {
   get isBound(): bool {
     var parent = this.parent;
     return parent.kind == ElementKind.CLASS
-        || parent.kind == ElementKind.PROPERTY_PROTOTYPE && parent.parent.kind == ElementKind.CLASS;
+        || parent.kind == ElementKind.PROPERTY_PROTOTYPE && (
+             parent.parent.kind == ElementKind.CLASS ||
+             parent.parent.kind == ElementKind.INTERFACE
+           );
   }
 
   /** Creates a clone of this prototype that is bound to a concrete class instead. */
@@ -3415,8 +3418,9 @@ export class Function extends TypedElement {
   /** Finalizes the function once compiled, releasing no longer needed resources. */
   finalize(module: Module, ref: FunctionRef): void {
     this.ref = ref;
-    assert(!this.breakStack || !this.breakStack.length); // internal error
-    this.breakStack = null;
+    var breakStack = this.breakStack;
+    assert(!breakStack || !breakStack.length); // internal error
+    this.breakStack = breakStack = null;
     this.breakLabel = null;
     this.tempI32s = this.tempI64s = this.tempF32s = this.tempF64s = null;
     if (this.program.options.sourceMap) {
@@ -3571,6 +3575,8 @@ export class PropertyPrototype extends DeclaredElement {
   getterPrototype: FunctionPrototype | null = null;
   /** Setter prototype. */
   setterPrototype: FunctionPrototype | null = null;
+  /** Property instance, if resolved. */
+  instance: Property | null = null;
 
   /** Constructs a new property prototype. */
   constructor(
@@ -3631,7 +3637,9 @@ export class Property extends VariableLikeElement {
     this.prototype = prototype;
     this.flags = prototype.flags;
     this.decoratorFlags = prototype.decoratorFlags;
-    registerConcreteElement(this.program, this);
+    if (this.is(CommonFlags.INSTANCE)) {
+      registerConcreteElement(this.program, this);
+    }
   }
 
   /* @override */
@@ -3908,9 +3916,10 @@ export class Class extends TypedElement {
         throw new Error("type argument count mismatch");
       }
       if (numTypeArguments) {
-        if (!this.contextualTypeArguments) this.contextualTypeArguments = new Map();
+        let contextualTypeArguments = this.contextualTypeArguments;
+        if (!contextualTypeArguments) this.contextualTypeArguments = contextualTypeArguments = new Map();
         for (let i = 0; i < numTypeArguments; ++i) {
-          this.contextualTypeArguments.set(typeParameters[i].name.text, typeArguments[i]);
+          contextualTypeArguments.set(typeParameters[i].name.text, typeArguments[i]);
         }
       }
     } else if (typeParameters !== null && typeParameters.length > 0) {

--- a/tests/compiler/builtins.optimized.wat
+++ b/tests/compiler/builtins.optimized.wat
@@ -592,9 +592,9 @@
   i32.const 5
   f64.const 0
   f64.const 0
-  f64.const 29
-  f64.const 30
-  f64.const 30
+  f64.const 23
+  f64.const 24
+  f64.const 24
   call $~lib/builtins/trace
   i32.const 1216
   i32.const 1216

--- a/tests/compiler/builtins.untouched.wat
+++ b/tests/compiler/builtins.untouched.wat
@@ -1727,11 +1727,11 @@
   local.set $0
   i32.const 0
   local.set $1
-  i32.const 29
+  i32.const 23
   local.set $6
-  i32.const 30
+  i32.const 24
   local.set $7
-  i32.const 30
+  i32.const 24
   local.set $8
   i32.const 128
   i32.const 5
@@ -1771,7 +1771,7 @@
    unreachable
   end
   local.get $6
-  i32.const 29
+  i32.const 23
   i32.eq
   i32.eqz
   if

--- a/tests/compiler/resolve-binary.untouched.wat
+++ b/tests/compiler/resolve-binary.untouched.wat
@@ -4625,7 +4625,7 @@
   (local $63 i32)
   i32.const 1
   i32.const 2
-  i32.lt_u
+  i32.lt_s
   call $~lib/number/Bool#toString
   local.tee $0
   i32.const 32
@@ -4641,7 +4641,7 @@
   end
   i32.const 1
   i32.const 2
-  i32.gt_u
+  i32.gt_s
   call $~lib/number/Bool#toString
   local.tee $1
   i32.const 64
@@ -4657,7 +4657,7 @@
   end
   i32.const 1
   i32.const 2
-  i32.le_u
+  i32.le_s
   call $~lib/number/Bool#toString
   local.tee $2
   i32.const 32
@@ -4673,7 +4673,7 @@
   end
   i32.const 1
   i32.const 2
-  i32.ge_u
+  i32.ge_s
   call $~lib/number/Bool#toString
   local.tee $3
   i32.const 64
@@ -5048,7 +5048,7 @@
   end
   i32.const 4
   i32.const 2
-  i32.div_u
+  i32.div_s
   call $~lib/number/I32#toString
   local.tee $24
   i32.const 656
@@ -5064,7 +5064,7 @@
   end
   i32.const 3
   i32.const 2
-  i32.rem_u
+  i32.rem_s
   call $~lib/number/I32#toString
   local.tee $25
   i32.const 624
@@ -5078,8 +5078,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 2
-  f64.convert_i32_u
+  f64.const 2
   f64.const 2
   call $~lib/math/NativeMath.pow
   i32.const 0
@@ -5114,7 +5113,7 @@
   end
   i32.const 2
   i32.const 1
-  i32.shr_u
+  i32.shr_s
   call $~lib/number/I32#toString
   local.tee $28
   i32.const 624

--- a/tests/compiler/resolve-propertyaccess.optimized.wat
+++ b/tests/compiler/resolve-propertyaccess.optimized.wat
@@ -17,7 +17,9 @@
  (data (i32.const 1328) "\02\00\00\00\01\00\00\00\01\00\00\00\02\00\00\004")
  (data (i32.const 1360) "\02\00\00\00\01\00\00\00\01\00\00\00\02\00\00\005")
  (data (i32.const 1392) "\04\00\00\00\01\00\00\00\01\00\00\00\04\00\00\005\005")
- (data (i32.const 1424) "\02\00\00\00\01\00\00\00\01\00\00\00\02\00\00\006")
+ (data (i32.const 1424) "\02\00\00\00\01\00\00\00\01\00\00\00\02\00\00\007")
+ (data (i32.const 1456) "\02\00\00\00\01\00\00\00\01\00\00\00\02\00\00\006")
+ (data (i32.const 1488) "\02\00\00\00\01\00\00\00\01\00\00\00\02\00\00\008")
  (global $~lib/rt/stub/offset (mut i32) (i32.const 0))
  (export "memory" (memory $0))
  (start $~start)
@@ -326,7 +328,7 @@
  )
  (func $start:resolve-propertyaccess
   (local $0 i32)
-  i32.const 1456
+  i32.const 1520
   global.set $~lib/rt/stub/offset
   i32.const 1
   call $~lib/number/I32#toString
@@ -427,7 +429,7 @@
   if
    i32.const 0
    i32.const 1104
-   i32.const 70
+   i32.const 72
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -440,7 +442,20 @@
   if
    i32.const 0
    i32.const 1104
-   i32.const 76
+   i32.const 78
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 7
+  call $~lib/number/I32#toString
+  i32.const 1440
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1104
+   i32.const 84
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -454,13 +469,26 @@
   local.get $0
   i32.load
   call $~lib/number/I32#toString
-  i32.const 1440
+  i32.const 1472
   call $~lib/string/String.__eq
   i32.eqz
   if
    i32.const 0
    i32.const 1104
-   i32.const 84
+   i32.const 92
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 8
+  call $~lib/number/I32#toString
+  i32.const 1504
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1104
+   i32.const 97
    i32.const 3
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-propertyaccess.ts
+++ b/tests/compiler/resolve-propertyaccess.ts
@@ -65,6 +65,8 @@ class Class {
   static staticField: i32 = 5;
   @lazy static lazyStaticField: i32 = 55;
   instanceField: i32 = 6;
+  static get staticProperty(): i32 { return 7; }
+  get instanceProperty(): i32 { return 8; }
 }
 
 assert(
@@ -79,11 +81,22 @@ assert(
   "55"
 );
 
+assert(
+  (Class.staticProperty).toString()
+  ==
+  "7"
+);
+
 {
   let instance = new Class();
   assert(
     (instance.instanceField).toString()
     ==
     "6"
+  );
+  assert(
+    (instance.instanceProperty).toString()
+    ==
+    "8"
   );
 }

--- a/tests/compiler/resolve-propertyaccess.untouched.wat
+++ b/tests/compiler/resolve-propertyaccess.untouched.wat
@@ -5,6 +5,7 @@
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
+ (type $none_=>_i32 (func (result i32)))
  (type $i32_i32_i32_i32_i32_=>_i32 (func (param i32 i32 i32 i32 i32) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (memory $0 1)
@@ -20,7 +21,9 @@
  (data (i32.const 720) "\02\00\00\00\01\00\00\00\01\00\00\00\02\00\00\004\00")
  (data (i32.const 752) "\02\00\00\00\01\00\00\00\01\00\00\00\02\00\00\005\00")
  (data (i32.const 784) "\04\00\00\00\01\00\00\00\01\00\00\00\04\00\00\005\005\00")
- (data (i32.const 816) "\02\00\00\00\01\00\00\00\01\00\00\00\02\00\00\006\00")
+ (data (i32.const 816) "\02\00\00\00\01\00\00\00\01\00\00\00\02\00\00\007\00")
+ (data (i32.const 848) "\02\00\00\00\01\00\00\00\01\00\00\00\02\00\00\006\00")
+ (data (i32.const 880) "\02\00\00\00\01\00\00\00\01\00\00\00\02\00\00\008\00")
  (table $0 1 funcref)
  (global $resolve-propertyaccess/Namespace.member i32 (i32.const 1))
  (global $~lib/rt/stub/startOffset (mut i32) (i32.const 0))
@@ -34,7 +37,7 @@
  (global $resolve-propertyaccess/Enum.VALUE i32 (i32.const 4))
  (global $resolve-propertyaccess/Class.staticField (mut i32) (i32.const 5))
  (global $resolve-propertyaccess/Class.lazyStaticField (mut i32) (i32.const 55))
- (global $~lib/heap/__heap_base i32 (i32.const 836))
+ (global $~lib/heap/__heap_base i32 (i32.const 900))
  (export "memory" (memory $0))
  (start $~start)
  (func $~lib/util/number/decimalCount32 (param $0 i32) (result i32)
@@ -630,6 +633,9 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
+ (func $resolve-propertyaccess/Class.get:staticProperty (result i32)
+  i32.const 7
+ )
  (func $resolve-propertyaccess/Class#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
@@ -645,6 +651,9 @@
   i32.store
   local.get $0
  )
+ (func $resolve-propertyaccess/Class#get:instanceProperty (param $0 i32) (result i32)
+  i32.const 8
+ )
  (func $start:resolve-propertyaccess
   (local $0 i32)
   (local $1 i32)
@@ -657,6 +666,8 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
   global.get $~lib/heap/__heap_base
   i32.const 15
   i32.add
@@ -774,7 +785,7 @@
   if
    i32.const 0
    i32.const 496
-   i32.const 70
+   i32.const 72
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -788,18 +799,14 @@
   if
    i32.const 0
    i32.const 496
-   i32.const 76
+   i32.const 78
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 0
-  call $resolve-propertyaccess/Class#constructor
-  local.set $9
-  local.get $9
-  i32.load
+  call $resolve-propertyaccess/Class.get:staticProperty
   call $~lib/number/I32#toString
-  local.tee $10
+  local.tee $9
   i32.const 832
   call $~lib/string/String.__eq
   i32.eqz
@@ -807,13 +814,48 @@
    i32.const 0
    i32.const 496
    i32.const 84
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 0
+  call $resolve-propertyaccess/Class#constructor
+  local.set $10
+  local.get $10
+  i32.load
+  call $~lib/number/I32#toString
+  local.tee $11
+  i32.const 864
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 496
+   i32.const 92
    i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $9
-  call $~lib/rt/stub/__release
   local.get $10
+  call $resolve-propertyaccess/Class#get:instanceProperty
+  call $~lib/number/I32#toString
+  local.tee $12
+  i32.const 896
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 496
+   i32.const 97
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $10
+  call $~lib/rt/stub/__release
+  local.get $11
+  call $~lib/rt/stub/__release
+  local.get $12
   call $~lib/rt/stub/__release
   local.get $0
   call $~lib/rt/stub/__release
@@ -832,6 +874,8 @@
   local.get $7
   call $~lib/rt/stub/__release
   local.get $8
+  call $~lib/rt/stub/__release
+  local.get $9
   call $~lib/rt/stub/__release
  )
  (func $~start

--- a/tests/compiler/resolve-ternary.untouched.wat
+++ b/tests/compiler/resolve-ternary.untouched.wat
@@ -4837,8 +4837,7 @@
   end
   global.get $resolve-ternary/b
   if (result f64)
-   i32.const 1
-   f64.convert_i32_u
+   f64.const 1
   else
    f64.const 2
   end


### PR DESCRIPTION
This PR fixes https://github.com/AssemblyScript/assemblyscript/issues/1252 by refactoring static property prototypes to have a singleton instance. Previously, the compiler would instead resolve the respective getter/setter, skipping over the static prototype, while it now behaves more like with functions. Note that this still does not apply to instance properties, since properties can never be generic anyway so these are resolved together with the class, which then doesn't contain property prototypes anymore.

While on it, I also made compilation of `this` arguments use the correct type, which is either the implicit or explicit `this` type of a function or getter/setter, or the class type for fields. Noticed that this was still TODO for properties, but then also implemented it for everything else. Has a couple implications on null checking, where some property accesses would not have complained previously, but now do (see the related compiler source changes, like `namespace.members ? namespace.members.x : y`, necessary to fix bootstrapping).