### PR TITLE
Experiment: What if locals are never free'd

### DIFF
--- a/src/flow.ts
+++ b/src/flow.ts
@@ -338,6 +338,7 @@ export class Flow {
 
   /** Frees the temporary local for reuse. */
   freeTempLocal(local: Local): void {
+    /*
     if (local.is(CommonFlags.INLINED)) return;
     assert(local.index >= 0);
     var parentFunction = this.parentFunction;
@@ -390,6 +391,7 @@ export class Flow {
     }
     assert(local.index >= 0);
     temps.push(local);
+    */
   }
 
   /** Gets the scoped local of the specified name. */

--- a/tests/compiler/abi.untouched.wat
+++ b/tests/compiler/abi.untouched.wat
@@ -19,6 +19,9 @@
  (func $start:abi
   (local $0 i32)
   (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
   call $abi/internal
   drop
   i32.const 0
@@ -42,28 +45,28 @@
    unreachable
   end
   i32.const 256
-  local.set $0
+  local.set $1
   global.get $abi/condition
   if
-   local.get $0
+   local.get $1
    i32.const 24
    i32.shl
    i32.const 24
    i32.shr_s
    i32.const 2
    i32.div_s
-   local.set $0
+   local.set $1
   else
-   local.get $0
+   local.get $1
    i32.const 24
    i32.shl
    i32.const 24
    i32.shr_s
    i32.const 2
    i32.div_s
-   local.set $0
+   local.set $1
   end
-  local.get $0
+  local.get $1
   i32.const 24
   i32.shl
   i32.const 24
@@ -79,24 +82,24 @@
    unreachable
   end
   i32.const 256
-  local.set $0
+  local.set $2
   global.get $abi/condition
   if
-   local.get $0
+   local.get $2
    i32.const 24
    i32.shl
    i32.const 24
    i32.shr_s
    i32.const 24
    i32.shr_s
-   local.set $0
+   local.set $2
   else
-   local.get $0
+   local.get $2
    i32.const 127
    i32.and
-   local.set $0
+   local.set $2
   end
-  local.get $0
+  local.get $2
   i32.eqz
   i32.eqz
   if
@@ -126,8 +129,8 @@
   end
   i32.const 2
   i32.ctz
-  local.set $0
-  local.get $0
+  local.set $3
+  local.get $3
   i32.const 0
   i32.ne
   i32.eqz
@@ -141,8 +144,8 @@
   end
   i32.const 1
   i32.clz
-  local.set $0
-  local.get $0
+  local.set $3
+  local.get $3
   i32.const 0
   i32.ne
   i32.eqz
@@ -156,8 +159,8 @@
   end
   i32.const 2
   i32.ctz
-  local.set $1
-  local.get $1
+  local.set $4
+  local.get $4
   i32.eqz
   if
    i32.const 0
@@ -169,8 +172,8 @@
   end
   i32.const 1
   i32.clz
-  local.set $1
-  local.get $1
+  local.set $4
+  local.get $4
   i32.eqz
   if
    i32.const 0

--- a/tests/compiler/assert-nonnull.untouched.wat
+++ b/tests/compiler/assert-nonnull.untouched.wat
@@ -34,6 +34,7 @@
  )
  (func $assert-nonnull/testVar (param $0 i32) (result i32)
   (local $1 i32)
+  (local $2 i32)
   local.get $0
   call $~lib/rt/stub/__retain
   local.set $0
@@ -50,13 +51,14 @@
    unreachable
   end
   call $~lib/rt/stub/__retain
-  local.set $1
+  local.set $2
   local.get $0
   call $~lib/rt/stub/__release
-  local.get $1
+  local.get $2
  )
  (func $assert-nonnull/testObj (param $0 i32) (result i32)
   (local $1 i32)
+  (local $2 i32)
   local.get $0
   call $~lib/rt/stub/__retain
   local.set $0
@@ -74,13 +76,14 @@
   end
   i32.load
   call $~lib/rt/stub/__retain
-  local.set $1
+  local.set $2
   local.get $0
   call $~lib/rt/stub/__release
-  local.get $1
+  local.get $2
  )
  (func $assert-nonnull/testProp (param $0 i32) (result i32)
   (local $1 i32)
+  (local $2 i32)
   local.get $0
   call $~lib/rt/stub/__retain
   local.set $0
@@ -98,10 +101,10 @@
    unreachable
   end
   call $~lib/rt/stub/__retain
-  local.set $1
+  local.set $2
   local.get $0
   call $~lib/rt/stub/__release
-  local.get $1
+  local.get $2
  )
  (func $~lib/array/Array<assert-nonnull/Foo>#__uget (param $0 i32) (param $1 i32) (result i32)
   local.get $0
@@ -152,6 +155,7 @@
  )
  (func $assert-nonnull/testArr (param $0 i32) (result i32)
   (local $1 i32)
+  (local $2 i32)
   local.get $0
   call $~lib/rt/stub/__retain
   local.set $0
@@ -169,10 +173,10 @@
   end
   i32.const 0
   call $~lib/array/Array<assert-nonnull/Foo>#__get
-  local.set $1
+  local.set $2
   local.get $0
   call $~lib/rt/stub/__release
-  local.get $1
+  local.get $2
  )
  (func $~lib/array/Array<assert-nonnull/Foo | null>#__uget (param $0 i32) (param $1 i32) (result i32)
   local.get $0
@@ -211,6 +215,7 @@
  )
  (func $assert-nonnull/testElem (param $0 i32) (result i32)
   (local $1 i32)
+  (local $2 i32)
   local.get $0
   call $~lib/rt/stub/__retain
   local.set $0
@@ -229,14 +234,17 @@
    unreachable
   end
   call $~lib/rt/stub/__retain
-  local.set $1
+  local.set $2
   local.get $0
   call $~lib/rt/stub/__release
-  local.get $1
+  local.get $2
  )
  (func $assert-nonnull/testAll (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
   local.get $0
   call $~lib/rt/stub/__retain
   local.set $0
@@ -254,10 +262,10 @@
   end
   i32.const 0
   call $~lib/array/Array<assert-nonnull/Foo | null>#__get
-  local.tee $1
   local.tee $2
+  local.tee $3
   if (result i32)
-   local.get $2
+   local.get $3
   else
    i32.const 0
    i32.const 32
@@ -267,9 +275,9 @@
    unreachable
   end
   i32.load
-  local.tee $2
+  local.tee $4
   if (result i32)
-   local.get $2
+   local.get $4
   else
    i32.const 0
    i32.const 32
@@ -279,16 +287,19 @@
    unreachable
   end
   call $~lib/rt/stub/__retain
-  local.set $2
-  local.get $1
+  local.set $5
+  local.get $2
   call $~lib/rt/stub/__release
   local.get $0
   call $~lib/rt/stub/__release
-  local.get $2
+  local.get $5
  )
  (func $assert-nonnull/testAll2 (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
   local.get $0
   call $~lib/rt/stub/__retain
   local.set $0
@@ -306,10 +317,10 @@
   end
   i32.const 0
   call $~lib/array/Array<assert-nonnull/Foo | null>#__get
-  local.tee $1
   local.tee $2
+  local.tee $3
   if (result i32)
-   local.get $2
+   local.get $3
   else
    i32.const 0
    i32.const 32
@@ -319,9 +330,9 @@
    unreachable
   end
   i32.load
-  local.tee $2
+  local.tee $4
   if (result i32)
-   local.get $2
+   local.get $4
   else
    i32.const 0
    i32.const 32
@@ -331,12 +342,12 @@
    unreachable
   end
   call $~lib/rt/stub/__retain
-  local.set $2
-  local.get $1
+  local.set $5
+  local.get $2
   call $~lib/rt/stub/__release
   local.get $0
   call $~lib/rt/stub/__release
-  local.get $2
+  local.get $5
  )
  (func $~setArgumentsLength (param $0 i32)
   local.get $0
@@ -353,6 +364,7 @@
  (func $assert-nonnull/testFn2 (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
+  (local $3 i32)
   local.get $0
   local.tee $1
   if (result i32)
@@ -370,11 +382,12 @@
   global.set $~argumentsLength
   local.get $2
   call_indirect (type $none_=>_i32)
-  local.tee $1
+  local.tee $3
  )
  (func $assert-nonnull/testRet (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
+  (local $3 i32)
   i32.const 0
   global.set $~argumentsLength
   local.get $0
@@ -392,10 +405,10 @@
    unreachable
   end
   call $~lib/rt/stub/__retain
-  local.set $2
+  local.set $3
   local.get $1
   call $~lib/rt/stub/__release
-  local.get $2
+  local.get $3
  )
  (func $assert-nonnull/testObjFn (param $0 i32) (result i32)
   (local $1 i32)
@@ -417,6 +430,7 @@
  (func $assert-nonnull/testObjRet (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
+  (local $3 i32)
   local.get $0
   call $~lib/rt/stub/__retain
   local.set $0
@@ -438,11 +452,11 @@
    unreachable
   end
   call $~lib/rt/stub/__retain
-  local.set $2
+  local.set $3
   local.get $1
   call $~lib/rt/stub/__release
   local.get $0
   call $~lib/rt/stub/__release
-  local.get $2
+  local.get $3
  )
 )

--- a/tests/compiler/binary.untouched.wat
+++ b/tests/compiler/binary.untouched.wat
@@ -26,18 +26,18 @@
   (local $7 i64)
   (local $8 i64)
   (local $9 i64)
-  (local $10 f64)
-  (local $11 i64)
-  (local $12 i32)
+  (local $10 i64)
+  (local $11 f64)
+  (local $12 i64)
   (local $13 i64)
   (local $14 i64)
-  (local $15 f64)
-  (local $16 f64)
-  (local $17 f64)
-  (local $18 f64)
-  (local $19 f64)
-  (local $20 f64)
-  (local $21 f64)
+  (local $15 i64)
+  (local $16 i32)
+  (local $17 i64)
+  (local $18 i64)
+  (local $19 i32)
+  (local $20 i64)
+  (local $21 i64)
   (local $22 f64)
   (local $23 f64)
   (local $24 f64)
@@ -55,12 +55,52 @@
   (local $36 f64)
   (local $37 f64)
   (local $38 f64)
-  (local $39 i32)
-  (local $40 i32)
-  (local $41 i32)
-  (local $42 i32)
-  (local $43 i64)
-  (local $44 i64)
+  (local $39 f64)
+  (local $40 f64)
+  (local $41 f64)
+  (local $42 f64)
+  (local $43 f64)
+  (local $44 f64)
+  (local $45 f64)
+  (local $46 f64)
+  (local $47 f64)
+  (local $48 f64)
+  (local $49 f64)
+  (local $50 f64)
+  (local $51 f64)
+  (local $52 f64)
+  (local $53 f64)
+  (local $54 f64)
+  (local $55 i32)
+  (local $56 f64)
+  (local $57 f64)
+  (local $58 i32)
+  (local $59 i64)
+  (local $60 i64)
+  (local $61 i64)
+  (local $62 i32)
+  (local $63 f64)
+  (local $64 f64)
+  (local $65 f64)
+  (local $66 f64)
+  (local $67 f64)
+  (local $68 f64)
+  (local $69 f64)
+  (local $70 i64)
+  (local $71 i32)
+  (local $72 f64)
+  (local $73 i32)
+  (local $74 i32)
+  (local $75 f64)
+  (local $76 i32)
+  (local $77 i64)
+  (local $78 i64)
+  (local $79 f64)
+  (local $80 f64)
+  (local $81 f64)
+  (local $82 f64)
+  (local $83 f64)
+  (local $84 f64)
   local.get $1
   f64.abs
   f64.const 2
@@ -239,8 +279,8 @@
      br $~lib/util/math/pow_lut|inlined.0
     end
     local.get $5
-    local.set $9
-    local.get $9
+    local.set $10
+    local.get $10
     i64.const 1
     i64.shl
     i64.const 1
@@ -253,7 +293,7 @@
      local.get $3
      local.get $3
      f64.mul
-     local.set $10
+     local.set $11
      local.get $5
      i64.const 63
      i64.shr_u
@@ -261,21 +301,21 @@
      if (result i32)
       block $~lib/util/math/checkint|inlined.0 (result i32)
        local.get $6
-       local.set $9
-       local.get $9
+       local.set $12
+       local.get $12
        i64.const 52
        i64.shr_u
        i64.const 2047
        i64.and
-       local.set $11
-       local.get $11
+       local.set $13
+       local.get $13
        i64.const 1023
        i64.lt_u
        if
         i32.const 0
         br $~lib/util/math/checkint|inlined.0
        end
-       local.get $11
+       local.get $13
        i64.const 1023
        i64.const 52
        i64.add
@@ -288,12 +328,12 @@
        i64.const 1023
        i64.const 52
        i64.add
-       local.get $11
+       local.get $13
        i64.sub
        i64.shl
-       local.set $11
-       local.get $9
-       local.get $11
+       local.set $13
+       local.get $12
+       local.get $13
        i64.const 1
        i64.sub
        i64.and
@@ -303,8 +343,8 @@
         i32.const 0
         br $~lib/util/math/checkint|inlined.0
        end
-       local.get $9
-       local.get $11
+       local.get $12
+       local.get $13
        i64.and
        i64.const 0
        i64.ne
@@ -320,9 +360,9 @@
       i32.const 0
      end
      if
-      local.get $10
+      local.get $11
       f64.neg
-      local.set $10
+      local.set $11
      end
      local.get $6
      i64.const 63
@@ -331,10 +371,10 @@
      i64.ne
      if (result f64)
       f64.const 1
-      local.get $10
+      local.get $11
       f64.div
      else
-      local.get $10
+      local.get $11
      end
      br $~lib/util/math/pow_lut|inlined.0
     end
@@ -346,21 +386,21 @@
     if
      block $~lib/util/math/checkint|inlined.1 (result i32)
       local.get $6
-      local.set $9
-      local.get $9
+      local.set $14
+      local.get $14
       i64.const 52
       i64.shr_u
       i64.const 2047
       i64.and
-      local.set $11
-      local.get $11
+      local.set $15
+      local.get $15
       i64.const 1023
       i64.lt_u
       if
        i32.const 0
        br $~lib/util/math/checkint|inlined.1
       end
-      local.get $11
+      local.get $15
       i64.const 1023
       i64.const 52
       i64.add
@@ -373,12 +413,12 @@
       i64.const 1023
       i64.const 52
       i64.add
-      local.get $11
+      local.get $15
       i64.sub
       i64.shl
-      local.set $11
-      local.get $9
-      local.get $11
+      local.set $15
+      local.get $14
+      local.get $15
       i64.const 1
       i64.sub
       i64.and
@@ -388,8 +428,8 @@
        i32.const 0
        br $~lib/util/math/checkint|inlined.1
       end
-      local.get $9
-      local.get $11
+      local.get $14
+      local.get $15
       i64.and
       i64.const 0
       i64.ne
@@ -399,8 +439,8 @@
       end
       i32.const 2
      end
-     local.set $12
-     local.get $12
+     local.set $16
+     local.get $16
      i32.const 0
      i32.eq
      if
@@ -413,7 +453,7 @@
       f64.div
       br $~lib/util/math/pow_lut|inlined.0
      end
-     local.get $12
+     local.get $16
      i32.const 1
      i32.eq
      if
@@ -491,12 +531,12 @@
     end
    end
    local.get $5
-   local.set $9
-   local.get $9
+   local.set $17
+   local.get $17
    i64.const 4604531861337669632
    i64.sub
-   local.set $11
-   local.get $11
+   local.set $18
+   local.get $18
    i64.const 52
    i64.const 7
    i64.sub
@@ -504,150 +544,150 @@
    i64.const 127
    i64.and
    i32.wrap_i64
-   local.set $12
-   local.get $11
+   local.set $19
+   local.get $18
    i64.const 52
    i64.shr_s
-   local.set $13
-   local.get $9
-   local.get $11
+   local.set $20
+   local.get $17
+   local.get $18
    i64.const 4095
    i64.const 52
    i64.shl
    i64.and
    i64.sub
-   local.set $14
-   local.get $14
+   local.set $21
+   local.get $21
    f64.reinterpret_i64
-   local.set $10
-   local.get $13
+   local.set $22
+   local.get $20
    f64.convert_i64_s
-   local.set $15
+   local.set $23
    i32.const 8
-   local.get $12
+   local.get $19
    i32.const 2
    i32.const 3
    i32.add
    i32.shl
    i32.add
    f64.load
-   local.set $16
+   local.set $24
    i32.const 8
-   local.get $12
+   local.get $19
    i32.const 2
    i32.const 3
    i32.add
    i32.shl
    i32.add
    f64.load offset=16
-   local.set $17
+   local.set $25
    i32.const 8
-   local.get $12
+   local.get $19
    i32.const 2
    i32.const 3
    i32.add
    i32.shl
    i32.add
    f64.load offset=24
-   local.set $18
-   local.get $14
+   local.set $26
+   local.get $21
    i64.const 2147483648
    i64.add
    i64.const -4294967296
    i64.and
    f64.reinterpret_i64
-   local.set $19
-   local.get $10
-   local.get $19
+   local.set $27
+   local.get $22
+   local.get $27
    f64.sub
-   local.set $20
-   local.get $19
-   local.get $16
+   local.set $28
+   local.get $27
+   local.get $24
    f64.mul
    f64.const 1
    f64.sub
-   local.set $21
-   local.get $20
-   local.get $16
-   f64.mul
-   local.set $22
-   local.get $21
-   local.get $22
-   f64.add
-   local.set $23
-   local.get $15
-   f64.const 0.6931471805598903
-   f64.mul
-   local.get $17
-   f64.add
-   local.set $24
-   local.get $24
-   local.get $23
-   f64.add
-   local.set $25
-   local.get $15
-   f64.const 5.497923018708371e-14
-   f64.mul
-   local.get $18
-   f64.add
-   local.set $26
-   local.get $24
-   local.get $25
-   f64.sub
-   local.get $23
-   f64.add
-   local.set $27
-   f64.const -0.5
-   local.get $23
-   f64.mul
-   local.set $28
-   local.get $23
-   local.get $28
-   f64.mul
    local.set $29
-   local.get $23
-   local.get $29
+   local.get $28
+   local.get $24
    f64.mul
    local.set $30
-   f64.const -0.5
-   local.get $21
-   f64.mul
+   local.get $29
+   local.get $30
+   f64.add
    local.set $31
-   local.get $21
-   local.get $31
+   local.get $23
+   f64.const 0.6931471805598903
    f64.mul
-   local.set $32
    local.get $25
+   f64.add
+   local.set $32
    local.get $32
+   local.get $31
    f64.add
    local.set $33
-   local.get $22
-   local.get $28
-   local.get $31
-   f64.add
+   local.get $23
+   f64.const 5.497923018708371e-14
    f64.mul
+   local.get $26
+   f64.add
    local.set $34
-   local.get $25
+   local.get $32
    local.get $33
    f64.sub
-   local.get $32
+   local.get $31
    f64.add
    local.set $35
+   f64.const -0.5
+   local.get $31
+   f64.mul
+   local.set $36
+   local.get $31
+   local.get $36
+   f64.mul
+   local.set $37
+   local.get $31
+   local.get $37
+   f64.mul
+   local.set $38
+   f64.const -0.5
+   local.get $29
+   f64.mul
+   local.set $39
+   local.get $29
+   local.get $39
+   f64.mul
+   local.set $40
+   local.get $33
+   local.get $40
+   f64.add
+   local.set $41
    local.get $30
+   local.get $36
+   local.get $39
+   f64.add
+   f64.mul
+   local.set $42
+   local.get $33
+   local.get $41
+   f64.sub
+   local.get $40
+   f64.add
+   local.set $43
+   local.get $38
    f64.const -0.6666666666666679
-   local.get $23
+   local.get $31
    f64.const 0.5000000000000007
    f64.mul
    f64.add
-   local.get $29
+   local.get $37
    f64.const 0.7999999995323976
-   local.get $23
+   local.get $31
    f64.const -0.6666666663487739
    f64.mul
    f64.add
-   local.get $29
+   local.get $37
    f64.const -1.142909628459501
-   local.get $23
+   local.get $31
    f64.const 1.0000415263675542
    f64.mul
    f64.add
@@ -656,88 +696,88 @@
    f64.mul
    f64.add
    f64.mul
-   local.set $36
-   local.get $26
-   local.get $27
-   f64.add
+   local.set $44
    local.get $34
-   f64.add
    local.get $35
    f64.add
-   local.get $36
+   local.get $42
    f64.add
-   local.set $37
-   local.get $33
-   local.get $37
+   local.get $43
    f64.add
-   local.set $38
-   local.get $33
-   local.get $38
+   local.get $44
+   f64.add
+   local.set $45
+   local.get $41
+   local.get $45
+   f64.add
+   local.set $46
+   local.get $41
+   local.get $46
    f64.sub
-   local.get $37
+   local.get $45
    f64.add
    global.set $~lib/util/math/log_tail
-   local.get $38
-   local.set $38
+   local.get $46
+   local.set $47
    global.get $~lib/util/math/log_tail
-   local.set $37
+   local.set $48
    local.get $6
    i64.const -134217728
    i64.and
    f64.reinterpret_i64
-   local.set $34
+   local.set $51
    local.get $2
-   local.get $34
+   local.get $51
    f64.sub
-   local.set $33
-   local.get $38
+   local.set $52
+   local.get $47
    i64.reinterpret_f64
    i64.const -134217728
    i64.and
    f64.reinterpret_i64
-   local.set $32
-   local.get $38
-   local.get $32
+   local.set $53
+   local.get $47
+   local.get $53
    f64.sub
-   local.get $37
+   local.get $48
    f64.add
-   local.set $31
-   local.get $34
-   local.get $32
+   local.set $54
+   local.get $51
+   local.get $53
    f64.mul
-   local.set $36
-   local.get $33
-   local.get $32
+   local.set $49
+   local.get $52
+   local.get $53
    f64.mul
    local.get $2
-   local.get $31
+   local.get $54
    f64.mul
    f64.add
-   local.set $35
+   local.set $50
    block $~lib/util/math/exp_inline|inlined.0 (result f64)
-    local.get $36
-    local.set $15
-    local.get $35
-    local.set $10
+    local.get $49
+    local.set $57
+    local.get $50
+    local.set $56
     local.get $4
-    local.set $12
-    local.get $15
+    local.set $55
+    local.get $57
     i64.reinterpret_f64
-    local.set $9
-    local.get $9
+    local.set $70
+    local.get $70
     i64.const 52
     i64.shr_u
     i32.wrap_i64
     i32.const 2047
     i32.and
-    local.set $39
-    local.get $39
+    local.set $58
+    local.get $58
     i32.const 969
     i32.sub
     i32.const 63
     i32.ge_u
     if
-     local.get $39
+     local.get $58
      i32.const 969
      i32.sub
      i32.const -2147483648
@@ -745,252 +785,252 @@
      if
       f64.const -1
       f64.const 1
-      local.get $12
+      local.get $55
       select
       br $~lib/util/math/exp_inline|inlined.0
      end
-     local.get $39
+     local.get $58
      i32.const 1033
      i32.ge_u
      if
-      local.get $9
+      local.get $70
       i64.const 63
       i64.shr_u
       i64.const 0
       i64.ne
       if (result f64)
-       local.get $12
-       local.set $41
-       local.get $41
-       local.set $42
+       local.get $55
+       local.set $71
+       local.get $71
+       local.set $73
        i64.const 1152921504606846976
        f64.reinterpret_i64
-       local.set $16
-       local.get $16
+       local.set $72
+       local.get $72
        f64.neg
-       local.get $16
-       local.get $42
+       local.get $72
+       local.get $73
        select
-       local.get $16
+       local.get $72
        f64.mul
       else
-       local.get $12
-       local.set $42
-       local.get $42
-       local.set $41
+       local.get $55
+       local.set $74
+       local.get $74
+       local.set $76
        i64.const 8070450532247928832
        f64.reinterpret_i64
-       local.set $17
-       local.get $17
+       local.set $75
+       local.get $75
        f64.neg
-       local.get $17
-       local.get $41
+       local.get $75
+       local.get $76
        select
-       local.get $17
+       local.get $75
        f64.mul
       end
       br $~lib/util/math/exp_inline|inlined.0
      end
      i32.const 0
-     local.set $39
+     local.set $58
     end
     f64.const 184.6649652337873
-    local.get $15
+    local.get $57
     f64.mul
-    local.set $29
-    local.get $29
+    local.set $64
+    local.get $64
     f64.const 6755399441055744
     f64.add
-    local.set $30
-    local.get $30
+    local.set $63
+    local.get $63
     i64.reinterpret_f64
-    local.set $14
-    local.get $30
+    local.set $59
+    local.get $63
     f64.const 6755399441055744
     f64.sub
-    local.set $30
-    local.get $15
-    local.get $30
+    local.set $63
+    local.get $57
+    local.get $63
     f64.const -0.005415212348111709
     f64.mul
     f64.add
-    local.get $30
+    local.get $63
     f64.const -1.2864023111638346e-14
     f64.mul
     f64.add
-    local.set $28
-    local.get $28
-    local.get $10
+    local.set $65
+    local.get $65
+    local.get $56
     f64.add
-    local.set $28
-    local.get $14
+    local.set $65
+    local.get $59
     i64.const 127
     i64.and
     i64.const 1
     i64.shl
     i32.wrap_i64
-    local.set $40
-    local.get $14
-    local.get $12
+    local.set $62
+    local.get $59
+    local.get $55
     i64.extend_i32_u
     i64.add
     i64.const 52
     i64.const 7
     i64.sub
     i64.shl
-    local.set $13
+    local.set $60
     i32.const 4104
-    local.get $40
+    local.get $62
     i32.const 3
     i32.shl
     i32.add
     i64.load
     f64.reinterpret_i64
-    local.set $25
+    local.set $68
     i32.const 4104
-    local.get $40
+    local.get $62
     i32.const 3
     i32.shl
     i32.add
     i64.load offset=8
-    local.get $13
+    local.get $60
     i64.add
-    local.set $11
-    local.get $28
-    local.get $28
+    local.set $61
+    local.get $65
+    local.get $65
     f64.mul
-    local.set $27
-    local.get $25
-    local.get $28
+    local.set $66
+    local.get $68
+    local.get $65
     f64.add
-    local.get $27
+    local.get $66
     f64.const 0.49999999999996786
-    local.get $28
+    local.get $65
     f64.const 0.16666666666665886
     f64.mul
     f64.add
     f64.mul
     f64.add
-    local.get $27
-    local.get $27
+    local.get $66
+    local.get $66
     f64.mul
     f64.const 0.0416666808410674
-    local.get $28
+    local.get $65
     f64.const 0.008333335853059549
     f64.mul
     f64.add
     f64.mul
     f64.add
-    local.set $24
-    local.get $39
+    local.set $69
+    local.get $58
     i32.const 0
     i32.eq
     if
      block $~lib/util/math/specialcase|inlined.0 (result f64)
-      local.get $24
-      local.set $18
-      local.get $11
-      local.set $44
-      local.get $14
-      local.set $43
-      local.get $43
+      local.get $69
+      local.set $79
+      local.get $61
+      local.set $78
+      local.get $59
+      local.set $77
+      local.get $77
       i64.const 2147483648
       i64.and
       i64.const 0
       i64.ne
       i32.eqz
       if
-       local.get $44
+       local.get $78
        i64.const 1009
        i64.const 52
        i64.shl
        i64.sub
-       local.set $44
-       local.get $44
+       local.set $78
+       local.get $78
        f64.reinterpret_i64
-       local.set $17
+       local.set $80
        f64.const 5486124068793688683255936e279
-       local.get $17
-       local.get $17
-       local.get $18
+       local.get $80
+       local.get $80
+       local.get $79
        f64.mul
        f64.add
        f64.mul
        br $~lib/util/math/specialcase|inlined.0
       end
-      local.get $44
+      local.get $78
       i64.const 1022
       i64.const 52
       i64.shl
       i64.add
-      local.set $44
-      local.get $44
+      local.set $78
+      local.get $78
       f64.reinterpret_i64
-      local.set $17
-      local.get $17
-      local.get $17
-      local.get $18
+      local.set $80
+      local.get $80
+      local.get $80
+      local.get $79
       f64.mul
       f64.add
-      local.set $16
-      local.get $16
+      local.set $81
+      local.get $81
       f64.abs
       f64.const 1
       f64.lt
       if
        f64.const 1
-       local.get $16
+       local.get $81
        f64.copysign
-       local.set $23
-       local.get $17
-       local.get $16
+       local.set $82
+       local.get $80
+       local.get $81
        f64.sub
-       local.get $17
-       local.get $18
+       local.get $80
+       local.get $79
        f64.mul
        f64.add
-       local.set $22
-       local.get $23
-       local.get $16
+       local.set $83
+       local.get $82
+       local.get $81
        f64.add
-       local.set $21
-       local.get $23
-       local.get $21
+       local.set $84
+       local.get $82
+       local.get $84
        f64.sub
-       local.get $16
+       local.get $81
        f64.add
-       local.get $22
+       local.get $83
        f64.add
-       local.set $22
-       local.get $21
-       local.get $22
+       local.set $83
+       local.get $84
+       local.get $83
        f64.add
-       local.get $23
+       local.get $82
        f64.sub
-       local.set $16
-       local.get $16
+       local.set $81
+       local.get $81
        f64.const 0
        f64.eq
        if
-        local.get $44
+        local.get $78
         i64.const -9223372036854775808
         i64.and
         f64.reinterpret_i64
-        local.set $16
+        local.set $81
        end
       end
-      local.get $16
+      local.get $81
       f64.const 2.2250738585072014e-308
       f64.mul
      end
      br $~lib/util/math/exp_inline|inlined.0
     end
-    local.get $11
+    local.get $61
     f64.reinterpret_i64
-    local.set $26
-    local.get $26
-    local.get $26
-    local.get $24
+    local.set $67
+    local.get $67
+    local.get $67
+    local.get $69
     f64.mul
     f64.add
    end
@@ -1253,22 +1293,44 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
-  (local $9 f32)
-  (local $10 i32)
+  (local $9 i32)
+  (local $10 f32)
   (local $11 i32)
   (local $12 i32)
   (local $13 i32)
   (local $14 i32)
-  (local $15 f64)
-  (local $16 f64)
-  (local $17 f64)
-  (local $18 f64)
-  (local $19 f64)
-  (local $20 f64)
-  (local $21 f64)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
   (local $22 f64)
-  (local $23 i64)
-  (local $24 i64)
+  (local $23 f64)
+  (local $24 f64)
+  (local $25 f64)
+  (local $26 f64)
+  (local $27 f64)
+  (local $28 f64)
+  (local $29 f64)
+  (local $30 f64)
+  (local $31 f64)
+  (local $32 i32)
+  (local $33 f32)
+  (local $34 i32)
+  (local $35 i32)
+  (local $36 f32)
+  (local $37 i32)
+  (local $38 i32)
+  (local $39 f64)
+  (local $40 f64)
+  (local $41 i64)
+  (local $42 f64)
+  (local $43 i64)
+  (local $44 f64)
+  (local $45 f64)
+  (local $46 f64)
   local.get $1
   f32.abs
   f32.const 2
@@ -1441,8 +1503,8 @@
      br $~lib/util/math/powf_lut|inlined.0
     end
     local.get $5
-    local.set $8
-    local.get $8
+    local.set $9
+    local.get $9
     i32.const 1
     i32.shl
     i32.const 1
@@ -1457,28 +1519,28 @@
      local.get $3
      local.get $3
      f32.mul
-     local.set $9
+     local.set $10
      local.get $5
      i32.const 31
      i32.shr_u
      if (result i32)
       block $~lib/util/math/checkintf|inlined.0 (result i32)
        local.get $6
-       local.set $8
-       local.get $8
+       local.set $11
+       local.get $11
        i32.const 23
        i32.shr_u
        i32.const 255
        i32.and
-       local.set $10
-       local.get $10
+       local.set $12
+       local.get $12
        i32.const 127
        i32.lt_u
        if
         i32.const 0
         br $~lib/util/math/checkintf|inlined.0
        end
-       local.get $10
+       local.get $12
        i32.const 127
        i32.const 23
        i32.add
@@ -1491,12 +1553,12 @@
        i32.const 127
        i32.const 23
        i32.add
-       local.get $10
+       local.get $12
        i32.sub
        i32.shl
-       local.set $10
-       local.get $8
-       local.get $10
+       local.set $12
+       local.get $11
+       local.get $12
        i32.const 1
        i32.sub
        i32.and
@@ -1504,8 +1566,8 @@
         i32.const 0
         br $~lib/util/math/checkintf|inlined.0
        end
-       local.get $8
-       local.get $10
+       local.get $11
+       local.get $12
        i32.and
        if
         i32.const 1
@@ -1519,19 +1581,19 @@
       i32.const 0
      end
      if
-      local.get $9
+      local.get $10
       f32.neg
-      local.set $9
+      local.set $10
      end
      local.get $6
      i32.const 31
      i32.shr_u
      if (result f32)
       f32.const 1
-      local.get $9
+      local.get $10
       f32.div
      else
-      local.get $9
+      local.get $10
      end
      br $~lib/util/math/powf_lut|inlined.0
     end
@@ -1541,21 +1603,21 @@
     if
      block $~lib/util/math/checkintf|inlined.1 (result i32)
       local.get $6
-      local.set $8
-      local.get $8
+      local.set $13
+      local.get $13
       i32.const 23
       i32.shr_u
       i32.const 255
       i32.and
-      local.set $10
-      local.get $10
+      local.set $14
+      local.get $14
       i32.const 127
       i32.lt_u
       if
        i32.const 0
        br $~lib/util/math/checkintf|inlined.1
       end
-      local.get $10
+      local.get $14
       i32.const 127
       i32.const 23
       i32.add
@@ -1568,12 +1630,12 @@
       i32.const 127
       i32.const 23
       i32.add
-      local.get $10
+      local.get $14
       i32.sub
       i32.shl
-      local.set $10
-      local.get $8
-      local.get $10
+      local.set $14
+      local.get $13
+      local.get $14
       i32.const 1
       i32.sub
       i32.and
@@ -1581,8 +1643,8 @@
        i32.const 0
        br $~lib/util/math/checkintf|inlined.1
       end
-      local.get $8
-      local.get $10
+      local.get $13
+      local.get $14
       i32.and
       if
        i32.const 1
@@ -1590,8 +1652,8 @@
       end
       i32.const 2
      end
-     local.set $10
-     local.get $10
+     local.set $15
+     local.get $15
      i32.const 0
      i32.eq
      if
@@ -1604,7 +1666,7 @@
       f32.div
       br $~lib/util/math/powf_lut|inlined.0
      end
-     local.get $10
+     local.get $15
      i32.const 1
      i32.eq
      if
@@ -1638,108 +1700,108 @@
     end
    end
    local.get $5
-   local.set $8
-   local.get $8
+   local.set $16
+   local.get $16
    i32.const 1060306944
    i32.sub
-   local.set $10
-   local.get $10
+   local.set $17
+   local.get $17
    i32.const 23
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 15
    i32.and
-   local.set $11
-   local.get $10
+   local.set $18
+   local.get $17
    i32.const -8388608
    i32.and
-   local.set $12
-   local.get $8
-   local.get $12
+   local.set $19
+   local.get $16
+   local.get $19
    i32.sub
-   local.set $13
-   local.get $12
+   local.set $20
+   local.get $19
    i32.const 23
    i32.shr_s
-   local.set $14
+   local.set $21
    i32.const 6152
-   local.get $11
+   local.get $18
    i32.const 1
    i32.const 3
    i32.add
    i32.shl
    i32.add
    f64.load
-   local.set $15
+   local.set $22
    i32.const 6152
-   local.get $11
+   local.get $18
    i32.const 1
    i32.const 3
    i32.add
    i32.shl
    i32.add
    f64.load offset=8
-   local.set $16
-   local.get $13
+   local.set $23
+   local.get $20
    f32.reinterpret_i32
    f64.promote_f32
-   local.set $17
-   local.get $17
-   local.get $15
+   local.set $24
+   local.get $24
+   local.get $22
    f64.mul
    f64.const 1
    f64.sub
-   local.set $18
-   local.get $16
-   local.get $14
+   local.set $25
+   local.get $23
+   local.get $21
    f64.convert_i32_s
    f64.add
-   local.set $19
+   local.set $26
    f64.const 0.288457581109214
-   local.get $18
+   local.get $25
    f64.mul
    f64.const -0.36092606229713164
    f64.add
-   local.set $20
+   local.set $27
    f64.const 0.480898481472577
-   local.get $18
+   local.get $25
    f64.mul
    f64.const -0.7213474675006291
    f64.add
-   local.set $21
+   local.set $28
    f64.const 1.4426950408774342
-   local.get $18
+   local.get $25
    f64.mul
-   local.get $19
+   local.get $26
    f64.add
-   local.set $22
-   local.get $18
-   local.get $18
+   local.set $29
+   local.get $25
+   local.get $25
    f64.mul
-   local.set $18
-   local.get $22
-   local.get $21
-   local.get $18
+   local.set $25
+   local.get $29
+   local.get $28
+   local.get $25
    f64.mul
    f64.add
-   local.set $22
-   local.get $20
-   local.get $18
-   local.get $18
+   local.set $29
+   local.get $27
+   local.get $25
+   local.get $25
    f64.mul
    f64.mul
-   local.get $22
+   local.get $29
    f64.add
-   local.set $20
-   local.get $20
-   local.set $22
+   local.set $27
+   local.get $27
+   local.set $30
    local.get $2
    f64.promote_f32
-   local.get $22
+   local.get $30
    f64.mul
-   local.set $21
-   local.get $21
+   local.set $31
+   local.get $31
    i64.reinterpret_f64
    i64.const 47
    i64.shr_u
@@ -1748,66 +1810,66 @@
    i64.const 32959
    i64.ge_u
    if
-    local.get $21
+    local.get $31
     f64.const 127.99999995700433
     f64.gt
     if
      local.get $4
-     local.set $8
-     local.get $8
-     local.set $10
+     local.set $32
+     local.get $32
+     local.set $34
      i32.const 1879048192
      f32.reinterpret_i32
-     local.set $9
-     local.get $9
+     local.set $33
+     local.get $33
      f32.neg
-     local.get $9
-     local.get $10
+     local.get $33
+     local.get $34
      select
-     local.get $9
+     local.get $33
      f32.mul
      br $~lib/util/math/powf_lut|inlined.0
     end
-    local.get $21
+    local.get $31
     f64.const -150
     f64.le
     if
      local.get $4
-     local.set $11
-     local.get $11
-     local.set $12
+     local.set $35
+     local.get $35
+     local.set $37
      i32.const 268435456
      f32.reinterpret_i32
-     local.set $9
-     local.get $9
+     local.set $36
+     local.get $36
      f32.neg
-     local.get $9
-     local.get $12
+     local.get $36
+     local.get $37
      select
-     local.get $9
+     local.get $36
      f32.mul
      br $~lib/util/math/powf_lut|inlined.0
     end
    end
-   local.get $21
-   local.set $15
+   local.get $31
+   local.set $39
    local.get $4
-   local.set $13
-   local.get $15
+   local.set $38
+   local.get $39
    f64.const 211106232532992
    f64.add
-   local.set $20
-   local.get $20
+   local.set $40
+   local.get $40
    i64.reinterpret_f64
-   local.set $23
-   local.get $15
-   local.get $20
+   local.set $41
+   local.get $39
+   local.get $40
    f64.const 211106232532992
    f64.sub
    f64.sub
-   local.set $19
+   local.set $42
    i32.const 6408
-   local.get $23
+   local.get $41
    i32.wrap_i64
    i32.const 31
    i32.and
@@ -1815,10 +1877,10 @@
    i32.shl
    i32.add
    i64.load
-   local.set $24
-   local.get $24
-   local.get $23
-   local.get $13
+   local.set $43
+   local.get $43
+   local.get $41
+   local.get $38
    i64.extend_i32_u
    i64.add
    i64.const 52
@@ -1826,35 +1888,35 @@
    i64.sub
    i64.shl
    i64.add
-   local.set $24
-   local.get $24
+   local.set $43
+   local.get $43
    f64.reinterpret_i64
-   local.set $16
+   local.set $46
    f64.const 0.05550361559341535
-   local.get $19
+   local.get $42
    f64.mul
    f64.const 0.2402284522445722
    f64.add
-   local.set $18
+   local.set $44
    f64.const 0.6931471806916203
-   local.get $19
+   local.get $42
    f64.mul
    f64.const 1
    f64.add
-   local.set $17
-   local.get $17
-   local.get $18
-   local.get $19
-   local.get $19
+   local.set $45
+   local.get $45
+   local.get $44
+   local.get $42
+   local.get $42
    f64.mul
    f64.mul
    f64.add
-   local.set $17
-   local.get $17
-   local.get $16
+   local.set $45
+   local.get $45
+   local.get $46
    f64.mul
-   local.set $17
-   local.get $17
+   local.set $45
+   local.get $45
    f32.demote_f64
   end
   return

--- a/tests/compiler/builtins.untouched.wat
+++ b/tests/compiler/builtins.untouched.wat
@@ -117,6 +117,9 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
   local.get $0
   call $~lib/rt/stub/__retain
   local.set $0
@@ -188,33 +191,33 @@
   end
   loop $while-continue|1
    local.get $4
-   local.tee $7
+   local.tee $8
    i32.const 1
    i32.sub
    local.set $4
-   local.get $7
-   local.set $7
-   local.get $7
+   local.get $8
+   local.set $9
+   local.get $9
    if
     local.get $5
     i32.load16_u
-    local.set $8
+    local.set $10
     local.get $6
     i32.load16_u
-    local.set $9
-    local.get $8
-    local.get $9
+    local.set $11
+    local.get $10
+    local.get $11
     i32.ne
     if
-     local.get $8
-     local.get $9
+     local.get $10
+     local.get $11
      i32.sub
-     local.set $10
+     local.set $12
      local.get $0
      call $~lib/rt/stub/__release
      local.get $2
      call $~lib/rt/stub/__release
-     local.get $10
+     local.get $12
      return
     end
     local.get $5
@@ -229,16 +232,19 @@
    end
   end
   i32.const 0
-  local.set $7
+  local.set $13
   local.get $0
   call $~lib/rt/stub/__release
   local.get $2
   call $~lib/rt/stub/__release
-  local.get $7
+  local.get $13
  )
  (func $~lib/string/String.__eq (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   local.get $0
   call $~lib/rt/stub/__retain
   local.set $0
@@ -270,44 +276,44 @@
   end
   if
    i32.const 0
-   local.set $2
+   local.set $3
    local.get $0
    call $~lib/rt/stub/__release
    local.get $1
    call $~lib/rt/stub/__release
-   local.get $2
+   local.get $3
    return
   end
   local.get $0
   call $~lib/string/String#get:length
-  local.set $3
-  local.get $3
+  local.set $4
+  local.get $4
   local.get $1
   call $~lib/string/String#get:length
   i32.ne
   if
    i32.const 0
-   local.set $2
+   local.set $5
    local.get $0
    call $~lib/rt/stub/__release
    local.get $1
    call $~lib/rt/stub/__release
-   local.get $2
+   local.get $5
    return
   end
   local.get $0
   i32.const 0
   local.get $1
   i32.const 0
-  local.get $3
+  local.get $4
   call $~lib/util/string/compareImpl
   i32.eqz
-  local.set $2
+  local.set $6
   local.get $0
   call $~lib/rt/stub/__release
   local.get $1
   call $~lib/rt/stub/__release
-  local.get $2
+  local.get $6
  )
  (func $start:builtins~anonymous|0
   nop
@@ -318,13 +324,53 @@
  (func $start:builtins
   (local $0 i32)
   (local $1 i32)
-  (local $2 i64)
-  (local $3 i64)
-  (local $4 f32)
-  (local $5 f64)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i64)
+  (local $13 i64)
+  (local $14 i64)
+  (local $15 i64)
+  (local $16 i64)
+  (local $17 i64)
+  (local $18 i64)
+  (local $19 i64)
+  (local $20 f32)
+  (local $21 f32)
+  (local $22 f32)
+  (local $23 f32)
+  (local $24 f32)
+  (local $25 f32)
+  (local $26 f32)
+  (local $27 f32)
+  (local $28 f64)
+  (local $29 f64)
+  (local $30 f64)
+  (local $31 f64)
+  (local $32 f64)
+  (local $33 f64)
+  (local $34 f64)
+  (local $35 f64)
+  (local $36 f32)
+  (local $37 f64)
+  (local $38 f32)
+  (local $39 f32)
+  (local $40 f64)
+  (local $41 f64)
+  (local $42 f32)
+  (local $43 f64)
+  (local $44 i32)
+  (local $45 i32)
+  (local $46 i32)
+  (local $47 i32)
+  (local $48 i32)
   i32.const 1
   drop
   i32.const 0
@@ -445,20 +491,20 @@
   i32.xor
   drop
   i32.const 1
-  local.tee $0
+  local.tee $2
   i32.const 2
-  local.tee $1
-  local.get $0
-  local.get $1
+  local.tee $3
+  local.get $2
+  local.get $3
   i32.gt_s
   select
   drop
   i32.const 1
-  local.tee $0
+  local.tee $4
   i32.const 2
-  local.tee $1
-  local.get $0
-  local.get $1
+  local.tee $5
+  local.get $4
+  local.get $5
   i32.lt_s
   select
   drop
@@ -480,13 +526,13 @@
   i32.rotr
   global.set $builtins/i
   i32.const -42
-  local.tee $0
+  local.tee $6
   i32.const 31
   i32.shr_s
-  local.tee $1
-  local.get $0
+  local.tee $7
+  local.get $6
   i32.add
-  local.get $1
+  local.get $7
   i32.xor
   global.set $builtins/i
   global.get $builtins/i
@@ -502,11 +548,11 @@
    unreachable
   end
   i32.const 1
-  local.tee $0
+  local.tee $8
   i32.const 2
-  local.tee $1
-  local.get $0
-  local.get $1
+  local.tee $9
+  local.get $8
+  local.get $9
   i32.gt_s
   select
   global.set $builtins/i
@@ -523,11 +569,11 @@
    unreachable
   end
   i32.const 1
-  local.tee $0
+  local.tee $10
   i32.const 2
-  local.tee $1
-  local.get $0
-  local.get $1
+  local.tee $11
+  local.get $10
+  local.get $11
   i32.lt_s
   select
   global.set $builtins/i
@@ -561,13 +607,13 @@
   i64.rotr
   drop
   i64.const -42
-  local.tee $2
+  local.tee $12
   i64.const 63
   i64.shr_s
-  local.tee $3
-  local.get $2
+  local.tee $13
+  local.get $12
   i64.add
-  local.get $3
+  local.get $13
   i64.xor
   drop
   i64.const 1
@@ -588,13 +634,13 @@
   i64.rotr
   global.set $builtins/I
   i64.const -42
-  local.tee $2
+  local.tee $14
   i64.const 63
   i64.shr_s
-  local.tee $3
-  local.get $2
+  local.tee $15
+  local.get $14
   i64.add
-  local.get $3
+  local.get $15
   i64.xor
   global.set $builtins/I
   global.get $builtins/I
@@ -610,11 +656,11 @@
    unreachable
   end
   i64.const 1
-  local.tee $2
+  local.tee $16
   i64.const 2
-  local.tee $3
-  local.get $2
-  local.get $3
+  local.tee $17
+  local.get $16
+  local.get $17
   i64.gt_s
   select
   global.set $builtins/I
@@ -631,11 +677,11 @@
    unreachable
   end
   i64.const 1
-  local.tee $2
+  local.tee $18
   i64.const 2
-  local.tee $3
-  local.get $2
-  local.get $3
+  local.tee $19
+  local.get $18
+  local.get $19
   i64.lt_s
   select
   global.set $builtins/I
@@ -686,22 +732,22 @@
   f32.trunc
   drop
   f32.const 1.25
-  local.tee $4
-  local.get $4
+  local.tee $20
+  local.get $20
   f32.ne
   i32.const 0
   i32.eq
   drop
   f32.const nan:0x400000
-  local.tee $4
-  local.get $4
+  local.tee $21
+  local.get $21
   f32.ne
   i32.const 1
   i32.eq
   drop
   f32.const 1.25
-  local.tee $4
-  local.get $4
+  local.tee $22
+  local.get $22
   f32.sub
   f32.const 0
   f32.eq
@@ -709,8 +755,8 @@
   i32.eq
   drop
   f32.const inf
-  local.tee $4
-  local.get $4
+  local.tee $23
+  local.get $23
   f32.sub
   f32.const 0
   f32.eq
@@ -719,8 +765,8 @@
   drop
   f32.const inf
   f32.neg
-  local.tee $4
-  local.get $4
+  local.tee $24
+  local.get $24
   f32.sub
   f32.const 0
   f32.eq
@@ -728,8 +774,8 @@
   i32.eq
   drop
   f32.const nan:0x400000
-  local.tee $4
-  local.get $4
+  local.tee $25
+  local.get $25
   f32.sub
   f32.const 0
   f32.eq
@@ -771,13 +817,13 @@
   f32.trunc
   global.set $builtins/f
   f32.const 1.25
-  local.tee $4
-  local.get $4
+  local.tee $26
+  local.get $26
   f32.ne
   global.set $builtins/b
   f32.const 1.25
-  local.tee $4
-  local.get $4
+  local.tee $27
+  local.get $27
   f32.sub
   f32.const 0
   f32.eq
@@ -821,22 +867,22 @@
   f64.trunc
   drop
   f64.const 1.25
-  local.tee $5
-  local.get $5
+  local.tee $28
+  local.get $28
   f64.ne
   i32.const 0
   i32.eq
   drop
   f64.const nan:0x8000000000000
-  local.tee $5
-  local.get $5
+  local.tee $29
+  local.get $29
   f64.ne
   i32.const 1
   i32.eq
   drop
   f64.const 1.25
-  local.tee $5
-  local.get $5
+  local.tee $30
+  local.get $30
   f64.sub
   f64.const 0
   f64.eq
@@ -844,8 +890,8 @@
   i32.eq
   drop
   f64.const inf
-  local.tee $5
-  local.get $5
+  local.tee $31
+  local.get $31
   f64.sub
   f64.const 0
   f64.eq
@@ -854,8 +900,8 @@
   drop
   f64.const inf
   f64.neg
-  local.tee $5
-  local.get $5
+  local.tee $32
+  local.get $32
   f64.sub
   f64.const 0
   f64.eq
@@ -863,8 +909,8 @@
   i32.eq
   drop
   f64.const nan:0x8000000000000
-  local.tee $5
-  local.get $5
+  local.tee $33
+  local.get $33
   f64.sub
   f64.const 0
   f64.eq
@@ -906,13 +952,13 @@
   f64.trunc
   global.set $builtins/F
   f64.const 1.25
-  local.tee $5
-  local.get $5
+  local.tee $34
+  local.get $34
   f64.ne
   global.set $builtins/b
   f64.const 1.25
-  local.tee $5
-  local.get $5
+  local.tee $35
+  local.get $35
   f64.sub
   f64.const 0
   f64.eq
@@ -1266,57 +1312,57 @@
   f64.ne
   drop
   f32.const nan:0x400000
-  local.tee $4
-  local.get $4
+  local.tee $36
+  local.get $36
   f32.ne
   drop
   f64.const nan:0x8000000000000
-  local.tee $5
-  local.get $5
+  local.tee $37
+  local.get $37
   f64.ne
   drop
   f32.const nan:0x400000
-  local.tee $4
-  local.get $4
+  local.tee $38
+  local.get $38
   f32.sub
   f32.const 0
   f32.eq
   i32.eqz
   drop
   f32.const inf
-  local.tee $4
-  local.get $4
+  local.tee $39
+  local.get $39
   f32.sub
   f32.const 0
   f32.eq
   i32.eqz
   drop
   f64.const nan:0x8000000000000
-  local.tee $5
-  local.get $5
+  local.tee $40
+  local.get $40
   f64.sub
   f64.const 0
   f64.eq
   i32.eqz
   drop
   f64.const inf
-  local.tee $5
-  local.get $5
+  local.tee $41
+  local.get $41
   f64.sub
   f64.const 0
   f64.eq
   i32.eqz
   drop
   f32.const 0
-  local.tee $4
-  local.get $4
+  local.tee $42
+  local.get $42
   f32.sub
   f32.const 0
   f32.eq
   drop
   f64.const 0
-  local.tee $5
-  local.get $5
+  local.tee $43
+  local.get $43
   f64.sub
   f64.const 0
   f64.eq
@@ -1724,30 +1770,30 @@
    unreachable
   end
   i32.const 0
-  local.set $0
+  local.set $44
   i32.const 0
-  local.set $1
+  local.set $45
   i32.const 29
-  local.set $6
+  local.set $46
   i32.const 30
-  local.set $7
+  local.set $47
   i32.const 30
-  local.set $8
+  local.set $48
   i32.const 128
   i32.const 5
-  local.get $0
+  local.get $44
   f64.convert_i32_u
-  local.get $1
+  local.get $45
   f64.convert_i32_u
-  local.get $6
+  local.get $46
   f64.convert_i32_u
-  local.get $7
+  local.get $47
   f64.convert_i32_u
-  local.get $8
+  local.get $48
   f64.convert_i32_u
   call $~lib/builtins/trace
-  local.get $0
-  local.get $1
+  local.get $44
+  local.get $45
   i32.eq
   i32.eqz
   if
@@ -1758,8 +1804,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
-  local.get $6
+  local.get $44
+  local.get $46
   i32.ne
   i32.eqz
   if
@@ -1770,7 +1816,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $6
+  local.get $46
   i32.const 29
   i32.eq
   i32.eqz
@@ -1782,8 +1828,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $7
-  local.get $8
+  local.get $47
+  local.get $48
   i32.eq
   i32.eqz
   if

--- a/tests/compiler/call-super.untouched.wat
+++ b/tests/compiler/call-super.untouched.wat
@@ -19,6 +19,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   memory.size
   local.set $1
   local.get $1
@@ -49,8 +50,8 @@
    local.get $5
    i32.gt_s
    select
-   local.set $4
-   local.get $4
+   local.set $6
+   local.get $6
    memory.grow
    i32.const 0
    i32.lt_s

--- a/tests/compiler/class-overloading.untouched.wat
+++ b/tests/compiler/class-overloading.untouched.wat
@@ -35,6 +35,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   memory.size
   local.set $1
   local.get $1
@@ -65,8 +66,8 @@
    local.get $5
    i32.gt_s
    select
-   local.set $4
-   local.get $4
+   local.set $6
+   local.get $6
    memory.grow
    i32.const 0
    i32.lt_s
@@ -195,6 +196,9 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
   local.get $0
   call $~lib/rt/stub/__retain
   local.set $0
@@ -266,33 +270,33 @@
   end
   loop $while-continue|1
    local.get $4
-   local.tee $7
+   local.tee $8
    i32.const 1
    i32.sub
    local.set $4
-   local.get $7
-   local.set $7
-   local.get $7
+   local.get $8
+   local.set $9
+   local.get $9
    if
     local.get $5
     i32.load16_u
-    local.set $8
+    local.set $10
     local.get $6
     i32.load16_u
-    local.set $9
-    local.get $8
-    local.get $9
+    local.set $11
+    local.get $10
+    local.get $11
     i32.ne
     if
-     local.get $8
-     local.get $9
+     local.get $10
+     local.get $11
      i32.sub
-     local.set $10
+     local.set $12
      local.get $0
      call $~lib/rt/stub/__release
      local.get $2
      call $~lib/rt/stub/__release
-     local.get $10
+     local.get $12
      return
     end
     local.get $5
@@ -307,16 +311,19 @@
    end
   end
   i32.const 0
-  local.set $7
+  local.set $13
   local.get $0
   call $~lib/rt/stub/__release
   local.get $2
   call $~lib/rt/stub/__release
-  local.get $7
+  local.get $13
  )
  (func $~lib/string/String.__eq (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   local.get $0
   call $~lib/rt/stub/__retain
   local.set $0
@@ -348,44 +355,44 @@
   end
   if
    i32.const 0
-   local.set $2
+   local.set $3
    local.get $0
    call $~lib/rt/stub/__release
    local.get $1
    call $~lib/rt/stub/__release
-   local.get $2
+   local.get $3
    return
   end
   local.get $0
   call $~lib/string/String#get:length
-  local.set $3
-  local.get $3
+  local.set $4
+  local.get $4
   local.get $1
   call $~lib/string/String#get:length
   i32.ne
   if
    i32.const 0
-   local.set $2
+   local.set $5
    local.get $0
    call $~lib/rt/stub/__release
    local.get $1
    call $~lib/rt/stub/__release
-   local.get $2
+   local.get $5
    return
   end
   local.get $0
   i32.const 0
   local.get $1
   i32.const 0
-  local.get $3
+  local.get $4
   call $~lib/util/string/compareImpl
   i32.eqz
-  local.set $2
+  local.set $6
   local.get $0
   call $~lib/rt/stub/__release
   local.get $1
   call $~lib/rt/stub/__release
-  local.get $2
+  local.get $6
  )
  (func $class-overloading/A#b (param $0 i32) (param $1 i32)
   (local $2 i32)
@@ -565,6 +572,26 @@
  )
  (func $start:class-overloading
   (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
   global.get $~lib/heap/__heap_base
   i32.const 15
   i32.add
@@ -615,10 +642,10 @@
    unreachable
   end
   i32.const 32
-  local.set $0
+  local.set $1
   global.get $class-overloading/which
   call $~lib/rt/stub/__release
-  local.get $0
+  local.get $1
   global.set $class-overloading/which
   global.get $class-overloading/a
   call $class-overloading/A#get:c@virtual
@@ -636,10 +663,10 @@
    unreachable
   end
   i32.const 32
-  local.set $0
+  local.set $2
   global.get $class-overloading/which
   call $~lib/rt/stub/__release
-  local.get $0
+  local.get $2
   global.set $class-overloading/which
   global.get $class-overloading/a
   i32.const 1
@@ -660,10 +687,10 @@
   call $class-overloading/C#constructor
   global.set $class-overloading/c
   i32.const 32
-  local.set $0
+  local.set $3
   global.get $class-overloading/which
   call $~lib/rt/stub/__release
-  local.get $0
+  local.get $3
   global.set $class-overloading/which
   global.get $class-overloading/c
   i32.const 1
@@ -681,10 +708,10 @@
    unreachable
   end
   i32.const 32
-  local.set $0
+  local.set $4
   global.get $class-overloading/which
   call $~lib/rt/stub/__release
-  local.get $0
+  local.get $4
   global.set $class-overloading/which
   global.get $class-overloading/c
   i32.const 1
@@ -702,10 +729,10 @@
    unreachable
   end
   i32.const 32
-  local.set $0
+  local.set $5
   global.get $class-overloading/which
   call $~lib/rt/stub/__release
-  local.get $0
+  local.get $5
   global.set $class-overloading/which
   global.get $class-overloading/c
   call $class-overloading/C#get:c
@@ -739,16 +766,16 @@
   end
   i32.const 0
   call $class-overloading/D#constructor
-  local.set $0
+  local.set $6
   global.get $class-overloading/a
   call $~lib/rt/stub/__release
-  local.get $0
+  local.get $6
   global.set $class-overloading/a
   i32.const 32
-  local.set $0
+  local.set $7
   global.get $class-overloading/which
   call $~lib/rt/stub/__release
-  local.get $0
+  local.get $7
   global.set $class-overloading/which
   global.get $class-overloading/a
   i32.const 1
@@ -766,10 +793,10 @@
    unreachable
   end
   i32.const 32
-  local.set $0
+  local.set $8
   global.get $class-overloading/which
   call $~lib/rt/stub/__release
-  local.get $0
+  local.get $8
   global.set $class-overloading/which
   global.get $class-overloading/a
   i32.const 1
@@ -787,10 +814,10 @@
    unreachable
   end
   i32.const 32
-  local.set $0
+  local.set $9
   global.get $class-overloading/which
   call $~lib/rt/stub/__release
-  local.get $0
+  local.get $9
   global.set $class-overloading/which
   global.get $class-overloading/a
   call $class-overloading/A#get:c@virtual
@@ -824,16 +851,16 @@
   end
   i32.const 0
   call $class-overloading/E#constructor
-  local.set $0
+  local.set $10
   global.get $class-overloading/a
   call $~lib/rt/stub/__release
-  local.get $0
+  local.get $10
   global.set $class-overloading/a
   i32.const 32
-  local.set $0
+  local.set $11
   global.get $class-overloading/which
   call $~lib/rt/stub/__release
-  local.get $0
+  local.get $11
   global.set $class-overloading/which
   global.get $class-overloading/a
   i32.const 1
@@ -851,10 +878,10 @@
    unreachable
   end
   i32.const 32
-  local.set $0
+  local.set $12
   global.get $class-overloading/which
   call $~lib/rt/stub/__release
-  local.get $0
+  local.get $12
   global.set $class-overloading/which
   global.get $class-overloading/a
   i32.const 1
@@ -872,10 +899,10 @@
    unreachable
   end
   i32.const 32
-  local.set $0
+  local.set $13
   global.get $class-overloading/which
   call $~lib/rt/stub/__release
-  local.get $0
+  local.get $13
   global.set $class-overloading/which
   global.get $class-overloading/a
   call $class-overloading/A#get:c@virtual
@@ -909,16 +936,16 @@
   end
   i32.const 0
   call $class-overloading/F#constructor
-  local.set $0
+  local.set $14
   global.get $class-overloading/a
   call $~lib/rt/stub/__release
-  local.get $0
+  local.get $14
   global.set $class-overloading/a
   i32.const 32
-  local.set $0
+  local.set $15
   global.get $class-overloading/which
   call $~lib/rt/stub/__release
-  local.get $0
+  local.get $15
   global.set $class-overloading/which
   global.get $class-overloading/a
   i32.const 1
@@ -936,10 +963,10 @@
    unreachable
   end
   i32.const 32
-  local.set $0
+  local.set $16
   global.get $class-overloading/which
   call $~lib/rt/stub/__release
-  local.get $0
+  local.get $16
   global.set $class-overloading/which
   global.get $class-overloading/a
   i32.const 1
@@ -957,10 +984,10 @@
    unreachable
   end
   i32.const 32
-  local.set $0
+  local.set $17
   global.get $class-overloading/which
   call $~lib/rt/stub/__release
-  local.get $0
+  local.get $17
   global.set $class-overloading/which
   global.get $class-overloading/a
   call $class-overloading/A#get:c@virtual
@@ -978,10 +1005,10 @@
    unreachable
   end
   i32.const 32
-  local.set $0
+  local.set $18
   global.get $class-overloading/which
   call $~lib/rt/stub/__release
-  local.get $0
+  local.get $18
   global.set $class-overloading/which
   global.get $class-overloading/a
   i32.const 1
@@ -1002,10 +1029,10 @@
   call $class-overloading/CA#constructor
   global.set $class-overloading/ia
   i32.const 32
-  local.set $0
+  local.set $19
   global.get $class-overloading/which
   call $~lib/rt/stub/__release
-  local.get $0
+  local.get $19
   global.set $class-overloading/which
   global.get $class-overloading/ia
   call $class-overloading/IA#foo@virtual
@@ -1025,10 +1052,10 @@
   call $class-overloading/CC#constructor
   global.set $class-overloading/ic
   i32.const 32
-  local.set $0
+  local.set $20
   global.get $class-overloading/which
   call $~lib/rt/stub/__release
-  local.get $0
+  local.get $20
   global.set $class-overloading/which
   global.get $class-overloading/ic
   call $class-overloading/IA#foo@virtual

--- a/tests/compiler/class.untouched.wat
+++ b/tests/compiler/class.untouched.wat
@@ -134,6 +134,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   memory.size
   local.set $1
   local.get $1
@@ -164,8 +165,8 @@
    local.get $5
    i32.gt_s
    select
-   local.set $4
-   local.get $4
+   local.set $6
+   local.get $6
    memory.grow
    i32.const 0
    i32.lt_s

--- a/tests/compiler/comma.untouched.wat
+++ b/tests/compiler/comma.untouched.wat
@@ -12,6 +12,7 @@
  (func $start:comma
   (local $0 i32)
   (local $1 i32)
+  (local $2 i32)
   global.get $comma/a
   local.tee $0
   i32.const 1
@@ -147,8 +148,8 @@
    local.get $1
    global.get $comma/a
    i32.lt_s
-   local.set $0
-   local.get $0
+   local.set $2
+   local.get $2
    if
     nop
     global.get $comma/a

--- a/tests/compiler/constructor.untouched.wat
+++ b/tests/compiler/constructor.untouched.wat
@@ -27,6 +27,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   memory.size
   local.set $1
   local.get $1
@@ -57,8 +58,8 @@
    local.get $5
    i32.gt_s
    select
-   local.set $4
-   local.get $4
+   local.set $6
+   local.get $6
    memory.grow
    i32.const 0
    i32.lt_s

--- a/tests/compiler/do.untouched.wat
+++ b/tests/compiler/do.untouched.wat
@@ -80,6 +80,7 @@
  (func $do/testEmpty
   (local $0 i32)
   (local $1 i32)
+  (local $2 i32)
   i32.const 10
   local.set $0
   loop $do-continue|0
@@ -90,8 +91,8 @@
    i32.sub
    local.set $0
    local.get $1
-   local.set $1
-   local.get $1
+   local.set $2
+   local.get $2
    br_if $do-continue|0
   end
   local.get $0
@@ -114,6 +115,7 @@
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
   i32.const 10
   local.set $0
   i32.const 0
@@ -168,8 +170,8 @@
     unreachable
    end
    local.get $0
-   local.set $3
-   local.get $3
+   local.set $4
+   local.get $4
    br_if $do-continue|0
   end
   local.get $0
@@ -451,6 +453,15 @@
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
   local.get $1
   i32.load
   local.set $2
@@ -587,59 +598,59 @@
   i32.eq
   if
    local.get $0
-   local.set $11
+   local.set $14
    local.get $4
-   local.set $10
+   local.set $13
    local.get $5
-   local.set $9
+   local.set $12
    local.get $7
-   local.set $8
-   local.get $11
-   local.get $10
+   local.set $11
+   local.get $14
+   local.get $13
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $12
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
+   local.get $11
    i32.store offset=96
    local.get $7
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $16
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $15
+    local.get $16
+    local.get $15
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $17
     local.get $0
-    local.set $8
+    local.set $20
     local.get $4
-    local.set $11
-    local.get $9
+    local.set $19
+    local.get $17
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
-    local.set $10
-    local.get $8
-    local.get $11
+    local.tee $17
+    local.set $18
+    local.get $20
+    local.get $19
     i32.const 2
     i32.shl
     i32.add
-    local.get $10
+    local.get $18
     i32.store offset=4
-    local.get $9
+    local.get $17
     i32.eqz
     if
      local.get $0
@@ -669,6 +680,20 @@
   (local $11 i32)
   (local $12 i32)
   (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local $22 i32)
+  (local $23 i32)
+  (local $24 i32)
+  (local $25 i32)
+  (local $26 i32)
+  (local $27 i32)
   i32.const 1
   drop
   local.get $1
@@ -731,8 +756,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $3
+   local.set $6
+   local.get $6
    i32.const 1073741808
    i32.lt_u
    if
@@ -743,16 +768,16 @@
     local.get $2
     i32.const 3
     i32.and
-    local.get $3
+    local.get $6
     i32.or
     local.tee $2
     i32.store
     local.get $1
-    local.set $6
-    local.get $6
+    local.set $7
+    local.get $7
     i32.const 16
     i32.add
-    local.get $6
+    local.get $7
     i32.load
     i32.const 3
     i32.const -1
@@ -770,18 +795,18 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $8
+   local.get $8
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
+   local.set $9
+   local.get $9
    i32.load
-   local.set $3
+   local.set $10
    i32.const 1
    drop
-   local.get $3
+   local.get $10
    i32.const 1
    i32.and
    i32.eqz
@@ -793,7 +818,7 @@
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $3
+   local.get $10
    i32.const 3
    i32.const -1
    i32.xor
@@ -806,23 +831,23 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $7
+   local.set $11
+   local.get $11
    i32.const 1073741808
    i32.lt_u
    if
     local.get $0
-    local.get $6
+    local.get $9
     call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
+    local.get $9
+    local.get $10
     i32.const 3
     i32.and
-    local.get $7
+    local.get $11
     i32.or
     local.tee $2
     i32.store
-    local.get $6
+    local.get $9
     local.set $1
    end
   end
@@ -836,14 +861,14 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $12
   i32.const 1
   drop
-  local.get $8
+  local.get $12
   i32.const 16
   i32.ge_u
   if (result i32)
-   local.get $8
+   local.get $12
    i32.const 1073741808
    i32.lt_u
   else
@@ -863,7 +888,7 @@
   local.get $1
   i32.const 16
   i32.add
-  local.get $8
+  local.get $12
   i32.add
   local.get $4
   i32.eq
@@ -881,24 +906,24 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $12
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $13
+   local.get $12
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $14
   else
    i32.const 31
-   local.get $8
+   local.get $12
    i32.clz
    i32.sub
-   local.set $9
-   local.get $8
-   local.get $9
+   local.set $13
+   local.get $12
+   local.get $13
    i32.const 4
    i32.sub
    i32.shr_u
@@ -906,21 +931,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $14
+   local.get $13
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $13
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $13
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $14
    i32.const 16
    i32.lt_u
   else
@@ -936,86 +961,86 @@
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
-  local.set $6
-  local.get $7
-  local.get $3
+  local.set $17
+  local.get $13
+  local.set $16
+  local.get $14
+  local.set $15
+  local.get $17
+  local.get $16
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $15
   i32.add
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=96
-  local.set $11
+  local.set $18
   local.get $1
   i32.const 0
   i32.store offset=16
   local.get $1
-  local.get $11
+  local.get $18
   i32.store offset=20
-  local.get $11
+  local.get $18
   if
-   local.get $11
+   local.get $18
    local.get $1
    i32.store offset=16
   end
   local.get $0
-  local.set $12
-  local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
+  local.set $22
+  local.get $13
+  local.set $21
+  local.get $14
+  local.set $20
   local.get $1
-  local.set $6
-  local.get $12
-  local.get $7
+  local.set $19
+  local.get $22
+  local.get $21
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $20
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $19
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $13
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.set $13
-  local.get $9
-  local.set $12
+  local.set $27
+  local.get $13
+  local.set $26
   local.get $0
-  local.set $3
-  local.get $9
-  local.set $6
-  local.get $3
-  local.get $6
+  local.set $24
+  local.get $13
+  local.set $23
+  local.get $24
+  local.get $23
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $14
   i32.shl
   i32.or
-  local.set $7
-  local.get $13
-  local.get $12
+  local.set $25
+  local.get $27
+  local.get $26
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $25
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -1026,6 +1051,7 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
   i32.const 1
   drop
   local.get $1
@@ -1165,11 +1191,11 @@
   i32.or
   i32.store
   local.get $0
-  local.set $9
+  local.set $10
   local.get $4
-  local.set $3
+  local.set $9
+  local.get $10
   local.get $9
-  local.get $3
   i32.store offset=1568
   local.get $0
   local.get $8
@@ -1189,6 +1215,12 @@
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
   global.get $~lib/rt/tlsf/ROOT
   local.set $0
   local.get $0
@@ -1245,66 +1277,66 @@
    local.get $4
    i32.store offset=1568
    i32.const 0
-   local.set $5
+   local.set $6
    loop $for-loop|0
-    local.get $5
+    local.get $6
     i32.const 23
     i32.lt_u
-    local.set $4
-    local.get $4
+    local.set $7
+    local.get $7
     if
      local.get $0
-     local.set $8
-     local.get $5
-     local.set $7
+     local.set $10
+     local.get $6
+     local.set $9
      i32.const 0
-     local.set $6
-     local.get $8
-     local.get $7
+     local.set $8
+     local.get $10
+     local.get $9
      i32.const 2
      i32.shl
      i32.add
-     local.get $6
+     local.get $8
      i32.store offset=4
      i32.const 0
-     local.set $8
+     local.set $11
      loop $for-loop|1
-      local.get $8
+      local.get $11
       i32.const 16
       i32.lt_u
-      local.set $7
-      local.get $7
+      local.set $12
+      local.get $12
       if
        local.get $0
-       local.set $11
-       local.get $5
-       local.set $10
-       local.get $8
-       local.set $9
-       i32.const 0
-       local.set $6
+       local.set $16
+       local.get $6
+       local.set $15
        local.get $11
-       local.get $10
+       local.set $14
+       i32.const 0
+       local.set $13
+       local.get $16
+       local.get $15
        i32.const 4
        i32.shl
-       local.get $9
+       local.get $14
        i32.add
        i32.const 2
        i32.shl
        i32.add
-       local.get $6
+       local.get $13
        i32.store offset=96
-       local.get $8
+       local.get $11
        i32.const 1
        i32.add
-       local.set $8
+       local.set $11
        br $for-loop|1
       end
      end
-     local.get $5
+     local.get $6
      i32.const 1
      i32.add
-     local.set $5
+     local.set $6
      br $for-loop|0
     end
    end
@@ -1317,11 +1349,11 @@
    i32.const -1
    i32.xor
    i32.and
-   local.set $5
+   local.set $17
    i32.const 0
    drop
    local.get $0
-   local.get $5
+   local.get $17
    memory.size
    i32.const 16
    i32.shl
@@ -1370,6 +1402,14 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
   local.get $1
   i32.const 256
   i32.lt_u
@@ -1443,11 +1483,11 @@
    unreachable
   end
   local.get $0
-  local.set $5
+  local.set $6
   local.get $2
-  local.set $4
+  local.set $5
+  local.get $6
   local.get $5
-  local.get $4
   i32.const 2
   i32.shl
   i32.add
@@ -1458,10 +1498,10 @@
   local.get $3
   i32.shl
   i32.and
-  local.set $6
-  i32.const 0
   local.set $7
-  local.get $6
+  i32.const 0
+  local.set $8
+  local.get $7
   i32.eqz
   if
    local.get $0
@@ -1474,30 +1514,30 @@
    i32.add
    i32.shl
    i32.and
-   local.set $5
-   local.get $5
+   local.set $9
+   local.get $9
    i32.eqz
    if
     i32.const 0
-    local.set $7
+    local.set $8
    else
-    local.get $5
+    local.get $9
     i32.ctz
     local.set $2
     local.get $0
-    local.set $8
+    local.set $11
     local.get $2
-    local.set $4
-    local.get $8
-    local.get $4
+    local.set $10
+    local.get $11
+    local.get $10
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $6
+    local.set $7
     i32.const 1
     drop
-    local.get $6
+    local.get $7
     i32.eqz
     if
      i32.const 0
@@ -1508,45 +1548,45 @@
      unreachable
     end
     local.get $0
-    local.set $9
+    local.set $14
     local.get $2
-    local.set $8
-    local.get $6
+    local.set $13
+    local.get $7
     i32.ctz
-    local.set $4
-    local.get $9
-    local.get $8
+    local.set $12
+    local.get $14
+    local.get $13
     i32.const 4
     i32.shl
-    local.get $4
+    local.get $12
     i32.add
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=96
-    local.set $7
+    local.set $8
    end
   else
    local.get $0
-   local.set $9
+   local.set $17
    local.get $2
-   local.set $8
-   local.get $6
+   local.set $16
+   local.get $7
    i32.ctz
-   local.set $4
-   local.get $9
-   local.get $8
+   local.set $15
+   local.get $17
+   local.get $16
    i32.const 4
    i32.shl
-   local.get $4
+   local.get $15
    i32.add
    i32.const 2
    i32.shl
    i32.add
    i32.load offset=96
-   local.set $7
+   local.set $8
   end
-  local.get $7
+  local.get $8
  )
  (func $~lib/rt/tlsf/growMemory (param $0 i32) (param $1 i32)
   (local $2 i32)
@@ -1555,6 +1595,7 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
   i32.const 0
   drop
   local.get $1
@@ -1601,15 +1642,15 @@
   i32.shr_u
   local.set $4
   local.get $2
-  local.tee $3
-  local.get $4
   local.tee $5
-  local.get $3
+  local.get $4
+  local.tee $6
   local.get $5
+  local.get $6
   i32.gt_s
   select
-  local.set $6
-  local.get $6
+  local.set $7
+  local.get $7
   memory.grow
   i32.const 0
   i32.lt_s
@@ -1623,12 +1664,12 @@
    end
   end
   memory.size
-  local.set $7
+  local.set $8
   local.get $0
   local.get $2
   i32.const 16
   i32.shl
-  local.get $7
+  local.get $8
   i32.const 16
   i32.shl
   call $~lib/rt/tlsf/addMemory
@@ -1638,6 +1679,8 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
   local.get $1
   i32.load
   local.set $3
@@ -1702,11 +1745,11 @@
    i32.and
    i32.store
    local.get $1
-   local.set $5
-   local.get $5
+   local.set $7
+   local.get $7
    i32.const 16
    i32.add
-   local.get $5
+   local.get $7
    i32.load
    i32.const 3
    i32.const -1
@@ -1714,11 +1757,11 @@
    i32.and
    i32.add
    local.get $1
-   local.set $5
-   local.get $5
+   local.set $6
+   local.get $6
    i32.const 16
    i32.add
-   local.get $5
+   local.get $6
    i32.load
    i32.const 3
    i32.const -1
@@ -1961,6 +2004,8 @@
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
   i32.const 0
   local.set $0
   i32.const 0
@@ -1991,15 +2036,15 @@
    else
     i32.const 0
     call $do/Ref#constructor
-    local.set $3
+    local.set $4
     local.get $1
     call $~lib/rt/pure/__release
-    local.get $3
+    local.get $4
     local.set $1
    end
    local.get $1
-   local.set $3
-   local.get $3
+   local.set $5
+   local.get $5
    br_if $do-continue|0
   end
   local.get $0
@@ -2039,6 +2084,8 @@
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
   i32.const 0
   local.set $0
   i32.const 0
@@ -2070,11 +2117,11 @@
      br $do-break|0
     end
     call $do/getRef
-    local.tee $2
-    local.set $3
-    local.get $2
+    local.tee $4
+    local.set $5
+    local.get $4
     call $~lib/rt/pure/__release
-    local.get $3
+    local.get $5
     br_if $do-continue|0
    end
   end

--- a/tests/compiler/exports.untouched.wat
+++ b/tests/compiler/exports.untouched.wat
@@ -73,6 +73,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   memory.size
   local.set $1
   local.get $1
@@ -103,8 +104,8 @@
    local.get $5
    i32.gt_s
    select
-   local.set $4
-   local.get $4
+   local.set $6
+   local.get $6
    memory.grow
    i32.const 0
    i32.lt_s

--- a/tests/compiler/extends-baseaggregate.optimized.wat
+++ b/tests/compiler/extends-baseaggregate.optimized.wat
@@ -1811,25 +1811,25 @@
   global.get $~lib/rt/pure/ROOTS
   local.tee $0
   local.tee $4
-  local.set $3
-  global.get $~lib/rt/pure/CUR
   local.set $1
+  global.get $~lib/rt/pure/CUR
+  local.set $2
   loop $for-loop|0
-   local.get $3
    local.get $1
+   local.get $2
    i32.lt_u
    if
-    local.get $3
+    local.get $1
     i32.load
-    local.tee $2
-    i32.load offset=4
     local.tee $5
+    i32.load offset=4
+    local.tee $3
     i32.const 1879048192
     i32.and
     i32.const 805306368
     i32.eq
     if (result i32)
-     local.get $5
+     local.get $3
      i32.const 268435455
      i32.and
      i32.const 0
@@ -1838,10 +1838,10 @@
      i32.const 0
     end
     if
-     local.get $2
+     local.get $5
      call $~lib/rt/pure/markGray
      local.get $4
-     local.get $2
+     local.get $5
      i32.store
      local.get $4
      i32.const 4
@@ -1849,30 +1849,30 @@
      local.set $4
     else
      i32.const 0
-     local.get $5
+     local.get $3
      i32.const 268435455
      i32.and
      i32.eqz
-     local.get $5
+     local.get $3
      i32.const 1879048192
      i32.and
      select
      if
       global.get $~lib/rt/tlsf/ROOT
-      local.get $2
+      local.get $5
       call $~lib/rt/tlsf/freeBlock
      else
-      local.get $2
       local.get $5
+      local.get $3
       i32.const 2147483647
       i32.and
       i32.store offset=4
      end
     end
-    local.get $3
+    local.get $1
     i32.const 4
     i32.add
-    local.set $3
+    local.set $1
     br $for-loop|0
    end
   end

--- a/tests/compiler/extends-baseaggregate.untouched.wat
+++ b/tests/compiler/extends-baseaggregate.untouched.wat
@@ -48,6 +48,15 @@
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
   local.get $1
   i32.load
   local.set $2
@@ -184,59 +193,59 @@
   i32.eq
   if
    local.get $0
-   local.set $11
+   local.set $14
    local.get $4
-   local.set $10
+   local.set $13
    local.get $5
-   local.set $9
+   local.set $12
    local.get $7
-   local.set $8
-   local.get $11
-   local.get $10
+   local.set $11
+   local.get $14
+   local.get $13
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $12
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
+   local.get $11
    i32.store offset=96
    local.get $7
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $16
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $15
+    local.get $16
+    local.get $15
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $17
     local.get $0
-    local.set $8
+    local.set $20
     local.get $4
-    local.set $11
-    local.get $9
+    local.set $19
+    local.get $17
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
-    local.set $10
-    local.get $8
-    local.get $11
+    local.tee $17
+    local.set $18
+    local.get $20
+    local.get $19
     i32.const 2
     i32.shl
     i32.add
-    local.get $10
+    local.get $18
     i32.store offset=4
-    local.get $9
+    local.get $17
     i32.eqz
     if
      local.get $0
@@ -266,6 +275,20 @@
   (local $11 i32)
   (local $12 i32)
   (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local $22 i32)
+  (local $23 i32)
+  (local $24 i32)
+  (local $25 i32)
+  (local $26 i32)
+  (local $27 i32)
   i32.const 1
   drop
   local.get $1
@@ -328,8 +351,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $3
+   local.set $6
+   local.get $6
    i32.const 1073741808
    i32.lt_u
    if
@@ -340,16 +363,16 @@
     local.get $2
     i32.const 3
     i32.and
-    local.get $3
+    local.get $6
     i32.or
     local.tee $2
     i32.store
     local.get $1
-    local.set $6
-    local.get $6
+    local.set $7
+    local.get $7
     i32.const 16
     i32.add
-    local.get $6
+    local.get $7
     i32.load
     i32.const 3
     i32.const -1
@@ -367,18 +390,18 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $8
+   local.get $8
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
+   local.set $9
+   local.get $9
    i32.load
-   local.set $3
+   local.set $10
    i32.const 1
    drop
-   local.get $3
+   local.get $10
    i32.const 1
    i32.and
    i32.eqz
@@ -390,7 +413,7 @@
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $3
+   local.get $10
    i32.const 3
    i32.const -1
    i32.xor
@@ -403,23 +426,23 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $7
+   local.set $11
+   local.get $11
    i32.const 1073741808
    i32.lt_u
    if
     local.get $0
-    local.get $6
+    local.get $9
     call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
+    local.get $9
+    local.get $10
     i32.const 3
     i32.and
-    local.get $7
+    local.get $11
     i32.or
     local.tee $2
     i32.store
-    local.get $6
+    local.get $9
     local.set $1
    end
   end
@@ -433,14 +456,14 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $12
   i32.const 1
   drop
-  local.get $8
+  local.get $12
   i32.const 16
   i32.ge_u
   if (result i32)
-   local.get $8
+   local.get $12
    i32.const 1073741808
    i32.lt_u
   else
@@ -460,7 +483,7 @@
   local.get $1
   i32.const 16
   i32.add
-  local.get $8
+  local.get $12
   i32.add
   local.get $4
   i32.eq
@@ -478,24 +501,24 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $12
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $13
+   local.get $12
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $14
   else
    i32.const 31
-   local.get $8
+   local.get $12
    i32.clz
    i32.sub
-   local.set $9
-   local.get $8
-   local.get $9
+   local.set $13
+   local.get $12
+   local.get $13
    i32.const 4
    i32.sub
    i32.shr_u
@@ -503,21 +526,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $14
+   local.get $13
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $13
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $13
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $14
    i32.const 16
    i32.lt_u
   else
@@ -533,86 +556,86 @@
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
-  local.set $6
-  local.get $7
-  local.get $3
+  local.set $17
+  local.get $13
+  local.set $16
+  local.get $14
+  local.set $15
+  local.get $17
+  local.get $16
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $15
   i32.add
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=96
-  local.set $11
+  local.set $18
   local.get $1
   i32.const 0
   i32.store offset=16
   local.get $1
-  local.get $11
+  local.get $18
   i32.store offset=20
-  local.get $11
+  local.get $18
   if
-   local.get $11
+   local.get $18
    local.get $1
    i32.store offset=16
   end
   local.get $0
-  local.set $12
-  local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
+  local.set $22
+  local.get $13
+  local.set $21
+  local.get $14
+  local.set $20
   local.get $1
-  local.set $6
-  local.get $12
-  local.get $7
+  local.set $19
+  local.get $22
+  local.get $21
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $20
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $19
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $13
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.set $13
-  local.get $9
-  local.set $12
+  local.set $27
+  local.get $13
+  local.set $26
   local.get $0
-  local.set $3
-  local.get $9
-  local.set $6
-  local.get $3
-  local.get $6
+  local.set $24
+  local.get $13
+  local.set $23
+  local.get $24
+  local.get $23
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $14
   i32.shl
   i32.or
-  local.set $7
-  local.get $13
-  local.get $12
+  local.set $25
+  local.get $27
+  local.get $26
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $25
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -623,6 +646,7 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
   i32.const 1
   drop
   local.get $1
@@ -762,11 +786,11 @@
   i32.or
   i32.store
   local.get $0
-  local.set $9
+  local.set $10
   local.get $4
-  local.set $3
+  local.set $9
+  local.get $10
   local.get $9
-  local.get $3
   i32.store offset=1568
   local.get $0
   local.get $8
@@ -786,6 +810,12 @@
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
   global.get $~lib/rt/tlsf/ROOT
   local.set $0
   local.get $0
@@ -842,66 +872,66 @@
    local.get $4
    i32.store offset=1568
    i32.const 0
-   local.set $5
+   local.set $6
    loop $for-loop|0
-    local.get $5
+    local.get $6
     i32.const 23
     i32.lt_u
-    local.set $4
-    local.get $4
+    local.set $7
+    local.get $7
     if
      local.get $0
-     local.set $8
-     local.get $5
-     local.set $7
+     local.set $10
+     local.get $6
+     local.set $9
      i32.const 0
-     local.set $6
-     local.get $8
-     local.get $7
+     local.set $8
+     local.get $10
+     local.get $9
      i32.const 2
      i32.shl
      i32.add
-     local.get $6
+     local.get $8
      i32.store offset=4
      i32.const 0
-     local.set $8
+     local.set $11
      loop $for-loop|1
-      local.get $8
+      local.get $11
       i32.const 16
       i32.lt_u
-      local.set $7
-      local.get $7
+      local.set $12
+      local.get $12
       if
        local.get $0
-       local.set $11
-       local.get $5
-       local.set $10
-       local.get $8
-       local.set $9
-       i32.const 0
-       local.set $6
+       local.set $16
+       local.get $6
+       local.set $15
        local.get $11
-       local.get $10
+       local.set $14
+       i32.const 0
+       local.set $13
+       local.get $16
+       local.get $15
        i32.const 4
        i32.shl
-       local.get $9
+       local.get $14
        i32.add
        i32.const 2
        i32.shl
        i32.add
-       local.get $6
+       local.get $13
        i32.store offset=96
-       local.get $8
+       local.get $11
        i32.const 1
        i32.add
-       local.set $8
+       local.set $11
        br $for-loop|1
       end
      end
-     local.get $5
+     local.get $6
      i32.const 1
      i32.add
-     local.set $5
+     local.set $6
      br $for-loop|0
     end
    end
@@ -914,11 +944,11 @@
    i32.const -1
    i32.xor
    i32.and
-   local.set $5
+   local.set $17
    i32.const 0
    drop
    local.get $0
-   local.get $5
+   local.get $17
    memory.size
    i32.const 16
    i32.shl
@@ -967,6 +997,14 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
   local.get $1
   i32.const 256
   i32.lt_u
@@ -1040,11 +1078,11 @@
    unreachable
   end
   local.get $0
-  local.set $5
+  local.set $6
   local.get $2
-  local.set $4
+  local.set $5
+  local.get $6
   local.get $5
-  local.get $4
   i32.const 2
   i32.shl
   i32.add
@@ -1055,10 +1093,10 @@
   local.get $3
   i32.shl
   i32.and
-  local.set $6
-  i32.const 0
   local.set $7
-  local.get $6
+  i32.const 0
+  local.set $8
+  local.get $7
   i32.eqz
   if
    local.get $0
@@ -1071,30 +1109,30 @@
    i32.add
    i32.shl
    i32.and
-   local.set $5
-   local.get $5
+   local.set $9
+   local.get $9
    i32.eqz
    if
     i32.const 0
-    local.set $7
+    local.set $8
    else
-    local.get $5
+    local.get $9
     i32.ctz
     local.set $2
     local.get $0
-    local.set $8
+    local.set $11
     local.get $2
-    local.set $4
-    local.get $8
-    local.get $4
+    local.set $10
+    local.get $11
+    local.get $10
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $6
+    local.set $7
     i32.const 1
     drop
-    local.get $6
+    local.get $7
     i32.eqz
     if
      i32.const 0
@@ -1105,45 +1143,45 @@
      unreachable
     end
     local.get $0
-    local.set $9
+    local.set $14
     local.get $2
-    local.set $8
-    local.get $6
+    local.set $13
+    local.get $7
     i32.ctz
-    local.set $4
-    local.get $9
-    local.get $8
+    local.set $12
+    local.get $14
+    local.get $13
     i32.const 4
     i32.shl
-    local.get $4
+    local.get $12
     i32.add
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=96
-    local.set $7
+    local.set $8
    end
   else
    local.get $0
-   local.set $9
+   local.set $17
    local.get $2
-   local.set $8
-   local.get $6
+   local.set $16
+   local.get $7
    i32.ctz
-   local.set $4
-   local.get $9
-   local.get $8
+   local.set $15
+   local.get $17
+   local.get $16
    i32.const 4
    i32.shl
-   local.get $4
+   local.get $15
    i32.add
    i32.const 2
    i32.shl
    i32.add
    i32.load offset=96
-   local.set $7
+   local.set $8
   end
-  local.get $7
+  local.get $8
  )
  (func $~lib/rt/tlsf/growMemory (param $0 i32) (param $1 i32)
   (local $2 i32)
@@ -1152,6 +1190,7 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
   i32.const 0
   drop
   local.get $1
@@ -1198,15 +1237,15 @@
   i32.shr_u
   local.set $4
   local.get $2
-  local.tee $3
-  local.get $4
   local.tee $5
-  local.get $3
+  local.get $4
+  local.tee $6
   local.get $5
+  local.get $6
   i32.gt_s
   select
-  local.set $6
-  local.get $6
+  local.set $7
+  local.get $7
   memory.grow
   i32.const 0
   i32.lt_s
@@ -1220,12 +1259,12 @@
    end
   end
   memory.size
-  local.set $7
+  local.set $8
   local.get $0
   local.get $2
   i32.const 16
   i32.shl
-  local.get $7
+  local.get $8
   i32.const 16
   i32.shl
   call $~lib/rt/tlsf/addMemory
@@ -1235,6 +1274,8 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
   local.get $1
   i32.load
   local.set $3
@@ -1299,11 +1340,11 @@
    i32.and
    i32.store
    local.get $1
-   local.set $5
-   local.get $5
+   local.set $7
+   local.get $7
    i32.const 16
    i32.add
-   local.get $5
+   local.get $7
    i32.load
    i32.const 3
    i32.const -1
@@ -1311,11 +1352,11 @@
    i32.and
    i32.add
    local.get $1
-   local.set $5
-   local.get $5
+   local.set $6
+   local.get $6
    i32.const 16
    i32.add
-   local.get $5
+   local.get $6
    i32.load
    i32.const 3
    i32.const -1
@@ -1615,6 +1656,88 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local $22 i32)
+  (local $23 i32)
+  (local $24 i32)
+  (local $25 i32)
+  (local $26 i32)
+  (local $27 i32)
+  (local $28 i32)
+  (local $29 i32)
+  (local $30 i32)
+  (local $31 i32)
+  (local $32 i32)
+  (local $33 i32)
+  (local $34 i32)
+  (local $35 i32)
+  (local $36 i32)
+  (local $37 i32)
+  (local $38 i32)
+  (local $39 i32)
+  (local $40 i32)
+  (local $41 i32)
+  (local $42 i32)
+  (local $43 i32)
+  (local $44 i32)
+  (local $45 i32)
+  (local $46 i32)
+  (local $47 i32)
+  (local $48 i32)
+  (local $49 i32)
+  (local $50 i32)
+  (local $51 i32)
+  (local $52 i32)
+  (local $53 i32)
+  (local $54 i32)
+  (local $55 i32)
+  (local $56 i32)
+  (local $57 i32)
+  (local $58 i32)
+  (local $59 i32)
+  (local $60 i32)
+  (local $61 i32)
+  (local $62 i32)
+  (local $63 i32)
+  (local $64 i32)
+  (local $65 i32)
+  (local $66 i32)
+  (local $67 i32)
+  (local $68 i32)
+  (local $69 i32)
+  (local $70 i32)
+  (local $71 i32)
+  (local $72 i32)
+  (local $73 i32)
+  (local $74 i32)
+  (local $75 i32)
+  (local $76 i32)
+  (local $77 i32)
+  (local $78 i32)
+  (local $79 i32)
+  (local $80 i32)
+  (local $81 i32)
+  (local $82 i32)
+  (local $83 i32)
+  (local $84 i32)
+  (local $85 i32)
+  (local $86 i32)
+  (local $87 i32)
+  (local $88 i32)
   loop $while-continue|0
    local.get $2
    if (result i32)
@@ -1634,11 +1757,11 @@
     local.set $0
     local.get $6
     local.get $1
-    local.tee $6
+    local.tee $7
     i32.const 1
     i32.add
     local.set $1
-    local.get $6
+    local.get $7
     i32.load8_u
     i32.store8
     local.get $2
@@ -1658,8 +1781,8 @@
     local.get $2
     i32.const 16
     i32.ge_u
-    local.set $5
-    local.get $5
+    local.set $8
+    local.get $8
     if
      local.get $0
      local.get $1
@@ -1768,17 +1891,17 @@
    i32.and
    if
     local.get $0
-    local.tee $5
+    local.tee $9
     i32.const 1
     i32.add
     local.set $0
-    local.get $5
+    local.get $9
     local.get $1
-    local.tee $5
+    local.tee $10
     i32.const 1
     i32.add
     local.set $1
-    local.get $5
+    local.get $10
     i32.load8_u
     i32.store8
    end
@@ -1795,16 +1918,16 @@
        local.get $0
        i32.const 3
        i32.and
-       local.set $5
-       local.get $5
+       local.set $11
+       local.get $11
        i32.const 1
        i32.eq
        br_if $case0|2
-       local.get $5
+       local.get $11
        i32.const 2
        i32.eq
        br_if $case1|2
-       local.get $5
+       local.get $11
        i32.const 3
        i32.eq
        br_if $case2|2
@@ -1814,45 +1937,45 @@
       i32.load
       local.set $3
       local.get $0
-      local.tee $5
+      local.tee $12
       i32.const 1
       i32.add
       local.set $0
-      local.get $5
+      local.get $12
       local.get $1
-      local.tee $5
+      local.tee $13
       i32.const 1
       i32.add
       local.set $1
-      local.get $5
+      local.get $13
       i32.load8_u
       i32.store8
       local.get $0
-      local.tee $5
+      local.tee $14
       i32.const 1
       i32.add
       local.set $0
-      local.get $5
+      local.get $14
       local.get $1
-      local.tee $5
+      local.tee $15
       i32.const 1
       i32.add
       local.set $1
-      local.get $5
+      local.get $15
       i32.load8_u
       i32.store8
       local.get $0
-      local.tee $5
+      local.tee $16
       i32.const 1
       i32.add
       local.set $0
-      local.get $5
+      local.get $16
       local.get $1
-      local.tee $5
+      local.tee $17
       i32.const 1
       i32.add
       local.set $1
-      local.get $5
+      local.get $17
       i32.load8_u
       i32.store8
       local.get $2
@@ -1863,8 +1986,8 @@
        local.get $2
        i32.const 17
        i32.ge_u
-       local.set $5
-       local.get $5
+       local.set $18
+       local.get $18
        if
         local.get $1
         i32.const 1
@@ -1949,31 +2072,31 @@
      i32.load
      local.set $3
      local.get $0
-     local.tee $5
+     local.tee $19
      i32.const 1
      i32.add
      local.set $0
-     local.get $5
+     local.get $19
      local.get $1
-     local.tee $5
+     local.tee $20
      i32.const 1
      i32.add
      local.set $1
-     local.get $5
+     local.get $20
      i32.load8_u
      i32.store8
      local.get $0
-     local.tee $5
+     local.tee $21
      i32.const 1
      i32.add
      local.set $0
-     local.get $5
+     local.get $21
      local.get $1
-     local.tee $5
+     local.tee $22
      i32.const 1
      i32.add
      local.set $1
-     local.get $5
+     local.get $22
      i32.load8_u
      i32.store8
      local.get $2
@@ -1984,8 +2107,8 @@
       local.get $2
       i32.const 18
       i32.ge_u
-      local.set $5
-      local.get $5
+      local.set $23
+      local.get $23
       if
        local.get $1
        i32.const 2
@@ -2070,17 +2193,17 @@
     i32.load
     local.set $3
     local.get $0
-    local.tee $5
+    local.tee $24
     i32.const 1
     i32.add
     local.set $0
-    local.get $5
+    local.get $24
     local.get $1
-    local.tee $5
+    local.tee $25
     i32.const 1
     i32.add
     local.set $1
-    local.get $5
+    local.get $25
     i32.load8_u
     i32.store8
     local.get $2
@@ -2091,8 +2214,8 @@
      local.get $2
      i32.const 19
      i32.ge_u
-     local.set $5
-     local.get $5
+     local.set $26
+     local.get $26
      if
       local.get $1
       i32.const 3
@@ -2179,227 +2302,227 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $27
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $27
    local.get $1
-   local.tee $5
+   local.tee $28
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $28
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $29
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $29
    local.get $1
-   local.tee $5
+   local.tee $30
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $30
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $31
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $31
    local.get $1
-   local.tee $5
+   local.tee $32
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $32
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $33
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $33
    local.get $1
-   local.tee $5
+   local.tee $34
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $34
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $35
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $35
    local.get $1
-   local.tee $5
+   local.tee $36
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $36
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $37
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $37
    local.get $1
-   local.tee $5
+   local.tee $38
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $38
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $39
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $39
    local.get $1
-   local.tee $5
+   local.tee $40
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $40
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $41
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $41
    local.get $1
-   local.tee $5
+   local.tee $42
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $42
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $43
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $43
    local.get $1
-   local.tee $5
+   local.tee $44
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $44
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $45
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $45
    local.get $1
-   local.tee $5
+   local.tee $46
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $46
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $47
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $47
    local.get $1
-   local.tee $5
+   local.tee $48
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $48
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $49
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $49
    local.get $1
-   local.tee $5
+   local.tee $50
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $50
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $51
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $51
    local.get $1
-   local.tee $5
+   local.tee $52
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $52
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $53
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $53
    local.get $1
-   local.tee $5
+   local.tee $54
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $54
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $55
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $55
    local.get $1
-   local.tee $5
+   local.tee $56
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $56
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $57
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $57
    local.get $1
-   local.tee $5
+   local.tee $58
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $58
    i32.load8_u
    i32.store8
   end
@@ -2408,115 +2531,115 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $59
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $59
    local.get $1
-   local.tee $5
+   local.tee $60
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $60
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $61
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $61
    local.get $1
-   local.tee $5
+   local.tee $62
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $62
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $63
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $63
    local.get $1
-   local.tee $5
+   local.tee $64
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $64
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $65
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $65
    local.get $1
-   local.tee $5
+   local.tee $66
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $66
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $67
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $67
    local.get $1
-   local.tee $5
+   local.tee $68
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $68
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $69
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $69
    local.get $1
-   local.tee $5
+   local.tee $70
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $70
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $71
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $71
    local.get $1
-   local.tee $5
+   local.tee $72
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $72
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $73
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $73
    local.get $1
-   local.tee $5
+   local.tee $74
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $74
    i32.load8_u
    i32.store8
   end
@@ -2525,59 +2648,59 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $75
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $75
    local.get $1
-   local.tee $5
+   local.tee $76
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $76
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $77
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $77
    local.get $1
-   local.tee $5
+   local.tee $78
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $78
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $79
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $79
    local.get $1
-   local.tee $5
+   local.tee $80
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $80
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $81
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $81
    local.get $1
-   local.tee $5
+   local.tee $82
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $82
    i32.load8_u
    i32.store8
   end
@@ -2586,31 +2709,31 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $83
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $83
    local.get $1
-   local.tee $5
+   local.tee $84
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $84
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $85
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $85
    local.get $1
-   local.tee $5
+   local.tee $86
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $86
    i32.load8_u
    i32.store8
   end
@@ -2619,17 +2742,17 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $87
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $87
    local.get $1
-   local.tee $5
+   local.tee $88
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $88
    i32.load8_u
    i32.store8
   end
@@ -2640,6 +2763,14 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
   block $~lib/util/memory/memmove|inlined.0
    local.get $0
    local.set $5
@@ -2717,11 +2848,11 @@
        local.set $5
        local.get $7
        local.get $4
-       local.tee $7
+       local.tee $8
        i32.const 1
        i32.add
        local.set $4
-       local.get $7
+       local.get $8
        i32.load8_u
        i32.store8
        br $while-continue|0
@@ -2731,8 +2862,8 @@
       local.get $3
       i32.const 8
       i32.ge_u
-      local.set $6
-      local.get $6
+      local.set $9
+      local.get $9
       if
        local.get $5
        local.get $4
@@ -2756,21 +2887,21 @@
     end
     loop $while-continue|2
      local.get $3
-     local.set $6
-     local.get $6
+     local.set $10
+     local.get $10
      if
       local.get $5
-      local.tee $7
+      local.tee $11
       i32.const 1
       i32.add
       local.set $5
-      local.get $7
+      local.get $11
       local.get $4
-      local.tee $7
+      local.tee $12
       i32.const 1
       i32.add
       local.set $4
-      local.get $7
+      local.get $12
       i32.load8_u
       i32.store8
       local.get $3
@@ -2799,8 +2930,8 @@
       i32.add
       i32.const 7
       i32.and
-      local.set $6
-      local.get $6
+      local.set $13
+      local.get $13
       if
        local.get $3
        i32.eqz
@@ -2825,8 +2956,8 @@
       local.get $3
       i32.const 8
       i32.ge_u
-      local.set $6
-      local.get $6
+      local.set $14
+      local.get $14
       if
        local.get $3
        i32.const 8
@@ -2846,8 +2977,8 @@
     end
     loop $while-continue|5
      local.get $3
-     local.set $6
-     local.get $6
+     local.set $15
+     local.get $15
      if
       local.get $5
       local.get $3
@@ -2889,6 +3020,7 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
   local.get $2
   call $~lib/rt/tlsf/prepareSize
   local.set $3
@@ -2946,8 +3078,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $5
-   local.get $5
+   local.set $8
+   local.get $8
    local.get $3
    i32.ge_u
    if
@@ -2958,7 +3090,7 @@
     local.get $4
     i32.const 3
     i32.and
-    local.get $5
+    local.get $8
     i32.or
     i32.store
     local.get $1
@@ -2977,12 +3109,12 @@
   local.get $1
   i32.load offset=8
   call $~lib/rt/tlsf/allocateBlock
-  local.set $8
-  local.get $8
+  local.set $9
+  local.get $9
   local.get $1
   i32.load offset=4
   i32.store offset=4
-  local.get $8
+  local.get $9
   i32.const 16
   i32.add
   local.get $1
@@ -3000,7 +3132,7 @@
    local.get $1
    call $~lib/rt/tlsf/freeBlock
   end
-  local.get $8
+  local.get $9
  )
  (func $~lib/rt/tlsf/__realloc (param $0 i32) (param $1 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
@@ -3338,13 +3470,16 @@
  (func $start:extends-baseaggregate
   (local $0 i32)
   (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
   global.get $extends-baseaggregate/poolA
   i32.const 0
   call $extends-baseaggregate/A2#constructor
-  local.tee $0
+  local.tee $4
   call $~lib/array/Array<extends-baseaggregate/A2>#push
   drop
-  local.get $0
+  local.get $4
   call $~lib/rt/pure/__release
  )
  (func $~start
@@ -3477,6 +3612,11 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
   i32.const 0
   drop
   global.get $~lib/rt/pure/ROOTS
@@ -3562,50 +3702,50 @@
   local.get $1
   global.set $~lib/rt/pure/CUR
   local.get $0
-  local.set $3
+  local.set $7
   loop $for-loop|1
-   local.get $3
+   local.get $7
    local.get $1
    i32.lt_u
-   local.set $2
-   local.get $2
+   local.set $8
+   local.get $8
    if
-    local.get $3
+    local.get $7
     i32.load
     call $~lib/rt/pure/scan
-    local.get $3
+    local.get $7
     i32.const 4
     i32.add
-    local.set $3
+    local.set $7
     br $for-loop|1
    end
   end
   local.get $0
-  local.set $3
+  local.set $9
   loop $for-loop|2
-   local.get $3
+   local.get $9
    local.get $1
    i32.lt_u
-   local.set $2
-   local.get $2
+   local.set $10
+   local.get $10
    if
-    local.get $3
+    local.get $9
     i32.load
-    local.set $4
-    local.get $4
-    local.get $4
+    local.set $11
+    local.get $11
+    local.get $11
     i32.load offset=4
     i32.const -2147483648
     i32.const -1
     i32.xor
     i32.and
     i32.store offset=4
-    local.get $4
+    local.get $11
     call $~lib/rt/pure/collectWhite
-    local.get $3
+    local.get $9
     i32.const 4
     i32.add
-    local.set $3
+    local.set $9
     br $for-loop|2
    end
   end
@@ -3832,6 +3972,7 @@
  (func $~lib/rt/pure/__visit (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.lt_u
@@ -3912,13 +4053,13 @@
      end
      local.get $2
      i32.load offset=4
-     local.set $3
-     local.get $3
+     local.set $4
+     local.get $4
      i32.const 268435455
      i32.const -1
      i32.xor
      i32.and
-     local.get $3
+     local.get $4
      i32.const 1
      i32.add
      i32.const 268435455
@@ -3936,11 +4077,11 @@
       unreachable
      end
      local.get $2
-     local.get $3
+     local.get $4
      i32.const 1
      i32.add
      i32.store offset=4
-     local.get $3
+     local.get $4
      i32.const 1879048192
      i32.and
      i32.const 0

--- a/tests/compiler/extends-recursive.untouched.wat
+++ b/tests/compiler/extends-recursive.untouched.wat
@@ -21,6 +21,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   memory.size
   local.set $1
   local.get $1
@@ -51,8 +52,8 @@
    local.get $5
    i32.gt_s
    select
-   local.set $4
-   local.get $4
+   local.set $6
+   local.get $6
    memory.grow
    i32.const 0
    i32.lt_s

--- a/tests/compiler/features/reference-types.untouched.wat
+++ b/tests/compiler/features/reference-types.untouched.wat
@@ -28,6 +28,7 @@
  (func $start:features/reference-types
   (local $0 anyref)
   (local $1 anyref)
+  (local $2 anyref)
   global.get $features/reference-types/someObject
   global.get $features/reference-types/someKey
   call $~lib/bindings/Reflect/has
@@ -139,7 +140,7 @@
   ref.func $features/reference-types/someFunc
   global.set $features/reference-types/funcGlobal
   ref.func $features/reference-types/someFunc
-  local.set $1
+  local.set $2
  )
  (func $features/reference-types/internal (param $0 anyref) (result anyref)
   (local $1 anyref)

--- a/tests/compiler/features/simd.untouched.wat
+++ b/tests/compiler/features/simd.untouched.wat
@@ -25,6 +25,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   memory.size
   local.set $1
   local.get $1
@@ -55,8 +56,8 @@
    local.get $5
    i32.gt_s
    select
-   local.set $4
-   local.get $4
+   local.set $6
+   local.get $6
    memory.grow
    i32.const 0
    i32.lt_s

--- a/tests/compiler/for.untouched.wat
+++ b/tests/compiler/for.untouched.wat
@@ -464,6 +464,15 @@
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
   local.get $1
   i32.load
   local.set $2
@@ -600,59 +609,59 @@
   i32.eq
   if
    local.get $0
-   local.set $11
+   local.set $14
    local.get $4
-   local.set $10
+   local.set $13
    local.get $5
-   local.set $9
+   local.set $12
    local.get $7
-   local.set $8
-   local.get $11
-   local.get $10
+   local.set $11
+   local.get $14
+   local.get $13
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $12
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
+   local.get $11
    i32.store offset=96
    local.get $7
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $16
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $15
+    local.get $16
+    local.get $15
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $17
     local.get $0
-    local.set $8
+    local.set $20
     local.get $4
-    local.set $11
-    local.get $9
+    local.set $19
+    local.get $17
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
-    local.set $10
-    local.get $8
-    local.get $11
+    local.tee $17
+    local.set $18
+    local.get $20
+    local.get $19
     i32.const 2
     i32.shl
     i32.add
-    local.get $10
+    local.get $18
     i32.store offset=4
-    local.get $9
+    local.get $17
     i32.eqz
     if
      local.get $0
@@ -682,6 +691,20 @@
   (local $11 i32)
   (local $12 i32)
   (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local $22 i32)
+  (local $23 i32)
+  (local $24 i32)
+  (local $25 i32)
+  (local $26 i32)
+  (local $27 i32)
   i32.const 1
   drop
   local.get $1
@@ -744,8 +767,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $3
+   local.set $6
+   local.get $6
    i32.const 1073741808
    i32.lt_u
    if
@@ -756,16 +779,16 @@
     local.get $2
     i32.const 3
     i32.and
-    local.get $3
+    local.get $6
     i32.or
     local.tee $2
     i32.store
     local.get $1
-    local.set $6
-    local.get $6
+    local.set $7
+    local.get $7
     i32.const 16
     i32.add
-    local.get $6
+    local.get $7
     i32.load
     i32.const 3
     i32.const -1
@@ -783,18 +806,18 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $8
+   local.get $8
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
+   local.set $9
+   local.get $9
    i32.load
-   local.set $3
+   local.set $10
    i32.const 1
    drop
-   local.get $3
+   local.get $10
    i32.const 1
    i32.and
    i32.eqz
@@ -806,7 +829,7 @@
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $3
+   local.get $10
    i32.const 3
    i32.const -1
    i32.xor
@@ -819,23 +842,23 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $7
+   local.set $11
+   local.get $11
    i32.const 1073741808
    i32.lt_u
    if
     local.get $0
-    local.get $6
+    local.get $9
     call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
+    local.get $9
+    local.get $10
     i32.const 3
     i32.and
-    local.get $7
+    local.get $11
     i32.or
     local.tee $2
     i32.store
-    local.get $6
+    local.get $9
     local.set $1
    end
   end
@@ -849,14 +872,14 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $12
   i32.const 1
   drop
-  local.get $8
+  local.get $12
   i32.const 16
   i32.ge_u
   if (result i32)
-   local.get $8
+   local.get $12
    i32.const 1073741808
    i32.lt_u
   else
@@ -876,7 +899,7 @@
   local.get $1
   i32.const 16
   i32.add
-  local.get $8
+  local.get $12
   i32.add
   local.get $4
   i32.eq
@@ -894,24 +917,24 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $12
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $13
+   local.get $12
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $14
   else
    i32.const 31
-   local.get $8
+   local.get $12
    i32.clz
    i32.sub
-   local.set $9
-   local.get $8
-   local.get $9
+   local.set $13
+   local.get $12
+   local.get $13
    i32.const 4
    i32.sub
    i32.shr_u
@@ -919,21 +942,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $14
+   local.get $13
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $13
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $13
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $14
    i32.const 16
    i32.lt_u
   else
@@ -949,86 +972,86 @@
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
-  local.set $6
-  local.get $7
-  local.get $3
+  local.set $17
+  local.get $13
+  local.set $16
+  local.get $14
+  local.set $15
+  local.get $17
+  local.get $16
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $15
   i32.add
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=96
-  local.set $11
+  local.set $18
   local.get $1
   i32.const 0
   i32.store offset=16
   local.get $1
-  local.get $11
+  local.get $18
   i32.store offset=20
-  local.get $11
+  local.get $18
   if
-   local.get $11
+   local.get $18
    local.get $1
    i32.store offset=16
   end
   local.get $0
-  local.set $12
-  local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
+  local.set $22
+  local.get $13
+  local.set $21
+  local.get $14
+  local.set $20
   local.get $1
-  local.set $6
-  local.get $12
-  local.get $7
+  local.set $19
+  local.get $22
+  local.get $21
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $20
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $19
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $13
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.set $13
-  local.get $9
-  local.set $12
+  local.set $27
+  local.get $13
+  local.set $26
   local.get $0
-  local.set $3
-  local.get $9
-  local.set $6
-  local.get $3
-  local.get $6
+  local.set $24
+  local.get $13
+  local.set $23
+  local.get $24
+  local.get $23
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $14
   i32.shl
   i32.or
-  local.set $7
-  local.get $13
-  local.get $12
+  local.set $25
+  local.get $27
+  local.get $26
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $25
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -1039,6 +1062,7 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
   i32.const 1
   drop
   local.get $1
@@ -1178,11 +1202,11 @@
   i32.or
   i32.store
   local.get $0
-  local.set $9
+  local.set $10
   local.get $4
-  local.set $3
+  local.set $9
+  local.get $10
   local.get $9
-  local.get $3
   i32.store offset=1568
   local.get $0
   local.get $8
@@ -1202,6 +1226,12 @@
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
   global.get $~lib/rt/tlsf/ROOT
   local.set $0
   local.get $0
@@ -1258,66 +1288,66 @@
    local.get $4
    i32.store offset=1568
    i32.const 0
-   local.set $5
+   local.set $6
    loop $for-loop|0
-    local.get $5
+    local.get $6
     i32.const 23
     i32.lt_u
-    local.set $4
-    local.get $4
+    local.set $7
+    local.get $7
     if
      local.get $0
-     local.set $8
-     local.get $5
-     local.set $7
+     local.set $10
+     local.get $6
+     local.set $9
      i32.const 0
-     local.set $6
-     local.get $8
-     local.get $7
+     local.set $8
+     local.get $10
+     local.get $9
      i32.const 2
      i32.shl
      i32.add
-     local.get $6
+     local.get $8
      i32.store offset=4
      i32.const 0
-     local.set $8
+     local.set $11
      loop $for-loop|1
-      local.get $8
+      local.get $11
       i32.const 16
       i32.lt_u
-      local.set $7
-      local.get $7
+      local.set $12
+      local.get $12
       if
        local.get $0
-       local.set $11
-       local.get $5
-       local.set $10
-       local.get $8
-       local.set $9
-       i32.const 0
-       local.set $6
+       local.set $16
+       local.get $6
+       local.set $15
        local.get $11
-       local.get $10
+       local.set $14
+       i32.const 0
+       local.set $13
+       local.get $16
+       local.get $15
        i32.const 4
        i32.shl
-       local.get $9
+       local.get $14
        i32.add
        i32.const 2
        i32.shl
        i32.add
-       local.get $6
+       local.get $13
        i32.store offset=96
-       local.get $8
+       local.get $11
        i32.const 1
        i32.add
-       local.set $8
+       local.set $11
        br $for-loop|1
       end
      end
-     local.get $5
+     local.get $6
      i32.const 1
      i32.add
-     local.set $5
+     local.set $6
      br $for-loop|0
     end
    end
@@ -1330,11 +1360,11 @@
    i32.const -1
    i32.xor
    i32.and
-   local.set $5
+   local.set $17
    i32.const 0
    drop
    local.get $0
-   local.get $5
+   local.get $17
    memory.size
    i32.const 16
    i32.shl
@@ -1383,6 +1413,14 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
   local.get $1
   i32.const 256
   i32.lt_u
@@ -1456,11 +1494,11 @@
    unreachable
   end
   local.get $0
-  local.set $5
+  local.set $6
   local.get $2
-  local.set $4
+  local.set $5
+  local.get $6
   local.get $5
-  local.get $4
   i32.const 2
   i32.shl
   i32.add
@@ -1471,10 +1509,10 @@
   local.get $3
   i32.shl
   i32.and
-  local.set $6
-  i32.const 0
   local.set $7
-  local.get $6
+  i32.const 0
+  local.set $8
+  local.get $7
   i32.eqz
   if
    local.get $0
@@ -1487,30 +1525,30 @@
    i32.add
    i32.shl
    i32.and
-   local.set $5
-   local.get $5
+   local.set $9
+   local.get $9
    i32.eqz
    if
     i32.const 0
-    local.set $7
+    local.set $8
    else
-    local.get $5
+    local.get $9
     i32.ctz
     local.set $2
     local.get $0
-    local.set $8
+    local.set $11
     local.get $2
-    local.set $4
-    local.get $8
-    local.get $4
+    local.set $10
+    local.get $11
+    local.get $10
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $6
+    local.set $7
     i32.const 1
     drop
-    local.get $6
+    local.get $7
     i32.eqz
     if
      i32.const 0
@@ -1521,45 +1559,45 @@
      unreachable
     end
     local.get $0
-    local.set $9
+    local.set $14
     local.get $2
-    local.set $8
-    local.get $6
+    local.set $13
+    local.get $7
     i32.ctz
-    local.set $4
-    local.get $9
-    local.get $8
+    local.set $12
+    local.get $14
+    local.get $13
     i32.const 4
     i32.shl
-    local.get $4
+    local.get $12
     i32.add
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=96
-    local.set $7
+    local.set $8
    end
   else
    local.get $0
-   local.set $9
+   local.set $17
    local.get $2
-   local.set $8
-   local.get $6
+   local.set $16
+   local.get $7
    i32.ctz
-   local.set $4
-   local.get $9
-   local.get $8
+   local.set $15
+   local.get $17
+   local.get $16
    i32.const 4
    i32.shl
-   local.get $4
+   local.get $15
    i32.add
    i32.const 2
    i32.shl
    i32.add
    i32.load offset=96
-   local.set $7
+   local.set $8
   end
-  local.get $7
+  local.get $8
  )
  (func $~lib/rt/tlsf/growMemory (param $0 i32) (param $1 i32)
   (local $2 i32)
@@ -1568,6 +1606,7 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
   i32.const 0
   drop
   local.get $1
@@ -1614,15 +1653,15 @@
   i32.shr_u
   local.set $4
   local.get $2
-  local.tee $3
-  local.get $4
   local.tee $5
-  local.get $3
+  local.get $4
+  local.tee $6
   local.get $5
+  local.get $6
   i32.gt_s
   select
-  local.set $6
-  local.get $6
+  local.set $7
+  local.get $7
   memory.grow
   i32.const 0
   i32.lt_s
@@ -1636,12 +1675,12 @@
    end
   end
   memory.size
-  local.set $7
+  local.set $8
   local.get $0
   local.get $2
   i32.const 16
   i32.shl
-  local.get $7
+  local.get $8
   i32.const 16
   i32.shl
   call $~lib/rt/tlsf/addMemory
@@ -1651,6 +1690,8 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
   local.get $1
   i32.load
   local.set $3
@@ -1715,11 +1756,11 @@
    i32.and
    i32.store
    local.get $1
-   local.set $5
-   local.get $5
+   local.set $7
+   local.get $7
    i32.const 16
    i32.add
-   local.get $5
+   local.get $7
    i32.load
    i32.const 3
    i32.const -1
@@ -1727,11 +1768,11 @@
    i32.and
    i32.add
    local.get $1
-   local.set $5
-   local.get $5
+   local.set $6
+   local.get $6
    i32.const 16
    i32.add
-   local.get $5
+   local.get $6
    i32.load
    i32.const 3
    i32.const -1
@@ -1975,6 +2016,7 @@
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
   i32.const 0
   local.set $0
   i32.const 0
@@ -2009,10 +2051,10 @@
     else
      i32.const 0
      call $for/Ref#constructor
-     local.set $4
+     local.set $5
      local.get $1
      call $~lib/rt/pure/__release
-     local.get $4
+     local.get $5
      local.set $1
     end
     br $for-loop|0
@@ -2056,6 +2098,9 @@
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
   i32.const 0
   local.set $0
   i32.const 0
@@ -2070,11 +2115,11 @@
   block $for-break0
    loop $for-loop|0
     call $for/getRef
-    local.tee $2
-    local.set $3
-    local.get $2
-    call $~lib/rt/pure/__release
+    local.tee $3
+    local.set $4
     local.get $3
+    call $~lib/rt/pure/__release
+    local.get $4
     if
      local.get $0
      i32.const 1
@@ -2084,26 +2129,26 @@
      i32.eq
      if
       i32.const 0
-      local.tee $2
+      local.tee $5
       local.get $1
-      local.tee $4
+      local.tee $6
       i32.ne
       if
-       local.get $2
+       local.get $5
        call $~lib/rt/pure/__retain
-       local.set $2
-       local.get $4
+       local.set $5
+       local.get $6
        call $~lib/rt/pure/__release
       end
-      local.get $2
+      local.get $5
       local.set $1
       br $for-break0
      end
      call $for/getRef
-     local.set $4
+     local.set $7
      local.get $1
      call $~lib/rt/pure/__release
-     local.get $4
+     local.get $7
      local.set $1
      br $for-loop|0
     end

--- a/tests/compiler/getter-call.untouched.wat
+++ b/tests/compiler/getter-call.untouched.wat
@@ -21,6 +21,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   memory.size
   local.set $1
   local.get $1
@@ -51,8 +52,8 @@
    local.get $5
    i32.gt_s
    select
-   local.set $4
-   local.get $4
+   local.set $6
+   local.get $6
    memory.grow
    i32.const 0
    i32.lt_s

--- a/tests/compiler/implicit-getter-setter.untouched.wat
+++ b/tests/compiler/implicit-getter-setter.untouched.wat
@@ -52,6 +52,15 @@
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
   local.get $1
   i32.load
   local.set $2
@@ -188,59 +197,59 @@
   i32.eq
   if
    local.get $0
-   local.set $11
+   local.set $14
    local.get $4
-   local.set $10
+   local.set $13
    local.get $5
-   local.set $9
+   local.set $12
    local.get $7
-   local.set $8
-   local.get $11
-   local.get $10
+   local.set $11
+   local.get $14
+   local.get $13
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $12
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
+   local.get $11
    i32.store offset=96
    local.get $7
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $16
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $15
+    local.get $16
+    local.get $15
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $17
     local.get $0
-    local.set $8
+    local.set $20
     local.get $4
-    local.set $11
-    local.get $9
+    local.set $19
+    local.get $17
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
-    local.set $10
-    local.get $8
-    local.get $11
+    local.tee $17
+    local.set $18
+    local.get $20
+    local.get $19
     i32.const 2
     i32.shl
     i32.add
-    local.get $10
+    local.get $18
     i32.store offset=4
-    local.get $9
+    local.get $17
     i32.eqz
     if
      local.get $0
@@ -270,6 +279,20 @@
   (local $11 i32)
   (local $12 i32)
   (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local $22 i32)
+  (local $23 i32)
+  (local $24 i32)
+  (local $25 i32)
+  (local $26 i32)
+  (local $27 i32)
   i32.const 1
   drop
   local.get $1
@@ -332,8 +355,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $3
+   local.set $6
+   local.get $6
    i32.const 1073741808
    i32.lt_u
    if
@@ -344,16 +367,16 @@
     local.get $2
     i32.const 3
     i32.and
-    local.get $3
+    local.get $6
     i32.or
     local.tee $2
     i32.store
     local.get $1
-    local.set $6
-    local.get $6
+    local.set $7
+    local.get $7
     i32.const 16
     i32.add
-    local.get $6
+    local.get $7
     i32.load
     i32.const 3
     i32.const -1
@@ -371,18 +394,18 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $8
+   local.get $8
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
+   local.set $9
+   local.get $9
    i32.load
-   local.set $3
+   local.set $10
    i32.const 1
    drop
-   local.get $3
+   local.get $10
    i32.const 1
    i32.and
    i32.eqz
@@ -394,7 +417,7 @@
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $3
+   local.get $10
    i32.const 3
    i32.const -1
    i32.xor
@@ -407,23 +430,23 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $7
+   local.set $11
+   local.get $11
    i32.const 1073741808
    i32.lt_u
    if
     local.get $0
-    local.get $6
+    local.get $9
     call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
+    local.get $9
+    local.get $10
     i32.const 3
     i32.and
-    local.get $7
+    local.get $11
     i32.or
     local.tee $2
     i32.store
-    local.get $6
+    local.get $9
     local.set $1
    end
   end
@@ -437,14 +460,14 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $12
   i32.const 1
   drop
-  local.get $8
+  local.get $12
   i32.const 16
   i32.ge_u
   if (result i32)
-   local.get $8
+   local.get $12
    i32.const 1073741808
    i32.lt_u
   else
@@ -464,7 +487,7 @@
   local.get $1
   i32.const 16
   i32.add
-  local.get $8
+  local.get $12
   i32.add
   local.get $4
   i32.eq
@@ -482,24 +505,24 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $12
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $13
+   local.get $12
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $14
   else
    i32.const 31
-   local.get $8
+   local.get $12
    i32.clz
    i32.sub
-   local.set $9
-   local.get $8
-   local.get $9
+   local.set $13
+   local.get $12
+   local.get $13
    i32.const 4
    i32.sub
    i32.shr_u
@@ -507,21 +530,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $14
+   local.get $13
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $13
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $13
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $14
    i32.const 16
    i32.lt_u
   else
@@ -537,86 +560,86 @@
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
-  local.set $6
-  local.get $7
-  local.get $3
+  local.set $17
+  local.get $13
+  local.set $16
+  local.get $14
+  local.set $15
+  local.get $17
+  local.get $16
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $15
   i32.add
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=96
-  local.set $11
+  local.set $18
   local.get $1
   i32.const 0
   i32.store offset=16
   local.get $1
-  local.get $11
+  local.get $18
   i32.store offset=20
-  local.get $11
+  local.get $18
   if
-   local.get $11
+   local.get $18
    local.get $1
    i32.store offset=16
   end
   local.get $0
-  local.set $12
-  local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
+  local.set $22
+  local.get $13
+  local.set $21
+  local.get $14
+  local.set $20
   local.get $1
-  local.set $6
-  local.get $12
-  local.get $7
+  local.set $19
+  local.get $22
+  local.get $21
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $20
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $19
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $13
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.set $13
-  local.get $9
-  local.set $12
+  local.set $27
+  local.get $13
+  local.set $26
   local.get $0
-  local.set $3
-  local.get $9
-  local.set $6
-  local.get $3
-  local.get $6
+  local.set $24
+  local.get $13
+  local.set $23
+  local.get $24
+  local.get $23
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $14
   i32.shl
   i32.or
-  local.set $7
-  local.get $13
-  local.get $12
+  local.set $25
+  local.get $27
+  local.get $26
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $25
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -627,6 +650,7 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
   i32.const 1
   drop
   local.get $1
@@ -766,11 +790,11 @@
   i32.or
   i32.store
   local.get $0
-  local.set $9
+  local.set $10
   local.get $4
-  local.set $3
+  local.set $9
+  local.get $10
   local.get $9
-  local.get $3
   i32.store offset=1568
   local.get $0
   local.get $8
@@ -790,6 +814,12 @@
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
   global.get $~lib/rt/tlsf/ROOT
   local.set $0
   local.get $0
@@ -846,66 +876,66 @@
    local.get $4
    i32.store offset=1568
    i32.const 0
-   local.set $5
+   local.set $6
    loop $for-loop|0
-    local.get $5
+    local.get $6
     i32.const 23
     i32.lt_u
-    local.set $4
-    local.get $4
+    local.set $7
+    local.get $7
     if
      local.get $0
-     local.set $8
-     local.get $5
-     local.set $7
+     local.set $10
+     local.get $6
+     local.set $9
      i32.const 0
-     local.set $6
-     local.get $8
-     local.get $7
+     local.set $8
+     local.get $10
+     local.get $9
      i32.const 2
      i32.shl
      i32.add
-     local.get $6
+     local.get $8
      i32.store offset=4
      i32.const 0
-     local.set $8
+     local.set $11
      loop $for-loop|1
-      local.get $8
+      local.get $11
       i32.const 16
       i32.lt_u
-      local.set $7
-      local.get $7
+      local.set $12
+      local.get $12
       if
        local.get $0
-       local.set $11
-       local.get $5
-       local.set $10
-       local.get $8
-       local.set $9
-       i32.const 0
-       local.set $6
+       local.set $16
+       local.get $6
+       local.set $15
        local.get $11
-       local.get $10
+       local.set $14
+       i32.const 0
+       local.set $13
+       local.get $16
+       local.get $15
        i32.const 4
        i32.shl
-       local.get $9
+       local.get $14
        i32.add
        i32.const 2
        i32.shl
        i32.add
-       local.get $6
+       local.get $13
        i32.store offset=96
-       local.get $8
+       local.get $11
        i32.const 1
        i32.add
-       local.set $8
+       local.set $11
        br $for-loop|1
       end
      end
-     local.get $5
+     local.get $6
      i32.const 1
      i32.add
-     local.set $5
+     local.set $6
      br $for-loop|0
     end
    end
@@ -918,11 +948,11 @@
    i32.const -1
    i32.xor
    i32.and
-   local.set $5
+   local.set $17
    i32.const 0
    drop
    local.get $0
-   local.get $5
+   local.get $17
    memory.size
    i32.const 16
    i32.shl
@@ -971,6 +1001,14 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
   local.get $1
   i32.const 256
   i32.lt_u
@@ -1044,11 +1082,11 @@
    unreachable
   end
   local.get $0
-  local.set $5
+  local.set $6
   local.get $2
-  local.set $4
+  local.set $5
+  local.get $6
   local.get $5
-  local.get $4
   i32.const 2
   i32.shl
   i32.add
@@ -1059,10 +1097,10 @@
   local.get $3
   i32.shl
   i32.and
-  local.set $6
-  i32.const 0
   local.set $7
-  local.get $6
+  i32.const 0
+  local.set $8
+  local.get $7
   i32.eqz
   if
    local.get $0
@@ -1075,30 +1113,30 @@
    i32.add
    i32.shl
    i32.and
-   local.set $5
-   local.get $5
+   local.set $9
+   local.get $9
    i32.eqz
    if
     i32.const 0
-    local.set $7
+    local.set $8
    else
-    local.get $5
+    local.get $9
     i32.ctz
     local.set $2
     local.get $0
-    local.set $8
+    local.set $11
     local.get $2
-    local.set $4
-    local.get $8
-    local.get $4
+    local.set $10
+    local.get $11
+    local.get $10
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $6
+    local.set $7
     i32.const 1
     drop
-    local.get $6
+    local.get $7
     i32.eqz
     if
      i32.const 0
@@ -1109,45 +1147,45 @@
      unreachable
     end
     local.get $0
-    local.set $9
+    local.set $14
     local.get $2
-    local.set $8
-    local.get $6
+    local.set $13
+    local.get $7
     i32.ctz
-    local.set $4
-    local.get $9
-    local.get $8
+    local.set $12
+    local.get $14
+    local.get $13
     i32.const 4
     i32.shl
-    local.get $4
+    local.get $12
     i32.add
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=96
-    local.set $7
+    local.set $8
    end
   else
    local.get $0
-   local.set $9
+   local.set $17
    local.get $2
-   local.set $8
-   local.get $6
+   local.set $16
+   local.get $7
    i32.ctz
-   local.set $4
-   local.get $9
-   local.get $8
+   local.set $15
+   local.get $17
+   local.get $16
    i32.const 4
    i32.shl
-   local.get $4
+   local.get $15
    i32.add
    i32.const 2
    i32.shl
    i32.add
    i32.load offset=96
-   local.set $7
+   local.set $8
   end
-  local.get $7
+  local.get $8
  )
  (func $~lib/rt/tlsf/growMemory (param $0 i32) (param $1 i32)
   (local $2 i32)
@@ -1156,6 +1194,7 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
   i32.const 0
   drop
   local.get $1
@@ -1202,15 +1241,15 @@
   i32.shr_u
   local.set $4
   local.get $2
-  local.tee $3
-  local.get $4
   local.tee $5
-  local.get $3
+  local.get $4
+  local.tee $6
   local.get $5
+  local.get $6
   i32.gt_s
   select
-  local.set $6
-  local.get $6
+  local.set $7
+  local.get $7
   memory.grow
   i32.const 0
   i32.lt_s
@@ -1224,12 +1263,12 @@
    end
   end
   memory.size
-  local.set $7
+  local.set $8
   local.get $0
   local.get $2
   i32.const 16
   i32.shl
-  local.get $7
+  local.get $8
   i32.const 16
   i32.shl
   call $~lib/rt/tlsf/addMemory
@@ -1239,6 +1278,8 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
   local.get $1
   i32.load
   local.set $3
@@ -1303,11 +1344,11 @@
    i32.and
    i32.store
    local.get $1
-   local.set $5
-   local.get $5
+   local.set $7
+   local.get $7
    i32.const 16
    i32.add
-   local.get $5
+   local.get $7
    i32.load
    i32.const 3
    i32.const -1
@@ -1315,11 +1356,11 @@
    i32.and
    i32.add
    local.get $1
-   local.set $5
-   local.get $5
+   local.set $6
+   local.get $6
    i32.const 16
    i32.add
-   local.get $5
+   local.get $6
    i32.load
    i32.const 3
    i32.const -1

--- a/tests/compiler/infer-array.untouched.wat
+++ b/tests/compiler/infer-array.untouched.wat
@@ -41,6 +41,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   memory.size
   local.set $1
   local.get $1
@@ -71,8 +72,8 @@
    local.get $5
    i32.gt_s
    select
-   local.set $4
-   local.get $4
+   local.set $6
+   local.get $6
    memory.grow
    i32.const 0
    i32.lt_s
@@ -149,6 +150,88 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local $22 i32)
+  (local $23 i32)
+  (local $24 i32)
+  (local $25 i32)
+  (local $26 i32)
+  (local $27 i32)
+  (local $28 i32)
+  (local $29 i32)
+  (local $30 i32)
+  (local $31 i32)
+  (local $32 i32)
+  (local $33 i32)
+  (local $34 i32)
+  (local $35 i32)
+  (local $36 i32)
+  (local $37 i32)
+  (local $38 i32)
+  (local $39 i32)
+  (local $40 i32)
+  (local $41 i32)
+  (local $42 i32)
+  (local $43 i32)
+  (local $44 i32)
+  (local $45 i32)
+  (local $46 i32)
+  (local $47 i32)
+  (local $48 i32)
+  (local $49 i32)
+  (local $50 i32)
+  (local $51 i32)
+  (local $52 i32)
+  (local $53 i32)
+  (local $54 i32)
+  (local $55 i32)
+  (local $56 i32)
+  (local $57 i32)
+  (local $58 i32)
+  (local $59 i32)
+  (local $60 i32)
+  (local $61 i32)
+  (local $62 i32)
+  (local $63 i32)
+  (local $64 i32)
+  (local $65 i32)
+  (local $66 i32)
+  (local $67 i32)
+  (local $68 i32)
+  (local $69 i32)
+  (local $70 i32)
+  (local $71 i32)
+  (local $72 i32)
+  (local $73 i32)
+  (local $74 i32)
+  (local $75 i32)
+  (local $76 i32)
+  (local $77 i32)
+  (local $78 i32)
+  (local $79 i32)
+  (local $80 i32)
+  (local $81 i32)
+  (local $82 i32)
+  (local $83 i32)
+  (local $84 i32)
+  (local $85 i32)
+  (local $86 i32)
+  (local $87 i32)
+  (local $88 i32)
   loop $while-continue|0
    local.get $2
    if (result i32)
@@ -168,11 +251,11 @@
     local.set $0
     local.get $6
     local.get $1
-    local.tee $6
+    local.tee $7
     i32.const 1
     i32.add
     local.set $1
-    local.get $6
+    local.get $7
     i32.load8_u
     i32.store8
     local.get $2
@@ -192,8 +275,8 @@
     local.get $2
     i32.const 16
     i32.ge_u
-    local.set $5
-    local.get $5
+    local.set $8
+    local.get $8
     if
      local.get $0
      local.get $1
@@ -302,17 +385,17 @@
    i32.and
    if
     local.get $0
-    local.tee $5
+    local.tee $9
     i32.const 1
     i32.add
     local.set $0
-    local.get $5
+    local.get $9
     local.get $1
-    local.tee $5
+    local.tee $10
     i32.const 1
     i32.add
     local.set $1
-    local.get $5
+    local.get $10
     i32.load8_u
     i32.store8
    end
@@ -329,16 +412,16 @@
        local.get $0
        i32.const 3
        i32.and
-       local.set $5
-       local.get $5
+       local.set $11
+       local.get $11
        i32.const 1
        i32.eq
        br_if $case0|2
-       local.get $5
+       local.get $11
        i32.const 2
        i32.eq
        br_if $case1|2
-       local.get $5
+       local.get $11
        i32.const 3
        i32.eq
        br_if $case2|2
@@ -348,45 +431,45 @@
       i32.load
       local.set $3
       local.get $0
-      local.tee $5
+      local.tee $12
       i32.const 1
       i32.add
       local.set $0
-      local.get $5
+      local.get $12
       local.get $1
-      local.tee $5
+      local.tee $13
       i32.const 1
       i32.add
       local.set $1
-      local.get $5
+      local.get $13
       i32.load8_u
       i32.store8
       local.get $0
-      local.tee $5
+      local.tee $14
       i32.const 1
       i32.add
       local.set $0
-      local.get $5
+      local.get $14
       local.get $1
-      local.tee $5
+      local.tee $15
       i32.const 1
       i32.add
       local.set $1
-      local.get $5
+      local.get $15
       i32.load8_u
       i32.store8
       local.get $0
-      local.tee $5
+      local.tee $16
       i32.const 1
       i32.add
       local.set $0
-      local.get $5
+      local.get $16
       local.get $1
-      local.tee $5
+      local.tee $17
       i32.const 1
       i32.add
       local.set $1
-      local.get $5
+      local.get $17
       i32.load8_u
       i32.store8
       local.get $2
@@ -397,8 +480,8 @@
        local.get $2
        i32.const 17
        i32.ge_u
-       local.set $5
-       local.get $5
+       local.set $18
+       local.get $18
        if
         local.get $1
         i32.const 1
@@ -483,31 +566,31 @@
      i32.load
      local.set $3
      local.get $0
-     local.tee $5
+     local.tee $19
      i32.const 1
      i32.add
      local.set $0
-     local.get $5
+     local.get $19
      local.get $1
-     local.tee $5
+     local.tee $20
      i32.const 1
      i32.add
      local.set $1
-     local.get $5
+     local.get $20
      i32.load8_u
      i32.store8
      local.get $0
-     local.tee $5
+     local.tee $21
      i32.const 1
      i32.add
      local.set $0
-     local.get $5
+     local.get $21
      local.get $1
-     local.tee $5
+     local.tee $22
      i32.const 1
      i32.add
      local.set $1
-     local.get $5
+     local.get $22
      i32.load8_u
      i32.store8
      local.get $2
@@ -518,8 +601,8 @@
       local.get $2
       i32.const 18
       i32.ge_u
-      local.set $5
-      local.get $5
+      local.set $23
+      local.get $23
       if
        local.get $1
        i32.const 2
@@ -604,17 +687,17 @@
     i32.load
     local.set $3
     local.get $0
-    local.tee $5
+    local.tee $24
     i32.const 1
     i32.add
     local.set $0
-    local.get $5
+    local.get $24
     local.get $1
-    local.tee $5
+    local.tee $25
     i32.const 1
     i32.add
     local.set $1
-    local.get $5
+    local.get $25
     i32.load8_u
     i32.store8
     local.get $2
@@ -625,8 +708,8 @@
      local.get $2
      i32.const 19
      i32.ge_u
-     local.set $5
-     local.get $5
+     local.set $26
+     local.get $26
      if
       local.get $1
       i32.const 3
@@ -713,227 +796,227 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $27
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $27
    local.get $1
-   local.tee $5
+   local.tee $28
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $28
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $29
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $29
    local.get $1
-   local.tee $5
+   local.tee $30
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $30
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $31
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $31
    local.get $1
-   local.tee $5
+   local.tee $32
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $32
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $33
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $33
    local.get $1
-   local.tee $5
+   local.tee $34
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $34
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $35
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $35
    local.get $1
-   local.tee $5
+   local.tee $36
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $36
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $37
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $37
    local.get $1
-   local.tee $5
+   local.tee $38
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $38
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $39
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $39
    local.get $1
-   local.tee $5
+   local.tee $40
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $40
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $41
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $41
    local.get $1
-   local.tee $5
+   local.tee $42
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $42
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $43
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $43
    local.get $1
-   local.tee $5
+   local.tee $44
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $44
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $45
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $45
    local.get $1
-   local.tee $5
+   local.tee $46
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $46
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $47
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $47
    local.get $1
-   local.tee $5
+   local.tee $48
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $48
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $49
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $49
    local.get $1
-   local.tee $5
+   local.tee $50
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $50
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $51
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $51
    local.get $1
-   local.tee $5
+   local.tee $52
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $52
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $53
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $53
    local.get $1
-   local.tee $5
+   local.tee $54
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $54
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $55
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $55
    local.get $1
-   local.tee $5
+   local.tee $56
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $56
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $57
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $57
    local.get $1
-   local.tee $5
+   local.tee $58
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $58
    i32.load8_u
    i32.store8
   end
@@ -942,115 +1025,115 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $59
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $59
    local.get $1
-   local.tee $5
+   local.tee $60
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $60
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $61
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $61
    local.get $1
-   local.tee $5
+   local.tee $62
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $62
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $63
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $63
    local.get $1
-   local.tee $5
+   local.tee $64
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $64
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $65
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $65
    local.get $1
-   local.tee $5
+   local.tee $66
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $66
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $67
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $67
    local.get $1
-   local.tee $5
+   local.tee $68
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $68
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $69
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $69
    local.get $1
-   local.tee $5
+   local.tee $70
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $70
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $71
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $71
    local.get $1
-   local.tee $5
+   local.tee $72
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $72
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $73
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $73
    local.get $1
-   local.tee $5
+   local.tee $74
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $74
    i32.load8_u
    i32.store8
   end
@@ -1059,59 +1142,59 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $75
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $75
    local.get $1
-   local.tee $5
+   local.tee $76
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $76
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $77
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $77
    local.get $1
-   local.tee $5
+   local.tee $78
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $78
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $79
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $79
    local.get $1
-   local.tee $5
+   local.tee $80
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $80
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $81
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $81
    local.get $1
-   local.tee $5
+   local.tee $82
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $82
    i32.load8_u
    i32.store8
   end
@@ -1120,31 +1203,31 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $83
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $83
    local.get $1
-   local.tee $5
+   local.tee $84
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $84
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $85
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $85
    local.get $1
-   local.tee $5
+   local.tee $86
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $86
    i32.load8_u
    i32.store8
   end
@@ -1153,17 +1236,17 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $87
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $87
    local.get $1
-   local.tee $5
+   local.tee $88
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $88
    i32.load8_u
    i32.store8
   end
@@ -1174,6 +1257,14 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
   block $~lib/util/memory/memmove|inlined.0
    local.get $0
    local.set $5
@@ -1251,11 +1342,11 @@
        local.set $5
        local.get $7
        local.get $4
-       local.tee $7
+       local.tee $8
        i32.const 1
        i32.add
        local.set $4
-       local.get $7
+       local.get $8
        i32.load8_u
        i32.store8
        br $while-continue|0
@@ -1265,8 +1356,8 @@
       local.get $3
       i32.const 8
       i32.ge_u
-      local.set $6
-      local.get $6
+      local.set $9
+      local.get $9
       if
        local.get $5
        local.get $4
@@ -1290,21 +1381,21 @@
     end
     loop $while-continue|2
      local.get $3
-     local.set $6
-     local.get $6
+     local.set $10
+     local.get $10
      if
       local.get $5
-      local.tee $7
+      local.tee $11
       i32.const 1
       i32.add
       local.set $5
-      local.get $7
+      local.get $11
       local.get $4
-      local.tee $7
+      local.tee $12
       i32.const 1
       i32.add
       local.set $4
-      local.get $7
+      local.get $12
       i32.load8_u
       i32.store8
       local.get $3
@@ -1333,8 +1424,8 @@
       i32.add
       i32.const 7
       i32.and
-      local.set $6
-      local.get $6
+      local.set $13
+      local.get $13
       if
        local.get $3
        i32.eqz
@@ -1359,8 +1450,8 @@
       local.get $3
       i32.const 8
       i32.ge_u
-      local.set $6
-      local.get $6
+      local.set $14
+      local.get $14
       if
        local.get $3
        i32.const 8
@@ -1380,8 +1471,8 @@
     end
     loop $while-continue|5
      local.get $3
-     local.set $6
-     local.get $6
+     local.set $15
+     local.get $15
      if
       local.get $5
       local.get $3
@@ -1740,9 +1831,61 @@
  (func $start:infer-array
   (local $0 i32)
   (local $1 i32)
-  (local $2 f32)
+  (local $2 i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 f32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local $22 i32)
+  (local $23 i32)
+  (local $24 i32)
+  (local $25 i32)
+  (local $26 i32)
+  (local $27 i32)
+  (local $28 i32)
+  (local $29 i32)
+  (local $30 i32)
+  (local $31 i32)
+  (local $32 i32)
+  (local $33 i32)
+  (local $34 i32)
+  (local $35 i32)
+  (local $36 i32)
+  (local $37 i32)
+  (local $38 i32)
+  (local $39 i32)
+  (local $40 i32)
+  (local $41 i32)
+  (local $42 i32)
+  (local $43 i32)
+  (local $44 i32)
+  (local $45 i32)
+  (local $46 i32)
+  (local $47 i32)
+  (local $48 i32)
+  (local $49 i32)
+  (local $50 i32)
+  (local $51 i32)
+  (local $52 i32)
+  (local $53 i32)
+  (local $54 i32)
+  (local $55 i32)
+  (local $56 i32)
   global.get $~lib/heap/__heap_base
   i32.const 15
   i32.add
@@ -1759,12 +1902,12 @@
   i32.const 32
   call $~lib/rt/__allocArray
   call $~lib/rt/stub/__retain
-  local.set $1
+  local.set $2
   i32.const 1
   drop
   i32.const 1
   drop
-  local.get $1
+  local.get $2
   call $~lib/rt/stub/__release
   i32.const 3
   i32.const 3
@@ -1772,10 +1915,10 @@
   i32.const 176
   call $~lib/rt/__allocArray
   call $~lib/rt/stub/__retain
-  local.set $0
+  local.set $5
   i32.const 1
   drop
-  local.get $0
+  local.get $5
   call $~lib/rt/stub/__release
   i32.const 2
   i32.const 2
@@ -1783,13 +1926,13 @@
   i32.const 224
   call $~lib/rt/__allocArray
   call $~lib/rt/stub/__retain
-  local.set $1
+  local.set $8
   i32.const 1
   drop
   i32.const 0
   i32.eqz
   drop
-  local.get $1
+  local.get $8
   i32.const 1
   call $~lib/array/Array<u32>#__get
   i32.const -1
@@ -1803,7 +1946,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $8
   call $~lib/rt/stub/__release
   i32.const 3
   i32.const 3
@@ -1811,10 +1954,10 @@
   i32.const 304
   call $~lib/rt/__allocArray
   call $~lib/rt/stub/__retain
-  local.set $0
+  local.set $11
   i32.const 1
   drop
-  local.get $0
+  local.get $11
   call $~lib/rt/stub/__release
   i32.const 3
   i32.const 2
@@ -1822,117 +1965,117 @@
   i32.const 352
   call $~lib/rt/__allocArray
   call $~lib/rt/stub/__retain
-  local.set $1
+  local.set $14
   i32.const 1
   drop
-  local.get $1
+  local.get $14
   i32.const 1
   call $~lib/array/Array<f32>#__get
-  local.set $2
-  local.get $1
+  local.set $15
+  local.get $14
   call $~lib/rt/stub/__release
   i32.const 0
   call $infer-array/Ref#constructor
-  local.set $1
+  local.set $16
   i32.const 0
   call $infer-array/Ref#constructor
-  local.set $0
+  local.set $17
   i32.const 2
   i32.const 2
   i32.const 8
   i32.const 0
   call $~lib/rt/__allocArray
   call $~lib/rt/stub/__retain
-  local.set $3
-  local.get $3
+  local.set $18
+  local.get $18
   i32.load offset=4
-  local.set $4
-  local.get $4
-  local.get $1
+  local.set $19
+  local.get $19
+  local.get $16
   call $~lib/rt/stub/__retain
   i32.store
-  local.get $4
-  local.get $0
+  local.get $19
+  local.get $17
   call $~lib/rt/stub/__retain
   i32.store offset=4
-  local.get $3
-  local.set $4
+  local.get $18
+  local.set $20
   i32.const 1
   drop
-  local.get $1
+  local.get $16
   call $~lib/rt/stub/__release
-  local.get $0
+  local.get $17
   call $~lib/rt/stub/__release
-  local.get $4
+  local.get $20
   call $~lib/rt/stub/__release
-  local.get $3
+  local.get $21
   call $~lib/rt/stub/__release
   i32.const 0
   call $infer-array/Ref#constructor
-  local.set $3
+  local.set $22
   i32.const 0
   call $infer-array/Ref#constructor
-  local.set $4
+  local.set $23
   i32.const 2
   i32.const 2
   i32.const 8
   i32.const 0
   call $~lib/rt/__allocArray
   call $~lib/rt/stub/__retain
-  local.set $0
-  local.get $0
+  local.set $24
+  local.get $24
   i32.load offset=4
-  local.set $1
-  local.get $1
-  local.get $3
+  local.set $25
+  local.get $25
+  local.get $22
   call $~lib/rt/stub/__retain
   i32.store
-  local.get $1
-  local.get $4
+  local.get $25
+  local.get $23
   call $~lib/rt/stub/__retain
   i32.store offset=4
-  local.get $0
-  local.set $1
+  local.get $24
+  local.set $26
   i32.const 1
   drop
-  local.get $3
+  local.get $22
   call $~lib/rt/stub/__release
-  local.get $4
+  local.get $23
   call $~lib/rt/stub/__release
-  local.get $1
+  local.get $26
   call $~lib/rt/stub/__release
-  local.get $0
+  local.get $27
   call $~lib/rt/stub/__release
   i32.const 0
   call $infer-array/Ref#constructor
-  local.set $0
+  local.set $28
   i32.const 2
   i32.const 2
   i32.const 8
   i32.const 0
   call $~lib/rt/__allocArray
   call $~lib/rt/stub/__retain
-  local.set $1
-  local.get $1
+  local.set $29
+  local.get $29
   i32.load offset=4
-  local.set $4
-  local.get $4
-  local.get $0
+  local.set $30
+  local.get $30
+  local.get $28
   call $~lib/rt/stub/__retain
   i32.store
-  local.get $4
+  local.get $30
   i32.const 0
   call $~lib/rt/stub/__retain
   i32.store offset=4
-  local.get $1
-  local.set $4
+  local.get $29
+  local.set $31
   i32.const 1
   drop
-  local.get $0
+  local.get $28
   call $~lib/rt/stub/__release
-  local.get $4
+  local.get $31
   call $~lib/rt/stub/__release
-  local.get $1
+  local.get $32
   call $~lib/rt/stub/__release
   i32.const 2
   i32.const 2
@@ -1940,12 +2083,12 @@
   i32.const 416
   call $~lib/rt/__allocArray
   call $~lib/rt/stub/__retain
-  local.set $4
+  local.set $35
   i32.const 1
   drop
-  local.get $4
+  local.get $35
   call $~lib/rt/stub/__release
-  local.get $1
+  local.get $36
   call $~lib/rt/stub/__release
   i32.const 1
   i32.const 2
@@ -1953,7 +2096,7 @@
   i32.const 448
   call $~lib/rt/__allocArray
   call $~lib/rt/stub/__retain
-  local.set $4
+  local.set $39
   i32.const 1
   drop
   i32.const 0
@@ -1965,15 +2108,15 @@
   i32.const 480
   call $~lib/rt/__allocArray
   call $~lib/rt/stub/__retain
-  local.set $0
+  local.set $42
   i32.const 1
   drop
   i32.const 0
   i32.eqz
   drop
-  local.get $4
+  local.get $39
   call $~lib/rt/stub/__release
-  local.get $0
+  local.get $42
   call $~lib/rt/stub/__release
   i32.const 2
   i32.const 2
@@ -1981,7 +2124,7 @@
   i32.const 512
   call $~lib/rt/__allocArray
   call $~lib/rt/stub/__retain
-  local.set $4
+  local.set $45
   i32.const 1
   drop
   i32.const 0
@@ -1993,15 +2136,15 @@
   i32.const 544
   call $~lib/rt/__allocArray
   call $~lib/rt/stub/__retain
-  local.set $1
+  local.set $48
   i32.const 1
   drop
   i32.const 0
   i32.eqz
   drop
-  local.get $4
+  local.get $45
   call $~lib/rt/stub/__release
-  local.get $1
+  local.get $48
   call $~lib/rt/stub/__release
   i32.const 2
   i32.const 2
@@ -2009,11 +2152,11 @@
   i32.const 0
   call $~lib/rt/__allocArray
   call $~lib/rt/stub/__retain
-  local.set $1
-  local.get $1
+  local.set $49
+  local.get $49
   i32.load offset=4
-  local.set $4
-  local.get $4
+  local.set $50
+  local.get $50
   i32.const 1
   i32.const 2
   i32.const 3
@@ -2021,7 +2164,7 @@
   call $~lib/rt/__allocArray
   call $~lib/rt/stub/__retain
   i32.store
-  local.get $4
+  local.get $50
   i32.const 1
   i32.const 2
   i32.const 3
@@ -2029,16 +2172,16 @@
   call $~lib/rt/__allocArray
   call $~lib/rt/stub/__retain
   i32.store offset=4
-  local.get $1
-  local.set $4
+  local.get $49
+  local.set $55
   i32.const 1
   drop
   i32.const 0
   i32.eqz
   drop
-  local.get $4
+  local.get $55
   call $~lib/rt/stub/__release
-  local.get $1
+  local.get $56
   call $~lib/rt/stub/__release
  )
  (func $~start

--- a/tests/compiler/infer-generic.untouched.wat
+++ b/tests/compiler/infer-generic.untouched.wat
@@ -62,6 +62,7 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
   local.get $2
   local.set $3
   i32.const 0
@@ -81,8 +82,8 @@
    i32.lt_s
    select
    i32.lt_s
-   local.set $6
-   local.get $6
+   local.set $8
+   local.get $8
    if
     local.get $3
     local.get $0

--- a/tests/compiler/inlining-blocklocals.untouched.wat
+++ b/tests/compiler/inlining-blocklocals.untouched.wat
@@ -16,6 +16,8 @@
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
   i32.const 1
   local.set $0
   local.get $0
@@ -24,24 +26,24 @@
   i32.add
   local.set $0
   local.get $1
-  local.set $3
+  local.set $5
   global.get $inlining-blocklocals/b
-  local.tee $1
+  local.tee $2
   i32.const 1
   i32.add
   global.set $inlining-blocklocals/b
-  local.get $1
-  local.set $2
+  local.get $2
+  local.set $4
   local.get $0
   i32.const 1
   i32.add
   local.tee $0
-  local.set $1
-  local.get $3
+  local.set $3
+  local.get $5
   global.set $inlining-blocklocals/theCall_a
-  local.get $2
+  local.get $4
   global.set $inlining-blocklocals/theCall_b
-  local.get $1
+  local.get $3
   global.set $inlining-blocklocals/theCall_c
   global.get $inlining-blocklocals/theCall_a
   i32.const 1

--- a/tests/compiler/inlining.untouched.wat
+++ b/tests/compiler/inlining.untouched.wat
@@ -46,6 +46,23 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local $22 i32)
+  (local $23 i32)
+  (local $24 i32)
   f32.const -1
   local.set $0
   f64.const -2
@@ -74,15 +91,15 @@
   drop
   block $inlining/func_ii|inlined.1 (result i32)
    i32.const 41
-   local.set $2
-   local.get $2
+   local.set $3
+   local.get $3
    i32.const 42
    i32.eq
    if
     i32.const 1
     br $inlining/func_ii|inlined.1
    end
-   local.get $2
+   local.get $3
    i32.const 42
    i32.lt_s
    if (result i32)
@@ -96,15 +113,15 @@
   drop
   block $inlining/func_ii|inlined.2 (result i32)
    i32.const 43
-   local.set $2
-   local.get $2
+   local.set $4
+   local.get $4
    i32.const 42
    i32.eq
    if
     i32.const 1
     br $inlining/func_ii|inlined.2
    end
-   local.get $2
+   local.get $4
    i32.const 42
    i32.lt_s
    if (result i32)
@@ -117,55 +134,55 @@
   i32.eq
   drop
   i32.const 0
-  local.set $2
-  local.get $2
+  local.set $5
+  local.get $5
   i32.const 0
   i32.eq
   drop
   i32.const 1
-  local.set $2
-  local.get $2
+  local.set $6
+  local.get $6
   i32.const 1
   i32.eq
   drop
   i32.const 2
-  local.set $2
-  local.get $2
-  local.set $3
+  local.set $7
+  local.get $7
+  local.set $8
   i32.const 1
   drop
-  local.get $3
-  local.set $5
-  local.get $5
-  local.set $6
-  local.get $6
+  local.get $8
+  local.set $10
+  local.get $10
+  local.set $11
+  local.get $11
   i32.const 1
   i32.add
-  local.set $4
-  local.get $4
+  local.set $9
+  local.get $9
   i32.const 3
   i32.eq
   drop
   i32.const 3
-  local.set $5
-  local.get $5
-  local.set $4
+  local.set $12
+  local.get $12
+  local.set $13
   i32.const 1
   drop
-  local.get $4
-  local.set $2
-  local.get $2
-  local.set $6
-  local.get $6
+  local.get $13
+  local.set $15
+  local.get $15
+  local.set $16
+  local.get $16
   i32.const 1
   i32.add
-  local.set $3
-  local.get $3
+  local.set $14
+  local.get $14
   i32.const 4
   i32.eq
   drop
   i32.const 0
-  local.set $2
+  local.set $17
   i32.const 2
   i32.const 1
   global.set $~argumentsLength
@@ -183,27 +200,27 @@
    unreachable
   end
   i32.const 42
-  local.set $6
+  local.set $18
   i32.const 2
-  local.set $2
-  local.get $6
-  local.get $2
+  local.set $19
+  local.get $18
+  local.get $19
   i32.add
   i32.const 44
   i32.eq
   drop
   i32.const 123
   call $~lib/rt/stub/__retain
-  local.set $7
-  local.get $7
-  local.set $4
+  local.set $20
+  local.get $20
+  local.set $22
   i32.const 43
-  local.set $5
+  local.set $21
   i32.const 3
-  local.set $2
-  local.get $4
+  local.set $23
+  local.get $22
   call $~lib/rt/stub/__retain
-  local.tee $2
+  local.tee $24
   i32.const 123
   i32.eq
   i32.eqz
@@ -215,9 +232,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $24
   call $~lib/rt/stub/__release
-  local.get $7
+  local.get $20
   call $~lib/rt/stub/__release
  )
  (func $~lib/rt/stub/maybeGrowMemory (param $0 i32)
@@ -226,6 +243,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   memory.size
   local.set $1
   local.get $1
@@ -256,8 +274,8 @@
    local.get $5
    i32.gt_s
    select
-   local.set $4
-   local.get $4
+   local.set $6
+   local.get $6
    memory.grow
    i32.const 0
    i32.lt_s

--- a/tests/compiler/instanceof-class.untouched.wat
+++ b/tests/compiler/instanceof-class.untouched.wat
@@ -23,6 +23,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   memory.size
   local.set $1
   local.get $1
@@ -53,8 +54,8 @@
    local.get $5
    i32.gt_s
    select
-   local.set $4
-   local.get $4
+   local.set $6
+   local.get $6
    memory.grow
    i32.const 0
    i32.lt_s

--- a/tests/compiler/issues/1095.untouched.wat
+++ b/tests/compiler/issues/1095.untouched.wat
@@ -38,6 +38,15 @@
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
   local.get $1
   i32.load
   local.set $2
@@ -174,59 +183,59 @@
   i32.eq
   if
    local.get $0
-   local.set $11
+   local.set $14
    local.get $4
-   local.set $10
+   local.set $13
    local.get $5
-   local.set $9
+   local.set $12
    local.get $7
-   local.set $8
-   local.get $11
-   local.get $10
+   local.set $11
+   local.get $14
+   local.get $13
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $12
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
+   local.get $11
    i32.store offset=96
    local.get $7
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $16
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $15
+    local.get $16
+    local.get $15
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $17
     local.get $0
-    local.set $8
+    local.set $20
     local.get $4
-    local.set $11
-    local.get $9
+    local.set $19
+    local.get $17
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
-    local.set $10
-    local.get $8
-    local.get $11
+    local.tee $17
+    local.set $18
+    local.get $20
+    local.get $19
     i32.const 2
     i32.shl
     i32.add
-    local.get $10
+    local.get $18
     i32.store offset=4
-    local.get $9
+    local.get $17
     i32.eqz
     if
      local.get $0
@@ -256,6 +265,20 @@
   (local $11 i32)
   (local $12 i32)
   (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local $22 i32)
+  (local $23 i32)
+  (local $24 i32)
+  (local $25 i32)
+  (local $26 i32)
+  (local $27 i32)
   i32.const 1
   drop
   local.get $1
@@ -318,8 +341,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $3
+   local.set $6
+   local.get $6
    i32.const 1073741808
    i32.lt_u
    if
@@ -330,16 +353,16 @@
     local.get $2
     i32.const 3
     i32.and
-    local.get $3
+    local.get $6
     i32.or
     local.tee $2
     i32.store
     local.get $1
-    local.set $6
-    local.get $6
+    local.set $7
+    local.get $7
     i32.const 16
     i32.add
-    local.get $6
+    local.get $7
     i32.load
     i32.const 3
     i32.const -1
@@ -357,18 +380,18 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $8
+   local.get $8
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
+   local.set $9
+   local.get $9
    i32.load
-   local.set $3
+   local.set $10
    i32.const 1
    drop
-   local.get $3
+   local.get $10
    i32.const 1
    i32.and
    i32.eqz
@@ -380,7 +403,7 @@
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $3
+   local.get $10
    i32.const 3
    i32.const -1
    i32.xor
@@ -393,23 +416,23 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $7
+   local.set $11
+   local.get $11
    i32.const 1073741808
    i32.lt_u
    if
     local.get $0
-    local.get $6
+    local.get $9
     call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
+    local.get $9
+    local.get $10
     i32.const 3
     i32.and
-    local.get $7
+    local.get $11
     i32.or
     local.tee $2
     i32.store
-    local.get $6
+    local.get $9
     local.set $1
    end
   end
@@ -423,14 +446,14 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $12
   i32.const 1
   drop
-  local.get $8
+  local.get $12
   i32.const 16
   i32.ge_u
   if (result i32)
-   local.get $8
+   local.get $12
    i32.const 1073741808
    i32.lt_u
   else
@@ -450,7 +473,7 @@
   local.get $1
   i32.const 16
   i32.add
-  local.get $8
+  local.get $12
   i32.add
   local.get $4
   i32.eq
@@ -468,24 +491,24 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $12
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $13
+   local.get $12
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $14
   else
    i32.const 31
-   local.get $8
+   local.get $12
    i32.clz
    i32.sub
-   local.set $9
-   local.get $8
-   local.get $9
+   local.set $13
+   local.get $12
+   local.get $13
    i32.const 4
    i32.sub
    i32.shr_u
@@ -493,21 +516,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $14
+   local.get $13
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $13
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $13
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $14
    i32.const 16
    i32.lt_u
   else
@@ -523,86 +546,86 @@
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
-  local.set $6
-  local.get $7
-  local.get $3
+  local.set $17
+  local.get $13
+  local.set $16
+  local.get $14
+  local.set $15
+  local.get $17
+  local.get $16
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $15
   i32.add
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=96
-  local.set $11
+  local.set $18
   local.get $1
   i32.const 0
   i32.store offset=16
   local.get $1
-  local.get $11
+  local.get $18
   i32.store offset=20
-  local.get $11
+  local.get $18
   if
-   local.get $11
+   local.get $18
    local.get $1
    i32.store offset=16
   end
   local.get $0
-  local.set $12
-  local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
+  local.set $22
+  local.get $13
+  local.set $21
+  local.get $14
+  local.set $20
   local.get $1
-  local.set $6
-  local.get $12
-  local.get $7
+  local.set $19
+  local.get $22
+  local.get $21
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $20
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $19
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $13
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.set $13
-  local.get $9
-  local.set $12
+  local.set $27
+  local.get $13
+  local.set $26
   local.get $0
-  local.set $3
-  local.get $9
-  local.set $6
-  local.get $3
-  local.get $6
+  local.set $24
+  local.get $13
+  local.set $23
+  local.get $24
+  local.get $23
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $14
   i32.shl
   i32.or
-  local.set $7
-  local.get $13
-  local.get $12
+  local.set $25
+  local.get $27
+  local.get $26
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $25
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -613,6 +636,7 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
   i32.const 1
   drop
   local.get $1
@@ -752,11 +776,11 @@
   i32.or
   i32.store
   local.get $0
-  local.set $9
+  local.set $10
   local.get $4
-  local.set $3
+  local.set $9
+  local.get $10
   local.get $9
-  local.get $3
   i32.store offset=1568
   local.get $0
   local.get $8
@@ -776,6 +800,12 @@
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
   global.get $~lib/rt/tlsf/ROOT
   local.set $0
   local.get $0
@@ -832,66 +862,66 @@
    local.get $4
    i32.store offset=1568
    i32.const 0
-   local.set $5
+   local.set $6
    loop $for-loop|0
-    local.get $5
+    local.get $6
     i32.const 23
     i32.lt_u
-    local.set $4
-    local.get $4
+    local.set $7
+    local.get $7
     if
      local.get $0
-     local.set $8
-     local.get $5
-     local.set $7
+     local.set $10
+     local.get $6
+     local.set $9
      i32.const 0
-     local.set $6
-     local.get $8
-     local.get $7
+     local.set $8
+     local.get $10
+     local.get $9
      i32.const 2
      i32.shl
      i32.add
-     local.get $6
+     local.get $8
      i32.store offset=4
      i32.const 0
-     local.set $8
+     local.set $11
      loop $for-loop|1
-      local.get $8
+      local.get $11
       i32.const 16
       i32.lt_u
-      local.set $7
-      local.get $7
+      local.set $12
+      local.get $12
       if
        local.get $0
-       local.set $11
-       local.get $5
-       local.set $10
-       local.get $8
-       local.set $9
-       i32.const 0
-       local.set $6
+       local.set $16
+       local.get $6
+       local.set $15
        local.get $11
-       local.get $10
+       local.set $14
+       i32.const 0
+       local.set $13
+       local.get $16
+       local.get $15
        i32.const 4
        i32.shl
-       local.get $9
+       local.get $14
        i32.add
        i32.const 2
        i32.shl
        i32.add
-       local.get $6
+       local.get $13
        i32.store offset=96
-       local.get $8
+       local.get $11
        i32.const 1
        i32.add
-       local.set $8
+       local.set $11
        br $for-loop|1
       end
      end
-     local.get $5
+     local.get $6
      i32.const 1
      i32.add
-     local.set $5
+     local.set $6
      br $for-loop|0
     end
    end
@@ -904,11 +934,11 @@
    i32.const -1
    i32.xor
    i32.and
-   local.set $5
+   local.set $17
    i32.const 0
    drop
    local.get $0
-   local.get $5
+   local.get $17
    memory.size
    i32.const 16
    i32.shl
@@ -957,6 +987,14 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
   local.get $1
   i32.const 256
   i32.lt_u
@@ -1030,11 +1068,11 @@
    unreachable
   end
   local.get $0
-  local.set $5
+  local.set $6
   local.get $2
-  local.set $4
+  local.set $5
+  local.get $6
   local.get $5
-  local.get $4
   i32.const 2
   i32.shl
   i32.add
@@ -1045,10 +1083,10 @@
   local.get $3
   i32.shl
   i32.and
-  local.set $6
-  i32.const 0
   local.set $7
-  local.get $6
+  i32.const 0
+  local.set $8
+  local.get $7
   i32.eqz
   if
    local.get $0
@@ -1061,30 +1099,30 @@
    i32.add
    i32.shl
    i32.and
-   local.set $5
-   local.get $5
+   local.set $9
+   local.get $9
    i32.eqz
    if
     i32.const 0
-    local.set $7
+    local.set $8
    else
-    local.get $5
+    local.get $9
     i32.ctz
     local.set $2
     local.get $0
-    local.set $8
+    local.set $11
     local.get $2
-    local.set $4
-    local.get $8
-    local.get $4
+    local.set $10
+    local.get $11
+    local.get $10
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $6
+    local.set $7
     i32.const 1
     drop
-    local.get $6
+    local.get $7
     i32.eqz
     if
      i32.const 0
@@ -1095,45 +1133,45 @@
      unreachable
     end
     local.get $0
-    local.set $9
+    local.set $14
     local.get $2
-    local.set $8
-    local.get $6
+    local.set $13
+    local.get $7
     i32.ctz
-    local.set $4
-    local.get $9
-    local.get $8
+    local.set $12
+    local.get $14
+    local.get $13
     i32.const 4
     i32.shl
-    local.get $4
+    local.get $12
     i32.add
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=96
-    local.set $7
+    local.set $8
    end
   else
    local.get $0
-   local.set $9
+   local.set $17
    local.get $2
-   local.set $8
-   local.get $6
+   local.set $16
+   local.get $7
    i32.ctz
-   local.set $4
-   local.get $9
-   local.get $8
+   local.set $15
+   local.get $17
+   local.get $16
    i32.const 4
    i32.shl
-   local.get $4
+   local.get $15
    i32.add
    i32.const 2
    i32.shl
    i32.add
    i32.load offset=96
-   local.set $7
+   local.set $8
   end
-  local.get $7
+  local.get $8
  )
  (func $~lib/rt/tlsf/growMemory (param $0 i32) (param $1 i32)
   (local $2 i32)
@@ -1142,6 +1180,7 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
   i32.const 0
   drop
   local.get $1
@@ -1188,15 +1227,15 @@
   i32.shr_u
   local.set $4
   local.get $2
-  local.tee $3
-  local.get $4
   local.tee $5
-  local.get $3
+  local.get $4
+  local.tee $6
   local.get $5
+  local.get $6
   i32.gt_s
   select
-  local.set $6
-  local.get $6
+  local.set $7
+  local.get $7
   memory.grow
   i32.const 0
   i32.lt_s
@@ -1210,12 +1249,12 @@
    end
   end
   memory.size
-  local.set $7
+  local.set $8
   local.get $0
   local.get $2
   i32.const 16
   i32.shl
-  local.get $7
+  local.get $8
   i32.const 16
   i32.shl
   call $~lib/rt/tlsf/addMemory
@@ -1225,6 +1264,8 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
   local.get $1
   i32.load
   local.set $3
@@ -1289,11 +1330,11 @@
    i32.and
    i32.store
    local.get $1
-   local.set $5
-   local.get $5
+   local.set $7
+   local.get $7
    i32.const 16
    i32.add
-   local.get $5
+   local.get $7
    i32.load
    i32.const 3
    i32.const -1
@@ -1301,11 +1342,11 @@
    i32.and
    i32.add
    local.get $1
-   local.set $5
-   local.get $5
+   local.set $6
+   local.get $6
    i32.const 16
    i32.add
-   local.get $5
+   local.get $6
    i32.load
    i32.const 3
    i32.const -1
@@ -1550,6 +1591,7 @@
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $0
@@ -1568,19 +1610,19 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.tee $1
+  local.tee $3
   local.get $2
   i32.load
-  local.tee $3
+  local.tee $4
   i32.ne
   if
-   local.get $1
-   call $~lib/rt/pure/__retain
-   local.set $1
    local.get $3
+   call $~lib/rt/pure/__retain
+   local.set $3
+   local.get $4
    call $~lib/rt/pure/__release
   end
-  local.get $1
+  local.get $3
   i32.store
   local.get $0
   call $~lib/rt/pure/__release

--- a/tests/compiler/issues/1225.untouched.wat
+++ b/tests/compiler/issues/1225.untouched.wat
@@ -40,6 +40,15 @@
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
   local.get $1
   i32.load
   local.set $2
@@ -176,59 +185,59 @@
   i32.eq
   if
    local.get $0
-   local.set $11
+   local.set $14
    local.get $4
-   local.set $10
+   local.set $13
    local.get $5
-   local.set $9
+   local.set $12
    local.get $7
-   local.set $8
-   local.get $11
-   local.get $10
+   local.set $11
+   local.get $14
+   local.get $13
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $12
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
+   local.get $11
    i32.store offset=96
    local.get $7
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $16
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $15
+    local.get $16
+    local.get $15
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $17
     local.get $0
-    local.set $8
+    local.set $20
     local.get $4
-    local.set $11
-    local.get $9
+    local.set $19
+    local.get $17
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
-    local.set $10
-    local.get $8
-    local.get $11
+    local.tee $17
+    local.set $18
+    local.get $20
+    local.get $19
     i32.const 2
     i32.shl
     i32.add
-    local.get $10
+    local.get $18
     i32.store offset=4
-    local.get $9
+    local.get $17
     i32.eqz
     if
      local.get $0
@@ -258,6 +267,20 @@
   (local $11 i32)
   (local $12 i32)
   (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local $22 i32)
+  (local $23 i32)
+  (local $24 i32)
+  (local $25 i32)
+  (local $26 i32)
+  (local $27 i32)
   i32.const 1
   drop
   local.get $1
@@ -320,8 +343,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $3
+   local.set $6
+   local.get $6
    i32.const 1073741808
    i32.lt_u
    if
@@ -332,16 +355,16 @@
     local.get $2
     i32.const 3
     i32.and
-    local.get $3
+    local.get $6
     i32.or
     local.tee $2
     i32.store
     local.get $1
-    local.set $6
-    local.get $6
+    local.set $7
+    local.get $7
     i32.const 16
     i32.add
-    local.get $6
+    local.get $7
     i32.load
     i32.const 3
     i32.const -1
@@ -359,18 +382,18 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $8
+   local.get $8
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
+   local.set $9
+   local.get $9
    i32.load
-   local.set $3
+   local.set $10
    i32.const 1
    drop
-   local.get $3
+   local.get $10
    i32.const 1
    i32.and
    i32.eqz
@@ -382,7 +405,7 @@
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $3
+   local.get $10
    i32.const 3
    i32.const -1
    i32.xor
@@ -395,23 +418,23 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $7
+   local.set $11
+   local.get $11
    i32.const 1073741808
    i32.lt_u
    if
     local.get $0
-    local.get $6
+    local.get $9
     call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
+    local.get $9
+    local.get $10
     i32.const 3
     i32.and
-    local.get $7
+    local.get $11
     i32.or
     local.tee $2
     i32.store
-    local.get $6
+    local.get $9
     local.set $1
    end
   end
@@ -425,14 +448,14 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $12
   i32.const 1
   drop
-  local.get $8
+  local.get $12
   i32.const 16
   i32.ge_u
   if (result i32)
-   local.get $8
+   local.get $12
    i32.const 1073741808
    i32.lt_u
   else
@@ -452,7 +475,7 @@
   local.get $1
   i32.const 16
   i32.add
-  local.get $8
+  local.get $12
   i32.add
   local.get $4
   i32.eq
@@ -470,24 +493,24 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $12
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $13
+   local.get $12
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $14
   else
    i32.const 31
-   local.get $8
+   local.get $12
    i32.clz
    i32.sub
-   local.set $9
-   local.get $8
-   local.get $9
+   local.set $13
+   local.get $12
+   local.get $13
    i32.const 4
    i32.sub
    i32.shr_u
@@ -495,21 +518,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $14
+   local.get $13
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $13
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $13
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $14
    i32.const 16
    i32.lt_u
   else
@@ -525,86 +548,86 @@
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
-  local.set $6
-  local.get $7
-  local.get $3
+  local.set $17
+  local.get $13
+  local.set $16
+  local.get $14
+  local.set $15
+  local.get $17
+  local.get $16
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $15
   i32.add
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=96
-  local.set $11
+  local.set $18
   local.get $1
   i32.const 0
   i32.store offset=16
   local.get $1
-  local.get $11
+  local.get $18
   i32.store offset=20
-  local.get $11
+  local.get $18
   if
-   local.get $11
+   local.get $18
    local.get $1
    i32.store offset=16
   end
   local.get $0
-  local.set $12
-  local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
+  local.set $22
+  local.get $13
+  local.set $21
+  local.get $14
+  local.set $20
   local.get $1
-  local.set $6
-  local.get $12
-  local.get $7
+  local.set $19
+  local.get $22
+  local.get $21
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $20
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $19
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $13
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.set $13
-  local.get $9
-  local.set $12
+  local.set $27
+  local.get $13
+  local.set $26
   local.get $0
-  local.set $3
-  local.get $9
-  local.set $6
-  local.get $3
-  local.get $6
+  local.set $24
+  local.get $13
+  local.set $23
+  local.get $24
+  local.get $23
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $14
   i32.shl
   i32.or
-  local.set $7
-  local.get $13
-  local.get $12
+  local.set $25
+  local.get $27
+  local.get $26
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $25
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -615,6 +638,7 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
   i32.const 1
   drop
   local.get $1
@@ -754,11 +778,11 @@
   i32.or
   i32.store
   local.get $0
-  local.set $9
+  local.set $10
   local.get $4
-  local.set $3
+  local.set $9
+  local.get $10
   local.get $9
-  local.get $3
   i32.store offset=1568
   local.get $0
   local.get $8
@@ -778,6 +802,12 @@
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
   global.get $~lib/rt/tlsf/ROOT
   local.set $0
   local.get $0
@@ -834,66 +864,66 @@
    local.get $4
    i32.store offset=1568
    i32.const 0
-   local.set $5
+   local.set $6
    loop $for-loop|0
-    local.get $5
+    local.get $6
     i32.const 23
     i32.lt_u
-    local.set $4
-    local.get $4
+    local.set $7
+    local.get $7
     if
      local.get $0
-     local.set $8
-     local.get $5
-     local.set $7
+     local.set $10
+     local.get $6
+     local.set $9
      i32.const 0
-     local.set $6
-     local.get $8
-     local.get $7
+     local.set $8
+     local.get $10
+     local.get $9
      i32.const 2
      i32.shl
      i32.add
-     local.get $6
+     local.get $8
      i32.store offset=4
      i32.const 0
-     local.set $8
+     local.set $11
      loop $for-loop|1
-      local.get $8
+      local.get $11
       i32.const 16
       i32.lt_u
-      local.set $7
-      local.get $7
+      local.set $12
+      local.get $12
       if
        local.get $0
-       local.set $11
-       local.get $5
-       local.set $10
-       local.get $8
-       local.set $9
-       i32.const 0
-       local.set $6
+       local.set $16
+       local.get $6
+       local.set $15
        local.get $11
-       local.get $10
+       local.set $14
+       i32.const 0
+       local.set $13
+       local.get $16
+       local.get $15
        i32.const 4
        i32.shl
-       local.get $9
+       local.get $14
        i32.add
        i32.const 2
        i32.shl
        i32.add
-       local.get $6
+       local.get $13
        i32.store offset=96
-       local.get $8
+       local.get $11
        i32.const 1
        i32.add
-       local.set $8
+       local.set $11
        br $for-loop|1
       end
      end
-     local.get $5
+     local.get $6
      i32.const 1
      i32.add
-     local.set $5
+     local.set $6
      br $for-loop|0
     end
    end
@@ -906,11 +936,11 @@
    i32.const -1
    i32.xor
    i32.and
-   local.set $5
+   local.set $17
    i32.const 0
    drop
    local.get $0
-   local.get $5
+   local.get $17
    memory.size
    i32.const 16
    i32.shl
@@ -959,6 +989,14 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
   local.get $1
   i32.const 256
   i32.lt_u
@@ -1032,11 +1070,11 @@
    unreachable
   end
   local.get $0
-  local.set $5
+  local.set $6
   local.get $2
-  local.set $4
+  local.set $5
+  local.get $6
   local.get $5
-  local.get $4
   i32.const 2
   i32.shl
   i32.add
@@ -1047,10 +1085,10 @@
   local.get $3
   i32.shl
   i32.and
-  local.set $6
-  i32.const 0
   local.set $7
-  local.get $6
+  i32.const 0
+  local.set $8
+  local.get $7
   i32.eqz
   if
    local.get $0
@@ -1063,30 +1101,30 @@
    i32.add
    i32.shl
    i32.and
-   local.set $5
-   local.get $5
+   local.set $9
+   local.get $9
    i32.eqz
    if
     i32.const 0
-    local.set $7
+    local.set $8
    else
-    local.get $5
+    local.get $9
     i32.ctz
     local.set $2
     local.get $0
-    local.set $8
+    local.set $11
     local.get $2
-    local.set $4
-    local.get $8
-    local.get $4
+    local.set $10
+    local.get $11
+    local.get $10
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $6
+    local.set $7
     i32.const 1
     drop
-    local.get $6
+    local.get $7
     i32.eqz
     if
      i32.const 0
@@ -1097,45 +1135,45 @@
      unreachable
     end
     local.get $0
-    local.set $9
+    local.set $14
     local.get $2
-    local.set $8
-    local.get $6
+    local.set $13
+    local.get $7
     i32.ctz
-    local.set $4
-    local.get $9
-    local.get $8
+    local.set $12
+    local.get $14
+    local.get $13
     i32.const 4
     i32.shl
-    local.get $4
+    local.get $12
     i32.add
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=96
-    local.set $7
+    local.set $8
    end
   else
    local.get $0
-   local.set $9
+   local.set $17
    local.get $2
-   local.set $8
-   local.get $6
+   local.set $16
+   local.get $7
    i32.ctz
-   local.set $4
-   local.get $9
-   local.get $8
+   local.set $15
+   local.get $17
+   local.get $16
    i32.const 4
    i32.shl
-   local.get $4
+   local.get $15
    i32.add
    i32.const 2
    i32.shl
    i32.add
    i32.load offset=96
-   local.set $7
+   local.set $8
   end
-  local.get $7
+  local.get $8
  )
  (func $~lib/rt/tlsf/growMemory (param $0 i32) (param $1 i32)
   (local $2 i32)
@@ -1144,6 +1182,7 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
   i32.const 0
   drop
   local.get $1
@@ -1190,15 +1229,15 @@
   i32.shr_u
   local.set $4
   local.get $2
-  local.tee $3
-  local.get $4
   local.tee $5
-  local.get $3
+  local.get $4
+  local.tee $6
   local.get $5
+  local.get $6
   i32.gt_s
   select
-  local.set $6
-  local.get $6
+  local.set $7
+  local.get $7
   memory.grow
   i32.const 0
   i32.lt_s
@@ -1212,12 +1251,12 @@
    end
   end
   memory.size
-  local.set $7
+  local.set $8
   local.get $0
   local.get $2
   i32.const 16
   i32.shl
-  local.get $7
+  local.get $8
   i32.const 16
   i32.shl
   call $~lib/rt/tlsf/addMemory
@@ -1227,6 +1266,8 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
   local.get $1
   i32.load
   local.set $3
@@ -1291,11 +1332,11 @@
    i32.and
    i32.store
    local.get $1
-   local.set $5
-   local.get $5
+   local.set $7
+   local.get $7
    i32.const 16
    i32.add
-   local.get $5
+   local.get $7
    i32.load
    i32.const 3
    i32.const -1
@@ -1303,11 +1344,11 @@
    i32.and
    i32.add
    local.get $1
-   local.set $5
-   local.get $5
+   local.set $6
+   local.get $6
    i32.const 16
    i32.add
-   local.get $5
+   local.get $6
    i32.load
    i32.const 3
    i32.const -1

--- a/tests/compiler/logical.untouched.wat
+++ b/tests/compiler/logical.untouched.wat
@@ -40,7 +40,28 @@
  )
  (func $start:logical
   (local $0 f64)
-  (local $1 f32)
+  (local $1 f64)
+  (local $2 f64)
+  (local $3 f64)
+  (local $4 f64)
+  (local $5 f64)
+  (local $6 f64)
+  (local $7 f32)
+  (local $8 f32)
+  (local $9 f64)
+  (local $10 f64)
+  (local $11 f32)
+  (local $12 f32)
+  (local $13 f64)
+  (local $14 f64)
+  (local $15 f32)
+  (local $16 f32)
+  (local $17 f32)
+  (local $18 f32)
+  (local $19 f64)
+  (local $20 f64)
+  (local $21 f64)
+  (local $22 f64)
   i32.const 0
   if (result i32)
    unreachable
@@ -70,11 +91,11 @@
   end
   drop
   f64.const 1
-  local.tee $0
+  local.tee $2
   f64.const 0
   f64.ne
-  local.get $0
-  local.get $0
+  local.get $2
+  local.get $2
   f64.eq
   i32.and
   if (result i32)
@@ -96,11 +117,11 @@
   end
   drop
   f64.const 1
-  local.tee $0
+  local.tee $4
   f64.const 0
   f64.ne
-  local.get $0
-  local.get $0
+  local.get $4
+  local.get $4
   f64.eq
   i32.and
   if (result f64)
@@ -108,11 +129,11 @@
   else
    f64.const 1
   end
-  local.tee $0
+  local.tee $5
   f64.const 0
   f64.ne
-  local.get $0
-  local.get $0
+  local.get $5
+  local.get $5
   f64.eq
   i32.and
   if (result i32)
@@ -202,11 +223,11 @@
    unreachable
   end
   f32.const 1
-  local.tee $1
+  local.tee $7
   f32.const 0
   f32.ne
-  local.get $1
-  local.get $1
+  local.get $7
+  local.get $7
   f32.eq
   i32.and
   if (result f32)
@@ -228,11 +249,11 @@
    unreachable
   end
   f32.const 0
-  local.tee $1
+  local.tee $8
   f32.const 0
   f32.ne
-  local.get $1
-  local.get $1
+  local.get $8
+  local.get $8
   f32.eq
   i32.and
   if (result f32)
@@ -254,11 +275,11 @@
    unreachable
   end
   f64.const 1
-  local.tee $0
+  local.tee $9
   f64.const 0
   f64.ne
-  local.get $0
-  local.get $0
+  local.get $9
+  local.get $9
   f64.eq
   i32.and
   if (result f64)
@@ -280,11 +301,11 @@
    unreachable
   end
   f64.const 0
-  local.tee $0
+  local.tee $10
   f64.const 0
   f64.ne
-  local.get $0
-  local.get $0
+  local.get $10
+  local.get $10
   f64.eq
   i32.and
   if (result f64)
@@ -306,11 +327,11 @@
    unreachable
   end
   f32.const nan:0x400000
-  local.tee $1
+  local.tee $11
   f32.const 0
   f32.ne
-  local.get $1
-  local.get $1
+  local.get $11
+  local.get $11
   f32.eq
   i32.and
   if (result f32)
@@ -332,11 +353,11 @@
    unreachable
   end
   f32.const 1
-  local.tee $1
+  local.tee $12
   f32.const 0
   f32.ne
-  local.get $1
-  local.get $1
+  local.get $12
+  local.get $12
   f32.eq
   i32.and
   if (result f32)
@@ -358,11 +379,11 @@
    unreachable
   end
   f64.const nan:0x8000000000000
-  local.tee $0
+  local.tee $13
   f64.const 0
   f64.ne
-  local.get $0
-  local.get $0
+  local.get $13
+  local.get $13
   f64.eq
   i32.and
   if (result f64)
@@ -384,11 +405,11 @@
    unreachable
   end
   f64.const 1
-  local.tee $0
+  local.tee $14
   f64.const 0
   f64.ne
-  local.get $0
-  local.get $0
+  local.get $14
+  local.get $14
   f64.eq
   i32.and
   if (result f64)
@@ -410,11 +431,11 @@
    unreachable
   end
   f32.const 1
-  local.tee $1
+  local.tee $15
   f32.const 0
   f32.ne
-  local.get $1
-  local.get $1
+  local.get $15
+  local.get $15
   f32.eq
   i32.and
   if (result f32)
@@ -424,8 +445,8 @@
   end
   global.set $logical/f
   global.get $logical/f
-  local.tee $1
-  local.get $1
+  local.tee $16
+  local.get $16
   f32.ne
   i32.eqz
   if
@@ -437,11 +458,11 @@
    unreachable
   end
   f32.const nan:0x400000
-  local.tee $1
+  local.tee $17
   f32.const 0
   f32.ne
-  local.get $1
-  local.get $1
+  local.get $17
+  local.get $17
   f32.eq
   i32.and
   if (result f32)
@@ -451,8 +472,8 @@
   end
   global.set $logical/f
   global.get $logical/f
-  local.tee $1
-  local.get $1
+  local.tee $18
+  local.get $18
   f32.ne
   i32.eqz
   if
@@ -464,11 +485,11 @@
    unreachable
   end
   f64.const 1
-  local.tee $0
+  local.tee $19
   f64.const 0
   f64.ne
-  local.get $0
-  local.get $0
+  local.get $19
+  local.get $19
   f64.eq
   i32.and
   if (result f64)
@@ -478,8 +499,8 @@
   end
   global.set $logical/F
   global.get $logical/F
-  local.tee $0
-  local.get $0
+  local.tee $20
+  local.get $20
   f64.ne
   i32.eqz
   if
@@ -491,11 +512,11 @@
    unreachable
   end
   f64.const nan:0x8000000000000
-  local.tee $0
+  local.tee $21
   f64.const 0
   f64.ne
-  local.get $0
-  local.get $0
+  local.get $21
+  local.get $21
   f64.eq
   i32.and
   if (result f64)
@@ -505,8 +526,8 @@
   end
   global.set $logical/F
   global.get $logical/F
-  local.tee $0
-  local.get $0
+  local.tee $22
+  local.get $22
   f64.ne
   i32.eqz
   if

--- a/tests/compiler/loop-wrap.untouched.wat
+++ b/tests/compiler/loop-wrap.untouched.wat
@@ -35,6 +35,7 @@
  (func $loop-wrap/testFirstWrapped
   (local $0 i32)
   (local $1 i32)
+  (local $2 i32)
   i32.const 0
   local.set $0
   block $do-break|1
@@ -53,8 +54,8 @@
     local.tee $0
     i32.const 255
     i32.and
-    local.set $1
-    local.get $1
+    local.set $2
+    local.get $2
     br_if $do-continue|1
    end
   end

--- a/tests/compiler/managed-cast.untouched.wat
+++ b/tests/compiler/managed-cast.untouched.wat
@@ -40,6 +40,15 @@
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
   local.get $1
   i32.load
   local.set $2
@@ -176,59 +185,59 @@
   i32.eq
   if
    local.get $0
-   local.set $11
+   local.set $14
    local.get $4
-   local.set $10
+   local.set $13
    local.get $5
-   local.set $9
+   local.set $12
    local.get $7
-   local.set $8
-   local.get $11
-   local.get $10
+   local.set $11
+   local.get $14
+   local.get $13
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $12
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
+   local.get $11
    i32.store offset=96
    local.get $7
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $16
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $15
+    local.get $16
+    local.get $15
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $17
     local.get $0
-    local.set $8
+    local.set $20
     local.get $4
-    local.set $11
-    local.get $9
+    local.set $19
+    local.get $17
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
-    local.set $10
-    local.get $8
-    local.get $11
+    local.tee $17
+    local.set $18
+    local.get $20
+    local.get $19
     i32.const 2
     i32.shl
     i32.add
-    local.get $10
+    local.get $18
     i32.store offset=4
-    local.get $9
+    local.get $17
     i32.eqz
     if
      local.get $0
@@ -258,6 +267,20 @@
   (local $11 i32)
   (local $12 i32)
   (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local $22 i32)
+  (local $23 i32)
+  (local $24 i32)
+  (local $25 i32)
+  (local $26 i32)
+  (local $27 i32)
   i32.const 1
   drop
   local.get $1
@@ -320,8 +343,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $3
+   local.set $6
+   local.get $6
    i32.const 1073741808
    i32.lt_u
    if
@@ -332,16 +355,16 @@
     local.get $2
     i32.const 3
     i32.and
-    local.get $3
+    local.get $6
     i32.or
     local.tee $2
     i32.store
     local.get $1
-    local.set $6
-    local.get $6
+    local.set $7
+    local.get $7
     i32.const 16
     i32.add
-    local.get $6
+    local.get $7
     i32.load
     i32.const 3
     i32.const -1
@@ -359,18 +382,18 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $8
+   local.get $8
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
+   local.set $9
+   local.get $9
    i32.load
-   local.set $3
+   local.set $10
    i32.const 1
    drop
-   local.get $3
+   local.get $10
    i32.const 1
    i32.and
    i32.eqz
@@ -382,7 +405,7 @@
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $3
+   local.get $10
    i32.const 3
    i32.const -1
    i32.xor
@@ -395,23 +418,23 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $7
+   local.set $11
+   local.get $11
    i32.const 1073741808
    i32.lt_u
    if
     local.get $0
-    local.get $6
+    local.get $9
     call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
+    local.get $9
+    local.get $10
     i32.const 3
     i32.and
-    local.get $7
+    local.get $11
     i32.or
     local.tee $2
     i32.store
-    local.get $6
+    local.get $9
     local.set $1
    end
   end
@@ -425,14 +448,14 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $12
   i32.const 1
   drop
-  local.get $8
+  local.get $12
   i32.const 16
   i32.ge_u
   if (result i32)
-   local.get $8
+   local.get $12
    i32.const 1073741808
    i32.lt_u
   else
@@ -452,7 +475,7 @@
   local.get $1
   i32.const 16
   i32.add
-  local.get $8
+  local.get $12
   i32.add
   local.get $4
   i32.eq
@@ -470,24 +493,24 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $12
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $13
+   local.get $12
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $14
   else
    i32.const 31
-   local.get $8
+   local.get $12
    i32.clz
    i32.sub
-   local.set $9
-   local.get $8
-   local.get $9
+   local.set $13
+   local.get $12
+   local.get $13
    i32.const 4
    i32.sub
    i32.shr_u
@@ -495,21 +518,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $14
+   local.get $13
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $13
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $13
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $14
    i32.const 16
    i32.lt_u
   else
@@ -525,86 +548,86 @@
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
-  local.set $6
-  local.get $7
-  local.get $3
+  local.set $17
+  local.get $13
+  local.set $16
+  local.get $14
+  local.set $15
+  local.get $17
+  local.get $16
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $15
   i32.add
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=96
-  local.set $11
+  local.set $18
   local.get $1
   i32.const 0
   i32.store offset=16
   local.get $1
-  local.get $11
+  local.get $18
   i32.store offset=20
-  local.get $11
+  local.get $18
   if
-   local.get $11
+   local.get $18
    local.get $1
    i32.store offset=16
   end
   local.get $0
-  local.set $12
-  local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
+  local.set $22
+  local.get $13
+  local.set $21
+  local.get $14
+  local.set $20
   local.get $1
-  local.set $6
-  local.get $12
-  local.get $7
+  local.set $19
+  local.get $22
+  local.get $21
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $20
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $19
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $13
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.set $13
-  local.get $9
-  local.set $12
+  local.set $27
+  local.get $13
+  local.set $26
   local.get $0
-  local.set $3
-  local.get $9
-  local.set $6
-  local.get $3
-  local.get $6
+  local.set $24
+  local.get $13
+  local.set $23
+  local.get $24
+  local.get $23
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $14
   i32.shl
   i32.or
-  local.set $7
-  local.get $13
-  local.get $12
+  local.set $25
+  local.get $27
+  local.get $26
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $25
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -615,6 +638,7 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
   i32.const 1
   drop
   local.get $1
@@ -754,11 +778,11 @@
   i32.or
   i32.store
   local.get $0
-  local.set $9
+  local.set $10
   local.get $4
-  local.set $3
+  local.set $9
+  local.get $10
   local.get $9
-  local.get $3
   i32.store offset=1568
   local.get $0
   local.get $8
@@ -778,6 +802,12 @@
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
   global.get $~lib/rt/tlsf/ROOT
   local.set $0
   local.get $0
@@ -834,66 +864,66 @@
    local.get $4
    i32.store offset=1568
    i32.const 0
-   local.set $5
+   local.set $6
    loop $for-loop|0
-    local.get $5
+    local.get $6
     i32.const 23
     i32.lt_u
-    local.set $4
-    local.get $4
+    local.set $7
+    local.get $7
     if
      local.get $0
-     local.set $8
-     local.get $5
-     local.set $7
+     local.set $10
+     local.get $6
+     local.set $9
      i32.const 0
-     local.set $6
-     local.get $8
-     local.get $7
+     local.set $8
+     local.get $10
+     local.get $9
      i32.const 2
      i32.shl
      i32.add
-     local.get $6
+     local.get $8
      i32.store offset=4
      i32.const 0
-     local.set $8
+     local.set $11
      loop $for-loop|1
-      local.get $8
+      local.get $11
       i32.const 16
       i32.lt_u
-      local.set $7
-      local.get $7
+      local.set $12
+      local.get $12
       if
        local.get $0
-       local.set $11
-       local.get $5
-       local.set $10
-       local.get $8
-       local.set $9
-       i32.const 0
-       local.set $6
+       local.set $16
+       local.get $6
+       local.set $15
        local.get $11
-       local.get $10
+       local.set $14
+       i32.const 0
+       local.set $13
+       local.get $16
+       local.get $15
        i32.const 4
        i32.shl
-       local.get $9
+       local.get $14
        i32.add
        i32.const 2
        i32.shl
        i32.add
-       local.get $6
+       local.get $13
        i32.store offset=96
-       local.get $8
+       local.get $11
        i32.const 1
        i32.add
-       local.set $8
+       local.set $11
        br $for-loop|1
       end
      end
-     local.get $5
+     local.get $6
      i32.const 1
      i32.add
-     local.set $5
+     local.set $6
      br $for-loop|0
     end
    end
@@ -906,11 +936,11 @@
    i32.const -1
    i32.xor
    i32.and
-   local.set $5
+   local.set $17
    i32.const 0
    drop
    local.get $0
-   local.get $5
+   local.get $17
    memory.size
    i32.const 16
    i32.shl
@@ -959,6 +989,14 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
   local.get $1
   i32.const 256
   i32.lt_u
@@ -1032,11 +1070,11 @@
    unreachable
   end
   local.get $0
-  local.set $5
+  local.set $6
   local.get $2
-  local.set $4
+  local.set $5
+  local.get $6
   local.get $5
-  local.get $4
   i32.const 2
   i32.shl
   i32.add
@@ -1047,10 +1085,10 @@
   local.get $3
   i32.shl
   i32.and
-  local.set $6
-  i32.const 0
   local.set $7
-  local.get $6
+  i32.const 0
+  local.set $8
+  local.get $7
   i32.eqz
   if
    local.get $0
@@ -1063,30 +1101,30 @@
    i32.add
    i32.shl
    i32.and
-   local.set $5
-   local.get $5
+   local.set $9
+   local.get $9
    i32.eqz
    if
     i32.const 0
-    local.set $7
+    local.set $8
    else
-    local.get $5
+    local.get $9
     i32.ctz
     local.set $2
     local.get $0
-    local.set $8
+    local.set $11
     local.get $2
-    local.set $4
-    local.get $8
-    local.get $4
+    local.set $10
+    local.get $11
+    local.get $10
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $6
+    local.set $7
     i32.const 1
     drop
-    local.get $6
+    local.get $7
     i32.eqz
     if
      i32.const 0
@@ -1097,45 +1135,45 @@
      unreachable
     end
     local.get $0
-    local.set $9
+    local.set $14
     local.get $2
-    local.set $8
-    local.get $6
+    local.set $13
+    local.get $7
     i32.ctz
-    local.set $4
-    local.get $9
-    local.get $8
+    local.set $12
+    local.get $14
+    local.get $13
     i32.const 4
     i32.shl
-    local.get $4
+    local.get $12
     i32.add
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=96
-    local.set $7
+    local.set $8
    end
   else
    local.get $0
-   local.set $9
+   local.set $17
    local.get $2
-   local.set $8
-   local.get $6
+   local.set $16
+   local.get $7
    i32.ctz
-   local.set $4
-   local.get $9
-   local.get $8
+   local.set $15
+   local.get $17
+   local.get $16
    i32.const 4
    i32.shl
-   local.get $4
+   local.get $15
    i32.add
    i32.const 2
    i32.shl
    i32.add
    i32.load offset=96
-   local.set $7
+   local.set $8
   end
-  local.get $7
+  local.get $8
  )
  (func $~lib/rt/tlsf/growMemory (param $0 i32) (param $1 i32)
   (local $2 i32)
@@ -1144,6 +1182,7 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
   i32.const 0
   drop
   local.get $1
@@ -1190,15 +1229,15 @@
   i32.shr_u
   local.set $4
   local.get $2
-  local.tee $3
-  local.get $4
   local.tee $5
-  local.get $3
+  local.get $4
+  local.tee $6
   local.get $5
+  local.get $6
   i32.gt_s
   select
-  local.set $6
-  local.get $6
+  local.set $7
+  local.get $7
   memory.grow
   i32.const 0
   i32.lt_s
@@ -1212,12 +1251,12 @@
    end
   end
   memory.size
-  local.set $7
+  local.set $8
   local.get $0
   local.get $2
   i32.const 16
   i32.shl
-  local.get $7
+  local.get $8
   i32.const 16
   i32.shl
   call $~lib/rt/tlsf/addMemory
@@ -1227,6 +1266,8 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
   local.get $1
   i32.load
   local.set $3
@@ -1291,11 +1332,11 @@
    i32.and
    i32.store
    local.get $1
-   local.set $5
-   local.get $5
+   local.set $7
+   local.get $7
    i32.const 16
    i32.add
-   local.get $5
+   local.get $7
    i32.load
    i32.const 3
    i32.const -1
@@ -1303,11 +1344,11 @@
    i32.and
    i32.add
    local.get $1
-   local.set $5
-   local.get $5
+   local.set $6
+   local.get $6
    i32.const 16
    i32.add
-   local.get $5
+   local.get $6
    i32.load
    i32.const 3
    i32.const -1
@@ -1697,6 +1738,7 @@
  )
  (func $managed-cast/testUpcastFromNullable (param $0 i32)
   (local $1 i32)
+  (local $2 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $0
@@ -1712,11 +1754,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.tee $1
+  local.tee $2
   i32.const 3
   call $~lib/rt/__instanceof
   if (result i32)
-   local.get $1
+   local.get $2
   else
    i32.const 0
    i32.const 192

--- a/tests/compiler/memcpy.untouched.wat
+++ b/tests/compiler/memcpy.untouched.wat
@@ -17,6 +17,88 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local $22 i32)
+  (local $23 i32)
+  (local $24 i32)
+  (local $25 i32)
+  (local $26 i32)
+  (local $27 i32)
+  (local $28 i32)
+  (local $29 i32)
+  (local $30 i32)
+  (local $31 i32)
+  (local $32 i32)
+  (local $33 i32)
+  (local $34 i32)
+  (local $35 i32)
+  (local $36 i32)
+  (local $37 i32)
+  (local $38 i32)
+  (local $39 i32)
+  (local $40 i32)
+  (local $41 i32)
+  (local $42 i32)
+  (local $43 i32)
+  (local $44 i32)
+  (local $45 i32)
+  (local $46 i32)
+  (local $47 i32)
+  (local $48 i32)
+  (local $49 i32)
+  (local $50 i32)
+  (local $51 i32)
+  (local $52 i32)
+  (local $53 i32)
+  (local $54 i32)
+  (local $55 i32)
+  (local $56 i32)
+  (local $57 i32)
+  (local $58 i32)
+  (local $59 i32)
+  (local $60 i32)
+  (local $61 i32)
+  (local $62 i32)
+  (local $63 i32)
+  (local $64 i32)
+  (local $65 i32)
+  (local $66 i32)
+  (local $67 i32)
+  (local $68 i32)
+  (local $69 i32)
+  (local $70 i32)
+  (local $71 i32)
+  (local $72 i32)
+  (local $73 i32)
+  (local $74 i32)
+  (local $75 i32)
+  (local $76 i32)
+  (local $77 i32)
+  (local $78 i32)
+  (local $79 i32)
+  (local $80 i32)
+  (local $81 i32)
+  (local $82 i32)
+  (local $83 i32)
+  (local $84 i32)
+  (local $85 i32)
+  (local $86 i32)
+  (local $87 i32)
+  (local $88 i32)
+  (local $89 i32)
   local.get $0
   local.set $3
   loop $while-continue|0
@@ -38,11 +120,11 @@
     local.set $0
     local.get $7
     local.get $1
-    local.tee $7
+    local.tee $8
     i32.const 1
     i32.add
     local.set $1
-    local.get $7
+    local.get $8
     i32.load8_u
     i32.store8
     local.get $2
@@ -62,8 +144,8 @@
     local.get $2
     i32.const 16
     i32.ge_u
-    local.set $6
-    local.get $6
+    local.set $9
+    local.get $9
     if
      local.get $0
      local.get $1
@@ -172,17 +254,17 @@
    i32.and
    if
     local.get $0
-    local.tee $6
+    local.tee $10
     i32.const 1
     i32.add
     local.set $0
-    local.get $6
+    local.get $10
     local.get $1
-    local.tee $6
+    local.tee $11
     i32.const 1
     i32.add
     local.set $1
-    local.get $6
+    local.get $11
     i32.load8_u
     i32.store8
    end
@@ -200,16 +282,16 @@
        local.get $0
        i32.const 4
        i32.rem_u
-       local.set $6
-       local.get $6
+       local.set $12
+       local.get $12
        i32.const 1
        i32.eq
        br_if $case0|2
-       local.get $6
+       local.get $12
        i32.const 2
        i32.eq
        br_if $case1|2
-       local.get $6
+       local.get $12
        i32.const 3
        i32.eq
        br_if $case2|2
@@ -219,45 +301,45 @@
       i32.load
       local.set $4
       local.get $0
-      local.tee $6
+      local.tee $13
       i32.const 1
       i32.add
       local.set $0
-      local.get $6
+      local.get $13
       local.get $1
-      local.tee $6
+      local.tee $14
       i32.const 1
       i32.add
       local.set $1
-      local.get $6
+      local.get $14
       i32.load8_u
       i32.store8
       local.get $0
-      local.tee $6
+      local.tee $15
       i32.const 1
       i32.add
       local.set $0
-      local.get $6
+      local.get $15
       local.get $1
-      local.tee $6
+      local.tee $16
       i32.const 1
       i32.add
       local.set $1
-      local.get $6
+      local.get $16
       i32.load8_u
       i32.store8
       local.get $0
-      local.tee $6
+      local.tee $17
       i32.const 1
       i32.add
       local.set $0
-      local.get $6
+      local.get $17
       local.get $1
-      local.tee $6
+      local.tee $18
       i32.const 1
       i32.add
       local.set $1
-      local.get $6
+      local.get $18
       i32.load8_u
       i32.store8
       local.get $2
@@ -268,8 +350,8 @@
        local.get $2
        i32.const 17
        i32.ge_u
-       local.set $6
-       local.get $6
+       local.set $19
+       local.get $19
        if
         local.get $1
         i32.const 1
@@ -354,31 +436,31 @@
      i32.load
      local.set $4
      local.get $0
-     local.tee $6
+     local.tee $20
      i32.const 1
      i32.add
      local.set $0
-     local.get $6
+     local.get $20
      local.get $1
-     local.tee $6
+     local.tee $21
      i32.const 1
      i32.add
      local.set $1
-     local.get $6
+     local.get $21
      i32.load8_u
      i32.store8
      local.get $0
-     local.tee $6
+     local.tee $22
      i32.const 1
      i32.add
      local.set $0
-     local.get $6
+     local.get $22
      local.get $1
-     local.tee $6
+     local.tee $23
      i32.const 1
      i32.add
      local.set $1
-     local.get $6
+     local.get $23
      i32.load8_u
      i32.store8
      local.get $2
@@ -389,8 +471,8 @@
       local.get $2
       i32.const 18
       i32.ge_u
-      local.set $6
-      local.get $6
+      local.set $24
+      local.get $24
       if
        local.get $1
        i32.const 2
@@ -475,17 +557,17 @@
     i32.load
     local.set $4
     local.get $0
-    local.tee $6
+    local.tee $25
     i32.const 1
     i32.add
     local.set $0
-    local.get $6
+    local.get $25
     local.get $1
-    local.tee $6
+    local.tee $26
     i32.const 1
     i32.add
     local.set $1
-    local.get $6
+    local.get $26
     i32.load8_u
     i32.store8
     local.get $2
@@ -496,8 +578,8 @@
      local.get $2
      i32.const 19
      i32.ge_u
-     local.set $6
-     local.get $6
+     local.set $27
+     local.get $27
      if
       local.get $1
       i32.const 3
@@ -584,227 +666,227 @@
   i32.and
   if
    local.get $0
-   local.tee $6
+   local.tee $28
    i32.const 1
    i32.add
    local.set $0
-   local.get $6
+   local.get $28
    local.get $1
-   local.tee $6
+   local.tee $29
    i32.const 1
    i32.add
    local.set $1
-   local.get $6
+   local.get $29
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $6
+   local.tee $30
    i32.const 1
    i32.add
    local.set $0
-   local.get $6
+   local.get $30
    local.get $1
-   local.tee $6
+   local.tee $31
    i32.const 1
    i32.add
    local.set $1
-   local.get $6
+   local.get $31
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $6
+   local.tee $32
    i32.const 1
    i32.add
    local.set $0
-   local.get $6
+   local.get $32
    local.get $1
-   local.tee $6
+   local.tee $33
    i32.const 1
    i32.add
    local.set $1
-   local.get $6
+   local.get $33
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $6
+   local.tee $34
    i32.const 1
    i32.add
    local.set $0
-   local.get $6
+   local.get $34
    local.get $1
-   local.tee $6
+   local.tee $35
    i32.const 1
    i32.add
    local.set $1
-   local.get $6
+   local.get $35
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $6
+   local.tee $36
    i32.const 1
    i32.add
    local.set $0
-   local.get $6
+   local.get $36
    local.get $1
-   local.tee $6
+   local.tee $37
    i32.const 1
    i32.add
    local.set $1
-   local.get $6
+   local.get $37
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $6
+   local.tee $38
    i32.const 1
    i32.add
    local.set $0
-   local.get $6
+   local.get $38
    local.get $1
-   local.tee $6
+   local.tee $39
    i32.const 1
    i32.add
    local.set $1
-   local.get $6
+   local.get $39
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $6
+   local.tee $40
    i32.const 1
    i32.add
    local.set $0
-   local.get $6
+   local.get $40
    local.get $1
-   local.tee $6
+   local.tee $41
    i32.const 1
    i32.add
    local.set $1
-   local.get $6
+   local.get $41
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $6
+   local.tee $42
    i32.const 1
    i32.add
    local.set $0
-   local.get $6
+   local.get $42
    local.get $1
-   local.tee $6
+   local.tee $43
    i32.const 1
    i32.add
    local.set $1
-   local.get $6
+   local.get $43
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $6
+   local.tee $44
    i32.const 1
    i32.add
    local.set $0
-   local.get $6
+   local.get $44
    local.get $1
-   local.tee $6
+   local.tee $45
    i32.const 1
    i32.add
    local.set $1
-   local.get $6
+   local.get $45
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $6
+   local.tee $46
    i32.const 1
    i32.add
    local.set $0
-   local.get $6
+   local.get $46
    local.get $1
-   local.tee $6
+   local.tee $47
    i32.const 1
    i32.add
    local.set $1
-   local.get $6
+   local.get $47
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $6
+   local.tee $48
    i32.const 1
    i32.add
    local.set $0
-   local.get $6
+   local.get $48
    local.get $1
-   local.tee $6
+   local.tee $49
    i32.const 1
    i32.add
    local.set $1
-   local.get $6
+   local.get $49
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $6
+   local.tee $50
    i32.const 1
    i32.add
    local.set $0
-   local.get $6
+   local.get $50
    local.get $1
-   local.tee $6
+   local.tee $51
    i32.const 1
    i32.add
    local.set $1
-   local.get $6
+   local.get $51
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $6
+   local.tee $52
    i32.const 1
    i32.add
    local.set $0
-   local.get $6
+   local.get $52
    local.get $1
-   local.tee $6
+   local.tee $53
    i32.const 1
    i32.add
    local.set $1
-   local.get $6
+   local.get $53
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $6
+   local.tee $54
    i32.const 1
    i32.add
    local.set $0
-   local.get $6
+   local.get $54
    local.get $1
-   local.tee $6
+   local.tee $55
    i32.const 1
    i32.add
    local.set $1
-   local.get $6
+   local.get $55
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $6
+   local.tee $56
    i32.const 1
    i32.add
    local.set $0
-   local.get $6
+   local.get $56
    local.get $1
-   local.tee $6
+   local.tee $57
    i32.const 1
    i32.add
    local.set $1
-   local.get $6
+   local.get $57
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $6
+   local.tee $58
    i32.const 1
    i32.add
    local.set $0
-   local.get $6
+   local.get $58
    local.get $1
-   local.tee $6
+   local.tee $59
    i32.const 1
    i32.add
    local.set $1
-   local.get $6
+   local.get $59
    i32.load8_u
    i32.store8
   end
@@ -813,115 +895,115 @@
   i32.and
   if
    local.get $0
-   local.tee $6
+   local.tee $60
    i32.const 1
    i32.add
    local.set $0
-   local.get $6
+   local.get $60
    local.get $1
-   local.tee $6
+   local.tee $61
    i32.const 1
    i32.add
    local.set $1
-   local.get $6
+   local.get $61
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $6
+   local.tee $62
    i32.const 1
    i32.add
    local.set $0
-   local.get $6
+   local.get $62
    local.get $1
-   local.tee $6
+   local.tee $63
    i32.const 1
    i32.add
    local.set $1
-   local.get $6
+   local.get $63
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $6
+   local.tee $64
    i32.const 1
    i32.add
    local.set $0
-   local.get $6
+   local.get $64
    local.get $1
-   local.tee $6
+   local.tee $65
    i32.const 1
    i32.add
    local.set $1
-   local.get $6
+   local.get $65
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $6
+   local.tee $66
    i32.const 1
    i32.add
    local.set $0
-   local.get $6
+   local.get $66
    local.get $1
-   local.tee $6
+   local.tee $67
    i32.const 1
    i32.add
    local.set $1
-   local.get $6
+   local.get $67
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $6
+   local.tee $68
    i32.const 1
    i32.add
    local.set $0
-   local.get $6
+   local.get $68
    local.get $1
-   local.tee $6
+   local.tee $69
    i32.const 1
    i32.add
    local.set $1
-   local.get $6
+   local.get $69
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $6
+   local.tee $70
    i32.const 1
    i32.add
    local.set $0
-   local.get $6
+   local.get $70
    local.get $1
-   local.tee $6
+   local.tee $71
    i32.const 1
    i32.add
    local.set $1
-   local.get $6
+   local.get $71
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $6
+   local.tee $72
    i32.const 1
    i32.add
    local.set $0
-   local.get $6
+   local.get $72
    local.get $1
-   local.tee $6
+   local.tee $73
    i32.const 1
    i32.add
    local.set $1
-   local.get $6
+   local.get $73
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $6
+   local.tee $74
    i32.const 1
    i32.add
    local.set $0
-   local.get $6
+   local.get $74
    local.get $1
-   local.tee $6
+   local.tee $75
    i32.const 1
    i32.add
    local.set $1
-   local.get $6
+   local.get $75
    i32.load8_u
    i32.store8
   end
@@ -930,59 +1012,59 @@
   i32.and
   if
    local.get $0
-   local.tee $6
+   local.tee $76
    i32.const 1
    i32.add
    local.set $0
-   local.get $6
+   local.get $76
    local.get $1
-   local.tee $6
+   local.tee $77
    i32.const 1
    i32.add
    local.set $1
-   local.get $6
+   local.get $77
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $6
+   local.tee $78
    i32.const 1
    i32.add
    local.set $0
-   local.get $6
+   local.get $78
    local.get $1
-   local.tee $6
+   local.tee $79
    i32.const 1
    i32.add
    local.set $1
-   local.get $6
+   local.get $79
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $6
+   local.tee $80
    i32.const 1
    i32.add
    local.set $0
-   local.get $6
+   local.get $80
    local.get $1
-   local.tee $6
+   local.tee $81
    i32.const 1
    i32.add
    local.set $1
-   local.get $6
+   local.get $81
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $6
+   local.tee $82
    i32.const 1
    i32.add
    local.set $0
-   local.get $6
+   local.get $82
    local.get $1
-   local.tee $6
+   local.tee $83
    i32.const 1
    i32.add
    local.set $1
-   local.get $6
+   local.get $83
    i32.load8_u
    i32.store8
   end
@@ -991,31 +1073,31 @@
   i32.and
   if
    local.get $0
-   local.tee $6
+   local.tee $84
    i32.const 1
    i32.add
    local.set $0
-   local.get $6
+   local.get $84
    local.get $1
-   local.tee $6
+   local.tee $85
    i32.const 1
    i32.add
    local.set $1
-   local.get $6
+   local.get $85
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $6
+   local.tee $86
    i32.const 1
    i32.add
    local.set $0
-   local.get $6
+   local.get $86
    local.get $1
-   local.tee $6
+   local.tee $87
    i32.const 1
    i32.add
    local.set $1
-   local.get $6
+   local.get $87
    i32.load8_u
    i32.store8
   end
@@ -1024,17 +1106,17 @@
   i32.and
   if
    local.get $0
-   local.tee $6
+   local.tee $88
    i32.const 1
    i32.add
    local.set $0
-   local.get $6
+   local.get $88
    local.get $1
-   local.tee $6
+   local.tee $89
    i32.const 1
    i32.add
    local.set $1
-   local.get $6
+   local.get $89
    i32.load8_u
    i32.store8
   end

--- a/tests/compiler/memmove.untouched.wat
+++ b/tests/compiler/memmove.untouched.wat
@@ -14,6 +14,14 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
   local.get $0
   local.set $3
   local.get $0
@@ -59,11 +67,11 @@
       local.set $0
       local.get $5
       local.get $1
-      local.tee $5
+      local.tee $6
       i32.const 1
       i32.add
       local.set $1
-      local.get $5
+      local.get $6
       i32.load8_u
       i32.store8
       br $while-continue|0
@@ -73,8 +81,8 @@
      local.get $2
      i32.const 8
      i32.ge_u
-     local.set $4
-     local.get $4
+     local.set $7
+     local.get $7
      if
       local.get $0
       local.get $1
@@ -98,21 +106,21 @@
    end
    loop $while-continue|2
     local.get $2
-    local.set $4
-    local.get $4
+    local.set $8
+    local.get $8
     if
      local.get $0
-     local.tee $5
+     local.tee $9
      i32.const 1
      i32.add
      local.set $0
-     local.get $5
+     local.get $9
      local.get $1
-     local.tee $5
+     local.tee $10
      i32.const 1
      i32.add
      local.set $1
-     local.get $5
+     local.get $10
      i32.load8_u
      i32.store8
      local.get $2
@@ -137,8 +145,8 @@
      i32.add
      i32.const 8
      i32.rem_u
-     local.set $4
-     local.get $4
+     local.set $11
+     local.get $11
      if
       local.get $2
       i32.eqz
@@ -164,8 +172,8 @@
      local.get $2
      i32.const 8
      i32.ge_u
-     local.set $4
-     local.get $4
+     local.set $12
+     local.get $12
      if
       local.get $2
       i32.const 8
@@ -185,8 +193,8 @@
    end
    loop $while-continue|5
     local.get $2
-    local.set $4
-    local.get $4
+    local.set $13
+    local.get $13
     if
      local.get $0
      local.get $2

--- a/tests/compiler/new.untouched.wat
+++ b/tests/compiler/new.untouched.wat
@@ -19,6 +19,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   memory.size
   local.set $1
   local.get $1
@@ -49,8 +50,8 @@
    local.get $5
    i32.gt_s
    select
-   local.set $4
-   local.get $4
+   local.set $6
+   local.get $6
    memory.grow
    i32.const 0
    i32.lt_s
@@ -185,6 +186,15 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
   global.get $~lib/heap/__heap_base
   i32.const 15
   i32.add
@@ -204,43 +214,18 @@
   global.set $new/ref
   i32.const 0
   call $new/Ref#constructor
-  local.set $0
+  local.set $1
   global.get $new/ref
   call $~lib/rt/stub/__release
-  local.get $0
+  local.get $1
   global.set $new/ref
   i32.const 0
   call $new/Ref#constructor
-  local.tee $0
+  local.tee $2
   call $new/Ref#get:ref
-  local.tee $1
-  local.tee $2
-  global.get $new/ref
   local.tee $3
-  i32.ne
-  if
-   local.get $2
-   call $~lib/rt/stub/__retain
-   local.set $2
-   local.get $3
-   call $~lib/rt/stub/__release
-  end
-  local.get $2
-  global.set $new/ref
-  i32.const 0
-  call $new/Gen<i32>#constructor
-  local.set $3
-  global.get $new/gen
-  call $~lib/rt/stub/__release
-  local.get $3
-  global.set $new/gen
-  i32.const 0
-  call $new/Gen<i32>#constructor
-  local.tee $3
-  call $new/Gen<i32>#get:gen
-  local.tee $2
   local.tee $4
-  global.get $new/gen
+  global.get $new/ref
   local.tee $5
   i32.ne
   if
@@ -251,50 +236,75 @@
    call $~lib/rt/stub/__release
   end
   local.get $4
+  global.set $new/ref
+  i32.const 0
+  call $new/Gen<i32>#constructor
+  local.set $6
+  global.get $new/gen
+  call $~lib/rt/stub/__release
+  local.get $6
+  global.set $new/gen
+  i32.const 0
+  call $new/Gen<i32>#constructor
+  local.tee $7
+  call $new/Gen<i32>#get:gen
+  local.tee $8
+  local.tee $9
+  global.get $new/gen
+  local.tee $10
+  i32.ne
+  if
+   local.get $9
+   call $~lib/rt/stub/__retain
+   local.set $9
+   local.get $10
+   call $~lib/rt/stub/__release
+  end
+  local.get $9
   global.set $new/gen
   i32.const 0
   call $new/ns.Ref#constructor
-  local.set $5
+  local.set $11
   global.get $new/ref2
   call $~lib/rt/stub/__release
-  local.get $5
+  local.get $11
   global.set $new/ref2
   i32.const 0
   call $new/ns.Ref#constructor
-  local.set $4
+  local.set $12
   global.get $new/ref2
   call $~lib/rt/stub/__release
-  local.get $4
+  local.get $12
   global.set $new/ref2
   i32.const 0
   call $new/ns.Ref#constructor
-  local.tee $4
+  local.tee $13
   call $new/ns.Ref#get:ref
-  local.tee $5
-  local.tee $6
+  local.tee $14
+  local.tee $15
   global.get $new/ref2
-  local.tee $7
+  local.tee $16
   i32.ne
   if
-   local.get $6
+   local.get $15
    call $~lib/rt/stub/__retain
-   local.set $6
-   local.get $7
+   local.set $15
+   local.get $16
    call $~lib/rt/stub/__release
   end
-  local.get $6
+  local.get $15
   global.set $new/ref2
-  local.get $0
-  call $~lib/rt/stub/__release
-  local.get $1
-  call $~lib/rt/stub/__release
   local.get $2
   call $~lib/rt/stub/__release
   local.get $3
   call $~lib/rt/stub/__release
-  local.get $4
+  local.get $7
   call $~lib/rt/stub/__release
-  local.get $5
+  local.get $8
+  call $~lib/rt/stub/__release
+  local.get $13
+  call $~lib/rt/stub/__release
+  local.get $14
   call $~lib/rt/stub/__release
  )
  (func $~start

--- a/tests/compiler/number.optimized.wat
+++ b/tests/compiler/number.optimized.wat
@@ -346,8 +346,8 @@
  )
  (func $~lib/util/number/genDigits (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (result i32)
   (local $6 i32)
-  (local $7 i64)
-  (local $8 i32)
+  (local $7 i32)
+  (local $8 i64)
   (local $9 i64)
   (local $10 i32)
   (local $11 i64)
@@ -369,7 +369,7 @@
   i64.sub
   local.tee $12
   i64.and
-  local.set $7
+  local.set $8
   local.get $3
   local.get $10
   i64.extend_i32_s
@@ -503,11 +503,11 @@
      local.set $2
     end
     local.get $2
-    local.get $8
+    local.get $7
     i32.or
     if
      local.get $0
-     local.get $8
+     local.get $7
      i32.const 1
      i32.shl
      i32.add
@@ -517,16 +517,16 @@
      i32.const 48
      i32.add
      i32.store16
-     local.get $8
+     local.get $7
      i32.const 1
      i32.add
-     local.set $8
+     local.set $7
     end
     local.get $4
     i32.const 1
     i32.sub
     local.set $4
-    local.get $7
+    local.get $8
     local.get $6
     i64.extend_i32_u
     local.get $10
@@ -552,7 +552,7 @@
      i64.shl
      local.set $3
      local.get $0
-     local.get $8
+     local.get $7
      i32.const 1
      i32.sub
      i32.const 1
@@ -569,11 +569,11 @@
       local.get $1
       local.get $3
       i64.add
-      local.tee $7
+      local.tee $8
       local.get $9
       i64.sub
       i64.gt_u
-      local.get $7
+      local.get $8
       local.get $9
       i64.lt_u
       select
@@ -604,7 +604,7 @@
      local.get $0
      local.get $4
      i32.store16
-     local.get $8
+     local.get $7
      return
     end
     br $while-continue|0
@@ -618,35 +618,35 @@
    i64.const 10
    i64.mul
    local.set $5
-   local.get $7
+   local.get $8
    i64.const 10
    i64.mul
    local.tee $3
    local.get $1
    i64.shr_u
-   local.tee $7
-   local.get $8
+   local.tee $8
+   local.get $7
    i64.extend_i32_s
    i64.or
    i64.const 0
    i64.ne
    if
     local.get $0
-    local.get $8
+    local.get $7
     i32.const 1
     i32.shl
     i32.add
-    local.get $7
+    local.get $8
     i32.wrap_i64
     i32.const 65535
     i32.and
     i32.const 48
     i32.add
     i32.store16
-    local.get $8
+    local.get $7
     i32.const 1
     i32.add
-    local.set $8
+    local.set $7
    end
    local.get $4
    i32.const 1
@@ -655,7 +655,7 @@
    local.get $3
    local.get $12
    i64.and
-   local.tee $7
+   local.tee $8
    local.get $5
    i64.ge_u
    br_if $while-continue|4
@@ -664,8 +664,6 @@
   global.get $~lib/util/number/_K
   i32.add
   global.set $~lib/util/number/_K
-  local.get $7
-  local.set $1
   local.get $9
   i32.const 0
   local.get $4
@@ -676,9 +674,9 @@
   i32.add
   i64.load32_u
   i64.mul
-  local.set $3
+  local.set $1
   local.get $0
-  local.get $8
+  local.get $7
   i32.const 1
   i32.sub
   i32.const 1
@@ -689,29 +687,29 @@
   local.set $4
   loop $while-continue|6
    i32.const 1
-   local.get $3
    local.get $1
+   local.get $8
    i64.sub
-   local.get $1
+   local.get $8
    local.get $11
    i64.add
-   local.tee $7
-   local.get $3
+   local.tee $3
+   local.get $1
    i64.sub
    i64.gt_u
-   local.get $7
    local.get $3
+   local.get $1
    i64.lt_u
    select
    i32.const 0
    local.get $5
-   local.get $1
+   local.get $8
    i64.sub
    local.get $11
    i64.ge_u
    i32.const 0
+   local.get $8
    local.get $1
-   local.get $3
    i64.lt_u
    select
    select
@@ -720,17 +718,17 @@
     i32.const 1
     i32.sub
     local.set $4
-    local.get $1
+    local.get $8
     local.get $11
     i64.add
-    local.set $1
+    local.set $8
     br $while-continue|6
    end
   end
   local.get $0
   local.get $4
   i32.store16
-  local.get $8
+  local.get $7
  )
  (func $~lib/memory/memory.copy (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)

--- a/tests/compiler/number.untouched.wat
+++ b/tests/compiler/number.untouched.wat
@@ -117,6 +117,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   memory.size
   local.set $1
   local.get $1
@@ -147,8 +148,8 @@
    local.get $5
    i32.gt_s
    select
-   local.set $4
-   local.get $4
+   local.set $6
+   local.get $6
    memory.grow
    i32.const 0
    i32.lt_s
@@ -230,6 +231,9 @@
   (local $9 i64)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
   loop $while-continue|0
    local.get $1
    i32.const 10000
@@ -294,30 +298,30 @@
    local.get $1
    i32.const 100
    i32.div_u
-   local.set $3
+   local.set $10
    local.get $1
    i32.const 100
    i32.rem_u
-   local.set $10
-   local.get $3
+   local.set $11
+   local.get $10
    local.set $1
    local.get $2
    i32.const 2
    i32.sub
    local.set $2
    i32.const 36
-   local.get $10
+   local.get $11
    i32.const 2
    i32.shl
    i32.add
    i32.load
-   local.set $11
+   local.set $12
    local.get $0
    local.get $2
    i32.const 1
    i32.shl
    i32.add
-   local.get $11
+   local.get $12
    i32.store
   end
   local.get $1
@@ -334,13 +338,13 @@
    i32.shl
    i32.add
    i32.load
-   local.set $11
+   local.set $13
    local.get $0
    local.get $2
    i32.const 1
    i32.shl
    i32.add
-   local.get $11
+   local.get $13
    i32.store
   else
    local.get $2
@@ -350,13 +354,13 @@
    i32.const 48
    local.get $1
    i32.add
-   local.set $11
+   local.set $14
    local.get $0
    local.get $2
    i32.const 1
    i32.shl
    i32.add
-   local.get $11
+   local.get $14
    i32.store16
   end
  )
@@ -457,6 +461,9 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
   local.get $0
   call $~lib/rt/stub/__retain
   local.set $0
@@ -528,33 +535,33 @@
   end
   loop $while-continue|1
    local.get $4
-   local.tee $7
+   local.tee $8
    i32.const 1
    i32.sub
    local.set $4
-   local.get $7
-   local.set $7
-   local.get $7
+   local.get $8
+   local.set $9
+   local.get $9
    if
     local.get $5
     i32.load16_u
-    local.set $8
+    local.set $10
     local.get $6
     i32.load16_u
-    local.set $9
-    local.get $8
-    local.get $9
+    local.set $11
+    local.get $10
+    local.get $11
     i32.ne
     if
-     local.get $8
-     local.get $9
+     local.get $10
+     local.get $11
      i32.sub
-     local.set $10
+     local.set $12
      local.get $0
      call $~lib/rt/stub/__release
      local.get $2
      call $~lib/rt/stub/__release
-     local.get $10
+     local.get $12
      return
     end
     local.get $5
@@ -569,16 +576,19 @@
    end
   end
   i32.const 0
-  local.set $7
+  local.set $13
   local.get $0
   call $~lib/rt/stub/__release
   local.get $2
   call $~lib/rt/stub/__release
-  local.get $7
+  local.get $13
  )
  (func $~lib/string/String.__eq (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   local.get $0
   call $~lib/rt/stub/__retain
   local.set $0
@@ -610,44 +620,44 @@
   end
   if
    i32.const 0
-   local.set $2
+   local.set $3
    local.get $0
    call $~lib/rt/stub/__release
    local.get $1
    call $~lib/rt/stub/__release
-   local.get $2
+   local.get $3
    return
   end
   local.get $0
   call $~lib/string/String#get:length
-  local.set $3
-  local.get $3
+  local.set $4
+  local.get $4
   local.get $1
   call $~lib/string/String#get:length
   i32.ne
   if
    i32.const 0
-   local.set $2
+   local.set $5
    local.get $0
    call $~lib/rt/stub/__release
    local.get $1
    call $~lib/rt/stub/__release
-   local.get $2
+   local.get $5
    return
   end
   local.get $0
   i32.const 0
   local.get $1
   i32.const 0
-  local.get $3
+  local.get $4
   call $~lib/util/string/compareImpl
   i32.eqz
-  local.set $2
+  local.set $6
   local.get $0
   call $~lib/rt/stub/__release
   local.get $1
   call $~lib/rt/stub/__release
-  local.get $2
+  local.get $6
  )
  (func $~lib/util/number/genDigits (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (param $6 i32) (result i32)
   (local $7 i32)
@@ -662,16 +672,31 @@
   (local $16 i32)
   (local $17 i32)
   (local $18 i32)
-  (local $19 i64)
+  (local $19 i32)
   (local $20 i64)
   (local $21 i64)
   (local $22 i64)
   (local $23 i64)
-  (local $24 i32)
+  (local $24 i64)
   (local $25 i32)
   (local $26 i32)
   (local $27 i32)
-  (local $28 i64)
+  (local $28 i32)
+  (local $29 i32)
+  (local $30 i32)
+  (local $31 i32)
+  (local $32 i64)
+  (local $33 i32)
+  (local $34 i64)
+  (local $35 i64)
+  (local $36 i64)
+  (local $37 i64)
+  (local $38 i32)
+  (local $39 i32)
+  (local $40 i32)
+  (local $41 i32)
+  (local $42 i32)
+  (local $43 i32)
   i32.const 0
   local.get $4
   i32.sub
@@ -875,11 +900,11 @@
     if
      local.get $0
      local.get $15
-     local.tee $18
+     local.tee $19
      i32.const 1
      i32.add
      local.set $15
-     local.get $18
+     local.get $19
      i32.const 1
      i32.shl
      i32.add
@@ -901,8 +926,8 @@
     i64.shl
     local.get $13
     i64.add
-    local.set $19
-    local.get $19
+    local.set $20
+    local.get $20
     local.get $5
     i64.le_u
     if
@@ -911,13 +936,13 @@
      i32.add
      global.set $~lib/util/number/_K
      local.get $0
-     local.set $24
+     local.set $26
      local.get $15
-     local.set $18
+     local.set $25
      local.get $5
+     local.set $24
+     local.get $20
      local.set $23
-     local.get $19
-     local.set $22
      i32.const 1544
      local.get $14
      i32.const 2
@@ -927,71 +952,71 @@
      local.get $7
      i64.extend_i32_s
      i64.shl
-     local.set $21
+     local.set $22
      local.get $10
-     local.set $20
-     local.get $24
-     local.get $18
+     local.set $21
+     local.get $26
+     local.get $25
      i32.const 1
      i32.sub
      i32.const 1
      i32.shl
      i32.add
-     local.set $25
-     local.get $25
+     local.set $27
+     local.get $27
      i32.load16_u
-     local.set $26
+     local.set $28
      loop $while-continue|3
-      local.get $22
-      local.get $20
+      local.get $23
+      local.get $21
       i64.lt_u
       if (result i32)
+       local.get $24
        local.get $23
-       local.get $22
        i64.sub
-       local.get $21
+       local.get $22
        i64.ge_u
       else
        i32.const 0
       end
       if (result i32)
+       local.get $23
        local.get $22
-       local.get $21
        i64.add
-       local.get $20
+       local.get $21
        i64.lt_u
        if (result i32)
         i32.const 1
        else
-        local.get $20
-        local.get $22
-        i64.sub
-        local.get $22
         local.get $21
+        local.get $23
+        i64.sub
+        local.get $23
+        local.get $22
         i64.add
-        local.get $20
+        local.get $21
         i64.sub
         i64.gt_u
        end
       else
        i32.const 0
       end
-      local.set $27
-      local.get $27
+      local.set $30
+      local.get $30
       if
-       local.get $26
+       local.get $28
        i32.const 1
        i32.sub
-       local.set $26
+       local.set $28
+       local.get $23
        local.get $22
-       local.get $21
        i64.add
-       local.set $22
+       local.set $23
        br $while-continue|3
       end
      end
-     local.get $25
-     local.get $26
+     local.get $27
+     local.get $28
      i32.store16
      local.get $15
      return
@@ -1001,8 +1026,8 @@
   end
   loop $while-continue|4
    i32.const 1
-   local.set $16
-   local.get $16
+   local.set $31
+   local.get $31
    if
     local.get $13
     i64.const 10
@@ -1016,8 +1041,8 @@
     local.get $7
     i64.extend_i32_s
     i64.shr_u
-    local.set $23
-    local.get $23
+    local.set $32
+    local.get $32
     local.get $15
     i64.extend_i32_s
     i64.or
@@ -1026,16 +1051,16 @@
     if
      local.get $0
      local.get $15
-     local.tee $26
+     local.tee $33
      i32.const 1
      i32.add
      local.set $15
-     local.get $26
+     local.get $33
      i32.const 1
      i32.shl
      i32.add
      i32.const 48
-     local.get $23
+     local.get $32
      i32.wrap_i64
      i32.const 65535
      i32.and
@@ -1070,79 +1095,79 @@
      i64.mul
      local.set $10
      local.get $0
-     local.set $18
+     local.set $39
      local.get $15
-     local.set $27
+     local.set $38
      local.get $5
-     local.set $28
+     local.set $37
      local.get $13
-     local.set $22
+     local.set $36
      local.get $8
-     local.set $21
+     local.set $35
      local.get $10
-     local.set $20
-     local.get $18
-     local.get $27
+     local.set $34
+     local.get $39
+     local.get $38
      i32.const 1
      i32.sub
      i32.const 1
      i32.shl
      i32.add
-     local.set $26
-     local.get $26
+     local.set $40
+     local.get $40
      i32.load16_u
-     local.set $25
+     local.set $41
      loop $while-continue|6
-      local.get $22
-      local.get $20
+      local.get $36
+      local.get $34
       i64.lt_u
       if (result i32)
-       local.get $28
-       local.get $22
+       local.get $37
+       local.get $36
        i64.sub
-       local.get $21
+       local.get $35
        i64.ge_u
       else
        i32.const 0
       end
       if (result i32)
-       local.get $22
-       local.get $21
+       local.get $36
+       local.get $35
        i64.add
-       local.get $20
+       local.get $34
        i64.lt_u
        if (result i32)
         i32.const 1
        else
-        local.get $20
-        local.get $22
+        local.get $34
+        local.get $36
         i64.sub
-        local.get $22
-        local.get $21
+        local.get $36
+        local.get $35
         i64.add
-        local.get $20
+        local.get $34
         i64.sub
         i64.gt_u
        end
       else
        i32.const 0
       end
-      local.set $24
-      local.get $24
+      local.set $43
+      local.get $43
       if
-       local.get $25
+       local.get $41
        i32.const 1
        i32.sub
-       local.set $25
-       local.get $22
-       local.get $21
+       local.set $41
+       local.get $36
+       local.get $35
        i64.add
-       local.set $22
+       local.set $36
        br $while-continue|6
       end
      end
-     local.get $26
-     local.get $25
+     local.get $40
+     local.get $41
      i32.store16
      local.get $15
      return
@@ -1157,6 +1182,88 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local $22 i32)
+  (local $23 i32)
+  (local $24 i32)
+  (local $25 i32)
+  (local $26 i32)
+  (local $27 i32)
+  (local $28 i32)
+  (local $29 i32)
+  (local $30 i32)
+  (local $31 i32)
+  (local $32 i32)
+  (local $33 i32)
+  (local $34 i32)
+  (local $35 i32)
+  (local $36 i32)
+  (local $37 i32)
+  (local $38 i32)
+  (local $39 i32)
+  (local $40 i32)
+  (local $41 i32)
+  (local $42 i32)
+  (local $43 i32)
+  (local $44 i32)
+  (local $45 i32)
+  (local $46 i32)
+  (local $47 i32)
+  (local $48 i32)
+  (local $49 i32)
+  (local $50 i32)
+  (local $51 i32)
+  (local $52 i32)
+  (local $53 i32)
+  (local $54 i32)
+  (local $55 i32)
+  (local $56 i32)
+  (local $57 i32)
+  (local $58 i32)
+  (local $59 i32)
+  (local $60 i32)
+  (local $61 i32)
+  (local $62 i32)
+  (local $63 i32)
+  (local $64 i32)
+  (local $65 i32)
+  (local $66 i32)
+  (local $67 i32)
+  (local $68 i32)
+  (local $69 i32)
+  (local $70 i32)
+  (local $71 i32)
+  (local $72 i32)
+  (local $73 i32)
+  (local $74 i32)
+  (local $75 i32)
+  (local $76 i32)
+  (local $77 i32)
+  (local $78 i32)
+  (local $79 i32)
+  (local $80 i32)
+  (local $81 i32)
+  (local $82 i32)
+  (local $83 i32)
+  (local $84 i32)
+  (local $85 i32)
+  (local $86 i32)
+  (local $87 i32)
+  (local $88 i32)
   loop $while-continue|0
    local.get $2
    if (result i32)
@@ -1176,11 +1283,11 @@
     local.set $0
     local.get $6
     local.get $1
-    local.tee $6
+    local.tee $7
     i32.const 1
     i32.add
     local.set $1
-    local.get $6
+    local.get $7
     i32.load8_u
     i32.store8
     local.get $2
@@ -1200,8 +1307,8 @@
     local.get $2
     i32.const 16
     i32.ge_u
-    local.set $5
-    local.get $5
+    local.set $8
+    local.get $8
     if
      local.get $0
      local.get $1
@@ -1310,17 +1417,17 @@
    i32.and
    if
     local.get $0
-    local.tee $5
+    local.tee $9
     i32.const 1
     i32.add
     local.set $0
-    local.get $5
+    local.get $9
     local.get $1
-    local.tee $5
+    local.tee $10
     i32.const 1
     i32.add
     local.set $1
-    local.get $5
+    local.get $10
     i32.load8_u
     i32.store8
    end
@@ -1337,16 +1444,16 @@
        local.get $0
        i32.const 3
        i32.and
-       local.set $5
-       local.get $5
+       local.set $11
+       local.get $11
        i32.const 1
        i32.eq
        br_if $case0|2
-       local.get $5
+       local.get $11
        i32.const 2
        i32.eq
        br_if $case1|2
-       local.get $5
+       local.get $11
        i32.const 3
        i32.eq
        br_if $case2|2
@@ -1356,45 +1463,45 @@
       i32.load
       local.set $3
       local.get $0
-      local.tee $5
+      local.tee $12
       i32.const 1
       i32.add
       local.set $0
-      local.get $5
+      local.get $12
       local.get $1
-      local.tee $5
+      local.tee $13
       i32.const 1
       i32.add
       local.set $1
-      local.get $5
+      local.get $13
       i32.load8_u
       i32.store8
       local.get $0
-      local.tee $5
+      local.tee $14
       i32.const 1
       i32.add
       local.set $0
-      local.get $5
+      local.get $14
       local.get $1
-      local.tee $5
+      local.tee $15
       i32.const 1
       i32.add
       local.set $1
-      local.get $5
+      local.get $15
       i32.load8_u
       i32.store8
       local.get $0
-      local.tee $5
+      local.tee $16
       i32.const 1
       i32.add
       local.set $0
-      local.get $5
+      local.get $16
       local.get $1
-      local.tee $5
+      local.tee $17
       i32.const 1
       i32.add
       local.set $1
-      local.get $5
+      local.get $17
       i32.load8_u
       i32.store8
       local.get $2
@@ -1405,8 +1512,8 @@
        local.get $2
        i32.const 17
        i32.ge_u
-       local.set $5
-       local.get $5
+       local.set $18
+       local.get $18
        if
         local.get $1
         i32.const 1
@@ -1491,31 +1598,31 @@
      i32.load
      local.set $3
      local.get $0
-     local.tee $5
+     local.tee $19
      i32.const 1
      i32.add
      local.set $0
-     local.get $5
+     local.get $19
      local.get $1
-     local.tee $5
+     local.tee $20
      i32.const 1
      i32.add
      local.set $1
-     local.get $5
+     local.get $20
      i32.load8_u
      i32.store8
      local.get $0
-     local.tee $5
+     local.tee $21
      i32.const 1
      i32.add
      local.set $0
-     local.get $5
+     local.get $21
      local.get $1
-     local.tee $5
+     local.tee $22
      i32.const 1
      i32.add
      local.set $1
-     local.get $5
+     local.get $22
      i32.load8_u
      i32.store8
      local.get $2
@@ -1526,8 +1633,8 @@
       local.get $2
       i32.const 18
       i32.ge_u
-      local.set $5
-      local.get $5
+      local.set $23
+      local.get $23
       if
        local.get $1
        i32.const 2
@@ -1612,17 +1719,17 @@
     i32.load
     local.set $3
     local.get $0
-    local.tee $5
+    local.tee $24
     i32.const 1
     i32.add
     local.set $0
-    local.get $5
+    local.get $24
     local.get $1
-    local.tee $5
+    local.tee $25
     i32.const 1
     i32.add
     local.set $1
-    local.get $5
+    local.get $25
     i32.load8_u
     i32.store8
     local.get $2
@@ -1633,8 +1740,8 @@
      local.get $2
      i32.const 19
      i32.ge_u
-     local.set $5
-     local.get $5
+     local.set $26
+     local.get $26
      if
       local.get $1
       i32.const 3
@@ -1721,227 +1828,227 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $27
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $27
    local.get $1
-   local.tee $5
+   local.tee $28
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $28
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $29
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $29
    local.get $1
-   local.tee $5
+   local.tee $30
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $30
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $31
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $31
    local.get $1
-   local.tee $5
+   local.tee $32
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $32
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $33
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $33
    local.get $1
-   local.tee $5
+   local.tee $34
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $34
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $35
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $35
    local.get $1
-   local.tee $5
+   local.tee $36
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $36
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $37
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $37
    local.get $1
-   local.tee $5
+   local.tee $38
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $38
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $39
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $39
    local.get $1
-   local.tee $5
+   local.tee $40
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $40
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $41
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $41
    local.get $1
-   local.tee $5
+   local.tee $42
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $42
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $43
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $43
    local.get $1
-   local.tee $5
+   local.tee $44
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $44
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $45
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $45
    local.get $1
-   local.tee $5
+   local.tee $46
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $46
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $47
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $47
    local.get $1
-   local.tee $5
+   local.tee $48
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $48
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $49
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $49
    local.get $1
-   local.tee $5
+   local.tee $50
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $50
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $51
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $51
    local.get $1
-   local.tee $5
+   local.tee $52
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $52
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $53
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $53
    local.get $1
-   local.tee $5
+   local.tee $54
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $54
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $55
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $55
    local.get $1
-   local.tee $5
+   local.tee $56
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $56
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $57
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $57
    local.get $1
-   local.tee $5
+   local.tee $58
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $58
    i32.load8_u
    i32.store8
   end
@@ -1950,115 +2057,115 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $59
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $59
    local.get $1
-   local.tee $5
+   local.tee $60
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $60
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $61
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $61
    local.get $1
-   local.tee $5
+   local.tee $62
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $62
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $63
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $63
    local.get $1
-   local.tee $5
+   local.tee $64
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $64
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $65
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $65
    local.get $1
-   local.tee $5
+   local.tee $66
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $66
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $67
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $67
    local.get $1
-   local.tee $5
+   local.tee $68
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $68
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $69
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $69
    local.get $1
-   local.tee $5
+   local.tee $70
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $70
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $71
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $71
    local.get $1
-   local.tee $5
+   local.tee $72
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $72
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $73
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $73
    local.get $1
-   local.tee $5
+   local.tee $74
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $74
    i32.load8_u
    i32.store8
   end
@@ -2067,59 +2174,59 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $75
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $75
    local.get $1
-   local.tee $5
+   local.tee $76
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $76
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $77
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $77
    local.get $1
-   local.tee $5
+   local.tee $78
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $78
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $79
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $79
    local.get $1
-   local.tee $5
+   local.tee $80
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $80
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $81
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $81
    local.get $1
-   local.tee $5
+   local.tee $82
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $82
    i32.load8_u
    i32.store8
   end
@@ -2128,31 +2235,31 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $83
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $83
    local.get $1
-   local.tee $5
+   local.tee $84
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $84
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $85
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $85
    local.get $1
-   local.tee $5
+   local.tee $86
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $86
    i32.load8_u
    i32.store8
   end
@@ -2161,17 +2268,17 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $87
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $87
    local.get $1
-   local.tee $5
+   local.tee $88
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $88
    i32.load8_u
    i32.store8
   end
@@ -2182,6 +2289,14 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
   block $~lib/util/memory/memmove|inlined.0
    local.get $0
    local.set $5
@@ -2259,11 +2374,11 @@
        local.set $5
        local.get $7
        local.get $4
-       local.tee $7
+       local.tee $8
        i32.const 1
        i32.add
        local.set $4
-       local.get $7
+       local.get $8
        i32.load8_u
        i32.store8
        br $while-continue|0
@@ -2273,8 +2388,8 @@
       local.get $3
       i32.const 8
       i32.ge_u
-      local.set $6
-      local.get $6
+      local.set $9
+      local.get $9
       if
        local.get $5
        local.get $4
@@ -2298,21 +2413,21 @@
     end
     loop $while-continue|2
      local.get $3
-     local.set $6
-     local.get $6
+     local.set $10
+     local.get $10
      if
       local.get $5
-      local.tee $7
+      local.tee $11
       i32.const 1
       i32.add
       local.set $5
-      local.get $7
+      local.get $11
       local.get $4
-      local.tee $7
+      local.tee $12
       i32.const 1
       i32.add
       local.set $4
-      local.get $7
+      local.get $12
       i32.load8_u
       i32.store8
       local.get $3
@@ -2341,8 +2456,8 @@
       i32.add
       i32.const 7
       i32.and
-      local.set $6
-      local.get $6
+      local.set $13
+      local.get $13
       if
        local.get $3
        i32.eqz
@@ -2367,8 +2482,8 @@
       local.get $3
       i32.const 8
       i32.ge_u
-      local.set $6
-      local.get $6
+      local.set $14
+      local.get $14
       if
        local.get $3
        i32.const 8
@@ -2388,8 +2503,8 @@
     end
     loop $while-continue|5
      local.get $3
-     local.set $6
-     local.get $6
+     local.set $15
+     local.get $15
      if
       local.get $5
       local.get $3
@@ -2418,6 +2533,19 @@
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local $22 i32)
+  (local $23 i32)
+  (local $24 i32)
   local.get $2
   i32.eqz
   if
@@ -2507,11 +2635,11 @@
     i32.const 1
     i32.shl
     i32.add
-    local.set $4
-    local.get $4
+    local.set $6
+    local.get $6
     i32.const 2
     i32.add
-    local.get $4
+    local.get $6
     i32.const 0
     local.get $2
     i32.sub
@@ -2544,9 +2672,9 @@
      i32.const 2
      local.get $3
      i32.sub
-     local.set $4
+     local.set $7
      local.get $0
-     local.get $4
+     local.get $7
      i32.const 1
      i32.shl
      i32.add
@@ -2563,30 +2691,30 @@
      i32.or
      i32.store
      i32.const 2
-     local.set $5
+     local.set $8
      loop $for-loop|1
-      local.get $5
-      local.get $4
+      local.get $8
+      local.get $7
       i32.lt_s
-      local.set $6
-      local.get $6
+      local.set $9
+      local.get $9
       if
        local.get $0
-       local.get $5
+       local.get $8
        i32.const 1
        i32.shl
        i32.add
        i32.const 48
        i32.store16
-       local.get $5
+       local.get $8
        i32.const 1
        i32.add
-       local.set $5
+       local.set $8
        br $for-loop|1
       end
      end
      local.get $1
-     local.get $4
+     local.get $7
      i32.add
      return
     else
@@ -2600,48 +2728,48 @@
       local.get $0
       i32.const 4
       i32.add
-      local.set $5
+      local.set $11
       local.get $3
       i32.const 1
       i32.sub
-      local.set $6
-      local.get $6
+      local.set $10
+      local.get $10
       i32.const 0
       i32.lt_s
-      local.set $4
-      local.get $4
+      local.set $12
+      local.get $12
       if
        i32.const 0
-       local.get $6
+       local.get $10
        i32.sub
-       local.set $6
+       local.set $10
       end
-      local.get $6
+      local.get $10
       call $~lib/util/number/decimalCount32
       i32.const 1
       i32.add
-      local.set $7
-      local.get $5
-      local.set $10
-      local.get $6
-      local.set $9
-      local.get $7
-      local.set $8
+      local.set $13
+      local.get $11
+      local.set $16
+      local.get $10
+      local.set $15
+      local.get $13
+      local.set $14
       i32.const 0
       i32.const 1
       i32.ge_s
       drop
-      local.get $10
-      local.get $9
-      local.get $8
+      local.get $16
+      local.get $15
+      local.get $14
       call $~lib/util/number/utoa32_lut
-      local.get $5
+      local.get $11
       i32.const 45
       i32.const 43
-      local.get $4
+      local.get $12
       select
       i32.store16
-      local.get $7
+      local.get $13
       local.set $1
       local.get $1
       i32.const 2
@@ -2651,14 +2779,14 @@
       local.get $1
       i32.const 1
       i32.shl
-      local.set $7
+      local.set $17
       local.get $0
       i32.const 4
       i32.add
       local.get $0
       i32.const 2
       i32.add
-      local.get $7
+      local.get $17
       i32.const 2
       i32.sub
       call $~lib/memory/memory.copy
@@ -2666,58 +2794,58 @@
       i32.const 46
       i32.store16 offset=2
       local.get $0
-      local.get $7
+      local.get $17
       i32.add
       i32.const 101
       i32.store16 offset=2
       local.get $1
       local.get $0
-      local.get $7
+      local.get $17
       i32.add
       i32.const 4
       i32.add
-      local.set $9
+      local.set $19
       local.get $3
       i32.const 1
       i32.sub
-      local.set $8
-      local.get $8
+      local.set $18
+      local.get $18
       i32.const 0
       i32.lt_s
-      local.set $4
-      local.get $4
+      local.set $20
+      local.get $20
       if
        i32.const 0
-       local.get $8
+       local.get $18
        i32.sub
-       local.set $8
+       local.set $18
       end
-      local.get $8
+      local.get $18
       call $~lib/util/number/decimalCount32
       i32.const 1
       i32.add
-      local.set $5
-      local.get $9
-      local.set $11
-      local.get $8
-      local.set $6
-      local.get $5
-      local.set $10
+      local.set $21
+      local.get $19
+      local.set $24
+      local.get $18
+      local.set $23
+      local.get $21
+      local.set $22
       i32.const 0
       i32.const 1
       i32.ge_s
       drop
-      local.get $11
-      local.get $6
-      local.get $10
+      local.get $24
+      local.get $23
+      local.get $22
       call $~lib/util/number/utoa32_lut
-      local.get $9
+      local.get $19
       i32.const 45
       i32.const 43
-      local.get $4
+      local.get $20
       select
       i32.store16
-      local.get $5
+      local.get $21
       i32.add
       local.set $1
       local.get $1
@@ -2748,19 +2876,51 @@
   (local $13 i32)
   (local $14 i32)
   (local $15 i32)
-  (local $16 f64)
-  (local $17 i64)
-  (local $18 i64)
-  (local $19 i64)
-  (local $20 i64)
+  (local $16 i32)
+  (local $17 f64)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
   (local $21 i64)
-  (local $22 i64)
+  (local $22 i32)
   (local $23 i64)
   (local $24 i64)
   (local $25 i64)
-  (local $26 i32)
+  (local $26 i64)
   (local $27 i64)
-  (local $28 i32)
+  (local $28 i64)
+  (local $29 i64)
+  (local $30 i64)
+  (local $31 i64)
+  (local $32 i64)
+  (local $33 i32)
+  (local $34 i32)
+  (local $35 i32)
+  (local $36 i64)
+  (local $37 i64)
+  (local $38 i64)
+  (local $39 i64)
+  (local $40 i64)
+  (local $41 i64)
+  (local $42 i64)
+  (local $43 i64)
+  (local $44 i64)
+  (local $45 i64)
+  (local $46 i32)
+  (local $47 i32)
+  (local $48 i32)
+  (local $49 i64)
+  (local $50 i64)
+  (local $51 i64)
+  (local $52 i64)
+  (local $53 i64)
+  (local $54 i64)
+  (local $55 i64)
+  (local $56 i64)
+  (local $57 i64)
+  (local $58 i64)
+  (local $59 i64)
+  (local $60 i32)
   local.get $1
   f64.const 0
   f64.lt
@@ -2864,47 +3024,47 @@
   local.get $13
   global.set $~lib/util/number/_exp
   global.get $~lib/util/number/_exp
-  local.set $10
+  local.set $16
   i32.const -61
-  local.get $10
+  local.get $16
   i32.sub
   f64.convert_i32_s
   f64.const 0.30102999566398114
   f64.mul
   f64.const 347
   f64.add
-  local.set $16
-  local.get $16
+  local.set $17
+  local.get $17
   i32.trunc_f64_s
-  local.set $15
-  local.get $15
-  local.get $15
+  local.set $18
+  local.get $18
+  local.get $18
   f64.convert_i32_s
-  local.get $16
+  local.get $17
   f64.ne
   i32.add
-  local.set $15
-  local.get $15
+  local.set $18
+  local.get $18
   i32.const 3
   i32.shr_s
   i32.const 1
   i32.add
-  local.set $14
+  local.set $19
   i32.const 348
-  local.get $14
+  local.get $19
   i32.const 3
   i32.shl
   i32.sub
   global.set $~lib/util/number/_K
   i32.const 672
-  local.get $14
+  local.get $19
   i32.const 3
   i32.shl
   i32.add
   i64.load
   global.set $~lib/util/number/_frc_pow
   i32.const 1368
-  local.get $14
+  local.get $19
   i32.const 1
   i32.shl
   i32.add
@@ -2913,249 +3073,249 @@
   local.get $9
   i64.clz
   i32.wrap_i64
-  local.set $14
+  local.set $20
   local.get $9
-  local.get $14
+  local.get $20
   i64.extend_i32_s
   i64.shl
   local.set $9
   local.get $7
-  local.get $14
+  local.get $20
   i32.sub
   local.set $7
   global.get $~lib/util/number/_frc_pow
-  local.set $12
+  local.set $21
   global.get $~lib/util/number/_exp_pow
-  local.set $15
+  local.set $22
   local.get $9
-  local.set $17
-  local.get $12
-  local.set $11
-  local.get $17
-  i64.const 4294967295
-  i64.and
-  local.set $18
-  local.get $11
-  i64.const 4294967295
-  i64.and
-  local.set $19
-  local.get $17
-  i64.const 32
-  i64.shr_u
-  local.set $20
-  local.get $11
-  i64.const 32
-  i64.shr_u
-  local.set $21
-  local.get $18
-  local.get $19
-  i64.mul
-  local.set $22
-  local.get $20
-  local.get $19
-  i64.mul
-  local.get $22
-  i64.const 32
-  i64.shr_u
-  i64.add
-  local.set $23
-  local.get $18
+  local.set $24
   local.get $21
-  i64.mul
+  local.set $23
+  local.get $24
+  i64.const 4294967295
+  i64.and
+  local.set $25
   local.get $23
   i64.const 4294967295
   i64.and
-  i64.add
-  local.set $24
+  local.set $26
   local.get $24
+  i64.const 32
+  i64.shr_u
+  local.set $27
+  local.get $23
+  i64.const 32
+  i64.shr_u
+  local.set $28
+  local.get $25
+  local.get $26
+  i64.mul
+  local.set $29
+  local.get $27
+  local.get $26
+  i64.mul
+  local.get $29
+  i64.const 32
+  i64.shr_u
+  i64.add
+  local.set $30
+  local.get $25
+  local.get $28
+  i64.mul
+  local.get $30
+  i64.const 4294967295
+  i64.and
+  i64.add
+  local.set $31
+  local.get $31
   i64.const 2147483647
   i64.add
-  local.set $24
-  local.get $23
+  local.set $31
+  local.get $30
   i64.const 32
   i64.shr_u
-  local.set $23
-  local.get $24
+  local.set $30
+  local.get $31
   i64.const 32
   i64.shr_u
-  local.set $24
-  local.get $20
-  local.get $21
+  local.set $31
+  local.get $27
+  local.get $28
   i64.mul
-  local.get $23
+  local.get $30
   i64.add
-  local.get $24
+  local.get $31
   i64.add
-  local.set $24
+  local.set $32
   local.get $7
-  local.set $10
-  local.get $15
-  local.set $13
-  local.get $10
-  local.get $13
+  local.set $34
+  local.get $22
+  local.set $33
+  local.get $34
+  local.get $33
   i32.add
   i32.const 64
   i32.add
-  local.set $10
+  local.set $35
   global.get $~lib/util/number/_frc_plus
-  local.set $17
-  local.get $12
-  local.set $11
-  local.get $17
-  i64.const 4294967295
-  i64.and
-  local.set $23
-  local.get $11
-  i64.const 4294967295
-  i64.and
-  local.set $22
-  local.get $17
-  i64.const 32
-  i64.shr_u
-  local.set $21
-  local.get $11
-  i64.const 32
-  i64.shr_u
-  local.set $20
-  local.get $23
-  local.get $22
-  i64.mul
-  local.set $19
+  local.set $37
   local.get $21
-  local.get $22
+  local.set $36
+  local.get $37
+  i64.const 4294967295
+  i64.and
+  local.set $38
+  local.get $36
+  i64.const 4294967295
+  i64.and
+  local.set $39
+  local.get $37
+  i64.const 32
+  i64.shr_u
+  local.set $40
+  local.get $36
+  i64.const 32
+  i64.shr_u
+  local.set $41
+  local.get $38
+  local.get $39
   i64.mul
-  local.get $19
+  local.set $42
+  local.get $40
+  local.get $39
+  i64.mul
+  local.get $42
   i64.const 32
   i64.shr_u
   i64.add
-  local.set $18
-  local.get $23
-  local.get $20
+  local.set $43
+  local.get $38
+  local.get $41
   i64.mul
-  local.get $18
+  local.get $43
   i64.const 4294967295
   i64.and
   i64.add
-  local.set $25
-  local.get $25
+  local.set $44
+  local.get $44
   i64.const 2147483647
   i64.add
-  local.set $25
-  local.get $18
+  local.set $44
+  local.get $43
   i64.const 32
   i64.shr_u
-  local.set $18
-  local.get $25
+  local.set $43
+  local.get $44
   i64.const 32
   i64.shr_u
-  local.set $25
-  local.get $21
-  local.get $20
+  local.set $44
+  local.get $40
+  local.get $41
   i64.mul
-  local.get $18
+  local.get $43
   i64.add
-  local.get $25
+  local.get $44
   i64.add
   i64.const 1
   i64.sub
-  local.set $25
+  local.set $45
   global.get $~lib/util/number/_exp
-  local.set $26
-  local.get $15
-  local.set $13
-  local.get $26
-  local.get $13
+  local.set $47
+  local.get $22
+  local.set $46
+  local.get $47
+  local.get $46
   i32.add
   i32.const 64
   i32.add
-  local.set $26
+  local.set $48
   global.get $~lib/util/number/_frc_minus
-  local.set $17
-  local.get $12
-  local.set $11
-  local.get $17
-  i64.const 4294967295
-  i64.and
-  local.set $18
-  local.get $11
-  i64.const 4294967295
-  i64.and
-  local.set $19
-  local.get $17
-  i64.const 32
-  i64.shr_u
-  local.set $20
-  local.get $11
-  i64.const 32
-  i64.shr_u
-  local.set $21
-  local.get $18
-  local.get $19
-  i64.mul
-  local.set $22
-  local.get $20
-  local.get $19
-  i64.mul
-  local.get $22
-  i64.const 32
-  i64.shr_u
-  i64.add
-  local.set $23
-  local.get $18
+  local.set $50
   local.get $21
+  local.set $49
+  local.get $50
+  i64.const 4294967295
+  i64.and
+  local.set $51
+  local.get $49
+  i64.const 4294967295
+  i64.and
+  local.set $52
+  local.get $50
+  i64.const 32
+  i64.shr_u
+  local.set $53
+  local.get $49
+  i64.const 32
+  i64.shr_u
+  local.set $54
+  local.get $51
+  local.get $52
   i64.mul
-  local.get $23
+  local.set $55
+  local.get $53
+  local.get $52
+  i64.mul
+  local.get $55
+  i64.const 32
+  i64.shr_u
+  i64.add
+  local.set $56
+  local.get $51
+  local.get $54
+  i64.mul
+  local.get $56
   i64.const 4294967295
   i64.and
   i64.add
-  local.set $27
-  local.get $27
+  local.set $57
+  local.get $57
   i64.const 2147483647
   i64.add
-  local.set $27
-  local.get $23
+  local.set $57
+  local.get $56
   i64.const 32
   i64.shr_u
-  local.set $23
-  local.get $27
+  local.set $56
+  local.get $57
   i64.const 32
   i64.shr_u
-  local.set $27
-  local.get $20
-  local.get $21
+  local.set $57
+  local.get $53
+  local.get $54
   i64.mul
-  local.get $23
+  local.get $56
   i64.add
-  local.get $27
+  local.get $57
   i64.add
   i64.const 1
   i64.add
-  local.set $27
-  local.get $25
-  local.get $27
+  local.set $58
+  local.get $45
+  local.get $58
   i64.sub
-  local.set $23
+  local.set $59
   local.get $4
-  local.get $24
-  local.get $10
-  local.get $25
-  local.get $26
-  local.get $23
+  local.get $32
+  local.get $35
+  local.get $45
+  local.get $48
+  local.get $59
   local.get $3
   call $~lib/util/number/genDigits
-  local.set $28
+  local.set $60
   local.get $0
   local.get $2
   i32.const 1
   i32.shl
   i32.add
-  local.get $28
+  local.get $60
   local.get $2
   i32.sub
   global.get $~lib/util/number/_K
   call $~lib/util/number/prettify
-  local.set $28
-  local.get $28
+  local.set $60
+  local.get $60
   local.get $2
   i32.add
  )
@@ -3169,6 +3329,16 @@
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
   local.get $0
   call $~lib/string/String#get:length
   local.set $3
@@ -3180,67 +3350,67 @@
   local.get $5
   i32.gt_s
   select
-  local.tee $4
+  local.tee $6
   local.get $3
-  local.tee $5
-  local.get $4
-  local.get $5
-  i32.lt_s
-  select
-  local.set $6
-  local.get $2
-  local.tee $4
-  i32.const 0
-  local.tee $5
-  local.get $4
-  local.get $5
-  i32.gt_s
-  select
-  local.tee $4
-  local.get $3
-  local.tee $5
-  local.get $4
-  local.get $5
-  i32.lt_s
-  select
-  local.set $7
+  local.tee $7
   local.get $6
-  local.tee $4
   local.get $7
-  local.tee $5
-  local.get $4
-  local.get $5
   i32.lt_s
   select
-  i32.const 1
-  i32.shl
   local.set $8
-  local.get $6
-  local.tee $4
-  local.get $7
-  local.tee $5
-  local.get $4
-  local.get $5
+  local.get $2
+  local.tee $9
+  i32.const 0
+  local.tee $10
+  local.get $9
+  local.get $10
+  i32.gt_s
+  select
+  local.tee $11
+  local.get $3
+  local.tee $12
+  local.get $11
+  local.get $12
+  i32.lt_s
+  select
+  local.set $13
+  local.get $8
+  local.tee $14
+  local.get $13
+  local.tee $15
+  local.get $14
+  local.get $15
+  i32.lt_s
+  select
+  i32.const 1
+  i32.shl
+  local.set $16
+  local.get $8
+  local.tee $17
+  local.get $13
+  local.tee $18
+  local.get $17
+  local.get $18
   i32.gt_s
   select
   i32.const 1
   i32.shl
-  local.set $9
-  local.get $9
-  local.get $8
+  local.set $19
+  local.get $19
+  local.get $16
   i32.sub
-  local.set $10
-  local.get $10
+  local.set $20
+  local.get $20
   i32.eqz
   if
    i32.const 1600
    call $~lib/rt/stub/__retain
    return
   end
-  local.get $8
+  local.get $16
   i32.eqz
   if (result i32)
-   local.get $9
+   local.get $19
    local.get $3
    i32.const 1
    i32.shl
@@ -3253,17 +3423,17 @@
    call $~lib/rt/stub/__retain
    return
   end
-  local.get $10
+  local.get $20
   i32.const 1
   call $~lib/rt/stub/__alloc
-  local.set $11
-  local.get $11
+  local.set $21
+  local.get $21
   local.get $0
-  local.get $8
+  local.get $16
   i32.add
-  local.get $10
+  local.get $20
   call $~lib/memory/memory.copy
-  local.get $11
+  local.get $21
   call $~lib/rt/stub/__retain
  )
  (func $~lib/rt/stub/__free (param $0 i32)
@@ -3461,8 +3631,10 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
-  (local $11 f32)
-  (local $12 f64)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 f32)
+  (local $14 f64)
   global.get $~lib/heap/__heap_base
   i32.const 15
   i32.add
@@ -3617,7 +3789,7 @@
   global.set $number/a
   local.get $9
   call $~lib/number/I32#toString
-  local.tee $9
+  local.tee $10
   i32.const 464
   call $~lib/string/String.__eq
   i32.eqz
@@ -3630,13 +3802,13 @@
    unreachable
   end
   global.get $number/a
-  local.tee $10
+  local.tee $11
   i32.const 1
   i32.sub
   global.set $number/a
-  local.get $10
+  local.get $11
   call $~lib/number/I32#toString
-  local.tee $10
+  local.tee $12
   i32.const 1792
   call $~lib/string/String.__eq
   i32.eqz
@@ -3649,8 +3821,8 @@
    unreachable
   end
   global.get $~lib/number/F32.NaN
-  local.tee $11
-  local.get $11
+  local.tee $13
+  local.get $13
   f32.ne
   drop
   global.get $~lib/builtins/f32.MIN_SAFE_INTEGER
@@ -3918,8 +4090,8 @@
    unreachable
   end
   global.get $~lib/number/F64.NaN
-  local.tee $12
-  local.get $12
+  local.tee $14
+  local.get $14
   f64.ne
   drop
   global.get $~lib/builtins/f64.MIN_SAFE_INTEGER
@@ -4204,9 +4376,9 @@
   call $~lib/rt/stub/__release
   local.get $8
   call $~lib/rt/stub/__release
-  local.get $9
-  call $~lib/rt/stub/__release
   local.get $10
+  call $~lib/rt/stub/__release
+  local.get $12
   call $~lib/rt/stub/__release
  )
  (func $~start

--- a/tests/compiler/object-literal.untouched.wat
+++ b/tests/compiler/object-literal.untouched.wat
@@ -46,6 +46,15 @@
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
   local.get $1
   i32.load
   local.set $2
@@ -182,59 +191,59 @@
   i32.eq
   if
    local.get $0
-   local.set $11
+   local.set $14
    local.get $4
-   local.set $10
+   local.set $13
    local.get $5
-   local.set $9
+   local.set $12
    local.get $7
-   local.set $8
-   local.get $11
-   local.get $10
+   local.set $11
+   local.get $14
+   local.get $13
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $12
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
+   local.get $11
    i32.store offset=96
    local.get $7
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $16
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $15
+    local.get $16
+    local.get $15
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $17
     local.get $0
-    local.set $8
+    local.set $20
     local.get $4
-    local.set $11
-    local.get $9
+    local.set $19
+    local.get $17
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
-    local.set $10
-    local.get $8
-    local.get $11
+    local.tee $17
+    local.set $18
+    local.get $20
+    local.get $19
     i32.const 2
     i32.shl
     i32.add
-    local.get $10
+    local.get $18
     i32.store offset=4
-    local.get $9
+    local.get $17
     i32.eqz
     if
      local.get $0
@@ -264,6 +273,20 @@
   (local $11 i32)
   (local $12 i32)
   (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local $22 i32)
+  (local $23 i32)
+  (local $24 i32)
+  (local $25 i32)
+  (local $26 i32)
+  (local $27 i32)
   i32.const 1
   drop
   local.get $1
@@ -326,8 +349,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $3
+   local.set $6
+   local.get $6
    i32.const 1073741808
    i32.lt_u
    if
@@ -338,16 +361,16 @@
     local.get $2
     i32.const 3
     i32.and
-    local.get $3
+    local.get $6
     i32.or
     local.tee $2
     i32.store
     local.get $1
-    local.set $6
-    local.get $6
+    local.set $7
+    local.get $7
     i32.const 16
     i32.add
-    local.get $6
+    local.get $7
     i32.load
     i32.const 3
     i32.const -1
@@ -365,18 +388,18 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $8
+   local.get $8
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
+   local.set $9
+   local.get $9
    i32.load
-   local.set $3
+   local.set $10
    i32.const 1
    drop
-   local.get $3
+   local.get $10
    i32.const 1
    i32.and
    i32.eqz
@@ -388,7 +411,7 @@
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $3
+   local.get $10
    i32.const 3
    i32.const -1
    i32.xor
@@ -401,23 +424,23 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $7
+   local.set $11
+   local.get $11
    i32.const 1073741808
    i32.lt_u
    if
     local.get $0
-    local.get $6
+    local.get $9
     call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
+    local.get $9
+    local.get $10
     i32.const 3
     i32.and
-    local.get $7
+    local.get $11
     i32.or
     local.tee $2
     i32.store
-    local.get $6
+    local.get $9
     local.set $1
    end
   end
@@ -431,14 +454,14 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $12
   i32.const 1
   drop
-  local.get $8
+  local.get $12
   i32.const 16
   i32.ge_u
   if (result i32)
-   local.get $8
+   local.get $12
    i32.const 1073741808
    i32.lt_u
   else
@@ -458,7 +481,7 @@
   local.get $1
   i32.const 16
   i32.add
-  local.get $8
+  local.get $12
   i32.add
   local.get $4
   i32.eq
@@ -476,24 +499,24 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $12
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $13
+   local.get $12
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $14
   else
    i32.const 31
-   local.get $8
+   local.get $12
    i32.clz
    i32.sub
-   local.set $9
-   local.get $8
-   local.get $9
+   local.set $13
+   local.get $12
+   local.get $13
    i32.const 4
    i32.sub
    i32.shr_u
@@ -501,21 +524,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $14
+   local.get $13
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $13
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $13
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $14
    i32.const 16
    i32.lt_u
   else
@@ -531,86 +554,86 @@
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
-  local.set $6
-  local.get $7
-  local.get $3
+  local.set $17
+  local.get $13
+  local.set $16
+  local.get $14
+  local.set $15
+  local.get $17
+  local.get $16
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $15
   i32.add
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=96
-  local.set $11
+  local.set $18
   local.get $1
   i32.const 0
   i32.store offset=16
   local.get $1
-  local.get $11
+  local.get $18
   i32.store offset=20
-  local.get $11
+  local.get $18
   if
-   local.get $11
+   local.get $18
    local.get $1
    i32.store offset=16
   end
   local.get $0
-  local.set $12
-  local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
+  local.set $22
+  local.get $13
+  local.set $21
+  local.get $14
+  local.set $20
   local.get $1
-  local.set $6
-  local.get $12
-  local.get $7
+  local.set $19
+  local.get $22
+  local.get $21
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $20
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $19
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $13
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.set $13
-  local.get $9
-  local.set $12
+  local.set $27
+  local.get $13
+  local.set $26
   local.get $0
-  local.set $3
-  local.get $9
-  local.set $6
-  local.get $3
-  local.get $6
+  local.set $24
+  local.get $13
+  local.set $23
+  local.get $24
+  local.get $23
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $14
   i32.shl
   i32.or
-  local.set $7
-  local.get $13
-  local.get $12
+  local.set $25
+  local.get $27
+  local.get $26
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $25
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -621,6 +644,7 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
   i32.const 1
   drop
   local.get $1
@@ -760,11 +784,11 @@
   i32.or
   i32.store
   local.get $0
-  local.set $9
+  local.set $10
   local.get $4
-  local.set $3
+  local.set $9
+  local.get $10
   local.get $9
-  local.get $3
   i32.store offset=1568
   local.get $0
   local.get $8
@@ -784,6 +808,12 @@
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
   global.get $~lib/rt/tlsf/ROOT
   local.set $0
   local.get $0
@@ -840,66 +870,66 @@
    local.get $4
    i32.store offset=1568
    i32.const 0
-   local.set $5
+   local.set $6
    loop $for-loop|0
-    local.get $5
+    local.get $6
     i32.const 23
     i32.lt_u
-    local.set $4
-    local.get $4
+    local.set $7
+    local.get $7
     if
      local.get $0
-     local.set $8
-     local.get $5
-     local.set $7
+     local.set $10
+     local.get $6
+     local.set $9
      i32.const 0
-     local.set $6
-     local.get $8
-     local.get $7
+     local.set $8
+     local.get $10
+     local.get $9
      i32.const 2
      i32.shl
      i32.add
-     local.get $6
+     local.get $8
      i32.store offset=4
      i32.const 0
-     local.set $8
+     local.set $11
      loop $for-loop|1
-      local.get $8
+      local.get $11
       i32.const 16
       i32.lt_u
-      local.set $7
-      local.get $7
+      local.set $12
+      local.get $12
       if
        local.get $0
-       local.set $11
-       local.get $5
-       local.set $10
-       local.get $8
-       local.set $9
-       i32.const 0
-       local.set $6
+       local.set $16
+       local.get $6
+       local.set $15
        local.get $11
-       local.get $10
+       local.set $14
+       i32.const 0
+       local.set $13
+       local.get $16
+       local.get $15
        i32.const 4
        i32.shl
-       local.get $9
+       local.get $14
        i32.add
        i32.const 2
        i32.shl
        i32.add
-       local.get $6
+       local.get $13
        i32.store offset=96
-       local.get $8
+       local.get $11
        i32.const 1
        i32.add
-       local.set $8
+       local.set $11
        br $for-loop|1
       end
      end
-     local.get $5
+     local.get $6
      i32.const 1
      i32.add
-     local.set $5
+     local.set $6
      br $for-loop|0
     end
    end
@@ -912,11 +942,11 @@
    i32.const -1
    i32.xor
    i32.and
-   local.set $5
+   local.set $17
    i32.const 0
    drop
    local.get $0
-   local.get $5
+   local.get $17
    memory.size
    i32.const 16
    i32.shl
@@ -965,6 +995,14 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
   local.get $1
   i32.const 256
   i32.lt_u
@@ -1038,11 +1076,11 @@
    unreachable
   end
   local.get $0
-  local.set $5
+  local.set $6
   local.get $2
-  local.set $4
+  local.set $5
+  local.get $6
   local.get $5
-  local.get $4
   i32.const 2
   i32.shl
   i32.add
@@ -1053,10 +1091,10 @@
   local.get $3
   i32.shl
   i32.and
-  local.set $6
-  i32.const 0
   local.set $7
-  local.get $6
+  i32.const 0
+  local.set $8
+  local.get $7
   i32.eqz
   if
    local.get $0
@@ -1069,30 +1107,30 @@
    i32.add
    i32.shl
    i32.and
-   local.set $5
-   local.get $5
+   local.set $9
+   local.get $9
    i32.eqz
    if
     i32.const 0
-    local.set $7
+    local.set $8
    else
-    local.get $5
+    local.get $9
     i32.ctz
     local.set $2
     local.get $0
-    local.set $8
+    local.set $11
     local.get $2
-    local.set $4
-    local.get $8
-    local.get $4
+    local.set $10
+    local.get $11
+    local.get $10
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $6
+    local.set $7
     i32.const 1
     drop
-    local.get $6
+    local.get $7
     i32.eqz
     if
      i32.const 0
@@ -1103,45 +1141,45 @@
      unreachable
     end
     local.get $0
-    local.set $9
+    local.set $14
     local.get $2
-    local.set $8
-    local.get $6
+    local.set $13
+    local.get $7
     i32.ctz
-    local.set $4
-    local.get $9
-    local.get $8
+    local.set $12
+    local.get $14
+    local.get $13
     i32.const 4
     i32.shl
-    local.get $4
+    local.get $12
     i32.add
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=96
-    local.set $7
+    local.set $8
    end
   else
    local.get $0
-   local.set $9
+   local.set $17
    local.get $2
-   local.set $8
-   local.get $6
+   local.set $16
+   local.get $7
    i32.ctz
-   local.set $4
-   local.get $9
-   local.get $8
+   local.set $15
+   local.get $17
+   local.get $16
    i32.const 4
    i32.shl
-   local.get $4
+   local.get $15
    i32.add
    i32.const 2
    i32.shl
    i32.add
    i32.load offset=96
-   local.set $7
+   local.set $8
   end
-  local.get $7
+  local.get $8
  )
  (func $~lib/rt/tlsf/growMemory (param $0 i32) (param $1 i32)
   (local $2 i32)
@@ -1150,6 +1188,7 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
   i32.const 0
   drop
   local.get $1
@@ -1196,15 +1235,15 @@
   i32.shr_u
   local.set $4
   local.get $2
-  local.tee $3
-  local.get $4
   local.tee $5
-  local.get $3
+  local.get $4
+  local.tee $6
   local.get $5
+  local.get $6
   i32.gt_s
   select
-  local.set $6
-  local.get $6
+  local.set $7
+  local.get $7
   memory.grow
   i32.const 0
   i32.lt_s
@@ -1218,12 +1257,12 @@
    end
   end
   memory.size
-  local.set $7
+  local.set $8
   local.get $0
   local.get $2
   i32.const 16
   i32.shl
-  local.get $7
+  local.get $8
   i32.const 16
   i32.shl
   call $~lib/rt/tlsf/addMemory
@@ -1233,6 +1272,8 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
   local.get $1
   i32.load
   local.set $3
@@ -1297,11 +1338,11 @@
    i32.and
    i32.store
    local.get $1
-   local.set $5
-   local.get $5
+   local.set $7
+   local.get $7
    i32.const 16
    i32.add
-   local.get $5
+   local.get $7
    i32.load
    i32.const 3
    i32.const -1
@@ -1309,11 +1350,11 @@
    i32.and
    i32.add
    local.get $1
-   local.set $5
-   local.get $5
+   local.set $6
+   local.get $6
    i32.const 16
    i32.add
-   local.get $5
+   local.get $6
    i32.load
    i32.const 3
    i32.const -1
@@ -1572,6 +1613,9 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $0
@@ -1643,33 +1687,33 @@
   end
   loop $while-continue|1
    local.get $4
-   local.tee $7
+   local.tee $8
    i32.const 1
    i32.sub
    local.set $4
-   local.get $7
-   local.set $7
-   local.get $7
+   local.get $8
+   local.set $9
+   local.get $9
    if
     local.get $5
     i32.load16_u
-    local.set $8
+    local.set $10
     local.get $6
     i32.load16_u
-    local.set $9
-    local.get $8
-    local.get $9
+    local.set $11
+    local.get $10
+    local.get $11
     i32.ne
     if
-     local.get $8
-     local.get $9
+     local.get $10
+     local.get $11
      i32.sub
-     local.set $10
+     local.set $12
      local.get $0
      call $~lib/rt/pure/__release
      local.get $2
      call $~lib/rt/pure/__release
-     local.get $10
+     local.get $12
      return
     end
     local.get $5
@@ -1684,16 +1728,19 @@
    end
   end
   i32.const 0
-  local.set $7
+  local.set $13
   local.get $0
   call $~lib/rt/pure/__release
   local.get $2
   call $~lib/rt/pure/__release
-  local.get $7
+  local.get $13
  )
  (func $~lib/string/String.__eq (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $0
@@ -1725,44 +1772,44 @@
   end
   if
    i32.const 0
-   local.set $2
+   local.set $3
    local.get $0
    call $~lib/rt/pure/__release
    local.get $1
    call $~lib/rt/pure/__release
-   local.get $2
+   local.get $3
    return
   end
   local.get $0
   call $~lib/string/String#get:length
-  local.set $3
-  local.get $3
+  local.set $4
+  local.get $4
   local.get $1
   call $~lib/string/String#get:length
   i32.ne
   if
    i32.const 0
-   local.set $2
+   local.set $5
    local.get $0
    call $~lib/rt/pure/__release
    local.get $1
    call $~lib/rt/pure/__release
-   local.get $2
+   local.get $5
    return
   end
   local.get $0
   i32.const 0
   local.get $1
   i32.const 0
-  local.get $3
+  local.get $4
   call $~lib/util/string/compareImpl
   i32.eqz
-  local.set $2
+  local.set $6
   local.get $0
   call $~lib/rt/pure/__release
   local.get $1
   call $~lib/rt/pure/__release
-  local.get $2
+  local.get $6
  )
  (func $object-literal/testManaged (param $0 i32)
   local.get $0
@@ -1802,6 +1849,88 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local $22 i32)
+  (local $23 i32)
+  (local $24 i32)
+  (local $25 i32)
+  (local $26 i32)
+  (local $27 i32)
+  (local $28 i32)
+  (local $29 i32)
+  (local $30 i32)
+  (local $31 i32)
+  (local $32 i32)
+  (local $33 i32)
+  (local $34 i32)
+  (local $35 i32)
+  (local $36 i32)
+  (local $37 i32)
+  (local $38 i32)
+  (local $39 i32)
+  (local $40 i32)
+  (local $41 i32)
+  (local $42 i32)
+  (local $43 i32)
+  (local $44 i32)
+  (local $45 i32)
+  (local $46 i32)
+  (local $47 i32)
+  (local $48 i32)
+  (local $49 i32)
+  (local $50 i32)
+  (local $51 i32)
+  (local $52 i32)
+  (local $53 i32)
+  (local $54 i32)
+  (local $55 i32)
+  (local $56 i32)
+  (local $57 i32)
+  (local $58 i32)
+  (local $59 i32)
+  (local $60 i32)
+  (local $61 i32)
+  (local $62 i32)
+  (local $63 i32)
+  (local $64 i32)
+  (local $65 i32)
+  (local $66 i32)
+  (local $67 i32)
+  (local $68 i32)
+  (local $69 i32)
+  (local $70 i32)
+  (local $71 i32)
+  (local $72 i32)
+  (local $73 i32)
+  (local $74 i32)
+  (local $75 i32)
+  (local $76 i32)
+  (local $77 i32)
+  (local $78 i32)
+  (local $79 i32)
+  (local $80 i32)
+  (local $81 i32)
+  (local $82 i32)
+  (local $83 i32)
+  (local $84 i32)
+  (local $85 i32)
+  (local $86 i32)
+  (local $87 i32)
+  (local $88 i32)
   loop $while-continue|0
    local.get $2
    if (result i32)
@@ -1821,11 +1950,11 @@
     local.set $0
     local.get $6
     local.get $1
-    local.tee $6
+    local.tee $7
     i32.const 1
     i32.add
     local.set $1
-    local.get $6
+    local.get $7
     i32.load8_u
     i32.store8
     local.get $2
@@ -1845,8 +1974,8 @@
     local.get $2
     i32.const 16
     i32.ge_u
-    local.set $5
-    local.get $5
+    local.set $8
+    local.get $8
     if
      local.get $0
      local.get $1
@@ -1955,17 +2084,17 @@
    i32.and
    if
     local.get $0
-    local.tee $5
+    local.tee $9
     i32.const 1
     i32.add
     local.set $0
-    local.get $5
+    local.get $9
     local.get $1
-    local.tee $5
+    local.tee $10
     i32.const 1
     i32.add
     local.set $1
-    local.get $5
+    local.get $10
     i32.load8_u
     i32.store8
    end
@@ -1982,16 +2111,16 @@
        local.get $0
        i32.const 3
        i32.and
-       local.set $5
-       local.get $5
+       local.set $11
+       local.get $11
        i32.const 1
        i32.eq
        br_if $case0|2
-       local.get $5
+       local.get $11
        i32.const 2
        i32.eq
        br_if $case1|2
-       local.get $5
+       local.get $11
        i32.const 3
        i32.eq
        br_if $case2|2
@@ -2001,45 +2130,45 @@
       i32.load
       local.set $3
       local.get $0
-      local.tee $5
+      local.tee $12
       i32.const 1
       i32.add
       local.set $0
-      local.get $5
+      local.get $12
       local.get $1
-      local.tee $5
+      local.tee $13
       i32.const 1
       i32.add
       local.set $1
-      local.get $5
+      local.get $13
       i32.load8_u
       i32.store8
       local.get $0
-      local.tee $5
+      local.tee $14
       i32.const 1
       i32.add
       local.set $0
-      local.get $5
+      local.get $14
       local.get $1
-      local.tee $5
+      local.tee $15
       i32.const 1
       i32.add
       local.set $1
-      local.get $5
+      local.get $15
       i32.load8_u
       i32.store8
       local.get $0
-      local.tee $5
+      local.tee $16
       i32.const 1
       i32.add
       local.set $0
-      local.get $5
+      local.get $16
       local.get $1
-      local.tee $5
+      local.tee $17
       i32.const 1
       i32.add
       local.set $1
-      local.get $5
+      local.get $17
       i32.load8_u
       i32.store8
       local.get $2
@@ -2050,8 +2179,8 @@
        local.get $2
        i32.const 17
        i32.ge_u
-       local.set $5
-       local.get $5
+       local.set $18
+       local.get $18
        if
         local.get $1
         i32.const 1
@@ -2136,31 +2265,31 @@
      i32.load
      local.set $3
      local.get $0
-     local.tee $5
+     local.tee $19
      i32.const 1
      i32.add
      local.set $0
-     local.get $5
+     local.get $19
      local.get $1
-     local.tee $5
+     local.tee $20
      i32.const 1
      i32.add
      local.set $1
-     local.get $5
+     local.get $20
      i32.load8_u
      i32.store8
      local.get $0
-     local.tee $5
+     local.tee $21
      i32.const 1
      i32.add
      local.set $0
-     local.get $5
+     local.get $21
      local.get $1
-     local.tee $5
+     local.tee $22
      i32.const 1
      i32.add
      local.set $1
-     local.get $5
+     local.get $22
      i32.load8_u
      i32.store8
      local.get $2
@@ -2171,8 +2300,8 @@
       local.get $2
       i32.const 18
       i32.ge_u
-      local.set $5
-      local.get $5
+      local.set $23
+      local.get $23
       if
        local.get $1
        i32.const 2
@@ -2257,17 +2386,17 @@
     i32.load
     local.set $3
     local.get $0
-    local.tee $5
+    local.tee $24
     i32.const 1
     i32.add
     local.set $0
-    local.get $5
+    local.get $24
     local.get $1
-    local.tee $5
+    local.tee $25
     i32.const 1
     i32.add
     local.set $1
-    local.get $5
+    local.get $25
     i32.load8_u
     i32.store8
     local.get $2
@@ -2278,8 +2407,8 @@
      local.get $2
      i32.const 19
      i32.ge_u
-     local.set $5
-     local.get $5
+     local.set $26
+     local.get $26
      if
       local.get $1
       i32.const 3
@@ -2366,227 +2495,227 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $27
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $27
    local.get $1
-   local.tee $5
+   local.tee $28
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $28
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $29
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $29
    local.get $1
-   local.tee $5
+   local.tee $30
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $30
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $31
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $31
    local.get $1
-   local.tee $5
+   local.tee $32
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $32
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $33
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $33
    local.get $1
-   local.tee $5
+   local.tee $34
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $34
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $35
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $35
    local.get $1
-   local.tee $5
+   local.tee $36
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $36
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $37
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $37
    local.get $1
-   local.tee $5
+   local.tee $38
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $38
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $39
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $39
    local.get $1
-   local.tee $5
+   local.tee $40
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $40
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $41
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $41
    local.get $1
-   local.tee $5
+   local.tee $42
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $42
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $43
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $43
    local.get $1
-   local.tee $5
+   local.tee $44
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $44
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $45
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $45
    local.get $1
-   local.tee $5
+   local.tee $46
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $46
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $47
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $47
    local.get $1
-   local.tee $5
+   local.tee $48
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $48
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $49
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $49
    local.get $1
-   local.tee $5
+   local.tee $50
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $50
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $51
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $51
    local.get $1
-   local.tee $5
+   local.tee $52
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $52
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $53
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $53
    local.get $1
-   local.tee $5
+   local.tee $54
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $54
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $55
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $55
    local.get $1
-   local.tee $5
+   local.tee $56
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $56
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $57
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $57
    local.get $1
-   local.tee $5
+   local.tee $58
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $58
    i32.load8_u
    i32.store8
   end
@@ -2595,115 +2724,115 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $59
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $59
    local.get $1
-   local.tee $5
+   local.tee $60
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $60
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $61
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $61
    local.get $1
-   local.tee $5
+   local.tee $62
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $62
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $63
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $63
    local.get $1
-   local.tee $5
+   local.tee $64
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $64
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $65
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $65
    local.get $1
-   local.tee $5
+   local.tee $66
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $66
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $67
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $67
    local.get $1
-   local.tee $5
+   local.tee $68
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $68
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $69
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $69
    local.get $1
-   local.tee $5
+   local.tee $70
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $70
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $71
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $71
    local.get $1
-   local.tee $5
+   local.tee $72
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $72
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $73
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $73
    local.get $1
-   local.tee $5
+   local.tee $74
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $74
    i32.load8_u
    i32.store8
   end
@@ -2712,59 +2841,59 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $75
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $75
    local.get $1
-   local.tee $5
+   local.tee $76
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $76
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $77
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $77
    local.get $1
-   local.tee $5
+   local.tee $78
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $78
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $79
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $79
    local.get $1
-   local.tee $5
+   local.tee $80
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $80
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $81
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $81
    local.get $1
-   local.tee $5
+   local.tee $82
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $82
    i32.load8_u
    i32.store8
   end
@@ -2773,31 +2902,31 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $83
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $83
    local.get $1
-   local.tee $5
+   local.tee $84
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $84
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $85
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $85
    local.get $1
-   local.tee $5
+   local.tee $86
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $86
    i32.load8_u
    i32.store8
   end
@@ -2806,17 +2935,17 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $87
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $87
    local.get $1
-   local.tee $5
+   local.tee $88
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $88
    i32.load8_u
    i32.store8
   end
@@ -2827,6 +2956,14 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
   block $~lib/util/memory/memmove|inlined.0
    local.get $0
    local.set $5
@@ -2904,11 +3041,11 @@
        local.set $5
        local.get $7
        local.get $4
-       local.tee $7
+       local.tee $8
        i32.const 1
        i32.add
        local.set $4
-       local.get $7
+       local.get $8
        i32.load8_u
        i32.store8
        br $while-continue|0
@@ -2918,8 +3055,8 @@
       local.get $3
       i32.const 8
       i32.ge_u
-      local.set $6
-      local.get $6
+      local.set $9
+      local.get $9
       if
        local.get $5
        local.get $4
@@ -2943,21 +3080,21 @@
     end
     loop $while-continue|2
      local.get $3
-     local.set $6
-     local.get $6
+     local.set $10
+     local.get $10
      if
       local.get $5
-      local.tee $7
+      local.tee $11
       i32.const 1
       i32.add
       local.set $5
-      local.get $7
+      local.get $11
       local.get $4
-      local.tee $7
+      local.tee $12
       i32.const 1
       i32.add
       local.set $4
-      local.get $7
+      local.get $12
       i32.load8_u
       i32.store8
       local.get $3
@@ -2986,8 +3123,8 @@
       i32.add
       i32.const 7
       i32.and
-      local.set $6
-      local.get $6
+      local.set $13
+      local.get $13
       if
        local.get $3
        i32.eqz
@@ -3012,8 +3149,8 @@
       local.get $3
       i32.const 8
       i32.ge_u
-      local.set $6
-      local.get $6
+      local.set $14
+      local.get $14
       if
        local.get $3
        i32.const 8
@@ -3033,8 +3170,8 @@
     end
     loop $while-continue|5
      local.get $3
-     local.set $6
-     local.get $6
+     local.set $15
+     local.get $15
      if
       local.get $5
       local.get $3
@@ -3063,6 +3200,16 @@
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
   local.get $0
   call $~lib/string/String#get:length
   local.set $3
@@ -3074,67 +3221,67 @@
   local.get $5
   i32.gt_s
   select
-  local.tee $4
+  local.tee $6
   local.get $3
-  local.tee $5
-  local.get $4
-  local.get $5
-  i32.lt_s
-  select
-  local.set $6
-  local.get $2
-  local.tee $4
-  i32.const 0
-  local.tee $5
-  local.get $4
-  local.get $5
-  i32.gt_s
-  select
-  local.tee $4
-  local.get $3
-  local.tee $5
-  local.get $4
-  local.get $5
-  i32.lt_s
-  select
-  local.set $7
+  local.tee $7
   local.get $6
-  local.tee $4
   local.get $7
-  local.tee $5
-  local.get $4
-  local.get $5
   i32.lt_s
   select
-  i32.const 1
-  i32.shl
   local.set $8
-  local.get $6
-  local.tee $4
-  local.get $7
-  local.tee $5
-  local.get $4
-  local.get $5
+  local.get $2
+  local.tee $9
+  i32.const 0
+  local.tee $10
+  local.get $9
+  local.get $10
+  i32.gt_s
+  select
+  local.tee $11
+  local.get $3
+  local.tee $12
+  local.get $11
+  local.get $12
+  i32.lt_s
+  select
+  local.set $13
+  local.get $8
+  local.tee $14
+  local.get $13
+  local.tee $15
+  local.get $14
+  local.get $15
+  i32.lt_s
+  select
+  i32.const 1
+  i32.shl
+  local.set $16
+  local.get $8
+  local.tee $17
+  local.get $13
+  local.tee $18
+  local.get $17
+  local.get $18
   i32.gt_s
   select
   i32.const 1
   i32.shl
-  local.set $9
-  local.get $9
-  local.get $8
+  local.set $19
+  local.get $19
+  local.get $16
   i32.sub
-  local.set $10
-  local.get $10
+  local.set $20
+  local.get $20
   i32.eqz
   if
    i32.const 304
    call $~lib/rt/pure/__retain
    return
   end
-  local.get $8
+  local.get $16
   i32.eqz
   if (result i32)
-   local.get $9
+   local.get $19
    local.get $3
    i32.const 1
    i32.shl
@@ -3147,17 +3294,17 @@
    call $~lib/rt/pure/__retain
    return
   end
-  local.get $10
+  local.get $20
   i32.const 1
   call $~lib/rt/tlsf/__alloc
-  local.set $11
-  local.get $11
+  local.set $21
+  local.get $21
   local.get $0
-  local.get $8
+  local.get $16
   i32.add
-  local.get $10
+  local.get $20
   call $~lib/memory/memory.copy
-  local.get $11
+  local.get $21
   call $~lib/rt/pure/__retain
  )
  (func $object-literal/Unmanaged#constructor (param $0 i32) (result i32)
@@ -3778,6 +3925,7 @@
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
   i32.const 0
   call $object-literal/Managed#constructor
   local.set $0
@@ -3805,98 +3953,98 @@
   call $object-literal/testUnmanaged
   i32.const 0
   call $object-literal/OmittedTypes#constructor
-  local.set $1
-  local.get $1
-  i32.const 0
-  i32.store
-  local.get $1
-  i32.const 0
-  i32.store offset=4
-  local.get $1
-  i64.const 0
-  i64.store offset=8
-  local.get $1
-  i64.const 0
-  i64.store offset=16
-  local.get $1
-  f32.const 0
-  f32.store offset=24
-  local.get $1
-  f64.const 0
-  f64.store offset=32
-  local.get $1
-  i32.const 0
-  i32.store8 offset=40
-  local.get $1
-  i32.const 0
-  i32.store8 offset=41
-  local.get $1
-  i32.const 0
-  i32.store16 offset=42
-  local.get $1
-  i32.const 0
-  i32.store16 offset=44
-  local.get $1
-  i32.const 0
-  i32.store offset=48
-  local.get $1
-  i32.const 0
-  i32.store offset=52
-  local.get $1
-  f64.const 0
-  f64.store offset=56
-  local.get $1
-  i32.const 0
-  i32.store8 offset=64
-  local.get $1
-  call $object-literal/testOmittedTypes
-  i32.const 0
-  call $object-literal/MixedOmitted#constructor
   local.set $2
   local.get $2
   i32.const 0
   i32.store
   local.get $2
-  i32.const 352
+  i32.const 0
   i32.store offset=4
   local.get $2
-  f64.const 0
-  f64.store offset=8
+  i64.const 0
+  i64.store offset=8
   local.get $2
-  call $object-literal/testMixedOmitted
+  i64.const 0
+  i64.store offset=16
+  local.get $2
+  f32.const 0
+  f32.store offset=24
+  local.get $2
+  f64.const 0
+  f64.store offset=32
+  local.get $2
   i32.const 0
-  call $object-literal/OmittedFoo#constructor
+  i32.store8 offset=40
+  local.get $2
+  i32.const 0
+  i32.store8 offset=41
+  local.get $2
+  i32.const 0
+  i32.store16 offset=42
+  local.get $2
+  i32.const 0
+  i32.store16 offset=44
+  local.get $2
+  i32.const 0
+  i32.store offset=48
+  local.get $2
+  i32.const 0
+  i32.store offset=52
+  local.get $2
+  f64.const 0
+  f64.store offset=56
+  local.get $2
+  i32.const 0
+  i32.store8 offset=64
+  local.get $2
+  call $object-literal/testOmittedTypes
+  i32.const 0
+  call $object-literal/MixedOmitted#constructor
   local.set $3
   local.get $3
   i32.const 0
-  i32.store offset=8
+  i32.store
   local.get $3
+  i32.const 352
+  i32.store offset=4
+  local.get $3
+  f64.const 0
+  f64.store offset=8
+  local.get $3
+  call $object-literal/testMixedOmitted
+  i32.const 0
+  call $object-literal/OmittedFoo#constructor
+  local.set $4
+  local.get $4
+  i32.const 0
+  i32.store offset=8
+  local.get $4
   i32.const 0
   i32.store offset=12
-  local.get $3
+  local.get $4
   i32.const 0
   i32.store offset=16
-  local.get $3
+  local.get $4
   i32.const 0
   i32.store offset=20
-  local.get $3
+  local.get $4
   i32.const 0
   i32.store offset=24
-  local.get $3
+  local.get $4
   i32.const 0
   i32.store offset=28
-  local.get $3
+  local.get $4
   i32.const 0
   i32.store offset=32
-  local.get $3
+  local.get $4
   call $object-literal/testOmittedFoo
   local.get $0
-  call $~lib/rt/pure/__release
-  local.get $1
   call $~lib/rt/pure/__release
   local.get $2
   call $~lib/rt/pure/__release
   local.get $3
+  call $~lib/rt/pure/__release
+  local.get $4
   call $~lib/rt/pure/__release
  )
  (func $~start

--- a/tests/compiler/optional-typeparameters.untouched.wat
+++ b/tests/compiler/optional-typeparameters.untouched.wat
@@ -26,6 +26,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   memory.size
   local.set $1
   local.get $1
@@ -56,8 +57,8 @@
    local.get $5
    i32.gt_s
    select
-   local.set $4
-   local.get $4
+   local.set $6
+   local.get $6
    memory.grow
    i32.const 0
    i32.lt_s

--- a/tests/compiler/overflow.untouched.wat
+++ b/tests/compiler/overflow.untouched.wat
@@ -11,6 +11,19 @@
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
   i32.const 127
   local.set $0
   local.get $0
@@ -77,11 +90,11 @@
    unreachable
   end
   local.get $0
-  local.tee $2
+  local.tee $3
   i32.const 1
   i32.sub
   local.set $0
-  local.get $2
+  local.get $3
   local.set $1
   local.get $0
   i32.const 24
@@ -200,12 +213,12 @@
    unreachable
   end
   i32.const 32767
-  local.set $1
-  local.get $1
+  local.set $4
+  local.get $4
   i32.const 1
   i32.add
-  local.set $1
-  local.get $1
+  local.set $4
+  local.get $4
   i32.const 16
   i32.shl
   i32.const 16
@@ -221,11 +234,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $4
   i32.const 1
   i32.sub
-  local.set $1
-  local.get $1
+  local.set $4
+  local.get $4
   i32.const 16
   i32.shl
   i32.const 16
@@ -241,14 +254,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
-  local.tee $2
+  local.get $4
+  local.tee $6
   i32.const 1
   i32.add
-  local.set $1
-  local.get $2
-  local.set $0
-  local.get $1
+  local.set $4
+  local.get $6
+  local.set $5
+  local.get $4
   i32.const 16
   i32.shl
   i32.const 16
@@ -264,14 +277,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
-  local.tee $2
+  local.get $4
+  local.tee $7
   i32.const 1
   i32.sub
-  local.set $1
-  local.get $2
-  local.set $0
-  local.get $1
+  local.set $4
+  local.get $7
+  local.set $5
+  local.get $4
   i32.const 16
   i32.shl
   i32.const 16
@@ -287,11 +300,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $4
   i32.const 1
   i32.add
-  local.set $1
-  local.get $1
+  local.set $4
+  local.get $4
   i32.const 16
   i32.shl
   i32.const 16
@@ -307,11 +320,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $4
   i32.const 1
   i32.sub
-  local.set $1
-  local.get $1
+  local.set $4
+  local.get $4
   i32.const 16
   i32.shl
   i32.const 16
@@ -327,12 +340,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $4
   i32.const 1
   i32.add
-  local.tee $1
-  local.set $0
-  local.get $1
+  local.tee $4
+  local.set $5
+  local.get $4
   i32.const 16
   i32.shl
   i32.const 16
@@ -348,12 +361,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $4
   i32.const 1
   i32.sub
-  local.tee $1
-  local.set $0
-  local.get $1
+  local.tee $4
+  local.set $5
+  local.get $4
   i32.const 16
   i32.shl
   i32.const 16
@@ -369,7 +382,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $4
   i32.const 1
   i32.add
   i32.const 16
@@ -388,12 +401,12 @@
    unreachable
   end
   i32.const 0
-  local.set $0
-  local.get $0
+  local.set $8
+  local.get $8
   i32.const 1
   i32.sub
-  local.set $0
-  local.get $0
+  local.set $8
+  local.get $8
   i32.const 255
   i32.and
   i32.const 255
@@ -407,11 +420,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $8
   i32.const 1
   i32.add
-  local.set $0
-  local.get $0
+  local.set $8
+  local.get $8
   i32.const 255
   i32.and
   i32.const 0
@@ -425,14 +438,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
-  local.tee $2
+  local.get $8
+  local.tee $10
   i32.const 1
   i32.sub
-  local.set $0
-  local.get $2
-  local.set $1
-  local.get $0
+  local.set $8
+  local.get $10
+  local.set $9
+  local.get $8
   i32.const 255
   i32.and
   i32.const 255
@@ -446,14 +459,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
-  local.tee $2
+  local.get $8
+  local.tee $11
   i32.const 1
   i32.add
-  local.set $0
-  local.get $2
-  local.set $1
-  local.get $0
+  local.set $8
+  local.get $11
+  local.set $9
+  local.get $8
   i32.const 255
   i32.and
   i32.const 0
@@ -467,11 +480,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $8
   i32.const 1
   i32.sub
-  local.set $0
-  local.get $0
+  local.set $8
+  local.get $8
   i32.const 255
   i32.and
   i32.const 255
@@ -485,11 +498,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $8
   i32.const 1
   i32.add
-  local.set $0
-  local.get $0
+  local.set $8
+  local.get $8
   i32.const 255
   i32.and
   i32.const 0
@@ -503,12 +516,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $8
   i32.const 1
   i32.sub
-  local.tee $0
-  local.set $1
-  local.get $0
+  local.tee $8
+  local.set $9
+  local.get $8
   i32.const 255
   i32.and
   i32.const 255
@@ -522,12 +535,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $8
   i32.const 1
   i32.add
-  local.tee $0
-  local.set $1
-  local.get $0
+  local.tee $8
+  local.set $9
+  local.get $8
   i32.const 255
   i32.and
   i32.const 0
@@ -541,7 +554,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $8
   i32.const 1
   i32.sub
   i32.const 255
@@ -558,12 +571,12 @@
    unreachable
   end
   i32.const 0
-  local.set $1
-  local.get $1
+  local.set $12
+  local.get $12
   i32.const 1
   i32.sub
-  local.set $1
-  local.get $1
+  local.set $12
+  local.get $12
   i32.const 65535
   i32.and
   i32.const 65535
@@ -577,11 +590,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $12
   i32.const 1
   i32.add
-  local.set $1
-  local.get $1
+  local.set $12
+  local.get $12
   i32.const 65535
   i32.and
   i32.const 0
@@ -595,14 +608,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
-  local.tee $2
+  local.get $12
+  local.tee $14
   i32.const 1
   i32.sub
-  local.set $1
-  local.get $2
-  local.set $0
-  local.get $1
+  local.set $12
+  local.get $14
+  local.set $13
+  local.get $12
   i32.const 65535
   i32.and
   i32.const 65535
@@ -616,14 +629,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
-  local.tee $2
+  local.get $12
+  local.tee $15
   i32.const 1
   i32.add
-  local.set $1
-  local.get $2
-  local.set $0
-  local.get $1
+  local.set $12
+  local.get $15
+  local.set $13
+  local.get $12
   i32.const 65535
   i32.and
   i32.const 0
@@ -637,11 +650,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $12
   i32.const 1
   i32.sub
-  local.set $1
-  local.get $1
+  local.set $12
+  local.get $12
   i32.const 65535
   i32.and
   i32.const 65535
@@ -655,11 +668,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $12
   i32.const 1
   i32.add
-  local.set $1
-  local.get $1
+  local.set $12
+  local.get $12
   i32.const 65535
   i32.and
   i32.const 0
@@ -673,12 +686,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $12
   i32.const 1
   i32.sub
-  local.tee $1
-  local.set $0
-  local.get $1
+  local.tee $12
+  local.set $13
+  local.get $12
   i32.const 65535
   i32.and
   i32.const 65535
@@ -692,12 +705,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $12
   i32.const 1
   i32.add
-  local.tee $1
-  local.set $0
-  local.get $1
+  local.tee $12
+  local.set $13
+  local.get $12
   i32.const 65535
   i32.and
   i32.const 0
@@ -711,7 +724,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $12
   i32.const 1
   i32.sub
   i32.const 65535

--- a/tests/compiler/rc/global-init.untouched.wat
+++ b/tests/compiler/rc/global-init.untouched.wat
@@ -102,6 +102,8 @@
  (func $start:rc/global-init
   (local $0 i32)
   (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
   call $rc/global-init/getRef
   global.set $rc/global-init/a
   call $rc/global-init/getRef
@@ -121,18 +123,18 @@
   local.get $0
   global.set $rc/global-init/a
   i32.const 0
-  local.tee $1
+  local.tee $2
   global.get $rc/global-init/b
-  local.tee $0
+  local.tee $3
   i32.ne
   if
-   local.get $1
+   local.get $2
    call $~lib/rt/pure/__retain
-   local.set $1
-   local.get $0
+   local.set $2
+   local.get $3
    call $~lib/rt/pure/__release
   end
-  local.get $1
+  local.get $2
   global.set $rc/global-init/b
  )
  (func $~start
@@ -149,6 +151,15 @@
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
   local.get $1
   i32.load
   local.set $2
@@ -285,59 +296,59 @@
   i32.eq
   if
    local.get $0
-   local.set $11
+   local.set $14
    local.get $4
-   local.set $10
+   local.set $13
    local.get $5
-   local.set $9
+   local.set $12
    local.get $7
-   local.set $8
-   local.get $11
-   local.get $10
+   local.set $11
+   local.get $14
+   local.get $13
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $12
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
+   local.get $11
    i32.store offset=96
    local.get $7
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $16
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $15
+    local.get $16
+    local.get $15
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $17
     local.get $0
-    local.set $8
+    local.set $20
     local.get $4
-    local.set $11
-    local.get $9
+    local.set $19
+    local.get $17
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
-    local.set $10
-    local.get $8
-    local.get $11
+    local.tee $17
+    local.set $18
+    local.get $20
+    local.get $19
     i32.const 2
     i32.shl
     i32.add
-    local.get $10
+    local.get $18
     i32.store offset=4
-    local.get $9
+    local.get $17
     i32.eqz
     if
      local.get $0
@@ -367,6 +378,20 @@
   (local $11 i32)
   (local $12 i32)
   (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local $22 i32)
+  (local $23 i32)
+  (local $24 i32)
+  (local $25 i32)
+  (local $26 i32)
+  (local $27 i32)
   i32.const 1
   drop
   local.get $1
@@ -429,8 +454,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $3
+   local.set $6
+   local.get $6
    i32.const 1073741808
    i32.lt_u
    if
@@ -441,16 +466,16 @@
     local.get $2
     i32.const 3
     i32.and
-    local.get $3
+    local.get $6
     i32.or
     local.tee $2
     i32.store
     local.get $1
-    local.set $6
-    local.get $6
+    local.set $7
+    local.get $7
     i32.const 16
     i32.add
-    local.get $6
+    local.get $7
     i32.load
     i32.const 3
     i32.const -1
@@ -468,18 +493,18 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $8
+   local.get $8
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
+   local.set $9
+   local.get $9
    i32.load
-   local.set $3
+   local.set $10
    i32.const 1
    drop
-   local.get $3
+   local.get $10
    i32.const 1
    i32.and
    i32.eqz
@@ -491,7 +516,7 @@
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $3
+   local.get $10
    i32.const 3
    i32.const -1
    i32.xor
@@ -504,23 +529,23 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $7
+   local.set $11
+   local.get $11
    i32.const 1073741808
    i32.lt_u
    if
     local.get $0
-    local.get $6
+    local.get $9
     call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
+    local.get $9
+    local.get $10
     i32.const 3
     i32.and
-    local.get $7
+    local.get $11
     i32.or
     local.tee $2
     i32.store
-    local.get $6
+    local.get $9
     local.set $1
    end
   end
@@ -534,14 +559,14 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $12
   i32.const 1
   drop
-  local.get $8
+  local.get $12
   i32.const 16
   i32.ge_u
   if (result i32)
-   local.get $8
+   local.get $12
    i32.const 1073741808
    i32.lt_u
   else
@@ -561,7 +586,7 @@
   local.get $1
   i32.const 16
   i32.add
-  local.get $8
+  local.get $12
   i32.add
   local.get $4
   i32.eq
@@ -579,24 +604,24 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $12
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $13
+   local.get $12
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $14
   else
    i32.const 31
-   local.get $8
+   local.get $12
    i32.clz
    i32.sub
-   local.set $9
-   local.get $8
-   local.get $9
+   local.set $13
+   local.get $12
+   local.get $13
    i32.const 4
    i32.sub
    i32.shr_u
@@ -604,21 +629,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $14
+   local.get $13
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $13
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $13
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $14
    i32.const 16
    i32.lt_u
   else
@@ -634,86 +659,86 @@
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
-  local.set $6
-  local.get $7
-  local.get $3
+  local.set $17
+  local.get $13
+  local.set $16
+  local.get $14
+  local.set $15
+  local.get $17
+  local.get $16
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $15
   i32.add
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=96
-  local.set $11
+  local.set $18
   local.get $1
   i32.const 0
   i32.store offset=16
   local.get $1
-  local.get $11
+  local.get $18
   i32.store offset=20
-  local.get $11
+  local.get $18
   if
-   local.get $11
+   local.get $18
    local.get $1
    i32.store offset=16
   end
   local.get $0
-  local.set $12
-  local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
+  local.set $22
+  local.get $13
+  local.set $21
+  local.get $14
+  local.set $20
   local.get $1
-  local.set $6
-  local.get $12
-  local.get $7
+  local.set $19
+  local.get $22
+  local.get $21
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $20
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $19
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $13
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.set $13
-  local.get $9
-  local.set $12
+  local.set $27
+  local.get $13
+  local.set $26
   local.get $0
-  local.set $3
-  local.get $9
-  local.set $6
-  local.get $3
-  local.get $6
+  local.set $24
+  local.get $13
+  local.set $23
+  local.get $24
+  local.get $23
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $14
   i32.shl
   i32.or
-  local.set $7
-  local.get $13
-  local.get $12
+  local.set $25
+  local.get $27
+  local.get $26
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $25
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/freeBlock (param $0 i32) (param $1 i32)

--- a/tests/compiler/rc/local-init.untouched.wat
+++ b/tests/compiler/rc/local-init.untouched.wat
@@ -51,6 +51,15 @@
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
   local.get $1
   i32.load
   local.set $2
@@ -187,59 +196,59 @@
   i32.eq
   if
    local.get $0
-   local.set $11
+   local.set $14
    local.get $4
-   local.set $10
+   local.set $13
    local.get $5
-   local.set $9
+   local.set $12
    local.get $7
-   local.set $8
-   local.get $11
-   local.get $10
+   local.set $11
+   local.get $14
+   local.get $13
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $12
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
+   local.get $11
    i32.store offset=96
    local.get $7
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $16
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $15
+    local.get $16
+    local.get $15
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $17
     local.get $0
-    local.set $8
+    local.set $20
     local.get $4
-    local.set $11
-    local.get $9
+    local.set $19
+    local.get $17
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
-    local.set $10
-    local.get $8
-    local.get $11
+    local.tee $17
+    local.set $18
+    local.get $20
+    local.get $19
     i32.const 2
     i32.shl
     i32.add
-    local.get $10
+    local.get $18
     i32.store offset=4
-    local.get $9
+    local.get $17
     i32.eqz
     if
      local.get $0
@@ -269,6 +278,20 @@
   (local $11 i32)
   (local $12 i32)
   (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local $22 i32)
+  (local $23 i32)
+  (local $24 i32)
+  (local $25 i32)
+  (local $26 i32)
+  (local $27 i32)
   i32.const 1
   drop
   local.get $1
@@ -331,8 +354,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $3
+   local.set $6
+   local.get $6
    i32.const 1073741808
    i32.lt_u
    if
@@ -343,16 +366,16 @@
     local.get $2
     i32.const 3
     i32.and
-    local.get $3
+    local.get $6
     i32.or
     local.tee $2
     i32.store
     local.get $1
-    local.set $6
-    local.get $6
+    local.set $7
+    local.get $7
     i32.const 16
     i32.add
-    local.get $6
+    local.get $7
     i32.load
     i32.const 3
     i32.const -1
@@ -370,18 +393,18 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $8
+   local.get $8
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
+   local.set $9
+   local.get $9
    i32.load
-   local.set $3
+   local.set $10
    i32.const 1
    drop
-   local.get $3
+   local.get $10
    i32.const 1
    i32.and
    i32.eqz
@@ -393,7 +416,7 @@
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $3
+   local.get $10
    i32.const 3
    i32.const -1
    i32.xor
@@ -406,23 +429,23 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $7
+   local.set $11
+   local.get $11
    i32.const 1073741808
    i32.lt_u
    if
     local.get $0
-    local.get $6
+    local.get $9
     call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
+    local.get $9
+    local.get $10
     i32.const 3
     i32.and
-    local.get $7
+    local.get $11
     i32.or
     local.tee $2
     i32.store
-    local.get $6
+    local.get $9
     local.set $1
    end
   end
@@ -436,14 +459,14 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $12
   i32.const 1
   drop
-  local.get $8
+  local.get $12
   i32.const 16
   i32.ge_u
   if (result i32)
-   local.get $8
+   local.get $12
    i32.const 1073741808
    i32.lt_u
   else
@@ -463,7 +486,7 @@
   local.get $1
   i32.const 16
   i32.add
-  local.get $8
+  local.get $12
   i32.add
   local.get $4
   i32.eq
@@ -481,24 +504,24 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $12
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $13
+   local.get $12
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $14
   else
    i32.const 31
-   local.get $8
+   local.get $12
    i32.clz
    i32.sub
-   local.set $9
-   local.get $8
-   local.get $9
+   local.set $13
+   local.get $12
+   local.get $13
    i32.const 4
    i32.sub
    i32.shr_u
@@ -506,21 +529,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $14
+   local.get $13
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $13
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $13
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $14
    i32.const 16
    i32.lt_u
   else
@@ -536,86 +559,86 @@
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
-  local.set $6
-  local.get $7
-  local.get $3
+  local.set $17
+  local.get $13
+  local.set $16
+  local.get $14
+  local.set $15
+  local.get $17
+  local.get $16
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $15
   i32.add
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=96
-  local.set $11
+  local.set $18
   local.get $1
   i32.const 0
   i32.store offset=16
   local.get $1
-  local.get $11
+  local.get $18
   i32.store offset=20
-  local.get $11
+  local.get $18
   if
-   local.get $11
+   local.get $18
    local.get $1
    i32.store offset=16
   end
   local.get $0
-  local.set $12
-  local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
+  local.set $22
+  local.get $13
+  local.set $21
+  local.get $14
+  local.set $20
   local.get $1
-  local.set $6
-  local.get $12
-  local.get $7
+  local.set $19
+  local.get $22
+  local.get $21
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $20
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $19
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $13
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.set $13
-  local.get $9
-  local.set $12
+  local.set $27
+  local.get $13
+  local.set $26
   local.get $0
-  local.set $3
-  local.get $9
-  local.set $6
-  local.get $3
-  local.get $6
+  local.set $24
+  local.get $13
+  local.set $23
+  local.get $24
+  local.get $23
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $14
   i32.shl
   i32.or
-  local.set $7
-  local.get $13
-  local.get $12
+  local.set $25
+  local.get $27
+  local.get $26
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $25
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -626,6 +649,7 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
   i32.const 1
   drop
   local.get $1
@@ -765,11 +789,11 @@
   i32.or
   i32.store
   local.get $0
-  local.set $9
+  local.set $10
   local.get $4
-  local.set $3
+  local.set $9
+  local.get $10
   local.get $9
-  local.get $3
   i32.store offset=1568
   local.get $0
   local.get $8
@@ -789,6 +813,12 @@
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
   global.get $~lib/rt/tlsf/ROOT
   local.set $0
   local.get $0
@@ -845,66 +875,66 @@
    local.get $4
    i32.store offset=1568
    i32.const 0
-   local.set $5
+   local.set $6
    loop $for-loop|0
-    local.get $5
+    local.get $6
     i32.const 23
     i32.lt_u
-    local.set $4
-    local.get $4
+    local.set $7
+    local.get $7
     if
      local.get $0
-     local.set $8
-     local.get $5
-     local.set $7
+     local.set $10
+     local.get $6
+     local.set $9
      i32.const 0
-     local.set $6
-     local.get $8
-     local.get $7
+     local.set $8
+     local.get $10
+     local.get $9
      i32.const 2
      i32.shl
      i32.add
-     local.get $6
+     local.get $8
      i32.store offset=4
      i32.const 0
-     local.set $8
+     local.set $11
      loop $for-loop|1
-      local.get $8
+      local.get $11
       i32.const 16
       i32.lt_u
-      local.set $7
-      local.get $7
+      local.set $12
+      local.get $12
       if
        local.get $0
-       local.set $11
-       local.get $5
-       local.set $10
-       local.get $8
-       local.set $9
-       i32.const 0
-       local.set $6
+       local.set $16
+       local.get $6
+       local.set $15
        local.get $11
-       local.get $10
+       local.set $14
+       i32.const 0
+       local.set $13
+       local.get $16
+       local.get $15
        i32.const 4
        i32.shl
-       local.get $9
+       local.get $14
        i32.add
        i32.const 2
        i32.shl
        i32.add
-       local.get $6
+       local.get $13
        i32.store offset=96
-       local.get $8
+       local.get $11
        i32.const 1
        i32.add
-       local.set $8
+       local.set $11
        br $for-loop|1
       end
      end
-     local.get $5
+     local.get $6
      i32.const 1
      i32.add
-     local.set $5
+     local.set $6
      br $for-loop|0
     end
    end
@@ -917,11 +947,11 @@
    i32.const -1
    i32.xor
    i32.and
-   local.set $5
+   local.set $17
    i32.const 0
    drop
    local.get $0
-   local.get $5
+   local.get $17
    memory.size
    i32.const 16
    i32.shl
@@ -970,6 +1000,14 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
   local.get $1
   i32.const 256
   i32.lt_u
@@ -1043,11 +1081,11 @@
    unreachable
   end
   local.get $0
-  local.set $5
+  local.set $6
   local.get $2
-  local.set $4
+  local.set $5
+  local.get $6
   local.get $5
-  local.get $4
   i32.const 2
   i32.shl
   i32.add
@@ -1058,10 +1096,10 @@
   local.get $3
   i32.shl
   i32.and
-  local.set $6
-  i32.const 0
   local.set $7
-  local.get $6
+  i32.const 0
+  local.set $8
+  local.get $7
   i32.eqz
   if
    local.get $0
@@ -1074,30 +1112,30 @@
    i32.add
    i32.shl
    i32.and
-   local.set $5
-   local.get $5
+   local.set $9
+   local.get $9
    i32.eqz
    if
     i32.const 0
-    local.set $7
+    local.set $8
    else
-    local.get $5
+    local.get $9
     i32.ctz
     local.set $2
     local.get $0
-    local.set $8
+    local.set $11
     local.get $2
-    local.set $4
-    local.get $8
-    local.get $4
+    local.set $10
+    local.get $11
+    local.get $10
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $6
+    local.set $7
     i32.const 1
     drop
-    local.get $6
+    local.get $7
     i32.eqz
     if
      i32.const 0
@@ -1108,45 +1146,45 @@
      unreachable
     end
     local.get $0
-    local.set $9
+    local.set $14
     local.get $2
-    local.set $8
-    local.get $6
+    local.set $13
+    local.get $7
     i32.ctz
-    local.set $4
-    local.get $9
-    local.get $8
+    local.set $12
+    local.get $14
+    local.get $13
     i32.const 4
     i32.shl
-    local.get $4
+    local.get $12
     i32.add
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=96
-    local.set $7
+    local.set $8
    end
   else
    local.get $0
-   local.set $9
+   local.set $17
    local.get $2
-   local.set $8
-   local.get $6
+   local.set $16
+   local.get $7
    i32.ctz
-   local.set $4
-   local.get $9
-   local.get $8
+   local.set $15
+   local.get $17
+   local.get $16
    i32.const 4
    i32.shl
-   local.get $4
+   local.get $15
    i32.add
    i32.const 2
    i32.shl
    i32.add
    i32.load offset=96
-   local.set $7
+   local.set $8
   end
-  local.get $7
+  local.get $8
  )
  (func $~lib/rt/tlsf/growMemory (param $0 i32) (param $1 i32)
   (local $2 i32)
@@ -1155,6 +1193,7 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
   i32.const 0
   drop
   local.get $1
@@ -1201,15 +1240,15 @@
   i32.shr_u
   local.set $4
   local.get $2
-  local.tee $3
-  local.get $4
   local.tee $5
-  local.get $3
+  local.get $4
+  local.tee $6
   local.get $5
+  local.get $6
   i32.gt_s
   select
-  local.set $6
-  local.get $6
+  local.set $7
+  local.get $7
   memory.grow
   i32.const 0
   i32.lt_s
@@ -1223,12 +1262,12 @@
    end
   end
   memory.size
-  local.set $7
+  local.set $8
   local.get $0
   local.get $2
   i32.const 16
   i32.shl
-  local.get $7
+  local.get $8
   i32.const 16
   i32.shl
   call $~lib/rt/tlsf/addMemory
@@ -1238,6 +1277,8 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
   local.get $1
   i32.load
   local.set $3
@@ -1302,11 +1343,11 @@
    i32.and
    i32.store
    local.get $1
-   local.set $5
-   local.get $5
+   local.set $7
+   local.get $7
    i32.const 16
    i32.add
-   local.get $5
+   local.get $7
    i32.load
    i32.const 3
    i32.const -1
@@ -1314,11 +1355,11 @@
    i32.and
    i32.add
    local.get $1
-   local.set $5
-   local.get $5
+   local.set $6
+   local.get $6
    i32.const 16
    i32.add
-   local.get $5
+   local.get $6
    i32.load
    i32.const 3
    i32.const -1
@@ -1547,18 +1588,20 @@
  )
  (func $start:rc/local-init
   (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
   i32.const 32
   local.set $0
   local.get $0
   call $~lib/rt/pure/__release
   call $rc/local-init/getRef
-  local.set $0
-  local.get $0
+  local.set $1
+  local.get $1
   call $~lib/rt/pure/__release
   i32.const 0
   call $rc/local-init/Ref#constructor
-  local.set $0
-  local.get $0
+  local.set $2
+  local.get $2
   call $~lib/rt/pure/__release
  )
  (func $~start

--- a/tests/compiler/rc/logical-and-mismatch.untouched.wat
+++ b/tests/compiler/rc/logical-and-mismatch.untouched.wat
@@ -37,6 +37,15 @@
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
   local.get $1
   i32.load
   local.set $2
@@ -173,59 +182,59 @@
   i32.eq
   if
    local.get $0
-   local.set $11
+   local.set $14
    local.get $4
-   local.set $10
+   local.set $13
    local.get $5
-   local.set $9
+   local.set $12
    local.get $7
-   local.set $8
-   local.get $11
-   local.get $10
+   local.set $11
+   local.get $14
+   local.get $13
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $12
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
+   local.get $11
    i32.store offset=96
    local.get $7
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $16
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $15
+    local.get $16
+    local.get $15
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $17
     local.get $0
-    local.set $8
+    local.set $20
     local.get $4
-    local.set $11
-    local.get $9
+    local.set $19
+    local.get $17
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
-    local.set $10
-    local.get $8
-    local.get $11
+    local.tee $17
+    local.set $18
+    local.get $20
+    local.get $19
     i32.const 2
     i32.shl
     i32.add
-    local.get $10
+    local.get $18
     i32.store offset=4
-    local.get $9
+    local.get $17
     i32.eqz
     if
      local.get $0
@@ -255,6 +264,20 @@
   (local $11 i32)
   (local $12 i32)
   (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local $22 i32)
+  (local $23 i32)
+  (local $24 i32)
+  (local $25 i32)
+  (local $26 i32)
+  (local $27 i32)
   i32.const 1
   drop
   local.get $1
@@ -317,8 +340,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $3
+   local.set $6
+   local.get $6
    i32.const 1073741808
    i32.lt_u
    if
@@ -329,16 +352,16 @@
     local.get $2
     i32.const 3
     i32.and
-    local.get $3
+    local.get $6
     i32.or
     local.tee $2
     i32.store
     local.get $1
-    local.set $6
-    local.get $6
+    local.set $7
+    local.get $7
     i32.const 16
     i32.add
-    local.get $6
+    local.get $7
     i32.load
     i32.const 3
     i32.const -1
@@ -356,18 +379,18 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $8
+   local.get $8
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
+   local.set $9
+   local.get $9
    i32.load
-   local.set $3
+   local.set $10
    i32.const 1
    drop
-   local.get $3
+   local.get $10
    i32.const 1
    i32.and
    i32.eqz
@@ -379,7 +402,7 @@
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $3
+   local.get $10
    i32.const 3
    i32.const -1
    i32.xor
@@ -392,23 +415,23 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $7
+   local.set $11
+   local.get $11
    i32.const 1073741808
    i32.lt_u
    if
     local.get $0
-    local.get $6
+    local.get $9
     call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
+    local.get $9
+    local.get $10
     i32.const 3
     i32.and
-    local.get $7
+    local.get $11
     i32.or
     local.tee $2
     i32.store
-    local.get $6
+    local.get $9
     local.set $1
    end
   end
@@ -422,14 +445,14 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $12
   i32.const 1
   drop
-  local.get $8
+  local.get $12
   i32.const 16
   i32.ge_u
   if (result i32)
-   local.get $8
+   local.get $12
    i32.const 1073741808
    i32.lt_u
   else
@@ -449,7 +472,7 @@
   local.get $1
   i32.const 16
   i32.add
-  local.get $8
+  local.get $12
   i32.add
   local.get $4
   i32.eq
@@ -467,24 +490,24 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $12
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $13
+   local.get $12
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $14
   else
    i32.const 31
-   local.get $8
+   local.get $12
    i32.clz
    i32.sub
-   local.set $9
-   local.get $8
-   local.get $9
+   local.set $13
+   local.get $12
+   local.get $13
    i32.const 4
    i32.sub
    i32.shr_u
@@ -492,21 +515,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $14
+   local.get $13
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $13
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $13
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $14
    i32.const 16
    i32.lt_u
   else
@@ -522,86 +545,86 @@
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
-  local.set $6
-  local.get $7
-  local.get $3
+  local.set $17
+  local.get $13
+  local.set $16
+  local.get $14
+  local.set $15
+  local.get $17
+  local.get $16
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $15
   i32.add
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=96
-  local.set $11
+  local.set $18
   local.get $1
   i32.const 0
   i32.store offset=16
   local.get $1
-  local.get $11
+  local.get $18
   i32.store offset=20
-  local.get $11
+  local.get $18
   if
-   local.get $11
+   local.get $18
    local.get $1
    i32.store offset=16
   end
   local.get $0
-  local.set $12
-  local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
+  local.set $22
+  local.get $13
+  local.set $21
+  local.get $14
+  local.set $20
   local.get $1
-  local.set $6
-  local.get $12
-  local.get $7
+  local.set $19
+  local.get $22
+  local.get $21
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $20
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $19
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $13
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.set $13
-  local.get $9
-  local.set $12
+  local.set $27
+  local.get $13
+  local.set $26
   local.get $0
-  local.set $3
-  local.get $9
-  local.set $6
-  local.get $3
-  local.get $6
+  local.set $24
+  local.get $13
+  local.set $23
+  local.get $24
+  local.get $23
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $14
   i32.shl
   i32.or
-  local.set $7
-  local.get $13
-  local.get $12
+  local.set $25
+  local.get $27
+  local.get $26
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $25
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -612,6 +635,7 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
   i32.const 1
   drop
   local.get $1
@@ -751,11 +775,11 @@
   i32.or
   i32.store
   local.get $0
-  local.set $9
+  local.set $10
   local.get $4
-  local.set $3
+  local.set $9
+  local.get $10
   local.get $9
-  local.get $3
   i32.store offset=1568
   local.get $0
   local.get $8
@@ -775,6 +799,12 @@
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
   global.get $~lib/rt/tlsf/ROOT
   local.set $0
   local.get $0
@@ -831,66 +861,66 @@
    local.get $4
    i32.store offset=1568
    i32.const 0
-   local.set $5
+   local.set $6
    loop $for-loop|0
-    local.get $5
+    local.get $6
     i32.const 23
     i32.lt_u
-    local.set $4
-    local.get $4
+    local.set $7
+    local.get $7
     if
      local.get $0
-     local.set $8
-     local.get $5
-     local.set $7
+     local.set $10
+     local.get $6
+     local.set $9
      i32.const 0
-     local.set $6
-     local.get $8
-     local.get $7
+     local.set $8
+     local.get $10
+     local.get $9
      i32.const 2
      i32.shl
      i32.add
-     local.get $6
+     local.get $8
      i32.store offset=4
      i32.const 0
-     local.set $8
+     local.set $11
      loop $for-loop|1
-      local.get $8
+      local.get $11
       i32.const 16
       i32.lt_u
-      local.set $7
-      local.get $7
+      local.set $12
+      local.get $12
       if
        local.get $0
-       local.set $11
-       local.get $5
-       local.set $10
-       local.get $8
-       local.set $9
-       i32.const 0
-       local.set $6
+       local.set $16
+       local.get $6
+       local.set $15
        local.get $11
-       local.get $10
+       local.set $14
+       i32.const 0
+       local.set $13
+       local.get $16
+       local.get $15
        i32.const 4
        i32.shl
-       local.get $9
+       local.get $14
        i32.add
        i32.const 2
        i32.shl
        i32.add
-       local.get $6
+       local.get $13
        i32.store offset=96
-       local.get $8
+       local.get $11
        i32.const 1
        i32.add
-       local.set $8
+       local.set $11
        br $for-loop|1
       end
      end
-     local.get $5
+     local.get $6
      i32.const 1
      i32.add
-     local.set $5
+     local.set $6
      br $for-loop|0
     end
    end
@@ -903,11 +933,11 @@
    i32.const -1
    i32.xor
    i32.and
-   local.set $5
+   local.set $17
    i32.const 0
    drop
    local.get $0
-   local.get $5
+   local.get $17
    memory.size
    i32.const 16
    i32.shl
@@ -956,6 +986,14 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
   local.get $1
   i32.const 256
   i32.lt_u
@@ -1029,11 +1067,11 @@
    unreachable
   end
   local.get $0
-  local.set $5
+  local.set $6
   local.get $2
-  local.set $4
+  local.set $5
+  local.get $6
   local.get $5
-  local.get $4
   i32.const 2
   i32.shl
   i32.add
@@ -1044,10 +1082,10 @@
   local.get $3
   i32.shl
   i32.and
-  local.set $6
-  i32.const 0
   local.set $7
-  local.get $6
+  i32.const 0
+  local.set $8
+  local.get $7
   i32.eqz
   if
    local.get $0
@@ -1060,30 +1098,30 @@
    i32.add
    i32.shl
    i32.and
-   local.set $5
-   local.get $5
+   local.set $9
+   local.get $9
    i32.eqz
    if
     i32.const 0
-    local.set $7
+    local.set $8
    else
-    local.get $5
+    local.get $9
     i32.ctz
     local.set $2
     local.get $0
-    local.set $8
+    local.set $11
     local.get $2
-    local.set $4
-    local.get $8
-    local.get $4
+    local.set $10
+    local.get $11
+    local.get $10
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $6
+    local.set $7
     i32.const 1
     drop
-    local.get $6
+    local.get $7
     i32.eqz
     if
      i32.const 0
@@ -1094,45 +1132,45 @@
      unreachable
     end
     local.get $0
-    local.set $9
+    local.set $14
     local.get $2
-    local.set $8
-    local.get $6
+    local.set $13
+    local.get $7
     i32.ctz
-    local.set $4
-    local.get $9
-    local.get $8
+    local.set $12
+    local.get $14
+    local.get $13
     i32.const 4
     i32.shl
-    local.get $4
+    local.get $12
     i32.add
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=96
-    local.set $7
+    local.set $8
    end
   else
    local.get $0
-   local.set $9
+   local.set $17
    local.get $2
-   local.set $8
-   local.get $6
+   local.set $16
+   local.get $7
    i32.ctz
-   local.set $4
-   local.get $9
-   local.get $8
+   local.set $15
+   local.get $17
+   local.get $16
    i32.const 4
    i32.shl
-   local.get $4
+   local.get $15
    i32.add
    i32.const 2
    i32.shl
    i32.add
    i32.load offset=96
-   local.set $7
+   local.set $8
   end
-  local.get $7
+  local.get $8
  )
  (func $~lib/rt/tlsf/growMemory (param $0 i32) (param $1 i32)
   (local $2 i32)
@@ -1141,6 +1179,7 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
   i32.const 0
   drop
   local.get $1
@@ -1187,15 +1226,15 @@
   i32.shr_u
   local.set $4
   local.get $2
-  local.tee $3
-  local.get $4
   local.tee $5
-  local.get $3
+  local.get $4
+  local.tee $6
   local.get $5
+  local.get $6
   i32.gt_s
   select
-  local.set $6
-  local.get $6
+  local.set $7
+  local.get $7
   memory.grow
   i32.const 0
   i32.lt_s
@@ -1209,12 +1248,12 @@
    end
   end
   memory.size
-  local.set $7
+  local.set $8
   local.get $0
   local.get $2
   i32.const 16
   i32.shl
-  local.get $7
+  local.get $8
   i32.const 16
   i32.shl
   call $~lib/rt/tlsf/addMemory
@@ -1224,6 +1263,8 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
   local.get $1
   i32.load
   local.set $3
@@ -1288,11 +1329,11 @@
    i32.and
    i32.store
    local.get $1
-   local.set $5
-   local.get $5
+   local.set $7
+   local.get $7
    i32.const 16
    i32.add
-   local.get $5
+   local.get $7
    i32.load
    i32.const 3
    i32.const -1
@@ -1300,11 +1341,11 @@
    i32.and
    i32.add
    local.get $1
-   local.set $5
-   local.get $5
+   local.set $6
+   local.get $6
    i32.const 16
    i32.add
-   local.get $5
+   local.get $6
    i32.load
    i32.const 3
    i32.const -1
@@ -1548,6 +1589,13 @@
  )
  (func $start:rc/logical-and-mismatch
   (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
   i32.const 0
   call $rc/logical-and-mismatch/Ref#constructor
   global.set $rc/logical-and-mismatch/gloRef
@@ -1561,42 +1609,42 @@
   else
    local.get $0
   end
-  local.set $0
-  local.get $0
+  local.set $1
+  local.get $1
   call $~lib/rt/pure/__release
   global.get $rc/logical-and-mismatch/gloRef
-  local.tee $0
+  local.tee $2
   if (result i32)
    call $rc/logical-and-mismatch/getRef
   else
-   local.get $0
+   local.get $2
    call $~lib/rt/pure/__retain
   end
-  local.set $0
-  local.get $0
+  local.set $3
+  local.get $3
   call $~lib/rt/pure/__release
   call $rc/logical-and-mismatch/getRef
-  local.tee $0
+  local.tee $4
   if (result i32)
-   local.get $0
+   local.get $4
    call $~lib/rt/pure/__release
    call $rc/logical-and-mismatch/getRef
   else
-   local.get $0
+   local.get $4
   end
-  local.set $0
-  local.get $0
+  local.set $5
+  local.get $5
   call $~lib/rt/pure/__release
   global.get $rc/logical-and-mismatch/gloRef
-  local.tee $0
+  local.tee $6
   if (result i32)
    global.get $rc/logical-and-mismatch/gloRef
   else
-   local.get $0
+   local.get $6
   end
   call $~lib/rt/pure/__retain
-  local.set $0
-  local.get $0
+  local.set $7
+  local.get $7
   call $~lib/rt/pure/__release
   global.get $rc/logical-and-mismatch/gloRef
   call $~lib/rt/pure/__release

--- a/tests/compiler/rc/logical-or-mismatch.untouched.wat
+++ b/tests/compiler/rc/logical-or-mismatch.untouched.wat
@@ -37,6 +37,15 @@
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
   local.get $1
   i32.load
   local.set $2
@@ -173,59 +182,59 @@
   i32.eq
   if
    local.get $0
-   local.set $11
+   local.set $14
    local.get $4
-   local.set $10
+   local.set $13
    local.get $5
-   local.set $9
+   local.set $12
    local.get $7
-   local.set $8
-   local.get $11
-   local.get $10
+   local.set $11
+   local.get $14
+   local.get $13
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $12
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
+   local.get $11
    i32.store offset=96
    local.get $7
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $16
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $15
+    local.get $16
+    local.get $15
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $17
     local.get $0
-    local.set $8
+    local.set $20
     local.get $4
-    local.set $11
-    local.get $9
+    local.set $19
+    local.get $17
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
-    local.set $10
-    local.get $8
-    local.get $11
+    local.tee $17
+    local.set $18
+    local.get $20
+    local.get $19
     i32.const 2
     i32.shl
     i32.add
-    local.get $10
+    local.get $18
     i32.store offset=4
-    local.get $9
+    local.get $17
     i32.eqz
     if
      local.get $0
@@ -255,6 +264,20 @@
   (local $11 i32)
   (local $12 i32)
   (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local $22 i32)
+  (local $23 i32)
+  (local $24 i32)
+  (local $25 i32)
+  (local $26 i32)
+  (local $27 i32)
   i32.const 1
   drop
   local.get $1
@@ -317,8 +340,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $3
+   local.set $6
+   local.get $6
    i32.const 1073741808
    i32.lt_u
    if
@@ -329,16 +352,16 @@
     local.get $2
     i32.const 3
     i32.and
-    local.get $3
+    local.get $6
     i32.or
     local.tee $2
     i32.store
     local.get $1
-    local.set $6
-    local.get $6
+    local.set $7
+    local.get $7
     i32.const 16
     i32.add
-    local.get $6
+    local.get $7
     i32.load
     i32.const 3
     i32.const -1
@@ -356,18 +379,18 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $8
+   local.get $8
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
+   local.set $9
+   local.get $9
    i32.load
-   local.set $3
+   local.set $10
    i32.const 1
    drop
-   local.get $3
+   local.get $10
    i32.const 1
    i32.and
    i32.eqz
@@ -379,7 +402,7 @@
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $3
+   local.get $10
    i32.const 3
    i32.const -1
    i32.xor
@@ -392,23 +415,23 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $7
+   local.set $11
+   local.get $11
    i32.const 1073741808
    i32.lt_u
    if
     local.get $0
-    local.get $6
+    local.get $9
     call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
+    local.get $9
+    local.get $10
     i32.const 3
     i32.and
-    local.get $7
+    local.get $11
     i32.or
     local.tee $2
     i32.store
-    local.get $6
+    local.get $9
     local.set $1
    end
   end
@@ -422,14 +445,14 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $12
   i32.const 1
   drop
-  local.get $8
+  local.get $12
   i32.const 16
   i32.ge_u
   if (result i32)
-   local.get $8
+   local.get $12
    i32.const 1073741808
    i32.lt_u
   else
@@ -449,7 +472,7 @@
   local.get $1
   i32.const 16
   i32.add
-  local.get $8
+  local.get $12
   i32.add
   local.get $4
   i32.eq
@@ -467,24 +490,24 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $12
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $13
+   local.get $12
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $14
   else
    i32.const 31
-   local.get $8
+   local.get $12
    i32.clz
    i32.sub
-   local.set $9
-   local.get $8
-   local.get $9
+   local.set $13
+   local.get $12
+   local.get $13
    i32.const 4
    i32.sub
    i32.shr_u
@@ -492,21 +515,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $14
+   local.get $13
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $13
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $13
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $14
    i32.const 16
    i32.lt_u
   else
@@ -522,86 +545,86 @@
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
-  local.set $6
-  local.get $7
-  local.get $3
+  local.set $17
+  local.get $13
+  local.set $16
+  local.get $14
+  local.set $15
+  local.get $17
+  local.get $16
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $15
   i32.add
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=96
-  local.set $11
+  local.set $18
   local.get $1
   i32.const 0
   i32.store offset=16
   local.get $1
-  local.get $11
+  local.get $18
   i32.store offset=20
-  local.get $11
+  local.get $18
   if
-   local.get $11
+   local.get $18
    local.get $1
    i32.store offset=16
   end
   local.get $0
-  local.set $12
-  local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
+  local.set $22
+  local.get $13
+  local.set $21
+  local.get $14
+  local.set $20
   local.get $1
-  local.set $6
-  local.get $12
-  local.get $7
+  local.set $19
+  local.get $22
+  local.get $21
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $20
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $19
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $13
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.set $13
-  local.get $9
-  local.set $12
+  local.set $27
+  local.get $13
+  local.set $26
   local.get $0
-  local.set $3
-  local.get $9
-  local.set $6
-  local.get $3
-  local.get $6
+  local.set $24
+  local.get $13
+  local.set $23
+  local.get $24
+  local.get $23
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $14
   i32.shl
   i32.or
-  local.set $7
-  local.get $13
-  local.get $12
+  local.set $25
+  local.get $27
+  local.get $26
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $25
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -612,6 +635,7 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
   i32.const 1
   drop
   local.get $1
@@ -751,11 +775,11 @@
   i32.or
   i32.store
   local.get $0
-  local.set $9
+  local.set $10
   local.get $4
-  local.set $3
+  local.set $9
+  local.get $10
   local.get $9
-  local.get $3
   i32.store offset=1568
   local.get $0
   local.get $8
@@ -775,6 +799,12 @@
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
   global.get $~lib/rt/tlsf/ROOT
   local.set $0
   local.get $0
@@ -831,66 +861,66 @@
    local.get $4
    i32.store offset=1568
    i32.const 0
-   local.set $5
+   local.set $6
    loop $for-loop|0
-    local.get $5
+    local.get $6
     i32.const 23
     i32.lt_u
-    local.set $4
-    local.get $4
+    local.set $7
+    local.get $7
     if
      local.get $0
-     local.set $8
-     local.get $5
-     local.set $7
+     local.set $10
+     local.get $6
+     local.set $9
      i32.const 0
-     local.set $6
-     local.get $8
-     local.get $7
+     local.set $8
+     local.get $10
+     local.get $9
      i32.const 2
      i32.shl
      i32.add
-     local.get $6
+     local.get $8
      i32.store offset=4
      i32.const 0
-     local.set $8
+     local.set $11
      loop $for-loop|1
-      local.get $8
+      local.get $11
       i32.const 16
       i32.lt_u
-      local.set $7
-      local.get $7
+      local.set $12
+      local.get $12
       if
        local.get $0
-       local.set $11
-       local.get $5
-       local.set $10
-       local.get $8
-       local.set $9
-       i32.const 0
-       local.set $6
+       local.set $16
+       local.get $6
+       local.set $15
        local.get $11
-       local.get $10
+       local.set $14
+       i32.const 0
+       local.set $13
+       local.get $16
+       local.get $15
        i32.const 4
        i32.shl
-       local.get $9
+       local.get $14
        i32.add
        i32.const 2
        i32.shl
        i32.add
-       local.get $6
+       local.get $13
        i32.store offset=96
-       local.get $8
+       local.get $11
        i32.const 1
        i32.add
-       local.set $8
+       local.set $11
        br $for-loop|1
       end
      end
-     local.get $5
+     local.get $6
      i32.const 1
      i32.add
-     local.set $5
+     local.set $6
      br $for-loop|0
     end
    end
@@ -903,11 +933,11 @@
    i32.const -1
    i32.xor
    i32.and
-   local.set $5
+   local.set $17
    i32.const 0
    drop
    local.get $0
-   local.get $5
+   local.get $17
    memory.size
    i32.const 16
    i32.shl
@@ -956,6 +986,14 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
   local.get $1
   i32.const 256
   i32.lt_u
@@ -1029,11 +1067,11 @@
    unreachable
   end
   local.get $0
-  local.set $5
+  local.set $6
   local.get $2
-  local.set $4
+  local.set $5
+  local.get $6
   local.get $5
-  local.get $4
   i32.const 2
   i32.shl
   i32.add
@@ -1044,10 +1082,10 @@
   local.get $3
   i32.shl
   i32.and
-  local.set $6
-  i32.const 0
   local.set $7
-  local.get $6
+  i32.const 0
+  local.set $8
+  local.get $7
   i32.eqz
   if
    local.get $0
@@ -1060,30 +1098,30 @@
    i32.add
    i32.shl
    i32.and
-   local.set $5
-   local.get $5
+   local.set $9
+   local.get $9
    i32.eqz
    if
     i32.const 0
-    local.set $7
+    local.set $8
    else
-    local.get $5
+    local.get $9
     i32.ctz
     local.set $2
     local.get $0
-    local.set $8
+    local.set $11
     local.get $2
-    local.set $4
-    local.get $8
-    local.get $4
+    local.set $10
+    local.get $11
+    local.get $10
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $6
+    local.set $7
     i32.const 1
     drop
-    local.get $6
+    local.get $7
     i32.eqz
     if
      i32.const 0
@@ -1094,45 +1132,45 @@
      unreachable
     end
     local.get $0
-    local.set $9
+    local.set $14
     local.get $2
-    local.set $8
-    local.get $6
+    local.set $13
+    local.get $7
     i32.ctz
-    local.set $4
-    local.get $9
-    local.get $8
+    local.set $12
+    local.get $14
+    local.get $13
     i32.const 4
     i32.shl
-    local.get $4
+    local.get $12
     i32.add
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=96
-    local.set $7
+    local.set $8
    end
   else
    local.get $0
-   local.set $9
+   local.set $17
    local.get $2
-   local.set $8
-   local.get $6
+   local.set $16
+   local.get $7
    i32.ctz
-   local.set $4
-   local.get $9
-   local.get $8
+   local.set $15
+   local.get $17
+   local.get $16
    i32.const 4
    i32.shl
-   local.get $4
+   local.get $15
    i32.add
    i32.const 2
    i32.shl
    i32.add
    i32.load offset=96
-   local.set $7
+   local.set $8
   end
-  local.get $7
+  local.get $8
  )
  (func $~lib/rt/tlsf/growMemory (param $0 i32) (param $1 i32)
   (local $2 i32)
@@ -1141,6 +1179,7 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
   i32.const 0
   drop
   local.get $1
@@ -1187,15 +1226,15 @@
   i32.shr_u
   local.set $4
   local.get $2
-  local.tee $3
-  local.get $4
   local.tee $5
-  local.get $3
+  local.get $4
+  local.tee $6
   local.get $5
+  local.get $6
   i32.gt_s
   select
-  local.set $6
-  local.get $6
+  local.set $7
+  local.get $7
   memory.grow
   i32.const 0
   i32.lt_s
@@ -1209,12 +1248,12 @@
    end
   end
   memory.size
-  local.set $7
+  local.set $8
   local.get $0
   local.get $2
   i32.const 16
   i32.shl
-  local.get $7
+  local.get $8
   i32.const 16
   i32.shl
   call $~lib/rt/tlsf/addMemory
@@ -1224,6 +1263,8 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
   local.get $1
   i32.load
   local.set $3
@@ -1288,11 +1329,11 @@
    i32.and
    i32.store
    local.get $1
-   local.set $5
-   local.get $5
+   local.set $7
+   local.get $7
    i32.const 16
    i32.add
-   local.get $5
+   local.get $7
    i32.load
    i32.const 3
    i32.const -1
@@ -1300,11 +1341,11 @@
    i32.and
    i32.add
    local.get $1
-   local.set $5
-   local.get $5
+   local.set $6
+   local.get $6
    i32.const 16
    i32.add
-   local.get $5
+   local.get $6
    i32.load
    i32.const 3
    i32.const -1
@@ -1548,6 +1589,13 @@
  )
  (func $start:rc/logical-or-mismatch
   (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
   i32.const 0
   call $rc/logical-or-mismatch/Ref#constructor
   global.set $rc/logical-or-mismatch/gloRef
@@ -1561,42 +1609,42 @@
    global.get $rc/logical-or-mismatch/gloRef
    call $~lib/rt/pure/__retain
   end
-  local.set $0
-  local.get $0
+  local.set $1
+  local.get $1
   call $~lib/rt/pure/__release
   global.get $rc/logical-or-mismatch/gloRef
-  local.tee $0
+  local.tee $2
   if (result i32)
-   local.get $0
+   local.get $2
    call $~lib/rt/pure/__retain
   else
    call $rc/logical-or-mismatch/getRef
   end
-  local.set $0
-  local.get $0
+  local.set $3
+  local.get $3
   call $~lib/rt/pure/__release
   call $rc/logical-or-mismatch/getRef
-  local.tee $0
+  local.tee $4
   if (result i32)
-   local.get $0
+   local.get $4
   else
-   local.get $0
+   local.get $4
    call $~lib/rt/pure/__release
    call $rc/logical-or-mismatch/getRef
   end
-  local.set $0
-  local.get $0
+  local.set $5
+  local.get $5
   call $~lib/rt/pure/__release
   global.get $rc/logical-or-mismatch/gloRef
-  local.tee $0
+  local.tee $6
   if (result i32)
-   local.get $0
+   local.get $6
   else
    global.get $rc/logical-or-mismatch/gloRef
   end
   call $~lib/rt/pure/__retain
-  local.set $0
-  local.get $0
+  local.set $7
+  local.get $7
   call $~lib/rt/pure/__release
   global.get $rc/logical-or-mismatch/gloRef
   call $~lib/rt/pure/__release

--- a/tests/compiler/rc/optimize.untouched.wat
+++ b/tests/compiler/rc/optimize.untouched.wat
@@ -140,6 +140,15 @@
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
   local.get $1
   i32.load
   local.set $2
@@ -276,59 +285,59 @@
   i32.eq
   if
    local.get $0
-   local.set $11
+   local.set $14
    local.get $4
-   local.set $10
+   local.set $13
    local.get $5
-   local.set $9
+   local.set $12
    local.get $7
-   local.set $8
-   local.get $11
-   local.get $10
+   local.set $11
+   local.get $14
+   local.get $13
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $12
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
+   local.get $11
    i32.store offset=96
    local.get $7
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $16
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $15
+    local.get $16
+    local.get $15
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $17
     local.get $0
-    local.set $8
+    local.set $20
     local.get $4
-    local.set $11
-    local.get $9
+    local.set $19
+    local.get $17
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
-    local.set $10
-    local.get $8
-    local.get $11
+    local.tee $17
+    local.set $18
+    local.get $20
+    local.get $19
     i32.const 2
     i32.shl
     i32.add
-    local.get $10
+    local.get $18
     i32.store offset=4
-    local.get $9
+    local.get $17
     i32.eqz
     if
      local.get $0
@@ -358,6 +367,20 @@
   (local $11 i32)
   (local $12 i32)
   (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local $22 i32)
+  (local $23 i32)
+  (local $24 i32)
+  (local $25 i32)
+  (local $26 i32)
+  (local $27 i32)
   i32.const 1
   drop
   local.get $1
@@ -420,8 +443,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $3
+   local.set $6
+   local.get $6
    i32.const 1073741808
    i32.lt_u
    if
@@ -432,16 +455,16 @@
     local.get $2
     i32.const 3
     i32.and
-    local.get $3
+    local.get $6
     i32.or
     local.tee $2
     i32.store
     local.get $1
-    local.set $6
-    local.get $6
+    local.set $7
+    local.get $7
     i32.const 16
     i32.add
-    local.get $6
+    local.get $7
     i32.load
     i32.const 3
     i32.const -1
@@ -459,18 +482,18 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $8
+   local.get $8
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
+   local.set $9
+   local.get $9
    i32.load
-   local.set $3
+   local.set $10
    i32.const 1
    drop
-   local.get $3
+   local.get $10
    i32.const 1
    i32.and
    i32.eqz
@@ -482,7 +505,7 @@
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $3
+   local.get $10
    i32.const 3
    i32.const -1
    i32.xor
@@ -495,23 +518,23 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $7
+   local.set $11
+   local.get $11
    i32.const 1073741808
    i32.lt_u
    if
     local.get $0
-    local.get $6
+    local.get $9
     call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
+    local.get $9
+    local.get $10
     i32.const 3
     i32.and
-    local.get $7
+    local.get $11
     i32.or
     local.tee $2
     i32.store
-    local.get $6
+    local.get $9
     local.set $1
    end
   end
@@ -525,14 +548,14 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $12
   i32.const 1
   drop
-  local.get $8
+  local.get $12
   i32.const 16
   i32.ge_u
   if (result i32)
-   local.get $8
+   local.get $12
    i32.const 1073741808
    i32.lt_u
   else
@@ -552,7 +575,7 @@
   local.get $1
   i32.const 16
   i32.add
-  local.get $8
+  local.get $12
   i32.add
   local.get $4
   i32.eq
@@ -570,24 +593,24 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $12
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $13
+   local.get $12
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $14
   else
    i32.const 31
-   local.get $8
+   local.get $12
    i32.clz
    i32.sub
-   local.set $9
-   local.get $8
-   local.get $9
+   local.set $13
+   local.get $12
+   local.get $13
    i32.const 4
    i32.sub
    i32.shr_u
@@ -595,21 +618,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $14
+   local.get $13
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $13
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $13
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $14
    i32.const 16
    i32.lt_u
   else
@@ -625,86 +648,86 @@
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
-  local.set $6
-  local.get $7
-  local.get $3
+  local.set $17
+  local.get $13
+  local.set $16
+  local.get $14
+  local.set $15
+  local.get $17
+  local.get $16
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $15
   i32.add
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=96
-  local.set $11
+  local.set $18
   local.get $1
   i32.const 0
   i32.store offset=16
   local.get $1
-  local.get $11
+  local.get $18
   i32.store offset=20
-  local.get $11
+  local.get $18
   if
-   local.get $11
+   local.get $18
    local.get $1
    i32.store offset=16
   end
   local.get $0
-  local.set $12
-  local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
+  local.set $22
+  local.get $13
+  local.set $21
+  local.get $14
+  local.set $20
   local.get $1
-  local.set $6
-  local.get $12
-  local.get $7
+  local.set $19
+  local.get $22
+  local.get $21
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $20
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $19
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $13
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.set $13
-  local.get $9
-  local.set $12
+  local.set $27
+  local.get $13
+  local.set $26
   local.get $0
-  local.set $3
-  local.get $9
-  local.set $6
-  local.get $3
-  local.get $6
+  local.set $24
+  local.get $13
+  local.set $23
+  local.get $24
+  local.get $23
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $14
   i32.shl
   i32.or
-  local.set $7
-  local.get $13
-  local.get $12
+  local.set $25
+  local.get $27
+  local.get $26
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $25
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -715,6 +738,7 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
   i32.const 1
   drop
   local.get $1
@@ -854,11 +878,11 @@
   i32.or
   i32.store
   local.get $0
-  local.set $9
+  local.set $10
   local.get $4
-  local.set $3
+  local.set $9
+  local.get $10
   local.get $9
-  local.get $3
   i32.store offset=1568
   local.get $0
   local.get $8
@@ -878,6 +902,12 @@
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
   global.get $~lib/rt/tlsf/ROOT
   local.set $0
   local.get $0
@@ -934,66 +964,66 @@
    local.get $4
    i32.store offset=1568
    i32.const 0
-   local.set $5
+   local.set $6
    loop $for-loop|0
-    local.get $5
+    local.get $6
     i32.const 23
     i32.lt_u
-    local.set $4
-    local.get $4
+    local.set $7
+    local.get $7
     if
      local.get $0
-     local.set $8
-     local.get $5
-     local.set $7
+     local.set $10
+     local.get $6
+     local.set $9
      i32.const 0
-     local.set $6
-     local.get $8
-     local.get $7
+     local.set $8
+     local.get $10
+     local.get $9
      i32.const 2
      i32.shl
      i32.add
-     local.get $6
+     local.get $8
      i32.store offset=4
      i32.const 0
-     local.set $8
+     local.set $11
      loop $for-loop|1
-      local.get $8
+      local.get $11
       i32.const 16
       i32.lt_u
-      local.set $7
-      local.get $7
+      local.set $12
+      local.get $12
       if
        local.get $0
-       local.set $11
-       local.get $5
-       local.set $10
-       local.get $8
-       local.set $9
-       i32.const 0
-       local.set $6
+       local.set $16
+       local.get $6
+       local.set $15
        local.get $11
-       local.get $10
+       local.set $14
+       i32.const 0
+       local.set $13
+       local.get $16
+       local.get $15
        i32.const 4
        i32.shl
-       local.get $9
+       local.get $14
        i32.add
        i32.const 2
        i32.shl
        i32.add
-       local.get $6
+       local.get $13
        i32.store offset=96
-       local.get $8
+       local.get $11
        i32.const 1
        i32.add
-       local.set $8
+       local.set $11
        br $for-loop|1
       end
      end
-     local.get $5
+     local.get $6
      i32.const 1
      i32.add
-     local.set $5
+     local.set $6
      br $for-loop|0
     end
    end
@@ -1006,11 +1036,11 @@
    i32.const -1
    i32.xor
    i32.and
-   local.set $5
+   local.set $17
    i32.const 0
    drop
    local.get $0
-   local.get $5
+   local.get $17
    memory.size
    i32.const 16
    i32.shl
@@ -1059,6 +1089,14 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
   local.get $1
   i32.const 256
   i32.lt_u
@@ -1132,11 +1170,11 @@
    unreachable
   end
   local.get $0
-  local.set $5
+  local.set $6
   local.get $2
-  local.set $4
+  local.set $5
+  local.get $6
   local.get $5
-  local.get $4
   i32.const 2
   i32.shl
   i32.add
@@ -1147,10 +1185,10 @@
   local.get $3
   i32.shl
   i32.and
-  local.set $6
-  i32.const 0
   local.set $7
-  local.get $6
+  i32.const 0
+  local.set $8
+  local.get $7
   i32.eqz
   if
    local.get $0
@@ -1163,30 +1201,30 @@
    i32.add
    i32.shl
    i32.and
-   local.set $5
-   local.get $5
+   local.set $9
+   local.get $9
    i32.eqz
    if
     i32.const 0
-    local.set $7
+    local.set $8
    else
-    local.get $5
+    local.get $9
     i32.ctz
     local.set $2
     local.get $0
-    local.set $8
+    local.set $11
     local.get $2
-    local.set $4
-    local.get $8
-    local.get $4
+    local.set $10
+    local.get $11
+    local.get $10
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $6
+    local.set $7
     i32.const 1
     drop
-    local.get $6
+    local.get $7
     i32.eqz
     if
      i32.const 0
@@ -1197,45 +1235,45 @@
      unreachable
     end
     local.get $0
-    local.set $9
+    local.set $14
     local.get $2
-    local.set $8
-    local.get $6
+    local.set $13
+    local.get $7
     i32.ctz
-    local.set $4
-    local.get $9
-    local.get $8
+    local.set $12
+    local.get $14
+    local.get $13
     i32.const 4
     i32.shl
-    local.get $4
+    local.get $12
     i32.add
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=96
-    local.set $7
+    local.set $8
    end
   else
    local.get $0
-   local.set $9
+   local.set $17
    local.get $2
-   local.set $8
-   local.get $6
+   local.set $16
+   local.get $7
    i32.ctz
-   local.set $4
-   local.get $9
-   local.get $8
+   local.set $15
+   local.get $17
+   local.get $16
    i32.const 4
    i32.shl
-   local.get $4
+   local.get $15
    i32.add
    i32.const 2
    i32.shl
    i32.add
    i32.load offset=96
-   local.set $7
+   local.set $8
   end
-  local.get $7
+  local.get $8
  )
  (func $~lib/rt/tlsf/growMemory (param $0 i32) (param $1 i32)
   (local $2 i32)
@@ -1244,6 +1282,7 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
   i32.const 0
   drop
   local.get $1
@@ -1290,15 +1329,15 @@
   i32.shr_u
   local.set $4
   local.get $2
-  local.tee $3
-  local.get $4
   local.tee $5
-  local.get $3
+  local.get $4
+  local.tee $6
   local.get $5
+  local.get $6
   i32.gt_s
   select
-  local.set $6
-  local.get $6
+  local.set $7
+  local.get $7
   memory.grow
   i32.const 0
   i32.lt_s
@@ -1312,12 +1351,12 @@
    end
   end
   memory.size
-  local.set $7
+  local.set $8
   local.get $0
   local.get $2
   i32.const 16
   i32.shl
-  local.get $7
+  local.get $8
   i32.const 16
   i32.shl
   call $~lib/rt/tlsf/addMemory
@@ -1327,6 +1366,8 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
   local.get $1
   i32.load
   local.set $3
@@ -1391,11 +1432,11 @@
    i32.and
    i32.store
    local.get $1
-   local.set $5
-   local.get $5
+   local.set $7
+   local.get $7
    i32.const 16
    i32.add
-   local.get $5
+   local.get $7
    i32.load
    i32.const 3
    i32.const -1
@@ -1403,11 +1444,11 @@
    i32.and
    i32.add
    local.get $1
-   local.set $5
-   local.get $5
+   local.set $6
+   local.get $6
    i32.const 16
    i32.add
-   local.get $5
+   local.get $6
    i32.load
    i32.const 3
    i32.const -1

--- a/tests/compiler/rc/rereturn.untouched.wat
+++ b/tests/compiler/rc/rereturn.untouched.wat
@@ -39,6 +39,15 @@
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
   local.get $1
   i32.load
   local.set $2
@@ -175,59 +184,59 @@
   i32.eq
   if
    local.get $0
-   local.set $11
+   local.set $14
    local.get $4
-   local.set $10
+   local.set $13
    local.get $5
-   local.set $9
+   local.set $12
    local.get $7
-   local.set $8
-   local.get $11
-   local.get $10
+   local.set $11
+   local.get $14
+   local.get $13
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $12
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
+   local.get $11
    i32.store offset=96
    local.get $7
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $16
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $15
+    local.get $16
+    local.get $15
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $17
     local.get $0
-    local.set $8
+    local.set $20
     local.get $4
-    local.set $11
-    local.get $9
+    local.set $19
+    local.get $17
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
-    local.set $10
-    local.get $8
-    local.get $11
+    local.tee $17
+    local.set $18
+    local.get $20
+    local.get $19
     i32.const 2
     i32.shl
     i32.add
-    local.get $10
+    local.get $18
     i32.store offset=4
-    local.get $9
+    local.get $17
     i32.eqz
     if
      local.get $0
@@ -257,6 +266,20 @@
   (local $11 i32)
   (local $12 i32)
   (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local $22 i32)
+  (local $23 i32)
+  (local $24 i32)
+  (local $25 i32)
+  (local $26 i32)
+  (local $27 i32)
   i32.const 1
   drop
   local.get $1
@@ -319,8 +342,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $3
+   local.set $6
+   local.get $6
    i32.const 1073741808
    i32.lt_u
    if
@@ -331,16 +354,16 @@
     local.get $2
     i32.const 3
     i32.and
-    local.get $3
+    local.get $6
     i32.or
     local.tee $2
     i32.store
     local.get $1
-    local.set $6
-    local.get $6
+    local.set $7
+    local.get $7
     i32.const 16
     i32.add
-    local.get $6
+    local.get $7
     i32.load
     i32.const 3
     i32.const -1
@@ -358,18 +381,18 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $8
+   local.get $8
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
+   local.set $9
+   local.get $9
    i32.load
-   local.set $3
+   local.set $10
    i32.const 1
    drop
-   local.get $3
+   local.get $10
    i32.const 1
    i32.and
    i32.eqz
@@ -381,7 +404,7 @@
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $3
+   local.get $10
    i32.const 3
    i32.const -1
    i32.xor
@@ -394,23 +417,23 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $7
+   local.set $11
+   local.get $11
    i32.const 1073741808
    i32.lt_u
    if
     local.get $0
-    local.get $6
+    local.get $9
     call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
+    local.get $9
+    local.get $10
     i32.const 3
     i32.and
-    local.get $7
+    local.get $11
     i32.or
     local.tee $2
     i32.store
-    local.get $6
+    local.get $9
     local.set $1
    end
   end
@@ -424,14 +447,14 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $12
   i32.const 1
   drop
-  local.get $8
+  local.get $12
   i32.const 16
   i32.ge_u
   if (result i32)
-   local.get $8
+   local.get $12
    i32.const 1073741808
    i32.lt_u
   else
@@ -451,7 +474,7 @@
   local.get $1
   i32.const 16
   i32.add
-  local.get $8
+  local.get $12
   i32.add
   local.get $4
   i32.eq
@@ -469,24 +492,24 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $12
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $13
+   local.get $12
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $14
   else
    i32.const 31
-   local.get $8
+   local.get $12
    i32.clz
    i32.sub
-   local.set $9
-   local.get $8
-   local.get $9
+   local.set $13
+   local.get $12
+   local.get $13
    i32.const 4
    i32.sub
    i32.shr_u
@@ -494,21 +517,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $14
+   local.get $13
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $13
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $13
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $14
    i32.const 16
    i32.lt_u
   else
@@ -524,86 +547,86 @@
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
-  local.set $6
-  local.get $7
-  local.get $3
+  local.set $17
+  local.get $13
+  local.set $16
+  local.get $14
+  local.set $15
+  local.get $17
+  local.get $16
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $15
   i32.add
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=96
-  local.set $11
+  local.set $18
   local.get $1
   i32.const 0
   i32.store offset=16
   local.get $1
-  local.get $11
+  local.get $18
   i32.store offset=20
-  local.get $11
+  local.get $18
   if
-   local.get $11
+   local.get $18
    local.get $1
    i32.store offset=16
   end
   local.get $0
-  local.set $12
-  local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
+  local.set $22
+  local.get $13
+  local.set $21
+  local.get $14
+  local.set $20
   local.get $1
-  local.set $6
-  local.get $12
-  local.get $7
+  local.set $19
+  local.get $22
+  local.get $21
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $20
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $19
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $13
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.set $13
-  local.get $9
-  local.set $12
+  local.set $27
+  local.get $13
+  local.set $26
   local.get $0
-  local.set $3
-  local.get $9
-  local.set $6
-  local.get $3
-  local.get $6
+  local.set $24
+  local.get $13
+  local.set $23
+  local.get $24
+  local.get $23
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $14
   i32.shl
   i32.or
-  local.set $7
-  local.get $13
-  local.get $12
+  local.set $25
+  local.get $27
+  local.get $26
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $25
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -614,6 +637,7 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
   i32.const 1
   drop
   local.get $1
@@ -753,11 +777,11 @@
   i32.or
   i32.store
   local.get $0
-  local.set $9
+  local.set $10
   local.get $4
-  local.set $3
+  local.set $9
+  local.get $10
   local.get $9
-  local.get $3
   i32.store offset=1568
   local.get $0
   local.get $8
@@ -777,6 +801,12 @@
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
   global.get $~lib/rt/tlsf/ROOT
   local.set $0
   local.get $0
@@ -833,66 +863,66 @@
    local.get $4
    i32.store offset=1568
    i32.const 0
-   local.set $5
+   local.set $6
    loop $for-loop|0
-    local.get $5
+    local.get $6
     i32.const 23
     i32.lt_u
-    local.set $4
-    local.get $4
+    local.set $7
+    local.get $7
     if
      local.get $0
-     local.set $8
-     local.get $5
-     local.set $7
+     local.set $10
+     local.get $6
+     local.set $9
      i32.const 0
-     local.set $6
-     local.get $8
-     local.get $7
+     local.set $8
+     local.get $10
+     local.get $9
      i32.const 2
      i32.shl
      i32.add
-     local.get $6
+     local.get $8
      i32.store offset=4
      i32.const 0
-     local.set $8
+     local.set $11
      loop $for-loop|1
-      local.get $8
+      local.get $11
       i32.const 16
       i32.lt_u
-      local.set $7
-      local.get $7
+      local.set $12
+      local.get $12
       if
        local.get $0
-       local.set $11
-       local.get $5
-       local.set $10
-       local.get $8
-       local.set $9
-       i32.const 0
-       local.set $6
+       local.set $16
+       local.get $6
+       local.set $15
        local.get $11
-       local.get $10
+       local.set $14
+       i32.const 0
+       local.set $13
+       local.get $16
+       local.get $15
        i32.const 4
        i32.shl
-       local.get $9
+       local.get $14
        i32.add
        i32.const 2
        i32.shl
        i32.add
-       local.get $6
+       local.get $13
        i32.store offset=96
-       local.get $8
+       local.get $11
        i32.const 1
        i32.add
-       local.set $8
+       local.set $11
        br $for-loop|1
       end
      end
-     local.get $5
+     local.get $6
      i32.const 1
      i32.add
-     local.set $5
+     local.set $6
      br $for-loop|0
     end
    end
@@ -905,11 +935,11 @@
    i32.const -1
    i32.xor
    i32.and
-   local.set $5
+   local.set $17
    i32.const 0
    drop
    local.get $0
-   local.get $5
+   local.get $17
    memory.size
    i32.const 16
    i32.shl
@@ -958,6 +988,14 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
   local.get $1
   i32.const 256
   i32.lt_u
@@ -1031,11 +1069,11 @@
    unreachable
   end
   local.get $0
-  local.set $5
+  local.set $6
   local.get $2
-  local.set $4
+  local.set $5
+  local.get $6
   local.get $5
-  local.get $4
   i32.const 2
   i32.shl
   i32.add
@@ -1046,10 +1084,10 @@
   local.get $3
   i32.shl
   i32.and
-  local.set $6
-  i32.const 0
   local.set $7
-  local.get $6
+  i32.const 0
+  local.set $8
+  local.get $7
   i32.eqz
   if
    local.get $0
@@ -1062,30 +1100,30 @@
    i32.add
    i32.shl
    i32.and
-   local.set $5
-   local.get $5
+   local.set $9
+   local.get $9
    i32.eqz
    if
     i32.const 0
-    local.set $7
+    local.set $8
    else
-    local.get $5
+    local.get $9
     i32.ctz
     local.set $2
     local.get $0
-    local.set $8
+    local.set $11
     local.get $2
-    local.set $4
-    local.get $8
-    local.get $4
+    local.set $10
+    local.get $11
+    local.get $10
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $6
+    local.set $7
     i32.const 1
     drop
-    local.get $6
+    local.get $7
     i32.eqz
     if
      i32.const 0
@@ -1096,45 +1134,45 @@
      unreachable
     end
     local.get $0
-    local.set $9
+    local.set $14
     local.get $2
-    local.set $8
-    local.get $6
+    local.set $13
+    local.get $7
     i32.ctz
-    local.set $4
-    local.get $9
-    local.get $8
+    local.set $12
+    local.get $14
+    local.get $13
     i32.const 4
     i32.shl
-    local.get $4
+    local.get $12
     i32.add
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=96
-    local.set $7
+    local.set $8
    end
   else
    local.get $0
-   local.set $9
+   local.set $17
    local.get $2
-   local.set $8
-   local.get $6
+   local.set $16
+   local.get $7
    i32.ctz
-   local.set $4
-   local.get $9
-   local.get $8
+   local.set $15
+   local.get $17
+   local.get $16
    i32.const 4
    i32.shl
-   local.get $4
+   local.get $15
    i32.add
    i32.const 2
    i32.shl
    i32.add
    i32.load offset=96
-   local.set $7
+   local.set $8
   end
-  local.get $7
+  local.get $8
  )
  (func $~lib/rt/tlsf/growMemory (param $0 i32) (param $1 i32)
   (local $2 i32)
@@ -1143,6 +1181,7 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
   i32.const 0
   drop
   local.get $1
@@ -1189,15 +1228,15 @@
   i32.shr_u
   local.set $4
   local.get $2
-  local.tee $3
-  local.get $4
   local.tee $5
-  local.get $3
+  local.get $4
+  local.tee $6
   local.get $5
+  local.get $6
   i32.gt_s
   select
-  local.set $6
-  local.get $6
+  local.set $7
+  local.get $7
   memory.grow
   i32.const 0
   i32.lt_s
@@ -1211,12 +1250,12 @@
    end
   end
   memory.size
-  local.set $7
+  local.set $8
   local.get $0
   local.get $2
   i32.const 16
   i32.shl
-  local.get $7
+  local.get $8
   i32.const 16
   i32.shl
   call $~lib/rt/tlsf/addMemory
@@ -1226,6 +1265,8 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
   local.get $1
   i32.load
   local.set $3
@@ -1290,11 +1331,11 @@
    i32.and
    i32.store
    local.get $1
-   local.set $5
-   local.get $5
+   local.set $7
+   local.get $7
    i32.const 16
    i32.add
-   local.get $5
+   local.get $7
    i32.load
    i32.const 3
    i32.const -1
@@ -1302,11 +1343,11 @@
    i32.and
    i32.add
    local.get $1
-   local.set $5
-   local.get $5
+   local.set $6
+   local.get $6
    i32.const 16
    i32.add
-   local.get $5
+   local.get $6
    i32.load
    i32.const 3
    i32.const -1

--- a/tests/compiler/rc/ternary-mismatch.untouched.wat
+++ b/tests/compiler/rc/ternary-mismatch.untouched.wat
@@ -39,6 +39,15 @@
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
   local.get $1
   i32.load
   local.set $2
@@ -175,59 +184,59 @@
   i32.eq
   if
    local.get $0
-   local.set $11
+   local.set $14
    local.get $4
-   local.set $10
+   local.set $13
    local.get $5
-   local.set $9
+   local.set $12
    local.get $7
-   local.set $8
-   local.get $11
-   local.get $10
+   local.set $11
+   local.get $14
+   local.get $13
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $12
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
+   local.get $11
    i32.store offset=96
    local.get $7
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $16
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $15
+    local.get $16
+    local.get $15
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $17
     local.get $0
-    local.set $8
+    local.set $20
     local.get $4
-    local.set $11
-    local.get $9
+    local.set $19
+    local.get $17
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
-    local.set $10
-    local.get $8
-    local.get $11
+    local.tee $17
+    local.set $18
+    local.get $20
+    local.get $19
     i32.const 2
     i32.shl
     i32.add
-    local.get $10
+    local.get $18
     i32.store offset=4
-    local.get $9
+    local.get $17
     i32.eqz
     if
      local.get $0
@@ -257,6 +266,20 @@
   (local $11 i32)
   (local $12 i32)
   (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local $22 i32)
+  (local $23 i32)
+  (local $24 i32)
+  (local $25 i32)
+  (local $26 i32)
+  (local $27 i32)
   i32.const 1
   drop
   local.get $1
@@ -319,8 +342,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $3
+   local.set $6
+   local.get $6
    i32.const 1073741808
    i32.lt_u
    if
@@ -331,16 +354,16 @@
     local.get $2
     i32.const 3
     i32.and
-    local.get $3
+    local.get $6
     i32.or
     local.tee $2
     i32.store
     local.get $1
-    local.set $6
-    local.get $6
+    local.set $7
+    local.get $7
     i32.const 16
     i32.add
-    local.get $6
+    local.get $7
     i32.load
     i32.const 3
     i32.const -1
@@ -358,18 +381,18 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $8
+   local.get $8
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
+   local.set $9
+   local.get $9
    i32.load
-   local.set $3
+   local.set $10
    i32.const 1
    drop
-   local.get $3
+   local.get $10
    i32.const 1
    i32.and
    i32.eqz
@@ -381,7 +404,7 @@
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $3
+   local.get $10
    i32.const 3
    i32.const -1
    i32.xor
@@ -394,23 +417,23 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $7
+   local.set $11
+   local.get $11
    i32.const 1073741808
    i32.lt_u
    if
     local.get $0
-    local.get $6
+    local.get $9
     call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
+    local.get $9
+    local.get $10
     i32.const 3
     i32.and
-    local.get $7
+    local.get $11
     i32.or
     local.tee $2
     i32.store
-    local.get $6
+    local.get $9
     local.set $1
    end
   end
@@ -424,14 +447,14 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $12
   i32.const 1
   drop
-  local.get $8
+  local.get $12
   i32.const 16
   i32.ge_u
   if (result i32)
-   local.get $8
+   local.get $12
    i32.const 1073741808
    i32.lt_u
   else
@@ -451,7 +474,7 @@
   local.get $1
   i32.const 16
   i32.add
-  local.get $8
+  local.get $12
   i32.add
   local.get $4
   i32.eq
@@ -469,24 +492,24 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $12
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $13
+   local.get $12
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $14
   else
    i32.const 31
-   local.get $8
+   local.get $12
    i32.clz
    i32.sub
-   local.set $9
-   local.get $8
-   local.get $9
+   local.set $13
+   local.get $12
+   local.get $13
    i32.const 4
    i32.sub
    i32.shr_u
@@ -494,21 +517,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $14
+   local.get $13
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $13
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $13
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $14
    i32.const 16
    i32.lt_u
   else
@@ -524,86 +547,86 @@
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
-  local.set $6
-  local.get $7
-  local.get $3
+  local.set $17
+  local.get $13
+  local.set $16
+  local.get $14
+  local.set $15
+  local.get $17
+  local.get $16
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $15
   i32.add
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=96
-  local.set $11
+  local.set $18
   local.get $1
   i32.const 0
   i32.store offset=16
   local.get $1
-  local.get $11
+  local.get $18
   i32.store offset=20
-  local.get $11
+  local.get $18
   if
-   local.get $11
+   local.get $18
    local.get $1
    i32.store offset=16
   end
   local.get $0
-  local.set $12
-  local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
+  local.set $22
+  local.get $13
+  local.set $21
+  local.get $14
+  local.set $20
   local.get $1
-  local.set $6
-  local.get $12
-  local.get $7
+  local.set $19
+  local.get $22
+  local.get $21
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $20
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $19
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $13
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.set $13
-  local.get $9
-  local.set $12
+  local.set $27
+  local.get $13
+  local.set $26
   local.get $0
-  local.set $3
-  local.get $9
-  local.set $6
-  local.get $3
-  local.get $6
+  local.set $24
+  local.get $13
+  local.set $23
+  local.get $24
+  local.get $23
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $14
   i32.shl
   i32.or
-  local.set $7
-  local.get $13
-  local.get $12
+  local.set $25
+  local.get $27
+  local.get $26
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $25
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -614,6 +637,7 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
   i32.const 1
   drop
   local.get $1
@@ -753,11 +777,11 @@
   i32.or
   i32.store
   local.get $0
-  local.set $9
+  local.set $10
   local.get $4
-  local.set $3
+  local.set $9
+  local.get $10
   local.get $9
-  local.get $3
   i32.store offset=1568
   local.get $0
   local.get $8
@@ -777,6 +801,12 @@
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
   global.get $~lib/rt/tlsf/ROOT
   local.set $0
   local.get $0
@@ -833,66 +863,66 @@
    local.get $4
    i32.store offset=1568
    i32.const 0
-   local.set $5
+   local.set $6
    loop $for-loop|0
-    local.get $5
+    local.get $6
     i32.const 23
     i32.lt_u
-    local.set $4
-    local.get $4
+    local.set $7
+    local.get $7
     if
      local.get $0
-     local.set $8
-     local.get $5
-     local.set $7
+     local.set $10
+     local.get $6
+     local.set $9
      i32.const 0
-     local.set $6
-     local.get $8
-     local.get $7
+     local.set $8
+     local.get $10
+     local.get $9
      i32.const 2
      i32.shl
      i32.add
-     local.get $6
+     local.get $8
      i32.store offset=4
      i32.const 0
-     local.set $8
+     local.set $11
      loop $for-loop|1
-      local.get $8
+      local.get $11
       i32.const 16
       i32.lt_u
-      local.set $7
-      local.get $7
+      local.set $12
+      local.get $12
       if
        local.get $0
-       local.set $11
-       local.get $5
-       local.set $10
-       local.get $8
-       local.set $9
-       i32.const 0
-       local.set $6
+       local.set $16
+       local.get $6
+       local.set $15
        local.get $11
-       local.get $10
+       local.set $14
+       i32.const 0
+       local.set $13
+       local.get $16
+       local.get $15
        i32.const 4
        i32.shl
-       local.get $9
+       local.get $14
        i32.add
        i32.const 2
        i32.shl
        i32.add
-       local.get $6
+       local.get $13
        i32.store offset=96
-       local.get $8
+       local.get $11
        i32.const 1
        i32.add
-       local.set $8
+       local.set $11
        br $for-loop|1
       end
      end
-     local.get $5
+     local.get $6
      i32.const 1
      i32.add
-     local.set $5
+     local.set $6
      br $for-loop|0
     end
    end
@@ -905,11 +935,11 @@
    i32.const -1
    i32.xor
    i32.and
-   local.set $5
+   local.set $17
    i32.const 0
    drop
    local.get $0
-   local.get $5
+   local.get $17
    memory.size
    i32.const 16
    i32.shl
@@ -958,6 +988,14 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
   local.get $1
   i32.const 256
   i32.lt_u
@@ -1031,11 +1069,11 @@
    unreachable
   end
   local.get $0
-  local.set $5
+  local.set $6
   local.get $2
-  local.set $4
+  local.set $5
+  local.get $6
   local.get $5
-  local.get $4
   i32.const 2
   i32.shl
   i32.add
@@ -1046,10 +1084,10 @@
   local.get $3
   i32.shl
   i32.and
-  local.set $6
-  i32.const 0
   local.set $7
-  local.get $6
+  i32.const 0
+  local.set $8
+  local.get $7
   i32.eqz
   if
    local.get $0
@@ -1062,30 +1100,30 @@
    i32.add
    i32.shl
    i32.and
-   local.set $5
-   local.get $5
+   local.set $9
+   local.get $9
    i32.eqz
    if
     i32.const 0
-    local.set $7
+    local.set $8
    else
-    local.get $5
+    local.get $9
     i32.ctz
     local.set $2
     local.get $0
-    local.set $8
+    local.set $11
     local.get $2
-    local.set $4
-    local.get $8
-    local.get $4
+    local.set $10
+    local.get $11
+    local.get $10
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $6
+    local.set $7
     i32.const 1
     drop
-    local.get $6
+    local.get $7
     i32.eqz
     if
      i32.const 0
@@ -1096,45 +1134,45 @@
      unreachable
     end
     local.get $0
-    local.set $9
+    local.set $14
     local.get $2
-    local.set $8
-    local.get $6
+    local.set $13
+    local.get $7
     i32.ctz
-    local.set $4
-    local.get $9
-    local.get $8
+    local.set $12
+    local.get $14
+    local.get $13
     i32.const 4
     i32.shl
-    local.get $4
+    local.get $12
     i32.add
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=96
-    local.set $7
+    local.set $8
    end
   else
    local.get $0
-   local.set $9
+   local.set $17
    local.get $2
-   local.set $8
-   local.get $6
+   local.set $16
+   local.get $7
    i32.ctz
-   local.set $4
-   local.get $9
-   local.get $8
+   local.set $15
+   local.get $17
+   local.get $16
    i32.const 4
    i32.shl
-   local.get $4
+   local.get $15
    i32.add
    i32.const 2
    i32.shl
    i32.add
    i32.load offset=96
-   local.set $7
+   local.set $8
   end
-  local.get $7
+  local.get $8
  )
  (func $~lib/rt/tlsf/growMemory (param $0 i32) (param $1 i32)
   (local $2 i32)
@@ -1143,6 +1181,7 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
   i32.const 0
   drop
   local.get $1
@@ -1189,15 +1228,15 @@
   i32.shr_u
   local.set $4
   local.get $2
-  local.tee $3
-  local.get $4
   local.tee $5
-  local.get $3
+  local.get $4
+  local.tee $6
   local.get $5
+  local.get $6
   i32.gt_s
   select
-  local.set $6
-  local.get $6
+  local.set $7
+  local.get $7
   memory.grow
   i32.const 0
   i32.lt_s
@@ -1211,12 +1250,12 @@
    end
   end
   memory.size
-  local.set $7
+  local.set $8
   local.get $0
   local.get $2
   i32.const 16
   i32.shl
-  local.get $7
+  local.get $8
   i32.const 16
   i32.shl
   call $~lib/rt/tlsf/addMemory
@@ -1226,6 +1265,8 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
   local.get $1
   i32.load
   local.set $3
@@ -1290,11 +1331,11 @@
    i32.and
    i32.store
    local.get $1
-   local.set $5
-   local.get $5
+   local.set $7
+   local.get $7
    i32.const 16
    i32.add
-   local.get $5
+   local.get $7
    i32.load
    i32.const 3
    i32.const -1
@@ -1302,11 +1343,11 @@
    i32.and
    i32.add
    local.get $1
-   local.set $5
-   local.get $5
+   local.set $6
+   local.get $6
    i32.const 16
    i32.add
-   local.get $5
+   local.get $6
    i32.load
    i32.const 3
    i32.const -1

--- a/tests/compiler/resolve-access.untouched.wat
+++ b/tests/compiler/resolve-access.untouched.wat
@@ -35,6 +35,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   memory.size
   local.set $1
   local.get $1
@@ -65,8 +66,8 @@
    local.get $5
    i32.gt_s
    select
-   local.set $4
-   local.get $4
+   local.set $6
+   local.get $6
    memory.grow
    i32.const 0
    i32.lt_s
@@ -143,6 +144,88 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local $22 i32)
+  (local $23 i32)
+  (local $24 i32)
+  (local $25 i32)
+  (local $26 i32)
+  (local $27 i32)
+  (local $28 i32)
+  (local $29 i32)
+  (local $30 i32)
+  (local $31 i32)
+  (local $32 i32)
+  (local $33 i32)
+  (local $34 i32)
+  (local $35 i32)
+  (local $36 i32)
+  (local $37 i32)
+  (local $38 i32)
+  (local $39 i32)
+  (local $40 i32)
+  (local $41 i32)
+  (local $42 i32)
+  (local $43 i32)
+  (local $44 i32)
+  (local $45 i32)
+  (local $46 i32)
+  (local $47 i32)
+  (local $48 i32)
+  (local $49 i32)
+  (local $50 i32)
+  (local $51 i32)
+  (local $52 i32)
+  (local $53 i32)
+  (local $54 i32)
+  (local $55 i32)
+  (local $56 i32)
+  (local $57 i32)
+  (local $58 i32)
+  (local $59 i32)
+  (local $60 i32)
+  (local $61 i32)
+  (local $62 i32)
+  (local $63 i32)
+  (local $64 i32)
+  (local $65 i32)
+  (local $66 i32)
+  (local $67 i32)
+  (local $68 i32)
+  (local $69 i32)
+  (local $70 i32)
+  (local $71 i32)
+  (local $72 i32)
+  (local $73 i32)
+  (local $74 i32)
+  (local $75 i32)
+  (local $76 i32)
+  (local $77 i32)
+  (local $78 i32)
+  (local $79 i32)
+  (local $80 i32)
+  (local $81 i32)
+  (local $82 i32)
+  (local $83 i32)
+  (local $84 i32)
+  (local $85 i32)
+  (local $86 i32)
+  (local $87 i32)
+  (local $88 i32)
   loop $while-continue|0
    local.get $2
    if (result i32)
@@ -162,11 +245,11 @@
     local.set $0
     local.get $6
     local.get $1
-    local.tee $6
+    local.tee $7
     i32.const 1
     i32.add
     local.set $1
-    local.get $6
+    local.get $7
     i32.load8_u
     i32.store8
     local.get $2
@@ -186,8 +269,8 @@
     local.get $2
     i32.const 16
     i32.ge_u
-    local.set $5
-    local.get $5
+    local.set $8
+    local.get $8
     if
      local.get $0
      local.get $1
@@ -296,17 +379,17 @@
    i32.and
    if
     local.get $0
-    local.tee $5
+    local.tee $9
     i32.const 1
     i32.add
     local.set $0
-    local.get $5
+    local.get $9
     local.get $1
-    local.tee $5
+    local.tee $10
     i32.const 1
     i32.add
     local.set $1
-    local.get $5
+    local.get $10
     i32.load8_u
     i32.store8
    end
@@ -323,16 +406,16 @@
        local.get $0
        i32.const 3
        i32.and
-       local.set $5
-       local.get $5
+       local.set $11
+       local.get $11
        i32.const 1
        i32.eq
        br_if $case0|2
-       local.get $5
+       local.get $11
        i32.const 2
        i32.eq
        br_if $case1|2
-       local.get $5
+       local.get $11
        i32.const 3
        i32.eq
        br_if $case2|2
@@ -342,45 +425,45 @@
       i32.load
       local.set $3
       local.get $0
-      local.tee $5
+      local.tee $12
       i32.const 1
       i32.add
       local.set $0
-      local.get $5
+      local.get $12
       local.get $1
-      local.tee $5
+      local.tee $13
       i32.const 1
       i32.add
       local.set $1
-      local.get $5
+      local.get $13
       i32.load8_u
       i32.store8
       local.get $0
-      local.tee $5
+      local.tee $14
       i32.const 1
       i32.add
       local.set $0
-      local.get $5
+      local.get $14
       local.get $1
-      local.tee $5
+      local.tee $15
       i32.const 1
       i32.add
       local.set $1
-      local.get $5
+      local.get $15
       i32.load8_u
       i32.store8
       local.get $0
-      local.tee $5
+      local.tee $16
       i32.const 1
       i32.add
       local.set $0
-      local.get $5
+      local.get $16
       local.get $1
-      local.tee $5
+      local.tee $17
       i32.const 1
       i32.add
       local.set $1
-      local.get $5
+      local.get $17
       i32.load8_u
       i32.store8
       local.get $2
@@ -391,8 +474,8 @@
        local.get $2
        i32.const 17
        i32.ge_u
-       local.set $5
-       local.get $5
+       local.set $18
+       local.get $18
        if
         local.get $1
         i32.const 1
@@ -477,31 +560,31 @@
      i32.load
      local.set $3
      local.get $0
-     local.tee $5
+     local.tee $19
      i32.const 1
      i32.add
      local.set $0
-     local.get $5
+     local.get $19
      local.get $1
-     local.tee $5
+     local.tee $20
      i32.const 1
      i32.add
      local.set $1
-     local.get $5
+     local.get $20
      i32.load8_u
      i32.store8
      local.get $0
-     local.tee $5
+     local.tee $21
      i32.const 1
      i32.add
      local.set $0
-     local.get $5
+     local.get $21
      local.get $1
-     local.tee $5
+     local.tee $22
      i32.const 1
      i32.add
      local.set $1
-     local.get $5
+     local.get $22
      i32.load8_u
      i32.store8
      local.get $2
@@ -512,8 +595,8 @@
       local.get $2
       i32.const 18
       i32.ge_u
-      local.set $5
-      local.get $5
+      local.set $23
+      local.get $23
       if
        local.get $1
        i32.const 2
@@ -598,17 +681,17 @@
     i32.load
     local.set $3
     local.get $0
-    local.tee $5
+    local.tee $24
     i32.const 1
     i32.add
     local.set $0
-    local.get $5
+    local.get $24
     local.get $1
-    local.tee $5
+    local.tee $25
     i32.const 1
     i32.add
     local.set $1
-    local.get $5
+    local.get $25
     i32.load8_u
     i32.store8
     local.get $2
@@ -619,8 +702,8 @@
      local.get $2
      i32.const 19
      i32.ge_u
-     local.set $5
-     local.get $5
+     local.set $26
+     local.get $26
      if
       local.get $1
       i32.const 3
@@ -707,227 +790,227 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $27
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $27
    local.get $1
-   local.tee $5
+   local.tee $28
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $28
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $29
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $29
    local.get $1
-   local.tee $5
+   local.tee $30
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $30
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $31
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $31
    local.get $1
-   local.tee $5
+   local.tee $32
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $32
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $33
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $33
    local.get $1
-   local.tee $5
+   local.tee $34
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $34
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $35
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $35
    local.get $1
-   local.tee $5
+   local.tee $36
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $36
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $37
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $37
    local.get $1
-   local.tee $5
+   local.tee $38
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $38
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $39
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $39
    local.get $1
-   local.tee $5
+   local.tee $40
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $40
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $41
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $41
    local.get $1
-   local.tee $5
+   local.tee $42
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $42
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $43
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $43
    local.get $1
-   local.tee $5
+   local.tee $44
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $44
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $45
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $45
    local.get $1
-   local.tee $5
+   local.tee $46
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $46
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $47
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $47
    local.get $1
-   local.tee $5
+   local.tee $48
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $48
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $49
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $49
    local.get $1
-   local.tee $5
+   local.tee $50
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $50
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $51
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $51
    local.get $1
-   local.tee $5
+   local.tee $52
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $52
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $53
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $53
    local.get $1
-   local.tee $5
+   local.tee $54
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $54
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $55
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $55
    local.get $1
-   local.tee $5
+   local.tee $56
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $56
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $57
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $57
    local.get $1
-   local.tee $5
+   local.tee $58
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $58
    i32.load8_u
    i32.store8
   end
@@ -936,115 +1019,115 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $59
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $59
    local.get $1
-   local.tee $5
+   local.tee $60
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $60
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $61
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $61
    local.get $1
-   local.tee $5
+   local.tee $62
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $62
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $63
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $63
    local.get $1
-   local.tee $5
+   local.tee $64
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $64
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $65
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $65
    local.get $1
-   local.tee $5
+   local.tee $66
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $66
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $67
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $67
    local.get $1
-   local.tee $5
+   local.tee $68
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $68
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $69
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $69
    local.get $1
-   local.tee $5
+   local.tee $70
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $70
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $71
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $71
    local.get $1
-   local.tee $5
+   local.tee $72
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $72
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $73
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $73
    local.get $1
-   local.tee $5
+   local.tee $74
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $74
    i32.load8_u
    i32.store8
   end
@@ -1053,59 +1136,59 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $75
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $75
    local.get $1
-   local.tee $5
+   local.tee $76
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $76
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $77
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $77
    local.get $1
-   local.tee $5
+   local.tee $78
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $78
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $79
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $79
    local.get $1
-   local.tee $5
+   local.tee $80
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $80
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $81
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $81
    local.get $1
-   local.tee $5
+   local.tee $82
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $82
    i32.load8_u
    i32.store8
   end
@@ -1114,31 +1197,31 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $83
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $83
    local.get $1
-   local.tee $5
+   local.tee $84
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $84
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $85
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $85
    local.get $1
-   local.tee $5
+   local.tee $86
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $86
    i32.load8_u
    i32.store8
   end
@@ -1147,17 +1230,17 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $87
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $87
    local.get $1
-   local.tee $5
+   local.tee $88
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $88
    i32.load8_u
    i32.store8
   end
@@ -1168,6 +1251,14 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
   block $~lib/util/memory/memmove|inlined.0
    local.get $0
    local.set $5
@@ -1245,11 +1336,11 @@
        local.set $5
        local.get $7
        local.get $4
-       local.tee $7
+       local.tee $8
        i32.const 1
        i32.add
        local.set $4
-       local.get $7
+       local.get $8
        i32.load8_u
        i32.store8
        br $while-continue|0
@@ -1259,8 +1350,8 @@
       local.get $3
       i32.const 8
       i32.ge_u
-      local.set $6
-      local.get $6
+      local.set $9
+      local.get $9
       if
        local.get $5
        local.get $4
@@ -1284,21 +1375,21 @@
     end
     loop $while-continue|2
      local.get $3
-     local.set $6
-     local.get $6
+     local.set $10
+     local.get $10
      if
       local.get $5
-      local.tee $7
+      local.tee $11
       i32.const 1
       i32.add
       local.set $5
-      local.get $7
+      local.get $11
       local.get $4
-      local.tee $7
+      local.tee $12
       i32.const 1
       i32.add
       local.set $4
-      local.get $7
+      local.get $12
       i32.load8_u
       i32.store8
       local.get $3
@@ -1327,8 +1418,8 @@
       i32.add
       i32.const 7
       i32.and
-      local.set $6
-      local.get $6
+      local.set $13
+      local.get $13
       if
        local.get $3
        i32.eqz
@@ -1353,8 +1444,8 @@
       local.get $3
       i32.const 8
       i32.ge_u
-      local.set $6
-      local.get $6
+      local.set $14
+      local.get $14
       if
        local.get $3
        i32.const 8
@@ -1374,8 +1465,8 @@
     end
     loop $while-continue|5
      local.get $3
-     local.set $6
-     local.get $6
+     local.set $15
+     local.get $15
      if
       local.get $5
       local.get $3
@@ -1540,6 +1631,9 @@
   (local $9 i64)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
   loop $while-continue|0
    local.get $1
    i32.const 10000
@@ -1604,30 +1698,30 @@
    local.get $1
    i32.const 100
    i32.div_u
-   local.set $3
+   local.set $10
    local.get $1
    i32.const 100
    i32.rem_u
-   local.set $10
-   local.get $3
+   local.set $11
+   local.get $10
    local.set $1
    local.get $2
    i32.const 2
    i32.sub
    local.set $2
    i32.const 180
-   local.get $10
+   local.get $11
    i32.const 2
    i32.shl
    i32.add
    i32.load
-   local.set $11
+   local.set $12
    local.get $0
    local.get $2
    i32.const 1
    i32.shl
    i32.add
-   local.get $11
+   local.get $12
    i32.store
   end
   local.get $1
@@ -1644,13 +1738,13 @@
    i32.shl
    i32.add
    i32.load
-   local.set $11
+   local.set $13
    local.get $0
    local.get $2
    i32.const 1
    i32.shl
    i32.add
-   local.get $11
+   local.get $13
    i32.store
   else
    local.get $2
@@ -1660,13 +1754,13 @@
    i32.const 48
    local.get $1
    i32.add
-   local.set $11
+   local.set $14
    local.get $0
    local.get $2
    i32.const 1
    i32.shl
    i32.add
-   local.get $11
+   local.get $14
    i32.store16
   end
  )
@@ -1859,7 +1953,10 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i64)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i64)
+  (local $10 i32)
   local.get $0
   i64.const 0
   i64.ne
@@ -1902,26 +1999,26 @@
   else
    local.get $0
    call $~lib/util/number/decimalCount64High
-   local.set $3
-   local.get $3
+   local.set $7
+   local.get $7
    i32.const 1
    i32.shl
    i32.const 1
    call $~lib/rt/stub/__alloc
    local.set $1
    local.get $1
-   local.set $5
+   local.set $10
    local.get $0
-   local.set $7
-   local.get $3
-   local.set $4
+   local.set $9
+   local.get $7
+   local.set $8
    i32.const 0
    i32.const 1
    i32.ge_s
    drop
-   local.get $5
-   local.get $7
-   local.get $4
+   local.get $10
+   local.get $9
+   local.get $8
    call $~lib/util/number/utoa64_lut
   end
   local.get $1
@@ -1951,21 +2048,23 @@
  (func $resolve-access/arrayAccess (result i32)
   (local $0 i32)
   (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
   i32.const 1
   i32.const 3
   i32.const 3
   i32.const 32
   call $~lib/rt/__allocArray
   call $~lib/rt/stub/__retain
-  local.set $1
-  local.get $1
+  local.set $2
+  local.get $2
   i32.const 0
   call $~lib/array/Array<u64>#__get
   call $~lib/number/U64#toString
-  local.set $0
-  local.get $1
+  local.set $3
+  local.get $2
   call $~lib/rt/stub/__release
-  local.get $0
+  local.get $3
  )
  (func $resolve-access/Container#constructor (param $0 i32) (result i32)
   local.get $0

--- a/tests/compiler/resolve-binary.optimized.wat
+++ b/tests/compiler/resolve-binary.optimized.wat
@@ -361,8 +361,8 @@
  )
  (func $~lib/util/number/genDigits (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (result i32)
   (local $6 i32)
-  (local $7 i64)
-  (local $8 i32)
+  (local $7 i32)
+  (local $8 i64)
   (local $9 i64)
   (local $10 i32)
   (local $11 i64)
@@ -384,7 +384,7 @@
   i64.sub
   local.tee $12
   i64.and
-  local.set $7
+  local.set $8
   local.get $3
   local.get $10
   i64.extend_i32_s
@@ -518,11 +518,11 @@
      local.set $2
     end
     local.get $2
-    local.get $8
+    local.get $7
     i32.or
     if
      local.get $0
-     local.get $8
+     local.get $7
      i32.const 1
      i32.shl
      i32.add
@@ -532,16 +532,16 @@
      i32.const 48
      i32.add
      i32.store16
-     local.get $8
+     local.get $7
      i32.const 1
      i32.add
-     local.set $8
+     local.set $7
     end
     local.get $4
     i32.const 1
     i32.sub
     local.set $4
-    local.get $7
+    local.get $8
     local.get $6
     i64.extend_i32_u
     local.get $10
@@ -567,7 +567,7 @@
      i64.shl
      local.set $3
      local.get $0
-     local.get $8
+     local.get $7
      i32.const 1
      i32.sub
      i32.const 1
@@ -584,11 +584,11 @@
       local.get $1
       local.get $3
       i64.add
-      local.tee $7
+      local.tee $8
       local.get $9
       i64.sub
       i64.gt_u
-      local.get $7
+      local.get $8
       local.get $9
       i64.lt_u
       select
@@ -619,7 +619,7 @@
      local.get $0
      local.get $4
      i32.store16
-     local.get $8
+     local.get $7
      return
     end
     br $while-continue|0
@@ -633,35 +633,35 @@
    i64.const 10
    i64.mul
    local.set $5
-   local.get $7
+   local.get $8
    i64.const 10
    i64.mul
    local.tee $3
    local.get $1
    i64.shr_u
-   local.tee $7
-   local.get $8
+   local.tee $8
+   local.get $7
    i64.extend_i32_s
    i64.or
    i64.const 0
    i64.ne
    if
     local.get $0
-    local.get $8
+    local.get $7
     i32.const 1
     i32.shl
     i32.add
-    local.get $7
+    local.get $8
     i32.wrap_i64
     i32.const 65535
     i32.and
     i32.const 48
     i32.add
     i32.store16
-    local.get $8
+    local.get $7
     i32.const 1
     i32.add
-    local.set $8
+    local.set $7
    end
    local.get $4
    i32.const 1
@@ -670,7 +670,7 @@
    local.get $3
    local.get $12
    i64.and
-   local.tee $7
+   local.tee $8
    local.get $5
    i64.ge_u
    br_if $while-continue|4
@@ -679,8 +679,6 @@
   global.get $~lib/util/number/_K
   i32.add
   global.set $~lib/util/number/_K
-  local.get $7
-  local.set $1
   local.get $9
   i32.const 0
   local.get $4
@@ -691,9 +689,9 @@
   i32.add
   i64.load32_u
   i64.mul
-  local.set $3
+  local.set $1
   local.get $0
-  local.get $8
+  local.get $7
   i32.const 1
   i32.sub
   i32.const 1
@@ -704,29 +702,29 @@
   local.set $4
   loop $while-continue|6
    i32.const 1
-   local.get $3
    local.get $1
+   local.get $8
    i64.sub
-   local.get $1
+   local.get $8
    local.get $11
    i64.add
-   local.tee $7
-   local.get $3
+   local.tee $3
+   local.get $1
    i64.sub
    i64.gt_u
-   local.get $7
    local.get $3
+   local.get $1
    i64.lt_u
    select
    i32.const 0
    local.get $5
-   local.get $1
+   local.get $8
    i64.sub
    local.get $11
    i64.ge_u
    i32.const 0
+   local.get $8
    local.get $1
-   local.get $3
    i64.lt_u
    select
    select
@@ -735,17 +733,17 @@
     i32.const 1
     i32.sub
     local.set $4
-    local.get $1
+    local.get $8
     local.get $11
     i64.add
-    local.set $1
+    local.set $8
     br $while-continue|6
    end
   end
   local.get $0
   local.get $4
   i32.store16
-  local.get $8
+  local.get $7
  )
  (func $~lib/memory/memory.copy (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)

--- a/tests/compiler/resolve-binary.untouched.wat
+++ b/tests/compiler/resolve-binary.untouched.wat
@@ -97,6 +97,9 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
   local.get $0
   call $~lib/rt/stub/__retain
   local.set $0
@@ -168,33 +171,33 @@
   end
   loop $while-continue|1
    local.get $4
-   local.tee $7
+   local.tee $8
    i32.const 1
    i32.sub
    local.set $4
-   local.get $7
-   local.set $7
-   local.get $7
+   local.get $8
+   local.set $9
+   local.get $9
    if
     local.get $5
     i32.load16_u
-    local.set $8
+    local.set $10
     local.get $6
     i32.load16_u
-    local.set $9
-    local.get $8
-    local.get $9
+    local.set $11
+    local.get $10
+    local.get $11
     i32.ne
     if
-     local.get $8
-     local.get $9
+     local.get $10
+     local.get $11
      i32.sub
-     local.set $10
+     local.set $12
      local.get $0
      call $~lib/rt/stub/__release
      local.get $2
      call $~lib/rt/stub/__release
-     local.get $10
+     local.get $12
      return
     end
     local.get $5
@@ -209,16 +212,19 @@
    end
   end
   i32.const 0
-  local.set $7
+  local.set $13
   local.get $0
   call $~lib/rt/stub/__release
   local.get $2
   call $~lib/rt/stub/__release
-  local.get $7
+  local.get $13
  )
  (func $~lib/string/String.__eq (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   local.get $0
   call $~lib/rt/stub/__retain
   local.set $0
@@ -250,44 +256,44 @@
   end
   if
    i32.const 0
-   local.set $2
+   local.set $3
    local.get $0
    call $~lib/rt/stub/__release
    local.get $1
    call $~lib/rt/stub/__release
-   local.get $2
+   local.get $3
    return
   end
   local.get $0
   call $~lib/string/String#get:length
-  local.set $3
-  local.get $3
+  local.set $4
+  local.get $4
   local.get $1
   call $~lib/string/String#get:length
   i32.ne
   if
    i32.const 0
-   local.set $2
+   local.set $5
    local.get $0
    call $~lib/rt/stub/__release
    local.get $1
    call $~lib/rt/stub/__release
-   local.get $2
+   local.get $5
    return
   end
   local.get $0
   i32.const 0
   local.get $1
   i32.const 0
-  local.get $3
+  local.get $4
   call $~lib/util/string/compareImpl
   i32.eqz
-  local.set $2
+  local.set $6
   local.get $0
   call $~lib/rt/stub/__release
   local.get $1
   call $~lib/rt/stub/__release
-  local.get $2
+  local.get $6
  )
  (func $~lib/util/number/decimalCount32 (param $0 i32) (result i32)
   local.get $0
@@ -350,6 +356,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   memory.size
   local.set $1
   local.get $1
@@ -380,8 +387,8 @@
    local.get $5
    i32.gt_s
    select
-   local.set $4
-   local.get $4
+   local.set $6
+   local.get $6
    memory.grow
    i32.const 0
    i32.lt_s
@@ -463,6 +470,9 @@
   (local $9 i64)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
   loop $while-continue|0
    local.get $1
    i32.const 10000
@@ -527,30 +537,30 @@
    local.get $1
    i32.const 100
    i32.div_u
-   local.set $3
+   local.set $10
    local.get $1
    i32.const 100
    i32.rem_u
-   local.set $10
-   local.get $3
+   local.set $11
+   local.get $10
    local.set $1
    local.get $2
    i32.const 2
    i32.sub
    local.set $2
    i32.const 196
-   local.get $10
+   local.get $11
    i32.const 2
    i32.shl
    i32.add
    i32.load
-   local.set $11
+   local.set $12
    local.get $0
    local.get $2
    i32.const 1
    i32.shl
    i32.add
-   local.get $11
+   local.get $12
    i32.store
   end
   local.get $1
@@ -567,13 +577,13 @@
    i32.shl
    i32.add
    i32.load
-   local.set $11
+   local.set $13
    local.get $0
    local.get $2
    i32.const 1
    i32.shl
    i32.add
-   local.get $11
+   local.get $13
    i32.store
   else
    local.get $2
@@ -583,13 +593,13 @@
    i32.const 48
    local.get $1
    i32.add
-   local.set $11
+   local.set $14
    local.get $0
    local.get $2
    i32.const 1
    i32.shl
    i32.add
-   local.get $11
+   local.get $14
    i32.store16
   end
  )
@@ -678,18 +688,18 @@
   (local $7 i64)
   (local $8 i64)
   (local $9 i64)
-  (local $10 f64)
-  (local $11 i64)
-  (local $12 i32)
+  (local $10 i64)
+  (local $11 f64)
+  (local $12 i64)
   (local $13 i64)
   (local $14 i64)
-  (local $15 f64)
-  (local $16 f64)
-  (local $17 f64)
-  (local $18 f64)
-  (local $19 f64)
-  (local $20 f64)
-  (local $21 f64)
+  (local $15 i64)
+  (local $16 i32)
+  (local $17 i64)
+  (local $18 i64)
+  (local $19 i32)
+  (local $20 i64)
+  (local $21 i64)
   (local $22 f64)
   (local $23 f64)
   (local $24 f64)
@@ -707,12 +717,52 @@
   (local $36 f64)
   (local $37 f64)
   (local $38 f64)
-  (local $39 i32)
-  (local $40 i32)
-  (local $41 i32)
-  (local $42 i32)
-  (local $43 i64)
-  (local $44 i64)
+  (local $39 f64)
+  (local $40 f64)
+  (local $41 f64)
+  (local $42 f64)
+  (local $43 f64)
+  (local $44 f64)
+  (local $45 f64)
+  (local $46 f64)
+  (local $47 f64)
+  (local $48 f64)
+  (local $49 f64)
+  (local $50 f64)
+  (local $51 f64)
+  (local $52 f64)
+  (local $53 f64)
+  (local $54 f64)
+  (local $55 i32)
+  (local $56 f64)
+  (local $57 f64)
+  (local $58 i32)
+  (local $59 i64)
+  (local $60 i64)
+  (local $61 i64)
+  (local $62 i32)
+  (local $63 f64)
+  (local $64 f64)
+  (local $65 f64)
+  (local $66 f64)
+  (local $67 f64)
+  (local $68 f64)
+  (local $69 f64)
+  (local $70 i64)
+  (local $71 i32)
+  (local $72 f64)
+  (local $73 i32)
+  (local $74 i32)
+  (local $75 f64)
+  (local $76 i32)
+  (local $77 i64)
+  (local $78 i64)
+  (local $79 f64)
+  (local $80 f64)
+  (local $81 f64)
+  (local $82 f64)
+  (local $83 f64)
+  (local $84 f64)
   local.get $1
   f64.abs
   f64.const 2
@@ -891,8 +941,8 @@
      br $~lib/util/math/pow_lut|inlined.0
     end
     local.get $5
-    local.set $9
-    local.get $9
+    local.set $10
+    local.get $10
     i64.const 1
     i64.shl
     i64.const 1
@@ -905,7 +955,7 @@
      local.get $3
      local.get $3
      f64.mul
-     local.set $10
+     local.set $11
      local.get $5
      i64.const 63
      i64.shr_u
@@ -913,21 +963,21 @@
      if (result i32)
       block $~lib/util/math/checkint|inlined.0 (result i32)
        local.get $6
-       local.set $9
-       local.get $9
+       local.set $12
+       local.get $12
        i64.const 52
        i64.shr_u
        i64.const 2047
        i64.and
-       local.set $11
-       local.get $11
+       local.set $13
+       local.get $13
        i64.const 1023
        i64.lt_u
        if
         i32.const 0
         br $~lib/util/math/checkint|inlined.0
        end
-       local.get $11
+       local.get $13
        i64.const 1023
        i64.const 52
        i64.add
@@ -940,12 +990,12 @@
        i64.const 1023
        i64.const 52
        i64.add
-       local.get $11
+       local.get $13
        i64.sub
        i64.shl
-       local.set $11
-       local.get $9
-       local.get $11
+       local.set $13
+       local.get $12
+       local.get $13
        i64.const 1
        i64.sub
        i64.and
@@ -955,8 +1005,8 @@
         i32.const 0
         br $~lib/util/math/checkint|inlined.0
        end
-       local.get $9
-       local.get $11
+       local.get $12
+       local.get $13
        i64.and
        i64.const 0
        i64.ne
@@ -972,9 +1022,9 @@
       i32.const 0
      end
      if
-      local.get $10
+      local.get $11
       f64.neg
-      local.set $10
+      local.set $11
      end
      local.get $6
      i64.const 63
@@ -983,10 +1033,10 @@
      i64.ne
      if (result f64)
       f64.const 1
-      local.get $10
+      local.get $11
       f64.div
      else
-      local.get $10
+      local.get $11
      end
      br $~lib/util/math/pow_lut|inlined.0
     end
@@ -998,21 +1048,21 @@
     if
      block $~lib/util/math/checkint|inlined.1 (result i32)
       local.get $6
-      local.set $9
-      local.get $9
+      local.set $14
+      local.get $14
       i64.const 52
       i64.shr_u
       i64.const 2047
       i64.and
-      local.set $11
-      local.get $11
+      local.set $15
+      local.get $15
       i64.const 1023
       i64.lt_u
       if
        i32.const 0
        br $~lib/util/math/checkint|inlined.1
       end
-      local.get $11
+      local.get $15
       i64.const 1023
       i64.const 52
       i64.add
@@ -1025,12 +1075,12 @@
       i64.const 1023
       i64.const 52
       i64.add
-      local.get $11
+      local.get $15
       i64.sub
       i64.shl
-      local.set $11
-      local.get $9
-      local.get $11
+      local.set $15
+      local.get $14
+      local.get $15
       i64.const 1
       i64.sub
       i64.and
@@ -1040,8 +1090,8 @@
        i32.const 0
        br $~lib/util/math/checkint|inlined.1
       end
-      local.get $9
-      local.get $11
+      local.get $14
+      local.get $15
       i64.and
       i64.const 0
       i64.ne
@@ -1051,8 +1101,8 @@
       end
       i32.const 2
      end
-     local.set $12
-     local.get $12
+     local.set $16
+     local.get $16
      i32.const 0
      i32.eq
      if
@@ -1065,7 +1115,7 @@
       f64.div
       br $~lib/util/math/pow_lut|inlined.0
      end
-     local.get $12
+     local.get $16
      i32.const 1
      i32.eq
      if
@@ -1143,12 +1193,12 @@
     end
    end
    local.get $5
-   local.set $9
-   local.get $9
+   local.set $17
+   local.get $17
    i64.const 4604531861337669632
    i64.sub
-   local.set $11
-   local.get $11
+   local.set $18
+   local.get $18
    i64.const 52
    i64.const 7
    i64.sub
@@ -1156,150 +1206,150 @@
    i64.const 127
    i64.and
    i32.wrap_i64
-   local.set $12
-   local.get $11
+   local.set $19
+   local.get $18
    i64.const 52
    i64.shr_s
-   local.set $13
-   local.get $9
-   local.get $11
+   local.set $20
+   local.get $17
+   local.get $18
    i64.const 4095
    i64.const 52
    i64.shl
    i64.and
    i64.sub
-   local.set $14
-   local.get $14
+   local.set $21
+   local.get $21
    f64.reinterpret_i64
-   local.set $10
-   local.get $13
+   local.set $22
+   local.get $20
    f64.convert_i64_s
-   local.set $15
+   local.set $23
    i32.const 664
-   local.get $12
+   local.get $19
    i32.const 2
    i32.const 3
    i32.add
    i32.shl
    i32.add
    f64.load
-   local.set $16
+   local.set $24
    i32.const 664
-   local.get $12
+   local.get $19
    i32.const 2
    i32.const 3
    i32.add
    i32.shl
    i32.add
    f64.load offset=16
-   local.set $17
+   local.set $25
    i32.const 664
-   local.get $12
+   local.get $19
    i32.const 2
    i32.const 3
    i32.add
    i32.shl
    i32.add
    f64.load offset=24
-   local.set $18
-   local.get $14
+   local.set $26
+   local.get $21
    i64.const 2147483648
    i64.add
    i64.const -4294967296
    i64.and
    f64.reinterpret_i64
-   local.set $19
-   local.get $10
-   local.get $19
+   local.set $27
+   local.get $22
+   local.get $27
    f64.sub
-   local.set $20
-   local.get $19
-   local.get $16
+   local.set $28
+   local.get $27
+   local.get $24
    f64.mul
    f64.const 1
    f64.sub
-   local.set $21
-   local.get $20
-   local.get $16
-   f64.mul
-   local.set $22
-   local.get $21
-   local.get $22
-   f64.add
-   local.set $23
-   local.get $15
-   f64.const 0.6931471805598903
-   f64.mul
-   local.get $17
-   f64.add
-   local.set $24
-   local.get $24
-   local.get $23
-   f64.add
-   local.set $25
-   local.get $15
-   f64.const 5.497923018708371e-14
-   f64.mul
-   local.get $18
-   f64.add
-   local.set $26
-   local.get $24
-   local.get $25
-   f64.sub
-   local.get $23
-   f64.add
-   local.set $27
-   f64.const -0.5
-   local.get $23
-   f64.mul
-   local.set $28
-   local.get $23
-   local.get $28
-   f64.mul
    local.set $29
-   local.get $23
-   local.get $29
+   local.get $28
+   local.get $24
    f64.mul
    local.set $30
-   f64.const -0.5
-   local.get $21
-   f64.mul
+   local.get $29
+   local.get $30
+   f64.add
    local.set $31
-   local.get $21
-   local.get $31
+   local.get $23
+   f64.const 0.6931471805598903
    f64.mul
-   local.set $32
    local.get $25
+   f64.add
+   local.set $32
    local.get $32
+   local.get $31
    f64.add
    local.set $33
-   local.get $22
-   local.get $28
-   local.get $31
-   f64.add
+   local.get $23
+   f64.const 5.497923018708371e-14
    f64.mul
+   local.get $26
+   f64.add
    local.set $34
-   local.get $25
+   local.get $32
    local.get $33
    f64.sub
-   local.get $32
+   local.get $31
    f64.add
    local.set $35
+   f64.const -0.5
+   local.get $31
+   f64.mul
+   local.set $36
+   local.get $31
+   local.get $36
+   f64.mul
+   local.set $37
+   local.get $31
+   local.get $37
+   f64.mul
+   local.set $38
+   f64.const -0.5
+   local.get $29
+   f64.mul
+   local.set $39
+   local.get $29
+   local.get $39
+   f64.mul
+   local.set $40
+   local.get $33
+   local.get $40
+   f64.add
+   local.set $41
    local.get $30
+   local.get $36
+   local.get $39
+   f64.add
+   f64.mul
+   local.set $42
+   local.get $33
+   local.get $41
+   f64.sub
+   local.get $40
+   f64.add
+   local.set $43
+   local.get $38
    f64.const -0.6666666666666679
-   local.get $23
+   local.get $31
    f64.const 0.5000000000000007
    f64.mul
    f64.add
-   local.get $29
+   local.get $37
    f64.const 0.7999999995323976
-   local.get $23
+   local.get $31
    f64.const -0.6666666663487739
    f64.mul
    f64.add
-   local.get $29
+   local.get $37
    f64.const -1.142909628459501
-   local.get $23
+   local.get $31
    f64.const 1.0000415263675542
    f64.mul
    f64.add
@@ -1308,88 +1358,88 @@
    f64.mul
    f64.add
    f64.mul
-   local.set $36
-   local.get $26
-   local.get $27
-   f64.add
+   local.set $44
    local.get $34
-   f64.add
    local.get $35
    f64.add
-   local.get $36
+   local.get $42
    f64.add
-   local.set $37
-   local.get $33
-   local.get $37
+   local.get $43
    f64.add
-   local.set $38
-   local.get $33
-   local.get $38
+   local.get $44
+   f64.add
+   local.set $45
+   local.get $41
+   local.get $45
+   f64.add
+   local.set $46
+   local.get $41
+   local.get $46
    f64.sub
-   local.get $37
+   local.get $45
    f64.add
    global.set $~lib/util/math/log_tail
-   local.get $38
-   local.set $38
+   local.get $46
+   local.set $47
    global.get $~lib/util/math/log_tail
-   local.set $37
+   local.set $48
    local.get $6
    i64.const -134217728
    i64.and
    f64.reinterpret_i64
-   local.set $34
+   local.set $51
    local.get $2
-   local.get $34
+   local.get $51
    f64.sub
-   local.set $33
-   local.get $38
+   local.set $52
+   local.get $47
    i64.reinterpret_f64
    i64.const -134217728
    i64.and
    f64.reinterpret_i64
-   local.set $32
-   local.get $38
-   local.get $32
+   local.set $53
+   local.get $47
+   local.get $53
    f64.sub
-   local.get $37
+   local.get $48
    f64.add
-   local.set $31
-   local.get $34
-   local.get $32
+   local.set $54
+   local.get $51
+   local.get $53
    f64.mul
-   local.set $36
-   local.get $33
-   local.get $32
+   local.set $49
+   local.get $52
+   local.get $53
    f64.mul
    local.get $2
-   local.get $31
+   local.get $54
    f64.mul
    f64.add
-   local.set $35
+   local.set $50
    block $~lib/util/math/exp_inline|inlined.0 (result f64)
-    local.get $36
-    local.set $15
-    local.get $35
-    local.set $10
+    local.get $49
+    local.set $57
+    local.get $50
+    local.set $56
     local.get $4
-    local.set $12
-    local.get $15
+    local.set $55
+    local.get $57
     i64.reinterpret_f64
-    local.set $9
-    local.get $9
+    local.set $70
+    local.get $70
     i64.const 52
     i64.shr_u
     i32.wrap_i64
     i32.const 2047
     i32.and
-    local.set $39
-    local.get $39
+    local.set $58
+    local.get $58
     i32.const 969
     i32.sub
     i32.const 63
     i32.ge_u
     if
-     local.get $39
+     local.get $58
      i32.const 969
      i32.sub
      i32.const -2147483648
@@ -1397,252 +1447,252 @@
      if
       f64.const -1
       f64.const 1
-      local.get $12
+      local.get $55
       select
       br $~lib/util/math/exp_inline|inlined.0
      end
-     local.get $39
+     local.get $58
      i32.const 1033
      i32.ge_u
      if
-      local.get $9
+      local.get $70
       i64.const 63
       i64.shr_u
       i64.const 0
       i64.ne
       if (result f64)
-       local.get $12
-       local.set $41
-       local.get $41
-       local.set $42
+       local.get $55
+       local.set $71
+       local.get $71
+       local.set $73
        i64.const 1152921504606846976
        f64.reinterpret_i64
-       local.set $16
-       local.get $16
+       local.set $72
+       local.get $72
        f64.neg
-       local.get $16
-       local.get $42
+       local.get $72
+       local.get $73
        select
-       local.get $16
+       local.get $72
        f64.mul
       else
-       local.get $12
-       local.set $42
-       local.get $42
-       local.set $41
+       local.get $55
+       local.set $74
+       local.get $74
+       local.set $76
        i64.const 8070450532247928832
        f64.reinterpret_i64
-       local.set $17
-       local.get $17
+       local.set $75
+       local.get $75
        f64.neg
-       local.get $17
-       local.get $41
+       local.get $75
+       local.get $76
        select
-       local.get $17
+       local.get $75
        f64.mul
       end
       br $~lib/util/math/exp_inline|inlined.0
      end
      i32.const 0
-     local.set $39
+     local.set $58
     end
     f64.const 184.6649652337873
-    local.get $15
+    local.get $57
     f64.mul
-    local.set $29
-    local.get $29
+    local.set $64
+    local.get $64
     f64.const 6755399441055744
     f64.add
-    local.set $30
-    local.get $30
+    local.set $63
+    local.get $63
     i64.reinterpret_f64
-    local.set $14
-    local.get $30
+    local.set $59
+    local.get $63
     f64.const 6755399441055744
     f64.sub
-    local.set $30
-    local.get $15
-    local.get $30
+    local.set $63
+    local.get $57
+    local.get $63
     f64.const -0.005415212348111709
     f64.mul
     f64.add
-    local.get $30
+    local.get $63
     f64.const -1.2864023111638346e-14
     f64.mul
     f64.add
-    local.set $28
-    local.get $28
-    local.get $10
+    local.set $65
+    local.get $65
+    local.get $56
     f64.add
-    local.set $28
-    local.get $14
+    local.set $65
+    local.get $59
     i64.const 127
     i64.and
     i64.const 1
     i64.shl
     i32.wrap_i64
-    local.set $40
-    local.get $14
-    local.get $12
+    local.set $62
+    local.get $59
+    local.get $55
     i64.extend_i32_u
     i64.add
     i64.const 52
     i64.const 7
     i64.sub
     i64.shl
-    local.set $13
+    local.set $60
     i32.const 4760
-    local.get $40
+    local.get $62
     i32.const 3
     i32.shl
     i32.add
     i64.load
     f64.reinterpret_i64
-    local.set $25
+    local.set $68
     i32.const 4760
-    local.get $40
+    local.get $62
     i32.const 3
     i32.shl
     i32.add
     i64.load offset=8
-    local.get $13
+    local.get $60
     i64.add
-    local.set $11
-    local.get $28
-    local.get $28
+    local.set $61
+    local.get $65
+    local.get $65
     f64.mul
-    local.set $27
-    local.get $25
-    local.get $28
+    local.set $66
+    local.get $68
+    local.get $65
     f64.add
-    local.get $27
+    local.get $66
     f64.const 0.49999999999996786
-    local.get $28
+    local.get $65
     f64.const 0.16666666666665886
     f64.mul
     f64.add
     f64.mul
     f64.add
-    local.get $27
-    local.get $27
+    local.get $66
+    local.get $66
     f64.mul
     f64.const 0.0416666808410674
-    local.get $28
+    local.get $65
     f64.const 0.008333335853059549
     f64.mul
     f64.add
     f64.mul
     f64.add
-    local.set $24
-    local.get $39
+    local.set $69
+    local.get $58
     i32.const 0
     i32.eq
     if
      block $~lib/util/math/specialcase|inlined.0 (result f64)
-      local.get $24
-      local.set $18
-      local.get $11
-      local.set $44
-      local.get $14
-      local.set $43
-      local.get $43
+      local.get $69
+      local.set $79
+      local.get $61
+      local.set $78
+      local.get $59
+      local.set $77
+      local.get $77
       i64.const 2147483648
       i64.and
       i64.const 0
       i64.ne
       i32.eqz
       if
-       local.get $44
+       local.get $78
        i64.const 1009
        i64.const 52
        i64.shl
        i64.sub
-       local.set $44
-       local.get $44
+       local.set $78
+       local.get $78
        f64.reinterpret_i64
-       local.set $17
+       local.set $80
        f64.const 5486124068793688683255936e279
-       local.get $17
-       local.get $17
-       local.get $18
+       local.get $80
+       local.get $80
+       local.get $79
        f64.mul
        f64.add
        f64.mul
        br $~lib/util/math/specialcase|inlined.0
       end
-      local.get $44
+      local.get $78
       i64.const 1022
       i64.const 52
       i64.shl
       i64.add
-      local.set $44
-      local.get $44
+      local.set $78
+      local.get $78
       f64.reinterpret_i64
-      local.set $17
-      local.get $17
-      local.get $17
-      local.get $18
+      local.set $80
+      local.get $80
+      local.get $80
+      local.get $79
       f64.mul
       f64.add
-      local.set $16
-      local.get $16
+      local.set $81
+      local.get $81
       f64.abs
       f64.const 1
       f64.lt
       if
        f64.const 1
-       local.get $16
+       local.get $81
        f64.copysign
-       local.set $23
-       local.get $17
-       local.get $16
+       local.set $82
+       local.get $80
+       local.get $81
        f64.sub
-       local.get $17
-       local.get $18
+       local.get $80
+       local.get $79
        f64.mul
        f64.add
-       local.set $22
-       local.get $23
-       local.get $16
+       local.set $83
+       local.get $82
+       local.get $81
        f64.add
-       local.set $21
-       local.get $23
-       local.get $21
+       local.set $84
+       local.get $82
+       local.get $84
        f64.sub
-       local.get $16
+       local.get $81
        f64.add
-       local.get $22
+       local.get $83
        f64.add
-       local.set $22
-       local.get $21
-       local.get $22
+       local.set $83
+       local.get $84
+       local.get $83
        f64.add
-       local.get $23
+       local.get $82
        f64.sub
-       local.set $16
-       local.get $16
+       local.set $81
+       local.get $81
        f64.const 0
        f64.eq
        if
-        local.get $44
+        local.get $78
         i64.const -9223372036854775808
         i64.and
         f64.reinterpret_i64
-        local.set $16
+        local.set $81
        end
       end
-      local.get $16
+      local.get $81
       f64.const 2.2250738585072014e-308
       f64.mul
      end
      br $~lib/util/math/exp_inline|inlined.0
     end
-    local.get $11
+    local.get $61
     f64.reinterpret_i64
-    local.set $26
-    local.get $26
-    local.get $26
-    local.get $24
+    local.set $67
+    local.get $67
+    local.get $67
+    local.get $69
     f64.mul
     f64.add
    end
@@ -1662,16 +1712,31 @@
   (local $16 i32)
   (local $17 i32)
   (local $18 i32)
-  (local $19 i64)
+  (local $19 i32)
   (local $20 i64)
   (local $21 i64)
   (local $22 i64)
   (local $23 i64)
-  (local $24 i32)
+  (local $24 i64)
   (local $25 i32)
   (local $26 i32)
   (local $27 i32)
-  (local $28 i64)
+  (local $28 i32)
+  (local $29 i32)
+  (local $30 i32)
+  (local $31 i32)
+  (local $32 i64)
+  (local $33 i32)
+  (local $34 i64)
+  (local $35 i64)
+  (local $36 i64)
+  (local $37 i64)
+  (local $38 i32)
+  (local $39 i32)
+  (local $40 i32)
+  (local $41 i32)
+  (local $42 i32)
+  (local $43 i32)
   i32.const 0
   local.get $4
   i32.sub
@@ -1875,11 +1940,11 @@
     if
      local.get $0
      local.get $15
-     local.tee $18
+     local.tee $19
      i32.const 1
      i32.add
      local.set $15
-     local.get $18
+     local.get $19
      i32.const 1
      i32.shl
      i32.add
@@ -1901,8 +1966,8 @@
     i64.shl
     local.get $13
     i64.add
-    local.set $19
-    local.get $19
+    local.set $20
+    local.get $20
     local.get $5
     i64.le_u
     if
@@ -1911,13 +1976,13 @@
      i32.add
      global.set $~lib/util/number/_K
      local.get $0
-     local.set $24
+     local.set $26
      local.get $15
-     local.set $18
+     local.set $25
      local.get $5
+     local.set $24
+     local.get $20
      local.set $23
-     local.get $19
-     local.set $22
      i32.const 7832
      local.get $14
      i32.const 2
@@ -1927,71 +1992,71 @@
      local.get $7
      i64.extend_i32_s
      i64.shl
-     local.set $21
+     local.set $22
      local.get $10
-     local.set $20
-     local.get $24
-     local.get $18
+     local.set $21
+     local.get $26
+     local.get $25
      i32.const 1
      i32.sub
      i32.const 1
      i32.shl
      i32.add
-     local.set $25
-     local.get $25
+     local.set $27
+     local.get $27
      i32.load16_u
-     local.set $26
+     local.set $28
      loop $while-continue|3
-      local.get $22
-      local.get $20
+      local.get $23
+      local.get $21
       i64.lt_u
       if (result i32)
+       local.get $24
        local.get $23
-       local.get $22
        i64.sub
-       local.get $21
+       local.get $22
        i64.ge_u
       else
        i32.const 0
       end
       if (result i32)
+       local.get $23
        local.get $22
-       local.get $21
        i64.add
-       local.get $20
+       local.get $21
        i64.lt_u
        if (result i32)
         i32.const 1
        else
-        local.get $20
-        local.get $22
-        i64.sub
-        local.get $22
         local.get $21
+        local.get $23
+        i64.sub
+        local.get $23
+        local.get $22
         i64.add
-        local.get $20
+        local.get $21
         i64.sub
         i64.gt_u
        end
       else
        i32.const 0
       end
-      local.set $27
-      local.get $27
+      local.set $30
+      local.get $30
       if
-       local.get $26
+       local.get $28
        i32.const 1
        i32.sub
-       local.set $26
+       local.set $28
+       local.get $23
        local.get $22
-       local.get $21
        i64.add
-       local.set $22
+       local.set $23
        br $while-continue|3
       end
      end
-     local.get $25
-     local.get $26
+     local.get $27
+     local.get $28
      i32.store16
      local.get $15
      return
@@ -2001,8 +2066,8 @@
   end
   loop $while-continue|4
    i32.const 1
-   local.set $16
-   local.get $16
+   local.set $31
+   local.get $31
    if
     local.get $13
     i64.const 10
@@ -2016,8 +2081,8 @@
     local.get $7
     i64.extend_i32_s
     i64.shr_u
-    local.set $23
-    local.get $23
+    local.set $32
+    local.get $32
     local.get $15
     i64.extend_i32_s
     i64.or
@@ -2026,16 +2091,16 @@
     if
      local.get $0
      local.get $15
-     local.tee $26
+     local.tee $33
      i32.const 1
      i32.add
      local.set $15
-     local.get $26
+     local.get $33
      i32.const 1
      i32.shl
      i32.add
      i32.const 48
-     local.get $23
+     local.get $32
      i32.wrap_i64
      i32.const 65535
      i32.and
@@ -2070,79 +2135,79 @@
      i64.mul
      local.set $10
      local.get $0
-     local.set $18
+     local.set $39
      local.get $15
-     local.set $27
+     local.set $38
      local.get $5
-     local.set $28
+     local.set $37
      local.get $13
-     local.set $22
+     local.set $36
      local.get $8
-     local.set $21
+     local.set $35
      local.get $10
-     local.set $20
-     local.get $18
-     local.get $27
+     local.set $34
+     local.get $39
+     local.get $38
      i32.const 1
      i32.sub
      i32.const 1
      i32.shl
      i32.add
-     local.set $26
-     local.get $26
+     local.set $40
+     local.get $40
      i32.load16_u
-     local.set $25
+     local.set $41
      loop $while-continue|6
-      local.get $22
-      local.get $20
+      local.get $36
+      local.get $34
       i64.lt_u
       if (result i32)
-       local.get $28
-       local.get $22
+       local.get $37
+       local.get $36
        i64.sub
-       local.get $21
+       local.get $35
        i64.ge_u
       else
        i32.const 0
       end
       if (result i32)
-       local.get $22
-       local.get $21
+       local.get $36
+       local.get $35
        i64.add
-       local.get $20
+       local.get $34
        i64.lt_u
        if (result i32)
         i32.const 1
        else
-        local.get $20
-        local.get $22
+        local.get $34
+        local.get $36
         i64.sub
-        local.get $22
-        local.get $21
+        local.get $36
+        local.get $35
         i64.add
-        local.get $20
+        local.get $34
         i64.sub
         i64.gt_u
        end
       else
        i32.const 0
       end
-      local.set $24
-      local.get $24
+      local.set $43
+      local.get $43
       if
-       local.get $25
+       local.get $41
        i32.const 1
        i32.sub
-       local.set $25
-       local.get $22
-       local.get $21
+       local.set $41
+       local.get $36
+       local.get $35
        i64.add
-       local.set $22
+       local.set $36
        br $while-continue|6
       end
      end
-     local.get $26
-     local.get $25
+     local.get $40
+     local.get $41
      i32.store16
      local.get $15
      return
@@ -2157,6 +2222,88 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local $22 i32)
+  (local $23 i32)
+  (local $24 i32)
+  (local $25 i32)
+  (local $26 i32)
+  (local $27 i32)
+  (local $28 i32)
+  (local $29 i32)
+  (local $30 i32)
+  (local $31 i32)
+  (local $32 i32)
+  (local $33 i32)
+  (local $34 i32)
+  (local $35 i32)
+  (local $36 i32)
+  (local $37 i32)
+  (local $38 i32)
+  (local $39 i32)
+  (local $40 i32)
+  (local $41 i32)
+  (local $42 i32)
+  (local $43 i32)
+  (local $44 i32)
+  (local $45 i32)
+  (local $46 i32)
+  (local $47 i32)
+  (local $48 i32)
+  (local $49 i32)
+  (local $50 i32)
+  (local $51 i32)
+  (local $52 i32)
+  (local $53 i32)
+  (local $54 i32)
+  (local $55 i32)
+  (local $56 i32)
+  (local $57 i32)
+  (local $58 i32)
+  (local $59 i32)
+  (local $60 i32)
+  (local $61 i32)
+  (local $62 i32)
+  (local $63 i32)
+  (local $64 i32)
+  (local $65 i32)
+  (local $66 i32)
+  (local $67 i32)
+  (local $68 i32)
+  (local $69 i32)
+  (local $70 i32)
+  (local $71 i32)
+  (local $72 i32)
+  (local $73 i32)
+  (local $74 i32)
+  (local $75 i32)
+  (local $76 i32)
+  (local $77 i32)
+  (local $78 i32)
+  (local $79 i32)
+  (local $80 i32)
+  (local $81 i32)
+  (local $82 i32)
+  (local $83 i32)
+  (local $84 i32)
+  (local $85 i32)
+  (local $86 i32)
+  (local $87 i32)
+  (local $88 i32)
   loop $while-continue|0
    local.get $2
    if (result i32)
@@ -2176,11 +2323,11 @@
     local.set $0
     local.get $6
     local.get $1
-    local.tee $6
+    local.tee $7
     i32.const 1
     i32.add
     local.set $1
-    local.get $6
+    local.get $7
     i32.load8_u
     i32.store8
     local.get $2
@@ -2200,8 +2347,8 @@
     local.get $2
     i32.const 16
     i32.ge_u
-    local.set $5
-    local.get $5
+    local.set $8
+    local.get $8
     if
      local.get $0
      local.get $1
@@ -2310,17 +2457,17 @@
    i32.and
    if
     local.get $0
-    local.tee $5
+    local.tee $9
     i32.const 1
     i32.add
     local.set $0
-    local.get $5
+    local.get $9
     local.get $1
-    local.tee $5
+    local.tee $10
     i32.const 1
     i32.add
     local.set $1
-    local.get $5
+    local.get $10
     i32.load8_u
     i32.store8
    end
@@ -2337,16 +2484,16 @@
        local.get $0
        i32.const 3
        i32.and
-       local.set $5
-       local.get $5
+       local.set $11
+       local.get $11
        i32.const 1
        i32.eq
        br_if $case0|2
-       local.get $5
+       local.get $11
        i32.const 2
        i32.eq
        br_if $case1|2
-       local.get $5
+       local.get $11
        i32.const 3
        i32.eq
        br_if $case2|2
@@ -2356,45 +2503,45 @@
       i32.load
       local.set $3
       local.get $0
-      local.tee $5
+      local.tee $12
       i32.const 1
       i32.add
       local.set $0
-      local.get $5
+      local.get $12
       local.get $1
-      local.tee $5
+      local.tee $13
       i32.const 1
       i32.add
       local.set $1
-      local.get $5
+      local.get $13
       i32.load8_u
       i32.store8
       local.get $0
-      local.tee $5
+      local.tee $14
       i32.const 1
       i32.add
       local.set $0
-      local.get $5
+      local.get $14
       local.get $1
-      local.tee $5
+      local.tee $15
       i32.const 1
       i32.add
       local.set $1
-      local.get $5
+      local.get $15
       i32.load8_u
       i32.store8
       local.get $0
-      local.tee $5
+      local.tee $16
       i32.const 1
       i32.add
       local.set $0
-      local.get $5
+      local.get $16
       local.get $1
-      local.tee $5
+      local.tee $17
       i32.const 1
       i32.add
       local.set $1
-      local.get $5
+      local.get $17
       i32.load8_u
       i32.store8
       local.get $2
@@ -2405,8 +2552,8 @@
        local.get $2
        i32.const 17
        i32.ge_u
-       local.set $5
-       local.get $5
+       local.set $18
+       local.get $18
        if
         local.get $1
         i32.const 1
@@ -2491,31 +2638,31 @@
      i32.load
      local.set $3
      local.get $0
-     local.tee $5
+     local.tee $19
      i32.const 1
      i32.add
      local.set $0
-     local.get $5
+     local.get $19
      local.get $1
-     local.tee $5
+     local.tee $20
      i32.const 1
      i32.add
      local.set $1
-     local.get $5
+     local.get $20
      i32.load8_u
      i32.store8
      local.get $0
-     local.tee $5
+     local.tee $21
      i32.const 1
      i32.add
      local.set $0
-     local.get $5
+     local.get $21
      local.get $1
-     local.tee $5
+     local.tee $22
      i32.const 1
      i32.add
      local.set $1
-     local.get $5
+     local.get $22
      i32.load8_u
      i32.store8
      local.get $2
@@ -2526,8 +2673,8 @@
       local.get $2
       i32.const 18
       i32.ge_u
-      local.set $5
-      local.get $5
+      local.set $23
+      local.get $23
       if
        local.get $1
        i32.const 2
@@ -2612,17 +2759,17 @@
     i32.load
     local.set $3
     local.get $0
-    local.tee $5
+    local.tee $24
     i32.const 1
     i32.add
     local.set $0
-    local.get $5
+    local.get $24
     local.get $1
-    local.tee $5
+    local.tee $25
     i32.const 1
     i32.add
     local.set $1
-    local.get $5
+    local.get $25
     i32.load8_u
     i32.store8
     local.get $2
@@ -2633,8 +2780,8 @@
      local.get $2
      i32.const 19
      i32.ge_u
-     local.set $5
-     local.get $5
+     local.set $26
+     local.get $26
      if
       local.get $1
       i32.const 3
@@ -2721,227 +2868,227 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $27
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $27
    local.get $1
-   local.tee $5
+   local.tee $28
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $28
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $29
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $29
    local.get $1
-   local.tee $5
+   local.tee $30
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $30
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $31
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $31
    local.get $1
-   local.tee $5
+   local.tee $32
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $32
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $33
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $33
    local.get $1
-   local.tee $5
+   local.tee $34
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $34
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $35
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $35
    local.get $1
-   local.tee $5
+   local.tee $36
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $36
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $37
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $37
    local.get $1
-   local.tee $5
+   local.tee $38
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $38
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $39
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $39
    local.get $1
-   local.tee $5
+   local.tee $40
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $40
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $41
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $41
    local.get $1
-   local.tee $5
+   local.tee $42
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $42
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $43
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $43
    local.get $1
-   local.tee $5
+   local.tee $44
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $44
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $45
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $45
    local.get $1
-   local.tee $5
+   local.tee $46
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $46
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $47
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $47
    local.get $1
-   local.tee $5
+   local.tee $48
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $48
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $49
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $49
    local.get $1
-   local.tee $5
+   local.tee $50
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $50
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $51
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $51
    local.get $1
-   local.tee $5
+   local.tee $52
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $52
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $53
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $53
    local.get $1
-   local.tee $5
+   local.tee $54
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $54
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $55
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $55
    local.get $1
-   local.tee $5
+   local.tee $56
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $56
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $57
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $57
    local.get $1
-   local.tee $5
+   local.tee $58
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $58
    i32.load8_u
    i32.store8
   end
@@ -2950,115 +3097,115 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $59
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $59
    local.get $1
-   local.tee $5
+   local.tee $60
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $60
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $61
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $61
    local.get $1
-   local.tee $5
+   local.tee $62
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $62
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $63
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $63
    local.get $1
-   local.tee $5
+   local.tee $64
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $64
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $65
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $65
    local.get $1
-   local.tee $5
+   local.tee $66
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $66
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $67
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $67
    local.get $1
-   local.tee $5
+   local.tee $68
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $68
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $69
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $69
    local.get $1
-   local.tee $5
+   local.tee $70
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $70
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $71
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $71
    local.get $1
-   local.tee $5
+   local.tee $72
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $72
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $73
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $73
    local.get $1
-   local.tee $5
+   local.tee $74
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $74
    i32.load8_u
    i32.store8
   end
@@ -3067,59 +3214,59 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $75
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $75
    local.get $1
-   local.tee $5
+   local.tee $76
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $76
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $77
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $77
    local.get $1
-   local.tee $5
+   local.tee $78
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $78
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $79
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $79
    local.get $1
-   local.tee $5
+   local.tee $80
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $80
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $81
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $81
    local.get $1
-   local.tee $5
+   local.tee $82
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $82
    i32.load8_u
    i32.store8
   end
@@ -3128,31 +3275,31 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $83
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $83
    local.get $1
-   local.tee $5
+   local.tee $84
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $84
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $85
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $85
    local.get $1
-   local.tee $5
+   local.tee $86
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $86
    i32.load8_u
    i32.store8
   end
@@ -3161,17 +3308,17 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $87
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $87
    local.get $1
-   local.tee $5
+   local.tee $88
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $88
    i32.load8_u
    i32.store8
   end
@@ -3182,6 +3329,14 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
   block $~lib/util/memory/memmove|inlined.0
    local.get $0
    local.set $5
@@ -3259,11 +3414,11 @@
        local.set $5
        local.get $7
        local.get $4
-       local.tee $7
+       local.tee $8
        i32.const 1
        i32.add
        local.set $4
-       local.get $7
+       local.get $8
        i32.load8_u
        i32.store8
        br $while-continue|0
@@ -3273,8 +3428,8 @@
       local.get $3
       i32.const 8
       i32.ge_u
-      local.set $6
-      local.get $6
+      local.set $9
+      local.get $9
       if
        local.get $5
        local.get $4
@@ -3298,21 +3453,21 @@
     end
     loop $while-continue|2
      local.get $3
-     local.set $6
-     local.get $6
+     local.set $10
+     local.get $10
      if
       local.get $5
-      local.tee $7
+      local.tee $11
       i32.const 1
       i32.add
       local.set $5
-      local.get $7
+      local.get $11
       local.get $4
-      local.tee $7
+      local.tee $12
       i32.const 1
       i32.add
       local.set $4
-      local.get $7
+      local.get $12
       i32.load8_u
       i32.store8
       local.get $3
@@ -3341,8 +3496,8 @@
       i32.add
       i32.const 7
       i32.and
-      local.set $6
-      local.get $6
+      local.set $13
+      local.get $13
       if
        local.get $3
        i32.eqz
@@ -3367,8 +3522,8 @@
       local.get $3
       i32.const 8
       i32.ge_u
-      local.set $6
-      local.get $6
+      local.set $14
+      local.get $14
       if
        local.get $3
        i32.const 8
@@ -3388,8 +3543,8 @@
     end
     loop $while-continue|5
      local.get $3
-     local.set $6
-     local.get $6
+     local.set $15
+     local.get $15
      if
       local.get $5
       local.get $3
@@ -3418,6 +3573,19 @@
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local $22 i32)
+  (local $23 i32)
+  (local $24 i32)
   local.get $2
   i32.eqz
   if
@@ -3507,11 +3675,11 @@
     i32.const 1
     i32.shl
     i32.add
-    local.set $4
-    local.get $4
+    local.set $6
+    local.get $6
     i32.const 2
     i32.add
-    local.get $4
+    local.get $6
     i32.const 0
     local.get $2
     i32.sub
@@ -3544,9 +3712,9 @@
      i32.const 2
      local.get $3
      i32.sub
-     local.set $4
+     local.set $7
      local.get $0
-     local.get $4
+     local.get $7
      i32.const 1
      i32.shl
      i32.add
@@ -3563,30 +3731,30 @@
      i32.or
      i32.store
      i32.const 2
-     local.set $5
+     local.set $8
      loop $for-loop|1
-      local.get $5
-      local.get $4
+      local.get $8
+      local.get $7
       i32.lt_s
-      local.set $6
-      local.get $6
+      local.set $9
+      local.get $9
       if
        local.get $0
-       local.get $5
+       local.get $8
        i32.const 1
        i32.shl
        i32.add
        i32.const 48
        i32.store16
-       local.get $5
+       local.get $8
        i32.const 1
        i32.add
-       local.set $5
+       local.set $8
        br $for-loop|1
       end
      end
      local.get $1
-     local.get $4
+     local.get $7
      i32.add
      return
     else
@@ -3600,48 +3768,48 @@
       local.get $0
       i32.const 4
       i32.add
-      local.set $5
+      local.set $11
       local.get $3
       i32.const 1
       i32.sub
-      local.set $6
-      local.get $6
+      local.set $10
+      local.get $10
       i32.const 0
       i32.lt_s
-      local.set $4
-      local.get $4
+      local.set $12
+      local.get $12
       if
        i32.const 0
-       local.get $6
+       local.get $10
        i32.sub
-       local.set $6
+       local.set $10
       end
-      local.get $6
+      local.get $10
       call $~lib/util/number/decimalCount32
       i32.const 1
       i32.add
-      local.set $7
-      local.get $5
-      local.set $10
-      local.get $6
-      local.set $9
-      local.get $7
-      local.set $8
+      local.set $13
+      local.get $11
+      local.set $16
+      local.get $10
+      local.set $15
+      local.get $13
+      local.set $14
       i32.const 0
       i32.const 1
       i32.ge_s
       drop
-      local.get $10
-      local.get $9
-      local.get $8
+      local.get $16
+      local.get $15
+      local.get $14
       call $~lib/util/number/utoa32_lut
-      local.get $5
+      local.get $11
       i32.const 45
       i32.const 43
-      local.get $4
+      local.get $12
       select
       i32.store16
-      local.get $7
+      local.get $13
       local.set $1
       local.get $1
       i32.const 2
@@ -3651,14 +3819,14 @@
       local.get $1
       i32.const 1
       i32.shl
-      local.set $7
+      local.set $17
       local.get $0
       i32.const 4
       i32.add
       local.get $0
       i32.const 2
       i32.add
-      local.get $7
+      local.get $17
       i32.const 2
       i32.sub
       call $~lib/memory/memory.copy
@@ -3666,58 +3834,58 @@
       i32.const 46
       i32.store16 offset=2
       local.get $0
-      local.get $7
+      local.get $17
       i32.add
       i32.const 101
       i32.store16 offset=2
       local.get $1
       local.get $0
-      local.get $7
+      local.get $17
       i32.add
       i32.const 4
       i32.add
-      local.set $9
+      local.set $19
       local.get $3
       i32.const 1
       i32.sub
-      local.set $8
-      local.get $8
+      local.set $18
+      local.get $18
       i32.const 0
       i32.lt_s
-      local.set $4
-      local.get $4
+      local.set $20
+      local.get $20
       if
        i32.const 0
-       local.get $8
+       local.get $18
        i32.sub
-       local.set $8
+       local.set $18
       end
-      local.get $8
+      local.get $18
       call $~lib/util/number/decimalCount32
       i32.const 1
       i32.add
-      local.set $5
-      local.get $9
-      local.set $11
-      local.get $8
-      local.set $6
-      local.get $5
-      local.set $10
+      local.set $21
+      local.get $19
+      local.set $24
+      local.get $18
+      local.set $23
+      local.get $21
+      local.set $22
       i32.const 0
       i32.const 1
       i32.ge_s
       drop
-      local.get $11
-      local.get $6
-      local.get $10
+      local.get $24
+      local.get $23
+      local.get $22
       call $~lib/util/number/utoa32_lut
-      local.get $9
+      local.get $19
       i32.const 45
       i32.const 43
-      local.get $4
+      local.get $20
       select
       i32.store16
-      local.get $5
+      local.get $21
       i32.add
       local.set $1
       local.get $1
@@ -3748,19 +3916,51 @@
   (local $13 i32)
   (local $14 i32)
   (local $15 i32)
-  (local $16 f64)
-  (local $17 i64)
-  (local $18 i64)
-  (local $19 i64)
-  (local $20 i64)
+  (local $16 i32)
+  (local $17 f64)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
   (local $21 i64)
-  (local $22 i64)
+  (local $22 i32)
   (local $23 i64)
   (local $24 i64)
   (local $25 i64)
-  (local $26 i32)
+  (local $26 i64)
   (local $27 i64)
-  (local $28 i32)
+  (local $28 i64)
+  (local $29 i64)
+  (local $30 i64)
+  (local $31 i64)
+  (local $32 i64)
+  (local $33 i32)
+  (local $34 i32)
+  (local $35 i32)
+  (local $36 i64)
+  (local $37 i64)
+  (local $38 i64)
+  (local $39 i64)
+  (local $40 i64)
+  (local $41 i64)
+  (local $42 i64)
+  (local $43 i64)
+  (local $44 i64)
+  (local $45 i64)
+  (local $46 i32)
+  (local $47 i32)
+  (local $48 i32)
+  (local $49 i64)
+  (local $50 i64)
+  (local $51 i64)
+  (local $52 i64)
+  (local $53 i64)
+  (local $54 i64)
+  (local $55 i64)
+  (local $56 i64)
+  (local $57 i64)
+  (local $58 i64)
+  (local $59 i64)
+  (local $60 i32)
   local.get $1
   f64.const 0
   f64.lt
@@ -3864,47 +4064,47 @@
   local.get $13
   global.set $~lib/util/number/_exp
   global.get $~lib/util/number/_exp
-  local.set $10
+  local.set $16
   i32.const -61
-  local.get $10
+  local.get $16
   i32.sub
   f64.convert_i32_s
   f64.const 0.30102999566398114
   f64.mul
   f64.const 347
   f64.add
-  local.set $16
-  local.get $16
+  local.set $17
+  local.get $17
   i32.trunc_f64_s
-  local.set $15
-  local.get $15
-  local.get $15
+  local.set $18
+  local.get $18
+  local.get $18
   f64.convert_i32_s
-  local.get $16
+  local.get $17
   f64.ne
   i32.add
-  local.set $15
-  local.get $15
+  local.set $18
+  local.get $18
   i32.const 3
   i32.shr_s
   i32.const 1
   i32.add
-  local.set $14
+  local.set $19
   i32.const 348
-  local.get $14
+  local.get $19
   i32.const 3
   i32.shl
   i32.sub
   global.set $~lib/util/number/_K
   i32.const 6960
-  local.get $14
+  local.get $19
   i32.const 3
   i32.shl
   i32.add
   i64.load
   global.set $~lib/util/number/_frc_pow
   i32.const 7656
-  local.get $14
+  local.get $19
   i32.const 1
   i32.shl
   i32.add
@@ -3913,249 +4113,249 @@
   local.get $9
   i64.clz
   i32.wrap_i64
-  local.set $14
+  local.set $20
   local.get $9
-  local.get $14
+  local.get $20
   i64.extend_i32_s
   i64.shl
   local.set $9
   local.get $7
-  local.get $14
+  local.get $20
   i32.sub
   local.set $7
   global.get $~lib/util/number/_frc_pow
-  local.set $12
+  local.set $21
   global.get $~lib/util/number/_exp_pow
-  local.set $15
+  local.set $22
   local.get $9
-  local.set $17
-  local.get $12
-  local.set $11
-  local.get $17
-  i64.const 4294967295
-  i64.and
-  local.set $18
-  local.get $11
-  i64.const 4294967295
-  i64.and
-  local.set $19
-  local.get $17
-  i64.const 32
-  i64.shr_u
-  local.set $20
-  local.get $11
-  i64.const 32
-  i64.shr_u
-  local.set $21
-  local.get $18
-  local.get $19
-  i64.mul
-  local.set $22
-  local.get $20
-  local.get $19
-  i64.mul
-  local.get $22
-  i64.const 32
-  i64.shr_u
-  i64.add
-  local.set $23
-  local.get $18
+  local.set $24
   local.get $21
-  i64.mul
+  local.set $23
+  local.get $24
+  i64.const 4294967295
+  i64.and
+  local.set $25
   local.get $23
   i64.const 4294967295
   i64.and
-  i64.add
-  local.set $24
+  local.set $26
   local.get $24
+  i64.const 32
+  i64.shr_u
+  local.set $27
+  local.get $23
+  i64.const 32
+  i64.shr_u
+  local.set $28
+  local.get $25
+  local.get $26
+  i64.mul
+  local.set $29
+  local.get $27
+  local.get $26
+  i64.mul
+  local.get $29
+  i64.const 32
+  i64.shr_u
+  i64.add
+  local.set $30
+  local.get $25
+  local.get $28
+  i64.mul
+  local.get $30
+  i64.const 4294967295
+  i64.and
+  i64.add
+  local.set $31
+  local.get $31
   i64.const 2147483647
   i64.add
-  local.set $24
-  local.get $23
+  local.set $31
+  local.get $30
   i64.const 32
   i64.shr_u
-  local.set $23
-  local.get $24
+  local.set $30
+  local.get $31
   i64.const 32
   i64.shr_u
-  local.set $24
-  local.get $20
-  local.get $21
+  local.set $31
+  local.get $27
+  local.get $28
   i64.mul
-  local.get $23
+  local.get $30
   i64.add
-  local.get $24
+  local.get $31
   i64.add
-  local.set $24
+  local.set $32
   local.get $7
-  local.set $10
-  local.get $15
-  local.set $13
-  local.get $10
-  local.get $13
+  local.set $34
+  local.get $22
+  local.set $33
+  local.get $34
+  local.get $33
   i32.add
   i32.const 64
   i32.add
-  local.set $10
+  local.set $35
   global.get $~lib/util/number/_frc_plus
-  local.set $17
-  local.get $12
-  local.set $11
-  local.get $17
-  i64.const 4294967295
-  i64.and
-  local.set $23
-  local.get $11
-  i64.const 4294967295
-  i64.and
-  local.set $22
-  local.get $17
-  i64.const 32
-  i64.shr_u
-  local.set $21
-  local.get $11
-  i64.const 32
-  i64.shr_u
-  local.set $20
-  local.get $23
-  local.get $22
-  i64.mul
-  local.set $19
+  local.set $37
   local.get $21
-  local.get $22
+  local.set $36
+  local.get $37
+  i64.const 4294967295
+  i64.and
+  local.set $38
+  local.get $36
+  i64.const 4294967295
+  i64.and
+  local.set $39
+  local.get $37
+  i64.const 32
+  i64.shr_u
+  local.set $40
+  local.get $36
+  i64.const 32
+  i64.shr_u
+  local.set $41
+  local.get $38
+  local.get $39
   i64.mul
-  local.get $19
+  local.set $42
+  local.get $40
+  local.get $39
+  i64.mul
+  local.get $42
   i64.const 32
   i64.shr_u
   i64.add
-  local.set $18
-  local.get $23
-  local.get $20
+  local.set $43
+  local.get $38
+  local.get $41
   i64.mul
-  local.get $18
+  local.get $43
   i64.const 4294967295
   i64.and
   i64.add
-  local.set $25
-  local.get $25
+  local.set $44
+  local.get $44
   i64.const 2147483647
   i64.add
-  local.set $25
-  local.get $18
+  local.set $44
+  local.get $43
   i64.const 32
   i64.shr_u
-  local.set $18
-  local.get $25
+  local.set $43
+  local.get $44
   i64.const 32
   i64.shr_u
-  local.set $25
-  local.get $21
-  local.get $20
+  local.set $44
+  local.get $40
+  local.get $41
   i64.mul
-  local.get $18
+  local.get $43
   i64.add
-  local.get $25
+  local.get $44
   i64.add
   i64.const 1
   i64.sub
-  local.set $25
+  local.set $45
   global.get $~lib/util/number/_exp
-  local.set $26
-  local.get $15
-  local.set $13
-  local.get $26
-  local.get $13
+  local.set $47
+  local.get $22
+  local.set $46
+  local.get $47
+  local.get $46
   i32.add
   i32.const 64
   i32.add
-  local.set $26
+  local.set $48
   global.get $~lib/util/number/_frc_minus
-  local.set $17
-  local.get $12
-  local.set $11
-  local.get $17
-  i64.const 4294967295
-  i64.and
-  local.set $18
-  local.get $11
-  i64.const 4294967295
-  i64.and
-  local.set $19
-  local.get $17
-  i64.const 32
-  i64.shr_u
-  local.set $20
-  local.get $11
-  i64.const 32
-  i64.shr_u
-  local.set $21
-  local.get $18
-  local.get $19
-  i64.mul
-  local.set $22
-  local.get $20
-  local.get $19
-  i64.mul
-  local.get $22
-  i64.const 32
-  i64.shr_u
-  i64.add
-  local.set $23
-  local.get $18
+  local.set $50
   local.get $21
+  local.set $49
+  local.get $50
+  i64.const 4294967295
+  i64.and
+  local.set $51
+  local.get $49
+  i64.const 4294967295
+  i64.and
+  local.set $52
+  local.get $50
+  i64.const 32
+  i64.shr_u
+  local.set $53
+  local.get $49
+  i64.const 32
+  i64.shr_u
+  local.set $54
+  local.get $51
+  local.get $52
   i64.mul
-  local.get $23
+  local.set $55
+  local.get $53
+  local.get $52
+  i64.mul
+  local.get $55
+  i64.const 32
+  i64.shr_u
+  i64.add
+  local.set $56
+  local.get $51
+  local.get $54
+  i64.mul
+  local.get $56
   i64.const 4294967295
   i64.and
   i64.add
-  local.set $27
-  local.get $27
+  local.set $57
+  local.get $57
   i64.const 2147483647
   i64.add
-  local.set $27
-  local.get $23
+  local.set $57
+  local.get $56
   i64.const 32
   i64.shr_u
-  local.set $23
-  local.get $27
+  local.set $56
+  local.get $57
   i64.const 32
   i64.shr_u
-  local.set $27
-  local.get $20
-  local.get $21
+  local.set $57
+  local.get $53
+  local.get $54
   i64.mul
-  local.get $23
+  local.get $56
   i64.add
-  local.get $27
+  local.get $57
   i64.add
   i64.const 1
   i64.add
-  local.set $27
-  local.get $25
-  local.get $27
+  local.set $58
+  local.get $45
+  local.get $58
   i64.sub
-  local.set $23
+  local.set $59
   local.get $4
-  local.get $24
-  local.get $10
-  local.get $25
-  local.get $26
-  local.get $23
+  local.get $32
+  local.get $35
+  local.get $45
+  local.get $48
+  local.get $59
   local.get $3
   call $~lib/util/number/genDigits
-  local.set $28
+  local.set $60
   local.get $0
   local.get $2
   i32.const 1
   i32.shl
   i32.add
-  local.get $28
+  local.get $60
   local.get $2
   i32.sub
   global.get $~lib/util/number/_K
   call $~lib/util/number/prettify
-  local.set $28
-  local.get $28
+  local.set $60
+  local.get $60
   local.get $2
   i32.add
  )
@@ -4169,6 +4369,16 @@
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
   local.get $0
   call $~lib/string/String#get:length
   local.set $3
@@ -4180,67 +4390,67 @@
   local.get $5
   i32.gt_s
   select
-  local.tee $4
+  local.tee $6
   local.get $3
-  local.tee $5
-  local.get $4
-  local.get $5
-  i32.lt_s
-  select
-  local.set $6
-  local.get $2
-  local.tee $4
-  i32.const 0
-  local.tee $5
-  local.get $4
-  local.get $5
-  i32.gt_s
-  select
-  local.tee $4
-  local.get $3
-  local.tee $5
-  local.get $4
-  local.get $5
-  i32.lt_s
-  select
-  local.set $7
+  local.tee $7
   local.get $6
-  local.tee $4
   local.get $7
-  local.tee $5
-  local.get $4
-  local.get $5
   i32.lt_s
   select
-  i32.const 1
-  i32.shl
   local.set $8
-  local.get $6
-  local.tee $4
-  local.get $7
-  local.tee $5
-  local.get $4
-  local.get $5
+  local.get $2
+  local.tee $9
+  i32.const 0
+  local.tee $10
+  local.get $9
+  local.get $10
+  i32.gt_s
+  select
+  local.tee $11
+  local.get $3
+  local.tee $12
+  local.get $11
+  local.get $12
+  i32.lt_s
+  select
+  local.set $13
+  local.get $8
+  local.tee $14
+  local.get $13
+  local.tee $15
+  local.get $14
+  local.get $15
+  i32.lt_s
+  select
+  i32.const 1
+  i32.shl
+  local.set $16
+  local.get $8
+  local.tee $17
+  local.get $13
+  local.tee $18
+  local.get $17
+  local.get $18
   i32.gt_s
   select
   i32.const 1
   i32.shl
-  local.set $9
-  local.get $9
-  local.get $8
+  local.set $19
+  local.get $19
+  local.get $16
   i32.sub
-  local.set $10
-  local.get $10
+  local.set $20
+  local.get $20
   i32.eqz
   if
    i32.const 7888
    call $~lib/rt/stub/__retain
    return
   end
-  local.get $8
+  local.get $16
   i32.eqz
   if (result i32)
-   local.get $9
+   local.get $19
    local.get $3
    i32.const 1
    i32.shl
@@ -4253,17 +4463,17 @@
    call $~lib/rt/stub/__retain
    return
   end
-  local.get $10
+  local.get $20
   i32.const 1
   call $~lib/rt/stub/__alloc
-  local.set $11
-  local.get $11
+  local.set $21
+  local.get $21
   local.get $0
-  local.get $8
+  local.get $16
   i32.add
-  local.get $10
+  local.get $20
   call $~lib/memory/memory.copy
-  local.get $11
+  local.get $21
   call $~lib/rt/stub/__retain
  )
  (func $~lib/rt/stub/__free (param $0 i32)
@@ -4623,6 +4833,7 @@
   (local $61 i32)
   (local $62 i32)
   (local $63 i32)
+  (local $64 i32)
   i32.const 1
   i32.const 2
   i32.lt_u
@@ -5500,7 +5711,7 @@
   global.set $resolve-binary/bar
   global.get $resolve-binary/bar
   call $resolve-binary/Bar#self
-  local.tee $62
+  local.tee $64
   global.get $resolve-binary/bar2
   i32.eq
   i32.eqz
@@ -5648,7 +5859,7 @@
   call $~lib/rt/stub/__release
   local.get $61
   call $~lib/rt/stub/__release
-  local.get $62
+  local.get $64
   call $~lib/rt/stub/__release
  )
  (func $~start

--- a/tests/compiler/resolve-elementaccess.optimized.wat
+++ b/tests/compiler/resolve-elementaccess.optimized.wat
@@ -752,8 +752,6 @@
    global.get $~lib/util/number/_K
    i32.add
    global.set $~lib/util/number/_K
-   local.get $8
-   local.set $1
    local.get $9
    i32.const 0
    local.get $4
@@ -764,7 +762,7 @@
    i32.add
    i64.load32_u
    i64.mul
-   local.set $3
+   local.set $1
    local.get $0
    local.get $6
    i32.const 1
@@ -777,30 +775,30 @@
    local.set $4
    loop $while-continue|6
     i32.const 1
-    local.get $3
     local.get $1
+    local.get $8
     i64.sub
-    local.get $1
+    local.get $8
     local.get $11
     i64.add
-    local.get $3
+    local.get $1
     i64.sub
     i64.gt_u
-    local.get $1
+    local.get $8
     local.get $11
     i64.add
-    local.get $3
+    local.get $1
     i64.lt_u
     select
     i32.const 0
     local.get $5
-    local.get $1
+    local.get $8
     i64.sub
     local.get $11
     i64.ge_u
     i32.const 0
+    local.get $8
     local.get $1
-    local.get $3
     i64.lt_u
     select
     select
@@ -809,10 +807,10 @@
      i32.const 1
      i32.sub
      local.set $4
-     local.get $1
+     local.get $8
      local.get $11
      i64.add
-     local.set $1
+     local.set $8
      br $while-continue|6
     end
    end

--- a/tests/compiler/resolve-elementaccess.untouched.wat
+++ b/tests/compiler/resolve-elementaccess.untouched.wat
@@ -61,6 +61,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   memory.size
   local.set $1
   local.get $1
@@ -91,8 +92,8 @@
    local.get $5
    i32.gt_s
    select
-   local.set $4
-   local.get $4
+   local.set $6
+   local.get $6
    memory.grow
    i32.const 0
    i32.lt_s
@@ -586,16 +587,31 @@
   (local $16 i32)
   (local $17 i32)
   (local $18 i32)
-  (local $19 i64)
+  (local $19 i32)
   (local $20 i64)
   (local $21 i64)
   (local $22 i64)
   (local $23 i64)
-  (local $24 i32)
+  (local $24 i64)
   (local $25 i32)
   (local $26 i32)
   (local $27 i32)
-  (local $28 i64)
+  (local $28 i32)
+  (local $29 i32)
+  (local $30 i32)
+  (local $31 i32)
+  (local $32 i64)
+  (local $33 i32)
+  (local $34 i64)
+  (local $35 i64)
+  (local $36 i64)
+  (local $37 i64)
+  (local $38 i32)
+  (local $39 i32)
+  (local $40 i32)
+  (local $41 i32)
+  (local $42 i32)
+  (local $43 i32)
   i32.const 0
   local.get $4
   i32.sub
@@ -799,11 +815,11 @@
     if
      local.get $0
      local.get $15
-     local.tee $18
+     local.tee $19
      i32.const 1
      i32.add
      local.set $15
-     local.get $18
+     local.get $19
      i32.const 1
      i32.shl
      i32.add
@@ -825,8 +841,8 @@
     i64.shl
     local.get $13
     i64.add
-    local.set $19
-    local.get $19
+    local.set $20
+    local.get $20
     local.get $5
     i64.le_u
     if
@@ -835,13 +851,13 @@
      i32.add
      global.set $~lib/util/number/_K
      local.get $0
-     local.set $24
+     local.set $26
      local.get $15
-     local.set $18
+     local.set $25
      local.get $5
+     local.set $24
+     local.get $20
      local.set $23
-     local.get $19
-     local.set $22
      i32.const 1272
      local.get $14
      i32.const 2
@@ -851,71 +867,71 @@
      local.get $7
      i64.extend_i32_s
      i64.shl
-     local.set $21
+     local.set $22
      local.get $10
-     local.set $20
-     local.get $24
-     local.get $18
+     local.set $21
+     local.get $26
+     local.get $25
      i32.const 1
      i32.sub
      i32.const 1
      i32.shl
      i32.add
-     local.set $25
-     local.get $25
+     local.set $27
+     local.get $27
      i32.load16_u
-     local.set $26
+     local.set $28
      loop $while-continue|3
-      local.get $22
-      local.get $20
+      local.get $23
+      local.get $21
       i64.lt_u
       if (result i32)
+       local.get $24
        local.get $23
-       local.get $22
        i64.sub
-       local.get $21
+       local.get $22
        i64.ge_u
       else
        i32.const 0
       end
       if (result i32)
+       local.get $23
        local.get $22
-       local.get $21
        i64.add
-       local.get $20
+       local.get $21
        i64.lt_u
        if (result i32)
         i32.const 1
        else
-        local.get $20
-        local.get $22
-        i64.sub
-        local.get $22
         local.get $21
+        local.get $23
+        i64.sub
+        local.get $23
+        local.get $22
         i64.add
-        local.get $20
+        local.get $21
         i64.sub
         i64.gt_u
        end
       else
        i32.const 0
       end
-      local.set $27
-      local.get $27
+      local.set $30
+      local.get $30
       if
-       local.get $26
+       local.get $28
        i32.const 1
        i32.sub
-       local.set $26
+       local.set $28
+       local.get $23
        local.get $22
-       local.get $21
        i64.add
-       local.set $22
+       local.set $23
        br $while-continue|3
       end
      end
-     local.get $25
-     local.get $26
+     local.get $27
+     local.get $28
      i32.store16
      local.get $15
      return
@@ -925,8 +941,8 @@
   end
   loop $while-continue|4
    i32.const 1
-   local.set $16
-   local.get $16
+   local.set $31
+   local.get $31
    if
     local.get $13
     i64.const 10
@@ -940,8 +956,8 @@
     local.get $7
     i64.extend_i32_s
     i64.shr_u
-    local.set $23
-    local.get $23
+    local.set $32
+    local.get $32
     local.get $15
     i64.extend_i32_s
     i64.or
@@ -950,16 +966,16 @@
     if
      local.get $0
      local.get $15
-     local.tee $26
+     local.tee $33
      i32.const 1
      i32.add
      local.set $15
-     local.get $26
+     local.get $33
      i32.const 1
      i32.shl
      i32.add
      i32.const 48
-     local.get $23
+     local.get $32
      i32.wrap_i64
      i32.const 65535
      i32.and
@@ -994,79 +1010,79 @@
      i64.mul
      local.set $10
      local.get $0
-     local.set $18
+     local.set $39
      local.get $15
-     local.set $27
+     local.set $38
      local.get $5
-     local.set $28
+     local.set $37
      local.get $13
-     local.set $22
+     local.set $36
      local.get $8
-     local.set $21
+     local.set $35
      local.get $10
-     local.set $20
-     local.get $18
-     local.get $27
+     local.set $34
+     local.get $39
+     local.get $38
      i32.const 1
      i32.sub
      i32.const 1
      i32.shl
      i32.add
-     local.set $26
-     local.get $26
+     local.set $40
+     local.get $40
      i32.load16_u
-     local.set $25
+     local.set $41
      loop $while-continue|6
-      local.get $22
-      local.get $20
+      local.get $36
+      local.get $34
       i64.lt_u
       if (result i32)
-       local.get $28
-       local.get $22
+       local.get $37
+       local.get $36
        i64.sub
-       local.get $21
+       local.get $35
        i64.ge_u
       else
        i32.const 0
       end
       if (result i32)
-       local.get $22
-       local.get $21
+       local.get $36
+       local.get $35
        i64.add
-       local.get $20
+       local.get $34
        i64.lt_u
        if (result i32)
         i32.const 1
        else
-        local.get $20
-        local.get $22
+        local.get $34
+        local.get $36
         i64.sub
-        local.get $22
-        local.get $21
+        local.get $36
+        local.get $35
         i64.add
-        local.get $20
+        local.get $34
         i64.sub
         i64.gt_u
        end
       else
        i32.const 0
       end
-      local.set $24
-      local.get $24
+      local.set $43
+      local.get $43
       if
-       local.get $25
+       local.get $41
        i32.const 1
        i32.sub
-       local.set $25
-       local.get $22
-       local.get $21
+       local.set $41
+       local.get $36
+       local.get $35
        i64.add
-       local.set $22
+       local.set $36
        br $while-continue|6
       end
      end
-     local.get $26
-     local.get $25
+     local.get $40
+     local.get $41
      i32.store16
      local.get $15
      return
@@ -1081,6 +1097,88 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local $22 i32)
+  (local $23 i32)
+  (local $24 i32)
+  (local $25 i32)
+  (local $26 i32)
+  (local $27 i32)
+  (local $28 i32)
+  (local $29 i32)
+  (local $30 i32)
+  (local $31 i32)
+  (local $32 i32)
+  (local $33 i32)
+  (local $34 i32)
+  (local $35 i32)
+  (local $36 i32)
+  (local $37 i32)
+  (local $38 i32)
+  (local $39 i32)
+  (local $40 i32)
+  (local $41 i32)
+  (local $42 i32)
+  (local $43 i32)
+  (local $44 i32)
+  (local $45 i32)
+  (local $46 i32)
+  (local $47 i32)
+  (local $48 i32)
+  (local $49 i32)
+  (local $50 i32)
+  (local $51 i32)
+  (local $52 i32)
+  (local $53 i32)
+  (local $54 i32)
+  (local $55 i32)
+  (local $56 i32)
+  (local $57 i32)
+  (local $58 i32)
+  (local $59 i32)
+  (local $60 i32)
+  (local $61 i32)
+  (local $62 i32)
+  (local $63 i32)
+  (local $64 i32)
+  (local $65 i32)
+  (local $66 i32)
+  (local $67 i32)
+  (local $68 i32)
+  (local $69 i32)
+  (local $70 i32)
+  (local $71 i32)
+  (local $72 i32)
+  (local $73 i32)
+  (local $74 i32)
+  (local $75 i32)
+  (local $76 i32)
+  (local $77 i32)
+  (local $78 i32)
+  (local $79 i32)
+  (local $80 i32)
+  (local $81 i32)
+  (local $82 i32)
+  (local $83 i32)
+  (local $84 i32)
+  (local $85 i32)
+  (local $86 i32)
+  (local $87 i32)
+  (local $88 i32)
   loop $while-continue|0
    local.get $2
    if (result i32)
@@ -1100,11 +1198,11 @@
     local.set $0
     local.get $6
     local.get $1
-    local.tee $6
+    local.tee $7
     i32.const 1
     i32.add
     local.set $1
-    local.get $6
+    local.get $7
     i32.load8_u
     i32.store8
     local.get $2
@@ -1124,8 +1222,8 @@
     local.get $2
     i32.const 16
     i32.ge_u
-    local.set $5
-    local.get $5
+    local.set $8
+    local.get $8
     if
      local.get $0
      local.get $1
@@ -1234,17 +1332,17 @@
    i32.and
    if
     local.get $0
-    local.tee $5
+    local.tee $9
     i32.const 1
     i32.add
     local.set $0
-    local.get $5
+    local.get $9
     local.get $1
-    local.tee $5
+    local.tee $10
     i32.const 1
     i32.add
     local.set $1
-    local.get $5
+    local.get $10
     i32.load8_u
     i32.store8
    end
@@ -1261,16 +1359,16 @@
        local.get $0
        i32.const 3
        i32.and
-       local.set $5
-       local.get $5
+       local.set $11
+       local.get $11
        i32.const 1
        i32.eq
        br_if $case0|2
-       local.get $5
+       local.get $11
        i32.const 2
        i32.eq
        br_if $case1|2
-       local.get $5
+       local.get $11
        i32.const 3
        i32.eq
        br_if $case2|2
@@ -1280,45 +1378,45 @@
       i32.load
       local.set $3
       local.get $0
-      local.tee $5
+      local.tee $12
       i32.const 1
       i32.add
       local.set $0
-      local.get $5
+      local.get $12
       local.get $1
-      local.tee $5
+      local.tee $13
       i32.const 1
       i32.add
       local.set $1
-      local.get $5
+      local.get $13
       i32.load8_u
       i32.store8
       local.get $0
-      local.tee $5
+      local.tee $14
       i32.const 1
       i32.add
       local.set $0
-      local.get $5
+      local.get $14
       local.get $1
-      local.tee $5
+      local.tee $15
       i32.const 1
       i32.add
       local.set $1
-      local.get $5
+      local.get $15
       i32.load8_u
       i32.store8
       local.get $0
-      local.tee $5
+      local.tee $16
       i32.const 1
       i32.add
       local.set $0
-      local.get $5
+      local.get $16
       local.get $1
-      local.tee $5
+      local.tee $17
       i32.const 1
       i32.add
       local.set $1
-      local.get $5
+      local.get $17
       i32.load8_u
       i32.store8
       local.get $2
@@ -1329,8 +1427,8 @@
        local.get $2
        i32.const 17
        i32.ge_u
-       local.set $5
-       local.get $5
+       local.set $18
+       local.get $18
        if
         local.get $1
         i32.const 1
@@ -1415,31 +1513,31 @@
      i32.load
      local.set $3
      local.get $0
-     local.tee $5
+     local.tee $19
      i32.const 1
      i32.add
      local.set $0
-     local.get $5
+     local.get $19
      local.get $1
-     local.tee $5
+     local.tee $20
      i32.const 1
      i32.add
      local.set $1
-     local.get $5
+     local.get $20
      i32.load8_u
      i32.store8
      local.get $0
-     local.tee $5
+     local.tee $21
      i32.const 1
      i32.add
      local.set $0
-     local.get $5
+     local.get $21
      local.get $1
-     local.tee $5
+     local.tee $22
      i32.const 1
      i32.add
      local.set $1
-     local.get $5
+     local.get $22
      i32.load8_u
      i32.store8
      local.get $2
@@ -1450,8 +1548,8 @@
       local.get $2
       i32.const 18
       i32.ge_u
-      local.set $5
-      local.get $5
+      local.set $23
+      local.get $23
       if
        local.get $1
        i32.const 2
@@ -1536,17 +1634,17 @@
     i32.load
     local.set $3
     local.get $0
-    local.tee $5
+    local.tee $24
     i32.const 1
     i32.add
     local.set $0
-    local.get $5
+    local.get $24
     local.get $1
-    local.tee $5
+    local.tee $25
     i32.const 1
     i32.add
     local.set $1
-    local.get $5
+    local.get $25
     i32.load8_u
     i32.store8
     local.get $2
@@ -1557,8 +1655,8 @@
      local.get $2
      i32.const 19
      i32.ge_u
-     local.set $5
-     local.get $5
+     local.set $26
+     local.get $26
      if
       local.get $1
       i32.const 3
@@ -1645,227 +1743,227 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $27
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $27
    local.get $1
-   local.tee $5
+   local.tee $28
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $28
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $29
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $29
    local.get $1
-   local.tee $5
+   local.tee $30
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $30
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $31
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $31
    local.get $1
-   local.tee $5
+   local.tee $32
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $32
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $33
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $33
    local.get $1
-   local.tee $5
+   local.tee $34
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $34
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $35
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $35
    local.get $1
-   local.tee $5
+   local.tee $36
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $36
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $37
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $37
    local.get $1
-   local.tee $5
+   local.tee $38
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $38
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $39
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $39
    local.get $1
-   local.tee $5
+   local.tee $40
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $40
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $41
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $41
    local.get $1
-   local.tee $5
+   local.tee $42
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $42
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $43
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $43
    local.get $1
-   local.tee $5
+   local.tee $44
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $44
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $45
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $45
    local.get $1
-   local.tee $5
+   local.tee $46
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $46
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $47
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $47
    local.get $1
-   local.tee $5
+   local.tee $48
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $48
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $49
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $49
    local.get $1
-   local.tee $5
+   local.tee $50
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $50
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $51
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $51
    local.get $1
-   local.tee $5
+   local.tee $52
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $52
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $53
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $53
    local.get $1
-   local.tee $5
+   local.tee $54
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $54
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $55
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $55
    local.get $1
-   local.tee $5
+   local.tee $56
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $56
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $57
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $57
    local.get $1
-   local.tee $5
+   local.tee $58
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $58
    i32.load8_u
    i32.store8
   end
@@ -1874,115 +1972,115 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $59
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $59
    local.get $1
-   local.tee $5
+   local.tee $60
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $60
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $61
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $61
    local.get $1
-   local.tee $5
+   local.tee $62
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $62
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $63
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $63
    local.get $1
-   local.tee $5
+   local.tee $64
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $64
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $65
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $65
    local.get $1
-   local.tee $5
+   local.tee $66
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $66
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $67
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $67
    local.get $1
-   local.tee $5
+   local.tee $68
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $68
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $69
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $69
    local.get $1
-   local.tee $5
+   local.tee $70
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $70
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $71
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $71
    local.get $1
-   local.tee $5
+   local.tee $72
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $72
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $73
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $73
    local.get $1
-   local.tee $5
+   local.tee $74
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $74
    i32.load8_u
    i32.store8
   end
@@ -1991,59 +2089,59 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $75
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $75
    local.get $1
-   local.tee $5
+   local.tee $76
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $76
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $77
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $77
    local.get $1
-   local.tee $5
+   local.tee $78
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $78
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $79
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $79
    local.get $1
-   local.tee $5
+   local.tee $80
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $80
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $81
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $81
    local.get $1
-   local.tee $5
+   local.tee $82
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $82
    i32.load8_u
    i32.store8
   end
@@ -2052,31 +2150,31 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $83
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $83
    local.get $1
-   local.tee $5
+   local.tee $84
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $84
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $85
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $85
    local.get $1
-   local.tee $5
+   local.tee $86
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $86
    i32.load8_u
    i32.store8
   end
@@ -2085,17 +2183,17 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $87
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $87
    local.get $1
-   local.tee $5
+   local.tee $88
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $88
    i32.load8_u
    i32.store8
   end
@@ -2106,6 +2204,14 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
   block $~lib/util/memory/memmove|inlined.0
    local.get $0
    local.set $5
@@ -2183,11 +2289,11 @@
        local.set $5
        local.get $7
        local.get $4
-       local.tee $7
+       local.tee $8
        i32.const 1
        i32.add
        local.set $4
-       local.get $7
+       local.get $8
        i32.load8_u
        i32.store8
        br $while-continue|0
@@ -2197,8 +2303,8 @@
       local.get $3
       i32.const 8
       i32.ge_u
-      local.set $6
-      local.get $6
+      local.set $9
+      local.get $9
       if
        local.get $5
        local.get $4
@@ -2222,21 +2328,21 @@
     end
     loop $while-continue|2
      local.get $3
-     local.set $6
-     local.get $6
+     local.set $10
+     local.get $10
      if
       local.get $5
-      local.tee $7
+      local.tee $11
       i32.const 1
       i32.add
       local.set $5
-      local.get $7
+      local.get $11
       local.get $4
-      local.tee $7
+      local.tee $12
       i32.const 1
       i32.add
       local.set $4
-      local.get $7
+      local.get $12
       i32.load8_u
       i32.store8
       local.get $3
@@ -2265,8 +2371,8 @@
       i32.add
       i32.const 7
       i32.and
-      local.set $6
-      local.get $6
+      local.set $13
+      local.get $13
       if
        local.get $3
        i32.eqz
@@ -2291,8 +2397,8 @@
       local.get $3
       i32.const 8
       i32.ge_u
-      local.set $6
-      local.get $6
+      local.set $14
+      local.get $14
       if
        local.get $3
        i32.const 8
@@ -2312,8 +2418,8 @@
     end
     loop $while-continue|5
      local.get $3
-     local.set $6
-     local.get $6
+     local.set $15
+     local.get $15
      if
       local.get $5
       local.get $3
@@ -2342,6 +2448,9 @@
   (local $9 i64)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
   loop $while-continue|0
    local.get $1
    i32.const 10000
@@ -2406,30 +2515,30 @@
    local.get $1
    i32.const 100
    i32.div_u
-   local.set $3
+   local.set $10
    local.get $1
    i32.const 100
    i32.rem_u
-   local.set $10
-   local.get $3
+   local.set $11
+   local.get $10
    local.set $1
    local.get $2
    i32.const 2
    i32.sub
    local.set $2
    i32.const 1312
-   local.get $10
+   local.get $11
    i32.const 2
    i32.shl
    i32.add
    i32.load
-   local.set $11
+   local.set $12
    local.get $0
    local.get $2
    i32.const 1
    i32.shl
    i32.add
-   local.get $11
+   local.get $12
    i32.store
   end
   local.get $1
@@ -2446,13 +2555,13 @@
    i32.shl
    i32.add
    i32.load
-   local.set $11
+   local.set $13
    local.get $0
    local.get $2
    i32.const 1
    i32.shl
    i32.add
-   local.get $11
+   local.get $13
    i32.store
   else
    local.get $2
@@ -2462,13 +2571,13 @@
    i32.const 48
    local.get $1
    i32.add
-   local.set $11
+   local.set $14
    local.get $0
    local.get $2
    i32.const 1
    i32.shl
    i32.add
-   local.get $11
+   local.get $14
    i32.store16
   end
  )
@@ -2482,6 +2591,19 @@
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local $22 i32)
+  (local $23 i32)
+  (local $24 i32)
   local.get $2
   i32.eqz
   if
@@ -2571,11 +2693,11 @@
     i32.const 1
     i32.shl
     i32.add
-    local.set $4
-    local.get $4
+    local.set $6
+    local.get $6
     i32.const 2
     i32.add
-    local.get $4
+    local.get $6
     i32.const 0
     local.get $2
     i32.sub
@@ -2608,9 +2730,9 @@
      i32.const 2
      local.get $3
      i32.sub
-     local.set $4
+     local.set $7
      local.get $0
-     local.get $4
+     local.get $7
      i32.const 1
      i32.shl
      i32.add
@@ -2627,30 +2749,30 @@
      i32.or
      i32.store
      i32.const 2
-     local.set $5
+     local.set $8
      loop $for-loop|1
-      local.get $5
-      local.get $4
+      local.get $8
+      local.get $7
       i32.lt_s
-      local.set $6
-      local.get $6
+      local.set $9
+      local.get $9
       if
        local.get $0
-       local.get $5
+       local.get $8
        i32.const 1
        i32.shl
        i32.add
        i32.const 48
        i32.store16
-       local.get $5
+       local.get $8
        i32.const 1
        i32.add
-       local.set $5
+       local.set $8
        br $for-loop|1
       end
      end
      local.get $1
-     local.get $4
+     local.get $7
      i32.add
      return
     else
@@ -2664,48 +2786,48 @@
       local.get $0
       i32.const 4
       i32.add
-      local.set $5
+      local.set $11
       local.get $3
       i32.const 1
       i32.sub
-      local.set $6
-      local.get $6
+      local.set $10
+      local.get $10
       i32.const 0
       i32.lt_s
-      local.set $4
-      local.get $4
+      local.set $12
+      local.get $12
       if
        i32.const 0
-       local.get $6
+       local.get $10
        i32.sub
-       local.set $6
+       local.set $10
       end
-      local.get $6
+      local.get $10
       call $~lib/util/number/decimalCount32
       i32.const 1
       i32.add
-      local.set $7
-      local.get $5
-      local.set $10
-      local.get $6
-      local.set $9
-      local.get $7
-      local.set $8
+      local.set $13
+      local.get $11
+      local.set $16
+      local.get $10
+      local.set $15
+      local.get $13
+      local.set $14
       i32.const 0
       i32.const 1
       i32.ge_s
       drop
-      local.get $10
-      local.get $9
-      local.get $8
+      local.get $16
+      local.get $15
+      local.get $14
       call $~lib/util/number/utoa32_lut
-      local.get $5
+      local.get $11
       i32.const 45
       i32.const 43
-      local.get $4
+      local.get $12
       select
       i32.store16
-      local.get $7
+      local.get $13
       local.set $1
       local.get $1
       i32.const 2
@@ -2715,14 +2837,14 @@
       local.get $1
       i32.const 1
       i32.shl
-      local.set $7
+      local.set $17
       local.get $0
       i32.const 4
       i32.add
       local.get $0
       i32.const 2
       i32.add
-      local.get $7
+      local.get $17
       i32.const 2
       i32.sub
       call $~lib/memory/memory.copy
@@ -2730,58 +2852,58 @@
       i32.const 46
       i32.store16 offset=2
       local.get $0
-      local.get $7
+      local.get $17
       i32.add
       i32.const 101
       i32.store16 offset=2
       local.get $1
       local.get $0
-      local.get $7
+      local.get $17
       i32.add
       i32.const 4
       i32.add
-      local.set $9
+      local.set $19
       local.get $3
       i32.const 1
       i32.sub
-      local.set $8
-      local.get $8
+      local.set $18
+      local.get $18
       i32.const 0
       i32.lt_s
-      local.set $4
-      local.get $4
+      local.set $20
+      local.get $20
       if
        i32.const 0
-       local.get $8
+       local.get $18
        i32.sub
-       local.set $8
+       local.set $18
       end
-      local.get $8
+      local.get $18
       call $~lib/util/number/decimalCount32
       i32.const 1
       i32.add
-      local.set $5
-      local.get $9
-      local.set $11
-      local.get $8
-      local.set $6
-      local.get $5
-      local.set $10
+      local.set $21
+      local.get $19
+      local.set $24
+      local.get $18
+      local.set $23
+      local.get $21
+      local.set $22
       i32.const 0
       i32.const 1
       i32.ge_s
       drop
-      local.get $11
-      local.get $6
-      local.get $10
+      local.get $24
+      local.get $23
+      local.get $22
       call $~lib/util/number/utoa32_lut
-      local.get $9
+      local.get $19
       i32.const 45
       i32.const 43
-      local.get $4
+      local.get $20
       select
       i32.store16
-      local.get $5
+      local.get $21
       i32.add
       local.set $1
       local.get $1
@@ -2812,19 +2934,51 @@
   (local $13 i32)
   (local $14 i32)
   (local $15 i32)
-  (local $16 f64)
-  (local $17 i64)
-  (local $18 i64)
-  (local $19 i64)
-  (local $20 i64)
+  (local $16 i32)
+  (local $17 f64)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
   (local $21 i64)
-  (local $22 i64)
+  (local $22 i32)
   (local $23 i64)
   (local $24 i64)
   (local $25 i64)
-  (local $26 i32)
+  (local $26 i64)
   (local $27 i64)
-  (local $28 i32)
+  (local $28 i64)
+  (local $29 i64)
+  (local $30 i64)
+  (local $31 i64)
+  (local $32 i64)
+  (local $33 i32)
+  (local $34 i32)
+  (local $35 i32)
+  (local $36 i64)
+  (local $37 i64)
+  (local $38 i64)
+  (local $39 i64)
+  (local $40 i64)
+  (local $41 i64)
+  (local $42 i64)
+  (local $43 i64)
+  (local $44 i64)
+  (local $45 i64)
+  (local $46 i32)
+  (local $47 i32)
+  (local $48 i32)
+  (local $49 i64)
+  (local $50 i64)
+  (local $51 i64)
+  (local $52 i64)
+  (local $53 i64)
+  (local $54 i64)
+  (local $55 i64)
+  (local $56 i64)
+  (local $57 i64)
+  (local $58 i64)
+  (local $59 i64)
+  (local $60 i32)
   local.get $1
   f64.const 0
   f64.lt
@@ -2928,47 +3082,47 @@
   local.get $13
   global.set $~lib/util/number/_exp
   global.get $~lib/util/number/_exp
-  local.set $10
+  local.set $16
   i32.const -61
-  local.get $10
+  local.get $16
   i32.sub
   f64.convert_i32_s
   f64.const 0.30102999566398114
   f64.mul
   f64.const 347
   f64.add
-  local.set $16
-  local.get $16
+  local.set $17
+  local.get $17
   i32.trunc_f64_s
-  local.set $15
-  local.get $15
-  local.get $15
+  local.set $18
+  local.get $18
+  local.get $18
   f64.convert_i32_s
-  local.get $16
+  local.get $17
   f64.ne
   i32.add
-  local.set $15
-  local.get $15
+  local.set $18
+  local.get $18
   i32.const 3
   i32.shr_s
   i32.const 1
   i32.add
-  local.set $14
+  local.set $19
   i32.const 348
-  local.get $14
+  local.get $19
   i32.const 3
   i32.shl
   i32.sub
   global.set $~lib/util/number/_K
   i32.const 400
-  local.get $14
+  local.get $19
   i32.const 3
   i32.shl
   i32.add
   i64.load
   global.set $~lib/util/number/_frc_pow
   i32.const 1096
-  local.get $14
+  local.get $19
   i32.const 1
   i32.shl
   i32.add
@@ -2977,249 +3131,249 @@
   local.get $9
   i64.clz
   i32.wrap_i64
-  local.set $14
+  local.set $20
   local.get $9
-  local.get $14
+  local.get $20
   i64.extend_i32_s
   i64.shl
   local.set $9
   local.get $7
-  local.get $14
+  local.get $20
   i32.sub
   local.set $7
   global.get $~lib/util/number/_frc_pow
-  local.set $12
+  local.set $21
   global.get $~lib/util/number/_exp_pow
-  local.set $15
+  local.set $22
   local.get $9
-  local.set $17
-  local.get $12
-  local.set $11
-  local.get $17
-  i64.const 4294967295
-  i64.and
-  local.set $18
-  local.get $11
-  i64.const 4294967295
-  i64.and
-  local.set $19
-  local.get $17
-  i64.const 32
-  i64.shr_u
-  local.set $20
-  local.get $11
-  i64.const 32
-  i64.shr_u
-  local.set $21
-  local.get $18
-  local.get $19
-  i64.mul
-  local.set $22
-  local.get $20
-  local.get $19
-  i64.mul
-  local.get $22
-  i64.const 32
-  i64.shr_u
-  i64.add
-  local.set $23
-  local.get $18
+  local.set $24
   local.get $21
-  i64.mul
+  local.set $23
+  local.get $24
+  i64.const 4294967295
+  i64.and
+  local.set $25
   local.get $23
   i64.const 4294967295
   i64.and
-  i64.add
-  local.set $24
+  local.set $26
   local.get $24
+  i64.const 32
+  i64.shr_u
+  local.set $27
+  local.get $23
+  i64.const 32
+  i64.shr_u
+  local.set $28
+  local.get $25
+  local.get $26
+  i64.mul
+  local.set $29
+  local.get $27
+  local.get $26
+  i64.mul
+  local.get $29
+  i64.const 32
+  i64.shr_u
+  i64.add
+  local.set $30
+  local.get $25
+  local.get $28
+  i64.mul
+  local.get $30
+  i64.const 4294967295
+  i64.and
+  i64.add
+  local.set $31
+  local.get $31
   i64.const 2147483647
   i64.add
-  local.set $24
-  local.get $23
+  local.set $31
+  local.get $30
   i64.const 32
   i64.shr_u
-  local.set $23
-  local.get $24
+  local.set $30
+  local.get $31
   i64.const 32
   i64.shr_u
-  local.set $24
-  local.get $20
-  local.get $21
+  local.set $31
+  local.get $27
+  local.get $28
   i64.mul
-  local.get $23
+  local.get $30
   i64.add
-  local.get $24
+  local.get $31
   i64.add
-  local.set $24
+  local.set $32
   local.get $7
-  local.set $10
-  local.get $15
-  local.set $13
-  local.get $10
-  local.get $13
+  local.set $34
+  local.get $22
+  local.set $33
+  local.get $34
+  local.get $33
   i32.add
   i32.const 64
   i32.add
-  local.set $10
+  local.set $35
   global.get $~lib/util/number/_frc_plus
-  local.set $17
-  local.get $12
-  local.set $11
-  local.get $17
-  i64.const 4294967295
-  i64.and
-  local.set $23
-  local.get $11
-  i64.const 4294967295
-  i64.and
-  local.set $22
-  local.get $17
-  i64.const 32
-  i64.shr_u
-  local.set $21
-  local.get $11
-  i64.const 32
-  i64.shr_u
-  local.set $20
-  local.get $23
-  local.get $22
-  i64.mul
-  local.set $19
+  local.set $37
   local.get $21
-  local.get $22
+  local.set $36
+  local.get $37
+  i64.const 4294967295
+  i64.and
+  local.set $38
+  local.get $36
+  i64.const 4294967295
+  i64.and
+  local.set $39
+  local.get $37
+  i64.const 32
+  i64.shr_u
+  local.set $40
+  local.get $36
+  i64.const 32
+  i64.shr_u
+  local.set $41
+  local.get $38
+  local.get $39
   i64.mul
-  local.get $19
+  local.set $42
+  local.get $40
+  local.get $39
+  i64.mul
+  local.get $42
   i64.const 32
   i64.shr_u
   i64.add
-  local.set $18
-  local.get $23
-  local.get $20
+  local.set $43
+  local.get $38
+  local.get $41
   i64.mul
-  local.get $18
+  local.get $43
   i64.const 4294967295
   i64.and
   i64.add
-  local.set $25
-  local.get $25
+  local.set $44
+  local.get $44
   i64.const 2147483647
   i64.add
-  local.set $25
-  local.get $18
+  local.set $44
+  local.get $43
   i64.const 32
   i64.shr_u
-  local.set $18
-  local.get $25
+  local.set $43
+  local.get $44
   i64.const 32
   i64.shr_u
-  local.set $25
-  local.get $21
-  local.get $20
+  local.set $44
+  local.get $40
+  local.get $41
   i64.mul
-  local.get $18
+  local.get $43
   i64.add
-  local.get $25
+  local.get $44
   i64.add
   i64.const 1
   i64.sub
-  local.set $25
+  local.set $45
   global.get $~lib/util/number/_exp
-  local.set $26
-  local.get $15
-  local.set $13
-  local.get $26
-  local.get $13
+  local.set $47
+  local.get $22
+  local.set $46
+  local.get $47
+  local.get $46
   i32.add
   i32.const 64
   i32.add
-  local.set $26
+  local.set $48
   global.get $~lib/util/number/_frc_minus
-  local.set $17
-  local.get $12
-  local.set $11
-  local.get $17
-  i64.const 4294967295
-  i64.and
-  local.set $18
-  local.get $11
-  i64.const 4294967295
-  i64.and
-  local.set $19
-  local.get $17
-  i64.const 32
-  i64.shr_u
-  local.set $20
-  local.get $11
-  i64.const 32
-  i64.shr_u
-  local.set $21
-  local.get $18
-  local.get $19
-  i64.mul
-  local.set $22
-  local.get $20
-  local.get $19
-  i64.mul
-  local.get $22
-  i64.const 32
-  i64.shr_u
-  i64.add
-  local.set $23
-  local.get $18
+  local.set $50
   local.get $21
+  local.set $49
+  local.get $50
+  i64.const 4294967295
+  i64.and
+  local.set $51
+  local.get $49
+  i64.const 4294967295
+  i64.and
+  local.set $52
+  local.get $50
+  i64.const 32
+  i64.shr_u
+  local.set $53
+  local.get $49
+  i64.const 32
+  i64.shr_u
+  local.set $54
+  local.get $51
+  local.get $52
   i64.mul
-  local.get $23
+  local.set $55
+  local.get $53
+  local.get $52
+  i64.mul
+  local.get $55
+  i64.const 32
+  i64.shr_u
+  i64.add
+  local.set $56
+  local.get $51
+  local.get $54
+  i64.mul
+  local.get $56
   i64.const 4294967295
   i64.and
   i64.add
-  local.set $27
-  local.get $27
+  local.set $57
+  local.get $57
   i64.const 2147483647
   i64.add
-  local.set $27
-  local.get $23
+  local.set $57
+  local.get $56
   i64.const 32
   i64.shr_u
-  local.set $23
-  local.get $27
+  local.set $56
+  local.get $57
   i64.const 32
   i64.shr_u
-  local.set $27
-  local.get $20
-  local.get $21
+  local.set $57
+  local.get $53
+  local.get $54
   i64.mul
-  local.get $23
+  local.get $56
   i64.add
-  local.get $27
+  local.get $57
   i64.add
   i64.const 1
   i64.add
-  local.set $27
-  local.get $25
-  local.get $27
+  local.set $58
+  local.get $45
+  local.get $58
   i64.sub
-  local.set $23
+  local.set $59
   local.get $4
-  local.get $24
-  local.get $10
-  local.get $25
-  local.get $26
-  local.get $23
+  local.get $32
+  local.get $35
+  local.get $45
+  local.get $48
+  local.get $59
   local.get $3
   call $~lib/util/number/genDigits
-  local.set $28
+  local.set $60
   local.get $0
   local.get $2
   i32.const 1
   i32.shl
   i32.add
-  local.get $28
+  local.get $60
   local.get $2
   i32.sub
   global.get $~lib/util/number/_K
   call $~lib/util/number/prettify
-  local.set $28
-  local.get $28
+  local.set $60
+  local.get $60
   local.get $2
   i32.add
  )
@@ -3241,6 +3395,16 @@
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
   local.get $0
   call $~lib/string/String#get:length
   local.set $3
@@ -3252,67 +3416,67 @@
   local.get $5
   i32.gt_s
   select
-  local.tee $4
+  local.tee $6
   local.get $3
-  local.tee $5
-  local.get $4
-  local.get $5
-  i32.lt_s
-  select
-  local.set $6
-  local.get $2
-  local.tee $4
-  i32.const 0
-  local.tee $5
-  local.get $4
-  local.get $5
-  i32.gt_s
-  select
-  local.tee $4
-  local.get $3
-  local.tee $5
-  local.get $4
-  local.get $5
-  i32.lt_s
-  select
-  local.set $7
+  local.tee $7
   local.get $6
-  local.tee $4
   local.get $7
-  local.tee $5
-  local.get $4
-  local.get $5
   i32.lt_s
   select
-  i32.const 1
-  i32.shl
   local.set $8
-  local.get $6
-  local.tee $4
-  local.get $7
-  local.tee $5
-  local.get $4
-  local.get $5
+  local.get $2
+  local.tee $9
+  i32.const 0
+  local.tee $10
+  local.get $9
+  local.get $10
+  i32.gt_s
+  select
+  local.tee $11
+  local.get $3
+  local.tee $12
+  local.get $11
+  local.get $12
+  i32.lt_s
+  select
+  local.set $13
+  local.get $8
+  local.tee $14
+  local.get $13
+  local.tee $15
+  local.get $14
+  local.get $15
+  i32.lt_s
+  select
+  i32.const 1
+  i32.shl
+  local.set $16
+  local.get $8
+  local.tee $17
+  local.get $13
+  local.tee $18
+  local.get $17
+  local.get $18
   i32.gt_s
   select
   i32.const 1
   i32.shl
-  local.set $9
-  local.get $9
-  local.get $8
+  local.set $19
+  local.get $19
+  local.get $16
   i32.sub
-  local.set $10
-  local.get $10
+  local.set $20
+  local.get $20
   i32.eqz
   if
    i32.const 1728
    call $~lib/rt/stub/__retain
    return
   end
-  local.get $8
+  local.get $16
   i32.eqz
   if (result i32)
-   local.get $9
+   local.get $19
    local.get $3
    i32.const 1
    i32.shl
@@ -3325,17 +3489,17 @@
    call $~lib/rt/stub/__retain
    return
   end
-  local.get $10
+  local.get $20
   i32.const 1
   call $~lib/rt/stub/__alloc
-  local.set $11
-  local.get $11
+  local.set $21
+  local.get $21
   local.get $0
-  local.get $8
+  local.get $16
   i32.add
-  local.get $10
+  local.get $20
   call $~lib/memory/memory.copy
-  local.get $11
+  local.get $21
   call $~lib/rt/stub/__retain
  )
  (func $~lib/rt/stub/__free (param $0 i32)
@@ -3463,6 +3627,9 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
   local.get $0
   call $~lib/rt/stub/__retain
   local.set $0
@@ -3534,33 +3701,33 @@
   end
   loop $while-continue|1
    local.get $4
-   local.tee $7
+   local.tee $8
    i32.const 1
    i32.sub
    local.set $4
-   local.get $7
-   local.set $7
-   local.get $7
+   local.get $8
+   local.set $9
+   local.get $9
    if
     local.get $5
     i32.load16_u
-    local.set $8
+    local.set $10
     local.get $6
     i32.load16_u
-    local.set $9
-    local.get $8
-    local.get $9
+    local.set $11
+    local.get $10
+    local.get $11
     i32.ne
     if
-     local.get $8
-     local.get $9
+     local.get $10
+     local.get $11
      i32.sub
-     local.set $10
+     local.set $12
      local.get $0
      call $~lib/rt/stub/__release
      local.get $2
      call $~lib/rt/stub/__release
-     local.get $10
+     local.get $12
      return
     end
     local.get $5
@@ -3575,16 +3742,19 @@
    end
   end
   i32.const 0
-  local.set $7
+  local.set $13
   local.get $0
   call $~lib/rt/stub/__release
   local.get $2
   call $~lib/rt/stub/__release
-  local.get $7
+  local.get $13
  )
  (func $~lib/string/String.__eq (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   local.get $0
   call $~lib/rt/stub/__retain
   local.set $0
@@ -3616,44 +3786,44 @@
   end
   if
    i32.const 0
-   local.set $2
+   local.set $3
    local.get $0
    call $~lib/rt/stub/__release
    local.get $1
    call $~lib/rt/stub/__release
-   local.get $2
+   local.get $3
    return
   end
   local.get $0
   call $~lib/string/String#get:length
-  local.set $3
-  local.get $3
+  local.set $4
+  local.get $4
   local.get $1
   call $~lib/string/String#get:length
   i32.ne
   if
    i32.const 0
-   local.set $2
+   local.set $5
    local.get $0
    call $~lib/rt/stub/__release
    local.get $1
    call $~lib/rt/stub/__release
-   local.get $2
+   local.get $5
    return
   end
   local.get $0
   i32.const 0
   local.get $1
   i32.const 0
-  local.get $3
+  local.get $4
   call $~lib/util/string/compareImpl
   i32.eqz
-  local.set $2
+  local.set $6
   local.get $0
   call $~lib/rt/stub/__release
   local.get $1
   call $~lib/rt/stub/__release
-  local.get $2
+  local.get $6
  )
  (func $~lib/typedarray/Uint8Array#constructor (param $0 i32) (param $1 i32) (result i32)
   local.get $0
@@ -3792,6 +3962,10 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
   global.get $~lib/heap/__heap_base
   i32.const 15
   i32.add
@@ -3860,7 +4034,7 @@
   local.get $3
   call $~lib/typedarray/Float32Array#__get
   call $~lib/number/F32#toString
-  local.tee $2
+  local.tee $4
   i32.const 1920
   call $~lib/string/String.__eq
   i32.eqz
@@ -3910,7 +4084,7 @@
   i32.const 0
   call $~lib/typedarray/Uint8Array#__get
   call $~lib/number/U8#toString
-  local.tee $3
+  local.tee $5
   i32.const 1984
   call $~lib/string/String.__eq
   i32.eqz
@@ -3926,7 +4100,7 @@
   i32.const 1
   call $~lib/typedarray/Uint8Array#__get
   call $~lib/number/U8#toString
-  local.tee $2
+  local.tee $6
   i32.const 2016
   call $~lib/string/String.__eq
   i32.eqz
@@ -3939,20 +4113,20 @@
    unreachable
   end
   global.get $resolve-elementaccess/buf
-  local.tee $4
+  local.tee $7
   i32.const 0
-  local.tee $5
+  local.tee $8
   global.get $resolve-elementaccess/buf
   i32.const 0
   call $~lib/typedarray/Uint8Array#__get
   i32.const 10
   i32.add
   call $~lib/typedarray/Uint8Array#__set
-  local.get $4
-  local.get $5
+  local.get $7
+  local.get $8
   call $~lib/typedarray/Uint8Array#__get
   call $~lib/number/U8#toString
-  local.tee $4
+  local.tee $9
   i32.const 2048
   call $~lib/string/String.__eq
   i32.eqz
@@ -3990,11 +4164,13 @@
   call $~lib/rt/stub/__release
   local.get $1
   call $~lib/rt/stub/__release
-  local.get $2
-  call $~lib/rt/stub/__release
-  local.get $3
-  call $~lib/rt/stub/__release
   local.get $4
+  call $~lib/rt/stub/__release
+  local.get $5
+  call $~lib/rt/stub/__release
+  local.get $6
+  call $~lib/rt/stub/__release
+  local.get $9
   call $~lib/rt/stub/__release
  )
  (func $~start

--- a/tests/compiler/resolve-function-expression.untouched.wat
+++ b/tests/compiler/resolve-function-expression.untouched.wat
@@ -102,6 +102,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   memory.size
   local.set $1
   local.get $1
@@ -132,8 +133,8 @@
    local.get $5
    i32.gt_s
    select
-   local.set $4
-   local.get $4
+   local.set $6
+   local.get $6
    memory.grow
    i32.const 0
    i32.lt_s
@@ -215,6 +216,9 @@
   (local $9 i64)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
   loop $while-continue|0
    local.get $1
    i32.const 10000
@@ -279,30 +283,30 @@
    local.get $1
    i32.const 100
    i32.div_u
-   local.set $3
+   local.set $10
    local.get $1
    i32.const 100
    i32.rem_u
-   local.set $10
-   local.get $3
+   local.set $11
+   local.get $10
    local.set $1
    local.get $2
    i32.const 2
    i32.sub
    local.set $2
    i32.const 116
-   local.get $10
+   local.get $11
    i32.const 2
    i32.shl
    i32.add
    i32.load
-   local.set $11
+   local.set $12
    local.get $0
    local.get $2
    i32.const 1
    i32.shl
    i32.add
-   local.get $11
+   local.get $12
    i32.store
   end
   local.get $1
@@ -319,13 +323,13 @@
    i32.shl
    i32.add
    i32.load
-   local.set $11
+   local.set $13
    local.get $0
    local.get $2
    i32.const 1
    i32.shl
    i32.add
-   local.get $11
+   local.get $13
    i32.store
   else
    local.get $2
@@ -335,13 +339,13 @@
    i32.const 48
    local.get $1
    i32.add
-   local.set $11
+   local.set $14
    local.get $0
    local.get $2
    i32.const 1
    i32.shl
    i32.add
-   local.get $11
+   local.get $14
    i32.store16
   end
  )
@@ -442,6 +446,9 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
   local.get $0
   call $~lib/rt/stub/__retain
   local.set $0
@@ -513,33 +520,33 @@
   end
   loop $while-continue|1
    local.get $4
-   local.tee $7
+   local.tee $8
    i32.const 1
    i32.sub
    local.set $4
-   local.get $7
-   local.set $7
-   local.get $7
+   local.get $8
+   local.set $9
+   local.get $9
    if
     local.get $5
     i32.load16_u
-    local.set $8
+    local.set $10
     local.get $6
     i32.load16_u
-    local.set $9
-    local.get $8
-    local.get $9
+    local.set $11
+    local.get $10
+    local.get $11
     i32.ne
     if
-     local.get $8
-     local.get $9
+     local.get $10
+     local.get $11
      i32.sub
-     local.set $10
+     local.set $12
      local.get $0
      call $~lib/rt/stub/__release
      local.get $2
      call $~lib/rt/stub/__release
-     local.get $10
+     local.get $12
      return
     end
     local.get $5
@@ -554,16 +561,19 @@
    end
   end
   i32.const 0
-  local.set $7
+  local.set $13
   local.get $0
   call $~lib/rt/stub/__release
   local.get $2
   call $~lib/rt/stub/__release
-  local.get $7
+  local.get $13
  )
  (func $~lib/string/String.__eq (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   local.get $0
   call $~lib/rt/stub/__retain
   local.set $0
@@ -595,44 +605,44 @@
   end
   if
    i32.const 0
-   local.set $2
+   local.set $3
    local.get $0
    call $~lib/rt/stub/__release
    local.get $1
    call $~lib/rt/stub/__release
-   local.get $2
+   local.get $3
    return
   end
   local.get $0
   call $~lib/string/String#get:length
-  local.set $3
-  local.get $3
+  local.set $4
+  local.get $4
   local.get $1
   call $~lib/string/String#get:length
   i32.ne
   if
    i32.const 0
-   local.set $2
+   local.set $5
    local.get $0
    call $~lib/rt/stub/__release
    local.get $1
    call $~lib/rt/stub/__release
-   local.get $2
+   local.get $5
    return
   end
   local.get $0
   i32.const 0
   local.get $1
   i32.const 0
-  local.get $3
+  local.get $4
   call $~lib/util/string/compareImpl
   i32.eqz
-  local.set $2
+  local.set $6
   local.get $0
   call $~lib/rt/stub/__release
   local.get $1
   call $~lib/rt/stub/__release
-  local.get $2
+  local.get $6
  )
  (func $start:resolve-function-expression
   (local $0 i32)

--- a/tests/compiler/resolve-nested.untouched.wat
+++ b/tests/compiler/resolve-nested.untouched.wat
@@ -42,6 +42,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   memory.size
   local.set $1
   local.get $1
@@ -72,8 +73,8 @@
    local.get $5
    i32.gt_s
    select
-   local.set $4
-   local.get $4
+   local.set $6
+   local.get $6
    memory.grow
    i32.const 0
    i32.lt_s

--- a/tests/compiler/resolve-new.untouched.wat
+++ b/tests/compiler/resolve-new.untouched.wat
@@ -17,6 +17,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   memory.size
   local.set $1
   local.get $1
@@ -47,8 +48,8 @@
    local.get $5
    i32.gt_s
    select
-   local.set $4
-   local.get $4
+   local.set $6
+   local.get $6
    memory.grow
    i32.const 0
    i32.lt_s

--- a/tests/compiler/resolve-propertyaccess.untouched.wat
+++ b/tests/compiler/resolve-propertyaccess.untouched.wat
@@ -98,6 +98,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   memory.size
   local.set $1
   local.get $1
@@ -128,8 +129,8 @@
    local.get $5
    i32.gt_s
    select
-   local.set $4
-   local.get $4
+   local.set $6
+   local.get $6
    memory.grow
    i32.const 0
    i32.lt_s
@@ -211,6 +212,9 @@
   (local $9 i64)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
   loop $while-continue|0
    local.get $1
    i32.const 10000
@@ -275,30 +279,30 @@
    local.get $1
    i32.const 100
    i32.div_u
-   local.set $3
+   local.set $10
    local.get $1
    i32.const 100
    i32.rem_u
-   local.set $10
-   local.get $3
+   local.set $11
+   local.get $10
    local.set $1
    local.get $2
    i32.const 2
    i32.sub
    local.set $2
    i32.const 36
-   local.get $10
+   local.get $11
    i32.const 2
    i32.shl
    i32.add
    i32.load
-   local.set $11
+   local.set $12
    local.get $0
    local.get $2
    i32.const 1
    i32.shl
    i32.add
-   local.get $11
+   local.get $12
    i32.store
   end
   local.get $1
@@ -315,13 +319,13 @@
    i32.shl
    i32.add
    i32.load
-   local.set $11
+   local.set $13
    local.get $0
    local.get $2
    i32.const 1
    i32.shl
    i32.add
-   local.get $11
+   local.get $13
    i32.store
   else
    local.get $2
@@ -331,13 +335,13 @@
    i32.const 48
    local.get $1
    i32.add
-   local.set $11
+   local.set $14
    local.get $0
    local.get $2
    i32.const 1
    i32.shl
    i32.add
-   local.get $11
+   local.get $14
    i32.store16
   end
  )
@@ -438,6 +442,9 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
   local.get $0
   call $~lib/rt/stub/__retain
   local.set $0
@@ -509,33 +516,33 @@
   end
   loop $while-continue|1
    local.get $4
-   local.tee $7
+   local.tee $8
    i32.const 1
    i32.sub
    local.set $4
-   local.get $7
-   local.set $7
-   local.get $7
+   local.get $8
+   local.set $9
+   local.get $9
    if
     local.get $5
     i32.load16_u
-    local.set $8
+    local.set $10
     local.get $6
     i32.load16_u
-    local.set $9
-    local.get $8
-    local.get $9
+    local.set $11
+    local.get $10
+    local.get $11
     i32.ne
     if
-     local.get $8
-     local.get $9
+     local.get $10
+     local.get $11
      i32.sub
-     local.set $10
+     local.set $12
      local.get $0
      call $~lib/rt/stub/__release
      local.get $2
      call $~lib/rt/stub/__release
-     local.get $10
+     local.get $12
      return
     end
     local.get $5
@@ -550,16 +557,19 @@
    end
   end
   i32.const 0
-  local.set $7
+  local.set $13
   local.get $0
   call $~lib/rt/stub/__release
   local.get $2
   call $~lib/rt/stub/__release
-  local.get $7
+  local.get $13
  )
  (func $~lib/string/String.__eq (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   local.get $0
   call $~lib/rt/stub/__retain
   local.set $0
@@ -591,44 +601,44 @@
   end
   if
    i32.const 0
-   local.set $2
+   local.set $3
    local.get $0
    call $~lib/rt/stub/__release
    local.get $1
    call $~lib/rt/stub/__release
-   local.get $2
+   local.get $3
    return
   end
   local.get $0
   call $~lib/string/String#get:length
-  local.set $3
-  local.get $3
+  local.set $4
+  local.get $4
   local.get $1
   call $~lib/string/String#get:length
   i32.ne
   if
    i32.const 0
-   local.set $2
+   local.set $5
    local.get $0
    call $~lib/rt/stub/__release
    local.get $1
    call $~lib/rt/stub/__release
-   local.get $2
+   local.get $5
    return
   end
   local.get $0
   i32.const 0
   local.get $1
   i32.const 0
-  local.get $3
+  local.get $4
   call $~lib/util/string/compareImpl
   i32.eqz
-  local.set $2
+  local.set $6
   local.get $0
   call $~lib/rt/stub/__release
   local.get $1
   call $~lib/rt/stub/__release
-  local.get $2
+  local.get $6
  )
  (func $resolve-propertyaccess/Class#constructor (param $0 i32) (result i32)
   local.get $0

--- a/tests/compiler/resolve-ternary.optimized.wat
+++ b/tests/compiler/resolve-ternary.optimized.wat
@@ -1300,8 +1300,8 @@
  )
  (func $~lib/util/number/genDigits (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (result i32)
   (local $6 i32)
-  (local $7 i64)
-  (local $8 i32)
+  (local $7 i32)
+  (local $8 i64)
   (local $9 i64)
   (local $10 i32)
   (local $11 i64)
@@ -1323,7 +1323,7 @@
   i64.sub
   local.tee $12
   i64.and
-  local.set $7
+  local.set $8
   local.get $3
   local.get $10
   i64.extend_i32_s
@@ -1457,11 +1457,11 @@
      local.set $2
     end
     local.get $2
-    local.get $8
+    local.get $7
     i32.or
     if
      local.get $0
-     local.get $8
+     local.get $7
      i32.const 1
      i32.shl
      i32.add
@@ -1471,16 +1471,16 @@
      i32.const 48
      i32.add
      i32.store16
-     local.get $8
+     local.get $7
      i32.const 1
      i32.add
-     local.set $8
+     local.set $7
     end
     local.get $4
     i32.const 1
     i32.sub
     local.set $4
-    local.get $7
+    local.get $8
     local.get $6
     i64.extend_i32_u
     local.get $10
@@ -1506,7 +1506,7 @@
      i64.shl
      local.set $3
      local.get $0
-     local.get $8
+     local.get $7
      i32.const 1
      i32.sub
      i32.const 1
@@ -1523,11 +1523,11 @@
       local.get $1
       local.get $3
       i64.add
-      local.tee $7
+      local.tee $8
       local.get $9
       i64.sub
       i64.gt_u
-      local.get $7
+      local.get $8
       local.get $9
       i64.lt_u
       select
@@ -1558,7 +1558,7 @@
      local.get $0
      local.get $4
      i32.store16
-     local.get $8
+     local.get $7
      return
     end
     br $while-continue|0
@@ -1572,35 +1572,35 @@
    i64.const 10
    i64.mul
    local.set $5
-   local.get $7
+   local.get $8
    i64.const 10
    i64.mul
    local.tee $3
    local.get $1
    i64.shr_u
-   local.tee $7
-   local.get $8
+   local.tee $8
+   local.get $7
    i64.extend_i32_s
    i64.or
    i64.const 0
    i64.ne
    if
     local.get $0
-    local.get $8
+    local.get $7
     i32.const 1
     i32.shl
     i32.add
-    local.get $7
+    local.get $8
     i32.wrap_i64
     i32.const 65535
     i32.and
     i32.const 48
     i32.add
     i32.store16
-    local.get $8
+    local.get $7
     i32.const 1
     i32.add
-    local.set $8
+    local.set $7
    end
    local.get $4
    i32.const 1
@@ -1609,7 +1609,7 @@
    local.get $3
    local.get $12
    i64.and
-   local.tee $7
+   local.tee $8
    local.get $5
    i64.ge_u
    br_if $while-continue|4
@@ -1618,8 +1618,6 @@
   global.get $~lib/util/number/_K
   i32.add
   global.set $~lib/util/number/_K
-  local.get $7
-  local.set $1
   local.get $9
   i32.const 0
   local.get $4
@@ -1630,9 +1628,9 @@
   i32.add
   i64.load32_u
   i64.mul
-  local.set $3
+  local.set $1
   local.get $0
-  local.get $8
+  local.get $7
   i32.const 1
   i32.sub
   i32.const 1
@@ -1643,29 +1641,29 @@
   local.set $4
   loop $while-continue|6
    i32.const 1
-   local.get $3
    local.get $1
+   local.get $8
    i64.sub
-   local.get $1
+   local.get $8
    local.get $11
    i64.add
-   local.tee $7
-   local.get $3
+   local.tee $3
+   local.get $1
    i64.sub
    i64.gt_u
-   local.get $7
    local.get $3
+   local.get $1
    i64.lt_u
    select
    i32.const 0
    local.get $5
-   local.get $1
+   local.get $8
    i64.sub
    local.get $11
    i64.ge_u
    i32.const 0
+   local.get $8
    local.get $1
-   local.get $3
    i64.lt_u
    select
    select
@@ -1674,17 +1672,17 @@
     i32.const 1
     i32.sub
     local.set $4
-    local.get $1
+    local.get $8
     local.get $11
     i64.add
-    local.set $1
+    local.set $8
     br $while-continue|6
    end
   end
   local.get $0
   local.get $4
   i32.store16
-  local.get $8
+  local.get $7
  )
  (func $~lib/memory/memory.copy (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)

--- a/tests/compiler/resolve-ternary.untouched.wat
+++ b/tests/compiler/resolve-ternary.untouched.wat
@@ -70,6 +70,15 @@
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
   local.get $1
   i32.load
   local.set $2
@@ -206,59 +215,59 @@
   i32.eq
   if
    local.get $0
-   local.set $11
+   local.set $14
    local.get $4
-   local.set $10
+   local.set $13
    local.get $5
-   local.set $9
+   local.set $12
    local.get $7
-   local.set $8
-   local.get $11
-   local.get $10
+   local.set $11
+   local.get $14
+   local.get $13
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $12
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
+   local.get $11
    i32.store offset=96
    local.get $7
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $16
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $15
+    local.get $16
+    local.get $15
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $17
     local.get $0
-    local.set $8
+    local.set $20
     local.get $4
-    local.set $11
-    local.get $9
+    local.set $19
+    local.get $17
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
-    local.set $10
-    local.get $8
-    local.get $11
+    local.tee $17
+    local.set $18
+    local.get $20
+    local.get $19
     i32.const 2
     i32.shl
     i32.add
-    local.get $10
+    local.get $18
     i32.store offset=4
-    local.get $9
+    local.get $17
     i32.eqz
     if
      local.get $0
@@ -288,6 +297,20 @@
   (local $11 i32)
   (local $12 i32)
   (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local $22 i32)
+  (local $23 i32)
+  (local $24 i32)
+  (local $25 i32)
+  (local $26 i32)
+  (local $27 i32)
   i32.const 1
   drop
   local.get $1
@@ -350,8 +373,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $3
+   local.set $6
+   local.get $6
    i32.const 1073741808
    i32.lt_u
    if
@@ -362,16 +385,16 @@
     local.get $2
     i32.const 3
     i32.and
-    local.get $3
+    local.get $6
     i32.or
     local.tee $2
     i32.store
     local.get $1
-    local.set $6
-    local.get $6
+    local.set $7
+    local.get $7
     i32.const 16
     i32.add
-    local.get $6
+    local.get $7
     i32.load
     i32.const 3
     i32.const -1
@@ -389,18 +412,18 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $8
+   local.get $8
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
+   local.set $9
+   local.get $9
    i32.load
-   local.set $3
+   local.set $10
    i32.const 1
    drop
-   local.get $3
+   local.get $10
    i32.const 1
    i32.and
    i32.eqz
@@ -412,7 +435,7 @@
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $3
+   local.get $10
    i32.const 3
    i32.const -1
    i32.xor
@@ -425,23 +448,23 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $7
+   local.set $11
+   local.get $11
    i32.const 1073741808
    i32.lt_u
    if
     local.get $0
-    local.get $6
+    local.get $9
     call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
+    local.get $9
+    local.get $10
     i32.const 3
     i32.and
-    local.get $7
+    local.get $11
     i32.or
     local.tee $2
     i32.store
-    local.get $6
+    local.get $9
     local.set $1
    end
   end
@@ -455,14 +478,14 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $12
   i32.const 1
   drop
-  local.get $8
+  local.get $12
   i32.const 16
   i32.ge_u
   if (result i32)
-   local.get $8
+   local.get $12
    i32.const 1073741808
    i32.lt_u
   else
@@ -482,7 +505,7 @@
   local.get $1
   i32.const 16
   i32.add
-  local.get $8
+  local.get $12
   i32.add
   local.get $4
   i32.eq
@@ -500,24 +523,24 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $12
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $13
+   local.get $12
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $14
   else
    i32.const 31
-   local.get $8
+   local.get $12
    i32.clz
    i32.sub
-   local.set $9
-   local.get $8
-   local.get $9
+   local.set $13
+   local.get $12
+   local.get $13
    i32.const 4
    i32.sub
    i32.shr_u
@@ -525,21 +548,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $14
+   local.get $13
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $13
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $13
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $14
    i32.const 16
    i32.lt_u
   else
@@ -555,86 +578,86 @@
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
-  local.set $6
-  local.get $7
-  local.get $3
+  local.set $17
+  local.get $13
+  local.set $16
+  local.get $14
+  local.set $15
+  local.get $17
+  local.get $16
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $15
   i32.add
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=96
-  local.set $11
+  local.set $18
   local.get $1
   i32.const 0
   i32.store offset=16
   local.get $1
-  local.get $11
+  local.get $18
   i32.store offset=20
-  local.get $11
+  local.get $18
   if
-   local.get $11
+   local.get $18
    local.get $1
    i32.store offset=16
   end
   local.get $0
-  local.set $12
-  local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
+  local.set $22
+  local.get $13
+  local.set $21
+  local.get $14
+  local.set $20
   local.get $1
-  local.set $6
-  local.get $12
-  local.get $7
+  local.set $19
+  local.get $22
+  local.get $21
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $20
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $19
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $13
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.set $13
-  local.get $9
-  local.set $12
+  local.set $27
+  local.get $13
+  local.set $26
   local.get $0
-  local.set $3
-  local.get $9
-  local.set $6
-  local.get $3
-  local.get $6
+  local.set $24
+  local.get $13
+  local.set $23
+  local.get $24
+  local.get $23
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $14
   i32.shl
   i32.or
-  local.set $7
-  local.get $13
-  local.get $12
+  local.set $25
+  local.get $27
+  local.get $26
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $25
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -645,6 +668,7 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
   i32.const 1
   drop
   local.get $1
@@ -784,11 +808,11 @@
   i32.or
   i32.store
   local.get $0
-  local.set $9
+  local.set $10
   local.get $4
-  local.set $3
+  local.set $9
+  local.get $10
   local.get $9
-  local.get $3
   i32.store offset=1568
   local.get $0
   local.get $8
@@ -808,6 +832,12 @@
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
   global.get $~lib/rt/tlsf/ROOT
   local.set $0
   local.get $0
@@ -864,66 +894,66 @@
    local.get $4
    i32.store offset=1568
    i32.const 0
-   local.set $5
+   local.set $6
    loop $for-loop|0
-    local.get $5
+    local.get $6
     i32.const 23
     i32.lt_u
-    local.set $4
-    local.get $4
+    local.set $7
+    local.get $7
     if
      local.get $0
-     local.set $8
-     local.get $5
-     local.set $7
+     local.set $10
+     local.get $6
+     local.set $9
      i32.const 0
-     local.set $6
-     local.get $8
-     local.get $7
+     local.set $8
+     local.get $10
+     local.get $9
      i32.const 2
      i32.shl
      i32.add
-     local.get $6
+     local.get $8
      i32.store offset=4
      i32.const 0
-     local.set $8
+     local.set $11
      loop $for-loop|1
-      local.get $8
+      local.get $11
       i32.const 16
       i32.lt_u
-      local.set $7
-      local.get $7
+      local.set $12
+      local.get $12
       if
        local.get $0
-       local.set $11
-       local.get $5
-       local.set $10
-       local.get $8
-       local.set $9
-       i32.const 0
-       local.set $6
+       local.set $16
+       local.get $6
+       local.set $15
        local.get $11
-       local.get $10
+       local.set $14
+       i32.const 0
+       local.set $13
+       local.get $16
+       local.get $15
        i32.const 4
        i32.shl
-       local.get $9
+       local.get $14
        i32.add
        i32.const 2
        i32.shl
        i32.add
-       local.get $6
+       local.get $13
        i32.store offset=96
-       local.get $8
+       local.get $11
        i32.const 1
        i32.add
-       local.set $8
+       local.set $11
        br $for-loop|1
       end
      end
-     local.get $5
+     local.get $6
      i32.const 1
      i32.add
-     local.set $5
+     local.set $6
      br $for-loop|0
     end
    end
@@ -936,11 +966,11 @@
    i32.const -1
    i32.xor
    i32.and
-   local.set $5
+   local.set $17
    i32.const 0
    drop
    local.get $0
-   local.get $5
+   local.get $17
    memory.size
    i32.const 16
    i32.shl
@@ -989,6 +1019,14 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
   local.get $1
   i32.const 256
   i32.lt_u
@@ -1062,11 +1100,11 @@
    unreachable
   end
   local.get $0
-  local.set $5
+  local.set $6
   local.get $2
-  local.set $4
+  local.set $5
+  local.get $6
   local.get $5
-  local.get $4
   i32.const 2
   i32.shl
   i32.add
@@ -1077,10 +1115,10 @@
   local.get $3
   i32.shl
   i32.and
-  local.set $6
-  i32.const 0
   local.set $7
-  local.get $6
+  i32.const 0
+  local.set $8
+  local.get $7
   i32.eqz
   if
    local.get $0
@@ -1093,30 +1131,30 @@
    i32.add
    i32.shl
    i32.and
-   local.set $5
-   local.get $5
+   local.set $9
+   local.get $9
    i32.eqz
    if
     i32.const 0
-    local.set $7
+    local.set $8
    else
-    local.get $5
+    local.get $9
     i32.ctz
     local.set $2
     local.get $0
-    local.set $8
+    local.set $11
     local.get $2
-    local.set $4
-    local.get $8
-    local.get $4
+    local.set $10
+    local.get $11
+    local.get $10
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $6
+    local.set $7
     i32.const 1
     drop
-    local.get $6
+    local.get $7
     i32.eqz
     if
      i32.const 0
@@ -1127,45 +1165,45 @@
      unreachable
     end
     local.get $0
-    local.set $9
+    local.set $14
     local.get $2
-    local.set $8
-    local.get $6
+    local.set $13
+    local.get $7
     i32.ctz
-    local.set $4
-    local.get $9
-    local.get $8
+    local.set $12
+    local.get $14
+    local.get $13
     i32.const 4
     i32.shl
-    local.get $4
+    local.get $12
     i32.add
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=96
-    local.set $7
+    local.set $8
    end
   else
    local.get $0
-   local.set $9
+   local.set $17
    local.get $2
-   local.set $8
-   local.get $6
+   local.set $16
+   local.get $7
    i32.ctz
-   local.set $4
-   local.get $9
-   local.get $8
+   local.set $15
+   local.get $17
+   local.get $16
    i32.const 4
    i32.shl
-   local.get $4
+   local.get $15
    i32.add
    i32.const 2
    i32.shl
    i32.add
    i32.load offset=96
-   local.set $7
+   local.set $8
   end
-  local.get $7
+  local.get $8
  )
  (func $~lib/rt/tlsf/growMemory (param $0 i32) (param $1 i32)
   (local $2 i32)
@@ -1174,6 +1212,7 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
   i32.const 0
   drop
   local.get $1
@@ -1220,15 +1259,15 @@
   i32.shr_u
   local.set $4
   local.get $2
-  local.tee $3
-  local.get $4
   local.tee $5
-  local.get $3
+  local.get $4
+  local.tee $6
   local.get $5
+  local.get $6
   i32.gt_s
   select
-  local.set $6
-  local.get $6
+  local.set $7
+  local.get $7
   memory.grow
   i32.const 0
   i32.lt_s
@@ -1242,12 +1281,12 @@
    end
   end
   memory.size
-  local.set $7
+  local.set $8
   local.get $0
   local.get $2
   i32.const 16
   i32.shl
-  local.get $7
+  local.get $8
   i32.const 16
   i32.shl
   call $~lib/rt/tlsf/addMemory
@@ -1257,6 +1296,8 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
   local.get $1
   i32.load
   local.set $3
@@ -1321,11 +1362,11 @@
    i32.and
    i32.store
    local.get $1
-   local.set $5
-   local.get $5
+   local.set $7
+   local.get $7
    i32.const 16
    i32.add
-   local.get $5
+   local.get $7
    i32.load
    i32.const 3
    i32.const -1
@@ -1333,11 +1374,11 @@
    i32.and
    i32.add
    local.get $1
-   local.set $5
-   local.get $5
+   local.set $6
+   local.get $6
    i32.const 16
    i32.add
-   local.get $5
+   local.get $6
    i32.load
    i32.const 3
    i32.const -1
@@ -1624,6 +1665,9 @@
   (local $9 i64)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
   loop $while-continue|0
    local.get $1
    i32.const 10000
@@ -1688,30 +1732,30 @@
    local.get $1
    i32.const 100
    i32.div_u
-   local.set $3
+   local.set $10
    local.get $1
    i32.const 100
    i32.rem_u
-   local.set $10
-   local.get $3
+   local.set $11
+   local.get $10
    local.set $1
    local.get $2
    i32.const 2
    i32.sub
    local.set $2
    i32.const 196
-   local.get $10
+   local.get $11
    i32.const 2
    i32.shl
    i32.add
    i32.load
-   local.set $11
+   local.set $12
    local.get $0
    local.get $2
    i32.const 1
    i32.shl
    i32.add
-   local.get $11
+   local.get $12
    i32.store
   end
   local.get $1
@@ -1728,13 +1772,13 @@
    i32.shl
    i32.add
    i32.load
-   local.set $11
+   local.set $13
    local.get $0
    local.get $2
    i32.const 1
    i32.shl
    i32.add
-   local.get $11
+   local.get $13
    i32.store
   else
    local.get $2
@@ -1744,13 +1788,13 @@
    i32.const 48
    local.get $1
    i32.add
-   local.set $11
+   local.set $14
    local.get $0
    local.get $2
    i32.const 1
    i32.shl
    i32.add
-   local.get $11
+   local.get $14
    i32.store16
   end
  )
@@ -1845,6 +1889,9 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $0
@@ -1916,33 +1963,33 @@
   end
   loop $while-continue|1
    local.get $4
-   local.tee $7
+   local.tee $8
    i32.const 1
    i32.sub
    local.set $4
-   local.get $7
-   local.set $7
-   local.get $7
+   local.get $8
+   local.set $9
+   local.get $9
    if
     local.get $5
     i32.load16_u
-    local.set $8
+    local.set $10
     local.get $6
     i32.load16_u
-    local.set $9
-    local.get $8
-    local.get $9
+    local.set $11
+    local.get $10
+    local.get $11
     i32.ne
     if
-     local.get $8
-     local.get $9
+     local.get $10
+     local.get $11
      i32.sub
-     local.set $10
+     local.set $12
      local.get $0
      call $~lib/rt/pure/__release
      local.get $2
      call $~lib/rt/pure/__release
-     local.get $10
+     local.get $12
      return
     end
     local.get $5
@@ -1957,16 +2004,19 @@
    end
   end
   i32.const 0
-  local.set $7
+  local.set $13
   local.get $0
   call $~lib/rt/pure/__release
   local.get $2
   call $~lib/rt/pure/__release
-  local.get $7
+  local.get $13
  )
  (func $~lib/string/String.__eq (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $0
@@ -1998,44 +2048,44 @@
   end
   if
    i32.const 0
-   local.set $2
+   local.set $3
    local.get $0
    call $~lib/rt/pure/__release
    local.get $1
    call $~lib/rt/pure/__release
-   local.get $2
+   local.get $3
    return
   end
   local.get $0
   call $~lib/string/String#get:length
-  local.set $3
-  local.get $3
+  local.set $4
+  local.get $4
   local.get $1
   call $~lib/string/String#get:length
   i32.ne
   if
    i32.const 0
-   local.set $2
+   local.set $5
    local.get $0
    call $~lib/rt/pure/__release
    local.get $1
    call $~lib/rt/pure/__release
-   local.get $2
+   local.get $5
    return
   end
   local.get $0
   i32.const 0
   local.get $1
   i32.const 0
-  local.get $3
+  local.get $4
   call $~lib/util/string/compareImpl
   i32.eqz
-  local.set $2
+  local.set $6
   local.get $0
   call $~lib/rt/pure/__release
   local.get $1
   call $~lib/rt/pure/__release
-  local.get $2
+  local.get $6
  )
  (func $~lib/util/number/genDigits (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (param $6 i32) (result i32)
   (local $7 i32)
@@ -2050,16 +2100,31 @@
   (local $16 i32)
   (local $17 i32)
   (local $18 i32)
-  (local $19 i64)
+  (local $19 i32)
   (local $20 i64)
   (local $21 i64)
   (local $22 i64)
   (local $23 i64)
-  (local $24 i32)
+  (local $24 i64)
   (local $25 i32)
   (local $26 i32)
   (local $27 i32)
-  (local $28 i64)
+  (local $28 i32)
+  (local $29 i32)
+  (local $30 i32)
+  (local $31 i32)
+  (local $32 i64)
+  (local $33 i32)
+  (local $34 i64)
+  (local $35 i64)
+  (local $36 i64)
+  (local $37 i64)
+  (local $38 i32)
+  (local $39 i32)
+  (local $40 i32)
+  (local $41 i32)
+  (local $42 i32)
+  (local $43 i32)
   i32.const 0
   local.get $4
   i32.sub
@@ -2263,11 +2328,11 @@
     if
      local.get $0
      local.get $15
-     local.tee $18
+     local.tee $19
      i32.const 1
      i32.add
      local.set $15
-     local.get $18
+     local.get $19
      i32.const 1
      i32.shl
      i32.add
@@ -2289,8 +2354,8 @@
     i64.shl
     local.get $13
     i64.add
-    local.set $19
-    local.get $19
+    local.set $20
+    local.get $20
     local.get $5
     i64.le_u
     if
@@ -2299,13 +2364,13 @@
      i32.add
      global.set $~lib/util/number/_K
      local.get $0
-     local.set $24
+     local.set $26
      local.get $15
-     local.set $18
+     local.set $25
      local.get $5
+     local.set $24
+     local.get $20
      local.set $23
-     local.get $19
-     local.set $22
      i32.const 1720
      local.get $14
      i32.const 2
@@ -2315,71 +2380,71 @@
      local.get $7
      i64.extend_i32_s
      i64.shl
-     local.set $21
+     local.set $22
      local.get $10
-     local.set $20
-     local.get $24
-     local.get $18
+     local.set $21
+     local.get $26
+     local.get $25
      i32.const 1
      i32.sub
      i32.const 1
      i32.shl
      i32.add
-     local.set $25
-     local.get $25
+     local.set $27
+     local.get $27
      i32.load16_u
-     local.set $26
+     local.set $28
      loop $while-continue|3
-      local.get $22
-      local.get $20
+      local.get $23
+      local.get $21
       i64.lt_u
       if (result i32)
+       local.get $24
        local.get $23
-       local.get $22
        i64.sub
-       local.get $21
+       local.get $22
        i64.ge_u
       else
        i32.const 0
       end
       if (result i32)
+       local.get $23
        local.get $22
-       local.get $21
        i64.add
-       local.get $20
+       local.get $21
        i64.lt_u
        if (result i32)
         i32.const 1
        else
-        local.get $20
-        local.get $22
-        i64.sub
-        local.get $22
         local.get $21
+        local.get $23
+        i64.sub
+        local.get $23
+        local.get $22
         i64.add
-        local.get $20
+        local.get $21
         i64.sub
         i64.gt_u
        end
       else
        i32.const 0
       end
-      local.set $27
-      local.get $27
+      local.set $30
+      local.get $30
       if
-       local.get $26
+       local.get $28
        i32.const 1
        i32.sub
-       local.set $26
+       local.set $28
+       local.get $23
        local.get $22
-       local.get $21
        i64.add
-       local.set $22
+       local.set $23
        br $while-continue|3
       end
      end
-     local.get $25
-     local.get $26
+     local.get $27
+     local.get $28
      i32.store16
      local.get $15
      return
@@ -2389,8 +2454,8 @@
   end
   loop $while-continue|4
    i32.const 1
-   local.set $16
-   local.get $16
+   local.set $31
+   local.get $31
    if
     local.get $13
     i64.const 10
@@ -2404,8 +2469,8 @@
     local.get $7
     i64.extend_i32_s
     i64.shr_u
-    local.set $23
-    local.get $23
+    local.set $32
+    local.get $32
     local.get $15
     i64.extend_i32_s
     i64.or
@@ -2414,16 +2479,16 @@
     if
      local.get $0
      local.get $15
-     local.tee $26
+     local.tee $33
      i32.const 1
      i32.add
      local.set $15
-     local.get $26
+     local.get $33
      i32.const 1
      i32.shl
      i32.add
      i32.const 48
-     local.get $23
+     local.get $32
      i32.wrap_i64
      i32.const 65535
      i32.and
@@ -2458,79 +2523,79 @@
      i64.mul
      local.set $10
      local.get $0
-     local.set $18
+     local.set $39
      local.get $15
-     local.set $27
+     local.set $38
      local.get $5
-     local.set $28
+     local.set $37
      local.get $13
-     local.set $22
+     local.set $36
      local.get $8
-     local.set $21
+     local.set $35
      local.get $10
-     local.set $20
-     local.get $18
-     local.get $27
+     local.set $34
+     local.get $39
+     local.get $38
      i32.const 1
      i32.sub
      i32.const 1
      i32.shl
      i32.add
-     local.set $26
-     local.get $26
+     local.set $40
+     local.get $40
      i32.load16_u
-     local.set $25
+     local.set $41
      loop $while-continue|6
-      local.get $22
-      local.get $20
+      local.get $36
+      local.get $34
       i64.lt_u
       if (result i32)
-       local.get $28
-       local.get $22
+       local.get $37
+       local.get $36
        i64.sub
-       local.get $21
+       local.get $35
        i64.ge_u
       else
        i32.const 0
       end
       if (result i32)
-       local.get $22
-       local.get $21
+       local.get $36
+       local.get $35
        i64.add
-       local.get $20
+       local.get $34
        i64.lt_u
        if (result i32)
         i32.const 1
        else
-        local.get $20
-        local.get $22
+        local.get $34
+        local.get $36
         i64.sub
-        local.get $22
-        local.get $21
+        local.get $36
+        local.get $35
         i64.add
-        local.get $20
+        local.get $34
         i64.sub
         i64.gt_u
        end
       else
        i32.const 0
       end
-      local.set $24
-      local.get $24
+      local.set $43
+      local.get $43
       if
-       local.get $25
+       local.get $41
        i32.const 1
        i32.sub
-       local.set $25
-       local.get $22
-       local.get $21
+       local.set $41
+       local.get $36
+       local.get $35
        i64.add
-       local.set $22
+       local.set $36
        br $while-continue|6
       end
      end
-     local.get $26
-     local.get $25
+     local.get $40
+     local.get $41
      i32.store16
      local.get $15
      return
@@ -2545,6 +2610,88 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local $22 i32)
+  (local $23 i32)
+  (local $24 i32)
+  (local $25 i32)
+  (local $26 i32)
+  (local $27 i32)
+  (local $28 i32)
+  (local $29 i32)
+  (local $30 i32)
+  (local $31 i32)
+  (local $32 i32)
+  (local $33 i32)
+  (local $34 i32)
+  (local $35 i32)
+  (local $36 i32)
+  (local $37 i32)
+  (local $38 i32)
+  (local $39 i32)
+  (local $40 i32)
+  (local $41 i32)
+  (local $42 i32)
+  (local $43 i32)
+  (local $44 i32)
+  (local $45 i32)
+  (local $46 i32)
+  (local $47 i32)
+  (local $48 i32)
+  (local $49 i32)
+  (local $50 i32)
+  (local $51 i32)
+  (local $52 i32)
+  (local $53 i32)
+  (local $54 i32)
+  (local $55 i32)
+  (local $56 i32)
+  (local $57 i32)
+  (local $58 i32)
+  (local $59 i32)
+  (local $60 i32)
+  (local $61 i32)
+  (local $62 i32)
+  (local $63 i32)
+  (local $64 i32)
+  (local $65 i32)
+  (local $66 i32)
+  (local $67 i32)
+  (local $68 i32)
+  (local $69 i32)
+  (local $70 i32)
+  (local $71 i32)
+  (local $72 i32)
+  (local $73 i32)
+  (local $74 i32)
+  (local $75 i32)
+  (local $76 i32)
+  (local $77 i32)
+  (local $78 i32)
+  (local $79 i32)
+  (local $80 i32)
+  (local $81 i32)
+  (local $82 i32)
+  (local $83 i32)
+  (local $84 i32)
+  (local $85 i32)
+  (local $86 i32)
+  (local $87 i32)
+  (local $88 i32)
   loop $while-continue|0
    local.get $2
    if (result i32)
@@ -2564,11 +2711,11 @@
     local.set $0
     local.get $6
     local.get $1
-    local.tee $6
+    local.tee $7
     i32.const 1
     i32.add
     local.set $1
-    local.get $6
+    local.get $7
     i32.load8_u
     i32.store8
     local.get $2
@@ -2588,8 +2735,8 @@
     local.get $2
     i32.const 16
     i32.ge_u
-    local.set $5
-    local.get $5
+    local.set $8
+    local.get $8
     if
      local.get $0
      local.get $1
@@ -2698,17 +2845,17 @@
    i32.and
    if
     local.get $0
-    local.tee $5
+    local.tee $9
     i32.const 1
     i32.add
     local.set $0
-    local.get $5
+    local.get $9
     local.get $1
-    local.tee $5
+    local.tee $10
     i32.const 1
     i32.add
     local.set $1
-    local.get $5
+    local.get $10
     i32.load8_u
     i32.store8
    end
@@ -2725,16 +2872,16 @@
        local.get $0
        i32.const 3
        i32.and
-       local.set $5
-       local.get $5
+       local.set $11
+       local.get $11
        i32.const 1
        i32.eq
        br_if $case0|2
-       local.get $5
+       local.get $11
        i32.const 2
        i32.eq
        br_if $case1|2
-       local.get $5
+       local.get $11
        i32.const 3
        i32.eq
        br_if $case2|2
@@ -2744,45 +2891,45 @@
       i32.load
       local.set $3
       local.get $0
-      local.tee $5
+      local.tee $12
       i32.const 1
       i32.add
       local.set $0
-      local.get $5
+      local.get $12
       local.get $1
-      local.tee $5
+      local.tee $13
       i32.const 1
       i32.add
       local.set $1
-      local.get $5
+      local.get $13
       i32.load8_u
       i32.store8
       local.get $0
-      local.tee $5
+      local.tee $14
       i32.const 1
       i32.add
       local.set $0
-      local.get $5
+      local.get $14
       local.get $1
-      local.tee $5
+      local.tee $15
       i32.const 1
       i32.add
       local.set $1
-      local.get $5
+      local.get $15
       i32.load8_u
       i32.store8
       local.get $0
-      local.tee $5
+      local.tee $16
       i32.const 1
       i32.add
       local.set $0
-      local.get $5
+      local.get $16
       local.get $1
-      local.tee $5
+      local.tee $17
       i32.const 1
       i32.add
       local.set $1
-      local.get $5
+      local.get $17
       i32.load8_u
       i32.store8
       local.get $2
@@ -2793,8 +2940,8 @@
        local.get $2
        i32.const 17
        i32.ge_u
-       local.set $5
-       local.get $5
+       local.set $18
+       local.get $18
        if
         local.get $1
         i32.const 1
@@ -2879,31 +3026,31 @@
      i32.load
      local.set $3
      local.get $0
-     local.tee $5
+     local.tee $19
      i32.const 1
      i32.add
      local.set $0
-     local.get $5
+     local.get $19
      local.get $1
-     local.tee $5
+     local.tee $20
      i32.const 1
      i32.add
      local.set $1
-     local.get $5
+     local.get $20
      i32.load8_u
      i32.store8
      local.get $0
-     local.tee $5
+     local.tee $21
      i32.const 1
      i32.add
      local.set $0
-     local.get $5
+     local.get $21
      local.get $1
-     local.tee $5
+     local.tee $22
      i32.const 1
      i32.add
      local.set $1
-     local.get $5
+     local.get $22
      i32.load8_u
      i32.store8
      local.get $2
@@ -2914,8 +3061,8 @@
       local.get $2
       i32.const 18
       i32.ge_u
-      local.set $5
-      local.get $5
+      local.set $23
+      local.get $23
       if
        local.get $1
        i32.const 2
@@ -3000,17 +3147,17 @@
     i32.load
     local.set $3
     local.get $0
-    local.tee $5
+    local.tee $24
     i32.const 1
     i32.add
     local.set $0
-    local.get $5
+    local.get $24
     local.get $1
-    local.tee $5
+    local.tee $25
     i32.const 1
     i32.add
     local.set $1
-    local.get $5
+    local.get $25
     i32.load8_u
     i32.store8
     local.get $2
@@ -3021,8 +3168,8 @@
      local.get $2
      i32.const 19
      i32.ge_u
-     local.set $5
-     local.get $5
+     local.set $26
+     local.get $26
      if
       local.get $1
       i32.const 3
@@ -3109,227 +3256,227 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $27
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $27
    local.get $1
-   local.tee $5
+   local.tee $28
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $28
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $29
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $29
    local.get $1
-   local.tee $5
+   local.tee $30
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $30
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $31
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $31
    local.get $1
-   local.tee $5
+   local.tee $32
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $32
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $33
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $33
    local.get $1
-   local.tee $5
+   local.tee $34
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $34
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $35
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $35
    local.get $1
-   local.tee $5
+   local.tee $36
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $36
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $37
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $37
    local.get $1
-   local.tee $5
+   local.tee $38
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $38
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $39
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $39
    local.get $1
-   local.tee $5
+   local.tee $40
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $40
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $41
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $41
    local.get $1
-   local.tee $5
+   local.tee $42
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $42
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $43
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $43
    local.get $1
-   local.tee $5
+   local.tee $44
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $44
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $45
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $45
    local.get $1
-   local.tee $5
+   local.tee $46
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $46
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $47
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $47
    local.get $1
-   local.tee $5
+   local.tee $48
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $48
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $49
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $49
    local.get $1
-   local.tee $5
+   local.tee $50
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $50
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $51
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $51
    local.get $1
-   local.tee $5
+   local.tee $52
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $52
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $53
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $53
    local.get $1
-   local.tee $5
+   local.tee $54
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $54
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $55
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $55
    local.get $1
-   local.tee $5
+   local.tee $56
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $56
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $57
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $57
    local.get $1
-   local.tee $5
+   local.tee $58
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $58
    i32.load8_u
    i32.store8
   end
@@ -3338,115 +3485,115 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $59
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $59
    local.get $1
-   local.tee $5
+   local.tee $60
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $60
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $61
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $61
    local.get $1
-   local.tee $5
+   local.tee $62
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $62
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $63
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $63
    local.get $1
-   local.tee $5
+   local.tee $64
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $64
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $65
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $65
    local.get $1
-   local.tee $5
+   local.tee $66
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $66
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $67
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $67
    local.get $1
-   local.tee $5
+   local.tee $68
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $68
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $69
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $69
    local.get $1
-   local.tee $5
+   local.tee $70
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $70
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $71
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $71
    local.get $1
-   local.tee $5
+   local.tee $72
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $72
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $73
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $73
    local.get $1
-   local.tee $5
+   local.tee $74
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $74
    i32.load8_u
    i32.store8
   end
@@ -3455,59 +3602,59 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $75
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $75
    local.get $1
-   local.tee $5
+   local.tee $76
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $76
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $77
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $77
    local.get $1
-   local.tee $5
+   local.tee $78
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $78
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $79
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $79
    local.get $1
-   local.tee $5
+   local.tee $80
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $80
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $81
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $81
    local.get $1
-   local.tee $5
+   local.tee $82
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $82
    i32.load8_u
    i32.store8
   end
@@ -3516,31 +3663,31 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $83
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $83
    local.get $1
-   local.tee $5
+   local.tee $84
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $84
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $85
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $85
    local.get $1
-   local.tee $5
+   local.tee $86
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $86
    i32.load8_u
    i32.store8
   end
@@ -3549,17 +3696,17 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $87
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $87
    local.get $1
-   local.tee $5
+   local.tee $88
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $88
    i32.load8_u
    i32.store8
   end
@@ -3570,6 +3717,14 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
   block $~lib/util/memory/memmove|inlined.0
    local.get $0
    local.set $5
@@ -3647,11 +3802,11 @@
        local.set $5
        local.get $7
        local.get $4
-       local.tee $7
+       local.tee $8
        i32.const 1
        i32.add
        local.set $4
-       local.get $7
+       local.get $8
        i32.load8_u
        i32.store8
        br $while-continue|0
@@ -3661,8 +3816,8 @@
       local.get $3
       i32.const 8
       i32.ge_u
-      local.set $6
-      local.get $6
+      local.set $9
+      local.get $9
       if
        local.get $5
        local.get $4
@@ -3686,21 +3841,21 @@
     end
     loop $while-continue|2
      local.get $3
-     local.set $6
-     local.get $6
+     local.set $10
+     local.get $10
      if
       local.get $5
-      local.tee $7
+      local.tee $11
       i32.const 1
       i32.add
       local.set $5
-      local.get $7
+      local.get $11
       local.get $4
-      local.tee $7
+      local.tee $12
       i32.const 1
       i32.add
       local.set $4
-      local.get $7
+      local.get $12
       i32.load8_u
       i32.store8
       local.get $3
@@ -3729,8 +3884,8 @@
       i32.add
       i32.const 7
       i32.and
-      local.set $6
-      local.get $6
+      local.set $13
+      local.get $13
       if
        local.get $3
        i32.eqz
@@ -3755,8 +3910,8 @@
       local.get $3
       i32.const 8
       i32.ge_u
-      local.set $6
-      local.get $6
+      local.set $14
+      local.get $14
       if
        local.get $3
        i32.const 8
@@ -3776,8 +3931,8 @@
     end
     loop $while-continue|5
      local.get $3
-     local.set $6
-     local.get $6
+     local.set $15
+     local.get $15
      if
       local.get $5
       local.get $3
@@ -3806,6 +3961,19 @@
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local $22 i32)
+  (local $23 i32)
+  (local $24 i32)
   local.get $2
   i32.eqz
   if
@@ -3895,11 +4063,11 @@
     i32.const 1
     i32.shl
     i32.add
-    local.set $4
-    local.get $4
+    local.set $6
+    local.get $6
     i32.const 2
     i32.add
-    local.get $4
+    local.get $6
     i32.const 0
     local.get $2
     i32.sub
@@ -3932,9 +4100,9 @@
      i32.const 2
      local.get $3
      i32.sub
-     local.set $4
+     local.set $7
      local.get $0
-     local.get $4
+     local.get $7
      i32.const 1
      i32.shl
      i32.add
@@ -3951,30 +4119,30 @@
      i32.or
      i32.store
      i32.const 2
-     local.set $5
+     local.set $8
      loop $for-loop|1
-      local.get $5
-      local.get $4
+      local.get $8
+      local.get $7
       i32.lt_s
-      local.set $6
-      local.get $6
+      local.set $9
+      local.get $9
       if
        local.get $0
-       local.get $5
+       local.get $8
        i32.const 1
        i32.shl
        i32.add
        i32.const 48
        i32.store16
-       local.get $5
+       local.get $8
        i32.const 1
        i32.add
-       local.set $5
+       local.set $8
        br $for-loop|1
       end
      end
      local.get $1
-     local.get $4
+     local.get $7
      i32.add
      return
     else
@@ -3988,48 +4156,48 @@
       local.get $0
       i32.const 4
       i32.add
-      local.set $5
+      local.set $11
       local.get $3
       i32.const 1
       i32.sub
-      local.set $6
-      local.get $6
+      local.set $10
+      local.get $10
       i32.const 0
       i32.lt_s
-      local.set $4
-      local.get $4
+      local.set $12
+      local.get $12
       if
        i32.const 0
-       local.get $6
+       local.get $10
        i32.sub
-       local.set $6
+       local.set $10
       end
-      local.get $6
+      local.get $10
       call $~lib/util/number/decimalCount32
       i32.const 1
       i32.add
-      local.set $7
-      local.get $5
-      local.set $10
-      local.get $6
-      local.set $9
-      local.get $7
-      local.set $8
+      local.set $13
+      local.get $11
+      local.set $16
+      local.get $10
+      local.set $15
+      local.get $13
+      local.set $14
       i32.const 0
       i32.const 1
       i32.ge_s
       drop
-      local.get $10
-      local.get $9
-      local.get $8
+      local.get $16
+      local.get $15
+      local.get $14
       call $~lib/util/number/utoa32_lut
-      local.get $5
+      local.get $11
       i32.const 45
       i32.const 43
-      local.get $4
+      local.get $12
       select
       i32.store16
-      local.get $7
+      local.get $13
       local.set $1
       local.get $1
       i32.const 2
@@ -4039,14 +4207,14 @@
       local.get $1
       i32.const 1
       i32.shl
-      local.set $7
+      local.set $17
       local.get $0
       i32.const 4
       i32.add
       local.get $0
       i32.const 2
       i32.add
-      local.get $7
+      local.get $17
       i32.const 2
       i32.sub
       call $~lib/memory/memory.copy
@@ -4054,58 +4222,58 @@
       i32.const 46
       i32.store16 offset=2
       local.get $0
-      local.get $7
+      local.get $17
       i32.add
       i32.const 101
       i32.store16 offset=2
       local.get $1
       local.get $0
-      local.get $7
+      local.get $17
       i32.add
       i32.const 4
       i32.add
-      local.set $9
+      local.set $19
       local.get $3
       i32.const 1
       i32.sub
-      local.set $8
-      local.get $8
+      local.set $18
+      local.get $18
       i32.const 0
       i32.lt_s
-      local.set $4
-      local.get $4
+      local.set $20
+      local.get $20
       if
        i32.const 0
-       local.get $8
+       local.get $18
        i32.sub
-       local.set $8
+       local.set $18
       end
-      local.get $8
+      local.get $18
       call $~lib/util/number/decimalCount32
       i32.const 1
       i32.add
-      local.set $5
-      local.get $9
-      local.set $11
-      local.get $8
-      local.set $6
-      local.get $5
-      local.set $10
+      local.set $21
+      local.get $19
+      local.set $24
+      local.get $18
+      local.set $23
+      local.get $21
+      local.set $22
       i32.const 0
       i32.const 1
       i32.ge_s
       drop
-      local.get $11
-      local.get $6
-      local.get $10
+      local.get $24
+      local.get $23
+      local.get $22
       call $~lib/util/number/utoa32_lut
-      local.get $9
+      local.get $19
       i32.const 45
       i32.const 43
-      local.get $4
+      local.get $20
       select
       i32.store16
-      local.get $5
+      local.get $21
       i32.add
       local.set $1
       local.get $1
@@ -4136,19 +4304,51 @@
   (local $13 i32)
   (local $14 i32)
   (local $15 i32)
-  (local $16 f64)
-  (local $17 i64)
-  (local $18 i64)
-  (local $19 i64)
-  (local $20 i64)
+  (local $16 i32)
+  (local $17 f64)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
   (local $21 i64)
-  (local $22 i64)
+  (local $22 i32)
   (local $23 i64)
   (local $24 i64)
   (local $25 i64)
-  (local $26 i32)
+  (local $26 i64)
   (local $27 i64)
-  (local $28 i32)
+  (local $28 i64)
+  (local $29 i64)
+  (local $30 i64)
+  (local $31 i64)
+  (local $32 i64)
+  (local $33 i32)
+  (local $34 i32)
+  (local $35 i32)
+  (local $36 i64)
+  (local $37 i64)
+  (local $38 i64)
+  (local $39 i64)
+  (local $40 i64)
+  (local $41 i64)
+  (local $42 i64)
+  (local $43 i64)
+  (local $44 i64)
+  (local $45 i64)
+  (local $46 i32)
+  (local $47 i32)
+  (local $48 i32)
+  (local $49 i64)
+  (local $50 i64)
+  (local $51 i64)
+  (local $52 i64)
+  (local $53 i64)
+  (local $54 i64)
+  (local $55 i64)
+  (local $56 i64)
+  (local $57 i64)
+  (local $58 i64)
+  (local $59 i64)
+  (local $60 i32)
   local.get $1
   f64.const 0
   f64.lt
@@ -4252,47 +4452,47 @@
   local.get $13
   global.set $~lib/util/number/_exp
   global.get $~lib/util/number/_exp
-  local.set $10
+  local.set $16
   i32.const -61
-  local.get $10
+  local.get $16
   i32.sub
   f64.convert_i32_s
   f64.const 0.30102999566398114
   f64.mul
   f64.const 347
   f64.add
-  local.set $16
-  local.get $16
+  local.set $17
+  local.get $17
   i32.trunc_f64_s
-  local.set $15
-  local.get $15
-  local.get $15
+  local.set $18
+  local.get $18
+  local.get $18
   f64.convert_i32_s
-  local.get $16
+  local.get $17
   f64.ne
   i32.add
-  local.set $15
-  local.get $15
+  local.set $18
+  local.get $18
   i32.const 3
   i32.shr_s
   i32.const 1
   i32.add
-  local.set $14
+  local.set $19
   i32.const 348
-  local.get $14
+  local.get $19
   i32.const 3
   i32.shl
   i32.sub
   global.set $~lib/util/number/_K
   i32.const 848
-  local.get $14
+  local.get $19
   i32.const 3
   i32.shl
   i32.add
   i64.load
   global.set $~lib/util/number/_frc_pow
   i32.const 1544
-  local.get $14
+  local.get $19
   i32.const 1
   i32.shl
   i32.add
@@ -4301,249 +4501,249 @@
   local.get $9
   i64.clz
   i32.wrap_i64
-  local.set $14
+  local.set $20
   local.get $9
-  local.get $14
+  local.get $20
   i64.extend_i32_s
   i64.shl
   local.set $9
   local.get $7
-  local.get $14
+  local.get $20
   i32.sub
   local.set $7
   global.get $~lib/util/number/_frc_pow
-  local.set $12
+  local.set $21
   global.get $~lib/util/number/_exp_pow
-  local.set $15
+  local.set $22
   local.get $9
-  local.set $17
-  local.get $12
-  local.set $11
-  local.get $17
-  i64.const 4294967295
-  i64.and
-  local.set $18
-  local.get $11
-  i64.const 4294967295
-  i64.and
-  local.set $19
-  local.get $17
-  i64.const 32
-  i64.shr_u
-  local.set $20
-  local.get $11
-  i64.const 32
-  i64.shr_u
-  local.set $21
-  local.get $18
-  local.get $19
-  i64.mul
-  local.set $22
-  local.get $20
-  local.get $19
-  i64.mul
-  local.get $22
-  i64.const 32
-  i64.shr_u
-  i64.add
-  local.set $23
-  local.get $18
+  local.set $24
   local.get $21
-  i64.mul
+  local.set $23
+  local.get $24
+  i64.const 4294967295
+  i64.and
+  local.set $25
   local.get $23
   i64.const 4294967295
   i64.and
-  i64.add
-  local.set $24
+  local.set $26
   local.get $24
+  i64.const 32
+  i64.shr_u
+  local.set $27
+  local.get $23
+  i64.const 32
+  i64.shr_u
+  local.set $28
+  local.get $25
+  local.get $26
+  i64.mul
+  local.set $29
+  local.get $27
+  local.get $26
+  i64.mul
+  local.get $29
+  i64.const 32
+  i64.shr_u
+  i64.add
+  local.set $30
+  local.get $25
+  local.get $28
+  i64.mul
+  local.get $30
+  i64.const 4294967295
+  i64.and
+  i64.add
+  local.set $31
+  local.get $31
   i64.const 2147483647
   i64.add
-  local.set $24
-  local.get $23
+  local.set $31
+  local.get $30
   i64.const 32
   i64.shr_u
-  local.set $23
-  local.get $24
+  local.set $30
+  local.get $31
   i64.const 32
   i64.shr_u
-  local.set $24
-  local.get $20
-  local.get $21
+  local.set $31
+  local.get $27
+  local.get $28
   i64.mul
-  local.get $23
+  local.get $30
   i64.add
-  local.get $24
+  local.get $31
   i64.add
-  local.set $24
+  local.set $32
   local.get $7
-  local.set $10
-  local.get $15
-  local.set $13
-  local.get $10
-  local.get $13
+  local.set $34
+  local.get $22
+  local.set $33
+  local.get $34
+  local.get $33
   i32.add
   i32.const 64
   i32.add
-  local.set $10
+  local.set $35
   global.get $~lib/util/number/_frc_plus
-  local.set $17
-  local.get $12
-  local.set $11
-  local.get $17
-  i64.const 4294967295
-  i64.and
-  local.set $23
-  local.get $11
-  i64.const 4294967295
-  i64.and
-  local.set $22
-  local.get $17
-  i64.const 32
-  i64.shr_u
-  local.set $21
-  local.get $11
-  i64.const 32
-  i64.shr_u
-  local.set $20
-  local.get $23
-  local.get $22
-  i64.mul
-  local.set $19
+  local.set $37
   local.get $21
-  local.get $22
+  local.set $36
+  local.get $37
+  i64.const 4294967295
+  i64.and
+  local.set $38
+  local.get $36
+  i64.const 4294967295
+  i64.and
+  local.set $39
+  local.get $37
+  i64.const 32
+  i64.shr_u
+  local.set $40
+  local.get $36
+  i64.const 32
+  i64.shr_u
+  local.set $41
+  local.get $38
+  local.get $39
   i64.mul
-  local.get $19
+  local.set $42
+  local.get $40
+  local.get $39
+  i64.mul
+  local.get $42
   i64.const 32
   i64.shr_u
   i64.add
-  local.set $18
-  local.get $23
-  local.get $20
+  local.set $43
+  local.get $38
+  local.get $41
   i64.mul
-  local.get $18
+  local.get $43
   i64.const 4294967295
   i64.and
   i64.add
-  local.set $25
-  local.get $25
+  local.set $44
+  local.get $44
   i64.const 2147483647
   i64.add
-  local.set $25
-  local.get $18
+  local.set $44
+  local.get $43
   i64.const 32
   i64.shr_u
-  local.set $18
-  local.get $25
+  local.set $43
+  local.get $44
   i64.const 32
   i64.shr_u
-  local.set $25
-  local.get $21
-  local.get $20
+  local.set $44
+  local.get $40
+  local.get $41
   i64.mul
-  local.get $18
+  local.get $43
   i64.add
-  local.get $25
+  local.get $44
   i64.add
   i64.const 1
   i64.sub
-  local.set $25
+  local.set $45
   global.get $~lib/util/number/_exp
-  local.set $26
-  local.get $15
-  local.set $13
-  local.get $26
-  local.get $13
+  local.set $47
+  local.get $22
+  local.set $46
+  local.get $47
+  local.get $46
   i32.add
   i32.const 64
   i32.add
-  local.set $26
+  local.set $48
   global.get $~lib/util/number/_frc_minus
-  local.set $17
-  local.get $12
-  local.set $11
-  local.get $17
-  i64.const 4294967295
-  i64.and
-  local.set $18
-  local.get $11
-  i64.const 4294967295
-  i64.and
-  local.set $19
-  local.get $17
-  i64.const 32
-  i64.shr_u
-  local.set $20
-  local.get $11
-  i64.const 32
-  i64.shr_u
-  local.set $21
-  local.get $18
-  local.get $19
-  i64.mul
-  local.set $22
-  local.get $20
-  local.get $19
-  i64.mul
-  local.get $22
-  i64.const 32
-  i64.shr_u
-  i64.add
-  local.set $23
-  local.get $18
+  local.set $50
   local.get $21
+  local.set $49
+  local.get $50
+  i64.const 4294967295
+  i64.and
+  local.set $51
+  local.get $49
+  i64.const 4294967295
+  i64.and
+  local.set $52
+  local.get $50
+  i64.const 32
+  i64.shr_u
+  local.set $53
+  local.get $49
+  i64.const 32
+  i64.shr_u
+  local.set $54
+  local.get $51
+  local.get $52
   i64.mul
-  local.get $23
+  local.set $55
+  local.get $53
+  local.get $52
+  i64.mul
+  local.get $55
+  i64.const 32
+  i64.shr_u
+  i64.add
+  local.set $56
+  local.get $51
+  local.get $54
+  i64.mul
+  local.get $56
   i64.const 4294967295
   i64.and
   i64.add
-  local.set $27
-  local.get $27
+  local.set $57
+  local.get $57
   i64.const 2147483647
   i64.add
-  local.set $27
-  local.get $23
+  local.set $57
+  local.get $56
   i64.const 32
   i64.shr_u
-  local.set $23
-  local.get $27
+  local.set $56
+  local.get $57
   i64.const 32
   i64.shr_u
-  local.set $27
-  local.get $20
-  local.get $21
+  local.set $57
+  local.get $53
+  local.get $54
   i64.mul
-  local.get $23
+  local.get $56
   i64.add
-  local.get $27
+  local.get $57
   i64.add
   i64.const 1
   i64.add
-  local.set $27
-  local.get $25
-  local.get $27
+  local.set $58
+  local.get $45
+  local.get $58
   i64.sub
-  local.set $23
+  local.set $59
   local.get $4
-  local.get $24
-  local.get $10
-  local.get $25
-  local.get $26
-  local.get $23
+  local.get $32
+  local.get $35
+  local.get $45
+  local.get $48
+  local.get $59
   local.get $3
   call $~lib/util/number/genDigits
-  local.set $28
+  local.set $60
   local.get $0
   local.get $2
   i32.const 1
   i32.shl
   i32.add
-  local.get $28
+  local.get $60
   local.get $2
   i32.sub
   global.get $~lib/util/number/_K
   call $~lib/util/number/prettify
-  local.set $28
-  local.get $28
+  local.set $60
+  local.get $60
   local.get $2
   i32.add
  )
@@ -4557,6 +4757,16 @@
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
   local.get $0
   call $~lib/string/String#get:length
   local.set $3
@@ -4568,67 +4778,67 @@
   local.get $5
   i32.gt_s
   select
-  local.tee $4
+  local.tee $6
   local.get $3
-  local.tee $5
-  local.get $4
-  local.get $5
-  i32.lt_s
-  select
-  local.set $6
-  local.get $2
-  local.tee $4
-  i32.const 0
-  local.tee $5
-  local.get $4
-  local.get $5
-  i32.gt_s
-  select
-  local.tee $4
-  local.get $3
-  local.tee $5
-  local.get $4
-  local.get $5
-  i32.lt_s
-  select
-  local.set $7
+  local.tee $7
   local.get $6
-  local.tee $4
   local.get $7
-  local.tee $5
-  local.get $4
-  local.get $5
   i32.lt_s
   select
-  i32.const 1
-  i32.shl
   local.set $8
-  local.get $6
-  local.tee $4
-  local.get $7
-  local.tee $5
-  local.get $4
-  local.get $5
+  local.get $2
+  local.tee $9
+  i32.const 0
+  local.tee $10
+  local.get $9
+  local.get $10
+  i32.gt_s
+  select
+  local.tee $11
+  local.get $3
+  local.tee $12
+  local.get $11
+  local.get $12
+  i32.lt_s
+  select
+  local.set $13
+  local.get $8
+  local.tee $14
+  local.get $13
+  local.tee $15
+  local.get $14
+  local.get $15
+  i32.lt_s
+  select
+  i32.const 1
+  i32.shl
+  local.set $16
+  local.get $8
+  local.tee $17
+  local.get $13
+  local.tee $18
+  local.get $17
+  local.get $18
   i32.gt_s
   select
   i32.const 1
   i32.shl
-  local.set $9
-  local.get $9
-  local.get $8
+  local.set $19
+  local.get $19
+  local.get $16
   i32.sub
-  local.set $10
-  local.get $10
+  local.set $20
+  local.get $20
   i32.eqz
   if
    i32.const 1776
    call $~lib/rt/pure/__retain
    return
   end
-  local.get $8
+  local.get $16
   i32.eqz
   if (result i32)
-   local.get $9
+   local.get $19
    local.get $3
    i32.const 1
    i32.shl
@@ -4641,17 +4851,17 @@
    call $~lib/rt/pure/__retain
    return
   end
-  local.get $10
+  local.get $20
   i32.const 1
   call $~lib/rt/tlsf/__alloc
-  local.set $11
-  local.get $11
+  local.set $21
+  local.get $21
   local.get $0
-  local.get $8
+  local.get $16
   i32.add
-  local.get $10
+  local.get $20
   call $~lib/memory/memory.copy
-  local.get $11
+  local.get $21
   call $~lib/rt/pure/__retain
  )
  (func $~lib/rt/tlsf/checkUsedBlock (param $0 i32) (result i32)

--- a/tests/compiler/resolve-unary.untouched.wat
+++ b/tests/compiler/resolve-unary.untouched.wat
@@ -97,6 +97,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   memory.size
   local.set $1
   local.get $1
@@ -127,8 +128,8 @@
    local.get $5
    i32.gt_s
    select
-   local.set $4
-   local.get $4
+   local.set $6
+   local.get $6
    memory.grow
    i32.const 0
    i32.lt_s
@@ -210,6 +211,9 @@
   (local $9 i64)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
   loop $while-continue|0
    local.get $1
    i32.const 10000
@@ -274,30 +278,30 @@
    local.get $1
    i32.const 100
    i32.div_u
-   local.set $3
+   local.set $10
    local.get $1
    i32.const 100
    i32.rem_u
-   local.set $10
-   local.get $3
+   local.set $11
+   local.get $10
    local.set $1
    local.get $2
    i32.const 2
    i32.sub
    local.set $2
    i32.const 36
-   local.get $10
+   local.get $11
    i32.const 2
    i32.shl
    i32.add
    i32.load
-   local.set $11
+   local.set $12
    local.get $0
    local.get $2
    i32.const 1
    i32.shl
    i32.add
-   local.get $11
+   local.get $12
    i32.store
   end
   local.get $1
@@ -314,13 +318,13 @@
    i32.shl
    i32.add
    i32.load
-   local.set $11
+   local.set $13
    local.get $0
    local.get $2
    i32.const 1
    i32.shl
    i32.add
-   local.get $11
+   local.get $13
    i32.store
   else
    local.get $2
@@ -330,13 +334,13 @@
    i32.const 48
    local.get $1
    i32.add
-   local.set $11
+   local.set $14
    local.get $0
    local.get $2
    i32.const 1
    i32.shl
    i32.add
-   local.get $11
+   local.get $14
    i32.store16
   end
  )
@@ -437,6 +441,9 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
   local.get $0
   call $~lib/rt/stub/__retain
   local.set $0
@@ -508,33 +515,33 @@
   end
   loop $while-continue|1
    local.get $4
-   local.tee $7
+   local.tee $8
    i32.const 1
    i32.sub
    local.set $4
-   local.get $7
-   local.set $7
-   local.get $7
+   local.get $8
+   local.set $9
+   local.get $9
    if
     local.get $5
     i32.load16_u
-    local.set $8
+    local.set $10
     local.get $6
     i32.load16_u
-    local.set $9
-    local.get $8
-    local.get $9
+    local.set $11
+    local.get $10
+    local.get $11
     i32.ne
     if
-     local.get $8
-     local.get $9
+     local.get $10
+     local.get $11
      i32.sub
-     local.set $10
+     local.set $12
      local.get $0
      call $~lib/rt/stub/__release
      local.get $2
      call $~lib/rt/stub/__release
-     local.get $10
+     local.get $12
      return
     end
     local.get $5
@@ -549,16 +556,19 @@
    end
   end
   i32.const 0
-  local.set $7
+  local.set $13
   local.get $0
   call $~lib/rt/stub/__release
   local.get $2
   call $~lib/rt/stub/__release
-  local.get $7
+  local.get $13
  )
  (func $~lib/string/String.__eq (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   local.get $0
   call $~lib/rt/stub/__retain
   local.set $0
@@ -590,44 +600,44 @@
   end
   if
    i32.const 0
-   local.set $2
+   local.set $3
    local.get $0
    call $~lib/rt/stub/__release
    local.get $1
    call $~lib/rt/stub/__release
-   local.get $2
+   local.get $3
    return
   end
   local.get $0
   call $~lib/string/String#get:length
-  local.set $3
-  local.get $3
+  local.set $4
+  local.get $4
   local.get $1
   call $~lib/string/String#get:length
   i32.ne
   if
    i32.const 0
-   local.set $2
+   local.set $5
    local.get $0
    call $~lib/rt/stub/__release
    local.get $1
    call $~lib/rt/stub/__release
-   local.get $2
+   local.get $5
    return
   end
   local.get $0
   i32.const 0
   local.get $1
   i32.const 0
-  local.get $3
+  local.get $4
   call $~lib/util/string/compareImpl
   i32.eqz
-  local.set $2
+  local.set $6
   local.get $0
   call $~lib/rt/stub/__release
   local.get $1
   call $~lib/rt/stub/__release
-  local.get $2
+  local.get $6
  )
  (func $~lib/number/Bool#toString (param $0 i32) (result i32)
   local.get $0
@@ -775,6 +785,20 @@
   (local $30 i32)
   (local $31 i32)
   (local $32 i32)
+  (local $33 i32)
+  (local $34 i32)
+  (local $35 i32)
+  (local $36 i32)
+  (local $37 i32)
+  (local $38 i32)
+  (local $39 i32)
+  (local $40 i32)
+  (local $41 i32)
+  (local $42 i32)
+  (local $43 i32)
+  (local $44 i32)
+  (local $45 i32)
+  (local $46 i32)
   global.get $~lib/heap/__heap_base
   i32.const 15
   i32.add
@@ -903,7 +927,7 @@
   global.set $resolve-unary/b
   local.get $7
   call $~lib/number/I32#toString
-  local.tee $7
+  local.tee $8
   i32.const 544
   call $~lib/string/String.__eq
   i32.eqz
@@ -916,13 +940,13 @@
    unreachable
   end
   global.get $resolve-unary/b
-  local.tee $8
+  local.tee $9
   i32.const 1
   i32.sub
   global.set $resolve-unary/b
-  local.get $8
+  local.get $9
   call $~lib/number/I32#toString
-  local.tee $8
+  local.tee $10
   i32.const 576
   call $~lib/string/String.__eq
   i32.eqz
@@ -939,9 +963,9 @@
   global.set $resolve-unary/foo
   global.get $resolve-unary/foo
   call $resolve-unary/Foo#plus
-  local.tee $9
+  local.tee $11
   call $~lib/string/String#toString
-  local.tee $10
+  local.tee $12
   i32.const 704
   call $~lib/string/String.__eq
   i32.eqz
@@ -955,9 +979,9 @@
   end
   global.get $resolve-unary/foo
   call $resolve-unary/Foo#minus
-  local.tee $11
+  local.tee $13
   call $~lib/string/String#toString
-  local.tee $12
+  local.tee $14
   i32.const 736
   call $~lib/string/String.__eq
   i32.eqz
@@ -971,36 +995,6 @@
   end
   global.get $resolve-unary/foo
   call $resolve-unary/Foo#prefix_inc
-  local.tee $13
-  local.tee $14
-  global.get $resolve-unary/foo
-  local.tee $15
-  i32.ne
-  if
-   local.get $14
-   call $~lib/rt/stub/__retain
-   local.set $14
-   local.get $15
-   call $~lib/rt/stub/__release
-  end
-  local.get $14
-  global.set $resolve-unary/foo
-  global.get $resolve-unary/foo
-  call $resolve-unary/Foo#self
-  local.tee $14
-  global.get $resolve-unary/foo
-  i32.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 496
-   i32.const 101
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $resolve-unary/foo
-  call $resolve-unary/Foo#prefix_dec
   local.tee $15
   local.tee $16
   global.get $resolve-unary/foo
@@ -1017,7 +1011,37 @@
   global.set $resolve-unary/foo
   global.get $resolve-unary/foo
   call $resolve-unary/Foo#self
-  local.tee $16
+  local.tee $18
+  global.get $resolve-unary/foo
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 496
+   i32.const 101
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $resolve-unary/foo
+  call $resolve-unary/Foo#prefix_dec
+  local.tee $19
+  local.tee $20
+  global.get $resolve-unary/foo
+  local.tee $21
+  i32.ne
+  if
+   local.get $20
+   call $~lib/rt/stub/__retain
+   local.set $20
+   local.get $21
+   call $~lib/rt/stub/__release
+  end
+  local.get $20
+  global.set $resolve-unary/foo
+  global.get $resolve-unary/foo
+  call $resolve-unary/Foo#self
+  local.tee $22
   global.get $resolve-unary/foo
   i32.eq
   i32.eqz
@@ -1031,9 +1055,9 @@
   end
   global.get $resolve-unary/foo
   call $resolve-unary/Foo#not
-  local.tee $17
+  local.tee $23
   call $~lib/string/String#toString
-  local.tee $18
+  local.tee $24
   i32.const 768
   call $~lib/string/String.__eq
   i32.eqz
@@ -1047,9 +1071,9 @@
   end
   global.get $resolve-unary/foo
   call $resolve-unary/Foo#bitwise_not
-  local.tee $19
+  local.tee $25
   call $~lib/string/String#toString
-  local.tee $20
+  local.tee $26
   i32.const 800
   call $~lib/string/String.__eq
   i32.eqz
@@ -1062,25 +1086,25 @@
    unreachable
   end
   global.get $resolve-unary/foo
-  local.tee $21
+  local.tee $27
   call $resolve-unary/Foo#postfix_inc
-  local.tee $22
-  local.tee $23
+  local.tee $28
+  local.tee $29
   global.get $resolve-unary/foo
-  local.tee $24
+  local.tee $30
   i32.ne
   if
-   local.get $23
+   local.get $29
    call $~lib/rt/stub/__retain
-   local.set $23
-   local.get $24
+   local.set $29
+   local.get $30
    call $~lib/rt/stub/__release
   end
-  local.get $23
+  local.get $29
   global.set $resolve-unary/foo
-  local.get $21
+  local.get $27
   call $resolve-unary/Foo#self
-  local.tee $21
+  local.tee $31
   global.get $resolve-unary/foo
   i32.eq
   i32.eqz
@@ -1093,25 +1117,25 @@
    unreachable
   end
   global.get $resolve-unary/foo
-  local.tee $23
+  local.tee $32
   call $resolve-unary/Foo#postfix_dec
-  local.tee $24
-  local.tee $25
+  local.tee $33
+  local.tee $34
   global.get $resolve-unary/foo
-  local.tee $26
+  local.tee $35
   i32.ne
   if
-   local.get $25
+   local.get $34
    call $~lib/rt/stub/__retain
-   local.set $25
-   local.get $26
+   local.set $34
+   local.get $35
    call $~lib/rt/stub/__release
   end
-  local.get $25
+  local.get $34
   global.set $resolve-unary/foo
-  local.get $23
+  local.get $32
   call $resolve-unary/Foo#self
-  local.tee $23
+  local.tee $36
   global.get $resolve-unary/foo
   i32.eq
   i32.eqz
@@ -1128,9 +1152,9 @@
   global.set $resolve-unary/bar
   global.get $resolve-unary/bar
   call $resolve-unary/Bar.prefix_inc
-  local.tee $25
+  local.tee $37
   call $~lib/string/String#toString
-  local.tee $26
+  local.tee $38
   i32.const 832
   call $~lib/string/String.__eq
   i32.eqz
@@ -1144,9 +1168,9 @@
   end
   global.get $resolve-unary/bar
   call $resolve-unary/Bar.prefix_dec
-  local.tee $27
+  local.tee $39
   call $~lib/string/String#toString
-  local.tee $28
+  local.tee $40
   i32.const 864
   call $~lib/string/String.__eq
   i32.eqz
@@ -1160,9 +1184,9 @@
   end
   global.get $resolve-unary/bar
   call $resolve-unary/Bar.postfix_inc
-  local.tee $29
+  local.tee $42
   call $~lib/string/String#toString
-  local.tee $30
+  local.tee $43
   i32.const 896
   call $~lib/string/String.__eq
   i32.eqz
@@ -1176,9 +1200,9 @@
   end
   global.get $resolve-unary/bar
   call $resolve-unary/Bar.postfix_dec
-  local.tee $31
+  local.tee $45
   call $~lib/string/String#toString
-  local.tee $32
+  local.tee $46
   i32.const 928
   call $~lib/string/String.__eq
   i32.eqz
@@ -1204,11 +1228,7 @@
   call $~lib/rt/stub/__release
   local.get $6
   call $~lib/rt/stub/__release
-  local.get $7
-  call $~lib/rt/stub/__release
   local.get $8
-  call $~lib/rt/stub/__release
-  local.get $9
   call $~lib/rt/stub/__release
   local.get $10
   call $~lib/rt/stub/__release
@@ -1222,17 +1242,9 @@
   call $~lib/rt/stub/__release
   local.get $15
   call $~lib/rt/stub/__release
-  local.get $16
-  call $~lib/rt/stub/__release
-  local.get $17
-  call $~lib/rt/stub/__release
   local.get $18
   call $~lib/rt/stub/__release
   local.get $19
-  call $~lib/rt/stub/__release
-  local.get $20
-  call $~lib/rt/stub/__release
-  local.get $21
   call $~lib/rt/stub/__release
   local.get $22
   call $~lib/rt/stub/__release
@@ -1244,17 +1256,29 @@
   call $~lib/rt/stub/__release
   local.get $26
   call $~lib/rt/stub/__release
-  local.get $27
-  call $~lib/rt/stub/__release
   local.get $28
-  call $~lib/rt/stub/__release
-  local.get $29
-  call $~lib/rt/stub/__release
-  local.get $30
   call $~lib/rt/stub/__release
   local.get $31
   call $~lib/rt/stub/__release
-  local.get $32
+  local.get $33
+  call $~lib/rt/stub/__release
+  local.get $36
+  call $~lib/rt/stub/__release
+  local.get $37
+  call $~lib/rt/stub/__release
+  local.get $38
+  call $~lib/rt/stub/__release
+  local.get $39
+  call $~lib/rt/stub/__release
+  local.get $40
+  call $~lib/rt/stub/__release
+  local.get $42
+  call $~lib/rt/stub/__release
+  local.get $43
+  call $~lib/rt/stub/__release
+  local.get $45
+  call $~lib/rt/stub/__release
+  local.get $46
   call $~lib/rt/stub/__release
  )
  (func $~start

--- a/tests/compiler/retain-release-sanity.optimized.wat
+++ b/tests/compiler/retain-release-sanity.optimized.wat
@@ -1770,16 +1770,16 @@
   i32.const 3
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
-  local.tee $3
+  local.tee $0
   i32.const 0
   i32.store
-  local.get $3
+  local.get $0
   i32.const 0
   i32.store offset=4
-  local.get $3
+  local.get $0
   i32.const 0
   i32.store offset=8
-  local.get $3
+  local.get $0
   i32.const 0
   i32.store offset=12
   i32.const 12
@@ -1789,35 +1789,36 @@
   i32.const 12
   call $~lib/memory/memory.fill
   local.get $2
-  local.tee $0
-  local.get $3
+  local.set $1
+  local.get $2
+  local.get $0
   i32.load
-  local.tee $4
+  local.tee $3
   i32.ne
   if
-   local.get $0
+   local.get $1
    call $~lib/rt/pure/__retain
-   local.set $0
-   local.get $4
+   local.set $1
+   local.get $3
    call $~lib/rt/pure/__release
   end
-  local.get $3
   local.get $0
+  local.get $1
   i32.store
-  local.get $3
+  local.get $0
   local.get $2
   i32.store offset=4
-  local.get $3
+  local.get $0
   i32.const 12
   i32.store offset=8
-  local.get $3
+  local.get $0
   i32.const 3
   i32.store offset=12
-  local.get $3
+  local.get $0
   call $~lib/array/Array<i32>#push
-  local.get $3
+  local.get $0
   call $~lib/array/Array<i32>#push
-  local.get $3
+  local.get $0
   i32.load offset=12
   local.tee $2
   i32.const 1
@@ -1830,7 +1831,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $0
   i32.load offset=4
   local.get $2
   i32.const 1
@@ -1841,25 +1842,25 @@
   i32.add
   i32.load
   drop
-  local.get $3
+  local.get $0
   local.get $2
   i32.store offset=12
-  local.get $3
+  local.get $0
   call $~lib/rt/pure/__release
   i32.const 16
   i32.const 5
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
-  local.tee $3
+  local.tee $0
   i32.const 0
   i32.store
-  local.get $3
+  local.get $0
   i32.const 0
   i32.store offset=4
-  local.get $3
+  local.get $0
   i32.const 0
   i32.store offset=8
-  local.get $3
+  local.get $0
   i32.const 0
   i32.store offset=12
   i32.const 0
@@ -1869,33 +1870,34 @@
   i32.const 0
   call $~lib/memory/memory.fill
   local.get $2
-  local.tee $0
-  local.get $3
+  local.set $1
+  local.get $2
+  local.get $0
   i32.load
-  local.tee $4
+  local.tee $3
   i32.ne
   if
-   local.get $0
+   local.get $1
    call $~lib/rt/pure/__retain
-   local.set $0
-   local.get $4
+   local.set $1
+   local.get $3
    call $~lib/rt/pure/__release
   end
-  local.get $3
   local.get $0
+  local.get $1
   i32.store
-  local.get $3
+  local.get $0
   local.get $2
   i32.store offset=4
-  local.get $3
+  local.get $0
   i32.const 0
   i32.store offset=8
-  local.get $3
+  local.get $0
   i32.const 0
   i32.store offset=12
-  local.get $3
+  local.get $0
   loop $for-loop|0
-   local.get $1
+   local.get $4
    i32.const 10
    i32.lt_s
    if
@@ -1903,16 +1905,16 @@
     i32.const 4
     call $~lib/rt/tlsf/__alloc
     call $~lib/rt/pure/__retain
-    local.tee $3
+    local.tee $0
     i32.const 0
     i32.store
-    local.get $3
+    local.get $0
     i32.const 0
     i32.store offset=4
-    local.get $3
+    local.get $0
     i32.const 0
     i32.store offset=8
-    local.get $3
+    local.get $0
     i32.const 0
     i32.store offset=12
     i32.const 0
@@ -1922,46 +1924,47 @@
     i32.const 0
     call $~lib/memory/memory.fill
     local.get $2
-    local.tee $0
-    local.get $3
+    local.set $1
+    local.get $2
+    local.get $0
     i32.load
     local.tee $5
     i32.ne
     if
-     local.get $0
+     local.get $1
      call $~lib/rt/pure/__retain
-     local.set $0
+     local.set $1
      local.get $5
      call $~lib/rt/pure/__release
     end
-    local.get $3
     local.get $0
+    local.get $1
     i32.store
-    local.get $3
+    local.get $0
     local.get $2
     i32.store offset=4
-    local.get $3
+    local.get $0
     i32.const 0
     i32.store offset=8
-    local.get $3
+    local.get $0
     i32.const 0
     i32.store offset=12
     i32.const 0
-    local.set $0
+    local.set $2
     loop $for-loop|1
-     local.get $0
+     local.get $2
      i32.const 10
      i32.lt_s
      if
-      local.get $3
-      local.get $3
+      local.get $0
+      local.get $0
       i32.load offset=12
       local.tee $5
       i32.const 1
       i32.add
-      local.tee $2
+      local.tee $1
       call $~lib/array/ensureSize
-      local.get $3
+      local.get $0
       i32.load offset=4
       local.get $5
       i32.const 2
@@ -1969,22 +1972,22 @@
       i32.add
       i32.const 1344
       i32.store
-      local.get $3
-      local.get $2
-      i32.store offset=12
       local.get $0
+      local.get $1
+      i32.store offset=12
+      local.get $2
       i32.const 1
       i32.add
-      local.set $0
+      local.set $2
       br $for-loop|1
      end
     end
-    local.get $3
+    local.get $0
     call $~lib/rt/pure/__release
-    local.get $1
+    local.get $4
     i32.const 1
     i32.add
-    local.set $1
+    local.set $4
     br $for-loop|0
    end
   end
@@ -1992,30 +1995,30 @@
   i32.const 1360
   i32.const 1392
   call $~lib/string/String.__concat
-  local.tee $1
+  local.tee $0
   i32.const 1456
   call $~lib/string/String.__concat
-  local.get $1
+  local.get $0
   call $~lib/rt/pure/__release
   call $~lib/rt/pure/__release
   i32.const 4
   i32.const 6
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
-  local.tee $2
+  local.tee $1
   i32.const 0
   i32.store
   i32.const 4
   i32.const 7
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
-  local.tee $3
+  local.tee $2
   i32.const 0
   i32.store
-  local.get $3
-  local.tee $0
   local.get $2
-  local.tee $1
+  local.tee $0
+  local.get $1
+  local.tee $3
   i32.load
   local.tee $4
   i32.ne
@@ -2026,63 +2029,30 @@
    local.get $4
    call $~lib/rt/pure/__release
   end
-  local.get $1
+  local.get $3
   local.get $0
   i32.store
-  local.get $1
-  local.set $0
-  local.get $3
-  local.tee $1
-  local.get $0
-  i32.load
-  local.tee $4
-  i32.ne
-  if
-   local.get $1
-   call $~lib/rt/pure/__retain
-   local.set $1
-   local.get $4
-   call $~lib/rt/pure/__release
-  end
-  local.get $0
-  local.get $1
-  i32.store
-  local.get $0
-  local.tee $1
-  local.get $3
+  local.get $2
   local.tee $0
-  i32.load
-  local.tee $4
-  i32.ne
-  if
-   local.get $1
-   call $~lib/rt/pure/__retain
-   local.set $1
-   local.get $4
-   call $~lib/rt/pure/__release
-  end
-  local.get $0
-  local.get $1
-  i32.store
-  local.get $2
-  local.tee $1
-  local.get $0
-  i32.load
-  local.tee $4
-  i32.ne
-  if
-   local.get $1
-   call $~lib/rt/pure/__retain
-   local.set $1
-   local.get $4
-   call $~lib/rt/pure/__release
-  end
-  local.get $0
-  local.get $1
-  i32.store
   local.get $3
+  local.tee $4
+  i32.load
+  local.tee $3
+  i32.ne
+  if
+   local.get $0
+   call $~lib/rt/pure/__retain
+   local.set $0
+   local.get $3
+   call $~lib/rt/pure/__release
+  end
+  local.get $4
+  local.get $0
+  i32.store
+  local.get $4
+  local.tee $0
   local.get $2
-  local.tee $1
+  local.tee $3
   i32.load
   local.tee $4
   i32.ne
@@ -2093,27 +2063,61 @@
    local.get $4
    call $~lib/rt/pure/__release
   end
-  local.get $1
+  local.get $3
   local.get $0
   i32.store
-  local.get $2
+  local.get $1
+  local.tee $0
   local.get $3
   i32.load
-  local.tee $0
+  local.tee $4
   i32.ne
   if
-   local.get $1
-   call $~lib/rt/pure/__retain
-   local.set $1
    local.get $0
+   call $~lib/rt/pure/__retain
+   local.set $0
+   local.get $4
    call $~lib/rt/pure/__release
   end
   local.get $3
-  local.get $1
+  local.get $0
   i32.store
+  local.get $3
+  local.tee $0
+  local.get $1
+  local.tee $4
+  i32.load
+  local.tee $3
+  i32.ne
+  if
+   local.get $0
+   call $~lib/rt/pure/__retain
+   local.set $0
+   local.get $3
+   call $~lib/rt/pure/__release
+  end
+  local.get $4
+  local.get $0
+  i32.store
+  local.get $4
+  local.tee $0
   local.get $2
+  i32.load
+  local.tee $3
+  i32.ne
+  if
+   local.get $0
+   call $~lib/rt/pure/__retain
+   local.set $0
+   local.get $3
+   call $~lib/rt/pure/__release
+  end
+  local.get $2
+  local.get $0
+  i32.store
+  local.get $1
   call $~lib/rt/pure/__release
-  local.get $3
+  local.get $2
   call $~lib/rt/pure/__release
   call $~lib/rt/pure/__collect
  )
@@ -2401,25 +2405,25 @@
   global.get $~lib/rt/pure/ROOTS
   local.tee $0
   local.tee $4
-  local.set $3
-  global.get $~lib/rt/pure/CUR
   local.set $1
+  global.get $~lib/rt/pure/CUR
+  local.set $2
   loop $for-loop|0
-   local.get $3
    local.get $1
+   local.get $2
    i32.lt_u
    if
-    local.get $3
+    local.get $1
     i32.load
-    local.tee $2
-    i32.load offset=4
     local.tee $5
+    i32.load offset=4
+    local.tee $3
     i32.const 1879048192
     i32.and
     i32.const 805306368
     i32.eq
     if (result i32)
-     local.get $5
+     local.get $3
      i32.const 268435455
      i32.and
      i32.const 0
@@ -2428,10 +2432,10 @@
      i32.const 0
     end
     if
-     local.get $2
+     local.get $5
      call $~lib/rt/pure/markGray
      local.get $4
-     local.get $2
+     local.get $5
      i32.store
      local.get $4
      i32.const 4
@@ -2439,30 +2443,30 @@
      local.set $4
     else
      i32.const 0
-     local.get $5
+     local.get $3
      i32.const 268435455
      i32.and
      i32.eqz
-     local.get $5
+     local.get $3
      i32.const 1879048192
      i32.and
      select
      if
       global.get $~lib/rt/tlsf/ROOT
-      local.get $2
+      local.get $5
       call $~lib/rt/tlsf/freeBlock
      else
-      local.get $2
       local.get $5
+      local.get $3
       i32.const 2147483647
       i32.and
       i32.store offset=4
      end
     end
-    local.get $3
+    local.get $1
     i32.const 4
     i32.add
-    local.set $3
+    local.set $1
     br $for-loop|0
    end
   end

--- a/tests/compiler/retain-release-sanity.untouched.wat
+++ b/tests/compiler/retain-release-sanity.untouched.wat
@@ -64,6 +64,15 @@
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
   local.get $1
   i32.load
   local.set $2
@@ -200,59 +209,59 @@
   i32.eq
   if
    local.get $0
-   local.set $11
+   local.set $14
    local.get $4
-   local.set $10
+   local.set $13
    local.get $5
-   local.set $9
+   local.set $12
    local.get $7
-   local.set $8
-   local.get $11
-   local.get $10
+   local.set $11
+   local.get $14
+   local.get $13
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $12
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
+   local.get $11
    i32.store offset=96
    local.get $7
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $16
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $15
+    local.get $16
+    local.get $15
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $17
     local.get $0
-    local.set $8
+    local.set $20
     local.get $4
-    local.set $11
-    local.get $9
+    local.set $19
+    local.get $17
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
-    local.set $10
-    local.get $8
-    local.get $11
+    local.tee $17
+    local.set $18
+    local.get $20
+    local.get $19
     i32.const 2
     i32.shl
     i32.add
-    local.get $10
+    local.get $18
     i32.store offset=4
-    local.get $9
+    local.get $17
     i32.eqz
     if
      local.get $0
@@ -282,6 +291,20 @@
   (local $11 i32)
   (local $12 i32)
   (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local $22 i32)
+  (local $23 i32)
+  (local $24 i32)
+  (local $25 i32)
+  (local $26 i32)
+  (local $27 i32)
   i32.const 1
   drop
   local.get $1
@@ -344,8 +367,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $3
+   local.set $6
+   local.get $6
    i32.const 1073741808
    i32.lt_u
    if
@@ -356,16 +379,16 @@
     local.get $2
     i32.const 3
     i32.and
-    local.get $3
+    local.get $6
     i32.or
     local.tee $2
     i32.store
     local.get $1
-    local.set $6
-    local.get $6
+    local.set $7
+    local.get $7
     i32.const 16
     i32.add
-    local.get $6
+    local.get $7
     i32.load
     i32.const 3
     i32.const -1
@@ -383,18 +406,18 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $8
+   local.get $8
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
+   local.set $9
+   local.get $9
    i32.load
-   local.set $3
+   local.set $10
    i32.const 1
    drop
-   local.get $3
+   local.get $10
    i32.const 1
    i32.and
    i32.eqz
@@ -406,7 +429,7 @@
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $3
+   local.get $10
    i32.const 3
    i32.const -1
    i32.xor
@@ -419,23 +442,23 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $7
+   local.set $11
+   local.get $11
    i32.const 1073741808
    i32.lt_u
    if
     local.get $0
-    local.get $6
+    local.get $9
     call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
+    local.get $9
+    local.get $10
     i32.const 3
     i32.and
-    local.get $7
+    local.get $11
     i32.or
     local.tee $2
     i32.store
-    local.get $6
+    local.get $9
     local.set $1
    end
   end
@@ -449,14 +472,14 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $12
   i32.const 1
   drop
-  local.get $8
+  local.get $12
   i32.const 16
   i32.ge_u
   if (result i32)
-   local.get $8
+   local.get $12
    i32.const 1073741808
    i32.lt_u
   else
@@ -476,7 +499,7 @@
   local.get $1
   i32.const 16
   i32.add
-  local.get $8
+  local.get $12
   i32.add
   local.get $4
   i32.eq
@@ -494,24 +517,24 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $12
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $13
+   local.get $12
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $14
   else
    i32.const 31
-   local.get $8
+   local.get $12
    i32.clz
    i32.sub
-   local.set $9
-   local.get $8
-   local.get $9
+   local.set $13
+   local.get $12
+   local.get $13
    i32.const 4
    i32.sub
    i32.shr_u
@@ -519,21 +542,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $14
+   local.get $13
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $13
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $13
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $14
    i32.const 16
    i32.lt_u
   else
@@ -549,86 +572,86 @@
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
-  local.set $6
-  local.get $7
-  local.get $3
+  local.set $17
+  local.get $13
+  local.set $16
+  local.get $14
+  local.set $15
+  local.get $17
+  local.get $16
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $15
   i32.add
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=96
-  local.set $11
+  local.set $18
   local.get $1
   i32.const 0
   i32.store offset=16
   local.get $1
-  local.get $11
+  local.get $18
   i32.store offset=20
-  local.get $11
+  local.get $18
   if
-   local.get $11
+   local.get $18
    local.get $1
    i32.store offset=16
   end
   local.get $0
-  local.set $12
-  local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
+  local.set $22
+  local.get $13
+  local.set $21
+  local.get $14
+  local.set $20
   local.get $1
-  local.set $6
-  local.get $12
-  local.get $7
+  local.set $19
+  local.get $22
+  local.get $21
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $20
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $19
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $13
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.set $13
-  local.get $9
-  local.set $12
+  local.set $27
+  local.get $13
+  local.set $26
   local.get $0
-  local.set $3
-  local.get $9
-  local.set $6
-  local.get $3
-  local.get $6
+  local.set $24
+  local.get $13
+  local.set $23
+  local.get $24
+  local.get $23
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $14
   i32.shl
   i32.or
-  local.set $7
-  local.get $13
-  local.get $12
+  local.set $25
+  local.get $27
+  local.get $26
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $25
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -639,6 +662,7 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
   i32.const 1
   drop
   local.get $1
@@ -778,11 +802,11 @@
   i32.or
   i32.store
   local.get $0
-  local.set $9
+  local.set $10
   local.get $4
-  local.set $3
+  local.set $9
+  local.get $10
   local.get $9
-  local.get $3
   i32.store offset=1568
   local.get $0
   local.get $8
@@ -802,6 +826,12 @@
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
   global.get $~lib/rt/tlsf/ROOT
   local.set $0
   local.get $0
@@ -858,66 +888,66 @@
    local.get $4
    i32.store offset=1568
    i32.const 0
-   local.set $5
+   local.set $6
    loop $for-loop|0
-    local.get $5
+    local.get $6
     i32.const 23
     i32.lt_u
-    local.set $4
-    local.get $4
+    local.set $7
+    local.get $7
     if
      local.get $0
-     local.set $8
-     local.get $5
-     local.set $7
+     local.set $10
+     local.get $6
+     local.set $9
      i32.const 0
-     local.set $6
-     local.get $8
-     local.get $7
+     local.set $8
+     local.get $10
+     local.get $9
      i32.const 2
      i32.shl
      i32.add
-     local.get $6
+     local.get $8
      i32.store offset=4
      i32.const 0
-     local.set $8
+     local.set $11
      loop $for-loop|1
-      local.get $8
+      local.get $11
       i32.const 16
       i32.lt_u
-      local.set $7
-      local.get $7
+      local.set $12
+      local.get $12
       if
        local.get $0
-       local.set $11
-       local.get $5
-       local.set $10
-       local.get $8
-       local.set $9
-       i32.const 0
-       local.set $6
+       local.set $16
+       local.get $6
+       local.set $15
        local.get $11
-       local.get $10
+       local.set $14
+       i32.const 0
+       local.set $13
+       local.get $16
+       local.get $15
        i32.const 4
        i32.shl
-       local.get $9
+       local.get $14
        i32.add
        i32.const 2
        i32.shl
        i32.add
-       local.get $6
+       local.get $13
        i32.store offset=96
-       local.get $8
+       local.get $11
        i32.const 1
        i32.add
-       local.set $8
+       local.set $11
        br $for-loop|1
       end
      end
-     local.get $5
+     local.get $6
      i32.const 1
      i32.add
-     local.set $5
+     local.set $6
      br $for-loop|0
     end
    end
@@ -930,11 +960,11 @@
    i32.const -1
    i32.xor
    i32.and
-   local.set $5
+   local.set $17
    i32.const 0
    drop
    local.get $0
-   local.get $5
+   local.get $17
    memory.size
    i32.const 16
    i32.shl
@@ -983,6 +1013,14 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
   local.get $1
   i32.const 256
   i32.lt_u
@@ -1056,11 +1094,11 @@
    unreachable
   end
   local.get $0
-  local.set $5
+  local.set $6
   local.get $2
-  local.set $4
+  local.set $5
+  local.get $6
   local.get $5
-  local.get $4
   i32.const 2
   i32.shl
   i32.add
@@ -1071,10 +1109,10 @@
   local.get $3
   i32.shl
   i32.and
-  local.set $6
-  i32.const 0
   local.set $7
-  local.get $6
+  i32.const 0
+  local.set $8
+  local.get $7
   i32.eqz
   if
    local.get $0
@@ -1087,30 +1125,30 @@
    i32.add
    i32.shl
    i32.and
-   local.set $5
-   local.get $5
+   local.set $9
+   local.get $9
    i32.eqz
    if
     i32.const 0
-    local.set $7
+    local.set $8
    else
-    local.get $5
+    local.get $9
     i32.ctz
     local.set $2
     local.get $0
-    local.set $8
+    local.set $11
     local.get $2
-    local.set $4
-    local.get $8
-    local.get $4
+    local.set $10
+    local.get $11
+    local.get $10
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $6
+    local.set $7
     i32.const 1
     drop
-    local.get $6
+    local.get $7
     i32.eqz
     if
      i32.const 0
@@ -1121,45 +1159,45 @@
      unreachable
     end
     local.get $0
-    local.set $9
+    local.set $14
     local.get $2
-    local.set $8
-    local.get $6
+    local.set $13
+    local.get $7
     i32.ctz
-    local.set $4
-    local.get $9
-    local.get $8
+    local.set $12
+    local.get $14
+    local.get $13
     i32.const 4
     i32.shl
-    local.get $4
+    local.get $12
     i32.add
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=96
-    local.set $7
+    local.set $8
    end
   else
    local.get $0
-   local.set $9
+   local.set $17
    local.get $2
-   local.set $8
-   local.get $6
+   local.set $16
+   local.get $7
    i32.ctz
-   local.set $4
-   local.get $9
-   local.get $8
+   local.set $15
+   local.get $17
+   local.get $16
    i32.const 4
    i32.shl
-   local.get $4
+   local.get $15
    i32.add
    i32.const 2
    i32.shl
    i32.add
    i32.load offset=96
-   local.set $7
+   local.set $8
   end
-  local.get $7
+  local.get $8
  )
  (func $~lib/rt/tlsf/growMemory (param $0 i32) (param $1 i32)
   (local $2 i32)
@@ -1168,6 +1206,7 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
   i32.const 0
   drop
   local.get $1
@@ -1214,15 +1253,15 @@
   i32.shr_u
   local.set $4
   local.get $2
-  local.tee $3
-  local.get $4
   local.tee $5
-  local.get $3
+  local.get $4
+  local.tee $6
   local.get $5
+  local.get $6
   i32.gt_s
   select
-  local.set $6
-  local.get $6
+  local.set $7
+  local.get $7
   memory.grow
   i32.const 0
   i32.lt_s
@@ -1236,12 +1275,12 @@
    end
   end
   memory.size
-  local.set $7
+  local.set $8
   local.get $0
   local.get $2
   i32.const 16
   i32.shl
-  local.get $7
+  local.get $8
   i32.const 16
   i32.shl
   call $~lib/rt/tlsf/addMemory
@@ -1251,6 +1290,8 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
   local.get $1
   i32.load
   local.set $3
@@ -1315,11 +1356,11 @@
    i32.and
    i32.store
    local.get $1
-   local.set $5
-   local.get $5
+   local.set $7
+   local.get $7
    i32.const 16
    i32.add
-   local.get $5
+   local.get $7
    i32.load
    i32.const 3
    i32.const -1
@@ -1327,11 +1368,11 @@
    i32.and
    i32.add
    local.get $1
-   local.set $5
-   local.get $5
+   local.set $6
+   local.get $6
    i32.const 16
    i32.add
-   local.get $5
+   local.get $6
    i32.load
    i32.const 3
    i32.const -1
@@ -1894,6 +1935,88 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local $22 i32)
+  (local $23 i32)
+  (local $24 i32)
+  (local $25 i32)
+  (local $26 i32)
+  (local $27 i32)
+  (local $28 i32)
+  (local $29 i32)
+  (local $30 i32)
+  (local $31 i32)
+  (local $32 i32)
+  (local $33 i32)
+  (local $34 i32)
+  (local $35 i32)
+  (local $36 i32)
+  (local $37 i32)
+  (local $38 i32)
+  (local $39 i32)
+  (local $40 i32)
+  (local $41 i32)
+  (local $42 i32)
+  (local $43 i32)
+  (local $44 i32)
+  (local $45 i32)
+  (local $46 i32)
+  (local $47 i32)
+  (local $48 i32)
+  (local $49 i32)
+  (local $50 i32)
+  (local $51 i32)
+  (local $52 i32)
+  (local $53 i32)
+  (local $54 i32)
+  (local $55 i32)
+  (local $56 i32)
+  (local $57 i32)
+  (local $58 i32)
+  (local $59 i32)
+  (local $60 i32)
+  (local $61 i32)
+  (local $62 i32)
+  (local $63 i32)
+  (local $64 i32)
+  (local $65 i32)
+  (local $66 i32)
+  (local $67 i32)
+  (local $68 i32)
+  (local $69 i32)
+  (local $70 i32)
+  (local $71 i32)
+  (local $72 i32)
+  (local $73 i32)
+  (local $74 i32)
+  (local $75 i32)
+  (local $76 i32)
+  (local $77 i32)
+  (local $78 i32)
+  (local $79 i32)
+  (local $80 i32)
+  (local $81 i32)
+  (local $82 i32)
+  (local $83 i32)
+  (local $84 i32)
+  (local $85 i32)
+  (local $86 i32)
+  (local $87 i32)
+  (local $88 i32)
   loop $while-continue|0
    local.get $2
    if (result i32)
@@ -1913,11 +2036,11 @@
     local.set $0
     local.get $6
     local.get $1
-    local.tee $6
+    local.tee $7
     i32.const 1
     i32.add
     local.set $1
-    local.get $6
+    local.get $7
     i32.load8_u
     i32.store8
     local.get $2
@@ -1937,8 +2060,8 @@
     local.get $2
     i32.const 16
     i32.ge_u
-    local.set $5
-    local.get $5
+    local.set $8
+    local.get $8
     if
      local.get $0
      local.get $1
@@ -2047,17 +2170,17 @@
    i32.and
    if
     local.get $0
-    local.tee $5
+    local.tee $9
     i32.const 1
     i32.add
     local.set $0
-    local.get $5
+    local.get $9
     local.get $1
-    local.tee $5
+    local.tee $10
     i32.const 1
     i32.add
     local.set $1
-    local.get $5
+    local.get $10
     i32.load8_u
     i32.store8
    end
@@ -2074,16 +2197,16 @@
        local.get $0
        i32.const 3
        i32.and
-       local.set $5
-       local.get $5
+       local.set $11
+       local.get $11
        i32.const 1
        i32.eq
        br_if $case0|2
-       local.get $5
+       local.get $11
        i32.const 2
        i32.eq
        br_if $case1|2
-       local.get $5
+       local.get $11
        i32.const 3
        i32.eq
        br_if $case2|2
@@ -2093,45 +2216,45 @@
       i32.load
       local.set $3
       local.get $0
-      local.tee $5
+      local.tee $12
       i32.const 1
       i32.add
       local.set $0
-      local.get $5
+      local.get $12
       local.get $1
-      local.tee $5
+      local.tee $13
       i32.const 1
       i32.add
       local.set $1
-      local.get $5
+      local.get $13
       i32.load8_u
       i32.store8
       local.get $0
-      local.tee $5
+      local.tee $14
       i32.const 1
       i32.add
       local.set $0
-      local.get $5
+      local.get $14
       local.get $1
-      local.tee $5
+      local.tee $15
       i32.const 1
       i32.add
       local.set $1
-      local.get $5
+      local.get $15
       i32.load8_u
       i32.store8
       local.get $0
-      local.tee $5
+      local.tee $16
       i32.const 1
       i32.add
       local.set $0
-      local.get $5
+      local.get $16
       local.get $1
-      local.tee $5
+      local.tee $17
       i32.const 1
       i32.add
       local.set $1
-      local.get $5
+      local.get $17
       i32.load8_u
       i32.store8
       local.get $2
@@ -2142,8 +2265,8 @@
        local.get $2
        i32.const 17
        i32.ge_u
-       local.set $5
-       local.get $5
+       local.set $18
+       local.get $18
        if
         local.get $1
         i32.const 1
@@ -2228,31 +2351,31 @@
      i32.load
      local.set $3
      local.get $0
-     local.tee $5
+     local.tee $19
      i32.const 1
      i32.add
      local.set $0
-     local.get $5
+     local.get $19
      local.get $1
-     local.tee $5
+     local.tee $20
      i32.const 1
      i32.add
      local.set $1
-     local.get $5
+     local.get $20
      i32.load8_u
      i32.store8
      local.get $0
-     local.tee $5
+     local.tee $21
      i32.const 1
      i32.add
      local.set $0
-     local.get $5
+     local.get $21
      local.get $1
-     local.tee $5
+     local.tee $22
      i32.const 1
      i32.add
      local.set $1
-     local.get $5
+     local.get $22
      i32.load8_u
      i32.store8
      local.get $2
@@ -2263,8 +2386,8 @@
       local.get $2
       i32.const 18
       i32.ge_u
-      local.set $5
-      local.get $5
+      local.set $23
+      local.get $23
       if
        local.get $1
        i32.const 2
@@ -2349,17 +2472,17 @@
     i32.load
     local.set $3
     local.get $0
-    local.tee $5
+    local.tee $24
     i32.const 1
     i32.add
     local.set $0
-    local.get $5
+    local.get $24
     local.get $1
-    local.tee $5
+    local.tee $25
     i32.const 1
     i32.add
     local.set $1
-    local.get $5
+    local.get $25
     i32.load8_u
     i32.store8
     local.get $2
@@ -2370,8 +2493,8 @@
      local.get $2
      i32.const 19
      i32.ge_u
-     local.set $5
-     local.get $5
+     local.set $26
+     local.get $26
      if
       local.get $1
       i32.const 3
@@ -2458,227 +2581,227 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $27
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $27
    local.get $1
-   local.tee $5
+   local.tee $28
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $28
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $29
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $29
    local.get $1
-   local.tee $5
+   local.tee $30
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $30
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $31
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $31
    local.get $1
-   local.tee $5
+   local.tee $32
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $32
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $33
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $33
    local.get $1
-   local.tee $5
+   local.tee $34
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $34
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $35
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $35
    local.get $1
-   local.tee $5
+   local.tee $36
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $36
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $37
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $37
    local.get $1
-   local.tee $5
+   local.tee $38
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $38
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $39
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $39
    local.get $1
-   local.tee $5
+   local.tee $40
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $40
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $41
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $41
    local.get $1
-   local.tee $5
+   local.tee $42
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $42
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $43
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $43
    local.get $1
-   local.tee $5
+   local.tee $44
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $44
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $45
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $45
    local.get $1
-   local.tee $5
+   local.tee $46
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $46
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $47
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $47
    local.get $1
-   local.tee $5
+   local.tee $48
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $48
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $49
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $49
    local.get $1
-   local.tee $5
+   local.tee $50
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $50
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $51
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $51
    local.get $1
-   local.tee $5
+   local.tee $52
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $52
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $53
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $53
    local.get $1
-   local.tee $5
+   local.tee $54
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $54
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $55
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $55
    local.get $1
-   local.tee $5
+   local.tee $56
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $56
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $57
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $57
    local.get $1
-   local.tee $5
+   local.tee $58
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $58
    i32.load8_u
    i32.store8
   end
@@ -2687,115 +2810,115 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $59
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $59
    local.get $1
-   local.tee $5
+   local.tee $60
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $60
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $61
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $61
    local.get $1
-   local.tee $5
+   local.tee $62
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $62
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $63
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $63
    local.get $1
-   local.tee $5
+   local.tee $64
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $64
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $65
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $65
    local.get $1
-   local.tee $5
+   local.tee $66
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $66
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $67
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $67
    local.get $1
-   local.tee $5
+   local.tee $68
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $68
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $69
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $69
    local.get $1
-   local.tee $5
+   local.tee $70
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $70
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $71
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $71
    local.get $1
-   local.tee $5
+   local.tee $72
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $72
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $73
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $73
    local.get $1
-   local.tee $5
+   local.tee $74
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $74
    i32.load8_u
    i32.store8
   end
@@ -2804,59 +2927,59 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $75
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $75
    local.get $1
-   local.tee $5
+   local.tee $76
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $76
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $77
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $77
    local.get $1
-   local.tee $5
+   local.tee $78
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $78
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $79
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $79
    local.get $1
-   local.tee $5
+   local.tee $80
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $80
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $81
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $81
    local.get $1
-   local.tee $5
+   local.tee $82
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $82
    i32.load8_u
    i32.store8
   end
@@ -2865,31 +2988,31 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $83
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $83
    local.get $1
-   local.tee $5
+   local.tee $84
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $84
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $85
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $85
    local.get $1
-   local.tee $5
+   local.tee $86
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $86
    i32.load8_u
    i32.store8
   end
@@ -2898,17 +3021,17 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $87
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $87
    local.get $1
-   local.tee $5
+   local.tee $88
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $88
    i32.load8_u
    i32.store8
   end
@@ -2919,6 +3042,14 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
   block $~lib/util/memory/memmove|inlined.0
    local.get $0
    local.set $5
@@ -2996,11 +3127,11 @@
        local.set $5
        local.get $7
        local.get $4
-       local.tee $7
+       local.tee $8
        i32.const 1
        i32.add
        local.set $4
-       local.get $7
+       local.get $8
        i32.load8_u
        i32.store8
        br $while-continue|0
@@ -3010,8 +3141,8 @@
       local.get $3
       i32.const 8
       i32.ge_u
-      local.set $6
-      local.get $6
+      local.set $9
+      local.get $9
       if
        local.get $5
        local.get $4
@@ -3035,21 +3166,21 @@
     end
     loop $while-continue|2
      local.get $3
-     local.set $6
-     local.get $6
+     local.set $10
+     local.get $10
      if
       local.get $5
-      local.tee $7
+      local.tee $11
       i32.const 1
       i32.add
       local.set $5
-      local.get $7
+      local.get $11
       local.get $4
-      local.tee $7
+      local.tee $12
       i32.const 1
       i32.add
       local.set $4
-      local.get $7
+      local.get $12
       i32.load8_u
       i32.store8
       local.get $3
@@ -3078,8 +3209,8 @@
       i32.add
       i32.const 7
       i32.and
-      local.set $6
-      local.get $6
+      local.set $13
+      local.get $13
       if
        local.get $3
        i32.eqz
@@ -3104,8 +3235,8 @@
       local.get $3
       i32.const 8
       i32.ge_u
-      local.set $6
-      local.get $6
+      local.set $14
+      local.get $14
       if
        local.get $3
        i32.const 8
@@ -3125,8 +3256,8 @@
     end
     loop $while-continue|5
      local.get $3
-     local.set $6
-     local.get $6
+     local.set $15
+     local.get $15
      if
       local.get $5
       local.get $3
@@ -3170,6 +3301,7 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
   local.get $2
   call $~lib/rt/tlsf/prepareSize
   local.set $3
@@ -3227,8 +3359,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $5
-   local.get $5
+   local.set $8
+   local.get $8
    local.get $3
    i32.ge_u
    if
@@ -3239,7 +3371,7 @@
     local.get $4
     i32.const 3
     i32.and
-    local.get $5
+    local.get $8
     i32.or
     i32.store
     local.get $1
@@ -3258,12 +3390,12 @@
   local.get $1
   i32.load offset=8
   call $~lib/rt/tlsf/allocateBlock
-  local.set $8
-  local.get $8
+  local.set $9
+  local.get $9
   local.get $1
   i32.load offset=4
   i32.store offset=4
-  local.get $8
+  local.get $9
   i32.const 16
   i32.add
   local.get $1
@@ -3278,13 +3410,13 @@
    i32.const 1
    drop
    local.get $1
-   local.get $8
+   local.get $9
    call $~lib/rt/rtrace/onrealloc
    local.get $0
    local.get $1
    call $~lib/rt/tlsf/freeBlock
   end
-  local.get $8
+  local.get $9
  )
  (func $~lib/rt/tlsf/__realloc (param $0 i32) (param $1 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
@@ -3636,6 +3768,8 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
   local.get $1
   call $~lib/rt/pure/__retain
   local.set $1
@@ -3678,32 +3812,32 @@
   if
    i32.const 336
    call $~lib/rt/pure/__retain
-   local.set $2
+   local.set $7
    local.get $1
    call $~lib/rt/pure/__release
-   local.get $2
+   local.get $7
    return
   end
   local.get $6
   i32.const 1
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
-  local.set $7
-  local.get $7
+  local.set $8
+  local.get $8
   local.get $0
   local.get $4
   call $~lib/memory/memory.copy
-  local.get $7
+  local.get $8
   local.get $4
   i32.add
   local.get $1
   local.get $5
   call $~lib/memory/memory.copy
-  local.get $7
-  local.set $2
+  local.get $8
+  local.set $9
   local.get $1
   call $~lib/rt/pure/__release
-  local.get $2
+  local.get $9
  )
  (func $~lib/string/String.__concat (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
@@ -3765,6 +3899,31 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local $22 i32)
+  (local $23 i32)
+  (local $24 i32)
+  (local $25 i32)
+  (local $26 i32)
+  (local $27 i32)
+  (local $28 i32)
+  (local $29 i32)
+  (local $30 i32)
   i32.const 0
   i32.const 3
   call $~lib/array/Array<i32>#constructor
@@ -3785,183 +3944,183 @@
   i32.const 0
   i32.const 0
   call $~lib/array/Array<~lib/array/Array<~lib/string/String>>#constructor
-  local.set $0
-  i32.const 0
   local.set $1
+  i32.const 0
+  local.set $2
   loop $for-loop|0
-   local.get $1
+   local.get $2
    i32.const 10
    i32.lt_s
-   local.set $2
-   local.get $2
+   local.set $3
+   local.get $3
    if
     i32.const 0
     i32.const 0
     call $~lib/array/Array<~lib/string/String>#constructor
-    local.set $3
-    i32.const 0
     local.set $4
+    i32.const 0
+    local.set $5
     loop $for-loop|1
-     local.get $4
+     local.get $5
      i32.const 10
      i32.lt_s
-     local.set $5
-     local.get $5
+     local.set $6
+     local.get $6
      if
-      local.get $3
+      local.get $4
       i32.const 336
       call $~lib/array/Array<~lib/string/String>#push
       drop
-      local.get $4
+      local.get $5
       i32.const 1
       i32.add
-      local.set $4
+      local.set $5
       br $for-loop|1
      end
     end
-    local.get $3
+    local.get $4
     call $~lib/rt/pure/__release
-    local.get $1
+    local.get $2
     i32.const 1
     i32.add
-    local.set $1
+    local.set $2
     br $for-loop|0
    end
   end
-  local.get $0
-  call $~lib/rt/pure/__release
-  i32.const 352
-  local.set $0
-  local.get $0
-  i32.const 384
-  call $~lib/string/String.__concat
-  local.tee $1
-  call $~lib/rt/pure/__retain
-  local.set $2
-  local.get $2
-  i32.const 448
-  call $~lib/string/String.__concat
-  local.tee $3
-  drop
-  local.get $0
-  call $~lib/rt/pure/__release
   local.get $1
   call $~lib/rt/pure/__release
-  local.get $2
+  i32.const 352
+  local.set $7
+  local.get $7
+  i32.const 384
+  call $~lib/string/String.__concat
+  local.tee $8
+  call $~lib/rt/pure/__retain
+  local.set $9
+  local.get $9
+  i32.const 448
+  call $~lib/string/String.__concat
+  local.tee $10
+  drop
+  local.get $7
   call $~lib/rt/pure/__release
-  local.get $3
+  local.get $8
+  call $~lib/rt/pure/__release
+  local.get $9
+  call $~lib/rt/pure/__release
+  local.get $10
   call $~lib/rt/pure/__release
   i32.const 0
   call $retain-release-sanity/A#constructor
-  local.set $3
+  local.set $11
   i32.const 0
   call $retain-release-sanity/B#constructor
-  local.set $2
-  local.get $3
-  local.tee $5
-  local.get $2
-  local.tee $4
-  local.get $5
+  local.set $12
+  local.get $11
+  local.tee $13
+  local.get $12
+  local.tee $14
+  local.get $13
   i32.load
-  local.tee $1
+  local.tee $15
   i32.ne
   if
-   local.get $4
+   local.get $14
    call $~lib/rt/pure/__retain
-   local.set $4
-   local.get $1
+   local.set $14
+   local.get $15
    call $~lib/rt/pure/__release
   end
-  local.get $4
+  local.get $14
   i32.store
-  local.get $3
-  local.tee $0
-  local.get $2
-  local.tee $1
-  local.get $0
+  local.get $11
+  local.tee $16
+  local.get $12
+  local.tee $17
+  local.get $16
   i32.load
-  local.tee $5
+  local.tee $18
   i32.ne
   if
-   local.get $1
+   local.get $17
    call $~lib/rt/pure/__retain
-   local.set $1
-   local.get $5
+   local.set $17
+   local.get $18
    call $~lib/rt/pure/__release
   end
-  local.get $1
+  local.get $17
   i32.store
-  local.get $2
-  local.tee $4
-  local.get $3
-  local.tee $5
-  local.get $4
+  local.get $12
+  local.tee $19
+  local.get $11
+  local.tee $20
+  local.get $19
   i32.load
-  local.tee $0
+  local.tee $21
   i32.ne
   if
-   local.get $5
+   local.get $20
    call $~lib/rt/pure/__retain
-   local.set $5
-   local.get $0
+   local.set $20
+   local.get $21
    call $~lib/rt/pure/__release
   end
-  local.get $5
+  local.get $20
   i32.store
-  local.get $2
-  local.tee $1
-  local.get $3
-  local.tee $0
-  local.get $1
+  local.get $12
+  local.tee $22
+  local.get $11
+  local.tee $23
+  local.get $22
   i32.load
-  local.tee $4
+  local.tee $24
   i32.ne
   if
-   local.get $0
+   local.get $23
    call $~lib/rt/pure/__retain
-   local.set $0
-   local.get $4
+   local.set $23
+   local.get $24
    call $~lib/rt/pure/__release
   end
-  local.get $0
+  local.get $23
   i32.store
-  local.get $3
-  local.tee $5
-  local.get $2
-  local.tee $4
-  local.get $5
+  local.get $11
+  local.tee $25
+  local.get $12
+  local.tee $26
+  local.get $25
   i32.load
-  local.tee $1
+  local.tee $27
   i32.ne
   if
-   local.get $4
+   local.get $26
    call $~lib/rt/pure/__retain
-   local.set $4
-   local.get $1
+   local.set $26
+   local.get $27
    call $~lib/rt/pure/__release
   end
-  local.get $4
+  local.get $26
   i32.store
-  local.get $2
-  local.tee $0
-  local.get $3
-  local.tee $1
-  local.get $0
+  local.get $12
+  local.tee $28
+  local.get $11
+  local.tee $29
+  local.get $28
   i32.load
-  local.tee $5
+  local.tee $30
   i32.ne
   if
-   local.get $1
+   local.get $29
    call $~lib/rt/pure/__retain
-   local.set $1
-   local.get $5
+   local.set $29
+   local.get $30
    call $~lib/rt/pure/__release
   end
-  local.get $1
+  local.get $29
   i32.store
-  local.get $3
+  local.get $11
   call $~lib/rt/pure/__release
-  local.get $2
+  local.get $12
   call $~lib/rt/pure/__release
   call $~lib/rt/pure/__collect
  )
@@ -4322,6 +4481,11 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
   i32.const 0
   drop
   global.get $~lib/rt/pure/ROOTS
@@ -4407,50 +4571,50 @@
   local.get $1
   global.set $~lib/rt/pure/CUR
   local.get $0
-  local.set $3
+  local.set $7
   loop $for-loop|1
-   local.get $3
+   local.get $7
    local.get $1
    i32.lt_u
-   local.set $2
-   local.get $2
+   local.set $8
+   local.get $8
    if
-    local.get $3
+    local.get $7
     i32.load
     call $~lib/rt/pure/scan
-    local.get $3
+    local.get $7
     i32.const 4
     i32.add
-    local.set $3
+    local.set $7
     br $for-loop|1
    end
   end
   local.get $0
-  local.set $3
+  local.set $9
   loop $for-loop|2
-   local.get $3
+   local.get $9
    local.get $1
    i32.lt_u
-   local.set $2
-   local.get $2
+   local.set $10
+   local.get $10
    if
-    local.get $3
+    local.get $9
     i32.load
-    local.set $4
-    local.get $4
-    local.get $4
+    local.set $11
+    local.get $11
+    local.get $11
     i32.load offset=4
     i32.const -2147483648
     i32.const -1
     i32.xor
     i32.and
     i32.store offset=4
-    local.get $4
+    local.get $11
     call $~lib/rt/pure/collectWhite
-    local.get $3
+    local.get $9
     i32.const 4
     i32.add
-    local.set $3
+    local.set $9
     br $for-loop|2
    end
   end
@@ -4460,6 +4624,7 @@
  (func $~lib/rt/pure/__visit (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
   local.get $0
   global.get $~lib/heap/__heap_base
   i32.lt_u
@@ -4540,13 +4705,13 @@
      end
      local.get $2
      i32.load offset=4
-     local.set $3
-     local.get $3
+     local.set $4
+     local.get $4
      i32.const 268435455
      i32.const -1
      i32.xor
      i32.and
-     local.get $3
+     local.get $4
      i32.const 1
      i32.add
      i32.const 268435455
@@ -4564,11 +4729,11 @@
       unreachable
      end
      local.get $2
-     local.get $3
+     local.get $4
      i32.const 1
      i32.add
      i32.store offset=4
-     local.get $3
+     local.get $4
      i32.const 1879048192
      i32.and
      i32.const 0

--- a/tests/compiler/retain-release.untouched.wat
+++ b/tests/compiler/retain-release.untouched.wat
@@ -64,6 +64,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   memory.size
   local.set $1
   local.get $1
@@ -94,8 +95,8 @@
    local.get $5
    i32.gt_s
    select
-   local.set $4
-   local.get $4
+   local.set $6
+   local.get $6
    memory.grow
    i32.const 0
    i32.lt_s
@@ -386,6 +387,8 @@
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   i32.const 0
   local.set $1
   local.get $0
@@ -407,22 +410,22 @@
   end
   global.get $retain-release/REF
   call $~lib/rt/stub/__retain
-  local.set $2
-  local.get $2
-  local.tee $3
+  local.set $4
+  local.get $4
+  local.tee $5
   local.get $1
-  local.tee $4
+  local.tee $6
   i32.ne
   if
-   local.get $3
+   local.get $5
    call $~lib/rt/stub/__retain
-   local.set $3
-   local.get $4
+   local.set $5
+   local.get $6
    call $~lib/rt/stub/__release
   end
-  local.get $3
+  local.get $5
   local.set $1
-  local.get $2
+  local.get $4
   call $~lib/rt/stub/__release
   local.get $1
   call $~lib/rt/stub/__release
@@ -481,6 +484,7 @@
  )
  (func $retain-release/scopeIfElse (param $0 i32)
   (local $1 i32)
+  (local $2 i32)
   local.get $0
   if
    global.get $retain-release/REF
@@ -491,8 +495,8 @@
   else
    global.get $retain-release/REF
    call $~lib/rt/stub/__retain
-   local.set $1
-   local.get $1
+   local.set $2
+   local.get $2
    call $~lib/rt/stub/__release
   end
  )

--- a/tests/compiler/retain-return.untouched.wat
+++ b/tests/compiler/retain-return.untouched.wat
@@ -43,6 +43,15 @@
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
   local.get $1
   i32.load
   local.set $2
@@ -179,59 +188,59 @@
   i32.eq
   if
    local.get $0
-   local.set $11
+   local.set $14
    local.get $4
-   local.set $10
+   local.set $13
    local.get $5
-   local.set $9
+   local.set $12
    local.get $7
-   local.set $8
-   local.get $11
-   local.get $10
+   local.set $11
+   local.get $14
+   local.get $13
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $12
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
+   local.get $11
    i32.store offset=96
    local.get $7
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $16
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $15
+    local.get $16
+    local.get $15
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $17
     local.get $0
-    local.set $8
+    local.set $20
     local.get $4
-    local.set $11
-    local.get $9
+    local.set $19
+    local.get $17
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
-    local.set $10
-    local.get $8
-    local.get $11
+    local.tee $17
+    local.set $18
+    local.get $20
+    local.get $19
     i32.const 2
     i32.shl
     i32.add
-    local.get $10
+    local.get $18
     i32.store offset=4
-    local.get $9
+    local.get $17
     i32.eqz
     if
      local.get $0
@@ -261,6 +270,20 @@
   (local $11 i32)
   (local $12 i32)
   (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local $22 i32)
+  (local $23 i32)
+  (local $24 i32)
+  (local $25 i32)
+  (local $26 i32)
+  (local $27 i32)
   i32.const 1
   drop
   local.get $1
@@ -323,8 +346,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $3
+   local.set $6
+   local.get $6
    i32.const 1073741808
    i32.lt_u
    if
@@ -335,16 +358,16 @@
     local.get $2
     i32.const 3
     i32.and
-    local.get $3
+    local.get $6
     i32.or
     local.tee $2
     i32.store
     local.get $1
-    local.set $6
-    local.get $6
+    local.set $7
+    local.get $7
     i32.const 16
     i32.add
-    local.get $6
+    local.get $7
     i32.load
     i32.const 3
     i32.const -1
@@ -362,18 +385,18 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $8
+   local.get $8
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
+   local.set $9
+   local.get $9
    i32.load
-   local.set $3
+   local.set $10
    i32.const 1
    drop
-   local.get $3
+   local.get $10
    i32.const 1
    i32.and
    i32.eqz
@@ -385,7 +408,7 @@
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $3
+   local.get $10
    i32.const 3
    i32.const -1
    i32.xor
@@ -398,23 +421,23 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $7
+   local.set $11
+   local.get $11
    i32.const 1073741808
    i32.lt_u
    if
     local.get $0
-    local.get $6
+    local.get $9
     call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
+    local.get $9
+    local.get $10
     i32.const 3
     i32.and
-    local.get $7
+    local.get $11
     i32.or
     local.tee $2
     i32.store
-    local.get $6
+    local.get $9
     local.set $1
    end
   end
@@ -428,14 +451,14 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $12
   i32.const 1
   drop
-  local.get $8
+  local.get $12
   i32.const 16
   i32.ge_u
   if (result i32)
-   local.get $8
+   local.get $12
    i32.const 1073741808
    i32.lt_u
   else
@@ -455,7 +478,7 @@
   local.get $1
   i32.const 16
   i32.add
-  local.get $8
+  local.get $12
   i32.add
   local.get $4
   i32.eq
@@ -473,24 +496,24 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $12
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $13
+   local.get $12
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $14
   else
    i32.const 31
-   local.get $8
+   local.get $12
    i32.clz
    i32.sub
-   local.set $9
-   local.get $8
-   local.get $9
+   local.set $13
+   local.get $12
+   local.get $13
    i32.const 4
    i32.sub
    i32.shr_u
@@ -498,21 +521,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $14
+   local.get $13
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $13
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $13
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $14
    i32.const 16
    i32.lt_u
   else
@@ -528,86 +551,86 @@
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
-  local.set $6
-  local.get $7
-  local.get $3
+  local.set $17
+  local.get $13
+  local.set $16
+  local.get $14
+  local.set $15
+  local.get $17
+  local.get $16
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $15
   i32.add
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=96
-  local.set $11
+  local.set $18
   local.get $1
   i32.const 0
   i32.store offset=16
   local.get $1
-  local.get $11
+  local.get $18
   i32.store offset=20
-  local.get $11
+  local.get $18
   if
-   local.get $11
+   local.get $18
    local.get $1
    i32.store offset=16
   end
   local.get $0
-  local.set $12
-  local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
+  local.set $22
+  local.get $13
+  local.set $21
+  local.get $14
+  local.set $20
   local.get $1
-  local.set $6
-  local.get $12
-  local.get $7
+  local.set $19
+  local.get $22
+  local.get $21
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $20
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $19
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $13
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.set $13
-  local.get $9
-  local.set $12
+  local.set $27
+  local.get $13
+  local.set $26
   local.get $0
-  local.set $3
-  local.get $9
-  local.set $6
-  local.get $3
-  local.get $6
+  local.set $24
+  local.get $13
+  local.set $23
+  local.get $24
+  local.get $23
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $14
   i32.shl
   i32.or
-  local.set $7
-  local.get $13
-  local.get $12
+  local.set $25
+  local.get $27
+  local.get $26
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $25
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -618,6 +641,7 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
   i32.const 1
   drop
   local.get $1
@@ -757,11 +781,11 @@
   i32.or
   i32.store
   local.get $0
-  local.set $9
+  local.set $10
   local.get $4
-  local.set $3
+  local.set $9
+  local.get $10
   local.get $9
-  local.get $3
   i32.store offset=1568
   local.get $0
   local.get $8
@@ -781,6 +805,12 @@
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
   global.get $~lib/rt/tlsf/ROOT
   local.set $0
   local.get $0
@@ -837,66 +867,66 @@
    local.get $4
    i32.store offset=1568
    i32.const 0
-   local.set $5
+   local.set $6
    loop $for-loop|0
-    local.get $5
+    local.get $6
     i32.const 23
     i32.lt_u
-    local.set $4
-    local.get $4
+    local.set $7
+    local.get $7
     if
      local.get $0
-     local.set $8
-     local.get $5
-     local.set $7
+     local.set $10
+     local.get $6
+     local.set $9
      i32.const 0
-     local.set $6
-     local.get $8
-     local.get $7
+     local.set $8
+     local.get $10
+     local.get $9
      i32.const 2
      i32.shl
      i32.add
-     local.get $6
+     local.get $8
      i32.store offset=4
      i32.const 0
-     local.set $8
+     local.set $11
      loop $for-loop|1
-      local.get $8
+      local.get $11
       i32.const 16
       i32.lt_u
-      local.set $7
-      local.get $7
+      local.set $12
+      local.get $12
       if
        local.get $0
-       local.set $11
-       local.get $5
-       local.set $10
-       local.get $8
-       local.set $9
-       i32.const 0
-       local.set $6
+       local.set $16
+       local.get $6
+       local.set $15
        local.get $11
-       local.get $10
+       local.set $14
+       i32.const 0
+       local.set $13
+       local.get $16
+       local.get $15
        i32.const 4
        i32.shl
-       local.get $9
+       local.get $14
        i32.add
        i32.const 2
        i32.shl
        i32.add
-       local.get $6
+       local.get $13
        i32.store offset=96
-       local.get $8
+       local.get $11
        i32.const 1
        i32.add
-       local.set $8
+       local.set $11
        br $for-loop|1
       end
      end
-     local.get $5
+     local.get $6
      i32.const 1
      i32.add
-     local.set $5
+     local.set $6
      br $for-loop|0
     end
    end
@@ -909,11 +939,11 @@
    i32.const -1
    i32.xor
    i32.and
-   local.set $5
+   local.set $17
    i32.const 0
    drop
    local.get $0
-   local.get $5
+   local.get $17
    memory.size
    i32.const 16
    i32.shl
@@ -962,6 +992,14 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
   local.get $1
   i32.const 256
   i32.lt_u
@@ -1035,11 +1073,11 @@
    unreachable
   end
   local.get $0
-  local.set $5
+  local.set $6
   local.get $2
-  local.set $4
+  local.set $5
+  local.get $6
   local.get $5
-  local.get $4
   i32.const 2
   i32.shl
   i32.add
@@ -1050,10 +1088,10 @@
   local.get $3
   i32.shl
   i32.and
-  local.set $6
-  i32.const 0
   local.set $7
-  local.get $6
+  i32.const 0
+  local.set $8
+  local.get $7
   i32.eqz
   if
    local.get $0
@@ -1066,30 +1104,30 @@
    i32.add
    i32.shl
    i32.and
-   local.set $5
-   local.get $5
+   local.set $9
+   local.get $9
    i32.eqz
    if
     i32.const 0
-    local.set $7
+    local.set $8
    else
-    local.get $5
+    local.get $9
     i32.ctz
     local.set $2
     local.get $0
-    local.set $8
+    local.set $11
     local.get $2
-    local.set $4
-    local.get $8
-    local.get $4
+    local.set $10
+    local.get $11
+    local.get $10
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $6
+    local.set $7
     i32.const 1
     drop
-    local.get $6
+    local.get $7
     i32.eqz
     if
      i32.const 0
@@ -1100,45 +1138,45 @@
      unreachable
     end
     local.get $0
-    local.set $9
+    local.set $14
     local.get $2
-    local.set $8
-    local.get $6
+    local.set $13
+    local.get $7
     i32.ctz
-    local.set $4
-    local.get $9
-    local.get $8
+    local.set $12
+    local.get $14
+    local.get $13
     i32.const 4
     i32.shl
-    local.get $4
+    local.get $12
     i32.add
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=96
-    local.set $7
+    local.set $8
    end
   else
    local.get $0
-   local.set $9
+   local.set $17
    local.get $2
-   local.set $8
-   local.get $6
+   local.set $16
+   local.get $7
    i32.ctz
-   local.set $4
-   local.get $9
-   local.get $8
+   local.set $15
+   local.get $17
+   local.get $16
    i32.const 4
    i32.shl
-   local.get $4
+   local.get $15
    i32.add
    i32.const 2
    i32.shl
    i32.add
    i32.load offset=96
-   local.set $7
+   local.set $8
   end
-  local.get $7
+  local.get $8
  )
  (func $~lib/rt/tlsf/growMemory (param $0 i32) (param $1 i32)
   (local $2 i32)
@@ -1147,6 +1185,7 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
   i32.const 0
   drop
   local.get $1
@@ -1193,15 +1232,15 @@
   i32.shr_u
   local.set $4
   local.get $2
-  local.tee $3
-  local.get $4
   local.tee $5
-  local.get $3
+  local.get $4
+  local.tee $6
   local.get $5
+  local.get $6
   i32.gt_s
   select
-  local.set $6
-  local.get $6
+  local.set $7
+  local.get $7
   memory.grow
   i32.const 0
   i32.lt_s
@@ -1215,12 +1254,12 @@
    end
   end
   memory.size
-  local.set $7
+  local.set $8
   local.get $0
   local.get $2
   i32.const 16
   i32.shl
-  local.get $7
+  local.get $8
   i32.const 16
   i32.shl
   call $~lib/rt/tlsf/addMemory
@@ -1230,6 +1269,8 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
   local.get $1
   i32.load
   local.set $3
@@ -1294,11 +1335,11 @@
    i32.and
    i32.store
    local.get $1
-   local.set $5
-   local.get $5
+   local.set $7
+   local.get $7
    i32.const 16
    i32.add
-   local.get $5
+   local.get $7
    i32.load
    i32.const 3
    i32.const -1
@@ -1306,11 +1347,11 @@
    i32.and
    i32.add
    local.get $1
-   local.set $5
-   local.get $5
+   local.set $6
+   local.get $6
    i32.const 16
    i32.add
-   local.get $5
+   local.get $6
    i32.load
    i32.const 3
    i32.const -1

--- a/tests/compiler/rt/instanceof.untouched.wat
+++ b/tests/compiler/rt/instanceof.untouched.wat
@@ -31,6 +31,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   memory.size
   local.set $1
   local.get $1
@@ -61,8 +62,8 @@
    local.get $5
    i32.gt_s
    select
-   local.set $4
-   local.get $4
+   local.set $6
+   local.get $6
    memory.grow
    i32.const 0
    i32.lt_s
@@ -221,6 +222,23 @@
  )
  (func $start:rt/instanceof
   (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
   global.get $~lib/heap/__heap_base
   i32.const 15
   i32.add
@@ -263,12 +281,12 @@
    unreachable
   end
   global.get $rt/instanceof/animal
-  local.tee $0
+  local.tee $1
   i32.eqz
   if (result i32)
    i32.const 0
   else
-   local.get $0
+   local.get $1
    i32.const 5
    call $~lib/rt/__instanceof
   end
@@ -285,12 +303,12 @@
   i32.const 1
   drop
   global.get $rt/instanceof/cat
-  local.tee $0
+  local.tee $2
   i32.eqz
   if (result i32)
    i32.const 0
   else
-   local.get $0
+   local.get $2
    i32.const 4
    call $~lib/rt/__instanceof
   end
@@ -304,12 +322,12 @@
    unreachable
   end
   global.get $rt/instanceof/cat
-  local.tee $0
+  local.tee $3
   i32.eqz
   if (result i32)
    i32.const 0
   else
-   local.get $0
+   local.get $3
    i32.const 5
    call $~lib/rt/__instanceof
   end
@@ -326,12 +344,12 @@
   i32.const 1
   drop
   global.get $rt/instanceof/blackcat
-  local.tee $0
+  local.tee $4
   i32.eqz
   if (result i32)
    i32.const 0
   else
-   local.get $0
+   local.get $4
    i32.const 4
    call $~lib/rt/__instanceof
   end
@@ -345,12 +363,12 @@
    unreachable
   end
   global.get $rt/instanceof/blackcat
-  local.tee $0
+  local.tee $5
   i32.eqz
   if (result i32)
    i32.const 0
   else
-   local.get $0
+   local.get $5
    i32.const 5
    call $~lib/rt/__instanceof
   end
@@ -385,12 +403,12 @@
    unreachable
   end
   global.get $rt/instanceof/nullableAnimal
-  local.tee $0
+  local.tee $6
   i32.eqz
   if (result i32)
    i32.const 0
   else
-   local.get $0
+   local.get $6
    i32.const 4
    call $~lib/rt/__instanceof
   end
@@ -405,12 +423,12 @@
    unreachable
   end
   global.get $rt/instanceof/nullableAnimal
-  local.tee $0
+  local.tee $7
   i32.eqz
   if (result i32)
    i32.const 0
   else
-   local.get $0
+   local.get $7
    i32.const 5
    call $~lib/rt/__instanceof
   end
@@ -437,12 +455,12 @@
    unreachable
   end
   global.get $rt/instanceof/nullableCat
-  local.tee $0
+  local.tee $8
   i32.eqz
   if (result i32)
    i32.const 0
   else
-   local.get $0
+   local.get $8
    i32.const 4
    call $~lib/rt/__instanceof
   end
@@ -456,12 +474,12 @@
    unreachable
   end
   global.get $rt/instanceof/nullableCat
-  local.tee $0
+  local.tee $9
   i32.eqz
   if (result i32)
    i32.const 0
   else
-   local.get $0
+   local.get $9
    i32.const 5
    call $~lib/rt/__instanceof
   end
@@ -488,12 +506,12 @@
    unreachable
   end
   global.get $rt/instanceof/nullableBlackcat
-  local.tee $0
+  local.tee $10
   i32.eqz
   if (result i32)
    i32.const 0
   else
-   local.get $0
+   local.get $10
    i32.const 4
    call $~lib/rt/__instanceof
   end
@@ -507,12 +525,12 @@
    unreachable
   end
   global.get $rt/instanceof/nullableBlackcat
-  local.tee $0
+  local.tee $11
   i32.eqz
   if (result i32)
    i32.const 0
   else
-   local.get $0
+   local.get $11
    i32.const 5
    call $~lib/rt/__instanceof
   end
@@ -539,12 +557,12 @@
    unreachable
   end
   global.get $rt/instanceof/nullAnimal
-  local.tee $0
+  local.tee $12
   i32.eqz
   if (result i32)
    i32.const 0
   else
-   local.get $0
+   local.get $12
    i32.const 4
    call $~lib/rt/__instanceof
   end
@@ -559,12 +577,12 @@
    unreachable
   end
   global.get $rt/instanceof/nullAnimal
-  local.tee $0
+  local.tee $13
   i32.eqz
   if (result i32)
    i32.const 0
   else
-   local.get $0
+   local.get $13
    i32.const 5
    call $~lib/rt/__instanceof
   end
@@ -592,12 +610,12 @@
    unreachable
   end
   global.get $rt/instanceof/nullCat
-  local.tee $0
+  local.tee $14
   i32.eqz
   if (result i32)
    i32.const 0
   else
-   local.get $0
+   local.get $14
    i32.const 4
    call $~lib/rt/__instanceof
   end
@@ -612,12 +630,12 @@
    unreachable
   end
   global.get $rt/instanceof/nullCat
-  local.tee $0
+  local.tee $15
   i32.eqz
   if (result i32)
    i32.const 0
   else
-   local.get $0
+   local.get $15
    i32.const 5
    call $~lib/rt/__instanceof
   end
@@ -645,12 +663,12 @@
    unreachable
   end
   global.get $rt/instanceof/nullBlackcat
-  local.tee $0
+  local.tee $16
   i32.eqz
   if (result i32)
    i32.const 0
   else
-   local.get $0
+   local.get $16
    i32.const 4
    call $~lib/rt/__instanceof
   end
@@ -665,12 +683,12 @@
    unreachable
   end
   global.get $rt/instanceof/nullBlackcat
-  local.tee $0
+  local.tee $17
   i32.eqz
   if (result i32)
    i32.const 0
   else
-   local.get $0
+   local.get $17
    i32.const 5
    call $~lib/rt/__instanceof
   end

--- a/tests/compiler/rt/stub-realloc.untouched.wat
+++ b/tests/compiler/rt/stub-realloc.untouched.wat
@@ -34,6 +34,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   memory.size
   local.set $1
   local.get $1
@@ -64,8 +65,8 @@
    local.get $5
    i32.gt_s
    select
-   local.set $4
-   local.get $4
+   local.set $6
+   local.get $6
    memory.grow
    i32.const 0
    i32.lt_s
@@ -155,6 +156,88 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local $22 i32)
+  (local $23 i32)
+  (local $24 i32)
+  (local $25 i32)
+  (local $26 i32)
+  (local $27 i32)
+  (local $28 i32)
+  (local $29 i32)
+  (local $30 i32)
+  (local $31 i32)
+  (local $32 i32)
+  (local $33 i32)
+  (local $34 i32)
+  (local $35 i32)
+  (local $36 i32)
+  (local $37 i32)
+  (local $38 i32)
+  (local $39 i32)
+  (local $40 i32)
+  (local $41 i32)
+  (local $42 i32)
+  (local $43 i32)
+  (local $44 i32)
+  (local $45 i32)
+  (local $46 i32)
+  (local $47 i32)
+  (local $48 i32)
+  (local $49 i32)
+  (local $50 i32)
+  (local $51 i32)
+  (local $52 i32)
+  (local $53 i32)
+  (local $54 i32)
+  (local $55 i32)
+  (local $56 i32)
+  (local $57 i32)
+  (local $58 i32)
+  (local $59 i32)
+  (local $60 i32)
+  (local $61 i32)
+  (local $62 i32)
+  (local $63 i32)
+  (local $64 i32)
+  (local $65 i32)
+  (local $66 i32)
+  (local $67 i32)
+  (local $68 i32)
+  (local $69 i32)
+  (local $70 i32)
+  (local $71 i32)
+  (local $72 i32)
+  (local $73 i32)
+  (local $74 i32)
+  (local $75 i32)
+  (local $76 i32)
+  (local $77 i32)
+  (local $78 i32)
+  (local $79 i32)
+  (local $80 i32)
+  (local $81 i32)
+  (local $82 i32)
+  (local $83 i32)
+  (local $84 i32)
+  (local $85 i32)
+  (local $86 i32)
+  (local $87 i32)
+  (local $88 i32)
   loop $while-continue|0
    local.get $2
    if (result i32)
@@ -174,11 +257,11 @@
     local.set $0
     local.get $6
     local.get $1
-    local.tee $6
+    local.tee $7
     i32.const 1
     i32.add
     local.set $1
-    local.get $6
+    local.get $7
     i32.load8_u
     i32.store8
     local.get $2
@@ -198,8 +281,8 @@
     local.get $2
     i32.const 16
     i32.ge_u
-    local.set $5
-    local.get $5
+    local.set $8
+    local.get $8
     if
      local.get $0
      local.get $1
@@ -308,17 +391,17 @@
    i32.and
    if
     local.get $0
-    local.tee $5
+    local.tee $9
     i32.const 1
     i32.add
     local.set $0
-    local.get $5
+    local.get $9
     local.get $1
-    local.tee $5
+    local.tee $10
     i32.const 1
     i32.add
     local.set $1
-    local.get $5
+    local.get $10
     i32.load8_u
     i32.store8
    end
@@ -335,16 +418,16 @@
        local.get $0
        i32.const 3
        i32.and
-       local.set $5
-       local.get $5
+       local.set $11
+       local.get $11
        i32.const 1
        i32.eq
        br_if $case0|2
-       local.get $5
+       local.get $11
        i32.const 2
        i32.eq
        br_if $case1|2
-       local.get $5
+       local.get $11
        i32.const 3
        i32.eq
        br_if $case2|2
@@ -354,45 +437,45 @@
       i32.load
       local.set $3
       local.get $0
-      local.tee $5
+      local.tee $12
       i32.const 1
       i32.add
       local.set $0
-      local.get $5
+      local.get $12
       local.get $1
-      local.tee $5
+      local.tee $13
       i32.const 1
       i32.add
       local.set $1
-      local.get $5
+      local.get $13
       i32.load8_u
       i32.store8
       local.get $0
-      local.tee $5
+      local.tee $14
       i32.const 1
       i32.add
       local.set $0
-      local.get $5
+      local.get $14
       local.get $1
-      local.tee $5
+      local.tee $15
       i32.const 1
       i32.add
       local.set $1
-      local.get $5
+      local.get $15
       i32.load8_u
       i32.store8
       local.get $0
-      local.tee $5
+      local.tee $16
       i32.const 1
       i32.add
       local.set $0
-      local.get $5
+      local.get $16
       local.get $1
-      local.tee $5
+      local.tee $17
       i32.const 1
       i32.add
       local.set $1
-      local.get $5
+      local.get $17
       i32.load8_u
       i32.store8
       local.get $2
@@ -403,8 +486,8 @@
        local.get $2
        i32.const 17
        i32.ge_u
-       local.set $5
-       local.get $5
+       local.set $18
+       local.get $18
        if
         local.get $1
         i32.const 1
@@ -489,31 +572,31 @@
      i32.load
      local.set $3
      local.get $0
-     local.tee $5
+     local.tee $19
      i32.const 1
      i32.add
      local.set $0
-     local.get $5
+     local.get $19
      local.get $1
-     local.tee $5
+     local.tee $20
      i32.const 1
      i32.add
      local.set $1
-     local.get $5
+     local.get $20
      i32.load8_u
      i32.store8
      local.get $0
-     local.tee $5
+     local.tee $21
      i32.const 1
      i32.add
      local.set $0
-     local.get $5
+     local.get $21
      local.get $1
-     local.tee $5
+     local.tee $22
      i32.const 1
      i32.add
      local.set $1
-     local.get $5
+     local.get $22
      i32.load8_u
      i32.store8
      local.get $2
@@ -524,8 +607,8 @@
       local.get $2
       i32.const 18
       i32.ge_u
-      local.set $5
-      local.get $5
+      local.set $23
+      local.get $23
       if
        local.get $1
        i32.const 2
@@ -610,17 +693,17 @@
     i32.load
     local.set $3
     local.get $0
-    local.tee $5
+    local.tee $24
     i32.const 1
     i32.add
     local.set $0
-    local.get $5
+    local.get $24
     local.get $1
-    local.tee $5
+    local.tee $25
     i32.const 1
     i32.add
     local.set $1
-    local.get $5
+    local.get $25
     i32.load8_u
     i32.store8
     local.get $2
@@ -631,8 +714,8 @@
      local.get $2
      i32.const 19
      i32.ge_u
-     local.set $5
-     local.get $5
+     local.set $26
+     local.get $26
      if
       local.get $1
       i32.const 3
@@ -719,227 +802,227 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $27
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $27
    local.get $1
-   local.tee $5
+   local.tee $28
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $28
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $29
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $29
    local.get $1
-   local.tee $5
+   local.tee $30
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $30
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $31
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $31
    local.get $1
-   local.tee $5
+   local.tee $32
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $32
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $33
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $33
    local.get $1
-   local.tee $5
+   local.tee $34
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $34
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $35
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $35
    local.get $1
-   local.tee $5
+   local.tee $36
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $36
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $37
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $37
    local.get $1
-   local.tee $5
+   local.tee $38
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $38
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $39
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $39
    local.get $1
-   local.tee $5
+   local.tee $40
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $40
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $41
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $41
    local.get $1
-   local.tee $5
+   local.tee $42
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $42
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $43
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $43
    local.get $1
-   local.tee $5
+   local.tee $44
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $44
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $45
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $45
    local.get $1
-   local.tee $5
+   local.tee $46
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $46
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $47
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $47
    local.get $1
-   local.tee $5
+   local.tee $48
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $48
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $49
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $49
    local.get $1
-   local.tee $5
+   local.tee $50
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $50
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $51
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $51
    local.get $1
-   local.tee $5
+   local.tee $52
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $52
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $53
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $53
    local.get $1
-   local.tee $5
+   local.tee $54
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $54
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $55
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $55
    local.get $1
-   local.tee $5
+   local.tee $56
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $56
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $57
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $57
    local.get $1
-   local.tee $5
+   local.tee $58
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $58
    i32.load8_u
    i32.store8
   end
@@ -948,115 +1031,115 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $59
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $59
    local.get $1
-   local.tee $5
+   local.tee $60
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $60
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $61
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $61
    local.get $1
-   local.tee $5
+   local.tee $62
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $62
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $63
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $63
    local.get $1
-   local.tee $5
+   local.tee $64
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $64
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $65
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $65
    local.get $1
-   local.tee $5
+   local.tee $66
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $66
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $67
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $67
    local.get $1
-   local.tee $5
+   local.tee $68
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $68
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $69
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $69
    local.get $1
-   local.tee $5
+   local.tee $70
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $70
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $71
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $71
    local.get $1
-   local.tee $5
+   local.tee $72
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $72
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $73
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $73
    local.get $1
-   local.tee $5
+   local.tee $74
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $74
    i32.load8_u
    i32.store8
   end
@@ -1065,59 +1148,59 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $75
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $75
    local.get $1
-   local.tee $5
+   local.tee $76
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $76
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $77
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $77
    local.get $1
-   local.tee $5
+   local.tee $78
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $78
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $79
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $79
    local.get $1
-   local.tee $5
+   local.tee $80
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $80
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $81
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $81
    local.get $1
-   local.tee $5
+   local.tee $82
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $82
    i32.load8_u
    i32.store8
   end
@@ -1126,31 +1209,31 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $83
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $83
    local.get $1
-   local.tee $5
+   local.tee $84
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $84
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $85
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $85
    local.get $1
-   local.tee $5
+   local.tee $86
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $86
    i32.load8_u
    i32.store8
   end
@@ -1159,17 +1242,17 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $87
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $87
    local.get $1
-   local.tee $5
+   local.tee $88
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $88
    i32.load8_u
    i32.store8
   end
@@ -1180,6 +1263,14 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
   block $~lib/util/memory/memmove|inlined.0
    local.get $0
    local.set $5
@@ -1257,11 +1348,11 @@
        local.set $5
        local.get $7
        local.get $4
-       local.tee $7
+       local.tee $8
        i32.const 1
        i32.add
        local.set $4
-       local.get $7
+       local.get $8
        i32.load8_u
        i32.store8
        br $while-continue|0
@@ -1271,8 +1362,8 @@
       local.get $3
       i32.const 8
       i32.ge_u
-      local.set $6
-      local.get $6
+      local.set $9
+      local.get $9
       if
        local.get $5
        local.get $4
@@ -1296,21 +1387,21 @@
     end
     loop $while-continue|2
      local.get $3
-     local.set $6
-     local.get $6
+     local.set $10
+     local.get $10
      if
       local.get $5
-      local.tee $7
+      local.tee $11
       i32.const 1
       i32.add
       local.set $5
-      local.get $7
+      local.get $11
       local.get $4
-      local.tee $7
+      local.tee $12
       i32.const 1
       i32.add
       local.set $4
-      local.get $7
+      local.get $12
       i32.load8_u
       i32.store8
       local.get $3
@@ -1339,8 +1430,8 @@
       i32.add
       i32.const 7
       i32.and
-      local.set $6
-      local.get $6
+      local.set $13
+      local.get $13
       if
        local.get $3
        i32.eqz
@@ -1365,8 +1456,8 @@
       local.get $3
       i32.const 8
       i32.ge_u
-      local.set $6
-      local.get $6
+      local.set $14
+      local.get $14
       if
        local.get $3
        i32.const 8
@@ -1386,8 +1477,8 @@
     end
     loop $while-continue|5
      local.get $3
-     local.set $6
-     local.get $6
+     local.set $15
+     local.get $15
      if
       local.get $5
       local.get $3
@@ -1413,6 +1504,7 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
   local.get $0
   i32.const 0
   i32.ne
@@ -1502,13 +1594,13 @@
     local.get $2
     i32.load offset=8
     call $~lib/rt/stub/__alloc
-    local.set $6
-    local.get $6
+    local.set $8
+    local.get $8
     local.get $0
     local.get $2
     i32.load offset=12
     call $~lib/memory/memory.copy
-    local.get $6
+    local.get $8
     local.tee $0
     i32.const 16
     i32.sub

--- a/tests/compiler/runtime-full.untouched.wat
+++ b/tests/compiler/runtime-full.untouched.wat
@@ -38,6 +38,15 @@
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
   local.get $1
   i32.load
   local.set $2
@@ -174,59 +183,59 @@
   i32.eq
   if
    local.get $0
-   local.set $11
+   local.set $14
    local.get $4
-   local.set $10
+   local.set $13
    local.get $5
-   local.set $9
+   local.set $12
    local.get $7
-   local.set $8
-   local.get $11
-   local.get $10
+   local.set $11
+   local.get $14
+   local.get $13
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $12
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
+   local.get $11
    i32.store offset=96
    local.get $7
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $16
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $15
+    local.get $16
+    local.get $15
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $17
     local.get $0
-    local.set $8
+    local.set $20
     local.get $4
-    local.set $11
-    local.get $9
+    local.set $19
+    local.get $17
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
-    local.set $10
-    local.get $8
-    local.get $11
+    local.tee $17
+    local.set $18
+    local.get $20
+    local.get $19
     i32.const 2
     i32.shl
     i32.add
-    local.get $10
+    local.get $18
     i32.store offset=4
-    local.get $9
+    local.get $17
     i32.eqz
     if
      local.get $0
@@ -256,6 +265,20 @@
   (local $11 i32)
   (local $12 i32)
   (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local $22 i32)
+  (local $23 i32)
+  (local $24 i32)
+  (local $25 i32)
+  (local $26 i32)
+  (local $27 i32)
   i32.const 1
   drop
   local.get $1
@@ -318,8 +341,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $3
+   local.set $6
+   local.get $6
    i32.const 1073741808
    i32.lt_u
    if
@@ -330,16 +353,16 @@
     local.get $2
     i32.const 3
     i32.and
-    local.get $3
+    local.get $6
     i32.or
     local.tee $2
     i32.store
     local.get $1
-    local.set $6
-    local.get $6
+    local.set $7
+    local.get $7
     i32.const 16
     i32.add
-    local.get $6
+    local.get $7
     i32.load
     i32.const 3
     i32.const -1
@@ -357,18 +380,18 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $8
+   local.get $8
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
+   local.set $9
+   local.get $9
    i32.load
-   local.set $3
+   local.set $10
    i32.const 1
    drop
-   local.get $3
+   local.get $10
    i32.const 1
    i32.and
    i32.eqz
@@ -380,7 +403,7 @@
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $3
+   local.get $10
    i32.const 3
    i32.const -1
    i32.xor
@@ -393,23 +416,23 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $7
+   local.set $11
+   local.get $11
    i32.const 1073741808
    i32.lt_u
    if
     local.get $0
-    local.get $6
+    local.get $9
     call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
+    local.get $9
+    local.get $10
     i32.const 3
     i32.and
-    local.get $7
+    local.get $11
     i32.or
     local.tee $2
     i32.store
-    local.get $6
+    local.get $9
     local.set $1
    end
   end
@@ -423,14 +446,14 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $12
   i32.const 1
   drop
-  local.get $8
+  local.get $12
   i32.const 16
   i32.ge_u
   if (result i32)
-   local.get $8
+   local.get $12
    i32.const 1073741808
    i32.lt_u
   else
@@ -450,7 +473,7 @@
   local.get $1
   i32.const 16
   i32.add
-  local.get $8
+  local.get $12
   i32.add
   local.get $4
   i32.eq
@@ -468,24 +491,24 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $12
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $13
+   local.get $12
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $14
   else
    i32.const 31
-   local.get $8
+   local.get $12
    i32.clz
    i32.sub
-   local.set $9
-   local.get $8
-   local.get $9
+   local.set $13
+   local.get $12
+   local.get $13
    i32.const 4
    i32.sub
    i32.shr_u
@@ -493,21 +516,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $14
+   local.get $13
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $13
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $13
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $14
    i32.const 16
    i32.lt_u
   else
@@ -523,86 +546,86 @@
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
-  local.set $6
-  local.get $7
-  local.get $3
+  local.set $17
+  local.get $13
+  local.set $16
+  local.get $14
+  local.set $15
+  local.get $17
+  local.get $16
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $15
   i32.add
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=96
-  local.set $11
+  local.set $18
   local.get $1
   i32.const 0
   i32.store offset=16
   local.get $1
-  local.get $11
+  local.get $18
   i32.store offset=20
-  local.get $11
+  local.get $18
   if
-   local.get $11
+   local.get $18
    local.get $1
    i32.store offset=16
   end
   local.get $0
-  local.set $12
-  local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
+  local.set $22
+  local.get $13
+  local.set $21
+  local.get $14
+  local.set $20
   local.get $1
-  local.set $6
-  local.get $12
-  local.get $7
+  local.set $19
+  local.get $22
+  local.get $21
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $20
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $19
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $13
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.set $13
-  local.get $9
-  local.set $12
+  local.set $27
+  local.get $13
+  local.set $26
   local.get $0
-  local.set $3
-  local.get $9
-  local.set $6
-  local.get $3
-  local.get $6
+  local.set $24
+  local.get $13
+  local.set $23
+  local.get $24
+  local.get $23
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $14
   i32.shl
   i32.or
-  local.set $7
-  local.get $13
-  local.get $12
+  local.set $25
+  local.get $27
+  local.get $26
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $25
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -613,6 +636,7 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
   i32.const 1
   drop
   local.get $1
@@ -752,11 +776,11 @@
   i32.or
   i32.store
   local.get $0
-  local.set $9
+  local.set $10
   local.get $4
-  local.set $3
+  local.set $9
+  local.get $10
   local.get $9
-  local.get $3
   i32.store offset=1568
   local.get $0
   local.get $8
@@ -776,6 +800,12 @@
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
   global.get $~lib/rt/tlsf/ROOT
   local.set $0
   local.get $0
@@ -832,66 +862,66 @@
    local.get $4
    i32.store offset=1568
    i32.const 0
-   local.set $5
+   local.set $6
    loop $for-loop|0
-    local.get $5
+    local.get $6
     i32.const 23
     i32.lt_u
-    local.set $4
-    local.get $4
+    local.set $7
+    local.get $7
     if
      local.get $0
-     local.set $8
-     local.get $5
-     local.set $7
+     local.set $10
+     local.get $6
+     local.set $9
      i32.const 0
-     local.set $6
-     local.get $8
-     local.get $7
+     local.set $8
+     local.get $10
+     local.get $9
      i32.const 2
      i32.shl
      i32.add
-     local.get $6
+     local.get $8
      i32.store offset=4
      i32.const 0
-     local.set $8
+     local.set $11
      loop $for-loop|1
-      local.get $8
+      local.get $11
       i32.const 16
       i32.lt_u
-      local.set $7
-      local.get $7
+      local.set $12
+      local.get $12
       if
        local.get $0
-       local.set $11
-       local.get $5
-       local.set $10
-       local.get $8
-       local.set $9
-       i32.const 0
-       local.set $6
+       local.set $16
+       local.get $6
+       local.set $15
        local.get $11
-       local.get $10
+       local.set $14
+       i32.const 0
+       local.set $13
+       local.get $16
+       local.get $15
        i32.const 4
        i32.shl
-       local.get $9
+       local.get $14
        i32.add
        i32.const 2
        i32.shl
        i32.add
-       local.get $6
+       local.get $13
        i32.store offset=96
-       local.get $8
+       local.get $11
        i32.const 1
        i32.add
-       local.set $8
+       local.set $11
        br $for-loop|1
       end
      end
-     local.get $5
+     local.get $6
      i32.const 1
      i32.add
-     local.set $5
+     local.set $6
      br $for-loop|0
     end
    end
@@ -904,11 +934,11 @@
    i32.const -1
    i32.xor
    i32.and
-   local.set $5
+   local.set $17
    i32.const 0
    drop
    local.get $0
-   local.get $5
+   local.get $17
    memory.size
    i32.const 16
    i32.shl
@@ -957,6 +987,14 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
   local.get $1
   i32.const 256
   i32.lt_u
@@ -1030,11 +1068,11 @@
    unreachable
   end
   local.get $0
-  local.set $5
+  local.set $6
   local.get $2
-  local.set $4
+  local.set $5
+  local.get $6
   local.get $5
-  local.get $4
   i32.const 2
   i32.shl
   i32.add
@@ -1045,10 +1083,10 @@
   local.get $3
   i32.shl
   i32.and
-  local.set $6
-  i32.const 0
   local.set $7
-  local.get $6
+  i32.const 0
+  local.set $8
+  local.get $7
   i32.eqz
   if
    local.get $0
@@ -1061,30 +1099,30 @@
    i32.add
    i32.shl
    i32.and
-   local.set $5
-   local.get $5
+   local.set $9
+   local.get $9
    i32.eqz
    if
     i32.const 0
-    local.set $7
+    local.set $8
    else
-    local.get $5
+    local.get $9
     i32.ctz
     local.set $2
     local.get $0
-    local.set $8
+    local.set $11
     local.get $2
-    local.set $4
-    local.get $8
-    local.get $4
+    local.set $10
+    local.get $11
+    local.get $10
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $6
+    local.set $7
     i32.const 1
     drop
-    local.get $6
+    local.get $7
     i32.eqz
     if
      i32.const 0
@@ -1095,45 +1133,45 @@
      unreachable
     end
     local.get $0
-    local.set $9
+    local.set $14
     local.get $2
-    local.set $8
-    local.get $6
+    local.set $13
+    local.get $7
     i32.ctz
-    local.set $4
-    local.get $9
-    local.get $8
+    local.set $12
+    local.get $14
+    local.get $13
     i32.const 4
     i32.shl
-    local.get $4
+    local.get $12
     i32.add
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=96
-    local.set $7
+    local.set $8
    end
   else
    local.get $0
-   local.set $9
+   local.set $17
    local.get $2
-   local.set $8
-   local.get $6
+   local.set $16
+   local.get $7
    i32.ctz
-   local.set $4
-   local.get $9
-   local.get $8
+   local.set $15
+   local.get $17
+   local.get $16
    i32.const 4
    i32.shl
-   local.get $4
+   local.get $15
    i32.add
    i32.const 2
    i32.shl
    i32.add
    i32.load offset=96
-   local.set $7
+   local.set $8
   end
-  local.get $7
+  local.get $8
  )
  (func $~lib/rt/tlsf/growMemory (param $0 i32) (param $1 i32)
   (local $2 i32)
@@ -1142,6 +1180,7 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
   i32.const 0
   drop
   local.get $1
@@ -1188,15 +1227,15 @@
   i32.shr_u
   local.set $4
   local.get $2
-  local.tee $3
-  local.get $4
   local.tee $5
-  local.get $3
+  local.get $4
+  local.tee $6
   local.get $5
+  local.get $6
   i32.gt_s
   select
-  local.set $6
-  local.get $6
+  local.set $7
+  local.get $7
   memory.grow
   i32.const 0
   i32.lt_s
@@ -1210,12 +1249,12 @@
    end
   end
   memory.size
-  local.set $7
+  local.set $8
   local.get $0
   local.get $2
   i32.const 16
   i32.shl
-  local.get $7
+  local.get $8
   i32.const 16
   i32.shl
   call $~lib/rt/tlsf/addMemory
@@ -1225,6 +1264,8 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
   local.get $1
   i32.load
   local.set $3
@@ -1289,11 +1330,11 @@
    i32.and
    i32.store
    local.get $1
-   local.set $5
-   local.get $5
+   local.set $7
+   local.get $7
    i32.const 16
    i32.add
-   local.get $5
+   local.get $7
    i32.load
    i32.const 3
    i32.const -1
@@ -1301,11 +1342,11 @@
    i32.and
    i32.add
    local.get $1
-   local.set $5
-   local.get $5
+   local.set $6
+   local.get $6
    i32.const 16
    i32.add
-   local.get $5
+   local.get $6
    i32.load
    i32.const 3
    i32.const -1

--- a/tests/compiler/runtime-stub.untouched.wat
+++ b/tests/compiler/runtime-stub.untouched.wat
@@ -24,6 +24,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   memory.size
   local.set $1
   local.get $1
@@ -54,8 +55,8 @@
    local.get $5
    i32.gt_s
    select
-   local.set $4
-   local.get $4
+   local.set $6
+   local.get $6
    memory.grow
    i32.const 0
    i32.lt_s

--- a/tests/compiler/scoped.untouched.wat
+++ b/tests/compiler/scoped.untouched.wat
@@ -10,17 +10,19 @@
  (start $~start)
  (func $scoped/fn (param $0 i32)
   (local $1 i32)
+  (local $2 i32)
   i32.const 0
   local.set $1
   local.get $0
-  local.set $1
+  local.set $2
  )
  (func $start:scoped
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
-  (local $3 i64)
-  (local $4 f32)
+  (local $3 i32)
+  (local $4 i64)
+  (local $5 f32)
   i32.const 0
   local.set $0
   loop $for-loop|0
@@ -39,27 +41,27 @@
    end
   end
   i32.const 0
-  local.set $1
+  local.set $2
   loop $for-loop|1
-   local.get $1
+   local.get $2
    i32.const 1
    i32.lt_s
-   local.set $2
-   local.get $2
+   local.set $3
+   local.get $3
    if
-    local.get $1
+    local.get $2
     drop
-    local.get $1
+    local.get $2
     i32.const 1
     i32.add
-    local.set $1
+    local.set $2
     br $for-loop|1
    end
   end
   i64.const 5
-  local.set $3
-  f32.const 10
   local.set $4
+  f32.const 10
+  local.set $5
   i32.const 42
   call $scoped/fn
  )

--- a/tests/compiler/std/array-access.untouched.wat
+++ b/tests/compiler/std/array-access.untouched.wat
@@ -203,6 +203,9 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
   local.get $0
   call $~lib/rt/stub/__retain
   local.set $0
@@ -274,33 +277,33 @@
   end
   loop $while-continue|1
    local.get $4
-   local.tee $7
+   local.tee $8
    i32.const 1
    i32.sub
    local.set $4
-   local.get $7
-   local.set $7
-   local.get $7
+   local.get $8
+   local.set $9
+   local.get $9
    if
     local.get $5
     i32.load16_u
-    local.set $8
+    local.set $10
     local.get $6
     i32.load16_u
-    local.set $9
-    local.get $8
-    local.get $9
+    local.set $11
+    local.get $10
+    local.get $11
     i32.ne
     if
-     local.get $8
-     local.get $9
+     local.get $10
+     local.get $11
      i32.sub
-     local.set $10
+     local.set $12
      local.get $0
      call $~lib/rt/stub/__release
      local.get $2
      call $~lib/rt/stub/__release
-     local.get $10
+     local.get $12
      return
     end
     local.get $5
@@ -315,12 +318,12 @@
    end
   end
   i32.const 0
-  local.set $7
+  local.set $13
   local.get $0
   call $~lib/rt/stub/__release
   local.get $2
   call $~lib/rt/stub/__release
-  local.get $7
+  local.get $13
  )
  (func $~lib/string/String#startsWith (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
@@ -328,6 +331,12 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
   local.get $1
   call $~lib/rt/stub/__retain
   local.set $1
@@ -354,48 +363,48 @@
   call $~lib/string/String#get:length
   local.set $5
   local.get $2
-  local.tee $3
+  local.tee $6
   i32.const 0
-  local.tee $4
-  local.get $3
-  local.get $4
+  local.tee $7
+  local.get $6
+  local.get $7
   i32.gt_s
   select
-  local.tee $3
+  local.tee $8
   local.get $5
-  local.tee $4
-  local.get $3
-  local.get $4
+  local.tee $9
+  local.get $8
+  local.get $9
   i32.lt_s
   select
-  local.set $6
+  local.set $10
   local.get $1
   call $~lib/string/String#get:length
-  local.set $7
-  local.get $7
-  local.get $6
+  local.set $11
+  local.get $11
+  local.get $10
   i32.add
   local.get $5
   i32.gt_s
   if
    i32.const 0
-   local.set $3
+   local.set $12
    local.get $1
    call $~lib/rt/stub/__release
-   local.get $3
+   local.get $12
    return
   end
   local.get $0
-  local.get $6
+  local.get $10
   local.get $1
   i32.const 0
-  local.get $7
+  local.get $11
   call $~lib/util/string/compareImpl
   i32.eqz
-  local.set $3
+  local.set $13
   local.get $1
   call $~lib/rt/stub/__release
-  local.get $3
+  local.get $13
  )
  (func $std/array-access/stringArrayMethodCall (param $0 i32) (result i32)
   (local $1 i32)

--- a/tests/compiler/std/array-literal.untouched.wat
+++ b/tests/compiler/std/array-literal.untouched.wat
@@ -125,6 +125,15 @@
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
   local.get $1
   i32.load
   local.set $2
@@ -261,59 +270,59 @@
   i32.eq
   if
    local.get $0
-   local.set $11
+   local.set $14
    local.get $4
-   local.set $10
+   local.set $13
    local.get $5
-   local.set $9
+   local.set $12
    local.get $7
-   local.set $8
-   local.get $11
-   local.get $10
+   local.set $11
+   local.get $14
+   local.get $13
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $12
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
+   local.get $11
    i32.store offset=96
    local.get $7
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $16
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $15
+    local.get $16
+    local.get $15
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $17
     local.get $0
-    local.set $8
+    local.set $20
     local.get $4
-    local.set $11
-    local.get $9
+    local.set $19
+    local.get $17
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
-    local.set $10
-    local.get $8
-    local.get $11
+    local.tee $17
+    local.set $18
+    local.get $20
+    local.get $19
     i32.const 2
     i32.shl
     i32.add
-    local.get $10
+    local.get $18
     i32.store offset=4
-    local.get $9
+    local.get $17
     i32.eqz
     if
      local.get $0
@@ -343,6 +352,20 @@
   (local $11 i32)
   (local $12 i32)
   (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local $22 i32)
+  (local $23 i32)
+  (local $24 i32)
+  (local $25 i32)
+  (local $26 i32)
+  (local $27 i32)
   i32.const 1
   drop
   local.get $1
@@ -405,8 +428,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $3
+   local.set $6
+   local.get $6
    i32.const 1073741808
    i32.lt_u
    if
@@ -417,16 +440,16 @@
     local.get $2
     i32.const 3
     i32.and
-    local.get $3
+    local.get $6
     i32.or
     local.tee $2
     i32.store
     local.get $1
-    local.set $6
-    local.get $6
+    local.set $7
+    local.get $7
     i32.const 16
     i32.add
-    local.get $6
+    local.get $7
     i32.load
     i32.const 3
     i32.const -1
@@ -444,18 +467,18 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $8
+   local.get $8
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
+   local.set $9
+   local.get $9
    i32.load
-   local.set $3
+   local.set $10
    i32.const 1
    drop
-   local.get $3
+   local.get $10
    i32.const 1
    i32.and
    i32.eqz
@@ -467,7 +490,7 @@
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $3
+   local.get $10
    i32.const 3
    i32.const -1
    i32.xor
@@ -480,23 +503,23 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $7
+   local.set $11
+   local.get $11
    i32.const 1073741808
    i32.lt_u
    if
     local.get $0
-    local.get $6
+    local.get $9
     call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
+    local.get $9
+    local.get $10
     i32.const 3
     i32.and
-    local.get $7
+    local.get $11
     i32.or
     local.tee $2
     i32.store
-    local.get $6
+    local.get $9
     local.set $1
    end
   end
@@ -510,14 +533,14 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $12
   i32.const 1
   drop
-  local.get $8
+  local.get $12
   i32.const 16
   i32.ge_u
   if (result i32)
-   local.get $8
+   local.get $12
    i32.const 1073741808
    i32.lt_u
   else
@@ -537,7 +560,7 @@
   local.get $1
   i32.const 16
   i32.add
-  local.get $8
+  local.get $12
   i32.add
   local.get $4
   i32.eq
@@ -555,24 +578,24 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $12
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $13
+   local.get $12
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $14
   else
    i32.const 31
-   local.get $8
+   local.get $12
    i32.clz
    i32.sub
-   local.set $9
-   local.get $8
-   local.get $9
+   local.set $13
+   local.get $12
+   local.get $13
    i32.const 4
    i32.sub
    i32.shr_u
@@ -580,21 +603,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $14
+   local.get $13
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $13
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $13
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $14
    i32.const 16
    i32.lt_u
   else
@@ -610,86 +633,86 @@
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
-  local.set $6
-  local.get $7
-  local.get $3
+  local.set $17
+  local.get $13
+  local.set $16
+  local.get $14
+  local.set $15
+  local.get $17
+  local.get $16
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $15
   i32.add
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=96
-  local.set $11
+  local.set $18
   local.get $1
   i32.const 0
   i32.store offset=16
   local.get $1
-  local.get $11
+  local.get $18
   i32.store offset=20
-  local.get $11
+  local.get $18
   if
-   local.get $11
+   local.get $18
    local.get $1
    i32.store offset=16
   end
   local.get $0
-  local.set $12
-  local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
+  local.set $22
+  local.get $13
+  local.set $21
+  local.get $14
+  local.set $20
   local.get $1
-  local.set $6
-  local.get $12
-  local.get $7
+  local.set $19
+  local.get $22
+  local.get $21
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $20
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $19
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $13
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.set $13
-  local.get $9
-  local.set $12
+  local.set $27
+  local.get $13
+  local.set $26
   local.get $0
-  local.set $3
-  local.get $9
-  local.set $6
-  local.get $3
-  local.get $6
+  local.set $24
+  local.get $13
+  local.set $23
+  local.get $24
+  local.get $23
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $14
   i32.shl
   i32.or
-  local.set $7
-  local.get $13
-  local.get $12
+  local.set $25
+  local.get $27
+  local.get $26
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $25
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -700,6 +723,7 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
   i32.const 1
   drop
   local.get $1
@@ -839,11 +863,11 @@
   i32.or
   i32.store
   local.get $0
-  local.set $9
+  local.set $10
   local.get $4
-  local.set $3
+  local.set $9
+  local.get $10
   local.get $9
-  local.get $3
   i32.store offset=1568
   local.get $0
   local.get $8
@@ -863,6 +887,12 @@
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
   global.get $~lib/rt/tlsf/ROOT
   local.set $0
   local.get $0
@@ -919,66 +949,66 @@
    local.get $4
    i32.store offset=1568
    i32.const 0
-   local.set $5
+   local.set $6
    loop $for-loop|0
-    local.get $5
+    local.get $6
     i32.const 23
     i32.lt_u
-    local.set $4
-    local.get $4
+    local.set $7
+    local.get $7
     if
      local.get $0
-     local.set $8
-     local.get $5
-     local.set $7
+     local.set $10
+     local.get $6
+     local.set $9
      i32.const 0
-     local.set $6
-     local.get $8
-     local.get $7
+     local.set $8
+     local.get $10
+     local.get $9
      i32.const 2
      i32.shl
      i32.add
-     local.get $6
+     local.get $8
      i32.store offset=4
      i32.const 0
-     local.set $8
+     local.set $11
      loop $for-loop|1
-      local.get $8
+      local.get $11
       i32.const 16
       i32.lt_u
-      local.set $7
-      local.get $7
+      local.set $12
+      local.get $12
       if
        local.get $0
-       local.set $11
-       local.get $5
-       local.set $10
-       local.get $8
-       local.set $9
-       i32.const 0
-       local.set $6
+       local.set $16
+       local.get $6
+       local.set $15
        local.get $11
-       local.get $10
+       local.set $14
+       i32.const 0
+       local.set $13
+       local.get $16
+       local.get $15
        i32.const 4
        i32.shl
-       local.get $9
+       local.get $14
        i32.add
        i32.const 2
        i32.shl
        i32.add
-       local.get $6
+       local.get $13
        i32.store offset=96
-       local.get $8
+       local.get $11
        i32.const 1
        i32.add
-       local.set $8
+       local.set $11
        br $for-loop|1
       end
      end
-     local.get $5
+     local.get $6
      i32.const 1
      i32.add
-     local.set $5
+     local.set $6
      br $for-loop|0
     end
    end
@@ -991,11 +1021,11 @@
    i32.const -1
    i32.xor
    i32.and
-   local.set $5
+   local.set $17
    i32.const 0
    drop
    local.get $0
-   local.get $5
+   local.get $17
    memory.size
    i32.const 16
    i32.shl
@@ -1044,6 +1074,14 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
   local.get $1
   i32.const 256
   i32.lt_u
@@ -1117,11 +1155,11 @@
    unreachable
   end
   local.get $0
-  local.set $5
+  local.set $6
   local.get $2
-  local.set $4
+  local.set $5
+  local.get $6
   local.get $5
-  local.get $4
   i32.const 2
   i32.shl
   i32.add
@@ -1132,10 +1170,10 @@
   local.get $3
   i32.shl
   i32.and
-  local.set $6
-  i32.const 0
   local.set $7
-  local.get $6
+  i32.const 0
+  local.set $8
+  local.get $7
   i32.eqz
   if
    local.get $0
@@ -1148,30 +1186,30 @@
    i32.add
    i32.shl
    i32.and
-   local.set $5
-   local.get $5
+   local.set $9
+   local.get $9
    i32.eqz
    if
     i32.const 0
-    local.set $7
+    local.set $8
    else
-    local.get $5
+    local.get $9
     i32.ctz
     local.set $2
     local.get $0
-    local.set $8
+    local.set $11
     local.get $2
-    local.set $4
-    local.get $8
-    local.get $4
+    local.set $10
+    local.get $11
+    local.get $10
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $6
+    local.set $7
     i32.const 1
     drop
-    local.get $6
+    local.get $7
     i32.eqz
     if
      i32.const 0
@@ -1182,45 +1220,45 @@
      unreachable
     end
     local.get $0
-    local.set $9
+    local.set $14
     local.get $2
-    local.set $8
-    local.get $6
+    local.set $13
+    local.get $7
     i32.ctz
-    local.set $4
-    local.get $9
-    local.get $8
+    local.set $12
+    local.get $14
+    local.get $13
     i32.const 4
     i32.shl
-    local.get $4
+    local.get $12
     i32.add
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=96
-    local.set $7
+    local.set $8
    end
   else
    local.get $0
-   local.set $9
+   local.set $17
    local.get $2
-   local.set $8
-   local.get $6
+   local.set $16
+   local.get $7
    i32.ctz
-   local.set $4
-   local.get $9
-   local.get $8
+   local.set $15
+   local.get $17
+   local.get $16
    i32.const 4
    i32.shl
-   local.get $4
+   local.get $15
    i32.add
    i32.const 2
    i32.shl
    i32.add
    i32.load offset=96
-   local.set $7
+   local.set $8
   end
-  local.get $7
+  local.get $8
  )
  (func $~lib/rt/tlsf/growMemory (param $0 i32) (param $1 i32)
   (local $2 i32)
@@ -1229,6 +1267,7 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
   i32.const 0
   drop
   local.get $1
@@ -1275,15 +1314,15 @@
   i32.shr_u
   local.set $4
   local.get $2
-  local.tee $3
-  local.get $4
   local.tee $5
-  local.get $3
+  local.get $4
+  local.tee $6
   local.get $5
+  local.get $6
   i32.gt_s
   select
-  local.set $6
-  local.get $6
+  local.set $7
+  local.get $7
   memory.grow
   i32.const 0
   i32.lt_s
@@ -1297,12 +1336,12 @@
    end
   end
   memory.size
-  local.set $7
+  local.set $8
   local.get $0
   local.get $2
   i32.const 16
   i32.shl
-  local.get $7
+  local.get $8
   i32.const 16
   i32.shl
   call $~lib/rt/tlsf/addMemory
@@ -1312,6 +1351,8 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
   local.get $1
   i32.load
   local.set $3
@@ -1376,11 +1417,11 @@
    i32.and
    i32.store
    local.get $1
-   local.set $5
-   local.get $5
+   local.set $7
+   local.get $7
    i32.const 16
    i32.add
-   local.get $5
+   local.get $7
    i32.load
    i32.const 3
    i32.const -1
@@ -1388,11 +1429,11 @@
    i32.and
    i32.add
    local.get $1
-   local.set $5
-   local.get $5
+   local.set $6
+   local.get $6
    i32.const 16
    i32.add
-   local.get $5
+   local.get $6
    i32.load
    i32.const 3
    i32.const -1
@@ -1547,6 +1588,88 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local $22 i32)
+  (local $23 i32)
+  (local $24 i32)
+  (local $25 i32)
+  (local $26 i32)
+  (local $27 i32)
+  (local $28 i32)
+  (local $29 i32)
+  (local $30 i32)
+  (local $31 i32)
+  (local $32 i32)
+  (local $33 i32)
+  (local $34 i32)
+  (local $35 i32)
+  (local $36 i32)
+  (local $37 i32)
+  (local $38 i32)
+  (local $39 i32)
+  (local $40 i32)
+  (local $41 i32)
+  (local $42 i32)
+  (local $43 i32)
+  (local $44 i32)
+  (local $45 i32)
+  (local $46 i32)
+  (local $47 i32)
+  (local $48 i32)
+  (local $49 i32)
+  (local $50 i32)
+  (local $51 i32)
+  (local $52 i32)
+  (local $53 i32)
+  (local $54 i32)
+  (local $55 i32)
+  (local $56 i32)
+  (local $57 i32)
+  (local $58 i32)
+  (local $59 i32)
+  (local $60 i32)
+  (local $61 i32)
+  (local $62 i32)
+  (local $63 i32)
+  (local $64 i32)
+  (local $65 i32)
+  (local $66 i32)
+  (local $67 i32)
+  (local $68 i32)
+  (local $69 i32)
+  (local $70 i32)
+  (local $71 i32)
+  (local $72 i32)
+  (local $73 i32)
+  (local $74 i32)
+  (local $75 i32)
+  (local $76 i32)
+  (local $77 i32)
+  (local $78 i32)
+  (local $79 i32)
+  (local $80 i32)
+  (local $81 i32)
+  (local $82 i32)
+  (local $83 i32)
+  (local $84 i32)
+  (local $85 i32)
+  (local $86 i32)
+  (local $87 i32)
+  (local $88 i32)
   loop $while-continue|0
    local.get $2
    if (result i32)
@@ -1566,11 +1689,11 @@
     local.set $0
     local.get $6
     local.get $1
-    local.tee $6
+    local.tee $7
     i32.const 1
     i32.add
     local.set $1
-    local.get $6
+    local.get $7
     i32.load8_u
     i32.store8
     local.get $2
@@ -1590,8 +1713,8 @@
     local.get $2
     i32.const 16
     i32.ge_u
-    local.set $5
-    local.get $5
+    local.set $8
+    local.get $8
     if
      local.get $0
      local.get $1
@@ -1700,17 +1823,17 @@
    i32.and
    if
     local.get $0
-    local.tee $5
+    local.tee $9
     i32.const 1
     i32.add
     local.set $0
-    local.get $5
+    local.get $9
     local.get $1
-    local.tee $5
+    local.tee $10
     i32.const 1
     i32.add
     local.set $1
-    local.get $5
+    local.get $10
     i32.load8_u
     i32.store8
    end
@@ -1727,16 +1850,16 @@
        local.get $0
        i32.const 3
        i32.and
-       local.set $5
-       local.get $5
+       local.set $11
+       local.get $11
        i32.const 1
        i32.eq
        br_if $case0|2
-       local.get $5
+       local.get $11
        i32.const 2
        i32.eq
        br_if $case1|2
-       local.get $5
+       local.get $11
        i32.const 3
        i32.eq
        br_if $case2|2
@@ -1746,45 +1869,45 @@
       i32.load
       local.set $3
       local.get $0
-      local.tee $5
+      local.tee $12
       i32.const 1
       i32.add
       local.set $0
-      local.get $5
+      local.get $12
       local.get $1
-      local.tee $5
+      local.tee $13
       i32.const 1
       i32.add
       local.set $1
-      local.get $5
+      local.get $13
       i32.load8_u
       i32.store8
       local.get $0
-      local.tee $5
+      local.tee $14
       i32.const 1
       i32.add
       local.set $0
-      local.get $5
+      local.get $14
       local.get $1
-      local.tee $5
+      local.tee $15
       i32.const 1
       i32.add
       local.set $1
-      local.get $5
+      local.get $15
       i32.load8_u
       i32.store8
       local.get $0
-      local.tee $5
+      local.tee $16
       i32.const 1
       i32.add
       local.set $0
-      local.get $5
+      local.get $16
       local.get $1
-      local.tee $5
+      local.tee $17
       i32.const 1
       i32.add
       local.set $1
-      local.get $5
+      local.get $17
       i32.load8_u
       i32.store8
       local.get $2
@@ -1795,8 +1918,8 @@
        local.get $2
        i32.const 17
        i32.ge_u
-       local.set $5
-       local.get $5
+       local.set $18
+       local.get $18
        if
         local.get $1
         i32.const 1
@@ -1881,31 +2004,31 @@
      i32.load
      local.set $3
      local.get $0
-     local.tee $5
+     local.tee $19
      i32.const 1
      i32.add
      local.set $0
-     local.get $5
+     local.get $19
      local.get $1
-     local.tee $5
+     local.tee $20
      i32.const 1
      i32.add
      local.set $1
-     local.get $5
+     local.get $20
      i32.load8_u
      i32.store8
      local.get $0
-     local.tee $5
+     local.tee $21
      i32.const 1
      i32.add
      local.set $0
-     local.get $5
+     local.get $21
      local.get $1
-     local.tee $5
+     local.tee $22
      i32.const 1
      i32.add
      local.set $1
-     local.get $5
+     local.get $22
      i32.load8_u
      i32.store8
      local.get $2
@@ -1916,8 +2039,8 @@
       local.get $2
       i32.const 18
       i32.ge_u
-      local.set $5
-      local.get $5
+      local.set $23
+      local.get $23
       if
        local.get $1
        i32.const 2
@@ -2002,17 +2125,17 @@
     i32.load
     local.set $3
     local.get $0
-    local.tee $5
+    local.tee $24
     i32.const 1
     i32.add
     local.set $0
-    local.get $5
+    local.get $24
     local.get $1
-    local.tee $5
+    local.tee $25
     i32.const 1
     i32.add
     local.set $1
-    local.get $5
+    local.get $25
     i32.load8_u
     i32.store8
     local.get $2
@@ -2023,8 +2146,8 @@
      local.get $2
      i32.const 19
      i32.ge_u
-     local.set $5
-     local.get $5
+     local.set $26
+     local.get $26
      if
       local.get $1
       i32.const 3
@@ -2111,227 +2234,227 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $27
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $27
    local.get $1
-   local.tee $5
+   local.tee $28
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $28
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $29
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $29
    local.get $1
-   local.tee $5
+   local.tee $30
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $30
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $31
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $31
    local.get $1
-   local.tee $5
+   local.tee $32
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $32
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $33
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $33
    local.get $1
-   local.tee $5
+   local.tee $34
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $34
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $35
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $35
    local.get $1
-   local.tee $5
+   local.tee $36
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $36
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $37
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $37
    local.get $1
-   local.tee $5
+   local.tee $38
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $38
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $39
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $39
    local.get $1
-   local.tee $5
+   local.tee $40
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $40
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $41
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $41
    local.get $1
-   local.tee $5
+   local.tee $42
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $42
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $43
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $43
    local.get $1
-   local.tee $5
+   local.tee $44
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $44
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $45
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $45
    local.get $1
-   local.tee $5
+   local.tee $46
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $46
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $47
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $47
    local.get $1
-   local.tee $5
+   local.tee $48
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $48
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $49
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $49
    local.get $1
-   local.tee $5
+   local.tee $50
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $50
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $51
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $51
    local.get $1
-   local.tee $5
+   local.tee $52
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $52
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $53
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $53
    local.get $1
-   local.tee $5
+   local.tee $54
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $54
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $55
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $55
    local.get $1
-   local.tee $5
+   local.tee $56
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $56
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $57
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $57
    local.get $1
-   local.tee $5
+   local.tee $58
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $58
    i32.load8_u
    i32.store8
   end
@@ -2340,115 +2463,115 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $59
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $59
    local.get $1
-   local.tee $5
+   local.tee $60
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $60
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $61
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $61
    local.get $1
-   local.tee $5
+   local.tee $62
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $62
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $63
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $63
    local.get $1
-   local.tee $5
+   local.tee $64
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $64
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $65
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $65
    local.get $1
-   local.tee $5
+   local.tee $66
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $66
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $67
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $67
    local.get $1
-   local.tee $5
+   local.tee $68
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $68
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $69
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $69
    local.get $1
-   local.tee $5
+   local.tee $70
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $70
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $71
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $71
    local.get $1
-   local.tee $5
+   local.tee $72
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $72
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $73
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $73
    local.get $1
-   local.tee $5
+   local.tee $74
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $74
    i32.load8_u
    i32.store8
   end
@@ -2457,59 +2580,59 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $75
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $75
    local.get $1
-   local.tee $5
+   local.tee $76
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $76
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $77
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $77
    local.get $1
-   local.tee $5
+   local.tee $78
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $78
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $79
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $79
    local.get $1
-   local.tee $5
+   local.tee $80
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $80
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $81
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $81
    local.get $1
-   local.tee $5
+   local.tee $82
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $82
    i32.load8_u
    i32.store8
   end
@@ -2518,31 +2641,31 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $83
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $83
    local.get $1
-   local.tee $5
+   local.tee $84
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $84
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $85
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $85
    local.get $1
-   local.tee $5
+   local.tee $86
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $86
    i32.load8_u
    i32.store8
   end
@@ -2551,17 +2674,17 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $87
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $87
    local.get $1
-   local.tee $5
+   local.tee $88
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $88
    i32.load8_u
    i32.store8
   end
@@ -2572,6 +2695,14 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
   block $~lib/util/memory/memmove|inlined.0
    local.get $0
    local.set $5
@@ -2649,11 +2780,11 @@
        local.set $5
        local.get $7
        local.get $4
-       local.tee $7
+       local.tee $8
        i32.const 1
        i32.add
        local.set $4
-       local.get $7
+       local.get $8
        i32.load8_u
        i32.store8
        br $while-continue|0
@@ -2663,8 +2794,8 @@
       local.get $3
       i32.const 8
       i32.ge_u
-      local.set $6
-      local.get $6
+      local.set $9
+      local.get $9
       if
        local.get $5
        local.get $4
@@ -2688,21 +2819,21 @@
     end
     loop $while-continue|2
      local.get $3
-     local.set $6
-     local.get $6
+     local.set $10
+     local.get $10
      if
       local.get $5
-      local.tee $7
+      local.tee $11
       i32.const 1
       i32.add
       local.set $5
-      local.get $7
+      local.get $11
       local.get $4
-      local.tee $7
+      local.tee $12
       i32.const 1
       i32.add
       local.set $4
-      local.get $7
+      local.get $12
       i32.load8_u
       i32.store8
       local.get $3
@@ -2731,8 +2862,8 @@
       i32.add
       i32.const 7
       i32.and
-      local.set $6
-      local.get $6
+      local.set $13
+      local.get $13
       if
        local.get $3
        i32.eqz
@@ -2757,8 +2888,8 @@
       local.get $3
       i32.const 8
       i32.ge_u
-      local.set $6
-      local.get $6
+      local.set $14
+      local.get $14
       if
        local.get $3
        i32.const 8
@@ -2778,8 +2909,8 @@
     end
     loop $while-continue|5
      local.get $3
-     local.set $6
-     local.get $6
+     local.set $15
+     local.get $15
      if
       local.get $5
       local.get $3
@@ -2963,6 +3094,21 @@
  (func $start:std/array-literal
   (local $0 i32)
   (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
   global.get $std/array-literal/staticArrayI8
   call $~lib/array/Array<i8>#get:length
   i32.const 3
@@ -3092,28 +3238,28 @@
   i32.const 0
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $1
-  local.get $1
+  local.set $6
+  local.get $6
   i32.load offset=4
-  local.set $0
-  local.get $0
+  local.set $7
+  local.get $7
   global.get $std/array-literal/i
   i32.store8
-  local.get $0
+  local.get $7
   global.get $std/array-literal/i
   i32.const 1
   i32.add
   global.set $std/array-literal/i
   global.get $std/array-literal/i
   i32.store8 offset=1
-  local.get $0
+  local.get $7
   global.get $std/array-literal/i
   i32.const 1
   i32.add
   global.set $std/array-literal/i
   global.get $std/array-literal/i
   i32.store8 offset=2
-  local.get $1
+  local.get $6
   global.set $std/array-literal/dynamicArrayI8
   global.get $std/array-literal/dynamicArrayI8
   call $~lib/array/Array<i8>#get:length
@@ -3178,28 +3324,28 @@
   i32.const 0
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $0
-  local.get $0
+  local.set $8
+  local.get $8
   i32.load offset=4
-  local.set $1
-  local.get $1
+  local.set $9
+  local.get $9
   global.get $std/array-literal/i
   i32.store
-  local.get $1
+  local.get $9
   global.get $std/array-literal/i
   i32.const 1
   i32.add
   global.set $std/array-literal/i
   global.get $std/array-literal/i
   i32.store offset=4
-  local.get $1
+  local.get $9
   global.get $std/array-literal/i
   i32.const 1
   i32.add
   global.set $std/array-literal/i
   global.get $std/array-literal/i
   i32.store offset=8
-  local.get $0
+  local.get $8
   global.set $std/array-literal/dynamicArrayI32
   global.get $std/array-literal/dynamicArrayI32
   call $~lib/array/Array<i32>#get:length
@@ -3262,23 +3408,23 @@
   i32.const 0
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $1
-  local.get $1
+  local.set $10
+  local.get $10
   i32.load offset=4
-  local.set $0
-  local.get $0
+  local.set $11
+  local.get $11
   i32.const 0
   call $std/array-literal/Ref#constructor
   i32.store
-  local.get $0
+  local.get $11
   i32.const 0
   call $std/array-literal/Ref#constructor
   i32.store offset=4
-  local.get $0
+  local.get $11
   i32.const 0
   call $std/array-literal/Ref#constructor
   i32.store offset=8
-  local.get $1
+  local.get $10
   global.set $std/array-literal/dynamicArrayRef
   global.get $std/array-literal/dynamicArrayRef
   call $~lib/array/Array<std/array-literal/Ref>#get:length
@@ -3299,23 +3445,23 @@
   i32.const 0
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $0
-  local.get $0
+  local.set $12
+  local.get $12
   i32.load offset=4
-  local.set $1
-  local.get $1
+  local.set $13
+  local.get $13
   i32.const 0
   call $std/array-literal/RefWithCtor#constructor
   i32.store
-  local.get $1
+  local.get $13
   i32.const 0
   call $std/array-literal/RefWithCtor#constructor
   i32.store offset=4
-  local.get $1
+  local.get $13
   i32.const 0
   call $std/array-literal/RefWithCtor#constructor
   i32.store offset=8
-  local.get $0
+  local.get $12
   global.set $std/array-literal/dynamicArrayRefWithCtor
   global.get $std/array-literal/dynamicArrayRefWithCtor
   call $~lib/array/Array<std/array-literal/RefWithCtor>#get:length
@@ -3346,18 +3492,18 @@
   i32.const 0
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $1
-  local.get $1
+  local.set $14
+  local.get $14
   i32.load offset=4
-  local.set $0
-  local.get $0
+  local.set $15
+  local.get $15
   i32.const 0
   call $std/array-literal/Ref#constructor
   i32.store
-  local.get $1
-  local.tee $0
+  local.get $14
+  local.tee $16
   call $std/array-literal/doesntLeak
-  local.get $0
+  local.get $16
   call $~lib/rt/pure/__release
  )
  (func $~start

--- a/tests/compiler/std/array.optimized.wat
+++ b/tests/compiler/std/array.optimized.wat
@@ -3252,26 +3252,27 @@
  )
  (func $start:std/array~anonymous|20 (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   local.get $1
   i32.eqz
   if
    loop $for-loop|0
-    local.get $3
+    local.get $5
     i32.const 4
     i32.lt_s
     if
      local.get $2
      call $~lib/array/Array<i32>#pop
      drop
-     local.get $3
+     local.get $5
      i32.const 1
      i32.add
-     local.set $3
+     local.set $5
      br $for-loop|0
     end
    end
-   i32.const 0
-   local.set $3
    loop $for-loop|1
     local.get $3
     i32.const 100
@@ -3289,39 +3290,35 @@
      br $for-loop|1
     end
    end
-   i32.const 0
-   local.set $3
    loop $for-loop|2
-    local.get $3
+    local.get $6
     i32.const 100
     i32.lt_s
     if
      local.get $2
      call $~lib/array/Array<i32>#pop
      drop
-     local.get $3
+     local.get $6
      i32.const 1
      i32.add
-     local.set $3
+     local.set $6
      br $for-loop|2
     end
    end
-   i32.const 0
-   local.set $3
    loop $for-loop|3
-    local.get $3
+    local.get $4
     i32.const 100
     i32.lt_s
     if
      local.get $2
-     local.get $3
+     local.get $4
      i32.const 200
      i32.add
      call $~lib/array/Array<i32>#push
-     local.get $3
+     local.get $4
      i32.const 1
      i32.add
-     local.set $3
+     local.set $4
      br $for-loop|3
     end
    end
@@ -3779,27 +3776,27 @@
   local.get $1
   i32.const 1
   i32.sub
-  local.set $3
+  local.set $2
   loop $for-loop|0
-   local.get $3
+   local.get $2
    i32.const 0
    i32.gt_s
    if
-    local.get $3
-    local.set $2
+    local.get $2
+    local.set $3
     loop $while-continue|1
-     local.get $2
+     local.get $3
      i32.const 1
      i32.and
      local.get $5
-     local.get $2
+     local.get $3
      i32.const 6
      i32.shr_u
      i32.const 2
      i32.shl
      i32.add
      i32.load
-     local.get $2
+     local.get $3
      i32.const 1
      i32.shr_s
      i32.const 31
@@ -3809,25 +3806,25 @@
      i32.and
      i32.eq
      if
-      local.get $2
+      local.get $3
       i32.const 1
       i32.shr_s
-      local.set $2
+      local.set $3
       br $while-continue|1
      end
     end
     local.get $0
-    local.get $2
+    local.get $3
     i32.const 1
     i32.shr_s
-    local.tee $2
+    local.tee $3
     i32.const 2
     i32.shl
     i32.add
     f32.load
     local.tee $4
     local.get $0
-    local.get $3
+    local.get $2
     i32.const 2
     i32.shl
     i32.add
@@ -3838,7 +3835,7 @@
     i32.lt_s
     if
      local.get $5
-     local.get $3
+     local.get $2
      i32.const 5
      i32.shr_u
      i32.const 2
@@ -3848,31 +3845,31 @@
      local.get $7
      i32.load
      i32.const 1
-     local.get $3
+     local.get $2
      i32.const 31
      i32.and
      i32.shl
      i32.xor
      i32.store
      local.get $0
-     local.get $3
+     local.get $2
      i32.const 2
      i32.shl
      i32.add
      local.get $4
      f32.store
      local.get $0
-     local.get $2
+     local.get $3
      i32.const 2
      i32.shl
      i32.add
      local.get $6
      f32.store
     end
-    local.get $3
+    local.get $2
     i32.const 1
     i32.sub
-    local.set $3
+    local.set $2
     br $for-loop|0
    end
   end
@@ -4059,27 +4056,27 @@
   local.get $1
   i32.const 1
   i32.sub
-  local.set $3
+  local.set $2
   loop $for-loop|0
-   local.get $3
+   local.get $2
    i32.const 0
    i32.gt_s
    if
-    local.get $3
-    local.set $2
+    local.get $2
+    local.set $3
     loop $while-continue|1
-     local.get $2
+     local.get $3
      i32.const 1
      i32.and
      local.get $5
-     local.get $2
+     local.get $3
      i32.const 6
      i32.shr_u
      i32.const 2
      i32.shl
      i32.add
      i32.load
-     local.get $2
+     local.get $3
      i32.const 1
      i32.shr_s
      i32.const 31
@@ -4089,25 +4086,25 @@
      i32.and
      i32.eq
      if
-      local.get $2
+      local.get $3
       i32.const 1
       i32.shr_s
-      local.set $2
+      local.set $3
       br $while-continue|1
      end
     end
     local.get $0
-    local.get $2
+    local.get $3
     i32.const 1
     i32.shr_s
-    local.tee $2
+    local.tee $3
     i32.const 3
     i32.shl
     i32.add
     f64.load
     local.tee $4
     local.get $0
-    local.get $3
+    local.get $2
     i32.const 3
     i32.shl
     i32.add
@@ -4118,7 +4115,7 @@
     i32.lt_s
     if
      local.get $5
-     local.get $3
+     local.get $2
      i32.const 5
      i32.shr_u
      i32.const 2
@@ -4128,31 +4125,31 @@
      local.get $7
      i32.load
      i32.const 1
-     local.get $3
+     local.get $2
      i32.const 31
      i32.and
      i32.shl
      i32.xor
      i32.store
      local.get $0
-     local.get $3
+     local.get $2
      i32.const 3
      i32.shl
      i32.add
      local.get $4
      f64.store
      local.get $0
-     local.get $2
+     local.get $3
      i32.const 3
      i32.shl
      i32.add
      local.get $6
      f64.store
     end
-    local.get $3
+    local.get $2
     i32.const 1
     i32.sub
-    local.set $3
+    local.set $2
     br $for-loop|0
    end
   end
@@ -4360,27 +4357,27 @@
   local.get $1
   i32.const 1
   i32.sub
-  local.set $4
+  local.set $3
   loop $for-loop|0
-   local.get $4
+   local.get $3
    i32.const 0
    i32.gt_s
    if
-    local.get $4
-    local.set $3
+    local.get $3
+    local.set $4
     loop $while-continue|1
-     local.get $3
+     local.get $4
      i32.const 1
      i32.and
      local.get $5
-     local.get $3
+     local.get $4
      i32.const 6
      i32.shr_u
      i32.const 2
      i32.shl
      i32.add
      i32.load
-     local.get $3
+     local.get $4
      i32.const 1
      i32.shr_s
      i32.const 31
@@ -4390,15 +4387,15 @@
      i32.and
      i32.eq
      if
-      local.get $3
+      local.get $4
       i32.const 1
       i32.shr_s
-      local.set $3
+      local.set $4
       br $while-continue|1
      end
     end
     local.get $0
-    local.get $3
+    local.get $4
     i32.const 1
     i32.shr_s
     local.tee $7
@@ -4406,9 +4403,9 @@
     i32.shl
     i32.add
     i32.load
-    local.tee $3
+    local.tee $4
     local.get $0
-    local.get $4
+    local.get $3
     i32.const 2
     i32.shl
     i32.add
@@ -4420,7 +4417,7 @@
     i32.lt_s
     if
      local.get $5
-     local.get $4
+     local.get $3
      i32.const 5
      i32.shr_u
      i32.const 2
@@ -4430,18 +4427,18 @@
      local.get $8
      i32.load
      i32.const 1
-     local.get $4
+     local.get $3
      i32.const 31
      i32.and
      i32.shl
      i32.xor
      i32.store
      local.get $0
-     local.get $4
+     local.get $3
      i32.const 2
      i32.shl
      i32.add
-     local.get $3
+     local.get $4
      i32.store
      local.get $0
      local.get $7
@@ -4451,10 +4448,10 @@
      local.get $6
      i32.store
     end
-    local.get $4
+    local.get $3
     i32.const 1
     i32.sub
-    local.set $4
+    local.set $3
     br $for-loop|0
    end
   end
@@ -6515,8 +6512,6 @@
    global.get $~lib/util/number/_K
    i32.add
    global.set $~lib/util/number/_K
-   local.get $8
-   local.set $1
    local.get $9
    i32.const 0
    local.get $4
@@ -6527,7 +6522,7 @@
    i32.add
    i64.load32_u
    i64.mul
-   local.set $3
+   local.set $1
    local.get $0
    local.get $6
    i32.const 1
@@ -6540,30 +6535,30 @@
    local.set $4
    loop $while-continue|6
     i32.const 1
-    local.get $3
     local.get $1
+    local.get $8
     i64.sub
-    local.get $1
+    local.get $8
     local.get $11
     i64.add
-    local.get $3
+    local.get $1
     i64.sub
     i64.gt_u
-    local.get $1
+    local.get $8
     local.get $11
     i64.add
-    local.get $3
+    local.get $1
     i64.lt_u
     select
     i32.const 0
     local.get $5
-    local.get $1
+    local.get $8
     i64.sub
     local.get $11
     i64.ge_u
     i32.const 0
+    local.get $8
     local.get $1
-    local.get $3
     i64.lt_u
     select
     select
@@ -6572,10 +6567,10 @@
      i32.const 1
      i32.sub
      local.set $4
-     local.get $1
+     local.get $8
      local.get $11
      i64.add
-     local.set $1
+     local.set $8
      br $while-continue|6
     end
    end
@@ -7367,53 +7362,54 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  local.get $2
+  local.set $4
   local.get $1
   i32.const 1
   i32.sub
-  local.tee $6
+  local.tee $5
   i32.const 0
   i32.lt_s
   if
    i32.const 6064
    return
   end
-  local.get $6
+  local.get $5
   i32.eqz
   if
    local.get $0
    i32.load
-   local.tee $5
+   local.tee $0
    if
-    local.get $5
+    local.get $0
     call $~lib/rt/pure/__retain
-    local.set $5
+    local.set $0
    end
-   local.get $5
+   local.get $0
    if (result i32)
-    local.get $5
+    local.get $0
     call $~lib/rt/pure/__retain
    else
     i32.const 6064
    end
-   local.get $5
+   local.get $0
    call $~lib/rt/pure/__release
    return
   end
   i32.const 6064
   local.set $1
-  local.get $2
-  local.tee $4
+  local.get $4
   call $~lib/string/String#get:length
   local.set $8
   loop $for-loop|0
-   local.get $5
    local.get $6
+   local.get $5
    i32.lt_s
    if
     local.get $3
     local.tee $2
     local.get $0
-    local.get $5
+    local.get $6
     i32.const 2
     i32.shl
     i32.add
@@ -7433,11 +7429,11 @@
      call $~lib/rt/pure/__retain
      local.tee $2
      local.get $1
+     local.get $1
      local.get $2
      call $~lib/string/String.__concat
      local.tee $9
      local.tee $2
-     local.get $1
      i32.ne
      if
       local.get $2
@@ -7455,47 +7451,49 @@
     local.get $8
     if
      local.get $1
-     local.tee $2
+     local.get $1
      local.get $4
      call $~lib/string/String.__concat
      local.tee $7
-     local.tee $1
-     local.get $2
+     local.tee $2
      i32.ne
      if
-      local.get $1
-      call $~lib/rt/pure/__retain
-      local.set $1
       local.get $2
+      call $~lib/rt/pure/__retain
+      local.set $2
+      local.get $1
       call $~lib/rt/pure/__release
      end
      local.get $7
      call $~lib/rt/pure/__release
+     local.get $2
+     local.set $1
     end
-    local.get $5
+    local.get $6
     i32.const 1
     i32.add
-    local.set $5
+    local.set $6
     br $for-loop|0
    end
   end
   local.get $0
-  local.get $6
+  local.get $5
   i32.const 2
   i32.shl
   i32.add
   i32.load
-  local.tee $2
+  local.tee $0
   local.get $3
   i32.ne
   if
-   local.get $2
+   local.get $0
    call $~lib/rt/pure/__retain
-   local.set $2
+   local.set $0
    local.get $3
    call $~lib/rt/pure/__release
   end
-  local.get $2
+  local.get $0
+  local.tee $2
   if
    local.get $2
    call $~lib/rt/pure/__retain
@@ -7503,21 +7501,21 @@
    local.get $1
    local.get $0
    call $~lib/string/String.__concat
+   local.tee $4
    local.tee $0
-   local.tee $3
    local.get $1
    i32.ne
    if
-    local.get $3
+    local.get $0
     call $~lib/rt/pure/__retain
-    local.set $3
+    local.set $0
     local.get $1
     call $~lib/rt/pure/__release
    end
    call $~lib/rt/pure/__release
-   local.get $0
+   local.get $4
    call $~lib/rt/pure/__release
-   local.get $3
+   local.get $0
    local.set $1
   end
   local.get $2
@@ -7542,29 +7540,29 @@
   local.get $1
   i32.const 1
   i32.sub
-  local.tee $5
+  local.tee $4
   i32.const 0
   i32.lt_s
   if
    i32.const 6064
    return
   end
-  local.get $5
+  local.get $4
   i32.eqz
   if
    local.get $0
    i32.load
-   local.tee $4
+   local.tee $0
    if
-    local.get $4
+    local.get $0
     call $~lib/rt/pure/__retain
-    local.set $4
+    local.set $0
    end
-   local.get $4
+   local.get $0
    call $~lib/rt/pure/__release
    i32.const 7984
    i32.const 6064
-   local.get $4
+   local.get $0
    select
    return
   end
@@ -7574,14 +7572,14 @@
   call $~lib/string/String#get:length
   local.set $7
   loop $for-loop|0
-   local.get $4
    local.get $5
+   local.get $4
    i32.lt_s
    if
     local.get $3
     local.tee $2
     local.get $0
-    local.get $4
+    local.get $5
     i32.const 2
     i32.shl
     i32.add
@@ -7598,33 +7596,12 @@
     local.get $3
     if
      local.get $1
+     local.tee $2
      local.get $1
      i32.const 7984
      call $~lib/string/String.__concat
      local.tee $6
-     local.tee $2
-     i32.ne
-     if
-      local.get $2
-      call $~lib/rt/pure/__retain
-      local.set $2
-      local.get $1
-      call $~lib/rt/pure/__release
-     end
-     local.get $6
-     call $~lib/rt/pure/__release
-     local.get $2
-     local.set $1
-    end
-    local.get $7
-    if
-     local.get $1
-     local.tee $2
-     i32.const 6304
-     call $~lib/string/String.__concat
-     local.tee $6
      local.tee $1
-     local.get $2
      i32.ne
      if
       local.get $1
@@ -7636,51 +7613,72 @@
      local.get $6
      call $~lib/rt/pure/__release
     end
-    local.get $4
+    local.get $7
+    if
+     local.get $1
+     local.tee $2
+     local.get $1
+     i32.const 6304
+     call $~lib/string/String.__concat
+     local.tee $6
+     local.tee $1
+     i32.ne
+     if
+      local.get $1
+      call $~lib/rt/pure/__retain
+      local.set $1
+      local.get $2
+      call $~lib/rt/pure/__release
+     end
+     local.get $6
+     call $~lib/rt/pure/__release
+    end
+    local.get $5
     i32.const 1
     i32.add
-    local.set $4
+    local.set $5
     br $for-loop|0
    end
   end
-  local.get $3
   local.get $0
-  local.get $5
+  local.get $4
   i32.const 2
   i32.shl
   i32.add
   i32.load
-  local.tee $2
+  local.tee $0
+  local.get $3
   i32.ne
   if
-   local.get $2
+   local.get $0
    call $~lib/rt/pure/__retain
-   local.set $2
+   local.set $0
    local.get $3
    call $~lib/rt/pure/__release
   end
-  local.get $2
+  local.get $0
+  local.tee $3
   if
-   local.get $1
    local.get $1
    i32.const 7984
    call $~lib/string/String.__concat
+   local.tee $2
    local.tee $0
-   local.tee $3
+   local.get $1
    i32.ne
    if
-    local.get $3
+    local.get $0
     call $~lib/rt/pure/__retain
-    local.set $3
+    local.set $0
     local.get $1
     call $~lib/rt/pure/__release
    end
-   local.get $0
+   local.get $2
    call $~lib/rt/pure/__release
-   local.get $3
+   local.get $0
    local.set $1
   end
-  local.get $2
+  local.get $3
   call $~lib/rt/pure/__release
   local.get $1
  )
@@ -8503,33 +8501,33 @@
   local.get $1
   i32.const 1
   i32.sub
-  local.tee $5
+  local.tee $4
   i32.const 0
   i32.lt_s
   if
    i32.const 6064
    return
   end
-  local.get $5
+  local.get $4
   i32.eqz
   if
    local.get $0
    i32.load
-   local.tee $4
+   local.tee $0
    if
-    local.get $4
+    local.get $0
     call $~lib/rt/pure/__retain
-    local.set $4
+    local.set $0
    end
-   local.get $4
+   local.get $0
    if (result i32)
-    local.get $4
+    local.get $0
     i32.const 6304
     call $~lib/array/Array<i32>#join
    else
     i32.const 6064
    end
-   local.get $4
+   local.get $0
    call $~lib/rt/pure/__release
    return
   end
@@ -8539,14 +8537,14 @@
   call $~lib/string/String#get:length
   local.set $7
   loop $for-loop|0
-   local.get $4
    local.get $5
+   local.get $4
    i32.lt_s
    if
     local.get $3
     local.tee $2
     local.get $0
-    local.get $4
+    local.get $5
     i32.const 2
     i32.shl
     i32.add
@@ -8562,29 +8560,29 @@
     end
     local.get $3
     if
+     local.get $1
+     local.set $2
      local.get $3
      i32.const 6304
      call $~lib/array/Array<i32>#join
-     local.tee $2
-     local.get $1
-     local.get $1
+     local.tee $1
      local.get $2
+     local.get $1
      call $~lib/string/String.__concat
      local.tee $8
-     local.tee $2
+     local.tee $1
+     local.get $2
      i32.ne
      if
-      local.get $2
-      call $~lib/rt/pure/__retain
-      local.set $2
       local.get $1
+      call $~lib/rt/pure/__retain
+      local.set $1
+      local.get $2
       call $~lib/rt/pure/__release
      end
      call $~lib/rt/pure/__release
      local.get $8
      call $~lib/rt/pure/__release
-     local.get $2
-     local.set $1
     end
     local.get $7
     if
@@ -8606,56 +8604,57 @@
      local.get $6
      call $~lib/rt/pure/__release
     end
-    local.get $4
+    local.get $5
     i32.const 1
     i32.add
-    local.set $4
+    local.set $5
     br $for-loop|0
    end
   end
   local.get $0
-  local.get $5
+  local.get $4
   i32.const 2
   i32.shl
   i32.add
   i32.load
-  local.tee $2
+  local.tee $0
   local.get $3
   i32.ne
   if
-   local.get $2
+   local.get $0
    call $~lib/rt/pure/__retain
-   local.set $2
+   local.set $0
    local.get $3
    call $~lib/rt/pure/__release
   end
-  local.get $2
+  local.get $0
+  local.tee $3
   if
-   local.get $2
+   local.get $3
    i32.const 6304
    call $~lib/array/Array<i32>#join
    local.tee $0
    local.get $1
-   local.get $1
    local.get $0
    call $~lib/string/String.__concat
+   local.tee $4
    local.tee $0
-   local.tee $3
+   local.get $1
    i32.ne
    if
-    local.get $3
+    local.get $0
     call $~lib/rt/pure/__retain
-    local.set $3
+    local.set $0
     local.get $1
     call $~lib/rt/pure/__release
    end
    call $~lib/rt/pure/__release
-   local.get $0
+   local.get $4
    call $~lib/rt/pure/__release
-   local.get $3
+   local.get $0
    local.set $1
   end
-  local.get $2
+  local.get $3
   call $~lib/rt/pure/__release
   local.get $1
  )
@@ -8813,32 +8812,32 @@
   local.get $1
   i32.const 1
   i32.sub
-  local.tee $5
+  local.tee $4
   i32.const 0
   i32.lt_s
   if
    i32.const 6064
    return
   end
-  local.get $5
+  local.get $4
   i32.eqz
   if
    local.get $0
    i32.load
-   local.tee $4
+   local.tee $0
    if
-    local.get $4
+    local.get $0
     call $~lib/rt/pure/__retain
-    local.set $4
+    local.set $0
    end
-   local.get $4
+   local.get $0
    if (result i32)
-    local.get $4
+    local.get $0
     call $~lib/array/Array<u8>#toString
    else
     i32.const 6064
    end
-   local.get $4
+   local.get $0
    call $~lib/rt/pure/__release
    return
   end
@@ -8848,14 +8847,14 @@
   call $~lib/string/String#get:length
   local.set $7
   loop $for-loop|0
-   local.get $4
    local.get $5
+   local.get $4
    i32.lt_s
    if
     local.get $3
     local.tee $2
     local.get $0
-    local.get $4
+    local.get $5
     i32.const 2
     i32.shl
     i32.add
@@ -8872,37 +8871,36 @@
     local.get $3
     if
      local.get $1
+     local.tee $2
      local.get $1
      local.get $3
      call $~lib/array/Array<u8>#toString
      local.tee $6
      call $~lib/string/String.__concat
      local.tee $8
-     local.tee $2
+     local.tee $1
      i32.ne
      if
-      local.get $2
-      call $~lib/rt/pure/__retain
-      local.set $2
       local.get $1
+      call $~lib/rt/pure/__retain
+      local.set $1
+      local.get $2
       call $~lib/rt/pure/__release
      end
      local.get $6
      call $~lib/rt/pure/__release
      local.get $8
      call $~lib/rt/pure/__release
-     local.get $2
-     local.set $1
     end
     local.get $7
     if
      local.get $1
      local.tee $2
+     local.get $1
      i32.const 6304
      call $~lib/string/String.__concat
      local.tee $6
      local.tee $1
-     local.get $2
      i32.ne
      if
       local.get $1
@@ -8914,55 +8912,56 @@
      local.get $6
      call $~lib/rt/pure/__release
     end
-    local.get $4
+    local.get $5
     i32.const 1
     i32.add
-    local.set $4
+    local.set $5
     br $for-loop|0
    end
   end
-  local.get $3
   local.get $0
-  local.get $5
+  local.get $4
   i32.const 2
   i32.shl
   i32.add
   i32.load
-  local.tee $2
+  local.tee $0
+  local.get $3
   i32.ne
   if
-   local.get $2
+   local.get $0
    call $~lib/rt/pure/__retain
-   local.set $2
+   local.set $0
    local.get $3
    call $~lib/rt/pure/__release
   end
-  local.get $2
+  local.get $0
+  local.tee $3
   if
    local.get $1
-   local.get $1
-   local.get $2
+   local.get $3
    call $~lib/array/Array<u8>#toString
-   local.tee $0
+   local.tee $2
    call $~lib/string/String.__concat
    local.tee $4
-   local.tee $3
+   local.tee $0
+   local.get $1
    i32.ne
    if
-    local.get $3
+    local.get $0
     call $~lib/rt/pure/__retain
-    local.set $3
+    local.set $0
     local.get $1
     call $~lib/rt/pure/__release
    end
-   local.get $0
+   local.get $2
    call $~lib/rt/pure/__release
    local.get $4
    call $~lib/rt/pure/__release
-   local.get $3
+   local.get $0
    local.set $1
   end
-  local.get $2
+  local.get $3
   call $~lib/rt/pure/__release
   local.get $1
  )
@@ -8977,33 +8976,33 @@
   local.get $1
   i32.const 1
   i32.sub
-  local.tee $5
+  local.tee $4
   i32.const 0
   i32.lt_s
   if
    i32.const 6064
    return
   end
-  local.get $5
+  local.get $4
   i32.eqz
   if
    local.get $0
    i32.load
-   local.tee $4
+   local.tee $0
    if
-    local.get $4
+    local.get $0
     call $~lib/rt/pure/__retain
-    local.set $4
+    local.set $0
    end
-   local.get $4
+   local.get $0
    if (result i32)
-    local.get $4
+    local.get $0
     i32.const 6304
     call $~lib/array/Array<u32>#join
    else
     i32.const 6064
    end
-   local.get $4
+   local.get $0
    call $~lib/rt/pure/__release
    return
   end
@@ -9013,14 +9012,14 @@
   call $~lib/string/String#get:length
   local.set $7
   loop $for-loop|0
-   local.get $4
    local.get $5
+   local.get $4
    i32.lt_s
    if
     local.get $3
     local.tee $2
     local.get $0
-    local.get $4
+    local.get $5
     i32.const 2
     i32.shl
     i32.add
@@ -9036,29 +9035,29 @@
     end
     local.get $3
     if
+     local.get $1
+     local.set $2
      local.get $3
      i32.const 6304
      call $~lib/array/Array<u32>#join
-     local.tee $2
-     local.get $1
-     local.get $1
+     local.tee $1
      local.get $2
+     local.get $1
      call $~lib/string/String.__concat
      local.tee $8
-     local.tee $2
+     local.tee $1
+     local.get $2
      i32.ne
      if
-      local.get $2
-      call $~lib/rt/pure/__retain
-      local.set $2
       local.get $1
+      call $~lib/rt/pure/__retain
+      local.set $1
+      local.get $2
       call $~lib/rt/pure/__release
      end
      call $~lib/rt/pure/__release
      local.get $8
      call $~lib/rt/pure/__release
-     local.get $2
-     local.set $1
     end
     local.get $7
     if
@@ -9080,56 +9079,57 @@
      local.get $6
      call $~lib/rt/pure/__release
     end
-    local.get $4
+    local.get $5
     i32.const 1
     i32.add
-    local.set $4
+    local.set $5
     br $for-loop|0
    end
   end
   local.get $0
-  local.get $5
+  local.get $4
   i32.const 2
   i32.shl
   i32.add
   i32.load
-  local.tee $2
+  local.tee $0
   local.get $3
   i32.ne
   if
-   local.get $2
+   local.get $0
    call $~lib/rt/pure/__retain
-   local.set $2
+   local.set $0
    local.get $3
    call $~lib/rt/pure/__release
   end
-  local.get $2
+  local.get $0
+  local.tee $3
   if
-   local.get $2
+   local.get $3
    i32.const 6304
    call $~lib/array/Array<u32>#join
    local.tee $0
    local.get $1
-   local.get $1
    local.get $0
    call $~lib/string/String.__concat
+   local.tee $4
    local.tee $0
-   local.tee $3
+   local.get $1
    i32.ne
    if
-    local.get $3
+    local.get $0
     call $~lib/rt/pure/__retain
-    local.set $3
+    local.set $0
     local.get $1
     call $~lib/rt/pure/__release
    end
    call $~lib/rt/pure/__release
-   local.get $0
+   local.get $4
    call $~lib/rt/pure/__release
-   local.get $3
+   local.get $0
    local.set $1
   end
-  local.get $2
+  local.get $3
   call $~lib/rt/pure/__release
   local.get $1
  )
@@ -9151,32 +9151,32 @@
   local.get $1
   i32.const 1
   i32.sub
-  local.tee $5
+  local.tee $4
   i32.const 0
   i32.lt_s
   if
    i32.const 6064
    return
   end
-  local.get $5
+  local.get $4
   i32.eqz
   if
    local.get $0
    i32.load
-   local.tee $4
+   local.tee $0
    if
-    local.get $4
+    local.get $0
     call $~lib/rt/pure/__retain
-    local.set $4
+    local.set $0
    end
-   local.get $4
+   local.get $0
    if (result i32)
-    local.get $4
+    local.get $0
     call $~lib/array/Array<~lib/array/Array<u32>>#toString
    else
     i32.const 6064
    end
-   local.get $4
+   local.get $0
    call $~lib/rt/pure/__release
    return
   end
@@ -9186,14 +9186,14 @@
   call $~lib/string/String#get:length
   local.set $7
   loop $for-loop|0
-   local.get $4
    local.get $5
+   local.get $4
    i32.lt_s
    if
     local.get $3
     local.tee $2
     local.get $0
-    local.get $4
+    local.get $5
     i32.const 2
     i32.shl
     i32.add
@@ -9210,37 +9210,36 @@
     local.get $3
     if
      local.get $1
+     local.tee $2
      local.get $1
      local.get $3
      call $~lib/array/Array<~lib/array/Array<u32>>#toString
      local.tee $6
      call $~lib/string/String.__concat
      local.tee $8
-     local.tee $2
+     local.tee $1
      i32.ne
      if
-      local.get $2
-      call $~lib/rt/pure/__retain
-      local.set $2
       local.get $1
+      call $~lib/rt/pure/__retain
+      local.set $1
+      local.get $2
       call $~lib/rt/pure/__release
      end
      local.get $6
      call $~lib/rt/pure/__release
      local.get $8
      call $~lib/rt/pure/__release
-     local.get $2
-     local.set $1
     end
     local.get $7
     if
      local.get $1
      local.tee $2
+     local.get $1
      i32.const 6304
      call $~lib/string/String.__concat
      local.tee $6
      local.tee $1
-     local.get $2
      i32.ne
      if
       local.get $1
@@ -9252,55 +9251,56 @@
      local.get $6
      call $~lib/rt/pure/__release
     end
-    local.get $4
+    local.get $5
     i32.const 1
     i32.add
-    local.set $4
+    local.set $5
     br $for-loop|0
    end
   end
-  local.get $3
   local.get $0
-  local.get $5
+  local.get $4
   i32.const 2
   i32.shl
   i32.add
   i32.load
-  local.tee $2
+  local.tee $0
+  local.get $3
   i32.ne
   if
-   local.get $2
+   local.get $0
    call $~lib/rt/pure/__retain
-   local.set $2
+   local.set $0
    local.get $3
    call $~lib/rt/pure/__release
   end
-  local.get $2
+  local.get $0
+  local.tee $3
   if
    local.get $1
-   local.get $1
-   local.get $2
+   local.get $3
    call $~lib/array/Array<~lib/array/Array<u32>>#toString
-   local.tee $0
+   local.tee $2
    call $~lib/string/String.__concat
    local.tee $4
-   local.tee $3
+   local.tee $0
+   local.get $1
    i32.ne
    if
-    local.get $3
+    local.get $0
     call $~lib/rt/pure/__retain
-    local.set $3
+    local.set $0
     local.get $1
     call $~lib/rt/pure/__release
    end
-   local.get $0
+   local.get $2
    call $~lib/rt/pure/__release
    local.get $4
    call $~lib/rt/pure/__release
-   local.get $3
+   local.get $0
    local.set $1
   end
-  local.get $2
+  local.get $3
   call $~lib/rt/pure/__release
   local.get $1
  )
@@ -9311,6 +9311,7 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
   local.get $0
   i32.load offset=12
   local.set $5
@@ -9318,12 +9319,12 @@
   i32.load offset=4
   local.set $6
   loop $for-loop|0
-   local.get $1
+   local.get $2
    local.get $5
    i32.lt_s
    if
     local.get $6
-    local.get $1
+    local.get $2
     i32.const 2
     i32.shl
     i32.add
@@ -9335,72 +9336,70 @@
     else
      i32.const 0
     end
-    local.get $2
-    i32.add
-    local.set $2
     local.get $1
-    i32.const 1
     i32.add
     local.set $1
+    local.get $2
+    i32.const 1
+    i32.add
+    local.set $2
     br $for-loop|0
    end
   end
-  local.get $2
+  local.get $1
   i32.const 2
   i32.shl
-  local.tee $1
+  local.tee $7
   i32.const 0
   call $~lib/rt/tlsf/__alloc
-  local.set $3
+  local.set $2
   i32.const 16
   i32.const 3
   call $~lib/rt/tlsf/__alloc
   local.tee $0
-  local.get $2
+  local.get $1
   i32.store offset=12
   local.get $0
-  local.get $1
+  local.get $7
   i32.store offset=8
   local.get $0
-  local.get $3
+  local.get $2
   i32.store offset=4
   local.get $0
-  local.get $3
+  local.get $2
   call $~lib/rt/pure/__retain
   i32.store
-  i32.const 0
-  local.set $1
   loop $for-loop|1
-   local.get $1
+   local.get $3
    local.get $5
    i32.lt_s
    if
     local.get $6
-    local.get $1
+    local.get $3
     i32.const 2
     i32.shl
     i32.add
     i32.load
-    local.tee $2
+    local.tee $1
     if
-     local.get $3
+     local.get $2
      local.get $4
      i32.add
-     local.get $2
+     local.get $1
      i32.load offset=4
-     local.get $2
+     local.get $1
      i32.load offset=8
-     local.tee $2
+     local.tee $1
      call $~lib/memory/memory.copy
-     local.get $2
+     local.get $1
      local.get $4
      i32.add
      local.set $4
     end
-    local.get $1
+    local.get $3
     i32.const 1
     i32.add
-    local.set $1
+    local.set $3
     br $for-loop|1
    end
   end
@@ -9415,18 +9414,19 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
   local.get $0
   i32.load offset=12
-  local.set $6
+  local.set $7
   local.get $0
   i32.load offset=4
-  local.set $7
+  local.set $8
   loop $for-loop|0
    local.get $1
-   local.get $6
+   local.get $7
    i32.lt_s
    if
-    local.get $7
+    local.get $8
     local.get $1
     i32.const 2
     i32.shl
@@ -9439,9 +9439,9 @@
     else
      i32.const 0
     end
-    local.get $2
+    local.get $3
     i32.add
-    local.set $2
+    local.set $3
     local.get $1
     i32.const 1
     i32.add
@@ -9449,88 +9449,84 @@
     br $for-loop|0
    end
   end
-  local.get $2
+  local.get $3
   i32.const 2
   i32.shl
-  local.tee $1
+  local.tee $2
   i32.const 0
   call $~lib/rt/tlsf/__alloc
   local.set $0
   i32.const 16
   i32.const 15
   call $~lib/rt/tlsf/__alloc
-  local.tee $3
-  local.get $2
+  local.tee $1
+  local.get $3
   i32.store offset=12
-  local.get $3
   local.get $1
+  local.get $2
   i32.store offset=8
-  local.get $3
+  local.get $1
   local.get $0
   i32.store offset=4
-  local.get $3
+  local.get $1
   local.get $0
   call $~lib/rt/pure/__retain
   i32.store
-  i32.const 0
-  local.set $1
   loop $for-loop|1
-   local.get $1
-   local.get $6
+   local.get $4
+   local.get $7
    i32.lt_s
    if
-    local.get $7
-    local.get $1
+    local.get $8
+    local.get $4
     i32.const 2
     i32.shl
     i32.add
     i32.load
-    local.tee $4
+    local.tee $2
     if
      local.get $0
      local.get $5
      i32.add
-     local.get $4
+     local.get $2
      i32.load offset=4
-     local.get $4
+     local.get $2
      i32.load offset=8
-     local.tee $4
+     local.tee $2
      call $~lib/memory/memory.copy
-     local.get $4
+     local.get $2
      local.get $5
      i32.add
      local.set $5
     end
-    local.get $1
+    local.get $4
     i32.const 1
     i32.add
-    local.set $1
+    local.set $4
     br $for-loop|1
    end
   end
-  i32.const 0
-  local.set $1
   loop $for-loop|2
-   local.get $1
-   local.get $2
+   local.get $6
+   local.get $3
    i32.lt_s
    if
     local.get $0
-    local.get $1
+    local.get $6
     i32.const 2
     i32.shl
     i32.add
     i32.load
     call $~lib/rt/pure/__retain
     drop
-    local.get $1
+    local.get $6
     i32.const 1
     i32.add
-    local.set $1
+    local.set $6
     br $for-loop|2
    end
   end
-  local.get $3
+  local.get $1
   call $~lib/rt/pure/__retain
  )
  (func $start:std/array
@@ -9547,9 +9543,9 @@
   (local $10 i32)
   (local $11 i32)
   (local $12 i32)
-  (local $13 i32)
-  (local $14 f32)
-  (local $15 f64)
+  (local $13 f32)
+  (local $14 f64)
+  (local $15 i32)
   (local $16 i32)
   (local $17 i32)
   (local $18 i32)
@@ -9568,9 +9564,9 @@
   (local $31 i32)
   (local $32 i32)
   (local $33 i32)
-  (local $34 f32)
-  (local $35 f64)
-  (local $36 i32)
+  (local $34 i32)
+  (local $35 f32)
+  (local $36 f64)
   (local $37 i32)
   (local $38 i32)
   (local $39 i32)
@@ -9596,6 +9592,7 @@
   (local $59 i32)
   (local $60 i32)
   (local $61 i32)
+  (local $62 i32)
   i32.const 0
   call $~lib/array/Array<i32>#constructor
   global.set $std/array/arr
@@ -10622,14 +10619,14 @@
   i32.const 2
   i32.const 2147483647
   call $~lib/array/Array<i32>#copyWithin
-  local.tee $16
+  local.tee $15
   i32.const 5
   i32.const 2
   i32.const 3
   i32.const 2304
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $20
+  local.tee $19
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -10654,7 +10651,7 @@
   i32.const 2
   i32.const 2147483647
   call $~lib/array/Array<i32>#copyWithin
-  local.tee $25
+  local.tee $26
   i32.const 5
   i32.const 2
   i32.const 3
@@ -10718,14 +10715,14 @@
   i32.const 3
   i32.const 4
   call $~lib/array/Array<i32>#copyWithin
-  local.tee $11
+  local.tee $10
   i32.const 5
   i32.const 2
   i32.const 3
   i32.const 2592
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $13
+  local.tee $12
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -10750,14 +10747,14 @@
   i32.const 2
   i32.const 4
   call $~lib/array/Array<i32>#copyWithin
-  local.tee $30
+  local.tee $31
   i32.const 5
   i32.const 2
   i32.const 3
   i32.const 2688
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $17
+  local.tee $16
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -10782,14 +10779,14 @@
   i32.const -2
   i32.const 2147483647
   call $~lib/array/Array<i32>#copyWithin
-  local.tee $18
+  local.tee $17
   i32.const 5
   i32.const 2
   i32.const 3
   i32.const 2784
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $19
+  local.tee $18
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -10814,14 +10811,14 @@
   i32.const -2
   i32.const -1
   call $~lib/array/Array<i32>#copyWithin
-  local.tee $12
+  local.tee $11
   i32.const 5
   i32.const 2
   i32.const 3
   i32.const 2880
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $21
+  local.tee $22
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -10847,14 +10844,14 @@
   i32.const -3
   i32.const -2
   call $~lib/array/Array<i32>#copyWithin
-  local.tee $22
+  local.tee $23
   i32.const 5
   i32.const 2
   i32.const 3
   i32.const 2976
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $23
+  local.tee $24
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -10880,14 +10877,14 @@
   i32.const -3
   i32.const -1
   call $~lib/array/Array<i32>#copyWithin
-  local.tee $24
+  local.tee $25
   i32.const 5
   i32.const 2
   i32.const 3
   i32.const 3072
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $26
+  local.tee $27
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -10920,7 +10917,7 @@
   i32.const 3168
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $27
+  local.tee $28
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -10942,11 +10939,11 @@
   call $~lib/rt/pure/__release
   local.get $5
   call $~lib/rt/pure/__release
-  local.get $16
+  local.get $15
   call $~lib/rt/pure/__release
-  local.get $20
+  local.get $19
   call $~lib/rt/pure/__release
-  local.get $25
+  local.get $26
   call $~lib/rt/pure/__release
   local.get $6
   call $~lib/rt/pure/__release
@@ -10954,21 +10951,19 @@
   call $~lib/rt/pure/__release
   local.get $9
   call $~lib/rt/pure/__release
-  local.get $11
+  local.get $10
   call $~lib/rt/pure/__release
-  local.get $13
+  local.get $12
   call $~lib/rt/pure/__release
-  local.get $30
+  local.get $31
+  call $~lib/rt/pure/__release
+  local.get $16
   call $~lib/rt/pure/__release
   local.get $17
   call $~lib/rt/pure/__release
   local.get $18
   call $~lib/rt/pure/__release
-  local.get $19
-  call $~lib/rt/pure/__release
-  local.get $12
-  call $~lib/rt/pure/__release
-  local.get $21
+  local.get $11
   call $~lib/rt/pure/__release
   local.get $22
   call $~lib/rt/pure/__release
@@ -10976,11 +10971,13 @@
   call $~lib/rt/pure/__release
   local.get $24
   call $~lib/rt/pure/__release
-  local.get $26
+  local.get $25
+  call $~lib/rt/pure/__release
+  local.get $27
   call $~lib/rt/pure/__release
   local.get $1
   call $~lib/rt/pure/__release
-  local.get $27
+  local.get $28
   call $~lib/rt/pure/__release
   global.get $std/array/arr
   i32.const 42
@@ -11932,14 +11929,14 @@
      i32.shl
      i32.add
      f32.load
-     local.tee $14
+     local.tee $13
      f32.const nan:0x400000
      f32.eq
      if (result i32)
       i32.const 1
      else
-      local.get $14
-      local.get $14
+      local.get $13
+      local.get $13
       f32.ne
      end
      br_if $__inlined_func$~lib/array/Array<f32>#includes
@@ -11986,27 +11983,27 @@
    drop
    local.get $3
    i32.load offset=4
-   local.set $16
+   local.set $15
    loop $while-continue|025
     local.get $1
     local.get $4
     i32.lt_s
     if
      i32.const 1
-     local.get $16
+     local.get $15
      local.get $1
      i32.const 3
      i32.shl
      i32.add
      f64.load
-     local.tee $15
+     local.tee $14
      f64.const nan:0x8000000000000
      f64.eq
      if (result i32)
       i32.const 1
      else
-      local.get $15
-      local.get $15
+      local.get $14
+      local.get $14
       f64.ne
      end
      br_if $__inlined_func$~lib/array/Array<f64>#includes
@@ -12200,14 +12197,14 @@
   i32.const 2
   i32.const 2147483647
   call $~lib/array/Array<i32>#splice
-  local.tee $11
+  local.tee $10
   i32.const 3
   i32.const 2
   i32.const 3
   i32.const 3616
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $13
+  local.tee $12
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -12226,7 +12223,7 @@
   i32.const 3648
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $17
+  local.tee $16
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -12251,14 +12248,14 @@
   i32.const 2
   i32.const 2
   call $~lib/array/Array<i32>#splice
-  local.tee $18
+  local.tee $17
   i32.const 2
   i32.const 2
   i32.const 3
   i32.const 3728
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $19
+  local.tee $18
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -12277,7 +12274,7 @@
   i32.const 3760
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $12
+  local.tee $11
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -12302,14 +12299,14 @@
   i32.const 0
   i32.const 1
   call $~lib/array/Array<i32>#splice
-  local.tee $21
+  local.tee $22
   i32.const 1
   i32.const 2
   i32.const 3
   i32.const 3840
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $22
+  local.tee $23
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -12328,7 +12325,7 @@
   i32.const 3872
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $23
+  local.tee $24
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -12352,14 +12349,14 @@
   i32.const -1
   i32.const 2147483647
   call $~lib/array/Array<i32>#splice
-  local.tee $24
+  local.tee $25
   i32.const 1
   i32.const 2
   i32.const 3
   i32.const 3952
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $26
+  local.tee $27
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -12378,7 +12375,7 @@
   i32.const 3984
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $27
+  local.tee $28
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -12402,14 +12399,14 @@
   i32.const -2
   i32.const 2147483647
   call $~lib/array/Array<i32>#splice
-  local.tee $31
+  local.tee $32
   i32.const 2
   i32.const 2
   i32.const 3
   i32.const 4064
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $32
+  local.tee $33
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -12428,7 +12425,7 @@
   i32.const 4096
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $33
+  local.tee $34
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -12452,14 +12449,14 @@
   i32.const -2
   i32.const 1
   call $~lib/array/Array<i32>#splice
-  local.tee $28
+  local.tee $29
   i32.const 1
   i32.const 2
   i32.const 3
   i32.const 4176
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $29
+  local.tee $30
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -12478,7 +12475,7 @@
   i32.const 4208
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $36
+  local.tee $37
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -12502,14 +12499,14 @@
   i32.const -7
   i32.const 1
   call $~lib/array/Array<i32>#splice
-  local.tee $37
+  local.tee $38
   i32.const 1
   i32.const 2
   i32.const 3
   i32.const 4288
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $38
+  local.tee $39
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -12528,7 +12525,7 @@
   i32.const 4320
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $39
+  local.tee $40
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -12552,14 +12549,14 @@
   i32.const -2
   i32.const -1
   call $~lib/array/Array<i32>#splice
-  local.tee $40
+  local.tee $41
   i32.const 0
   i32.const 2
   i32.const 3
   i32.const 4400
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $41
+  local.tee $42
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -12578,7 +12575,7 @@
   i32.const 4416
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $42
+  local.tee $43
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -12602,14 +12599,14 @@
   i32.const 1
   i32.const -2
   call $~lib/array/Array<i32>#splice
-  local.tee $43
+  local.tee $44
   i32.const 0
   i32.const 2
   i32.const 3
   i32.const 4512
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $44
+  local.tee $45
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -12628,7 +12625,7 @@
   i32.const 4528
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $45
+  local.tee $46
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -12653,14 +12650,14 @@
   i32.const 4
   i32.const 0
   call $~lib/array/Array<i32>#splice
-  local.tee $46
+  local.tee $47
   i32.const 0
   i32.const 2
   i32.const 3
   i32.const 4624
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $47
+  local.tee $48
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -12679,7 +12676,7 @@
   i32.const 4640
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $48
+  local.tee $49
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -12704,14 +12701,14 @@
   i32.const 7
   i32.const 0
   call $~lib/array/Array<i32>#splice
-  local.tee $49
+  local.tee $50
   i32.const 0
   i32.const 2
   i32.const 3
   i32.const 4736
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $50
+  local.tee $51
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -12730,7 +12727,7 @@
   i32.const 4752
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $51
+  local.tee $52
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -12755,14 +12752,14 @@
   i32.const 7
   i32.const 5
   call $~lib/array/Array<i32>#splice
-  local.tee $52
+  local.tee $53
   i32.const 0
   i32.const 2
   i32.const 3
   i32.const 4848
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $53
+  local.tee $54
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -12781,7 +12778,7 @@
   i32.const 4864
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $54
+  local.tee $55
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -12802,7 +12799,7 @@
   local.tee $2
   i32.const 1
   call $~lib/array/Array<std/array/Ref>#splice
-  local.tee $20
+  local.tee $19
   i32.load offset=12
   if
    i32.const 0
@@ -12828,7 +12825,7 @@
   i32.const 0
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $16
+  local.tee $15
   i32.load offset=4
   local.tee $0
   i32.const 1
@@ -12852,13 +12849,13 @@
   i32.store offset=16
   local.get $2
   call $~lib/rt/pure/__release
-  local.get $16
+  local.get $15
   i32.const 2
   call $~lib/array/Array<std/array/Ref>#splice
-  local.set $25
-  local.get $20
+  local.set $26
+  local.get $19
   call $~lib/rt/pure/__release
-  local.get $25
+  local.get $26
   i32.load offset=12
   i32.const 2
   i32.ne
@@ -12870,10 +12867,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $25
+  local.get $26
   i32.const 0
   call $~lib/array/Array<std/array/Ref>#__get
-  local.tee $55
+  local.tee $56
   i32.load
   i32.const 3
   i32.ne
@@ -12885,10 +12882,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $25
+  local.get $26
   i32.const 1
   call $~lib/array/Array<std/array/Ref>#__get
-  local.tee $56
+  local.tee $57
   i32.load
   i32.const 4
   i32.ne
@@ -12900,7 +12897,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $16
+  local.get $15
   i32.load offset=12
   i32.const 3
   i32.ne
@@ -12912,10 +12909,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $16
+  local.get $15
   i32.const 0
   call $~lib/array/Array<std/array/Ref>#__get
-  local.tee $57
+  local.tee $58
   i32.load
   i32.const 1
   i32.ne
@@ -12927,10 +12924,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $16
+  local.get $15
   i32.const 1
   call $~lib/array/Array<std/array/Ref>#__get
-  local.tee $58
+  local.tee $59
   i32.load
   i32.const 2
   i32.ne
@@ -12942,10 +12939,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $16
+  local.get $15
   i32.const 2
   call $~lib/array/Array<std/array/Ref>#__get
-  local.tee $59
+  local.tee $60
   i32.load
   i32.const 5
   i32.ne
@@ -12963,7 +12960,7 @@
   i32.const 0
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $20
+  local.tee $19
   i32.load offset=4
   local.tee $0
   i32.const 1
@@ -12976,9 +12973,9 @@
   i32.const 2
   call $std/array/Ref#constructor
   i32.store offset=8
-  local.get $20
+  local.get $19
   call $~lib/array/Array<std/array/Ref | null>#splice
-  local.tee $30
+  local.tee $31
   i32.load offset=12
   i32.const 1
   i32.ne
@@ -12990,7 +12987,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $30
+  local.get $31
   i32.const 0
   call $~lib/array/Array<std/array/Ref | null>#__get
   local.tee $0
@@ -13015,7 +13012,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $20
+  local.get $19
   i32.load offset=12
   i32.const 2
   i32.ne
@@ -13027,10 +13024,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $20
+  local.get $19
   i32.const 0
   call $~lib/array/Array<std/array/Ref | null>#__get
-  local.tee $60
+  local.tee $61
   if
    i32.const 0
    i32.const 1296
@@ -13039,7 +13036,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $20
+  local.get $19
   i32.const 1
   call $~lib/array/Array<std/array/Ref | null>#__get
   local.tee $2
@@ -13078,19 +13075,17 @@
   call $~lib/rt/pure/__release
   local.get $9
   call $~lib/rt/pure/__release
-  local.get $11
+  local.get $10
   call $~lib/rt/pure/__release
-  local.get $13
+  local.get $12
+  call $~lib/rt/pure/__release
+  local.get $16
   call $~lib/rt/pure/__release
   local.get $17
   call $~lib/rt/pure/__release
   local.get $18
   call $~lib/rt/pure/__release
-  local.get $19
-  call $~lib/rt/pure/__release
-  local.get $12
-  call $~lib/rt/pure/__release
-  local.get $21
+  local.get $11
   call $~lib/rt/pure/__release
   local.get $22
   call $~lib/rt/pure/__release
@@ -13098,21 +13093,21 @@
   call $~lib/rt/pure/__release
   local.get $24
   call $~lib/rt/pure/__release
-  local.get $26
+  local.get $25
   call $~lib/rt/pure/__release
   local.get $27
   call $~lib/rt/pure/__release
-  local.get $31
+  local.get $28
   call $~lib/rt/pure/__release
   local.get $32
   call $~lib/rt/pure/__release
   local.get $33
   call $~lib/rt/pure/__release
-  local.get $28
+  local.get $34
   call $~lib/rt/pure/__release
   local.get $29
   call $~lib/rt/pure/__release
-  local.get $36
+  local.get $30
   call $~lib/rt/pure/__release
   local.get $37
   call $~lib/rt/pure/__release
@@ -13160,9 +13155,11 @@
   call $~lib/rt/pure/__release
   local.get $59
   call $~lib/rt/pure/__release
+  local.get $60
+  call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
-  local.get $60
+  local.get $61
   call $~lib/rt/pure/__release
   local.get $2
   call $~lib/rt/pure/__release
@@ -14278,19 +14275,19 @@
    if
     local.get $4
     f32.load offset=4
-    local.tee $14
+    local.tee $13
     local.get $4
     f32.load
-    local.tee $34
+    local.tee $35
     call $~lib/util/sort/COMPARATOR<f32>~anonymous|0
     i32.const 0
     i32.lt_s
     if
      local.get $4
-     local.get $34
+     local.get $35
      f32.store offset=4
      local.get $4
-     local.get $14
+     local.get $13
      f32.store
     end
     local.get $3
@@ -14314,7 +14311,7 @@
       i32.shl
       i32.add
       f32.load
-      local.set $14
+      local.set $13
       local.get $2
       i32.const 1
       i32.sub
@@ -14324,14 +14321,14 @@
        i32.const 0
        i32.ge_s
        if
-        local.get $14
+        local.get $13
         local.get $4
         local.get $0
         i32.const 2
         i32.shl
         i32.add
         f32.load
-        local.tee $34
+        local.tee $35
         call $~lib/util/sort/COMPARATOR<f32>~anonymous|0
         i32.const 0
         i32.lt_s
@@ -14348,7 +14345,7 @@
          i32.const 2
          i32.shl
          i32.add
-         local.get $34
+         local.get $35
          f32.store
          br $while-continue|1
         end
@@ -14361,7 +14358,7 @@
       i32.const 2
       i32.shl
       i32.add
-      local.get $14
+      local.get $13
       f32.store
       local.get $2
       i32.const 1
@@ -14411,15 +14408,15 @@
       local.get $3
       local.get $1
       call $~lib/array/Array<f32>#__get
-      local.tee $14
-      local.get $14
+      local.tee $13
+      local.get $13
       f32.ne
       if (result i32)
        local.get $7
        local.get $1
        call $~lib/array/Array<f32>#__get
-       local.tee $14
-       local.get $14
+       local.tee $13
+       local.get $13
        f32.ne
       else
        i32.const 0
@@ -14482,19 +14479,19 @@
    if
     local.get $5
     f64.load offset=8
-    local.tee $15
+    local.tee $14
     local.get $5
     f64.load
-    local.tee $35
+    local.tee $36
     call $~lib/util/sort/COMPARATOR<f64>~anonymous|0
     i32.const 0
     i32.lt_s
     if
      local.get $5
-     local.get $35
+     local.get $36
      f64.store offset=8
      local.get $5
-     local.get $15
+     local.get $14
      f64.store
     end
     local.get $4
@@ -14518,7 +14515,7 @@
       i32.shl
       i32.add
       f64.load
-      local.set $15
+      local.set $14
       local.get $2
       i32.const 1
       i32.sub
@@ -14528,14 +14525,14 @@
        i32.const 0
        i32.ge_s
        if
-        local.get $15
+        local.get $14
         local.get $5
         local.get $0
         i32.const 3
         i32.shl
         i32.add
         f64.load
-        local.tee $35
+        local.tee $36
         call $~lib/util/sort/COMPARATOR<f64>~anonymous|0
         i32.const 0
         i32.lt_s
@@ -14552,7 +14549,7 @@
          i32.const 3
          i32.shl
          i32.add
-         local.get $35
+         local.get $36
          f64.store
          br $while-continue|13
         end
@@ -14565,7 +14562,7 @@
       i32.const 3
       i32.shl
       i32.add
-      local.get $15
+      local.get $14
       f64.store
       local.get $2
       i32.const 1
@@ -14615,15 +14612,15 @@
       local.get $4
       local.get $1
       call $~lib/array/Array<f64>#__get
-      local.tee $15
-      local.get $15
+      local.tee $14
+      local.get $14
       f64.ne
       if (result i32)
        local.get $2
        local.get $1
        call $~lib/array/Array<f64>#__get
-       local.tee $15
-       local.get $15
+       local.tee $14
+       local.get $14
        f64.ne
       else
        i32.const 0
@@ -14666,18 +14663,18 @@
   i32.const 5536
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $17
+  local.tee $16
   i32.const 46
   call $~lib/array/Array<i32>#sort
   call $~lib/rt/pure/__release
-  local.get $17
+  local.get $16
   i32.const 5
   i32.const 2
   i32.const 3
   i32.const 5584
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $21
+  local.tee $22
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -14695,18 +14692,18 @@
   i32.const 5632
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $18
+  local.tee $17
   i32.const 47
   call $~lib/array/Array<i32>#sort
   call $~lib/rt/pure/__release
-  local.get $18
+  local.get $17
   i32.const 5
   i32.const 2
   i32.const 7
   i32.const 5680
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $22
+  local.tee $23
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -14724,7 +14721,7 @@
   i32.const 5728
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $19
+  local.set $18
   i32.const 1
   i32.const 2
   i32.const 3
@@ -14761,14 +14758,14 @@
   local.set $9
   i32.const 1024
   call $std/array/createReverseOrderedArray
-  local.set $11
+  local.set $10
   i32.const 10000
   call $std/array/createReverseOrderedArray
-  local.set $13
+  local.set $12
   i32.const 512
   call $std/array/createRandomOrderedArray
-  local.set $12
-  local.get $19
+  local.set $11
+  local.get $18
   i32.const 48
   call $std/array/assertSorted<i32>
   local.get $1
@@ -14781,7 +14778,7 @@
   i32.const 5872
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $23
+  local.tee $24
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -14803,7 +14800,7 @@
   i32.const 5904
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $24
+  local.tee $25
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -14863,10 +14860,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $11
+  local.get $10
   i32.const 48
   call $std/array/assertSorted<i32>
-  local.get $11
+  local.get $10
   local.get $0
   i32.const 4
   call $std/array/isArraysEqual<u32>
@@ -14879,10 +14876,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $13
+  local.get $12
   i32.const 48
   call $std/array/assertSorted<i32>
-  local.get $13
+  local.get $12
   local.get $0
   i32.const 4
   call $std/array/isArraysEqual<u32>
@@ -14895,7 +14892,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $12
+  local.get $11
   i32.const 48
   call $std/array/assertSorted<i32>
   local.get $3
@@ -14906,15 +14903,15 @@
   call $~lib/rt/pure/__release
   local.get $2
   call $~lib/rt/pure/__release
-  local.get $17
-  call $~lib/rt/pure/__release
-  local.get $21
-  call $~lib/rt/pure/__release
-  local.get $18
+  local.get $16
   call $~lib/rt/pure/__release
   local.get $22
   call $~lib/rt/pure/__release
-  local.get $19
+  local.get $17
+  call $~lib/rt/pure/__release
+  local.get $23
+  call $~lib/rt/pure/__release
+  local.get $18
   call $~lib/rt/pure/__release
   local.get $1
   call $~lib/rt/pure/__release
@@ -14928,15 +14925,15 @@
   call $~lib/rt/pure/__release
   local.get $9
   call $~lib/rt/pure/__release
-  local.get $11
-  call $~lib/rt/pure/__release
-  local.get $13
+  local.get $10
   call $~lib/rt/pure/__release
   local.get $12
   call $~lib/rt/pure/__release
-  local.get $23
+  local.get $11
   call $~lib/rt/pure/__release
   local.get $24
+  call $~lib/rt/pure/__release
+  local.get $25
   call $~lib/rt/pure/__release
   i32.const 64
   call $std/array/createRandomOrderedArray
@@ -15334,7 +15331,7 @@
   local.tee $9
   i32.const 6576
   call $~lib/array/Array<i32>#join
-  local.tee $11
+  local.tee $10
   i32.const 6608
   call $~lib/string/String.__eq
   i32.eqz
@@ -15357,7 +15354,7 @@
   local.get $1
   i32.load offset=12
   call $~lib/util/string/joinFloatArray<f64>
-  local.tee $13
+  local.tee $12
   i32.const 7824
   call $~lib/string/String.__eq
   i32.eqz
@@ -15375,10 +15372,10 @@
   i32.const 7952
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $17
+  local.tee $16
   i32.const 6064
   call $~lib/array/Array<~lib/string/String | null>#join
-  local.tee $18
+  local.tee $17
   i32.const 7920
   call $~lib/string/String.__eq
   i32.eqz
@@ -15411,7 +15408,7 @@
   i32.store offset=8
   local.get $2
   call $~lib/array/Array<std/array/Ref | null>#join
-  local.tee $19
+  local.tee $18
   i32.const 8032
   call $~lib/string/String.__eq
   i32.eqz
@@ -15431,17 +15428,17 @@
   call $~lib/rt/pure/__retain
   local.tee $3
   i32.load offset=4
-  local.tee $12
+  local.tee $11
   i32.const 0
   call $std/array/Ref#constructor
   i32.store
-  local.get $12
+  local.get $11
   i32.const 0
   call $std/array/Ref#constructor
   i32.store offset=4
   local.get $3
   call $~lib/array/Array<std/array/Ref | null>#join
-  local.tee $12
+  local.tee $11
   i32.const 8112
   call $~lib/string/String.__eq
   i32.eqz
@@ -15467,23 +15464,23 @@
   call $~lib/rt/pure/__release
   local.get $9
   call $~lib/rt/pure/__release
-  local.get $11
+  local.get $10
   call $~lib/rt/pure/__release
   local.get $1
   call $~lib/rt/pure/__release
-  local.get $13
+  local.get $12
+  call $~lib/rt/pure/__release
+  local.get $16
   call $~lib/rt/pure/__release
   local.get $17
   call $~lib/rt/pure/__release
-  local.get $18
-  call $~lib/rt/pure/__release
   local.get $2
   call $~lib/rt/pure/__release
-  local.get $19
+  local.get $18
   call $~lib/rt/pure/__release
   local.get $3
   call $~lib/rt/pure/__release
-  local.get $12
+  local.get $11
   call $~lib/rt/pure/__release
   i32.const 0
   i32.const 2
@@ -15533,7 +15530,7 @@
   i32.const 6304
   call $~lib/array/Array<i32>#join
   local.tee $0
-  local.set $17
+  local.set $16
   local.get $0
   i32.const 7920
   call $~lib/string/String.__eq
@@ -15550,7 +15547,7 @@
   i32.const 6304
   call $~lib/array/Array<i32>#join
   local.tee $0
-  local.set $18
+  local.set $17
   local.get $0
   i32.const 8304
   call $~lib/string/String.__eq
@@ -15567,7 +15564,7 @@
   i32.const 6304
   call $~lib/array/Array<i32>#join
   local.tee $0
-  local.set $19
+  local.set $18
   local.get $0
   i32.const 8336
   call $~lib/string/String.__eq
@@ -15592,7 +15589,7 @@
   i32.load offset=12
   call $~lib/util/string/joinIntegerArray<i8>
   local.tee $0
-  local.set $12
+  local.set $11
   local.get $0
   i32.const 8400
   call $~lib/string/String.__eq
@@ -15617,7 +15614,7 @@
   i32.load offset=12
   call $~lib/util/string/joinIntegerArray<u16>
   local.tee $0
-  local.set $21
+  local.set $22
   local.get $0
   i32.const 8464
   call $~lib/string/String.__eq
@@ -15642,7 +15639,7 @@
   i32.load offset=12
   call $~lib/util/string/joinIntegerArray<u64>
   local.tee $0
-  local.set $22
+  local.set $23
   local.get $0
   i32.const 8560
   call $~lib/string/String.__eq
@@ -15661,13 +15658,13 @@
   i32.const 8624
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $11
+  local.tee $10
   i32.load offset=4
-  local.get $11
+  local.get $10
   i32.load offset=12
   call $~lib/util/string/joinIntegerArray<i64>
   local.tee $0
-  local.set $23
+  local.set $24
   local.get $0
   i32.const 8672
   call $~lib/string/String.__eq
@@ -15686,11 +15683,11 @@
   i32.const 8784
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $24
+  local.tee $25
   i32.const 6304
   call $~lib/array/Array<~lib/string/String | null>#join
   local.tee $0
-  local.set $26
+  local.set $27
   local.get $0
   i32.const 8832
   call $~lib/string/String.__eq
@@ -15709,11 +15706,11 @@
   i32.const 8944
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $27
+  local.tee $28
   i32.const 6304
   call $~lib/array/Array<~lib/string/String | null>#join
   local.tee $0
-  local.set $31
+  local.set $32
   local.get $0
   i32.const 8976
   call $~lib/string/String.__eq
@@ -15756,7 +15753,7 @@
   i32.load offset=12
   call $~lib/util/string/joinReferenceArray<~lib/array/Array<i32>>
   local.tee $1
-  local.set $32
+  local.set $33
   local.get $1
   i32.const 9072
   call $~lib/string/String.__eq
@@ -15799,7 +15796,7 @@
   i32.load offset=12
   call $~lib/util/string/joinReferenceArray<~lib/array/Array<u8>>
   local.tee $2
-  local.set $33
+  local.set $34
   local.get $2
   i32.const 9072
   call $~lib/string/String.__eq
@@ -15826,7 +15823,7 @@
   i32.const 0
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $29
+  local.tee $30
   i32.load offset=4
   i32.const 1
   i32.const 2
@@ -15835,16 +15832,16 @@
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
   i32.store
-  local.get $29
+  local.get $30
   i32.store
   local.get $2
   i32.load offset=4
   local.get $2
   i32.load offset=12
   call $~lib/util/string/joinReferenceArray<~lib/array/Array<~lib/array/Array<u32>>>
-  local.tee $28
-  local.set $29
-  local.get $28
+  local.tee $29
+  local.set $30
+  local.get $29
   i32.const 7920
   call $~lib/string/String.__eq
   i32.eqz
@@ -15865,41 +15862,41 @@
   local.get $7
   call $~lib/rt/pure/__release
   call $~lib/rt/pure/__release
+  local.get $16
+  call $~lib/rt/pure/__release
   local.get $17
   call $~lib/rt/pure/__release
   local.get $18
   call $~lib/rt/pure/__release
-  local.get $19
-  call $~lib/rt/pure/__release
   local.get $6
-  call $~lib/rt/pure/__release
-  local.get $12
-  call $~lib/rt/pure/__release
-  local.get $8
-  call $~lib/rt/pure/__release
-  local.get $21
-  call $~lib/rt/pure/__release
-  local.get $9
-  call $~lib/rt/pure/__release
-  local.get $22
   call $~lib/rt/pure/__release
   local.get $11
   call $~lib/rt/pure/__release
+  local.get $8
+  call $~lib/rt/pure/__release
+  local.get $22
+  call $~lib/rt/pure/__release
+  local.get $9
+  call $~lib/rt/pure/__release
   local.get $23
+  call $~lib/rt/pure/__release
+  local.get $10
   call $~lib/rt/pure/__release
   local.get $24
   call $~lib/rt/pure/__release
-  local.get $26
+  local.get $25
   call $~lib/rt/pure/__release
   local.get $27
   call $~lib/rt/pure/__release
-  local.get $31
+  local.get $28
   call $~lib/rt/pure/__release
   local.get $32
   call $~lib/rt/pure/__release
   local.get $33
   call $~lib/rt/pure/__release
-  local.get $29
+  local.get $34
+  call $~lib/rt/pure/__release
+  local.get $30
   call $~lib/rt/pure/__release
   global.get $std/array/arr
   call $~lib/rt/pure/__release
@@ -15958,14 +15955,14 @@
    unreachable
   end
   loop $for-loop|1
-   local.get $10
+   local.get $20
    i32.const 10
    i32.lt_s
    if
     local.get $7
-    local.get $10
+    local.get $20
     call $~lib/array/Array<u32>#__get
-    local.get $10
+    local.get $20
     i32.ne
     if
      i32.const 0
@@ -15975,10 +15972,10 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $10
+    local.get $20
     i32.const 1
     i32.add
-    local.set $10
+    local.set $20
     br $for-loop|1
    end
   end
@@ -16044,22 +16041,20 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 0
-  local.set $10
   loop $for-loop|2
-   local.get $10
+   local.get $21
    local.get $4
    i32.load offset=12
    i32.lt_s
    if
     local.get $3
-    local.get $10
+    local.get $21
+    call $~lib/array/Array<std/array/Ref | null>#__get
+    local.tee $20
+    local.get $4
+    local.get $21
     call $~lib/array/Array<std/array/Ref | null>#__get
     local.tee $8
-    local.get $4
-    local.get $10
-    call $~lib/array/Array<std/array/Ref | null>#__get
-    local.tee $9
     call $~lib/string/String.__eq
     i32.eqz
     if
@@ -16070,14 +16065,14 @@
      call $~lib/builtins/abort
      unreachable
     end
+    local.get $20
+    call $~lib/rt/pure/__release
     local.get $8
     call $~lib/rt/pure/__release
-    local.get $9
-    call $~lib/rt/pure/__release
-    local.get $10
+    local.get $21
     i32.const 1
     i32.add
-    local.set $10
+    local.set $21
     br $for-loop|2
    end
   end
@@ -16087,9 +16082,9 @@
   i32.const 0
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $10
+  local.tee $20
   i32.load offset=4
-  local.tee $8
+  local.tee $21
   i32.const 0
   i32.const 2
   i32.const 3
@@ -16097,7 +16092,7 @@
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
   i32.store
-  local.get $8
+  local.get $21
   i32.const 0
   i32.const 2
   i32.const 3
@@ -16105,9 +16100,9 @@
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
   i32.store offset=4
-  local.get $10
+  local.get $20
   call $~lib/array/Array<~lib/array/Array<i32>>#flat
-  local.tee $8
+  local.tee $21
   i32.load offset=12
   if
    i32.const 0
@@ -16117,17 +16112,17 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $10
-  call $~lib/rt/pure/__release
-  local.get $8
-  call $~lib/rt/pure/__release
-  local.get $16
-  call $~lib/rt/pure/__release
-  local.get $25
-  call $~lib/rt/pure/__release
   local.get $20
   call $~lib/rt/pure/__release
-  local.get $30
+  local.get $21
+  call $~lib/rt/pure/__release
+  local.get $15
+  call $~lib/rt/pure/__release
+  local.get $26
+  call $~lib/rt/pure/__release
+  local.get $19
+  call $~lib/rt/pure/__release
+  local.get $31
   call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release

--- a/tests/compiler/std/array.untouched.wat
+++ b/tests/compiler/std/array.untouched.wat
@@ -283,6 +283,15 @@
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
   local.get $1
   i32.load
   local.set $2
@@ -419,59 +428,59 @@
   i32.eq
   if
    local.get $0
-   local.set $11
+   local.set $14
    local.get $4
-   local.set $10
+   local.set $13
    local.get $5
-   local.set $9
+   local.set $12
    local.get $7
-   local.set $8
-   local.get $11
-   local.get $10
+   local.set $11
+   local.get $14
+   local.get $13
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $12
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
+   local.get $11
    i32.store offset=96
    local.get $7
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $16
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $15
+    local.get $16
+    local.get $15
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $17
     local.get $0
-    local.set $8
+    local.set $20
     local.get $4
-    local.set $11
-    local.get $9
+    local.set $19
+    local.get $17
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
-    local.set $10
-    local.get $8
-    local.get $11
+    local.tee $17
+    local.set $18
+    local.get $20
+    local.get $19
     i32.const 2
     i32.shl
     i32.add
-    local.get $10
+    local.get $18
     i32.store offset=4
-    local.get $9
+    local.get $17
     i32.eqz
     if
      local.get $0
@@ -501,6 +510,20 @@
   (local $11 i32)
   (local $12 i32)
   (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local $22 i32)
+  (local $23 i32)
+  (local $24 i32)
+  (local $25 i32)
+  (local $26 i32)
+  (local $27 i32)
   i32.const 1
   drop
   local.get $1
@@ -563,8 +586,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $3
+   local.set $6
+   local.get $6
    i32.const 1073741808
    i32.lt_u
    if
@@ -575,16 +598,16 @@
     local.get $2
     i32.const 3
     i32.and
-    local.get $3
+    local.get $6
     i32.or
     local.tee $2
     i32.store
     local.get $1
-    local.set $6
-    local.get $6
+    local.set $7
+    local.get $7
     i32.const 16
     i32.add
-    local.get $6
+    local.get $7
     i32.load
     i32.const 3
     i32.const -1
@@ -602,18 +625,18 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $8
+   local.get $8
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
+   local.set $9
+   local.get $9
    i32.load
-   local.set $3
+   local.set $10
    i32.const 1
    drop
-   local.get $3
+   local.get $10
    i32.const 1
    i32.and
    i32.eqz
@@ -625,7 +648,7 @@
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $3
+   local.get $10
    i32.const 3
    i32.const -1
    i32.xor
@@ -638,23 +661,23 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $7
+   local.set $11
+   local.get $11
    i32.const 1073741808
    i32.lt_u
    if
     local.get $0
-    local.get $6
+    local.get $9
     call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
+    local.get $9
+    local.get $10
     i32.const 3
     i32.and
-    local.get $7
+    local.get $11
     i32.or
     local.tee $2
     i32.store
-    local.get $6
+    local.get $9
     local.set $1
    end
   end
@@ -668,14 +691,14 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $12
   i32.const 1
   drop
-  local.get $8
+  local.get $12
   i32.const 16
   i32.ge_u
   if (result i32)
-   local.get $8
+   local.get $12
    i32.const 1073741808
    i32.lt_u
   else
@@ -695,7 +718,7 @@
   local.get $1
   i32.const 16
   i32.add
-  local.get $8
+  local.get $12
   i32.add
   local.get $4
   i32.eq
@@ -713,24 +736,24 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $12
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $13
+   local.get $12
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $14
   else
    i32.const 31
-   local.get $8
+   local.get $12
    i32.clz
    i32.sub
-   local.set $9
-   local.get $8
-   local.get $9
+   local.set $13
+   local.get $12
+   local.get $13
    i32.const 4
    i32.sub
    i32.shr_u
@@ -738,21 +761,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $14
+   local.get $13
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $13
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $13
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $14
    i32.const 16
    i32.lt_u
   else
@@ -768,86 +791,86 @@
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
-  local.set $6
-  local.get $7
-  local.get $3
+  local.set $17
+  local.get $13
+  local.set $16
+  local.get $14
+  local.set $15
+  local.get $17
+  local.get $16
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $15
   i32.add
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=96
-  local.set $11
+  local.set $18
   local.get $1
   i32.const 0
   i32.store offset=16
   local.get $1
-  local.get $11
+  local.get $18
   i32.store offset=20
-  local.get $11
+  local.get $18
   if
-   local.get $11
+   local.get $18
    local.get $1
    i32.store offset=16
   end
   local.get $0
-  local.set $12
-  local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
+  local.set $22
+  local.get $13
+  local.set $21
+  local.get $14
+  local.set $20
   local.get $1
-  local.set $6
-  local.get $12
-  local.get $7
+  local.set $19
+  local.get $22
+  local.get $21
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $20
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $19
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $13
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.set $13
-  local.get $9
-  local.set $12
+  local.set $27
+  local.get $13
+  local.set $26
   local.get $0
-  local.set $3
-  local.get $9
-  local.set $6
-  local.get $3
-  local.get $6
+  local.set $24
+  local.get $13
+  local.set $23
+  local.get $24
+  local.get $23
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $14
   i32.shl
   i32.or
-  local.set $7
-  local.get $13
-  local.get $12
+  local.set $25
+  local.get $27
+  local.get $26
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $25
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -858,6 +881,7 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
   i32.const 1
   drop
   local.get $1
@@ -997,11 +1021,11 @@
   i32.or
   i32.store
   local.get $0
-  local.set $9
+  local.set $10
   local.get $4
-  local.set $3
+  local.set $9
+  local.get $10
   local.get $9
-  local.get $3
   i32.store offset=1568
   local.get $0
   local.get $8
@@ -1021,6 +1045,12 @@
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
   global.get $~lib/rt/tlsf/ROOT
   local.set $0
   local.get $0
@@ -1077,66 +1107,66 @@
    local.get $4
    i32.store offset=1568
    i32.const 0
-   local.set $5
+   local.set $6
    loop $for-loop|0
-    local.get $5
+    local.get $6
     i32.const 23
     i32.lt_u
-    local.set $4
-    local.get $4
+    local.set $7
+    local.get $7
     if
      local.get $0
-     local.set $8
-     local.get $5
-     local.set $7
+     local.set $10
+     local.get $6
+     local.set $9
      i32.const 0
-     local.set $6
-     local.get $8
-     local.get $7
+     local.set $8
+     local.get $10
+     local.get $9
      i32.const 2
      i32.shl
      i32.add
-     local.get $6
+     local.get $8
      i32.store offset=4
      i32.const 0
-     local.set $8
+     local.set $11
      loop $for-loop|1
-      local.get $8
+      local.get $11
       i32.const 16
       i32.lt_u
-      local.set $7
-      local.get $7
+      local.set $12
+      local.get $12
       if
        local.get $0
-       local.set $11
-       local.get $5
-       local.set $10
-       local.get $8
-       local.set $9
-       i32.const 0
-       local.set $6
+       local.set $16
+       local.get $6
+       local.set $15
        local.get $11
-       local.get $10
+       local.set $14
+       i32.const 0
+       local.set $13
+       local.get $16
+       local.get $15
        i32.const 4
        i32.shl
-       local.get $9
+       local.get $14
        i32.add
        i32.const 2
        i32.shl
        i32.add
-       local.get $6
+       local.get $13
        i32.store offset=96
-       local.get $8
+       local.get $11
        i32.const 1
        i32.add
-       local.set $8
+       local.set $11
        br $for-loop|1
       end
      end
-     local.get $5
+     local.get $6
      i32.const 1
      i32.add
-     local.set $5
+     local.set $6
      br $for-loop|0
     end
    end
@@ -1149,11 +1179,11 @@
    i32.const -1
    i32.xor
    i32.and
-   local.set $5
+   local.set $17
    i32.const 0
    drop
    local.get $0
-   local.get $5
+   local.get $17
    memory.size
    i32.const 16
    i32.shl
@@ -1202,6 +1232,14 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
   local.get $1
   i32.const 256
   i32.lt_u
@@ -1275,11 +1313,11 @@
    unreachable
   end
   local.get $0
-  local.set $5
+  local.set $6
   local.get $2
-  local.set $4
+  local.set $5
+  local.get $6
   local.get $5
-  local.get $4
   i32.const 2
   i32.shl
   i32.add
@@ -1290,10 +1328,10 @@
   local.get $3
   i32.shl
   i32.and
-  local.set $6
-  i32.const 0
   local.set $7
-  local.get $6
+  i32.const 0
+  local.set $8
+  local.get $7
   i32.eqz
   if
    local.get $0
@@ -1306,30 +1344,30 @@
    i32.add
    i32.shl
    i32.and
-   local.set $5
-   local.get $5
+   local.set $9
+   local.get $9
    i32.eqz
    if
     i32.const 0
-    local.set $7
+    local.set $8
    else
-    local.get $5
+    local.get $9
     i32.ctz
     local.set $2
     local.get $0
-    local.set $8
+    local.set $11
     local.get $2
-    local.set $4
-    local.get $8
-    local.get $4
+    local.set $10
+    local.get $11
+    local.get $10
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $6
+    local.set $7
     i32.const 1
     drop
-    local.get $6
+    local.get $7
     i32.eqz
     if
      i32.const 0
@@ -1340,45 +1378,45 @@
      unreachable
     end
     local.get $0
-    local.set $9
+    local.set $14
     local.get $2
-    local.set $8
-    local.get $6
+    local.set $13
+    local.get $7
     i32.ctz
-    local.set $4
-    local.get $9
-    local.get $8
+    local.set $12
+    local.get $14
+    local.get $13
     i32.const 4
     i32.shl
-    local.get $4
+    local.get $12
     i32.add
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=96
-    local.set $7
+    local.set $8
    end
   else
    local.get $0
-   local.set $9
+   local.set $17
    local.get $2
-   local.set $8
-   local.get $6
+   local.set $16
+   local.get $7
    i32.ctz
-   local.set $4
-   local.get $9
-   local.get $8
+   local.set $15
+   local.get $17
+   local.get $16
    i32.const 4
    i32.shl
-   local.get $4
+   local.get $15
    i32.add
    i32.const 2
    i32.shl
    i32.add
    i32.load offset=96
-   local.set $7
+   local.set $8
   end
-  local.get $7
+  local.get $8
  )
  (func $~lib/rt/tlsf/growMemory (param $0 i32) (param $1 i32)
   (local $2 i32)
@@ -1387,6 +1425,7 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
   i32.const 0
   drop
   local.get $1
@@ -1433,15 +1472,15 @@
   i32.shr_u
   local.set $4
   local.get $2
-  local.tee $3
-  local.get $4
   local.tee $5
-  local.get $3
+  local.get $4
+  local.tee $6
   local.get $5
+  local.get $6
   i32.gt_s
   select
-  local.set $6
-  local.get $6
+  local.set $7
+  local.get $7
   memory.grow
   i32.const 0
   i32.lt_s
@@ -1455,12 +1494,12 @@
    end
   end
   memory.size
-  local.set $7
+  local.set $8
   local.get $0
   local.get $2
   i32.const 16
   i32.shl
-  local.get $7
+  local.get $8
   i32.const 16
   i32.shl
   call $~lib/rt/tlsf/addMemory
@@ -1470,6 +1509,8 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
   local.get $1
   i32.load
   local.set $3
@@ -1534,11 +1575,11 @@
    i32.and
    i32.store
    local.get $1
-   local.set $5
-   local.get $5
+   local.set $7
+   local.get $7
    i32.const 16
    i32.add
-   local.get $5
+   local.get $7
    i32.load
    i32.const 3
    i32.const -1
@@ -1546,11 +1587,11 @@
    i32.and
    i32.add
    local.get $1
-   local.set $5
-   local.get $5
+   local.set $6
+   local.get $6
    i32.const 16
    i32.add
-   local.get $5
+   local.get $6
    i32.load
    i32.const 3
    i32.const -1
@@ -2264,6 +2305,88 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local $22 i32)
+  (local $23 i32)
+  (local $24 i32)
+  (local $25 i32)
+  (local $26 i32)
+  (local $27 i32)
+  (local $28 i32)
+  (local $29 i32)
+  (local $30 i32)
+  (local $31 i32)
+  (local $32 i32)
+  (local $33 i32)
+  (local $34 i32)
+  (local $35 i32)
+  (local $36 i32)
+  (local $37 i32)
+  (local $38 i32)
+  (local $39 i32)
+  (local $40 i32)
+  (local $41 i32)
+  (local $42 i32)
+  (local $43 i32)
+  (local $44 i32)
+  (local $45 i32)
+  (local $46 i32)
+  (local $47 i32)
+  (local $48 i32)
+  (local $49 i32)
+  (local $50 i32)
+  (local $51 i32)
+  (local $52 i32)
+  (local $53 i32)
+  (local $54 i32)
+  (local $55 i32)
+  (local $56 i32)
+  (local $57 i32)
+  (local $58 i32)
+  (local $59 i32)
+  (local $60 i32)
+  (local $61 i32)
+  (local $62 i32)
+  (local $63 i32)
+  (local $64 i32)
+  (local $65 i32)
+  (local $66 i32)
+  (local $67 i32)
+  (local $68 i32)
+  (local $69 i32)
+  (local $70 i32)
+  (local $71 i32)
+  (local $72 i32)
+  (local $73 i32)
+  (local $74 i32)
+  (local $75 i32)
+  (local $76 i32)
+  (local $77 i32)
+  (local $78 i32)
+  (local $79 i32)
+  (local $80 i32)
+  (local $81 i32)
+  (local $82 i32)
+  (local $83 i32)
+  (local $84 i32)
+  (local $85 i32)
+  (local $86 i32)
+  (local $87 i32)
+  (local $88 i32)
   loop $while-continue|0
    local.get $2
    if (result i32)
@@ -2283,11 +2406,11 @@
     local.set $0
     local.get $6
     local.get $1
-    local.tee $6
+    local.tee $7
     i32.const 1
     i32.add
     local.set $1
-    local.get $6
+    local.get $7
     i32.load8_u
     i32.store8
     local.get $2
@@ -2307,8 +2430,8 @@
     local.get $2
     i32.const 16
     i32.ge_u
-    local.set $5
-    local.get $5
+    local.set $8
+    local.get $8
     if
      local.get $0
      local.get $1
@@ -2417,17 +2540,17 @@
    i32.and
    if
     local.get $0
-    local.tee $5
+    local.tee $9
     i32.const 1
     i32.add
     local.set $0
-    local.get $5
+    local.get $9
     local.get $1
-    local.tee $5
+    local.tee $10
     i32.const 1
     i32.add
     local.set $1
-    local.get $5
+    local.get $10
     i32.load8_u
     i32.store8
    end
@@ -2444,16 +2567,16 @@
        local.get $0
        i32.const 3
        i32.and
-       local.set $5
-       local.get $5
+       local.set $11
+       local.get $11
        i32.const 1
        i32.eq
        br_if $case0|2
-       local.get $5
+       local.get $11
        i32.const 2
        i32.eq
        br_if $case1|2
-       local.get $5
+       local.get $11
        i32.const 3
        i32.eq
        br_if $case2|2
@@ -2463,45 +2586,45 @@
       i32.load
       local.set $3
       local.get $0
-      local.tee $5
+      local.tee $12
       i32.const 1
       i32.add
       local.set $0
-      local.get $5
+      local.get $12
       local.get $1
-      local.tee $5
+      local.tee $13
       i32.const 1
       i32.add
       local.set $1
-      local.get $5
+      local.get $13
       i32.load8_u
       i32.store8
       local.get $0
-      local.tee $5
+      local.tee $14
       i32.const 1
       i32.add
       local.set $0
-      local.get $5
+      local.get $14
       local.get $1
-      local.tee $5
+      local.tee $15
       i32.const 1
       i32.add
       local.set $1
-      local.get $5
+      local.get $15
       i32.load8_u
       i32.store8
       local.get $0
-      local.tee $5
+      local.tee $16
       i32.const 1
       i32.add
       local.set $0
-      local.get $5
+      local.get $16
       local.get $1
-      local.tee $5
+      local.tee $17
       i32.const 1
       i32.add
       local.set $1
-      local.get $5
+      local.get $17
       i32.load8_u
       i32.store8
       local.get $2
@@ -2512,8 +2635,8 @@
        local.get $2
        i32.const 17
        i32.ge_u
-       local.set $5
-       local.get $5
+       local.set $18
+       local.get $18
        if
         local.get $1
         i32.const 1
@@ -2598,31 +2721,31 @@
      i32.load
      local.set $3
      local.get $0
-     local.tee $5
+     local.tee $19
      i32.const 1
      i32.add
      local.set $0
-     local.get $5
+     local.get $19
      local.get $1
-     local.tee $5
+     local.tee $20
      i32.const 1
      i32.add
      local.set $1
-     local.get $5
+     local.get $20
      i32.load8_u
      i32.store8
      local.get $0
-     local.tee $5
+     local.tee $21
      i32.const 1
      i32.add
      local.set $0
-     local.get $5
+     local.get $21
      local.get $1
-     local.tee $5
+     local.tee $22
      i32.const 1
      i32.add
      local.set $1
-     local.get $5
+     local.get $22
      i32.load8_u
      i32.store8
      local.get $2
@@ -2633,8 +2756,8 @@
       local.get $2
       i32.const 18
       i32.ge_u
-      local.set $5
-      local.get $5
+      local.set $23
+      local.get $23
       if
        local.get $1
        i32.const 2
@@ -2719,17 +2842,17 @@
     i32.load
     local.set $3
     local.get $0
-    local.tee $5
+    local.tee $24
     i32.const 1
     i32.add
     local.set $0
-    local.get $5
+    local.get $24
     local.get $1
-    local.tee $5
+    local.tee $25
     i32.const 1
     i32.add
     local.set $1
-    local.get $5
+    local.get $25
     i32.load8_u
     i32.store8
     local.get $2
@@ -2740,8 +2863,8 @@
      local.get $2
      i32.const 19
      i32.ge_u
-     local.set $5
-     local.get $5
+     local.set $26
+     local.get $26
      if
       local.get $1
       i32.const 3
@@ -2828,227 +2951,227 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $27
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $27
    local.get $1
-   local.tee $5
+   local.tee $28
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $28
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $29
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $29
    local.get $1
-   local.tee $5
+   local.tee $30
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $30
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $31
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $31
    local.get $1
-   local.tee $5
+   local.tee $32
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $32
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $33
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $33
    local.get $1
-   local.tee $5
+   local.tee $34
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $34
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $35
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $35
    local.get $1
-   local.tee $5
+   local.tee $36
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $36
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $37
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $37
    local.get $1
-   local.tee $5
+   local.tee $38
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $38
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $39
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $39
    local.get $1
-   local.tee $5
+   local.tee $40
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $40
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $41
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $41
    local.get $1
-   local.tee $5
+   local.tee $42
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $42
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $43
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $43
    local.get $1
-   local.tee $5
+   local.tee $44
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $44
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $45
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $45
    local.get $1
-   local.tee $5
+   local.tee $46
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $46
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $47
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $47
    local.get $1
-   local.tee $5
+   local.tee $48
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $48
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $49
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $49
    local.get $1
-   local.tee $5
+   local.tee $50
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $50
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $51
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $51
    local.get $1
-   local.tee $5
+   local.tee $52
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $52
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $53
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $53
    local.get $1
-   local.tee $5
+   local.tee $54
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $54
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $55
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $55
    local.get $1
-   local.tee $5
+   local.tee $56
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $56
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $57
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $57
    local.get $1
-   local.tee $5
+   local.tee $58
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $58
    i32.load8_u
    i32.store8
   end
@@ -3057,115 +3180,115 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $59
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $59
    local.get $1
-   local.tee $5
+   local.tee $60
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $60
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $61
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $61
    local.get $1
-   local.tee $5
+   local.tee $62
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $62
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $63
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $63
    local.get $1
-   local.tee $5
+   local.tee $64
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $64
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $65
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $65
    local.get $1
-   local.tee $5
+   local.tee $66
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $66
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $67
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $67
    local.get $1
-   local.tee $5
+   local.tee $68
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $68
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $69
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $69
    local.get $1
-   local.tee $5
+   local.tee $70
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $70
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $71
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $71
    local.get $1
-   local.tee $5
+   local.tee $72
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $72
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $73
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $73
    local.get $1
-   local.tee $5
+   local.tee $74
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $74
    i32.load8_u
    i32.store8
   end
@@ -3174,59 +3297,59 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $75
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $75
    local.get $1
-   local.tee $5
+   local.tee $76
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $76
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $77
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $77
    local.get $1
-   local.tee $5
+   local.tee $78
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $78
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $79
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $79
    local.get $1
-   local.tee $5
+   local.tee $80
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $80
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $81
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $81
    local.get $1
-   local.tee $5
+   local.tee $82
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $82
    i32.load8_u
    i32.store8
   end
@@ -3235,31 +3358,31 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $83
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $83
    local.get $1
-   local.tee $5
+   local.tee $84
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $84
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $85
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $85
    local.get $1
-   local.tee $5
+   local.tee $86
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $86
    i32.load8_u
    i32.store8
   end
@@ -3268,17 +3391,17 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $87
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $87
    local.get $1
-   local.tee $5
+   local.tee $88
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $88
    i32.load8_u
    i32.store8
   end
@@ -3289,6 +3412,14 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
   block $~lib/util/memory/memmove|inlined.0
    local.get $0
    local.set $5
@@ -3366,11 +3497,11 @@
        local.set $5
        local.get $7
        local.get $4
-       local.tee $7
+       local.tee $8
        i32.const 1
        i32.add
        local.set $4
-       local.get $7
+       local.get $8
        i32.load8_u
        i32.store8
        br $while-continue|0
@@ -3380,8 +3511,8 @@
       local.get $3
       i32.const 8
       i32.ge_u
-      local.set $6
-      local.get $6
+      local.set $9
+      local.get $9
       if
        local.get $5
        local.get $4
@@ -3405,21 +3536,21 @@
     end
     loop $while-continue|2
      local.get $3
-     local.set $6
-     local.get $6
+     local.set $10
+     local.get $10
      if
       local.get $5
-      local.tee $7
+      local.tee $11
       i32.const 1
       i32.add
       local.set $5
-      local.get $7
+      local.get $11
       local.get $4
-      local.tee $7
+      local.tee $12
       i32.const 1
       i32.add
       local.set $4
-      local.get $7
+      local.get $12
       i32.load8_u
       i32.store8
       local.get $3
@@ -3448,8 +3579,8 @@
       i32.add
       i32.const 7
       i32.and
-      local.set $6
-      local.get $6
+      local.set $13
+      local.get $13
       if
        local.get $3
        i32.eqz
@@ -3474,8 +3605,8 @@
       local.get $3
       i32.const 8
       i32.ge_u
-      local.set $6
-      local.get $6
+      local.set $14
+      local.get $14
       if
        local.get $3
        i32.const 8
@@ -3495,8 +3626,8 @@
     end
     loop $while-continue|5
      local.get $3
-     local.set $6
-     local.get $6
+     local.set $15
+     local.get $15
      if
       local.get $5
       local.get $3
@@ -3567,6 +3698,12 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
   local.get $0
   i32.load offset=4
   local.set $4
@@ -3589,11 +3726,11 @@
    select
   else
    local.get $2
-   local.tee $6
+   local.tee $8
    local.get $5
-   local.tee $7
-   local.get $6
-   local.get $7
+   local.tee $9
+   local.get $8
+   local.get $9
    i32.lt_s
    select
   end
@@ -3605,20 +3742,20 @@
    local.get $5
    local.get $3
    i32.add
-   local.tee $6
+   local.tee $10
    i32.const 0
-   local.tee $7
-   local.get $6
-   local.get $7
+   local.tee $11
+   local.get $10
+   local.get $11
    i32.gt_s
    select
   else
    local.get $3
-   local.tee $6
+   local.tee $12
    local.get $5
-   local.tee $7
-   local.get $6
-   local.get $7
+   local.tee $13
+   local.get $12
+   local.get $13
    i32.lt_s
    select
   end
@@ -3684,6 +3821,9 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $0
@@ -3715,63 +3855,70 @@
    i32.eq
    if
     i32.const 1
-    local.set $3
+    local.set $4
     local.get $0
     call $~lib/rt/pure/__release
     local.get $1
     call $~lib/rt/pure/__release
-    local.get $3
+    local.get $4
     return
    end
   end
   i32.const 0
-  local.set $3
+  local.set $5
   loop $for-loop|0
-   local.get $3
+   local.get $5
    local.get $2
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $6
+   local.get $6
    if
     i32.const 0
     drop
     local.get $0
-    local.get $3
+    local.get $5
     call $~lib/array/Array<u8>#__get
     local.get $1
-    local.get $3
+    local.get $5
     call $~lib/array/Array<u8>#__get
     i32.ne
     if
      i32.const 0
-     local.set $5
+     local.set $7
      local.get $0
      call $~lib/rt/pure/__release
      local.get $1
      call $~lib/rt/pure/__release
-     local.get $5
+     local.get $7
      return
     end
-    local.get $3
+    local.get $5
     i32.const 1
     i32.add
-    local.set $3
+    local.set $5
     br $for-loop|0
    end
   end
   i32.const 1
-  local.set $3
+  local.set $8
   local.get $0
   call $~lib/rt/pure/__release
   local.get $1
   call $~lib/rt/pure/__release
-  local.get $3
+  local.get $8
  )
  (func $~lib/array/Array<u32>#fill (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
   local.get $0
   i32.load offset=4
   local.set $4
@@ -3794,11 +3941,11 @@
    select
   else
    local.get $2
-   local.tee $6
+   local.tee $8
    local.get $5
-   local.tee $7
-   local.get $6
-   local.get $7
+   local.tee $9
+   local.get $8
+   local.get $9
    i32.lt_s
    select
   end
@@ -3810,20 +3957,20 @@
    local.get $5
    local.get $3
    i32.add
-   local.tee $6
+   local.tee $10
    i32.const 0
-   local.tee $7
-   local.get $6
-   local.get $7
+   local.tee $11
+   local.get $10
+   local.get $11
    i32.gt_s
    select
   else
    local.get $3
-   local.tee $6
+   local.tee $12
    local.get $5
-   local.tee $7
-   local.get $6
-   local.get $7
+   local.tee $13
+   local.get $12
+   local.get $13
    i32.lt_s
    select
   end
@@ -3838,8 +3985,8 @@
    local.get $2
    local.get $3
    i32.lt_s
-   local.set $6
-   local.get $6
+   local.set $14
+   local.get $14
    if
     local.get $4
     local.get $2
@@ -3897,6 +4044,9 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $0
@@ -3928,57 +4078,57 @@
    i32.eq
    if
     i32.const 1
-    local.set $3
+    local.set $4
     local.get $0
     call $~lib/rt/pure/__release
     local.get $1
     call $~lib/rt/pure/__release
-    local.get $3
+    local.get $4
     return
    end
   end
   i32.const 0
-  local.set $3
+  local.set $5
   loop $for-loop|0
-   local.get $3
+   local.get $5
    local.get $2
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $6
+   local.get $6
    if
     i32.const 0
     drop
     local.get $0
-    local.get $3
+    local.get $5
     call $~lib/array/Array<u32>#__get
     local.get $1
-    local.get $3
+    local.get $5
     call $~lib/array/Array<u32>#__get
     i32.ne
     if
      i32.const 0
-     local.set $5
+     local.set $7
      local.get $0
      call $~lib/rt/pure/__release
      local.get $1
      call $~lib/rt/pure/__release
-     local.get $5
+     local.get $7
      return
     end
-    local.get $3
+    local.get $5
     i32.const 1
     i32.add
-    local.set $3
+    local.set $5
     br $for-loop|0
    end
   end
   i32.const 1
-  local.set $3
+  local.set $8
   local.get $0
   call $~lib/rt/pure/__release
   local.get $1
   call $~lib/rt/pure/__release
-  local.get $3
+  local.get $8
  )
  (func $~lib/array/Array<i32>#get:length (param $0 i32) (result i32)
   local.get $0
@@ -4084,6 +4234,7 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
   local.get $2
   call $~lib/rt/tlsf/prepareSize
   local.set $3
@@ -4141,8 +4292,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $5
-   local.get $5
+   local.set $8
+   local.get $8
    local.get $3
    i32.ge_u
    if
@@ -4153,7 +4304,7 @@
     local.get $4
     i32.const 3
     i32.and
-    local.get $5
+    local.get $8
     i32.or
     i32.store
     local.get $1
@@ -4172,12 +4323,12 @@
   local.get $1
   i32.load offset=8
   call $~lib/rt/tlsf/allocateBlock
-  local.set $8
-  local.get $8
+  local.set $9
+  local.get $9
   local.get $1
   i32.load offset=4
   i32.store offset=4
-  local.get $8
+  local.get $9
   i32.const 16
   i32.add
   local.get $1
@@ -4192,13 +4343,13 @@
    i32.const 1
    drop
    local.get $1
-   local.get $8
+   local.get $9
    call $~lib/rt/rtrace/onrealloc
    local.get $0
    local.get $1
    call $~lib/rt/tlsf/freeBlock
   end
-  local.get $8
+  local.get $9
  )
  (func $~lib/rt/tlsf/__realloc (param $0 i32) (param $1 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
@@ -4508,6 +4659,20 @@
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local $22 i32)
+  (local $23 i32)
+  (local $24 i32)
+  (local $25 i32)
   local.get $0
   i32.load offset=4
   local.set $4
@@ -4530,24 +4695,24 @@
    local.get $5
    local.get $1
    i32.add
-   local.tee $6
+   local.tee $8
    i32.const 0
-   local.tee $7
-   local.get $6
-   local.get $7
+   local.tee $9
+   local.get $8
+   local.get $9
    i32.gt_s
    select
   else
    local.get $1
-   local.tee $6
+   local.tee $10
    local.get $5
-   local.tee $7
-   local.get $6
-   local.get $7
+   local.tee $11
+   local.get $10
+   local.get $11
    i32.lt_s
    select
   end
-  local.set $8
+  local.set $12
   local.get $2
   i32.const 0
   i32.lt_s
@@ -4555,24 +4720,24 @@
    local.get $5
    local.get $2
    i32.add
-   local.tee $6
+   local.tee $13
    i32.const 0
-   local.tee $7
-   local.get $6
-   local.get $7
+   local.tee $14
+   local.get $13
+   local.get $14
    i32.gt_s
    select
   else
    local.get $2
-   local.tee $6
+   local.tee $15
    local.get $5
-   local.tee $7
-   local.get $6
-   local.get $7
+   local.tee $16
+   local.get $15
+   local.get $16
    i32.lt_s
    select
   end
-  local.set $9
+  local.set $17
   local.get $3
   i32.const 0
   i32.lt_s
@@ -4580,50 +4745,50 @@
    local.get $5
    local.get $3
    i32.add
-   local.tee $6
+   local.tee $18
    i32.const 0
-   local.tee $7
-   local.get $6
-   local.get $7
+   local.tee $19
+   local.get $18
+   local.get $19
    i32.gt_s
    select
   else
    local.get $3
-   local.tee $6
+   local.tee $20
    local.get $5
-   local.tee $7
-   local.get $6
-   local.get $7
+   local.tee $21
+   local.get $20
+   local.get $21
    i32.lt_s
    select
   end
-  local.set $10
-  local.get $10
-  local.get $9
+  local.set $22
+  local.get $22
+  local.get $17
   i32.sub
-  local.tee $6
+  local.tee $23
   local.get $5
-  local.get $8
+  local.get $12
   i32.sub
-  local.tee $7
-  local.get $6
-  local.get $7
+  local.tee $24
+  local.get $23
+  local.get $24
   i32.lt_s
   select
-  local.set $11
+  local.set $25
   i32.const 0
   drop
   local.get $4
-  local.get $8
+  local.get $12
   i32.const 2
   i32.shl
   i32.add
   local.get $4
-  local.get $9
+  local.get $17
   i32.const 2
   i32.shl
   i32.add
-  local.get $11
+  local.get $25
   i32.const 2
   i32.shl
   call $~lib/memory/memory.copy
@@ -4634,6 +4799,9 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $0
@@ -4665,57 +4833,57 @@
    i32.eq
    if
     i32.const 1
-    local.set $3
+    local.set $4
     local.get $0
     call $~lib/rt/pure/__release
     local.get $1
     call $~lib/rt/pure/__release
-    local.get $3
+    local.get $4
     return
    end
   end
   i32.const 0
-  local.set $3
+  local.set $5
   loop $for-loop|0
-   local.get $3
+   local.get $5
    local.get $2
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $6
+   local.get $6
    if
     i32.const 0
     drop
     local.get $0
-    local.get $3
+    local.get $5
     call $~lib/array/Array<i32>#__get
     local.get $1
-    local.get $3
+    local.get $5
     call $~lib/array/Array<i32>#__get
     i32.ne
     if
      i32.const 0
-     local.set $5
+     local.set $7
      local.get $0
      call $~lib/rt/pure/__release
      local.get $1
      call $~lib/rt/pure/__release
-     local.get $5
+     local.get $7
      return
     end
-    local.get $3
+    local.get $5
     i32.const 1
     i32.add
-    local.set $3
+    local.set $5
     br $for-loop|0
    end
   end
   i32.const 1
-  local.set $3
+  local.set $8
   local.get $0
   call $~lib/rt/pure/__release
   local.get $1
   call $~lib/rt/pure/__release
-  local.get $3
+  local.get $8
  )
  (func $~lib/array/Array<i32>#unshift (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
@@ -4861,6 +5029,7 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
   local.get $0
   i32.load offset=12
   local.set $3
@@ -4901,8 +5070,8 @@
    local.get $2
    local.get $3
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $7
+   local.get $7
    if
     local.get $6
     local.get $2
@@ -4930,6 +5099,7 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
   local.get $0
   i32.load offset=12
   local.set $3
@@ -4970,8 +5140,8 @@
    local.get $2
    local.get $3
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $7
+   local.get $7
    if
     local.get $6
     local.get $2
@@ -4999,6 +5169,7 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
   local.get $0
   i32.load offset=12
   local.set $3
@@ -5039,8 +5210,8 @@
    local.get $2
    local.get $3
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $7
+   local.get $7
    if
     local.get $6
     local.get $2
@@ -5078,7 +5249,9 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  (local $6 f32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 f32)
   i32.const 1
   drop
   local.get $0
@@ -5116,29 +5289,29 @@
   end
   local.get $0
   i32.load offset=4
-  local.set $4
+  local.set $6
   loop $while-continue|0
    local.get $2
    local.get $3
    i32.lt_s
-   local.set $5
-   local.get $5
+   local.set $7
+   local.get $7
    if
-    local.get $4
+    local.get $6
     local.get $2
     i32.const 2
     i32.shl
     i32.add
     f32.load
-    local.set $6
-    local.get $6
+    local.set $8
+    local.get $8
     local.get $1
     f32.eq
     if (result i32)
      i32.const 1
     else
-     local.get $6
-     local.get $6
+     local.get $8
+     local.get $8
      f32.ne
      local.get $1
      local.get $1
@@ -5163,7 +5336,9 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  (local $6 f64)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 f64)
   i32.const 1
   drop
   local.get $0
@@ -5201,29 +5376,29 @@
   end
   local.get $0
   i32.load offset=4
-  local.set $4
+  local.set $6
   loop $while-continue|0
    local.get $2
    local.get $3
    i32.lt_s
-   local.set $5
-   local.get $5
+   local.set $7
+   local.get $7
    if
-    local.get $4
+    local.get $6
     local.get $2
     i32.const 3
     i32.shl
     i32.add
     f64.load
-    local.set $6
-    local.get $6
+    local.set $8
+    local.get $8
     local.get $1
     f64.eq
     if (result i32)
      i32.const 1
     else
-     local.get $6
-     local.get $6
+     local.get $8
+     local.get $8
      f64.ne
      local.get $1
      local.get $1
@@ -5253,6 +5428,12 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
   local.get $0
   i32.load offset=12
   local.set $3
@@ -5272,30 +5453,30 @@
    select
   else
    local.get $1
-   local.tee $4
+   local.tee $6
    local.get $3
-   local.tee $5
-   local.get $4
-   local.get $5
+   local.tee $7
+   local.get $6
+   local.get $7
    i32.lt_s
    select
   end
   local.set $1
   local.get $2
-  local.tee $4
+  local.tee $8
   local.get $3
   local.get $1
   i32.sub
-  local.tee $5
-  local.get $4
-  local.get $5
+  local.tee $9
+  local.get $8
+  local.get $9
   i32.lt_s
   select
-  local.tee $4
+  local.tee $10
   i32.const 0
-  local.tee $5
-  local.get $4
-  local.get $5
+  local.tee $11
+  local.get $10
+  local.get $11
   i32.gt_s
   select
   local.set $2
@@ -5305,21 +5486,21 @@
   i32.const 0
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $6
-  local.get $6
+  local.set $12
+  local.get $12
   i32.load offset=4
-  local.set $7
+  local.set $13
   local.get $0
   i32.load offset=4
-  local.set $8
-  local.get $8
+  local.set $14
+  local.get $14
   local.get $1
   i32.const 2
   i32.shl
   i32.add
-  local.set $9
-  local.get $7
-  local.get $9
+  local.set $15
+  local.get $13
+  local.get $15
   local.get $2
   i32.const 2
   i32.shl
@@ -5327,19 +5508,19 @@
   local.get $1
   local.get $2
   i32.add
-  local.set $10
+  local.set $16
   local.get $3
-  local.get $10
+  local.get $16
   i32.ne
   if
-   local.get $9
-   local.get $8
-   local.get $10
+   local.get $15
+   local.get $14
+   local.get $16
    i32.const 2
    i32.shl
    i32.add
    local.get $3
-   local.get $10
+   local.get $16
    i32.sub
    i32.const 2
    i32.shl
@@ -5350,7 +5531,7 @@
   local.get $2
   i32.sub
   i32.store offset=12
-  local.get $6
+  local.get $12
  )
  (func $~lib/array/Array<std/array/Ref>#splice (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
@@ -5361,6 +5542,12 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
   local.get $0
   i32.load offset=12
   local.set $3
@@ -5380,30 +5567,30 @@
    select
   else
    local.get $1
-   local.tee $4
+   local.tee $6
    local.get $3
-   local.tee $5
-   local.get $4
-   local.get $5
+   local.tee $7
+   local.get $6
+   local.get $7
    i32.lt_s
    select
   end
   local.set $1
   local.get $2
-  local.tee $4
+  local.tee $8
   local.get $3
   local.get $1
   i32.sub
-  local.tee $5
-  local.get $4
-  local.get $5
+  local.tee $9
+  local.get $8
+  local.get $9
   i32.lt_s
   select
-  local.tee $4
+  local.tee $10
   i32.const 0
-  local.tee $5
-  local.get $4
-  local.get $5
+  local.tee $11
+  local.get $10
+  local.get $11
   i32.gt_s
   select
   local.set $2
@@ -5413,21 +5600,21 @@
   i32.const 0
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $6
-  local.get $6
+  local.set $12
+  local.get $12
   i32.load offset=4
-  local.set $7
+  local.set $13
   local.get $0
   i32.load offset=4
-  local.set $8
-  local.get $8
+  local.set $14
+  local.get $14
   local.get $1
   i32.const 2
   i32.shl
   i32.add
-  local.set $9
-  local.get $7
-  local.get $9
+  local.set $15
+  local.get $13
+  local.get $15
   local.get $2
   i32.const 2
   i32.shl
@@ -5435,19 +5622,19 @@
   local.get $1
   local.get $2
   i32.add
-  local.set $10
+  local.set $16
   local.get $3
-  local.get $10
+  local.get $16
   i32.ne
   if
-   local.get $9
-   local.get $8
-   local.get $10
+   local.get $15
+   local.get $14
+   local.get $16
    i32.const 2
    i32.shl
    i32.add
    local.get $3
-   local.get $10
+   local.get $16
    i32.sub
    i32.const 2
    i32.shl
@@ -5458,7 +5645,7 @@
   local.get $2
   i32.sub
   i32.store offset=12
-  local.get $6
+  local.get $12
  )
  (func $~lib/array/Array<std/array/Ref>#__uget (param $0 i32) (param $1 i32) (result i32)
   local.get $0
@@ -5516,6 +5703,12 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
   local.get $0
   i32.load offset=12
   local.set $3
@@ -5535,30 +5728,30 @@
    select
   else
    local.get $1
-   local.tee $4
+   local.tee $6
    local.get $3
-   local.tee $5
-   local.get $4
-   local.get $5
+   local.tee $7
+   local.get $6
+   local.get $7
    i32.lt_s
    select
   end
   local.set $1
   local.get $2
-  local.tee $4
+  local.tee $8
   local.get $3
   local.get $1
   i32.sub
-  local.tee $5
-  local.get $4
-  local.get $5
+  local.tee $9
+  local.get $8
+  local.get $9
   i32.lt_s
   select
-  local.tee $4
+  local.tee $10
   i32.const 0
-  local.tee $5
-  local.get $4
-  local.get $5
+  local.tee $11
+  local.get $10
+  local.get $11
   i32.gt_s
   select
   local.set $2
@@ -5568,21 +5761,21 @@
   i32.const 0
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $6
-  local.get $6
+  local.set $12
+  local.get $12
   i32.load offset=4
-  local.set $7
+  local.set $13
   local.get $0
   i32.load offset=4
-  local.set $8
-  local.get $8
+  local.set $14
+  local.get $14
   local.get $1
   i32.const 2
   i32.shl
   i32.add
-  local.set $9
-  local.get $7
-  local.get $9
+  local.set $15
+  local.get $13
+  local.get $15
   local.get $2
   i32.const 2
   i32.shl
@@ -5590,19 +5783,19 @@
   local.get $1
   local.get $2
   i32.add
-  local.set $10
+  local.set $16
   local.get $3
-  local.get $10
+  local.get $16
   i32.ne
   if
-   local.get $9
-   local.get $8
-   local.get $10
+   local.get $15
+   local.get $14
+   local.get $16
    i32.const 2
    i32.shl
    i32.add
    local.get $3
-   local.get $10
+   local.get $16
    i32.sub
    i32.const 2
    i32.shl
@@ -5613,7 +5806,7 @@
   local.get $2
   i32.sub
   i32.store offset=12
-  local.get $6
+  local.get $12
  )
  (func $~lib/array/Array<std/array/Ref | null>#get:length (param $0 i32) (result i32)
   local.get $0
@@ -5722,6 +5915,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   i32.const 0
   local.set $2
   local.get $0
@@ -5739,8 +5933,8 @@
    i32.lt_s
    select
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $6
+   local.get $6
    if
     local.get $0
     i32.load offset=4
@@ -5858,6 +6052,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   i32.const 0
   local.set $2
   local.get $0
@@ -5875,8 +6070,8 @@
    i32.lt_s
    select
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $6
+   local.get $6
    if
     local.get $0
     i32.load offset=4
@@ -5982,6 +6177,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   i32.const 0
   local.set $2
   local.get $0
@@ -5999,8 +6195,8 @@
    i32.lt_s
    select
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $6
+   local.get $6
    if
     local.get $0
     i32.load offset=4
@@ -6103,6 +6299,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   i32.const 0
   local.set $2
   local.get $0
@@ -6120,8 +6317,8 @@
    i32.lt_s
    select
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $6
+   local.get $6
    if
     local.get $0
     i32.load offset=4
@@ -6187,6 +6384,12 @@
  (func $start:std/array~anonymous|20 (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
   local.get $2
   call $~lib/rt/pure/__retain
   local.set $2
@@ -6214,65 +6417,65 @@
     end
    end
    i32.const 0
-   local.set $3
+   local.set $5
    loop $for-loop|1
-    local.get $3
+    local.get $5
     i32.const 100
     i32.lt_s
-    local.set $4
-    local.get $4
+    local.set $6
+    local.get $6
     if
      local.get $2
      i32.const 100
-     local.get $3
+     local.get $5
      i32.add
      call $~lib/array/Array<i32>#push
      drop
-     local.get $3
+     local.get $5
      i32.const 1
      i32.add
-     local.set $3
+     local.set $5
      br $for-loop|1
     end
    end
    i32.const 0
-   local.set $3
+   local.set $7
    loop $for-loop|2
-    local.get $3
+    local.get $7
     i32.const 100
     i32.lt_s
-    local.set $4
-    local.get $4
+    local.set $8
+    local.get $8
     if
      local.get $2
      call $~lib/array/Array<i32>#pop
      drop
-     local.get $3
+     local.get $7
      i32.const 1
      i32.add
-     local.set $3
+     local.set $7
      br $for-loop|2
     end
    end
    i32.const 0
-   local.set $3
+   local.set $9
    loop $for-loop|3
-    local.get $3
+    local.get $9
     i32.const 100
     i32.lt_s
-    local.set $4
-    local.get $4
+    local.set $10
+    local.get $10
     if
      local.get $2
-     local.get $3
+     local.get $9
      i32.const 200
      i32.add
      call $~lib/array/Array<i32>#push
      drop
-     local.get $3
+     local.get $9
      i32.const 1
      i32.add
-     local.set $3
+     local.set $9
      br $for-loop|3
     end
    end
@@ -6316,7 +6519,8 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 f32)
+  (local $8 i32)
+  (local $9 f32)
   local.get $0
   i32.load offset=12
   local.set $2
@@ -6344,8 +6548,8 @@
    i32.lt_s
    select
    i32.lt_s
-   local.set $6
-   local.get $6
+   local.set $8
+   local.get $8
    if
     local.get $0
     i32.load offset=4
@@ -6360,7 +6564,7 @@
     global.set $~argumentsLength
     local.get $1
     call_indirect (type $i32_i32_i32_=>_f32)
-    local.set $8
+    local.set $9
     i32.const 0
     drop
     local.get $4
@@ -6368,7 +6572,7 @@
     i32.const 2
     i32.shl
     i32.add
-    local.get $8
+    local.get $9
     f32.store
     local.get $5
     i32.const 1
@@ -6440,6 +6644,8 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
   local.get $0
   i32.load offset=12
   local.set $2
@@ -6467,8 +6673,8 @@
    i32.lt_s
    select
    i32.lt_s
-   local.set $6
-   local.get $6
+   local.set $8
+   local.get $8
    if
     local.get $0
     i32.load offset=4
@@ -6483,7 +6689,7 @@
     global.set $~argumentsLength
     local.get $1
     call_indirect (type $i32_i32_i32_=>_i32)
-    local.set $7
+    local.set $9
     i32.const 0
     drop
     local.get $4
@@ -6491,7 +6697,7 @@
     i32.const 2
     i32.shl
     i32.add
-    local.get $7
+    local.get $9
     i32.store
     local.get $5
     i32.const 1
@@ -6554,6 +6760,8 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
   i32.const 0
   i32.const 2
   i32.const 3
@@ -6578,8 +6786,8 @@
    i32.lt_s
    select
    i32.lt_s
-   local.set $5
-   local.get $5
+   local.set $7
+   local.get $7
    if
     local.get $0
     i32.load offset=4
@@ -6588,8 +6796,8 @@
     i32.shl
     i32.add
     i32.load
-    local.set $6
-    local.get $6
+    local.set $8
+    local.get $8
     local.get $3
     local.get $0
     i32.const 3
@@ -6598,7 +6806,7 @@
     call_indirect (type $i32_i32_i32_=>_i32)
     if
      local.get $2
-     local.get $6
+     local.get $8
      call $~lib/array/Array<i32>#push
      drop
     end
@@ -6688,6 +6896,7 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
   local.get $2
   local.set $3
   i32.const 0
@@ -6707,8 +6916,8 @@
    i32.lt_s
    select
    i32.lt_s
-   local.set $6
-   local.get $6
+   local.set $8
+   local.get $8
    if
     local.get $3
     local.get $0
@@ -6771,6 +6980,7 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
   local.get $2
   local.set $3
   i32.const 0
@@ -6790,8 +7000,8 @@
    i32.lt_s
    select
    i32.lt_s
-   local.set $6
-   local.get $6
+   local.set $8
+   local.get $8
    if
     local.get $3
     local.get $0
@@ -7292,10 +7502,18 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
-  (local $9 f32)
+  (local $9 i32)
   (local $10 f32)
-  (local $11 i32)
-  (local $12 f32)
+  (local $11 f32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 f32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 f32)
+  (local $20 f32)
   local.get $1
   i32.const 31
   i32.add
@@ -7359,23 +7577,23 @@
     local.get $7
     i32.const 1
     i32.shr_s
-    local.set $8
+    local.set $9
     local.get $0
-    local.get $8
+    local.get $9
     i32.const 2
     i32.shl
     i32.add
     f32.load
-    local.set $9
+    local.set $10
     local.get $0
     local.get $5
     i32.const 2
     i32.shl
     i32.add
     f32.load
-    local.set $10
-    local.get $9
+    local.set $11
     local.get $10
+    local.get $11
     i32.const 2
     global.set $~argumentsLength
     local.get $2
@@ -7410,14 +7628,14 @@
      i32.const 2
      i32.shl
      i32.add
-     local.get $9
+     local.get $10
      f32.store
      local.get $0
-     local.get $8
+     local.get $9
      i32.const 2
      i32.shl
      i32.add
-     local.get $10
+     local.get $11
      f32.store
     end
     local.get $5
@@ -7430,83 +7648,83 @@
   local.get $1
   i32.const 1
   i32.sub
-  local.set $5
+  local.set $12
   loop $for-loop|2
-   local.get $5
+   local.get $12
    i32.const 2
    i32.ge_s
-   local.set $6
-   local.get $6
+   local.set $13
+   local.get $13
    if
     local.get $0
     f32.load
-    local.set $10
+    local.set $14
     local.get $0
     local.get $0
-    local.get $5
+    local.get $12
     i32.const 2
     i32.shl
     i32.add
     f32.load
     f32.store
     local.get $0
-    local.get $5
+    local.get $12
     i32.const 2
     i32.shl
     i32.add
-    local.get $10
+    local.get $14
     f32.store
     i32.const 1
-    local.set $8
+    local.set $15
     loop $while-continue|3
-     local.get $8
+     local.get $15
      i32.const 1
      i32.shl
      local.get $4
-     local.get $8
+     local.get $15
      i32.const 5
      i32.shr_u
      i32.const 2
      i32.shl
      i32.add
      i32.load
-     local.get $8
+     local.get $15
      i32.const 31
      i32.and
      i32.shr_u
      i32.const 1
      i32.and
      i32.add
-     local.tee $7
-     local.get $5
+     local.tee $16
+     local.get $12
      i32.lt_s
-     local.set $11
-     local.get $11
+     local.set $17
+     local.get $17
      if
-      local.get $7
-      local.set $8
+      local.get $16
+      local.set $15
       br $while-continue|3
      end
     end
     loop $while-continue|4
-     local.get $8
+     local.get $15
      i32.const 0
      i32.gt_s
-     local.set $11
-     local.get $11
+     local.set $18
+     local.get $18
      if
       local.get $0
       f32.load
-      local.set $10
+      local.set $14
       local.get $0
-      local.get $8
+      local.get $15
       i32.const 2
       i32.shl
       i32.add
       f32.load
-      local.set $9
-      local.get $10
-      local.get $9
+      local.set $19
+      local.get $14
+      local.get $19
       i32.const 2
       global.set $~argumentsLength
       local.get $2
@@ -7515,14 +7733,14 @@
       i32.lt_s
       if
        local.get $4
-       local.get $8
+       local.get $15
        i32.const 5
        i32.shr_u
        i32.const 2
        i32.shl
        i32.add
        local.get $4
-       local.get $8
+       local.get $15
        i32.const 5
        i32.shr_u
        i32.const 2
@@ -7530,34 +7748,34 @@
        i32.add
        i32.load
        i32.const 1
-       local.get $8
+       local.get $15
        i32.const 31
        i32.and
        i32.shl
        i32.xor
        i32.store
        local.get $0
-       local.get $8
+       local.get $15
        i32.const 2
        i32.shl
        i32.add
-       local.get $10
+       local.get $14
        f32.store
        local.get $0
-       local.get $9
+       local.get $19
        f32.store
       end
-      local.get $8
+      local.get $15
       i32.const 1
       i32.shr_s
-      local.set $8
+      local.set $15
       br $while-continue|4
      end
     end
-    local.get $5
+    local.get $12
     i32.const 1
     i32.sub
-    local.set $5
+    local.set $12
     br $for-loop|2
    end
   end
@@ -7565,13 +7783,13 @@
   call $~lib/rt/tlsf/__free
   local.get $0
   f32.load offset=4
-  local.set $12
+  local.set $20
   local.get $0
   local.get $0
   f32.load
   f32.store offset=4
   local.get $0
-  local.get $12
+  local.get $20
   f32.store
  )
  (func $~lib/array/Array<f32>#sort (param $0 i32) (param $1 i32) (result i32)
@@ -7714,8 +7932,12 @@
  (func $std/array/isArraysEqual<f32> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
-  (local $5 f32)
+  (local $5 i32)
   (local $6 i32)
+  (local $7 f32)
+  (local $8 f32)
+  (local $9 i32)
+  (local $10 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $0
@@ -7747,39 +7969,39 @@
    i32.eq
    if
     i32.const 1
-    local.set $3
+    local.set $4
     local.get $0
     call $~lib/rt/pure/__release
     local.get $1
     call $~lib/rt/pure/__release
-    local.get $3
+    local.get $4
     return
    end
   end
   i32.const 0
-  local.set $3
+  local.set $5
   loop $for-loop|0
-   local.get $3
+   local.get $5
    local.get $2
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $6
+   local.get $6
    if
     block $for-continue|0
      i32.const 1
      drop
      local.get $0
-     local.get $3
-     call $~lib/array/Array<f32>#__get
-     local.tee $5
      local.get $5
+     call $~lib/array/Array<f32>#__get
+     local.tee $7
+     local.get $7
      f32.ne
      if (result i32)
       local.get $1
-      local.get $3
-      call $~lib/array/Array<f32>#__get
-      local.tee $5
       local.get $5
+      call $~lib/array/Array<f32>#__get
+      local.tee $8
+      local.get $8
       f32.ne
      else
       i32.const 0
@@ -7788,37 +8010,37 @@
       br $for-continue|0
      end
      local.get $0
-     local.get $3
+     local.get $5
      call $~lib/array/Array<f32>#__get
      local.get $1
-     local.get $3
+     local.get $5
      call $~lib/array/Array<f32>#__get
      f32.ne
      if
       i32.const 0
-      local.set $6
+      local.set $9
       local.get $0
       call $~lib/rt/pure/__release
       local.get $1
       call $~lib/rt/pure/__release
-      local.get $6
+      local.get $9
       return
      end
     end
-    local.get $3
+    local.get $5
     i32.const 1
     i32.add
-    local.set $3
+    local.set $5
     br $for-loop|0
    end
   end
   i32.const 1
-  local.set $3
+  local.set $10
   local.get $0
   call $~lib/rt/pure/__release
   local.get $1
   call $~lib/rt/pure/__release
-  local.get $3
+  local.get $10
  )
  (func $~lib/util/sort/insertionSort<f64> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
@@ -7917,10 +8139,18 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
-  (local $9 f64)
+  (local $9 i32)
   (local $10 f64)
-  (local $11 i32)
-  (local $12 f64)
+  (local $11 f64)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 f64)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 f64)
+  (local $20 f64)
   local.get $1
   i32.const 31
   i32.add
@@ -7984,23 +8214,23 @@
     local.get $7
     i32.const 1
     i32.shr_s
-    local.set $8
+    local.set $9
     local.get $0
-    local.get $8
+    local.get $9
     i32.const 3
     i32.shl
     i32.add
     f64.load
-    local.set $9
+    local.set $10
     local.get $0
     local.get $5
     i32.const 3
     i32.shl
     i32.add
     f64.load
-    local.set $10
-    local.get $9
+    local.set $11
     local.get $10
+    local.get $11
     i32.const 2
     global.set $~argumentsLength
     local.get $2
@@ -8035,14 +8265,14 @@
      i32.const 3
      i32.shl
      i32.add
-     local.get $9
+     local.get $10
      f64.store
      local.get $0
-     local.get $8
+     local.get $9
      i32.const 3
      i32.shl
      i32.add
-     local.get $10
+     local.get $11
      f64.store
     end
     local.get $5
@@ -8055,83 +8285,83 @@
   local.get $1
   i32.const 1
   i32.sub
-  local.set $5
+  local.set $12
   loop $for-loop|2
-   local.get $5
+   local.get $12
    i32.const 2
    i32.ge_s
-   local.set $6
-   local.get $6
+   local.set $13
+   local.get $13
    if
     local.get $0
     f64.load
-    local.set $10
+    local.set $14
     local.get $0
     local.get $0
-    local.get $5
+    local.get $12
     i32.const 3
     i32.shl
     i32.add
     f64.load
     f64.store
     local.get $0
-    local.get $5
+    local.get $12
     i32.const 3
     i32.shl
     i32.add
-    local.get $10
+    local.get $14
     f64.store
     i32.const 1
-    local.set $8
+    local.set $15
     loop $while-continue|3
-     local.get $8
+     local.get $15
      i32.const 1
      i32.shl
      local.get $4
-     local.get $8
+     local.get $15
      i32.const 5
      i32.shr_u
      i32.const 2
      i32.shl
      i32.add
      i32.load
-     local.get $8
+     local.get $15
      i32.const 31
      i32.and
      i32.shr_u
      i32.const 1
      i32.and
      i32.add
-     local.tee $7
-     local.get $5
+     local.tee $16
+     local.get $12
      i32.lt_s
-     local.set $11
-     local.get $11
+     local.set $17
+     local.get $17
      if
-      local.get $7
-      local.set $8
+      local.get $16
+      local.set $15
       br $while-continue|3
      end
     end
     loop $while-continue|4
-     local.get $8
+     local.get $15
      i32.const 0
      i32.gt_s
-     local.set $11
-     local.get $11
+     local.set $18
+     local.get $18
      if
       local.get $0
       f64.load
-      local.set $10
+      local.set $14
       local.get $0
-      local.get $8
+      local.get $15
       i32.const 3
       i32.shl
       i32.add
       f64.load
-      local.set $9
-      local.get $10
-      local.get $9
+      local.set $19
+      local.get $14
+      local.get $19
       i32.const 2
       global.set $~argumentsLength
       local.get $2
@@ -8140,14 +8370,14 @@
       i32.lt_s
       if
        local.get $4
-       local.get $8
+       local.get $15
        i32.const 5
        i32.shr_u
        i32.const 2
        i32.shl
        i32.add
        local.get $4
-       local.get $8
+       local.get $15
        i32.const 5
        i32.shr_u
        i32.const 2
@@ -8155,34 +8385,34 @@
        i32.add
        i32.load
        i32.const 1
-       local.get $8
+       local.get $15
        i32.const 31
        i32.and
        i32.shl
        i32.xor
        i32.store
        local.get $0
-       local.get $8
+       local.get $15
        i32.const 3
        i32.shl
        i32.add
-       local.get $10
+       local.get $14
        f64.store
        local.get $0
-       local.get $9
+       local.get $19
        f64.store
       end
-      local.get $8
+      local.get $15
       i32.const 1
       i32.shr_s
-      local.set $8
+      local.set $15
       br $while-continue|4
      end
     end
-    local.get $5
+    local.get $12
     i32.const 1
     i32.sub
-    local.set $5
+    local.set $12
     br $for-loop|2
    end
   end
@@ -8190,13 +8420,13 @@
   call $~lib/rt/tlsf/__free
   local.get $0
   f64.load offset=8
-  local.set $12
+  local.set $20
   local.get $0
   local.get $0
   f64.load
   f64.store offset=8
   local.get $0
-  local.get $12
+  local.get $20
   f64.store
  )
  (func $~lib/array/Array<f64>#sort (param $0 i32) (param $1 i32) (result i32)
@@ -8374,8 +8604,12 @@
  (func $std/array/isArraysEqual<f64> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
-  (local $5 f64)
+  (local $5 i32)
   (local $6 i32)
+  (local $7 f64)
+  (local $8 f64)
+  (local $9 i32)
+  (local $10 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $0
@@ -8407,39 +8641,39 @@
    i32.eq
    if
     i32.const 1
-    local.set $3
+    local.set $4
     local.get $0
     call $~lib/rt/pure/__release
     local.get $1
     call $~lib/rt/pure/__release
-    local.get $3
+    local.get $4
     return
    end
   end
   i32.const 0
-  local.set $3
+  local.set $5
   loop $for-loop|0
-   local.get $3
+   local.get $5
    local.get $2
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $6
+   local.get $6
    if
     block $for-continue|0
      i32.const 1
      drop
      local.get $0
-     local.get $3
-     call $~lib/array/Array<f64>#__get
-     local.tee $5
      local.get $5
+     call $~lib/array/Array<f64>#__get
+     local.tee $7
+     local.get $7
      f64.ne
      if (result i32)
       local.get $1
-      local.get $3
-      call $~lib/array/Array<f64>#__get
-      local.tee $5
       local.get $5
+      call $~lib/array/Array<f64>#__get
+      local.tee $8
+      local.get $8
       f64.ne
      else
       i32.const 0
@@ -8448,37 +8682,37 @@
       br $for-continue|0
      end
      local.get $0
-     local.get $3
+     local.get $5
      call $~lib/array/Array<f64>#__get
      local.get $1
-     local.get $3
+     local.get $5
      call $~lib/array/Array<f64>#__get
      f64.ne
      if
       i32.const 0
-      local.set $6
+      local.set $9
       local.get $0
       call $~lib/rt/pure/__release
       local.get $1
       call $~lib/rt/pure/__release
-      local.get $6
+      local.get $9
       return
      end
     end
-    local.get $3
+    local.get $5
     i32.const 1
     i32.add
-    local.set $3
+    local.set $5
     br $for-loop|0
    end
   end
   i32.const 1
-  local.set $3
+  local.set $10
   local.get $0
   call $~lib/rt/pure/__release
   local.get $1
   call $~lib/rt/pure/__release
-  local.get $3
+  local.get $10
  )
  (func $~lib/util/sort/insertionSort<i32> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
@@ -8581,6 +8815,14 @@
   (local $10 i32)
   (local $11 i32)
   (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
   local.get $1
   i32.const 31
   i32.add
@@ -8644,23 +8886,23 @@
     local.get $7
     i32.const 1
     i32.shr_s
-    local.set $8
+    local.set $9
     local.get $0
-    local.get $8
+    local.get $9
     i32.const 2
     i32.shl
     i32.add
     i32.load
-    local.set $9
+    local.set $10
     local.get $0
     local.get $5
     i32.const 2
     i32.shl
     i32.add
     i32.load
-    local.set $10
-    local.get $9
+    local.set $11
     local.get $10
+    local.get $11
     i32.const 2
     global.set $~argumentsLength
     local.get $2
@@ -8695,14 +8937,14 @@
      i32.const 2
      i32.shl
      i32.add
-     local.get $9
+     local.get $10
      i32.store
      local.get $0
-     local.get $8
+     local.get $9
      i32.const 2
      i32.shl
      i32.add
-     local.get $10
+     local.get $11
      i32.store
     end
     local.get $5
@@ -8715,83 +8957,83 @@
   local.get $1
   i32.const 1
   i32.sub
-  local.set $5
+  local.set $12
   loop $for-loop|2
-   local.get $5
+   local.get $12
    i32.const 2
    i32.ge_s
-   local.set $6
-   local.get $6
+   local.set $13
+   local.get $13
    if
     local.get $0
     i32.load
-    local.set $10
+    local.set $14
     local.get $0
     local.get $0
-    local.get $5
+    local.get $12
     i32.const 2
     i32.shl
     i32.add
     i32.load
     i32.store
     local.get $0
-    local.get $5
+    local.get $12
     i32.const 2
     i32.shl
     i32.add
-    local.get $10
+    local.get $14
     i32.store
     i32.const 1
-    local.set $9
+    local.set $15
     loop $while-continue|3
-     local.get $9
+     local.get $15
      i32.const 1
      i32.shl
      local.get $4
-     local.get $9
+     local.get $15
      i32.const 5
      i32.shr_u
      i32.const 2
      i32.shl
      i32.add
      i32.load
-     local.get $9
+     local.get $15
      i32.const 31
      i32.and
      i32.shr_u
      i32.const 1
      i32.and
      i32.add
-     local.tee $8
-     local.get $5
+     local.tee $16
+     local.get $12
      i32.lt_s
-     local.set $7
-     local.get $7
+     local.set $17
+     local.get $17
      if
-      local.get $8
-      local.set $9
+      local.get $16
+      local.set $15
       br $while-continue|3
      end
     end
     loop $while-continue|4
-     local.get $9
+     local.get $15
      i32.const 0
      i32.gt_s
-     local.set $7
-     local.get $7
+     local.set $18
+     local.get $18
      if
       local.get $0
       i32.load
-      local.set $10
+      local.set $14
       local.get $0
-      local.get $9
+      local.get $15
       i32.const 2
       i32.shl
       i32.add
       i32.load
-      local.set $11
-      local.get $10
-      local.get $11
+      local.set $19
+      local.get $14
+      local.get $19
       i32.const 2
       global.set $~argumentsLength
       local.get $2
@@ -8800,14 +9042,14 @@
       i32.lt_s
       if
        local.get $4
-       local.get $9
+       local.get $15
        i32.const 5
        i32.shr_u
        i32.const 2
        i32.shl
        i32.add
        local.get $4
-       local.get $9
+       local.get $15
        i32.const 5
        i32.shr_u
        i32.const 2
@@ -8815,34 +9057,34 @@
        i32.add
        i32.load
        i32.const 1
-       local.get $9
+       local.get $15
        i32.const 31
        i32.and
        i32.shl
        i32.xor
        i32.store
        local.get $0
-       local.get $9
+       local.get $15
        i32.const 2
        i32.shl
        i32.add
-       local.get $10
+       local.get $14
        i32.store
        local.get $0
-       local.get $11
+       local.get $19
        i32.store
       end
-      local.get $9
+      local.get $15
       i32.const 1
       i32.shr_s
-      local.set $9
+      local.set $15
       br $while-continue|4
      end
     end
-    local.get $5
+    local.get $12
     i32.const 1
     i32.sub
-    local.set $5
+    local.set $12
     br $for-loop|2
    end
   end
@@ -8850,13 +9092,13 @@
   call $~lib/rt/tlsf/__free
   local.get $0
   i32.load offset=4
-  local.set $12
+  local.set $20
   local.get $0
   local.get $0
   i32.load
   i32.store offset=4
   local.get $0
-  local.get $12
+  local.get $20
   i32.store
  )
  (func $~lib/array/Array<i32>#sort (param $0 i32) (param $1 i32) (result i32)
@@ -8865,6 +9107,8 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
   local.get $0
   i32.load offset=12
   local.set $2
@@ -8910,25 +9154,25 @@
    return
   end
   local.get $3
-  local.set $6
+  local.set $8
   local.get $2
-  local.set $5
+  local.set $7
   local.get $1
-  local.set $4
+  local.set $6
   i32.const 0
   drop
-  local.get $5
+  local.get $7
   i32.const 256
   i32.lt_s
   if
+   local.get $8
+   local.get $7
    local.get $6
-   local.get $5
-   local.get $4
    call $~lib/util/sort/insertionSort<i32>
   else
+   local.get $8
+   local.get $7
    local.get $6
-   local.get $5
-   local.get $4
    call $~lib/util/sort/weakHeapSort<i32>
   end
   local.get $0
@@ -9070,6 +9314,14 @@
   (local $10 i32)
   (local $11 i32)
   (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
   local.get $1
   i32.const 31
   i32.add
@@ -9133,23 +9385,23 @@
     local.get $7
     i32.const 1
     i32.shr_s
-    local.set $8
+    local.set $9
     local.get $0
-    local.get $8
+    local.get $9
     i32.const 2
     i32.shl
     i32.add
     i32.load
-    local.set $9
+    local.set $10
     local.get $0
     local.get $5
     i32.const 2
     i32.shl
     i32.add
     i32.load
-    local.set $10
-    local.get $9
+    local.set $11
     local.get $10
+    local.get $11
     i32.const 2
     global.set $~argumentsLength
     local.get $2
@@ -9184,14 +9436,14 @@
      i32.const 2
      i32.shl
      i32.add
-     local.get $9
+     local.get $10
      i32.store
      local.get $0
-     local.get $8
+     local.get $9
      i32.const 2
      i32.shl
      i32.add
-     local.get $10
+     local.get $11
      i32.store
     end
     local.get $5
@@ -9204,83 +9456,83 @@
   local.get $1
   i32.const 1
   i32.sub
-  local.set $5
+  local.set $12
   loop $for-loop|2
-   local.get $5
+   local.get $12
    i32.const 2
    i32.ge_s
-   local.set $6
-   local.get $6
+   local.set $13
+   local.get $13
    if
     local.get $0
     i32.load
-    local.set $10
+    local.set $14
     local.get $0
     local.get $0
-    local.get $5
+    local.get $12
     i32.const 2
     i32.shl
     i32.add
     i32.load
     i32.store
     local.get $0
-    local.get $5
+    local.get $12
     i32.const 2
     i32.shl
     i32.add
-    local.get $10
+    local.get $14
     i32.store
     i32.const 1
-    local.set $9
+    local.set $15
     loop $while-continue|3
-     local.get $9
+     local.get $15
      i32.const 1
      i32.shl
      local.get $4
-     local.get $9
+     local.get $15
      i32.const 5
      i32.shr_u
      i32.const 2
      i32.shl
      i32.add
      i32.load
-     local.get $9
+     local.get $15
      i32.const 31
      i32.and
      i32.shr_u
      i32.const 1
      i32.and
      i32.add
-     local.tee $8
-     local.get $5
+     local.tee $16
+     local.get $12
      i32.lt_s
-     local.set $7
-     local.get $7
+     local.set $17
+     local.get $17
      if
-      local.get $8
-      local.set $9
+      local.get $16
+      local.set $15
       br $while-continue|3
      end
     end
     loop $while-continue|4
-     local.get $9
+     local.get $15
      i32.const 0
      i32.gt_s
-     local.set $7
-     local.get $7
+     local.set $18
+     local.get $18
      if
       local.get $0
       i32.load
-      local.set $10
+      local.set $14
       local.get $0
-      local.get $9
+      local.get $15
       i32.const 2
       i32.shl
       i32.add
       i32.load
-      local.set $11
-      local.get $10
-      local.get $11
+      local.set $19
+      local.get $14
+      local.get $19
       i32.const 2
       global.set $~argumentsLength
       local.get $2
@@ -9289,14 +9541,14 @@
       i32.lt_s
       if
        local.get $4
-       local.get $9
+       local.get $15
        i32.const 5
        i32.shr_u
        i32.const 2
        i32.shl
        i32.add
        local.get $4
-       local.get $9
+       local.get $15
        i32.const 5
        i32.shr_u
        i32.const 2
@@ -9304,34 +9556,34 @@
        i32.add
        i32.load
        i32.const 1
-       local.get $9
+       local.get $15
        i32.const 31
        i32.and
        i32.shl
        i32.xor
        i32.store
        local.get $0
-       local.get $9
+       local.get $15
        i32.const 2
        i32.shl
        i32.add
-       local.get $10
+       local.get $14
        i32.store
        local.get $0
-       local.get $11
+       local.get $19
        i32.store
       end
-      local.get $9
+      local.get $15
       i32.const 1
       i32.shr_s
-      local.set $9
+      local.set $15
       br $while-continue|4
      end
     end
-    local.get $5
+    local.get $12
     i32.const 1
     i32.sub
-    local.set $5
+    local.set $12
     br $for-loop|2
    end
   end
@@ -9339,13 +9591,13 @@
   call $~lib/rt/tlsf/__free
   local.get $0
   i32.load offset=4
-  local.set $12
+  local.set $20
   local.get $0
   local.get $0
   i32.load
   i32.store offset=4
   local.get $0
-  local.get $12
+  local.get $20
   i32.store
  )
  (func $~lib/array/Array<u32>#sort (param $0 i32) (param $1 i32) (result i32)
@@ -9354,6 +9606,8 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
   local.get $0
   i32.load offset=12
   local.set $2
@@ -9399,25 +9653,25 @@
    return
   end
   local.get $3
-  local.set $6
+  local.set $8
   local.get $2
-  local.set $5
+  local.set $7
   local.get $1
-  local.set $4
+  local.set $6
   i32.const 0
   drop
-  local.get $5
+  local.get $7
   i32.const 256
   i32.lt_s
   if
+   local.get $8
+   local.get $7
    local.get $6
-   local.get $5
-   local.get $4
    call $~lib/util/sort/insertionSort<u32>
   else
+   local.get $8
+   local.get $7
    local.get $6
-   local.get $5
-   local.get $4
    call $~lib/util/sort/weakHeapSort<u32>
   end
   local.get $0
@@ -9592,6 +9846,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $0
@@ -9637,10 +9892,10 @@
    end
   end
   i32.const 1
-  local.set $3
+  local.set $6
   local.get $0
   call $~lib/rt/pure/__release
-  local.get $3
+  local.get $6
  )
  (func $std/array/assertSorted<i32> (param $0 i32) (param $1 i32)
   (local $2 i32)
@@ -10037,6 +10292,9 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
   local.get $0
   i32.load offset=12
   local.set $2
@@ -10090,16 +10348,16 @@
    return
   end
   local.get $3
-  local.set $5
+  local.set $9
   local.get $2
-  local.set $4
+  local.set $8
   local.get $1
-  local.set $6
+  local.set $7
   i32.const 1
   drop
-  local.get $5
-  local.get $4
-  local.get $6
+  local.get $9
+  local.get $8
+  local.get $7
   call $~lib/util/sort/insertionSort<~lib/array/Array<i32>>
   local.get $0
   call $~lib/rt/pure/__retain
@@ -10162,6 +10420,7 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $0
@@ -10217,10 +10476,10 @@
    end
   end
   i32.const 1
-  local.set $3
+  local.set $8
   local.get $0
   call $~lib/rt/pure/__release
-  local.get $3
+  local.get $8
  )
  (func $std/array/assertSorted<~lib/array/Array<i32>> (param $0 i32) (param $1 i32)
   (local $2 i32)
@@ -10581,6 +10840,9 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
   local.get $0
   i32.load offset=12
   local.set $2
@@ -10634,16 +10896,16 @@
    return
   end
   local.get $3
-  local.set $5
+  local.set $9
   local.get $2
-  local.set $4
+  local.set $8
   local.get $1
-  local.set $6
+  local.set $7
   i32.const 1
   drop
-  local.get $5
-  local.get $4
-  local.get $6
+  local.get $9
+  local.get $8
+  local.get $7
   call $~lib/util/sort/insertionSort<std/array/Proxy<i32>>
   local.get $0
   call $~lib/rt/pure/__retain
@@ -10706,6 +10968,7 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $0
@@ -10761,10 +11024,10 @@
    end
   end
   i32.const 1
-  local.set $3
+  local.set $8
   local.get $0
   call $~lib/rt/pure/__release
-  local.get $3
+  local.get $8
  )
  (func $std/array/assertSorted<std/array/Proxy<i32>> (param $0 i32) (param $1 i32)
   (local $2 i32)
@@ -10895,6 +11158,9 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
   local.get $0
   i32.load offset=12
   local.set $2
@@ -10948,16 +11214,16 @@
    return
   end
   local.get $3
-  local.set $5
+  local.set $9
   local.get $2
-  local.set $4
+  local.set $8
   local.get $1
-  local.set $6
+  local.set $7
   i32.const 1
   drop
-  local.get $5
-  local.get $4
-  local.get $6
+  local.get $9
+  local.get $8
+  local.get $7
   call $~lib/util/sort/insertionSort<~lib/string/String | null>
   local.get $0
   call $~lib/rt/pure/__retain
@@ -11008,6 +11274,7 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $0
@@ -11063,10 +11330,10 @@
    end
   end
   i32.const 1
-  local.set $3
+  local.set $8
   local.get $0
   call $~lib/rt/pure/__release
-  local.get $3
+  local.get $8
  )
  (func $std/array/assertSorted<~lib/string/String | null> (param $0 i32) (param $1 i32)
   (local $2 i32)
@@ -11108,6 +11375,9 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $0
@@ -11179,33 +11449,33 @@
   end
   loop $while-continue|1
    local.get $4
-   local.tee $7
+   local.tee $8
    i32.const 1
    i32.sub
    local.set $4
-   local.get $7
-   local.set $7
-   local.get $7
+   local.get $8
+   local.set $9
+   local.get $9
    if
     local.get $5
     i32.load16_u
-    local.set $8
+    local.set $10
     local.get $6
     i32.load16_u
-    local.set $9
-    local.get $8
-    local.get $9
+    local.set $11
+    local.get $10
+    local.get $11
     i32.ne
     if
-     local.get $8
-     local.get $9
+     local.get $10
+     local.get $11
      i32.sub
-     local.set $10
+     local.set $12
      local.get $0
      call $~lib/rt/pure/__release
      local.get $2
      call $~lib/rt/pure/__release
-     local.get $10
+     local.get $12
      return
     end
     local.get $5
@@ -11220,18 +11490,23 @@
    end
   end
   i32.const 0
-  local.set $7
+  local.set $13
   local.get $0
   call $~lib/rt/pure/__release
   local.get $2
   call $~lib/rt/pure/__release
-  local.get $7
+  local.get $13
  )
  (func $~lib/util/sort/COMPARATOR<~lib/string/String | null>~anonymous|0 (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $0
@@ -11281,36 +11556,36 @@
   end
   if
    i32.const 0
-   local.set $2
+   local.set $5
    local.get $0
    call $~lib/rt/pure/__release
    local.get $1
    call $~lib/rt/pure/__release
-   local.get $2
+   local.get $5
    return
   end
   local.get $3
   i32.eqz
   if
    i32.const -1
-   local.set $2
+   local.set $6
    local.get $0
    call $~lib/rt/pure/__release
    local.get $1
    call $~lib/rt/pure/__release
-   local.get $2
+   local.get $6
    return
   end
   local.get $4
   i32.eqz
   if
    i32.const 1
-   local.set $2
+   local.set $7
    local.get $0
    call $~lib/rt/pure/__release
    local.get $1
    call $~lib/rt/pure/__release
-   local.get $2
+   local.get $7
    return
   end
   local.get $0
@@ -11318,20 +11593,20 @@
   local.get $1
   i32.const 0
   local.get $3
-  local.tee $2
+  local.tee $8
   local.get $4
-  local.tee $5
-  local.get $2
-  local.get $5
+  local.tee $9
+  local.get $8
+  local.get $9
   i32.lt_s
   select
   call $~lib/util/string/compareImpl
-  local.set $2
+  local.set $10
   local.get $0
   call $~lib/rt/pure/__release
   local.get $1
   call $~lib/rt/pure/__release
-  local.get $2
+  local.get $10
  )
  (func $std/array/assertSorted<~lib/string/String | null>@varargs (param $0 i32) (param $1 i32)
   block $1of1
@@ -11363,6 +11638,9 @@
  (func $~lib/string/String.__eq (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $0
@@ -11394,44 +11672,44 @@
   end
   if
    i32.const 0
-   local.set $2
+   local.set $3
    local.get $0
    call $~lib/rt/pure/__release
    local.get $1
    call $~lib/rt/pure/__release
-   local.get $2
+   local.get $3
    return
   end
   local.get $0
   call $~lib/string/String#get:length
-  local.set $3
-  local.get $3
+  local.set $4
+  local.get $4
   local.get $1
   call $~lib/string/String#get:length
   i32.ne
   if
    i32.const 0
-   local.set $2
+   local.set $5
    local.get $0
    call $~lib/rt/pure/__release
    local.get $1
    call $~lib/rt/pure/__release
-   local.get $2
+   local.get $5
    return
   end
   local.get $0
   i32.const 0
   local.get $1
   i32.const 0
-  local.get $3
+  local.get $4
   call $~lib/util/string/compareImpl
   i32.eqz
-  local.set $2
+  local.set $6
   local.get $0
   call $~lib/rt/pure/__release
   local.get $1
   call $~lib/rt/pure/__release
-  local.get $2
+  local.get $6
  )
  (func $~lib/string/String.__ne (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
@@ -11458,6 +11736,9 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $0
@@ -11489,67 +11770,67 @@
    i32.eq
    if
     i32.const 1
-    local.set $3
+    local.set $4
     local.get $0
     call $~lib/rt/pure/__release
     local.get $1
     call $~lib/rt/pure/__release
-    local.get $3
+    local.get $4
     return
    end
   end
   i32.const 0
-  local.set $3
+  local.set $5
   loop $for-loop|0
-   local.get $3
+   local.get $5
    local.get $2
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $6
+   local.get $6
    if
     i32.const 0
     drop
     local.get $0
-    local.get $3
+    local.get $5
     call $~lib/array/Array<~lib/string/String | null>#__get
-    local.tee $5
+    local.tee $7
     local.get $1
-    local.get $3
+    local.get $5
     call $~lib/array/Array<~lib/string/String | null>#__get
-    local.tee $6
+    local.tee $8
     call $~lib/string/String.__ne
     if
      i32.const 0
-     local.set $7
+     local.set $9
      local.get $0
      call $~lib/rt/pure/__release
      local.get $1
      call $~lib/rt/pure/__release
-     local.get $5
-     call $~lib/rt/pure/__release
-     local.get $6
-     call $~lib/rt/pure/__release
      local.get $7
+     call $~lib/rt/pure/__release
+     local.get $8
+     call $~lib/rt/pure/__release
+     local.get $9
      return
     end
+    local.get $7
+    call $~lib/rt/pure/__release
+    local.get $8
+    call $~lib/rt/pure/__release
     local.get $5
-    call $~lib/rt/pure/__release
-    local.get $6
-    call $~lib/rt/pure/__release
-    local.get $3
     i32.const 1
     i32.add
-    local.set $3
+    local.set $5
     br $for-loop|0
    end
   end
   i32.const 1
-  local.set $3
+  local.set $10
   local.get $0
   call $~lib/rt/pure/__release
   local.get $1
   call $~lib/rt/pure/__release
-  local.get $3
+  local.get $10
  )
  (func $~lib/array/Array<~lib/string/String>#constructor (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
@@ -11666,6 +11947,8 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
   local.get $1
   call $~lib/rt/pure/__retain
   local.set $1
@@ -11708,32 +11991,32 @@
   if
    i32.const 5056
    call $~lib/rt/pure/__retain
-   local.set $2
+   local.set $7
    local.get $1
    call $~lib/rt/pure/__release
-   local.get $2
+   local.get $7
    return
   end
   local.get $6
   i32.const 1
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
-  local.set $7
-  local.get $7
+  local.set $8
+  local.get $8
   local.get $0
   local.get $4
   call $~lib/memory/memory.copy
-  local.get $7
+  local.get $8
   local.get $4
   i32.add
   local.get $1
   local.get $5
   call $~lib/memory/memory.copy
-  local.get $7
-  local.set $2
+  local.get $8
+  local.set $9
   local.get $1
   call $~lib/rt/pure/__release
-  local.get $2
+  local.get $9
  )
  (func $~lib/string/String.__concat (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
@@ -12034,6 +12317,9 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
   local.get $0
   i32.load offset=12
   local.set $2
@@ -12087,16 +12373,16 @@
    return
   end
   local.get $3
-  local.set $5
+  local.set $9
   local.get $2
-  local.set $4
+  local.set $8
   local.get $1
-  local.set $6
+  local.set $7
   i32.const 1
   drop
-  local.get $5
-  local.get $4
-  local.get $6
+  local.get $9
+  local.get $8
+  local.get $7
   call $~lib/util/sort/insertionSort<~lib/string/String>
   local.get $0
   call $~lib/rt/pure/__retain
@@ -12159,6 +12445,7 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $0
@@ -12214,10 +12501,10 @@
    end
   end
   i32.const 1
-  local.set $3
+  local.set $8
   local.get $0
   call $~lib/rt/pure/__release
-  local.get $3
+  local.get $8
  )
  (func $std/array/assertSorted<~lib/string/String> (param $0 i32) (param $1 i32)
   (local $2 i32)
@@ -12249,6 +12536,11 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $0
@@ -12298,36 +12590,36 @@
   end
   if
    i32.const 0
-   local.set $2
+   local.set $5
    local.get $0
    call $~lib/rt/pure/__release
    local.get $1
    call $~lib/rt/pure/__release
-   local.get $2
+   local.get $5
    return
   end
   local.get $3
   i32.eqz
   if
    i32.const -1
-   local.set $2
+   local.set $6
    local.get $0
    call $~lib/rt/pure/__release
    local.get $1
    call $~lib/rt/pure/__release
-   local.get $2
+   local.get $6
    return
   end
   local.get $4
   i32.eqz
   if
    i32.const 1
-   local.set $2
+   local.set $7
    local.get $0
    call $~lib/rt/pure/__release
    local.get $1
    call $~lib/rt/pure/__release
-   local.get $2
+   local.get $7
    return
   end
   local.get $0
@@ -12335,20 +12627,20 @@
   local.get $1
   i32.const 0
   local.get $3
-  local.tee $2
+  local.tee $8
   local.get $4
-  local.tee $5
-  local.get $2
-  local.get $5
+  local.tee $9
+  local.get $8
+  local.get $9
   i32.lt_s
   select
   call $~lib/util/string/compareImpl
-  local.set $2
+  local.set $10
   local.get $0
   call $~lib/rt/pure/__release
   local.get $1
   call $~lib/rt/pure/__release
-  local.get $2
+  local.get $10
  )
  (func $std/array/assertSorted<~lib/string/String>@varargs (param $0 i32) (param $1 i32)
   block $1of1
@@ -12387,6 +12679,16 @@
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
   local.get $0
   call $~lib/string/String#get:length
   local.set $3
@@ -12398,67 +12700,67 @@
   local.get $5
   i32.gt_s
   select
-  local.tee $4
+  local.tee $6
   local.get $3
-  local.tee $5
-  local.get $4
-  local.get $5
-  i32.lt_s
-  select
-  local.set $6
-  local.get $2
-  local.tee $4
-  i32.const 0
-  local.tee $5
-  local.get $4
-  local.get $5
-  i32.gt_s
-  select
-  local.tee $4
-  local.get $3
-  local.tee $5
-  local.get $4
-  local.get $5
-  i32.lt_s
-  select
-  local.set $7
+  local.tee $7
   local.get $6
-  local.tee $4
   local.get $7
-  local.tee $5
-  local.get $4
-  local.get $5
   i32.lt_s
   select
-  i32.const 1
-  i32.shl
   local.set $8
-  local.get $6
-  local.tee $4
-  local.get $7
-  local.tee $5
-  local.get $4
-  local.get $5
+  local.get $2
+  local.tee $9
+  i32.const 0
+  local.tee $10
+  local.get $9
+  local.get $10
+  i32.gt_s
+  select
+  local.tee $11
+  local.get $3
+  local.tee $12
+  local.get $11
+  local.get $12
+  i32.lt_s
+  select
+  local.set $13
+  local.get $8
+  local.tee $14
+  local.get $13
+  local.tee $15
+  local.get $14
+  local.get $15
+  i32.lt_s
+  select
+  i32.const 1
+  i32.shl
+  local.set $16
+  local.get $8
+  local.tee $17
+  local.get $13
+  local.tee $18
+  local.get $17
+  local.get $18
   i32.gt_s
   select
   i32.const 1
   i32.shl
-  local.set $9
-  local.get $9
-  local.get $8
+  local.set $19
+  local.get $19
+  local.get $16
   i32.sub
-  local.set $10
-  local.get $10
+  local.set $20
+  local.get $20
   i32.eqz
   if
    i32.const 5056
    call $~lib/rt/pure/__retain
    return
   end
-  local.get $8
+  local.get $16
   i32.eqz
   if (result i32)
-   local.get $9
+   local.get $19
    local.get $3
    i32.const 1
    i32.shl
@@ -12471,17 +12773,17 @@
    call $~lib/rt/pure/__retain
    return
   end
-  local.get $10
+  local.get $20
   i32.const 1
   call $~lib/rt/tlsf/__alloc
-  local.set $11
-  local.get $11
+  local.set $21
+  local.get $21
   local.get $0
-  local.get $8
+  local.get $16
   i32.add
-  local.get $10
+  local.get $20
   call $~lib/memory/memory.copy
-  local.get $11
+  local.get $21
   call $~lib/rt/pure/__retain
  )
  (func $~lib/util/string/joinBooleanArray (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -12495,6 +12797,11 @@
   (local $10 i32)
   (local $11 i32)
   (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
   local.get $2
   call $~lib/rt/pure/__retain
   local.set $2
@@ -12522,91 +12829,91 @@
    i32.load8_u
    select
    call $~lib/rt/pure/__retain
-   local.set $4
+   local.set $5
    local.get $2
    call $~lib/rt/pure/__release
-   local.get $4
+   local.get $5
    return
   end
   local.get $2
   call $~lib/string/String#get:length
-  local.set $5
-  i32.const 5
   local.set $6
+  i32.const 5
+  local.set $7
+  local.get $7
   local.get $6
-  local.get $5
   i32.add
   local.get $3
   i32.mul
-  local.get $6
-  i32.add
-  local.set $7
   local.get $7
+  i32.add
+  local.set $8
+  local.get $8
   i32.const 1
   i32.shl
   i32.const 1
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
-  local.set $8
-  i32.const 0
   local.set $9
   i32.const 0
-  local.set $4
+  local.set $10
+  i32.const 0
+  local.set $14
   loop $for-loop|1
-   local.get $4
+   local.get $14
    local.get $3
    i32.lt_s
-   local.set $12
-   local.get $12
+   local.set $15
+   local.get $15
    if
     local.get $0
-    local.get $4
+    local.get $14
     i32.add
     i32.load8_u
-    local.set $10
+    local.set $11
     i32.const 4
-    local.get $10
+    local.get $11
     i32.eqz
     i32.add
-    local.set $6
-    local.get $8
+    local.set $7
     local.get $9
+    local.get $10
     i32.const 1
     i32.shl
     i32.add
     i32.const 5232
     i32.const 5264
-    local.get $10
+    local.get $11
     select
-    local.get $6
+    local.get $7
     i32.const 1
     i32.shl
     call $~lib/memory/memory.copy
-    local.get $9
-    local.get $6
+    local.get $10
+    local.get $7
     i32.add
-    local.set $9
-    local.get $5
+    local.set $10
+    local.get $6
     if
-     local.get $8
      local.get $9
+     local.get $10
      i32.const 1
      i32.shl
      i32.add
      local.get $2
-     local.get $5
+     local.get $6
      i32.const 1
      i32.shl
      call $~lib/memory/memory.copy
-     local.get $9
-     local.get $5
+     local.get $10
+     local.get $6
      i32.add
-     local.set $9
+     local.set $10
     end
-    local.get $4
+    local.get $14
     i32.const 1
     i32.add
-    local.set $4
+    local.set $14
     br $for-loop|1
    end
   end
@@ -12614,50 +12921,50 @@
   local.get $3
   i32.add
   i32.load8_u
-  local.set $10
+  local.set $11
   i32.const 4
-  local.get $10
+  local.get $11
   i32.eqz
   i32.add
-  local.set $6
-  local.get $8
+  local.set $7
   local.get $9
+  local.get $10
   i32.const 1
   i32.shl
   i32.add
   i32.const 5232
   i32.const 5264
-  local.get $10
+  local.get $11
   select
-  local.get $6
+  local.get $7
   i32.const 1
   i32.shl
   call $~lib/memory/memory.copy
-  local.get $9
-  local.get $6
-  i32.add
-  local.set $9
+  local.get $10
   local.get $7
-  local.get $9
+  i32.add
+  local.set $10
+  local.get $8
+  local.get $10
   i32.gt_s
   if
-   local.get $8
-   i32.const 0
    local.get $9
+   i32.const 0
+   local.get $10
    call $~lib/string/String#substring
-   local.set $4
+   local.set $16
    local.get $2
    call $~lib/rt/pure/__release
-   local.get $8
+   local.get $9
    call $~lib/rt/pure/__release
-   local.get $4
+   local.get $16
    return
   end
-  local.get $8
-  local.set $4
+  local.get $9
+  local.set $17
   local.get $2
   call $~lib/rt/pure/__release
-  local.get $4
+  local.get $17
  )
  (func $~lib/array/Array<bool>#join (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
@@ -12749,6 +13056,9 @@
   (local $9 i64)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
   loop $while-continue|0
    local.get $1
    i32.const 10000
@@ -12813,30 +13123,30 @@
    local.get $1
    i32.const 100
    i32.div_u
-   local.set $3
+   local.set $10
    local.get $1
    i32.const 100
    i32.rem_u
-   local.set $10
-   local.get $3
+   local.set $11
+   local.get $10
    local.set $1
    local.get $2
    i32.const 2
    i32.sub
    local.set $2
    i32.const 5412
-   local.get $10
+   local.get $11
    i32.const 2
    i32.shl
    i32.add
    i32.load
-   local.set $11
+   local.set $12
    local.get $0
    local.get $2
    i32.const 1
    i32.shl
    i32.add
-   local.get $11
+   local.get $12
    i32.store
   end
   local.get $1
@@ -12853,13 +13163,13 @@
    i32.shl
    i32.add
    i32.load
-   local.set $11
+   local.set $13
    local.get $0
    local.get $2
    i32.const 1
    i32.shl
    i32.add
-   local.get $11
+   local.get $13
    i32.store
   else
    local.get $2
@@ -12869,13 +13179,13 @@
    i32.const 48
    local.get $1
    i32.add
-   local.set $11
+   local.set $14
    local.get $0
    local.get $2
    i32.const 1
    i32.shl
    i32.add
-   local.get $11
+   local.get $14
    i32.store16
   end
  )
@@ -13045,6 +13355,11 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
   local.get $2
   call $~lib/rt/pure/__retain
   local.set $2
@@ -13069,77 +13384,77 @@
    local.get $0
    i32.load
    call $~lib/util/number/itoa<i32>
-   local.tee $4
-   local.set $5
+   local.tee $5
+   local.set $6
    local.get $2
    call $~lib/rt/pure/__release
-   local.get $5
+   local.get $6
    return
   end
   local.get $2
   call $~lib/string/String#get:length
-  local.set $6
+  local.set $7
   i32.const 11
-  local.get $6
+  local.get $7
   i32.add
   local.get $3
   i32.mul
   i32.const 11
   i32.add
-  local.set $7
-  local.get $7
+  local.set $8
+  local.get $8
   i32.const 1
   i32.shl
   i32.const 1
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
-  local.set $8
-  i32.const 0
   local.set $9
   i32.const 0
-  local.set $4
+  local.set $10
+  i32.const 0
+  local.set $12
   loop $for-loop|0
-   local.get $4
+   local.get $12
    local.get $3
    i32.lt_s
-   local.set $5
-   local.get $5
+   local.set $13
+   local.get $13
    if
     local.get $0
-    local.get $4
+    local.get $12
     i32.const 2
     i32.shl
     i32.add
     i32.load
-    local.set $10
-    local.get $9
-    local.get $8
+    local.set $11
+    local.get $10
     local.get $9
     local.get $10
+    local.get $11
     call $~lib/util/number/itoa_stream<i32>
     i32.add
-    local.set $9
-    local.get $6
+    local.set $10
+    local.get $7
     if
-     local.get $8
      local.get $9
+     local.get $10
      i32.const 1
      i32.shl
      i32.add
      local.get $2
-     local.get $6
+     local.get $7
      i32.const 1
      i32.shl
      call $~lib/memory/memory.copy
-     local.get $9
-     local.get $6
+     local.get $10
+     local.get $7
      i32.add
-     local.set $9
+     local.set $10
     end
-    local.get $4
+    local.get $12
     i32.const 1
     i32.add
-    local.set $4
+    local.set $12
     br $for-loop|0
    end
   end
@@ -13149,35 +13464,35 @@
   i32.shl
   i32.add
   i32.load
-  local.set $10
-  local.get $9
-  local.get $8
+  local.set $11
+  local.get $10
   local.get $9
   local.get $10
+  local.get $11
   call $~lib/util/number/itoa_stream<i32>
   i32.add
-  local.set $9
-  local.get $7
-  local.get $9
+  local.set $10
+  local.get $8
+  local.get $10
   i32.gt_s
   if
-   local.get $8
-   i32.const 0
    local.get $9
+   i32.const 0
+   local.get $10
    call $~lib/string/String#substring
-   local.set $4
+   local.set $14
    local.get $2
    call $~lib/rt/pure/__release
-   local.get $8
+   local.get $9
    call $~lib/rt/pure/__release
-   local.get $4
+   local.get $14
    return
   end
-  local.get $8
-  local.set $4
+  local.get $9
+  local.set $15
   local.get $2
   call $~lib/rt/pure/__release
-  local.get $4
+  local.get $15
  )
  (func $~lib/array/Array<i32>#join (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
@@ -13328,6 +13643,11 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
   local.get $2
   call $~lib/rt/pure/__retain
   local.set $2
@@ -13352,77 +13672,77 @@
    local.get $0
    i32.load
    call $~lib/util/number/itoa<u32>
-   local.tee $4
-   local.set $5
+   local.tee $5
+   local.set $6
    local.get $2
    call $~lib/rt/pure/__release
-   local.get $5
+   local.get $6
    return
   end
   local.get $2
   call $~lib/string/String#get:length
-  local.set $6
+  local.set $7
   i32.const 10
-  local.get $6
+  local.get $7
   i32.add
   local.get $3
   i32.mul
   i32.const 10
   i32.add
-  local.set $7
-  local.get $7
+  local.set $8
+  local.get $8
   i32.const 1
   i32.shl
   i32.const 1
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
-  local.set $8
-  i32.const 0
   local.set $9
   i32.const 0
-  local.set $4
+  local.set $10
+  i32.const 0
+  local.set $12
   loop $for-loop|0
-   local.get $4
+   local.get $12
    local.get $3
    i32.lt_s
-   local.set $5
-   local.get $5
+   local.set $13
+   local.get $13
    if
     local.get $0
-    local.get $4
+    local.get $12
     i32.const 2
     i32.shl
     i32.add
     i32.load
-    local.set $10
-    local.get $9
-    local.get $8
+    local.set $11
+    local.get $10
     local.get $9
     local.get $10
+    local.get $11
     call $~lib/util/number/itoa_stream<u32>
     i32.add
-    local.set $9
-    local.get $6
+    local.set $10
+    local.get $7
     if
-     local.get $8
      local.get $9
+     local.get $10
      i32.const 1
      i32.shl
      i32.add
      local.get $2
-     local.get $6
+     local.get $7
      i32.const 1
      i32.shl
      call $~lib/memory/memory.copy
-     local.get $9
-     local.get $6
+     local.get $10
+     local.get $7
      i32.add
-     local.set $9
+     local.set $10
     end
-    local.get $4
+    local.get $12
     i32.const 1
     i32.add
-    local.set $4
+    local.set $12
     br $for-loop|0
    end
   end
@@ -13432,35 +13752,35 @@
   i32.shl
   i32.add
   i32.load
-  local.set $10
-  local.get $9
-  local.get $8
+  local.set $11
+  local.get $10
   local.get $9
   local.get $10
+  local.get $11
   call $~lib/util/number/itoa_stream<u32>
   i32.add
-  local.set $9
-  local.get $7
-  local.get $9
+  local.set $10
+  local.get $8
+  local.get $10
   i32.gt_s
   if
-   local.get $8
-   i32.const 0
    local.get $9
+   i32.const 0
+   local.get $10
    call $~lib/string/String#substring
-   local.set $4
+   local.set $14
    local.get $2
    call $~lib/rt/pure/__release
-   local.get $8
+   local.get $9
    call $~lib/rt/pure/__release
-   local.get $4
+   local.get $14
    return
   end
-  local.get $8
-  local.set $4
+  local.get $9
+  local.set $15
   local.get $2
   call $~lib/rt/pure/__release
-  local.get $4
+  local.get $15
  )
  (func $~lib/array/Array<u32>#join (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
@@ -13502,16 +13822,31 @@
   (local $16 i32)
   (local $17 i32)
   (local $18 i32)
-  (local $19 i64)
+  (local $19 i32)
   (local $20 i64)
   (local $21 i64)
   (local $22 i64)
   (local $23 i64)
-  (local $24 i32)
+  (local $24 i64)
   (local $25 i32)
   (local $26 i32)
   (local $27 i32)
-  (local $28 i64)
+  (local $28 i32)
+  (local $29 i32)
+  (local $30 i32)
+  (local $31 i32)
+  (local $32 i64)
+  (local $33 i32)
+  (local $34 i64)
+  (local $35 i64)
+  (local $36 i64)
+  (local $37 i64)
+  (local $38 i32)
+  (local $39 i32)
+  (local $40 i32)
+  (local $41 i32)
+  (local $42 i32)
+  (local $43 i32)
   i32.const 0
   local.get $4
   i32.sub
@@ -13715,11 +14050,11 @@
     if
      local.get $0
      local.get $15
-     local.tee $18
+     local.tee $19
      i32.const 1
      i32.add
      local.set $15
-     local.get $18
+     local.get $19
      i32.const 1
      i32.shl
      i32.add
@@ -13741,8 +14076,8 @@
     i64.shl
     local.get $13
     i64.add
-    local.set $19
-    local.get $19
+    local.set $20
+    local.get $20
     local.get $5
     i64.le_u
     if
@@ -13751,13 +14086,13 @@
      i32.add
      global.set $~lib/util/number/_K
      local.get $0
-     local.set $24
+     local.set $26
      local.get $15
-     local.set $18
+     local.set $25
      local.get $5
+     local.set $24
+     local.get $20
      local.set $23
-     local.get $19
-     local.set $22
      i32.const 7160
      local.get $14
      i32.const 2
@@ -13767,71 +14102,71 @@
      local.get $7
      i64.extend_i32_s
      i64.shl
-     local.set $21
+     local.set $22
      local.get $10
-     local.set $20
-     local.get $24
-     local.get $18
+     local.set $21
+     local.get $26
+     local.get $25
      i32.const 1
      i32.sub
      i32.const 1
      i32.shl
      i32.add
-     local.set $25
-     local.get $25
+     local.set $27
+     local.get $27
      i32.load16_u
-     local.set $26
+     local.set $28
      loop $while-continue|3
-      local.get $22
-      local.get $20
+      local.get $23
+      local.get $21
       i64.lt_u
       if (result i32)
+       local.get $24
        local.get $23
-       local.get $22
        i64.sub
-       local.get $21
+       local.get $22
        i64.ge_u
       else
        i32.const 0
       end
       if (result i32)
+       local.get $23
        local.get $22
-       local.get $21
        i64.add
-       local.get $20
+       local.get $21
        i64.lt_u
        if (result i32)
         i32.const 1
        else
-        local.get $20
-        local.get $22
-        i64.sub
-        local.get $22
         local.get $21
+        local.get $23
+        i64.sub
+        local.get $23
+        local.get $22
         i64.add
-        local.get $20
+        local.get $21
         i64.sub
         i64.gt_u
        end
       else
        i32.const 0
       end
-      local.set $27
-      local.get $27
+      local.set $30
+      local.get $30
       if
-       local.get $26
+       local.get $28
        i32.const 1
        i32.sub
-       local.set $26
+       local.set $28
+       local.get $23
        local.get $22
-       local.get $21
        i64.add
-       local.set $22
+       local.set $23
        br $while-continue|3
       end
      end
-     local.get $25
-     local.get $26
+     local.get $27
+     local.get $28
      i32.store16
      local.get $15
      return
@@ -13841,8 +14176,8 @@
   end
   loop $while-continue|4
    i32.const 1
-   local.set $16
-   local.get $16
+   local.set $31
+   local.get $31
    if
     local.get $13
     i64.const 10
@@ -13856,8 +14191,8 @@
     local.get $7
     i64.extend_i32_s
     i64.shr_u
-    local.set $23
-    local.get $23
+    local.set $32
+    local.get $32
     local.get $15
     i64.extend_i32_s
     i64.or
@@ -13866,16 +14201,16 @@
     if
      local.get $0
      local.get $15
-     local.tee $26
+     local.tee $33
      i32.const 1
      i32.add
      local.set $15
-     local.get $26
+     local.get $33
      i32.const 1
      i32.shl
      i32.add
      i32.const 48
-     local.get $23
+     local.get $32
      i32.wrap_i64
      i32.const 65535
      i32.and
@@ -13910,79 +14245,79 @@
      i64.mul
      local.set $10
      local.get $0
-     local.set $18
+     local.set $39
      local.get $15
-     local.set $27
+     local.set $38
      local.get $5
-     local.set $28
+     local.set $37
      local.get $13
-     local.set $22
+     local.set $36
      local.get $8
-     local.set $21
+     local.set $35
      local.get $10
-     local.set $20
-     local.get $18
-     local.get $27
+     local.set $34
+     local.get $39
+     local.get $38
      i32.const 1
      i32.sub
      i32.const 1
      i32.shl
      i32.add
-     local.set $26
-     local.get $26
+     local.set $40
+     local.get $40
      i32.load16_u
-     local.set $25
+     local.set $41
      loop $while-continue|6
-      local.get $22
-      local.get $20
+      local.get $36
+      local.get $34
       i64.lt_u
       if (result i32)
-       local.get $28
-       local.get $22
+       local.get $37
+       local.get $36
        i64.sub
-       local.get $21
+       local.get $35
        i64.ge_u
       else
        i32.const 0
       end
       if (result i32)
-       local.get $22
-       local.get $21
+       local.get $36
+       local.get $35
        i64.add
-       local.get $20
+       local.get $34
        i64.lt_u
        if (result i32)
         i32.const 1
        else
-        local.get $20
-        local.get $22
+        local.get $34
+        local.get $36
         i64.sub
-        local.get $22
-        local.get $21
+        local.get $36
+        local.get $35
         i64.add
-        local.get $20
+        local.get $34
         i64.sub
         i64.gt_u
        end
       else
        i32.const 0
       end
-      local.set $24
-      local.get $24
+      local.set $43
+      local.get $43
       if
-       local.get $25
+       local.get $41
        i32.const 1
        i32.sub
-       local.set $25
-       local.get $22
-       local.get $21
+       local.set $41
+       local.get $36
+       local.get $35
        i64.add
-       local.set $22
+       local.set $36
        br $while-continue|6
       end
      end
-     local.get $26
-     local.get $25
+     local.get $40
+     local.get $41
      i32.store16
      local.get $15
      return
@@ -14002,6 +14337,19 @@
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local $22 i32)
+  (local $23 i32)
+  (local $24 i32)
   local.get $2
   i32.eqz
   if
@@ -14091,11 +14439,11 @@
     i32.const 1
     i32.shl
     i32.add
-    local.set $4
-    local.get $4
+    local.set $6
+    local.get $6
     i32.const 2
     i32.add
-    local.get $4
+    local.get $6
     i32.const 0
     local.get $2
     i32.sub
@@ -14128,9 +14476,9 @@
      i32.const 2
      local.get $3
      i32.sub
-     local.set $4
+     local.set $7
      local.get $0
-     local.get $4
+     local.get $7
      i32.const 1
      i32.shl
      i32.add
@@ -14147,30 +14495,30 @@
      i32.or
      i32.store
      i32.const 2
-     local.set $5
+     local.set $8
      loop $for-loop|1
-      local.get $5
-      local.get $4
+      local.get $8
+      local.get $7
       i32.lt_s
-      local.set $6
-      local.get $6
+      local.set $9
+      local.get $9
       if
        local.get $0
-       local.get $5
+       local.get $8
        i32.const 1
        i32.shl
        i32.add
        i32.const 48
        i32.store16
-       local.get $5
+       local.get $8
        i32.const 1
        i32.add
-       local.set $5
+       local.set $8
        br $for-loop|1
       end
      end
      local.get $1
-     local.get $4
+     local.get $7
      i32.add
      return
     else
@@ -14184,48 +14532,48 @@
       local.get $0
       i32.const 4
       i32.add
-      local.set $5
+      local.set $11
       local.get $3
       i32.const 1
       i32.sub
-      local.set $6
-      local.get $6
+      local.set $10
+      local.get $10
       i32.const 0
       i32.lt_s
-      local.set $4
-      local.get $4
+      local.set $12
+      local.get $12
       if
        i32.const 0
-       local.get $6
+       local.get $10
        i32.sub
-       local.set $6
+       local.set $10
       end
-      local.get $6
+      local.get $10
       call $~lib/util/number/decimalCount32
       i32.const 1
       i32.add
-      local.set $7
-      local.get $5
-      local.set $10
-      local.get $6
-      local.set $9
-      local.get $7
-      local.set $8
+      local.set $13
+      local.get $11
+      local.set $16
+      local.get $10
+      local.set $15
+      local.get $13
+      local.set $14
       i32.const 0
       i32.const 1
       i32.ge_s
       drop
-      local.get $10
-      local.get $9
-      local.get $8
+      local.get $16
+      local.get $15
+      local.get $14
       call $~lib/util/number/utoa32_lut
-      local.get $5
+      local.get $11
       i32.const 45
       i32.const 43
-      local.get $4
+      local.get $12
       select
       i32.store16
-      local.get $7
+      local.get $13
       local.set $1
       local.get $1
       i32.const 2
@@ -14235,14 +14583,14 @@
       local.get $1
       i32.const 1
       i32.shl
-      local.set $7
+      local.set $17
       local.get $0
       i32.const 4
       i32.add
       local.get $0
       i32.const 2
       i32.add
-      local.get $7
+      local.get $17
       i32.const 2
       i32.sub
       call $~lib/memory/memory.copy
@@ -14250,58 +14598,58 @@
       i32.const 46
       i32.store16 offset=2
       local.get $0
-      local.get $7
+      local.get $17
       i32.add
       i32.const 101
       i32.store16 offset=2
       local.get $1
       local.get $0
-      local.get $7
+      local.get $17
       i32.add
       i32.const 4
       i32.add
-      local.set $9
+      local.set $19
       local.get $3
       i32.const 1
       i32.sub
-      local.set $8
-      local.get $8
+      local.set $18
+      local.get $18
       i32.const 0
       i32.lt_s
-      local.set $4
-      local.get $4
+      local.set $20
+      local.get $20
       if
        i32.const 0
-       local.get $8
+       local.get $18
        i32.sub
-       local.set $8
+       local.set $18
       end
-      local.get $8
+      local.get $18
       call $~lib/util/number/decimalCount32
       i32.const 1
       i32.add
-      local.set $5
-      local.get $9
-      local.set $11
-      local.get $8
-      local.set $6
-      local.get $5
-      local.set $10
+      local.set $21
+      local.get $19
+      local.set $24
+      local.get $18
+      local.set $23
+      local.get $21
+      local.set $22
       i32.const 0
       i32.const 1
       i32.ge_s
       drop
-      local.get $11
-      local.get $6
-      local.get $10
+      local.get $24
+      local.get $23
+      local.get $22
       call $~lib/util/number/utoa32_lut
-      local.get $9
+      local.get $19
       i32.const 45
       i32.const 43
-      local.get $4
+      local.get $20
       select
       i32.store16
-      local.get $5
+      local.get $21
       i32.add
       local.set $1
       local.get $1
@@ -14332,19 +14680,51 @@
   (local $13 i32)
   (local $14 i32)
   (local $15 i32)
-  (local $16 f64)
-  (local $17 i64)
-  (local $18 i64)
-  (local $19 i64)
-  (local $20 i64)
+  (local $16 i32)
+  (local $17 f64)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
   (local $21 i64)
-  (local $22 i64)
+  (local $22 i32)
   (local $23 i64)
   (local $24 i64)
   (local $25 i64)
-  (local $26 i32)
+  (local $26 i64)
   (local $27 i64)
-  (local $28 i32)
+  (local $28 i64)
+  (local $29 i64)
+  (local $30 i64)
+  (local $31 i64)
+  (local $32 i64)
+  (local $33 i32)
+  (local $34 i32)
+  (local $35 i32)
+  (local $36 i64)
+  (local $37 i64)
+  (local $38 i64)
+  (local $39 i64)
+  (local $40 i64)
+  (local $41 i64)
+  (local $42 i64)
+  (local $43 i64)
+  (local $44 i64)
+  (local $45 i64)
+  (local $46 i32)
+  (local $47 i32)
+  (local $48 i32)
+  (local $49 i64)
+  (local $50 i64)
+  (local $51 i64)
+  (local $52 i64)
+  (local $53 i64)
+  (local $54 i64)
+  (local $55 i64)
+  (local $56 i64)
+  (local $57 i64)
+  (local $58 i64)
+  (local $59 i64)
+  (local $60 i32)
   local.get $1
   f64.const 0
   f64.lt
@@ -14448,47 +14828,47 @@
   local.get $13
   global.set $~lib/util/number/_exp
   global.get $~lib/util/number/_exp
-  local.set $10
+  local.set $16
   i32.const -61
-  local.get $10
+  local.get $16
   i32.sub
   f64.convert_i32_s
   f64.const 0.30102999566398114
   f64.mul
   f64.const 347
   f64.add
-  local.set $16
-  local.get $16
+  local.set $17
+  local.get $17
   i32.trunc_f64_s
-  local.set $15
-  local.get $15
-  local.get $15
+  local.set $18
+  local.get $18
+  local.get $18
   f64.convert_i32_s
-  local.get $16
+  local.get $17
   f64.ne
   i32.add
-  local.set $15
-  local.get $15
+  local.set $18
+  local.get $18
   i32.const 3
   i32.shr_s
   i32.const 1
   i32.add
-  local.set $14
+  local.set $19
   i32.const 348
-  local.get $14
+  local.get $19
   i32.const 3
   i32.shl
   i32.sub
   global.set $~lib/util/number/_K
   i32.const 6288
-  local.get $14
+  local.get $19
   i32.const 3
   i32.shl
   i32.add
   i64.load
   global.set $~lib/util/number/_frc_pow
   i32.const 6984
-  local.get $14
+  local.get $19
   i32.const 1
   i32.shl
   i32.add
@@ -14497,249 +14877,249 @@
   local.get $9
   i64.clz
   i32.wrap_i64
-  local.set $14
+  local.set $20
   local.get $9
-  local.get $14
+  local.get $20
   i64.extend_i32_s
   i64.shl
   local.set $9
   local.get $7
-  local.get $14
+  local.get $20
   i32.sub
   local.set $7
   global.get $~lib/util/number/_frc_pow
-  local.set $12
+  local.set $21
   global.get $~lib/util/number/_exp_pow
-  local.set $15
+  local.set $22
   local.get $9
-  local.set $17
-  local.get $12
-  local.set $11
-  local.get $17
-  i64.const 4294967295
-  i64.and
-  local.set $18
-  local.get $11
-  i64.const 4294967295
-  i64.and
-  local.set $19
-  local.get $17
-  i64.const 32
-  i64.shr_u
-  local.set $20
-  local.get $11
-  i64.const 32
-  i64.shr_u
-  local.set $21
-  local.get $18
-  local.get $19
-  i64.mul
-  local.set $22
-  local.get $20
-  local.get $19
-  i64.mul
-  local.get $22
-  i64.const 32
-  i64.shr_u
-  i64.add
-  local.set $23
-  local.get $18
+  local.set $24
   local.get $21
-  i64.mul
+  local.set $23
+  local.get $24
+  i64.const 4294967295
+  i64.and
+  local.set $25
   local.get $23
   i64.const 4294967295
   i64.and
-  i64.add
-  local.set $24
+  local.set $26
   local.get $24
+  i64.const 32
+  i64.shr_u
+  local.set $27
+  local.get $23
+  i64.const 32
+  i64.shr_u
+  local.set $28
+  local.get $25
+  local.get $26
+  i64.mul
+  local.set $29
+  local.get $27
+  local.get $26
+  i64.mul
+  local.get $29
+  i64.const 32
+  i64.shr_u
+  i64.add
+  local.set $30
+  local.get $25
+  local.get $28
+  i64.mul
+  local.get $30
+  i64.const 4294967295
+  i64.and
+  i64.add
+  local.set $31
+  local.get $31
   i64.const 2147483647
   i64.add
-  local.set $24
-  local.get $23
+  local.set $31
+  local.get $30
   i64.const 32
   i64.shr_u
-  local.set $23
-  local.get $24
+  local.set $30
+  local.get $31
   i64.const 32
   i64.shr_u
-  local.set $24
-  local.get $20
-  local.get $21
+  local.set $31
+  local.get $27
+  local.get $28
   i64.mul
-  local.get $23
+  local.get $30
   i64.add
-  local.get $24
+  local.get $31
   i64.add
-  local.set $24
+  local.set $32
   local.get $7
-  local.set $10
-  local.get $15
-  local.set $13
-  local.get $10
-  local.get $13
+  local.set $34
+  local.get $22
+  local.set $33
+  local.get $34
+  local.get $33
   i32.add
   i32.const 64
   i32.add
-  local.set $10
+  local.set $35
   global.get $~lib/util/number/_frc_plus
-  local.set $17
-  local.get $12
-  local.set $11
-  local.get $17
-  i64.const 4294967295
-  i64.and
-  local.set $23
-  local.get $11
-  i64.const 4294967295
-  i64.and
-  local.set $22
-  local.get $17
-  i64.const 32
-  i64.shr_u
-  local.set $21
-  local.get $11
-  i64.const 32
-  i64.shr_u
-  local.set $20
-  local.get $23
-  local.get $22
-  i64.mul
-  local.set $19
+  local.set $37
   local.get $21
-  local.get $22
+  local.set $36
+  local.get $37
+  i64.const 4294967295
+  i64.and
+  local.set $38
+  local.get $36
+  i64.const 4294967295
+  i64.and
+  local.set $39
+  local.get $37
+  i64.const 32
+  i64.shr_u
+  local.set $40
+  local.get $36
+  i64.const 32
+  i64.shr_u
+  local.set $41
+  local.get $38
+  local.get $39
   i64.mul
-  local.get $19
+  local.set $42
+  local.get $40
+  local.get $39
+  i64.mul
+  local.get $42
   i64.const 32
   i64.shr_u
   i64.add
-  local.set $18
-  local.get $23
-  local.get $20
+  local.set $43
+  local.get $38
+  local.get $41
   i64.mul
-  local.get $18
+  local.get $43
   i64.const 4294967295
   i64.and
   i64.add
-  local.set $25
-  local.get $25
+  local.set $44
+  local.get $44
   i64.const 2147483647
   i64.add
-  local.set $25
-  local.get $18
+  local.set $44
+  local.get $43
   i64.const 32
   i64.shr_u
-  local.set $18
-  local.get $25
+  local.set $43
+  local.get $44
   i64.const 32
   i64.shr_u
-  local.set $25
-  local.get $21
-  local.get $20
+  local.set $44
+  local.get $40
+  local.get $41
   i64.mul
-  local.get $18
+  local.get $43
   i64.add
-  local.get $25
+  local.get $44
   i64.add
   i64.const 1
   i64.sub
-  local.set $25
+  local.set $45
   global.get $~lib/util/number/_exp
-  local.set $26
-  local.get $15
-  local.set $13
-  local.get $26
-  local.get $13
+  local.set $47
+  local.get $22
+  local.set $46
+  local.get $47
+  local.get $46
   i32.add
   i32.const 64
   i32.add
-  local.set $26
+  local.set $48
   global.get $~lib/util/number/_frc_minus
-  local.set $17
-  local.get $12
-  local.set $11
-  local.get $17
-  i64.const 4294967295
-  i64.and
-  local.set $18
-  local.get $11
-  i64.const 4294967295
-  i64.and
-  local.set $19
-  local.get $17
-  i64.const 32
-  i64.shr_u
-  local.set $20
-  local.get $11
-  i64.const 32
-  i64.shr_u
-  local.set $21
-  local.get $18
-  local.get $19
-  i64.mul
-  local.set $22
-  local.get $20
-  local.get $19
-  i64.mul
-  local.get $22
-  i64.const 32
-  i64.shr_u
-  i64.add
-  local.set $23
-  local.get $18
+  local.set $50
   local.get $21
+  local.set $49
+  local.get $50
+  i64.const 4294967295
+  i64.and
+  local.set $51
+  local.get $49
+  i64.const 4294967295
+  i64.and
+  local.set $52
+  local.get $50
+  i64.const 32
+  i64.shr_u
+  local.set $53
+  local.get $49
+  i64.const 32
+  i64.shr_u
+  local.set $54
+  local.get $51
+  local.get $52
   i64.mul
-  local.get $23
+  local.set $55
+  local.get $53
+  local.get $52
+  i64.mul
+  local.get $55
+  i64.const 32
+  i64.shr_u
+  i64.add
+  local.set $56
+  local.get $51
+  local.get $54
+  i64.mul
+  local.get $56
   i64.const 4294967295
   i64.and
   i64.add
-  local.set $27
-  local.get $27
+  local.set $57
+  local.get $57
   i64.const 2147483647
   i64.add
-  local.set $27
-  local.get $23
+  local.set $57
+  local.get $56
   i64.const 32
   i64.shr_u
-  local.set $23
-  local.get $27
+  local.set $56
+  local.get $57
   i64.const 32
   i64.shr_u
-  local.set $27
-  local.get $20
-  local.get $21
+  local.set $57
+  local.get $53
+  local.get $54
   i64.mul
-  local.get $23
+  local.get $56
   i64.add
-  local.get $27
+  local.get $57
   i64.add
   i64.const 1
   i64.add
-  local.set $27
-  local.get $25
-  local.get $27
+  local.set $58
+  local.get $45
+  local.get $58
   i64.sub
-  local.set $23
+  local.set $59
   local.get $4
-  local.get $24
-  local.get $10
-  local.get $25
-  local.get $26
-  local.get $23
+  local.get $32
+  local.get $35
+  local.get $45
+  local.get $48
+  local.get $59
   local.get $3
   call $~lib/util/number/genDigits
-  local.set $28
+  local.set $60
   local.get $0
   local.get $2
   i32.const 1
   i32.shl
   i32.add
-  local.get $28
+  local.get $60
   local.get $2
   i32.sub
   global.get $~lib/util/number/_K
   call $~lib/util/number/prettify
-  local.set $28
-  local.get $28
+  local.set $60
+  local.get $60
   local.get $2
   i32.add
  )
@@ -14890,7 +15270,12 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
-  (local $10 f64)
+  (local $10 i32)
+  (local $11 f64)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
   local.get $2
   call $~lib/rt/pure/__retain
   local.set $2
@@ -14915,77 +15300,77 @@
    local.get $0
    f64.load
    call $~lib/util/number/dtoa
-   local.tee $4
-   local.set $5
+   local.tee $5
+   local.set $6
    local.get $2
    call $~lib/rt/pure/__release
-   local.get $5
+   local.get $6
    return
   end
   local.get $2
   call $~lib/string/String#get:length
-  local.set $6
+  local.set $7
   i32.const 28
-  local.get $6
+  local.get $7
   i32.add
   local.get $3
   i32.mul
   i32.const 28
   i32.add
-  local.set $7
-  local.get $7
+  local.set $8
+  local.get $8
   i32.const 1
   i32.shl
   i32.const 1
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
-  local.set $8
-  i32.const 0
   local.set $9
   i32.const 0
-  local.set $4
+  local.set $10
+  i32.const 0
+  local.set $12
   loop $for-loop|0
-   local.get $4
+   local.get $12
    local.get $3
    i32.lt_s
-   local.set $5
-   local.get $5
+   local.set $13
+   local.get $13
    if
     local.get $0
-    local.get $4
+    local.get $12
     i32.const 3
     i32.shl
     i32.add
     f64.load
-    local.set $10
-    local.get $9
-    local.get $8
+    local.set $11
+    local.get $10
     local.get $9
     local.get $10
+    local.get $11
     call $~lib/util/number/dtoa_stream
     i32.add
-    local.set $9
-    local.get $6
+    local.set $10
+    local.get $7
     if
-     local.get $8
      local.get $9
+     local.get $10
      i32.const 1
      i32.shl
      i32.add
      local.get $2
-     local.get $6
+     local.get $7
      i32.const 1
      i32.shl
      call $~lib/memory/memory.copy
-     local.get $9
-     local.get $6
+     local.get $10
+     local.get $7
      i32.add
-     local.set $9
+     local.set $10
     end
-    local.get $4
+    local.get $12
     i32.const 1
     i32.add
-    local.set $4
+    local.set $12
     br $for-loop|0
    end
   end
@@ -14995,35 +15380,35 @@
   i32.shl
   i32.add
   f64.load
-  local.set $10
-  local.get $9
-  local.get $8
+  local.set $11
+  local.get $10
   local.get $9
   local.get $10
+  local.get $11
   call $~lib/util/number/dtoa_stream
   i32.add
-  local.set $9
-  local.get $7
-  local.get $9
+  local.set $10
+  local.get $8
+  local.get $10
   i32.gt_s
   if
-   local.get $8
-   i32.const 0
    local.get $9
+   i32.const 0
+   local.get $10
    call $~lib/string/String#substring
-   local.set $4
+   local.set $14
    local.get $2
    call $~lib/rt/pure/__release
-   local.get $8
+   local.get $9
    call $~lib/rt/pure/__release
-   local.get $4
+   local.get $14
    return
   end
-  local.get $8
-  local.set $4
+  local.get $9
+  local.set $15
   local.get $2
   call $~lib/rt/pure/__release
-  local.get $4
+  local.get $15
  )
  (func $~lib/array/Array<f64>#join (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
@@ -15065,6 +15450,17 @@
   (local $10 i32)
   (local $11 i32)
   (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local $22 i32)
+  (local $23 i32)
   local.get $2
   call $~lib/rt/pure/__retain
   local.set $2
@@ -15088,75 +15484,75 @@
   if
    local.get $0
    i32.load
-   local.tee $4
+   local.tee $5
    if (result i32)
-    local.get $4
+    local.get $5
     call $~lib/rt/pure/__retain
    else
     i32.const 5056
    end
-   local.set $4
+   local.set $6
    local.get $2
    call $~lib/rt/pure/__release
-   local.get $4
+   local.get $6
    return
   end
   i32.const 0
-  local.set $5
+  local.set $7
   i32.const 0
-  local.set $6
+  local.set $8
   i32.const 0
-  local.set $4
+  local.set $9
   loop $for-loop|0
-   local.get $4
+   local.get $9
    local.get $1
    i32.lt_s
-   local.set $7
-   local.get $7
+   local.set $10
+   local.get $10
    if
     local.get $0
-    local.get $4
+    local.get $9
     i32.const 2
     i32.shl
     i32.add
     i32.load
-    local.tee $8
-    local.get $6
-    local.tee $9
+    local.tee $11
+    local.get $8
+    local.tee $12
     i32.ne
     if
-     local.get $8
+     local.get $11
      call $~lib/rt/pure/__retain
-     local.set $8
-     local.get $9
+     local.set $11
+     local.get $12
      call $~lib/rt/pure/__release
     end
+    local.get $11
+    local.set $8
     local.get $8
-    local.set $6
-    local.get $6
     i32.const 0
     i32.ne
     if
-     local.get $5
-     local.get $6
+     local.get $7
+     local.get $8
      call $~lib/string/String#get:length
      i32.add
-     local.set $5
+     local.set $7
     end
-    local.get $4
+    local.get $9
     i32.const 1
     i32.add
-    local.set $4
+    local.set $9
     br $for-loop|0
    end
   end
   i32.const 0
-  local.set $10
+  local.set $13
   local.get $2
   call $~lib/string/String#get:length
-  local.set $11
-  local.get $5
-  local.get $11
+  local.set $14
+  local.get $7
+  local.get $14
   local.get $3
   i32.mul
   i32.add
@@ -15164,78 +15560,78 @@
   i32.shl
   i32.const 1
   call $~lib/rt/tlsf/__alloc
-  local.set $12
+  local.set $15
   i32.const 0
-  local.set $4
+  local.set $16
   loop $for-loop|1
-   local.get $4
+   local.get $16
    local.get $3
    i32.lt_s
-   local.set $7
-   local.get $7
+   local.set $17
+   local.get $17
    if
     local.get $0
-    local.get $4
+    local.get $16
     i32.const 2
     i32.shl
     i32.add
     i32.load
-    local.tee $9
-    local.get $6
-    local.tee $8
+    local.tee $18
+    local.get $8
+    local.tee $19
     i32.ne
     if
-     local.get $9
+     local.get $18
      call $~lib/rt/pure/__retain
-     local.set $9
-     local.get $8
+     local.set $18
+     local.get $19
      call $~lib/rt/pure/__release
     end
-    local.get $9
-    local.set $6
-    local.get $6
+    local.get $18
+    local.set $8
+    local.get $8
     i32.const 0
     i32.ne
     if
-     local.get $6
+     local.get $8
      call $~lib/string/String#get:length
-     local.set $9
-     local.get $12
-     local.get $10
+     local.set $20
+     local.get $15
+     local.get $13
      i32.const 1
      i32.shl
      i32.add
-     local.get $6
-     local.get $9
+     local.get $8
+     local.get $20
      i32.const 1
      i32.shl
      call $~lib/memory/memory.copy
-     local.get $10
-     local.get $9
+     local.get $13
+     local.get $20
      i32.add
-     local.set $10
+     local.set $13
     end
-    local.get $11
+    local.get $14
     if
-     local.get $12
-     local.get $10
+     local.get $15
+     local.get $13
      i32.const 1
      i32.shl
      i32.add
      local.get $2
-     local.get $11
+     local.get $14
      i32.const 1
      i32.shl
      call $~lib/memory/memory.copy
-     local.get $10
-     local.get $11
+     local.get $13
+     local.get $14
      i32.add
-     local.set $10
+     local.set $13
     end
-    local.get $4
+    local.get $16
     i32.const 1
     i32.add
-    local.set $4
+    local.set $16
     br $for-loop|1
    end
   end
@@ -15245,43 +15641,43 @@
   i32.shl
   i32.add
   i32.load
-  local.tee $8
-  local.get $6
-  local.tee $4
+  local.tee $21
+  local.get $8
+  local.tee $22
   i32.ne
   if
-   local.get $8
+   local.get $21
    call $~lib/rt/pure/__retain
-   local.set $8
-   local.get $4
+   local.set $21
+   local.get $22
    call $~lib/rt/pure/__release
   end
+  local.get $21
+  local.set $8
   local.get $8
-  local.set $6
-  local.get $6
   i32.const 0
   i32.ne
   if
-   local.get $12
-   local.get $10
+   local.get $15
+   local.get $13
    i32.const 1
    i32.shl
    i32.add
-   local.get $6
-   local.get $6
+   local.get $8
+   local.get $8
    call $~lib/string/String#get:length
    i32.const 1
    i32.shl
    call $~lib/memory/memory.copy
   end
-  local.get $12
+  local.get $15
   call $~lib/rt/pure/__retain
-  local.set $8
+  local.set $23
   local.get $2
   call $~lib/rt/pure/__release
-  local.get $6
-  call $~lib/rt/pure/__release
   local.get $8
+  call $~lib/rt/pure/__release
+  local.get $23
  )
  (func $~lib/array/Array<~lib/string/String | null>#join (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
@@ -15332,6 +15728,22 @@
   (local $10 i32)
   (local $11 i32)
   (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local $22 i32)
+  (local $23 i32)
+  (local $24 i32)
+  (local $25 i32)
+  (local $26 i32)
+  (local $27 i32)
+  (local $28 i32)
   local.get $2
   call $~lib/rt/pure/__retain
   local.set $2
@@ -15357,18 +15769,18 @@
   if
    local.get $0
    i32.load
-   local.tee $4
-   local.get $5
    local.tee $6
+   local.get $5
+   local.tee $7
    i32.ne
    if
-    local.get $4
-    call $~lib/rt/pure/__retain
-    local.set $4
     local.get $6
+    call $~lib/rt/pure/__retain
+    local.set $6
+    local.get $7
     call $~lib/rt/pure/__release
    end
-   local.get $4
+   local.get $6
    local.set $5
    local.get $5
    i32.const 0
@@ -15379,101 +15791,101 @@
    else
     i32.const 5056
    end
-   local.set $4
+   local.set $8
    local.get $2
    call $~lib/rt/pure/__release
    local.get $5
    call $~lib/rt/pure/__release
-   local.get $4
+   local.get $8
    return
   end
   i32.const 5056
-  local.set $7
+  local.set $9
   local.get $2
   call $~lib/string/String#get:length
-  local.set $8
+  local.set $10
   i32.const 0
-  local.set $4
+  local.set $11
   loop $for-loop|0
-   local.get $4
+   local.get $11
    local.get $3
    i32.lt_s
-   local.set $6
-   local.get $6
+   local.set $12
+   local.get $12
    if
     local.get $0
-    local.get $4
+    local.get $11
     i32.const 2
     i32.shl
     i32.add
     i32.load
-    local.tee $9
+    local.tee $13
     local.get $5
-    local.tee $10
+    local.tee $14
     i32.ne
     if
-     local.get $9
+     local.get $13
      call $~lib/rt/pure/__retain
-     local.set $9
-     local.get $10
+     local.set $13
+     local.get $14
      call $~lib/rt/pure/__release
     end
-    local.get $9
+    local.get $13
     local.set $5
     local.get $5
     i32.const 0
     i32.ne
     if
-     local.get $7
+     local.get $9
      local.get $5
      call $std/array/Ref#toString
-     local.tee $9
+     local.tee $15
      call $~lib/string/String.__concat
-     local.tee $10
-     local.tee $11
-     local.get $7
-     local.tee $12
+     local.tee $16
+     local.tee $17
+     local.get $9
+     local.tee $18
      i32.ne
      if
-      local.get $11
+      local.get $17
       call $~lib/rt/pure/__retain
-      local.set $11
-      local.get $12
+      local.set $17
+      local.get $18
       call $~lib/rt/pure/__release
      end
-     local.get $11
-     local.set $7
-     local.get $9
+     local.get $17
+     local.set $9
+     local.get $15
      call $~lib/rt/pure/__release
-     local.get $10
+     local.get $16
      call $~lib/rt/pure/__release
     end
-    local.get $8
+    local.get $10
     if
-     local.get $7
+     local.get $9
      local.get $2
      call $~lib/string/String.__concat
-     local.tee $10
-     local.tee $12
-     local.get $7
-     local.tee $9
+     local.tee $19
+     local.tee $20
+     local.get $9
+     local.tee $21
      i32.ne
      if
-      local.get $12
+      local.get $20
       call $~lib/rt/pure/__retain
-      local.set $12
-      local.get $9
+      local.set $20
+      local.get $21
       call $~lib/rt/pure/__release
      end
-     local.get $12
-     local.set $7
-     local.get $10
+     local.get $20
+     local.set $9
+     local.get $19
      call $~lib/rt/pure/__release
     end
-    local.get $4
+    local.get $11
     i32.const 1
     i32.add
-    local.set $4
+    local.set $11
     br $for-loop|0
    end
   end
@@ -15483,54 +15895,54 @@
   i32.shl
   i32.add
   i32.load
-  local.tee $11
+  local.tee $22
   local.get $5
-  local.tee $4
+  local.tee $23
   i32.ne
   if
-   local.get $11
+   local.get $22
    call $~lib/rt/pure/__retain
-   local.set $11
-   local.get $4
+   local.set $22
+   local.get $23
    call $~lib/rt/pure/__release
   end
-  local.get $11
+  local.get $22
   local.set $5
   local.get $5
   i32.const 0
   i32.ne
   if
-   local.get $7
+   local.get $9
    local.get $5
    call $std/array/Ref#toString
-   local.tee $11
+   local.tee $24
    call $~lib/string/String.__concat
-   local.tee $4
-   local.tee $9
-   local.get $7
-   local.tee $6
+   local.tee $25
+   local.tee $26
+   local.get $9
+   local.tee $27
    i32.ne
    if
-    local.get $9
+    local.get $26
     call $~lib/rt/pure/__retain
-    local.set $9
-    local.get $6
+    local.set $26
+    local.get $27
     call $~lib/rt/pure/__release
    end
-   local.get $9
-   local.set $7
-   local.get $11
+   local.get $26
+   local.set $9
+   local.get $24
    call $~lib/rt/pure/__release
-   local.get $4
+   local.get $25
    call $~lib/rt/pure/__release
   end
-  local.get $7
-  local.set $4
+  local.get $9
+  local.set $28
   local.get $2
   call $~lib/rt/pure/__release
   local.get $5
   call $~lib/rt/pure/__release
-  local.get $4
+  local.get $28
  )
  (func $~lib/array/Array<std/array/Ref | null>#join (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
@@ -15580,6 +15992,22 @@
   (local $10 i32)
   (local $11 i32)
   (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local $22 i32)
+  (local $23 i32)
+  (local $24 i32)
+  (local $25 i32)
+  (local $26 i32)
+  (local $27 i32)
+  (local $28 i32)
   local.get $2
   call $~lib/rt/pure/__retain
   local.set $2
@@ -15605,18 +16033,18 @@
   if
    local.get $0
    i32.load
-   local.tee $4
-   local.get $5
    local.tee $6
+   local.get $5
+   local.tee $7
    i32.ne
    if
-    local.get $4
-    call $~lib/rt/pure/__retain
-    local.set $4
     local.get $6
+    call $~lib/rt/pure/__retain
+    local.set $6
+    local.get $7
     call $~lib/rt/pure/__release
    end
-   local.get $4
+   local.get $6
    local.set $5
    local.get $5
    i32.const 0
@@ -15627,101 +16055,101 @@
    else
     i32.const 5056
    end
-   local.set $4
+   local.set $8
    local.get $2
    call $~lib/rt/pure/__release
    local.get $5
    call $~lib/rt/pure/__release
-   local.get $4
+   local.get $8
    return
   end
   i32.const 5056
-  local.set $7
+  local.set $9
   local.get $2
   call $~lib/string/String#get:length
-  local.set $8
+  local.set $10
   i32.const 0
-  local.set $4
+  local.set $11
   loop $for-loop|0
-   local.get $4
+   local.get $11
    local.get $3
    i32.lt_s
-   local.set $6
-   local.get $6
+   local.set $12
+   local.get $12
    if
     local.get $0
-    local.get $4
+    local.get $11
     i32.const 2
     i32.shl
     i32.add
     i32.load
-    local.tee $9
+    local.tee $13
     local.get $5
-    local.tee $10
+    local.tee $14
     i32.ne
     if
-     local.get $9
+     local.get $13
      call $~lib/rt/pure/__retain
-     local.set $9
-     local.get $10
+     local.set $13
+     local.get $14
      call $~lib/rt/pure/__release
     end
-    local.get $9
+    local.get $13
     local.set $5
     local.get $5
     i32.const 0
     i32.ne
     if
-     local.get $7
+     local.get $9
      local.get $5
      call $std/array/Ref#toString
-     local.tee $9
+     local.tee $15
      call $~lib/string/String.__concat
-     local.tee $10
-     local.tee $11
-     local.get $7
-     local.tee $12
+     local.tee $16
+     local.tee $17
+     local.get $9
+     local.tee $18
      i32.ne
      if
-      local.get $11
+      local.get $17
       call $~lib/rt/pure/__retain
-      local.set $11
-      local.get $12
+      local.set $17
+      local.get $18
       call $~lib/rt/pure/__release
      end
-     local.get $11
-     local.set $7
-     local.get $9
+     local.get $17
+     local.set $9
+     local.get $15
      call $~lib/rt/pure/__release
-     local.get $10
+     local.get $16
      call $~lib/rt/pure/__release
     end
-    local.get $8
+    local.get $10
     if
-     local.get $7
+     local.get $9
      local.get $2
      call $~lib/string/String.__concat
-     local.tee $10
-     local.tee $12
-     local.get $7
-     local.tee $9
+     local.tee $19
+     local.tee $20
+     local.get $9
+     local.tee $21
      i32.ne
      if
-      local.get $12
+      local.get $20
       call $~lib/rt/pure/__retain
-      local.set $12
-      local.get $9
+      local.set $20
+      local.get $21
       call $~lib/rt/pure/__release
      end
-     local.get $12
-     local.set $7
-     local.get $10
+     local.get $20
+     local.set $9
+     local.get $19
      call $~lib/rt/pure/__release
     end
-    local.get $4
+    local.get $11
     i32.const 1
     i32.add
-    local.set $4
+    local.set $11
     br $for-loop|0
    end
   end
@@ -15731,54 +16159,54 @@
   i32.shl
   i32.add
   i32.load
-  local.tee $11
+  local.tee $22
   local.get $5
-  local.tee $4
+  local.tee $23
   i32.ne
   if
-   local.get $11
+   local.get $22
    call $~lib/rt/pure/__retain
-   local.set $11
-   local.get $4
+   local.set $22
+   local.get $23
    call $~lib/rt/pure/__release
   end
-  local.get $11
+  local.get $22
   local.set $5
   local.get $5
   i32.const 0
   i32.ne
   if
-   local.get $7
+   local.get $9
    local.get $5
    call $std/array/Ref#toString
-   local.tee $11
+   local.tee $24
    call $~lib/string/String.__concat
-   local.tee $4
-   local.tee $9
-   local.get $7
-   local.tee $6
+   local.tee $25
+   local.tee $26
+   local.get $9
+   local.tee $27
    i32.ne
    if
-    local.get $9
+    local.get $26
     call $~lib/rt/pure/__retain
-    local.set $9
-    local.get $6
+    local.set $26
+    local.get $27
     call $~lib/rt/pure/__release
    end
-   local.get $9
-   local.set $7
-   local.get $11
+   local.get $26
+   local.set $9
+   local.get $24
    call $~lib/rt/pure/__release
-   local.get $4
+   local.get $25
    call $~lib/rt/pure/__release
   end
-  local.get $7
-  local.set $4
+  local.get $9
+  local.set $28
   local.get $2
   call $~lib/rt/pure/__release
   local.get $5
   call $~lib/rt/pure/__release
-  local.get $4
+  local.get $28
  )
  (func $~lib/array/Array<std/array/Ref>#join (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
@@ -15954,6 +16382,11 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
   local.get $2
   call $~lib/rt/pure/__retain
   local.set $2
@@ -15978,77 +16411,77 @@
    local.get $0
    i32.load8_s
    call $~lib/util/number/itoa<i8>
-   local.tee $4
-   local.set $5
+   local.tee $5
+   local.set $6
    local.get $2
    call $~lib/rt/pure/__release
-   local.get $5
+   local.get $6
    return
   end
   local.get $2
   call $~lib/string/String#get:length
-  local.set $6
+  local.set $7
   i32.const 11
-  local.get $6
+  local.get $7
   i32.add
   local.get $3
   i32.mul
   i32.const 11
   i32.add
-  local.set $7
-  local.get $7
+  local.set $8
+  local.get $8
   i32.const 1
   i32.shl
   i32.const 1
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
-  local.set $8
-  i32.const 0
   local.set $9
   i32.const 0
-  local.set $4
+  local.set $10
+  i32.const 0
+  local.set $12
   loop $for-loop|0
-   local.get $4
+   local.get $12
    local.get $3
    i32.lt_s
-   local.set $5
-   local.get $5
+   local.set $13
+   local.get $13
    if
     local.get $0
-    local.get $4
+    local.get $12
     i32.const 0
     i32.shl
     i32.add
     i32.load8_s
-    local.set $10
-    local.get $9
-    local.get $8
+    local.set $11
+    local.get $10
     local.get $9
     local.get $10
+    local.get $11
     call $~lib/util/number/itoa_stream<i8>
     i32.add
-    local.set $9
-    local.get $6
+    local.set $10
+    local.get $7
     if
-     local.get $8
      local.get $9
+     local.get $10
      i32.const 1
      i32.shl
      i32.add
      local.get $2
-     local.get $6
+     local.get $7
      i32.const 1
      i32.shl
      call $~lib/memory/memory.copy
-     local.get $9
-     local.get $6
+     local.get $10
+     local.get $7
      i32.add
-     local.set $9
+     local.set $10
     end
-    local.get $4
+    local.get $12
     i32.const 1
     i32.add
-    local.set $4
+    local.set $12
     br $for-loop|0
    end
   end
@@ -16058,35 +16491,35 @@
   i32.shl
   i32.add
   i32.load8_s
-  local.set $10
-  local.get $9
-  local.get $8
+  local.set $11
+  local.get $10
   local.get $9
   local.get $10
+  local.get $11
   call $~lib/util/number/itoa_stream<i8>
   i32.add
-  local.set $9
-  local.get $7
-  local.get $9
+  local.set $10
+  local.get $8
+  local.get $10
   i32.gt_s
   if
-   local.get $8
-   i32.const 0
    local.get $9
+   i32.const 0
+   local.get $10
    call $~lib/string/String#substring
-   local.set $4
+   local.set $14
    local.get $2
    call $~lib/rt/pure/__release
-   local.get $8
+   local.get $9
    call $~lib/rt/pure/__release
-   local.get $4
+   local.get $14
    return
   end
-  local.get $8
-  local.set $4
+  local.get $9
+  local.set $15
   local.get $2
   call $~lib/rt/pure/__release
-  local.get $4
+  local.get $15
  )
  (func $~lib/array/Array<i8>#join (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
@@ -16214,6 +16647,11 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
   local.get $2
   call $~lib/rt/pure/__retain
   local.set $2
@@ -16238,77 +16676,77 @@
    local.get $0
    i32.load16_u
    call $~lib/util/number/itoa<u16>
-   local.tee $4
-   local.set $5
+   local.tee $5
+   local.set $6
    local.get $2
    call $~lib/rt/pure/__release
-   local.get $5
+   local.get $6
    return
   end
   local.get $2
   call $~lib/string/String#get:length
-  local.set $6
+  local.set $7
   i32.const 10
-  local.get $6
+  local.get $7
   i32.add
   local.get $3
   i32.mul
   i32.const 10
   i32.add
-  local.set $7
-  local.get $7
+  local.set $8
+  local.get $8
   i32.const 1
   i32.shl
   i32.const 1
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
-  local.set $8
-  i32.const 0
   local.set $9
   i32.const 0
-  local.set $4
+  local.set $10
+  i32.const 0
+  local.set $12
   loop $for-loop|0
-   local.get $4
+   local.get $12
    local.get $3
    i32.lt_s
-   local.set $5
-   local.get $5
+   local.set $13
+   local.get $13
    if
     local.get $0
-    local.get $4
+    local.get $12
     i32.const 1
     i32.shl
     i32.add
     i32.load16_u
-    local.set $10
-    local.get $9
-    local.get $8
+    local.set $11
+    local.get $10
     local.get $9
     local.get $10
+    local.get $11
     call $~lib/util/number/itoa_stream<u16>
     i32.add
-    local.set $9
-    local.get $6
+    local.set $10
+    local.get $7
     if
-     local.get $8
      local.get $9
+     local.get $10
      i32.const 1
      i32.shl
      i32.add
      local.get $2
-     local.get $6
+     local.get $7
      i32.const 1
      i32.shl
      call $~lib/memory/memory.copy
-     local.get $9
-     local.get $6
+     local.get $10
+     local.get $7
      i32.add
-     local.set $9
+     local.set $10
     end
-    local.get $4
+    local.get $12
     i32.const 1
     i32.add
-    local.set $4
+    local.set $12
     br $for-loop|0
    end
   end
@@ -16318,35 +16756,35 @@
   i32.shl
   i32.add
   i32.load16_u
-  local.set $10
-  local.get $9
-  local.get $8
+  local.set $11
+  local.get $10
   local.get $9
   local.get $10
+  local.get $11
   call $~lib/util/number/itoa_stream<u16>
   i32.add
-  local.set $9
-  local.get $7
-  local.get $9
+  local.set $10
+  local.get $8
+  local.get $10
   i32.gt_s
   if
-   local.get $8
-   i32.const 0
    local.get $9
+   i32.const 0
+   local.get $10
    call $~lib/string/String#substring
-   local.set $4
+   local.set $14
    local.get $2
    call $~lib/rt/pure/__release
-   local.get $8
+   local.get $9
    call $~lib/rt/pure/__release
-   local.get $4
+   local.get $14
    return
   end
-  local.get $8
-  local.set $4
+  local.get $9
+  local.set $15
   local.get $2
   call $~lib/rt/pure/__release
-  local.get $4
+  local.get $15
  )
  (func $~lib/array/Array<u16>#join (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
@@ -16569,7 +17007,10 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i64)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i64)
+  (local $10 i32)
   local.get $0
   i64.const 0
   i64.ne
@@ -16612,26 +17053,26 @@
   else
    local.get $0
    call $~lib/util/number/decimalCount64High
-   local.set $3
-   local.get $3
+   local.set $7
+   local.get $7
    i32.const 1
    i32.shl
    i32.const 1
    call $~lib/rt/tlsf/__alloc
    local.set $1
    local.get $1
-   local.set $5
+   local.set $10
    local.get $0
-   local.set $7
-   local.get $3
-   local.set $4
+   local.set $9
+   local.get $7
+   local.set $8
    i32.const 0
    i32.const 1
    i32.ge_s
    drop
-   local.get $5
-   local.get $7
-   local.get $4
+   local.get $10
+   local.get $9
+   local.get $8
    call $~lib/util/number/utoa64_lut
   end
   local.get $1
@@ -16658,7 +17099,9 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
-  (local $9 i64)
+  (local $9 i32)
+  (local $10 i64)
+  (local $11 i32)
   local.get $0
   local.get $1
   i32.const 1
@@ -16727,18 +17170,18 @@
    i32.add
    local.set $4
    local.get $0
-   local.set $7
+   local.set $11
    local.get $2
-   local.set $9
+   local.set $10
    local.get $4
-   local.set $6
+   local.set $9
    i32.const 0
    i32.const 1
    i32.ge_s
    drop
-   local.get $7
+   local.get $11
+   local.get $10
    local.get $9
-   local.get $6
    call $~lib/util/number/utoa64_lut
   end
   local.get $4
@@ -16751,7 +17194,12 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
-  (local $10 i64)
+  (local $10 i32)
+  (local $11 i64)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
   local.get $2
   call $~lib/rt/pure/__retain
   local.set $2
@@ -16776,77 +17224,77 @@
    local.get $0
    i64.load
    call $~lib/util/number/itoa<u64>
-   local.tee $4
-   local.set $5
+   local.tee $5
+   local.set $6
    local.get $2
    call $~lib/rt/pure/__release
-   local.get $5
+   local.get $6
    return
   end
   local.get $2
   call $~lib/string/String#get:length
-  local.set $6
+  local.set $7
   i32.const 20
-  local.get $6
+  local.get $7
   i32.add
   local.get $3
   i32.mul
   i32.const 20
   i32.add
-  local.set $7
-  local.get $7
+  local.set $8
+  local.get $8
   i32.const 1
   i32.shl
   i32.const 1
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
-  local.set $8
-  i32.const 0
   local.set $9
   i32.const 0
-  local.set $4
+  local.set $10
+  i32.const 0
+  local.set $12
   loop $for-loop|0
-   local.get $4
+   local.get $12
    local.get $3
    i32.lt_s
-   local.set $5
-   local.get $5
+   local.set $13
+   local.get $13
    if
     local.get $0
-    local.get $4
+    local.get $12
     i32.const 3
     i32.shl
     i32.add
     i64.load
-    local.set $10
-    local.get $9
-    local.get $8
+    local.set $11
+    local.get $10
     local.get $9
     local.get $10
+    local.get $11
     call $~lib/util/number/itoa_stream<u64>
     i32.add
-    local.set $9
-    local.get $6
+    local.set $10
+    local.get $7
     if
-     local.get $8
      local.get $9
+     local.get $10
      i32.const 1
      i32.shl
      i32.add
      local.get $2
-     local.get $6
+     local.get $7
      i32.const 1
      i32.shl
      call $~lib/memory/memory.copy
-     local.get $9
-     local.get $6
+     local.get $10
+     local.get $7
      i32.add
-     local.set $9
+     local.set $10
     end
-    local.get $4
+    local.get $12
     i32.const 1
     i32.add
-    local.set $4
+    local.set $12
     br $for-loop|0
    end
   end
@@ -16856,35 +17304,35 @@
   i32.shl
   i32.add
   i64.load
-  local.set $10
-  local.get $9
-  local.get $8
+  local.set $11
+  local.get $10
   local.get $9
   local.get $10
+  local.get $11
   call $~lib/util/number/itoa_stream<u64>
   i32.add
-  local.set $9
-  local.get $7
-  local.get $9
+  local.set $10
+  local.get $8
+  local.get $10
   i32.gt_s
   if
-   local.get $8
-   i32.const 0
    local.get $9
+   i32.const 0
+   local.get $10
    call $~lib/string/String#substring
-   local.set $4
+   local.set $14
    local.get $2
    call $~lib/rt/pure/__release
-   local.get $8
+   local.get $9
    call $~lib/rt/pure/__release
-   local.get $4
+   local.get $14
    return
   end
-  local.get $8
-  local.set $4
+  local.get $9
+  local.set $15
   local.get $2
   call $~lib/rt/pure/__release
-  local.get $4
+  local.get $15
  )
  (func $~lib/array/Array<u64>#join (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
@@ -16926,7 +17374,10 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i64)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i64)
+  (local $11 i32)
   local.get $0
   i64.const 0
   i64.ne
@@ -16985,26 +17436,26 @@
    call $~lib/util/number/decimalCount64High
    local.get $1
    i32.add
-   local.set $4
-   local.get $4
+   local.set $8
+   local.get $8
    i32.const 1
    i32.shl
    i32.const 1
    call $~lib/rt/tlsf/__alloc
    local.set $2
    local.get $2
-   local.set $6
+   local.set $11
    local.get $0
-   local.set $8
-   local.get $4
-   local.set $5
+   local.set $10
+   local.get $8
+   local.set $9
    i32.const 0
    i32.const 1
    i32.ge_s
    drop
-   local.get $6
-   local.get $8
-   local.get $5
+   local.get $11
+   local.get $10
+   local.get $9
    call $~lib/util/number/utoa64_lut
   end
   local.get $1
@@ -17037,7 +17488,9 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
-  (local $9 i64)
+  (local $9 i32)
+  (local $10 i64)
+  (local $11 i32)
   local.get $0
   local.get $1
   i32.const 1
@@ -17130,18 +17583,18 @@
    i32.add
    local.set $4
    local.get $0
-   local.set $7
+   local.set $11
    local.get $2
-   local.set $9
+   local.set $10
    local.get $4
-   local.set $6
+   local.set $9
    i32.const 0
    i32.const 1
    i32.ge_s
    drop
-   local.get $7
+   local.get $11
+   local.get $10
    local.get $9
-   local.get $6
    call $~lib/util/number/utoa64_lut
   end
   local.get $4
@@ -17154,7 +17607,12 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
-  (local $10 i64)
+  (local $10 i32)
+  (local $11 i64)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
   local.get $2
   call $~lib/rt/pure/__retain
   local.set $2
@@ -17179,77 +17637,77 @@
    local.get $0
    i64.load
    call $~lib/util/number/itoa<i64>
-   local.tee $4
-   local.set $5
+   local.tee $5
+   local.set $6
    local.get $2
    call $~lib/rt/pure/__release
-   local.get $5
+   local.get $6
    return
   end
   local.get $2
   call $~lib/string/String#get:length
-  local.set $6
+  local.set $7
   i32.const 21
-  local.get $6
+  local.get $7
   i32.add
   local.get $3
   i32.mul
   i32.const 21
   i32.add
-  local.set $7
-  local.get $7
+  local.set $8
+  local.get $8
   i32.const 1
   i32.shl
   i32.const 1
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
-  local.set $8
-  i32.const 0
   local.set $9
   i32.const 0
-  local.set $4
+  local.set $10
+  i32.const 0
+  local.set $12
   loop $for-loop|0
-   local.get $4
+   local.get $12
    local.get $3
    i32.lt_s
-   local.set $5
-   local.get $5
+   local.set $13
+   local.get $13
    if
     local.get $0
-    local.get $4
+    local.get $12
     i32.const 3
     i32.shl
     i32.add
     i64.load
-    local.set $10
-    local.get $9
-    local.get $8
+    local.set $11
+    local.get $10
     local.get $9
     local.get $10
+    local.get $11
     call $~lib/util/number/itoa_stream<i64>
     i32.add
-    local.set $9
-    local.get $6
+    local.set $10
+    local.get $7
     if
-     local.get $8
      local.get $9
+     local.get $10
      i32.const 1
      i32.shl
      i32.add
      local.get $2
-     local.get $6
+     local.get $7
      i32.const 1
      i32.shl
      call $~lib/memory/memory.copy
-     local.get $9
-     local.get $6
+     local.get $10
+     local.get $7
      i32.add
-     local.set $9
+     local.set $10
     end
-    local.get $4
+    local.get $12
     i32.const 1
     i32.add
-    local.set $4
+    local.set $12
     br $for-loop|0
    end
   end
@@ -17259,35 +17717,35 @@
   i32.shl
   i32.add
   i64.load
-  local.set $10
-  local.get $9
-  local.get $8
+  local.set $11
+  local.get $10
   local.get $9
   local.get $10
+  local.get $11
   call $~lib/util/number/itoa_stream<i64>
   i32.add
-  local.set $9
-  local.get $7
-  local.get $9
+  local.set $10
+  local.get $8
+  local.get $10
   i32.gt_s
   if
-   local.get $8
-   i32.const 0
    local.get $9
+   i32.const 0
+   local.get $10
    call $~lib/string/String#substring
-   local.set $4
+   local.set $14
    local.get $2
    call $~lib/rt/pure/__release
-   local.get $8
+   local.get $9
    call $~lib/rt/pure/__release
-   local.get $4
+   local.get $14
    return
   end
-  local.get $8
-  local.set $4
+  local.get $9
+  local.set $15
   local.get $2
   call $~lib/rt/pure/__release
-  local.get $4
+  local.get $15
  )
  (func $~lib/array/Array<i64>#join (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
@@ -17337,6 +17795,22 @@
   (local $10 i32)
   (local $11 i32)
   (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local $22 i32)
+  (local $23 i32)
+  (local $24 i32)
+  (local $25 i32)
+  (local $26 i32)
+  (local $27 i32)
+  (local $28 i32)
   local.get $2
   call $~lib/rt/pure/__retain
   local.set $2
@@ -17362,18 +17836,18 @@
   if
    local.get $0
    i32.load
-   local.tee $4
-   local.get $5
    local.tee $6
+   local.get $5
+   local.tee $7
    i32.ne
    if
-    local.get $4
-    call $~lib/rt/pure/__retain
-    local.set $4
     local.get $6
+    call $~lib/rt/pure/__retain
+    local.set $6
+    local.get $7
     call $~lib/rt/pure/__release
    end
-   local.get $4
+   local.get $6
    local.set $5
    local.get $5
    i32.const 0
@@ -17384,101 +17858,101 @@
    else
     i32.const 5056
    end
-   local.set $4
+   local.set $8
    local.get $2
    call $~lib/rt/pure/__release
    local.get $5
    call $~lib/rt/pure/__release
-   local.get $4
+   local.get $8
    return
   end
   i32.const 5056
-  local.set $7
+  local.set $9
   local.get $2
   call $~lib/string/String#get:length
-  local.set $8
+  local.set $10
   i32.const 0
-  local.set $4
+  local.set $11
   loop $for-loop|0
-   local.get $4
+   local.get $11
    local.get $3
    i32.lt_s
-   local.set $6
-   local.get $6
+   local.set $12
+   local.get $12
    if
     local.get $0
-    local.get $4
+    local.get $11
     i32.const 2
     i32.shl
     i32.add
     i32.load
-    local.tee $9
+    local.tee $13
     local.get $5
-    local.tee $10
+    local.tee $14
     i32.ne
     if
-     local.get $9
+     local.get $13
      call $~lib/rt/pure/__retain
-     local.set $9
-     local.get $10
+     local.set $13
+     local.get $14
      call $~lib/rt/pure/__release
     end
-    local.get $9
+    local.get $13
     local.set $5
     local.get $5
     i32.const 0
     i32.ne
     if
-     local.get $7
+     local.get $9
      local.get $5
      call $~lib/array/Array<i32>#toString
-     local.tee $9
+     local.tee $15
      call $~lib/string/String.__concat
-     local.tee $10
-     local.tee $11
-     local.get $7
-     local.tee $12
+     local.tee $16
+     local.tee $17
+     local.get $9
+     local.tee $18
      i32.ne
      if
-      local.get $11
+      local.get $17
       call $~lib/rt/pure/__retain
-      local.set $11
-      local.get $12
+      local.set $17
+      local.get $18
       call $~lib/rt/pure/__release
      end
-     local.get $11
-     local.set $7
-     local.get $9
+     local.get $17
+     local.set $9
+     local.get $15
      call $~lib/rt/pure/__release
-     local.get $10
+     local.get $16
      call $~lib/rt/pure/__release
     end
-    local.get $8
+    local.get $10
     if
-     local.get $7
+     local.get $9
      local.get $2
      call $~lib/string/String.__concat
-     local.tee $10
-     local.tee $12
-     local.get $7
-     local.tee $9
+     local.tee $19
+     local.tee $20
+     local.get $9
+     local.tee $21
      i32.ne
      if
-      local.get $12
+      local.get $20
       call $~lib/rt/pure/__retain
-      local.set $12
-      local.get $9
+      local.set $20
+      local.get $21
       call $~lib/rt/pure/__release
      end
-     local.get $12
-     local.set $7
-     local.get $10
+     local.get $20
+     local.set $9
+     local.get $19
      call $~lib/rt/pure/__release
     end
-    local.get $4
+    local.get $11
     i32.const 1
     i32.add
-    local.set $4
+    local.set $11
     br $for-loop|0
    end
   end
@@ -17488,54 +17962,54 @@
   i32.shl
   i32.add
   i32.load
-  local.tee $11
+  local.tee $22
   local.get $5
-  local.tee $4
+  local.tee $23
   i32.ne
   if
-   local.get $11
+   local.get $22
    call $~lib/rt/pure/__retain
-   local.set $11
-   local.get $4
+   local.set $22
+   local.get $23
    call $~lib/rt/pure/__release
   end
-  local.get $11
+  local.get $22
   local.set $5
   local.get $5
   i32.const 0
   i32.ne
   if
-   local.get $7
+   local.get $9
    local.get $5
    call $~lib/array/Array<i32>#toString
-   local.tee $11
+   local.tee $24
    call $~lib/string/String.__concat
-   local.tee $4
-   local.tee $9
-   local.get $7
-   local.tee $6
+   local.tee $25
+   local.tee $26
+   local.get $9
+   local.tee $27
    i32.ne
    if
-    local.get $9
+    local.get $26
     call $~lib/rt/pure/__retain
-    local.set $9
-    local.get $6
+    local.set $26
+    local.get $27
     call $~lib/rt/pure/__release
    end
-   local.get $9
-   local.set $7
-   local.get $11
+   local.get $26
+   local.set $9
+   local.get $24
    call $~lib/rt/pure/__release
-   local.get $4
+   local.get $25
    call $~lib/rt/pure/__release
   end
-  local.get $7
-  local.set $4
+  local.get $9
+  local.set $28
   local.get $2
   call $~lib/rt/pure/__release
   local.get $5
   call $~lib/rt/pure/__release
-  local.get $4
+  local.get $28
  )
  (func $~lib/array/Array<~lib/array/Array<i32>>#join (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
@@ -17673,6 +18147,11 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
   local.get $2
   call $~lib/rt/pure/__retain
   local.set $2
@@ -17697,77 +18176,77 @@
    local.get $0
    i32.load8_u
    call $~lib/util/number/itoa<u8>
-   local.tee $4
-   local.set $5
+   local.tee $5
+   local.set $6
    local.get $2
    call $~lib/rt/pure/__release
-   local.get $5
+   local.get $6
    return
   end
   local.get $2
   call $~lib/string/String#get:length
-  local.set $6
+  local.set $7
   i32.const 10
-  local.get $6
+  local.get $7
   i32.add
   local.get $3
   i32.mul
   i32.const 10
   i32.add
-  local.set $7
-  local.get $7
+  local.set $8
+  local.get $8
   i32.const 1
   i32.shl
   i32.const 1
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
-  local.set $8
-  i32.const 0
   local.set $9
   i32.const 0
-  local.set $4
+  local.set $10
+  i32.const 0
+  local.set $12
   loop $for-loop|0
-   local.get $4
+   local.get $12
    local.get $3
    i32.lt_s
-   local.set $5
-   local.get $5
+   local.set $13
+   local.get $13
    if
     local.get $0
-    local.get $4
+    local.get $12
     i32.const 0
     i32.shl
     i32.add
     i32.load8_u
-    local.set $10
-    local.get $9
-    local.get $8
+    local.set $11
+    local.get $10
     local.get $9
     local.get $10
+    local.get $11
     call $~lib/util/number/itoa_stream<u8>
     i32.add
-    local.set $9
-    local.get $6
+    local.set $10
+    local.get $7
     if
-     local.get $8
      local.get $9
+     local.get $10
      i32.const 1
      i32.shl
      i32.add
      local.get $2
-     local.get $6
+     local.get $7
      i32.const 1
      i32.shl
      call $~lib/memory/memory.copy
-     local.get $9
-     local.get $6
+     local.get $10
+     local.get $7
      i32.add
-     local.set $9
+     local.set $10
     end
-    local.get $4
+    local.get $12
     i32.const 1
     i32.add
-    local.set $4
+    local.set $12
     br $for-loop|0
    end
   end
@@ -17777,35 +18256,35 @@
   i32.shl
   i32.add
   i32.load8_u
-  local.set $10
-  local.get $9
-  local.get $8
+  local.set $11
+  local.get $10
   local.get $9
   local.get $10
+  local.get $11
   call $~lib/util/number/itoa_stream<u8>
   i32.add
-  local.set $9
-  local.get $7
-  local.get $9
+  local.set $10
+  local.get $8
+  local.get $10
   i32.gt_s
   if
-   local.get $8
-   i32.const 0
    local.get $9
+   i32.const 0
+   local.get $10
    call $~lib/string/String#substring
-   local.set $4
+   local.set $14
    local.get $2
    call $~lib/rt/pure/__release
-   local.get $8
+   local.get $9
    call $~lib/rt/pure/__release
-   local.get $4
+   local.get $14
    return
   end
-  local.get $8
-  local.set $4
+  local.get $9
+  local.set $15
   local.get $2
   call $~lib/rt/pure/__release
-  local.get $4
+  local.get $15
  )
  (func $~lib/array/Array<u8>#join (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
@@ -17850,6 +18329,22 @@
   (local $10 i32)
   (local $11 i32)
   (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local $22 i32)
+  (local $23 i32)
+  (local $24 i32)
+  (local $25 i32)
+  (local $26 i32)
+  (local $27 i32)
+  (local $28 i32)
   local.get $2
   call $~lib/rt/pure/__retain
   local.set $2
@@ -17875,18 +18370,18 @@
   if
    local.get $0
    i32.load
-   local.tee $4
-   local.get $5
    local.tee $6
+   local.get $5
+   local.tee $7
    i32.ne
    if
-    local.get $4
-    call $~lib/rt/pure/__retain
-    local.set $4
     local.get $6
+    call $~lib/rt/pure/__retain
+    local.set $6
+    local.get $7
     call $~lib/rt/pure/__release
    end
-   local.get $4
+   local.get $6
    local.set $5
    local.get $5
    i32.const 0
@@ -17897,101 +18392,101 @@
    else
     i32.const 5056
    end
-   local.set $4
+   local.set $8
    local.get $2
    call $~lib/rt/pure/__release
    local.get $5
    call $~lib/rt/pure/__release
-   local.get $4
+   local.get $8
    return
   end
   i32.const 5056
-  local.set $7
+  local.set $9
   local.get $2
   call $~lib/string/String#get:length
-  local.set $8
+  local.set $10
   i32.const 0
-  local.set $4
+  local.set $11
   loop $for-loop|0
-   local.get $4
+   local.get $11
    local.get $3
    i32.lt_s
-   local.set $6
-   local.get $6
+   local.set $12
+   local.get $12
    if
     local.get $0
-    local.get $4
+    local.get $11
     i32.const 2
     i32.shl
     i32.add
     i32.load
-    local.tee $9
+    local.tee $13
     local.get $5
-    local.tee $10
+    local.tee $14
     i32.ne
     if
-     local.get $9
+     local.get $13
      call $~lib/rt/pure/__retain
-     local.set $9
-     local.get $10
+     local.set $13
+     local.get $14
      call $~lib/rt/pure/__release
     end
-    local.get $9
+    local.get $13
     local.set $5
     local.get $5
     i32.const 0
     i32.ne
     if
-     local.get $7
+     local.get $9
      local.get $5
      call $~lib/array/Array<u8>#toString
-     local.tee $9
+     local.tee $15
      call $~lib/string/String.__concat
-     local.tee $10
-     local.tee $11
-     local.get $7
-     local.tee $12
+     local.tee $16
+     local.tee $17
+     local.get $9
+     local.tee $18
      i32.ne
      if
-      local.get $11
+      local.get $17
       call $~lib/rt/pure/__retain
-      local.set $11
-      local.get $12
+      local.set $17
+      local.get $18
       call $~lib/rt/pure/__release
      end
-     local.get $11
-     local.set $7
-     local.get $9
+     local.get $17
+     local.set $9
+     local.get $15
      call $~lib/rt/pure/__release
-     local.get $10
+     local.get $16
      call $~lib/rt/pure/__release
     end
-    local.get $8
+    local.get $10
     if
-     local.get $7
+     local.get $9
      local.get $2
      call $~lib/string/String.__concat
-     local.tee $10
-     local.tee $12
-     local.get $7
-     local.tee $9
+     local.tee $19
+     local.tee $20
+     local.get $9
+     local.tee $21
      i32.ne
      if
-      local.get $12
+      local.get $20
       call $~lib/rt/pure/__retain
-      local.set $12
-      local.get $9
+      local.set $20
+      local.get $21
       call $~lib/rt/pure/__release
      end
-     local.get $12
-     local.set $7
-     local.get $10
+     local.get $20
+     local.set $9
+     local.get $19
      call $~lib/rt/pure/__release
     end
-    local.get $4
+    local.get $11
     i32.const 1
     i32.add
-    local.set $4
+    local.set $11
     br $for-loop|0
    end
   end
@@ -18001,54 +18496,54 @@
   i32.shl
   i32.add
   i32.load
-  local.tee $11
+  local.tee $22
   local.get $5
-  local.tee $4
+  local.tee $23
   i32.ne
   if
-   local.get $11
+   local.get $22
    call $~lib/rt/pure/__retain
-   local.set $11
-   local.get $4
+   local.set $22
+   local.get $23
    call $~lib/rt/pure/__release
   end
-  local.get $11
+  local.get $22
   local.set $5
   local.get $5
   i32.const 0
   i32.ne
   if
-   local.get $7
+   local.get $9
    local.get $5
    call $~lib/array/Array<u8>#toString
-   local.tee $11
+   local.tee $24
    call $~lib/string/String.__concat
-   local.tee $4
-   local.tee $9
-   local.get $7
-   local.tee $6
+   local.tee $25
+   local.tee $26
+   local.get $9
+   local.tee $27
    i32.ne
    if
-    local.get $9
+    local.get $26
     call $~lib/rt/pure/__retain
-    local.set $9
-    local.get $6
+    local.set $26
+    local.get $27
     call $~lib/rt/pure/__release
    end
-   local.get $9
-   local.set $7
-   local.get $11
+   local.get $26
+   local.set $9
+   local.get $24
    call $~lib/rt/pure/__release
-   local.get $4
+   local.get $25
    call $~lib/rt/pure/__release
   end
-  local.get $7
-  local.set $4
+  local.get $9
+  local.set $28
   local.get $2
   call $~lib/rt/pure/__release
   local.get $5
   call $~lib/rt/pure/__release
-  local.get $4
+  local.get $28
  )
  (func $~lib/array/Array<~lib/array/Array<u8>>#join (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
@@ -18108,6 +18603,22 @@
   (local $10 i32)
   (local $11 i32)
   (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local $22 i32)
+  (local $23 i32)
+  (local $24 i32)
+  (local $25 i32)
+  (local $26 i32)
+  (local $27 i32)
+  (local $28 i32)
   local.get $2
   call $~lib/rt/pure/__retain
   local.set $2
@@ -18133,18 +18644,18 @@
   if
    local.get $0
    i32.load
-   local.tee $4
-   local.get $5
    local.tee $6
+   local.get $5
+   local.tee $7
    i32.ne
    if
-    local.get $4
-    call $~lib/rt/pure/__retain
-    local.set $4
     local.get $6
+    call $~lib/rt/pure/__retain
+    local.set $6
+    local.get $7
     call $~lib/rt/pure/__release
    end
-   local.get $4
+   local.get $6
    local.set $5
    local.get $5
    i32.const 0
@@ -18155,101 +18666,101 @@
    else
     i32.const 5056
    end
-   local.set $4
+   local.set $8
    local.get $2
    call $~lib/rt/pure/__release
    local.get $5
    call $~lib/rt/pure/__release
-   local.get $4
+   local.get $8
    return
   end
   i32.const 5056
-  local.set $7
+  local.set $9
   local.get $2
   call $~lib/string/String#get:length
-  local.set $8
+  local.set $10
   i32.const 0
-  local.set $4
+  local.set $11
   loop $for-loop|0
-   local.get $4
+   local.get $11
    local.get $3
    i32.lt_s
-   local.set $6
-   local.get $6
+   local.set $12
+   local.get $12
    if
     local.get $0
-    local.get $4
+    local.get $11
     i32.const 2
     i32.shl
     i32.add
     i32.load
-    local.tee $9
+    local.tee $13
     local.get $5
-    local.tee $10
+    local.tee $14
     i32.ne
     if
-     local.get $9
+     local.get $13
      call $~lib/rt/pure/__retain
-     local.set $9
-     local.get $10
+     local.set $13
+     local.get $14
      call $~lib/rt/pure/__release
     end
-    local.get $9
+    local.get $13
     local.set $5
     local.get $5
     i32.const 0
     i32.ne
     if
-     local.get $7
+     local.get $9
      local.get $5
      call $~lib/array/Array<u32>#toString
-     local.tee $9
+     local.tee $15
      call $~lib/string/String.__concat
-     local.tee $10
-     local.tee $11
-     local.get $7
-     local.tee $12
+     local.tee $16
+     local.tee $17
+     local.get $9
+     local.tee $18
      i32.ne
      if
-      local.get $11
+      local.get $17
       call $~lib/rt/pure/__retain
-      local.set $11
-      local.get $12
+      local.set $17
+      local.get $18
       call $~lib/rt/pure/__release
      end
-     local.get $11
-     local.set $7
-     local.get $9
+     local.get $17
+     local.set $9
+     local.get $15
      call $~lib/rt/pure/__release
-     local.get $10
+     local.get $16
      call $~lib/rt/pure/__release
     end
-    local.get $8
+    local.get $10
     if
-     local.get $7
+     local.get $9
      local.get $2
      call $~lib/string/String.__concat
-     local.tee $10
-     local.tee $12
-     local.get $7
-     local.tee $9
+     local.tee $19
+     local.tee $20
+     local.get $9
+     local.tee $21
      i32.ne
      if
-      local.get $12
+      local.get $20
       call $~lib/rt/pure/__retain
-      local.set $12
-      local.get $9
+      local.set $20
+      local.get $21
       call $~lib/rt/pure/__release
      end
-     local.get $12
-     local.set $7
-     local.get $10
+     local.get $20
+     local.set $9
+     local.get $19
      call $~lib/rt/pure/__release
     end
-    local.get $4
+    local.get $11
     i32.const 1
     i32.add
-    local.set $4
+    local.set $11
     br $for-loop|0
    end
   end
@@ -18259,54 +18770,54 @@
   i32.shl
   i32.add
   i32.load
-  local.tee $11
+  local.tee $22
   local.get $5
-  local.tee $4
+  local.tee $23
   i32.ne
   if
-   local.get $11
+   local.get $22
    call $~lib/rt/pure/__retain
-   local.set $11
-   local.get $4
+   local.set $22
+   local.get $23
    call $~lib/rt/pure/__release
   end
-  local.get $11
+  local.get $22
   local.set $5
   local.get $5
   i32.const 0
   i32.ne
   if
-   local.get $7
+   local.get $9
    local.get $5
    call $~lib/array/Array<u32>#toString
-   local.tee $11
+   local.tee $24
    call $~lib/string/String.__concat
-   local.tee $4
-   local.tee $9
-   local.get $7
-   local.tee $6
+   local.tee $25
+   local.tee $26
+   local.get $9
+   local.tee $27
    i32.ne
    if
-    local.get $9
+    local.get $26
     call $~lib/rt/pure/__retain
-    local.set $9
-    local.get $6
+    local.set $26
+    local.get $27
     call $~lib/rt/pure/__release
    end
-   local.get $9
-   local.set $7
-   local.get $11
+   local.get $26
+   local.set $9
+   local.get $24
    call $~lib/rt/pure/__release
-   local.get $4
+   local.get $25
    call $~lib/rt/pure/__release
   end
-  local.get $7
-  local.set $4
+  local.get $9
+  local.set $28
   local.get $2
   call $~lib/rt/pure/__release
   local.get $5
   call $~lib/rt/pure/__release
-  local.get $4
+  local.get $28
  )
  (func $~lib/array/Array<~lib/array/Array<u32>>#join (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
@@ -18361,6 +18872,22 @@
   (local $10 i32)
   (local $11 i32)
   (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local $22 i32)
+  (local $23 i32)
+  (local $24 i32)
+  (local $25 i32)
+  (local $26 i32)
+  (local $27 i32)
+  (local $28 i32)
   local.get $2
   call $~lib/rt/pure/__retain
   local.set $2
@@ -18386,18 +18913,18 @@
   if
    local.get $0
    i32.load
-   local.tee $4
-   local.get $5
    local.tee $6
+   local.get $5
+   local.tee $7
    i32.ne
    if
-    local.get $4
-    call $~lib/rt/pure/__retain
-    local.set $4
     local.get $6
+    call $~lib/rt/pure/__retain
+    local.set $6
+    local.get $7
     call $~lib/rt/pure/__release
    end
-   local.get $4
+   local.get $6
    local.set $5
    local.get $5
    i32.const 0
@@ -18408,101 +18935,101 @@
    else
     i32.const 5056
    end
-   local.set $4
+   local.set $8
    local.get $2
    call $~lib/rt/pure/__release
    local.get $5
    call $~lib/rt/pure/__release
-   local.get $4
+   local.get $8
    return
   end
   i32.const 5056
-  local.set $7
+  local.set $9
   local.get $2
   call $~lib/string/String#get:length
-  local.set $8
+  local.set $10
   i32.const 0
-  local.set $4
+  local.set $11
   loop $for-loop|0
-   local.get $4
+   local.get $11
    local.get $3
    i32.lt_s
-   local.set $6
-   local.get $6
+   local.set $12
+   local.get $12
    if
     local.get $0
-    local.get $4
+    local.get $11
     i32.const 2
     i32.shl
     i32.add
     i32.load
-    local.tee $9
+    local.tee $13
     local.get $5
-    local.tee $10
+    local.tee $14
     i32.ne
     if
-     local.get $9
+     local.get $13
      call $~lib/rt/pure/__retain
-     local.set $9
-     local.get $10
+     local.set $13
+     local.get $14
      call $~lib/rt/pure/__release
     end
-    local.get $9
+    local.get $13
     local.set $5
     local.get $5
     i32.const 0
     i32.ne
     if
-     local.get $7
+     local.get $9
      local.get $5
      call $~lib/array/Array<~lib/array/Array<u32>>#toString
-     local.tee $9
+     local.tee $15
      call $~lib/string/String.__concat
-     local.tee $10
-     local.tee $11
-     local.get $7
-     local.tee $12
+     local.tee $16
+     local.tee $17
+     local.get $9
+     local.tee $18
      i32.ne
      if
-      local.get $11
+      local.get $17
       call $~lib/rt/pure/__retain
-      local.set $11
-      local.get $12
+      local.set $17
+      local.get $18
       call $~lib/rt/pure/__release
      end
-     local.get $11
-     local.set $7
-     local.get $9
+     local.get $17
+     local.set $9
+     local.get $15
      call $~lib/rt/pure/__release
-     local.get $10
+     local.get $16
      call $~lib/rt/pure/__release
     end
-    local.get $8
+    local.get $10
     if
-     local.get $7
+     local.get $9
      local.get $2
      call $~lib/string/String.__concat
-     local.tee $10
-     local.tee $12
-     local.get $7
-     local.tee $9
+     local.tee $19
+     local.tee $20
+     local.get $9
+     local.tee $21
      i32.ne
      if
-      local.get $12
+      local.get $20
       call $~lib/rt/pure/__retain
-      local.set $12
-      local.get $9
+      local.set $20
+      local.get $21
       call $~lib/rt/pure/__release
      end
-     local.get $12
-     local.set $7
-     local.get $10
+     local.get $20
+     local.set $9
+     local.get $19
      call $~lib/rt/pure/__release
     end
-    local.get $4
+    local.get $11
     i32.const 1
     i32.add
-    local.set $4
+    local.set $11
     br $for-loop|0
    end
   end
@@ -18512,54 +19039,54 @@
   i32.shl
   i32.add
   i32.load
-  local.tee $11
+  local.tee $22
   local.get $5
-  local.tee $4
+  local.tee $23
   i32.ne
   if
-   local.get $11
+   local.get $22
    call $~lib/rt/pure/__retain
-   local.set $11
-   local.get $4
+   local.set $22
+   local.get $23
    call $~lib/rt/pure/__release
   end
-  local.get $11
+  local.get $22
   local.set $5
   local.get $5
   i32.const 0
   i32.ne
   if
-   local.get $7
+   local.get $9
    local.get $5
    call $~lib/array/Array<~lib/array/Array<u32>>#toString
-   local.tee $11
+   local.tee $24
    call $~lib/string/String.__concat
-   local.tee $4
-   local.tee $9
-   local.get $7
-   local.tee $6
+   local.tee $25
+   local.tee $26
+   local.get $9
+   local.tee $27
    i32.ne
    if
-    local.get $9
+    local.get $26
     call $~lib/rt/pure/__retain
-    local.set $9
-    local.get $6
+    local.set $26
+    local.get $27
     call $~lib/rt/pure/__release
    end
-   local.get $9
-   local.set $7
-   local.get $11
+   local.get $26
+   local.set $9
+   local.get $24
    call $~lib/rt/pure/__release
-   local.get $4
+   local.get $25
    call $~lib/rt/pure/__release
   end
-  local.get $7
-  local.set $4
+  local.get $9
+  local.set $28
   local.get $2
   call $~lib/rt/pure/__release
   local.get $5
   call $~lib/rt/pure/__release
-  local.get $4
+  local.get $28
  )
  (func $~lib/array/Array<~lib/array/Array<~lib/array/Array<u32>>>#join (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
@@ -18615,6 +19142,9 @@
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
   i32.const 1
   i32.eqz
   drop
@@ -18689,47 +19219,47 @@
   i32.const 0
   local.set $10
   i32.const 0
-  local.set $4
+  local.set $11
   loop $for-loop|1
-   local.get $4
+   local.get $11
    local.get $1
    i32.lt_s
-   local.set $5
-   local.get $5
+   local.set $12
+   local.get $12
    if
     block $for-continue|1
      local.get $2
-     local.get $4
+     local.get $11
      i32.const 2
      i32.shl
      i32.add
      i32.load
-     local.set $6
-     local.get $6
+     local.set $13
+     local.get $13
      i32.const 0
      i32.eq
      if
       br $for-continue|1
      end
-     local.get $6
+     local.get $13
      i32.load offset=8
-     local.set $11
+     local.set $14
      local.get $8
      local.get $10
      i32.add
-     local.get $6
+     local.get $13
      i32.load offset=4
-     local.get $11
+     local.get $14
      call $~lib/memory/memory.copy
      local.get $10
-     local.get $11
+     local.get $14
      i32.add
      local.set $10
     end
-    local.get $4
+    local.get $11
     i32.const 1
     i32.add
-    local.set $4
+    local.set $11
     br $for-loop|1
    end
   end
@@ -18750,6 +19280,11 @@
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
   i32.const 1
   i32.eqz
   drop
@@ -18824,73 +19359,73 @@
   i32.const 0
   local.set $10
   i32.const 0
-  local.set $4
+  local.set $11
   loop $for-loop|1
-   local.get $4
+   local.get $11
    local.get $1
    i32.lt_s
-   local.set $5
-   local.get $5
+   local.set $12
+   local.get $12
    if
     block $for-continue|1
      local.get $2
-     local.get $4
+     local.get $11
      i32.const 2
      i32.shl
      i32.add
      i32.load
-     local.set $6
-     local.get $6
+     local.set $13
+     local.get $13
      i32.const 0
      i32.eq
      if
       br $for-continue|1
      end
-     local.get $6
+     local.get $13
      i32.load offset=8
-     local.set $11
+     local.set $14
      local.get $8
      local.get $10
      i32.add
-     local.get $6
+     local.get $13
      i32.load offset=4
-     local.get $11
+     local.get $14
      call $~lib/memory/memory.copy
      local.get $10
-     local.get $11
+     local.get $14
      i32.add
      local.set $10
     end
-    local.get $4
+    local.get $11
     i32.const 1
     i32.add
-    local.set $4
+    local.set $11
     br $for-loop|1
    end
   end
   i32.const 1
   drop
   i32.const 0
-  local.set $4
+  local.set $15
   loop $for-loop|2
-   local.get $4
+   local.get $15
    local.get $3
    i32.lt_s
-   local.set $5
-   local.get $5
+   local.set $16
+   local.get $16
    if
     local.get $8
-    local.get $4
+    local.get $15
     i32.const 2
     i32.shl
     i32.add
     i32.load
     call $~lib/rt/pure/__retain
     drop
-    local.get $4
+    local.get $15
     i32.const 1
     i32.add
-    local.set $4
+    local.set $15
     br $for-loop|2
    end
   end
@@ -18962,6 +19497,459 @@
   (local $61 i32)
   (local $62 i32)
   (local $63 i32)
+  (local $64 i32)
+  (local $65 i32)
+  (local $66 i32)
+  (local $67 i32)
+  (local $68 i32)
+  (local $69 i32)
+  (local $70 i32)
+  (local $71 i32)
+  (local $72 i32)
+  (local $73 i32)
+  (local $74 i32)
+  (local $75 i32)
+  (local $76 i32)
+  (local $77 i32)
+  (local $78 i32)
+  (local $79 i32)
+  (local $80 i32)
+  (local $81 i32)
+  (local $82 i32)
+  (local $83 i32)
+  (local $84 i32)
+  (local $85 i32)
+  (local $86 i32)
+  (local $87 i32)
+  (local $88 i32)
+  (local $89 i32)
+  (local $90 i32)
+  (local $91 i32)
+  (local $92 i32)
+  (local $93 i32)
+  (local $94 i32)
+  (local $95 i32)
+  (local $96 i32)
+  (local $97 i32)
+  (local $98 i32)
+  (local $99 i32)
+  (local $100 i32)
+  (local $101 i32)
+  (local $102 i32)
+  (local $103 i32)
+  (local $104 i32)
+  (local $105 i32)
+  (local $106 i32)
+  (local $107 i32)
+  (local $108 i32)
+  (local $109 i32)
+  (local $110 i32)
+  (local $111 i32)
+  (local $112 i32)
+  (local $113 i32)
+  (local $114 i32)
+  (local $115 i32)
+  (local $116 i32)
+  (local $117 i32)
+  (local $118 i32)
+  (local $119 i32)
+  (local $120 i32)
+  (local $121 i32)
+  (local $122 i32)
+  (local $123 i32)
+  (local $124 i32)
+  (local $125 i32)
+  (local $126 i32)
+  (local $127 i32)
+  (local $128 i32)
+  (local $129 i32)
+  (local $130 i32)
+  (local $131 i32)
+  (local $132 i32)
+  (local $133 i32)
+  (local $134 i32)
+  (local $135 i32)
+  (local $136 i32)
+  (local $137 i32)
+  (local $138 i32)
+  (local $139 i32)
+  (local $140 i32)
+  (local $141 i32)
+  (local $142 i32)
+  (local $143 i32)
+  (local $144 i32)
+  (local $145 i32)
+  (local $146 i32)
+  (local $147 i32)
+  (local $148 i32)
+  (local $149 i32)
+  (local $150 i32)
+  (local $151 i32)
+  (local $152 i32)
+  (local $153 i32)
+  (local $154 i32)
+  (local $155 i32)
+  (local $156 i32)
+  (local $157 i32)
+  (local $158 i32)
+  (local $159 i32)
+  (local $160 i32)
+  (local $161 i32)
+  (local $162 i32)
+  (local $163 i32)
+  (local $164 i32)
+  (local $165 i32)
+  (local $166 i32)
+  (local $167 i32)
+  (local $168 i32)
+  (local $169 i32)
+  (local $170 i32)
+  (local $171 i32)
+  (local $172 i32)
+  (local $173 i32)
+  (local $174 i32)
+  (local $175 i32)
+  (local $176 i32)
+  (local $177 i32)
+  (local $178 i32)
+  (local $179 i32)
+  (local $180 i32)
+  (local $181 i32)
+  (local $182 i32)
+  (local $183 i32)
+  (local $184 i32)
+  (local $185 i32)
+  (local $186 i32)
+  (local $187 i32)
+  (local $188 i32)
+  (local $189 i32)
+  (local $190 i32)
+  (local $191 i32)
+  (local $192 i32)
+  (local $193 i32)
+  (local $194 i32)
+  (local $195 i32)
+  (local $196 i32)
+  (local $197 i32)
+  (local $198 i32)
+  (local $199 i32)
+  (local $200 i32)
+  (local $201 i32)
+  (local $202 i32)
+  (local $203 i32)
+  (local $204 i32)
+  (local $205 i32)
+  (local $206 i32)
+  (local $207 i32)
+  (local $208 i32)
+  (local $209 i32)
+  (local $210 i32)
+  (local $211 i32)
+  (local $212 i32)
+  (local $213 i32)
+  (local $214 i32)
+  (local $215 i32)
+  (local $216 i32)
+  (local $217 i32)
+  (local $218 i32)
+  (local $219 i32)
+  (local $220 i32)
+  (local $221 i32)
+  (local $222 i32)
+  (local $223 i32)
+  (local $224 i32)
+  (local $225 i32)
+  (local $226 i32)
+  (local $227 i32)
+  (local $228 i32)
+  (local $229 i32)
+  (local $230 i32)
+  (local $231 i32)
+  (local $232 i32)
+  (local $233 i32)
+  (local $234 i32)
+  (local $235 i32)
+  (local $236 i32)
+  (local $237 i32)
+  (local $238 i32)
+  (local $239 i32)
+  (local $240 i32)
+  (local $241 i32)
+  (local $242 i32)
+  (local $243 i32)
+  (local $244 i32)
+  (local $245 i32)
+  (local $246 i32)
+  (local $247 i32)
+  (local $248 i32)
+  (local $249 i32)
+  (local $250 i32)
+  (local $251 i32)
+  (local $252 i32)
+  (local $253 i32)
+  (local $254 i32)
+  (local $255 i32)
+  (local $256 i32)
+  (local $257 i32)
+  (local $258 i32)
+  (local $259 i32)
+  (local $260 i32)
+  (local $261 i32)
+  (local $262 i32)
+  (local $263 i32)
+  (local $264 i32)
+  (local $265 i32)
+  (local $266 i32)
+  (local $267 i32)
+  (local $268 i32)
+  (local $269 i32)
+  (local $270 i32)
+  (local $271 i32)
+  (local $272 i32)
+  (local $273 i32)
+  (local $274 i32)
+  (local $275 i32)
+  (local $276 i32)
+  (local $277 i32)
+  (local $278 i32)
+  (local $279 i32)
+  (local $280 i32)
+  (local $281 i32)
+  (local $282 i32)
+  (local $283 i32)
+  (local $284 i32)
+  (local $285 i32)
+  (local $286 i32)
+  (local $287 i32)
+  (local $288 i32)
+  (local $289 i32)
+  (local $290 i32)
+  (local $291 i32)
+  (local $292 i32)
+  (local $293 i32)
+  (local $294 i32)
+  (local $295 i32)
+  (local $296 i32)
+  (local $297 i32)
+  (local $298 i32)
+  (local $299 i32)
+  (local $300 i32)
+  (local $301 i32)
+  (local $302 i32)
+  (local $303 i32)
+  (local $304 i32)
+  (local $305 i32)
+  (local $306 i32)
+  (local $307 i32)
+  (local $308 i32)
+  (local $309 i32)
+  (local $310 i32)
+  (local $311 i32)
+  (local $312 i32)
+  (local $313 i32)
+  (local $314 i32)
+  (local $315 i32)
+  (local $316 i32)
+  (local $317 i32)
+  (local $318 i32)
+  (local $319 i32)
+  (local $320 i32)
+  (local $321 i32)
+  (local $322 i32)
+  (local $323 i32)
+  (local $324 i32)
+  (local $325 i32)
+  (local $326 i32)
+  (local $327 i32)
+  (local $328 i32)
+  (local $329 i32)
+  (local $330 i32)
+  (local $331 i32)
+  (local $332 i32)
+  (local $333 i32)
+  (local $334 i32)
+  (local $335 i32)
+  (local $336 i32)
+  (local $337 i32)
+  (local $338 i32)
+  (local $339 i32)
+  (local $340 i32)
+  (local $341 i32)
+  (local $342 i32)
+  (local $343 i32)
+  (local $344 i32)
+  (local $345 i32)
+  (local $346 i32)
+  (local $347 i32)
+  (local $348 i32)
+  (local $349 i32)
+  (local $350 i32)
+  (local $351 i32)
+  (local $352 i32)
+  (local $353 i32)
+  (local $354 i32)
+  (local $355 i32)
+  (local $356 i32)
+  (local $357 i32)
+  (local $358 i32)
+  (local $359 i32)
+  (local $360 i32)
+  (local $361 i32)
+  (local $362 i32)
+  (local $363 i32)
+  (local $364 i32)
+  (local $365 i32)
+  (local $366 i32)
+  (local $367 i32)
+  (local $368 i32)
+  (local $369 i32)
+  (local $370 i32)
+  (local $371 i32)
+  (local $372 i32)
+  (local $373 i32)
+  (local $374 i32)
+  (local $375 i32)
+  (local $376 i32)
+  (local $377 i32)
+  (local $378 i32)
+  (local $379 i32)
+  (local $380 i32)
+  (local $381 i32)
+  (local $382 i32)
+  (local $383 i32)
+  (local $384 i32)
+  (local $385 i32)
+  (local $386 i32)
+  (local $387 i32)
+  (local $388 i32)
+  (local $389 i32)
+  (local $390 i32)
+  (local $391 i32)
+  (local $392 i32)
+  (local $393 i32)
+  (local $394 i32)
+  (local $395 i32)
+  (local $396 i32)
+  (local $397 i32)
+  (local $398 i32)
+  (local $399 i32)
+  (local $400 i32)
+  (local $401 i32)
+  (local $402 i32)
+  (local $403 i32)
+  (local $404 i32)
+  (local $405 i32)
+  (local $406 i32)
+  (local $407 i32)
+  (local $408 i32)
+  (local $409 i32)
+  (local $410 i32)
+  (local $411 i32)
+  (local $412 i32)
+  (local $413 i32)
+  (local $414 i32)
+  (local $415 i32)
+  (local $416 i32)
+  (local $417 i32)
+  (local $418 i32)
+  (local $419 i32)
+  (local $420 i32)
+  (local $421 i32)
+  (local $422 i32)
+  (local $423 i32)
+  (local $424 i32)
+  (local $425 i32)
+  (local $426 i32)
+  (local $427 i32)
+  (local $428 i32)
+  (local $429 i32)
+  (local $430 i32)
+  (local $431 i32)
+  (local $432 i32)
+  (local $433 i32)
+  (local $434 i32)
+  (local $435 i32)
+  (local $436 i32)
+  (local $437 i32)
+  (local $438 i32)
+  (local $439 i32)
+  (local $440 i32)
+  (local $441 i32)
+  (local $442 i32)
+  (local $443 i32)
+  (local $444 i32)
+  (local $445 i32)
+  (local $446 i32)
+  (local $447 i32)
+  (local $448 i32)
+  (local $449 i32)
+  (local $450 i32)
+  (local $451 i32)
+  (local $452 i32)
+  (local $453 i32)
+  (local $454 i32)
+  (local $455 i32)
+  (local $456 i32)
+  (local $457 i32)
+  (local $458 i32)
+  (local $459 i32)
+  (local $460 i32)
+  (local $461 i32)
+  (local $462 i32)
+  (local $463 i32)
+  (local $464 i32)
+  (local $465 i32)
+  (local $466 i32)
+  (local $467 i32)
+  (local $468 i32)
+  (local $469 i32)
+  (local $470 i32)
+  (local $471 i32)
+  (local $472 i32)
+  (local $473 i32)
+  (local $474 i32)
+  (local $475 i32)
+  (local $476 i32)
+  (local $477 i32)
+  (local $478 i32)
+  (local $479 i32)
+  (local $480 i32)
+  (local $481 i32)
+  (local $482 i32)
+  (local $483 i32)
+  (local $484 i32)
+  (local $485 i32)
+  (local $486 i32)
+  (local $487 i32)
+  (local $488 i32)
+  (local $489 i32)
+  (local $490 i32)
+  (local $491 i32)
+  (local $492 i32)
+  (local $493 i32)
+  (local $494 i32)
+  (local $495 i32)
+  (local $496 i32)
+  (local $497 i32)
+  (local $498 i32)
+  (local $499 i32)
+  (local $500 i32)
+  (local $501 i32)
+  (local $502 i32)
+  (local $503 i32)
+  (local $504 i32)
+  (local $505 i32)
+  (local $506 i32)
+  (local $507 i32)
+  (local $508 i32)
+  (local $509 i32)
+  (local $510 i32)
+  (local $511 i32)
+  (local $512 i32)
+  (local $513 i32)
+  (local $514 i32)
+  (local $515 i32)
+  (local $516 i32)
   i32.const 0
   i32.const 0
   i32.eq
@@ -19065,21 +20053,21 @@
   i32.const 432
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $0
-  local.get $0
+  local.set $4
+  local.get $4
   i32.const 1
   i32.const 1
   i32.const 3
   call $~lib/array/Array<u8>#fill
   call $~lib/rt/pure/__release
-  local.get $0
+  local.get $4
   i32.const 5
   i32.const 0
   i32.const 6
   i32.const 464
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $2
+  local.tee $7
   i32.const 0
   call $std/array/isArraysEqual<u8>
   i32.eqz
@@ -19091,20 +20079,20 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $4
   i32.const 0
   i32.const 0
   global.get $~lib/builtins/i32.MAX_VALUE
   call $~lib/array/Array<u8>#fill
   call $~lib/rt/pure/__release
-  local.get $0
+  local.get $4
   i32.const 5
   i32.const 0
   i32.const 6
   i32.const 560
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $3
+  local.tee $10
   i32.const 0
   call $std/array/isArraysEqual<u8>
   i32.eqz
@@ -19116,20 +20104,20 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $4
   i32.const 1
   i32.const 0
   i32.const -3
   call $~lib/array/Array<u8>#fill
   call $~lib/rt/pure/__release
-  local.get $0
+  local.get $4
   i32.const 5
   i32.const 0
   i32.const 6
   i32.const 592
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $4
+  local.tee $13
   i32.const 0
   call $std/array/isArraysEqual<u8>
   i32.eqz
@@ -19141,20 +20129,20 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $4
   i32.const 2
   i32.const -2
   global.get $~lib/builtins/i32.MAX_VALUE
   call $~lib/array/Array<u8>#fill
   call $~lib/rt/pure/__release
-  local.get $0
+  local.get $4
   i32.const 5
   i32.const 0
   i32.const 6
   i32.const 624
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $5
+  local.tee $16
   i32.const 0
   call $std/array/isArraysEqual<u8>
   i32.eqz
@@ -19166,20 +20154,20 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $4
   i32.const 0
   i32.const 1
   i32.const 0
   call $~lib/array/Array<u8>#fill
   call $~lib/rt/pure/__release
-  local.get $0
+  local.get $4
   i32.const 5
   i32.const 0
   i32.const 6
   i32.const 656
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $6
+  local.tee $19
   i32.const 0
   call $std/array/isArraysEqual<u8>
   i32.eqz
@@ -19191,17 +20179,17 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
-  call $~lib/rt/pure/__release
-  local.get $2
-  call $~lib/rt/pure/__release
-  local.get $3
-  call $~lib/rt/pure/__release
   local.get $4
   call $~lib/rt/pure/__release
-  local.get $5
+  local.get $7
   call $~lib/rt/pure/__release
-  local.get $6
+  local.get $10
+  call $~lib/rt/pure/__release
+  local.get $13
+  call $~lib/rt/pure/__release
+  local.get $16
+  call $~lib/rt/pure/__release
+  local.get $19
   call $~lib/rt/pure/__release
   i32.const 5
   i32.const 2
@@ -19209,21 +20197,21 @@
   i32.const 688
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $5
-  local.get $5
+  local.set $22
+  local.get $22
   i32.const 1
   i32.const 1
   i32.const 3
   call $~lib/array/Array<u32>#fill
   call $~lib/rt/pure/__release
-  local.get $5
+  local.get $22
   i32.const 5
   i32.const 2
   i32.const 7
   i32.const 736
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $4
+  local.tee $25
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -19235,20 +20223,20 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $22
   i32.const 0
   i32.const 0
   global.get $~lib/builtins/i32.MAX_VALUE
   call $~lib/array/Array<u32>#fill
   call $~lib/rt/pure/__release
-  local.get $5
+  local.get $22
   i32.const 5
   i32.const 2
   i32.const 7
   i32.const 784
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $3
+  local.tee $28
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -19260,20 +20248,20 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $22
   i32.const 1
   i32.const 0
   i32.const -3
   call $~lib/array/Array<u32>#fill
   call $~lib/rt/pure/__release
-  local.get $5
+  local.get $22
   i32.const 5
   i32.const 2
   i32.const 7
   i32.const 832
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $2
+  local.tee $31
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -19285,20 +20273,20 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $22
   i32.const 2
   i32.const -2
   global.get $~lib/builtins/i32.MAX_VALUE
   call $~lib/array/Array<u32>#fill
   call $~lib/rt/pure/__release
-  local.get $5
+  local.get $22
   i32.const 5
   i32.const 2
   i32.const 7
   i32.const 880
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $0
+  local.tee $34
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -19310,20 +20298,20 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $22
   i32.const 0
   i32.const 1
   i32.const 0
   call $~lib/array/Array<u32>#fill
   call $~lib/rt/pure/__release
-  local.get $5
+  local.get $22
   i32.const 5
   i32.const 2
   i32.const 7
   i32.const 928
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $1
+  local.tee $37
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -19335,17 +20323,17 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $22
   call $~lib/rt/pure/__release
-  local.get $4
+  local.get $25
   call $~lib/rt/pure/__release
-  local.get $3
+  local.get $28
   call $~lib/rt/pure/__release
-  local.get $2
+  local.get $31
   call $~lib/rt/pure/__release
-  local.get $0
+  local.get $34
   call $~lib/rt/pure/__release
-  local.get $1
+  local.get $37
   call $~lib/rt/pure/__release
   global.get $std/array/arr
   call $~lib/array/Array<i32>#get:length
@@ -19419,8 +20407,8 @@
   end
   global.get $std/array/arr
   call $~lib/array/Array<i32>#pop
-  local.set $1
-  local.get $1
+  local.set $38
+  local.get $38
   i32.const 42
   i32.eq
   i32.eqz
@@ -19638,26 +20626,26 @@
   i32.const 0
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $1
-  local.get $1
+  local.set $39
+  local.get $39
   i32.load offset=4
-  local.set $0
-  local.get $0
+  local.set $40
+  local.get $40
   i32.const 0
   i32.const 0
   call $std/array/Ref#constructor
   i32.store
-  local.get $0
+  local.get $40
   i32.const 0
   i32.const 0
   call $std/array/Ref#constructor
   i32.store offset=4
-  local.get $1
-  local.set $0
-  local.get $0
+  local.get $39
+  local.set $41
+  local.get $41
   i32.const 0
   call $~lib/array/Array<std/array/Ref>#set:length
-  local.get $0
+  local.get $41
   call $~lib/array/Array<std/array/Ref>#get:length
   i32.const 0
   i32.eq
@@ -19670,16 +20658,16 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $41
   call $~lib/rt/pure/__release
   i32.const 0
   i32.const 0
   call $~lib/array/Array<i32>#constructor
-  local.set $0
+  local.set $42
   global.get $std/array/arr
-  local.get $0
+  local.get $42
   call $~lib/array/Array<i32>#concat
-  local.set $1
+  local.set $43
   global.get $std/array/arr
   call $std/array/internalCapacity<i32>
   i32.const 3
@@ -19706,7 +20694,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $43
   call $~lib/array/Array<i32>#get:length
   i32.const 3
   i32.eq
@@ -19719,14 +20707,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $43
   i32.const 0
   i32.const 2
   i32.const 3
   i32.const 1024
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $3
+  local.tee $46
   call $~lib/array/Array<i32>#concat
   call $~lib/rt/pure/__release
   global.get $std/array/arr
@@ -19742,7 +20730,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $43
   i32.const 0
   call $~lib/array/Array<i32>#__get
   i32.const 43
@@ -19756,7 +20744,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $43
   i32.const 1
   call $~lib/array/Array<i32>#__get
   i32.const 44
@@ -19770,7 +20758,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $43
   i32.const 2
   call $~lib/array/Array<i32>#__get
   i32.const 45
@@ -19784,22 +20772,22 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $42
   i32.const 46
   call $~lib/array/Array<i32>#push
   drop
-  local.get $0
+  local.get $42
   i32.const 47
   call $~lib/array/Array<i32>#push
   drop
   global.get $std/array/arr
-  local.get $0
+  local.get $42
   call $~lib/array/Array<i32>#concat
-  local.set $6
-  local.get $1
+  local.set $47
+  local.get $43
   call $~lib/rt/pure/__release
-  local.get $6
-  local.set $1
+  local.get $47
+  local.set $43
   global.get $std/array/arr
   call $std/array/internalCapacity<i32>
   i32.const 3
@@ -19813,7 +20801,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $42
   call $~lib/array/Array<i32>#get:length
   i32.const 2
   i32.eq
@@ -19826,7 +20814,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $43
   call $~lib/array/Array<i32>#get:length
   i32.const 5
   i32.eq
@@ -19839,7 +20827,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $43
   i32.const 0
   call $~lib/array/Array<i32>#__get
   i32.const 43
@@ -19853,7 +20841,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $43
   i32.const 1
   call $~lib/array/Array<i32>#__get
   i32.const 44
@@ -19867,7 +20855,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $43
   i32.const 2
   call $~lib/array/Array<i32>#__get
   i32.const 45
@@ -19881,7 +20869,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $43
   i32.const 3
   call $~lib/array/Array<i32>#__get
   i32.const 46
@@ -19895,7 +20883,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $43
   i32.const 4
   call $~lib/array/Array<i32>#__get
   i32.const 47
@@ -19909,10 +20897,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $43
   call $~lib/array/Array<i32>#pop
   drop
-  local.get $1
+  local.get $43
   call $~lib/array/Array<i32>#get:length
   i32.const 4
   i32.eq
@@ -19931,8 +20919,8 @@
   i32.const 1040
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $2
-  local.get $2
+  local.set $50
+  local.get $50
   call $~lib/array/Array<i32>#get:length
   i32.const 0
   i32.eq
@@ -19945,15 +20933,15 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $50
   global.get $std/array/arr
   call $~lib/array/Array<i32>#concat
-  local.set $5
-  local.get $1
+  local.set $51
+  local.get $43
   call $~lib/rt/pure/__release
-  local.get $5
-  local.set $1
-  local.get $1
+  local.get $51
+  local.set $43
+  local.get $43
   call $~lib/array/Array<i32>#get:length
   i32.const 3
   i32.eq
@@ -19966,7 +20954,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $50
   call $~lib/array/Array<i32>#get:length
   i32.const 0
   i32.eq
@@ -19979,13 +20967,13 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $42
   call $~lib/rt/pure/__release
-  local.get $1
+  local.get $43
   call $~lib/rt/pure/__release
-  local.get $3
+  local.get $46
   call $~lib/rt/pure/__release
-  local.get $2
+  local.get $50
   call $~lib/rt/pure/__release
   i32.const 5
   i32.const 2
@@ -19993,20 +20981,20 @@
   i32.const 1056
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $3
-  local.get $3
+  local.set $54
+  local.get $54
   i32.const 0
   i32.const 3
   global.get $~lib/builtins/i32.MAX_VALUE
   call $~lib/array/Array<i32>#copyWithin
-  local.tee $2
+  local.tee $55
   i32.const 5
   i32.const 2
   i32.const 3
   i32.const 1104
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $0
+  local.tee $58
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -20024,24 +21012,24 @@
   i32.const 1152
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $4
-  local.get $3
+  local.set $61
+  local.get $54
   call $~lib/rt/pure/__release
-  local.get $4
-  local.set $3
-  local.get $3
+  local.get $61
+  local.set $54
+  local.get $54
   i32.const 1
   i32.const 3
   global.get $~lib/builtins/i32.MAX_VALUE
   call $~lib/array/Array<i32>#copyWithin
-  local.tee $4
+  local.tee $62
   i32.const 5
   i32.const 2
   i32.const 3
   i32.const 1200
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $1
+  local.tee $65
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -20059,24 +21047,24 @@
   i32.const 1248
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $5
-  local.get $3
+  local.set $68
+  local.get $54
   call $~lib/rt/pure/__release
-  local.get $5
-  local.set $3
-  local.get $3
+  local.get $68
+  local.set $54
+  local.get $54
   i32.const 1
   i32.const 2
   global.get $~lib/builtins/i32.MAX_VALUE
   call $~lib/array/Array<i32>#copyWithin
-  local.tee $5
+  local.tee $69
   i32.const 5
   i32.const 2
   i32.const 3
   i32.const 1296
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $7
+  local.tee $72
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -20094,24 +21082,24 @@
   i32.const 1344
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $6
-  local.get $3
+  local.set $75
+  local.get $54
   call $~lib/rt/pure/__release
-  local.get $6
-  local.set $3
-  local.get $3
+  local.get $75
+  local.set $54
+  local.get $54
   i32.const 2
   i32.const 2
   global.get $~lib/builtins/i32.MAX_VALUE
   call $~lib/array/Array<i32>#copyWithin
-  local.tee $6
+  local.tee $76
   i32.const 5
   i32.const 2
   i32.const 3
   i32.const 1392
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $9
+  local.tee $79
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -20129,24 +21117,24 @@
   i32.const 1440
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $8
-  local.get $3
+  local.set $82
+  local.get $54
   call $~lib/rt/pure/__release
-  local.get $8
-  local.set $3
-  local.get $3
+  local.get $82
+  local.set $54
+  local.get $54
   i32.const 0
   i32.const 3
   i32.const 4
   call $~lib/array/Array<i32>#copyWithin
-  local.tee $8
+  local.tee $83
   i32.const 5
   i32.const 2
   i32.const 3
   i32.const 1488
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $11
+  local.tee $86
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -20164,24 +21152,24 @@
   i32.const 1536
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $10
-  local.get $3
+  local.set $89
+  local.get $54
   call $~lib/rt/pure/__release
-  local.get $10
-  local.set $3
-  local.get $3
+  local.get $89
+  local.set $54
+  local.get $54
   i32.const 1
   i32.const 3
   i32.const 4
   call $~lib/array/Array<i32>#copyWithin
-  local.tee $10
+  local.tee $90
   i32.const 5
   i32.const 2
   i32.const 3
   i32.const 1584
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $13
+  local.tee $93
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -20199,24 +21187,24 @@
   i32.const 1632
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $12
-  local.get $3
+  local.set $96
+  local.get $54
   call $~lib/rt/pure/__release
-  local.get $12
-  local.set $3
-  local.get $3
+  local.get $96
+  local.set $54
+  local.get $54
   i32.const 1
   i32.const 2
   i32.const 4
   call $~lib/array/Array<i32>#copyWithin
-  local.tee $12
+  local.tee $97
   i32.const 5
   i32.const 2
   i32.const 3
   i32.const 1680
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $15
+  local.tee $100
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -20234,24 +21222,24 @@
   i32.const 1728
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $14
-  local.get $3
+  local.set $103
+  local.get $54
   call $~lib/rt/pure/__release
-  local.get $14
-  local.set $3
-  local.get $3
+  local.get $103
+  local.set $54
+  local.get $54
   i32.const 0
   i32.const -2
   global.get $~lib/builtins/i32.MAX_VALUE
   call $~lib/array/Array<i32>#copyWithin
-  local.tee $14
+  local.tee $104
   i32.const 5
   i32.const 2
   i32.const 3
   i32.const 1776
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $17
+  local.tee $107
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -20269,24 +21257,24 @@
   i32.const 1824
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $16
-  local.get $3
+  local.set $110
+  local.get $54
   call $~lib/rt/pure/__release
-  local.get $16
-  local.set $3
-  local.get $3
+  local.get $110
+  local.set $54
+  local.get $54
   i32.const 0
   i32.const -2
   i32.const -1
   call $~lib/array/Array<i32>#copyWithin
-  local.tee $16
+  local.tee $111
   i32.const 5
   i32.const 2
   i32.const 3
   i32.const 1872
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $19
+  local.tee $114
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -20304,24 +21292,24 @@
   i32.const 1920
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $18
-  local.get $3
+  local.set $117
+  local.get $54
   call $~lib/rt/pure/__release
-  local.get $18
-  local.set $3
-  local.get $3
+  local.get $117
+  local.set $54
+  local.get $54
   i32.const -4
   i32.const -3
   i32.const -2
   call $~lib/array/Array<i32>#copyWithin
-  local.tee $18
+  local.tee $118
   i32.const 5
   i32.const 2
   i32.const 3
   i32.const 1968
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $21
+  local.tee $121
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -20339,24 +21327,24 @@
   i32.const 2016
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $20
-  local.get $3
+  local.set $124
+  local.get $54
   call $~lib/rt/pure/__release
-  local.get $20
-  local.set $3
-  local.get $3
+  local.get $124
+  local.set $54
+  local.get $54
   i32.const -4
   i32.const -3
   i32.const -1
   call $~lib/array/Array<i32>#copyWithin
-  local.tee $20
+  local.tee $125
   i32.const 5
   i32.const 2
   i32.const 3
   i32.const 2064
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $23
+  local.tee $128
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -20374,24 +21362,24 @@
   i32.const 2112
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $22
-  local.get $3
+  local.set $131
+  local.get $54
   call $~lib/rt/pure/__release
-  local.get $22
-  local.set $3
-  local.get $3
+  local.get $131
+  local.set $54
+  local.get $54
   i32.const -4
   i32.const -3
   global.get $~lib/builtins/i32.MAX_VALUE
   call $~lib/array/Array<i32>#copyWithin
-  local.tee $22
+  local.tee $132
   i32.const 5
   i32.const 2
   i32.const 3
   i32.const 2160
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $25
+  local.tee $135
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -20403,55 +21391,55 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $54
   call $~lib/rt/pure/__release
-  local.get $2
+  local.get $55
   call $~lib/rt/pure/__release
-  local.get $0
+  local.get $58
   call $~lib/rt/pure/__release
-  local.get $4
+  local.get $62
   call $~lib/rt/pure/__release
-  local.get $1
+  local.get $65
   call $~lib/rt/pure/__release
-  local.get $5
+  local.get $69
   call $~lib/rt/pure/__release
-  local.get $7
+  local.get $72
   call $~lib/rt/pure/__release
-  local.get $6
+  local.get $76
   call $~lib/rt/pure/__release
-  local.get $9
+  local.get $79
   call $~lib/rt/pure/__release
-  local.get $8
+  local.get $83
   call $~lib/rt/pure/__release
-  local.get $11
+  local.get $86
   call $~lib/rt/pure/__release
-  local.get $10
+  local.get $90
   call $~lib/rt/pure/__release
-  local.get $13
+  local.get $93
   call $~lib/rt/pure/__release
-  local.get $12
+  local.get $97
   call $~lib/rt/pure/__release
-  local.get $15
+  local.get $100
   call $~lib/rt/pure/__release
-  local.get $14
+  local.get $104
   call $~lib/rt/pure/__release
-  local.get $17
+  local.get $107
   call $~lib/rt/pure/__release
-  local.get $16
+  local.get $111
   call $~lib/rt/pure/__release
-  local.get $19
+  local.get $114
   call $~lib/rt/pure/__release
-  local.get $18
+  local.get $118
   call $~lib/rt/pure/__release
-  local.get $21
+  local.get $121
   call $~lib/rt/pure/__release
-  local.get $20
+  local.get $125
   call $~lib/rt/pure/__release
-  local.get $23
+  local.get $128
   call $~lib/rt/pure/__release
-  local.get $22
+  local.get $132
   call $~lib/rt/pure/__release
-  local.get $25
+  local.get $135
   call $~lib/rt/pure/__release
   global.get $std/array/arr
   i32.const 42
@@ -21074,7 +22062,7 @@
   i32.const 2208
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $22
+  local.tee $138
   f32.const nan:0x400000
   i32.const 0
   call $~lib/array/Array<f32>#indexOf
@@ -21095,7 +22083,7 @@
   i32.const 2240
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $23
+  local.tee $141
   f64.const nan:0x8000000000000
   i32.const 0
   call $~lib/array/Array<f64>#indexOf
@@ -21110,16 +22098,16 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $22
+  local.get $138
   call $~lib/rt/pure/__release
-  local.get $23
+  local.get $141
   call $~lib/rt/pure/__release
   global.get $std/array/arr
   i32.const 44
   i32.const 0
   call $~lib/array/Array<i32>#includes
-  local.set $23
-  local.get $23
+  local.set $142
+  local.get $142
   i32.const 1
   i32.eq
   i32.eqz
@@ -21135,8 +22123,8 @@
   i32.const 42
   i32.const 0
   call $~lib/array/Array<i32>#includes
-  local.set $23
-  local.get $23
+  local.set $142
+  local.get $142
   i32.const 1
   i32.eq
   i32.eqz
@@ -21152,8 +22140,8 @@
   i32.const 45
   i32.const 0
   call $~lib/array/Array<i32>#includes
-  local.set $23
-  local.get $23
+  local.set $142
+  local.get $142
   i32.const 0
   i32.eq
   i32.eqz
@@ -21169,8 +22157,8 @@
   i32.const 43
   i32.const 100
   call $~lib/array/Array<i32>#includes
-  local.set $23
-  local.get $23
+  local.set $142
+  local.get $142
   i32.const 0
   i32.eq
   i32.eqz
@@ -21186,8 +22174,8 @@
   i32.const 43
   i32.const -100
   call $~lib/array/Array<i32>#includes
-  local.set $23
-  local.get $23
+  local.set $142
+  local.get $142
   i32.const 1
   i32.eq
   i32.eqz
@@ -21203,8 +22191,8 @@
   i32.const 43
   i32.const -2
   call $~lib/array/Array<i32>#includes
-  local.set $23
-  local.get $23
+  local.set $142
+  local.get $142
   i32.const 1
   i32.eq
   i32.eqz
@@ -21220,8 +22208,8 @@
   i32.const 43
   i32.const -4
   call $~lib/array/Array<i32>#includes
-  local.set $23
-  local.get $23
+  local.set $142
+  local.get $142
   i32.const 1
   i32.eq
   i32.eqz
@@ -21237,8 +22225,8 @@
   i32.const 43
   i32.const 0
   call $~lib/array/Array<i32>#includes
-  local.set $23
-  local.get $23
+  local.set $142
+  local.get $142
   i32.const 1
   i32.eq
   i32.eqz
@@ -21254,8 +22242,8 @@
   i32.const 43
   i32.const 1
   call $~lib/array/Array<i32>#includes
-  local.set $23
-  local.get $23
+  local.set $142
+  local.get $142
   i32.const 1
   i32.eq
   i32.eqz
@@ -21271,8 +22259,8 @@
   i32.const 43
   i32.const 2
   call $~lib/array/Array<i32>#includes
-  local.set $23
-  local.get $23
+  local.set $142
+  local.get $142
   i32.const 1
   i32.eq
   i32.eqz
@@ -21290,7 +22278,7 @@
   i32.const 2272
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $25
+  local.tee $145
   f32.const nan:0x400000
   i32.const 0
   call $~lib/array/Array<f32>#includes
@@ -21309,7 +22297,7 @@
   i32.const 2304
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $20
+  local.tee $148
   f64.const nan:0x8000000000000
   i32.const 0
   call $~lib/array/Array<f64>#includes
@@ -21381,9 +22369,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $25
+  local.get $145
   call $~lib/rt/pure/__release
-  local.get $20
+  local.get $148
   call $~lib/rt/pure/__release
   i32.const 5
   i32.const 2
@@ -21391,19 +22379,19 @@
   i32.const 2336
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $25
-  local.get $25
+  local.set $151
+  local.get $151
   i32.const 0
   global.get $~lib/builtins/i32.MAX_VALUE
   call $~lib/array/Array<i32>#splice
-  local.tee $20
+  local.tee $152
   i32.const 5
   i32.const 2
   i32.const 3
   i32.const 2384
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $22
+  local.tee $155
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -21415,14 +22403,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $25
+  local.get $151
   i32.const 0
   i32.const 2
   i32.const 3
   i32.const 2432
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $21
+  local.tee $158
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -21440,23 +22428,23 @@
   i32.const 2448
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $24
-  local.get $25
+  local.set $161
+  local.get $151
   call $~lib/rt/pure/__release
-  local.get $24
-  local.set $25
-  local.get $25
+  local.get $161
+  local.set $151
+  local.get $151
   i32.const 0
   i32.const 0
   call $~lib/array/Array<i32>#splice
-  local.tee $24
+  local.tee $162
   i32.const 0
   i32.const 2
   i32.const 3
   i32.const 2496
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $23
+  local.tee $165
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -21468,14 +22456,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $25
+  local.get $151
   i32.const 5
   i32.const 2
   i32.const 3
   i32.const 2512
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $19
+  local.tee $168
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -21493,23 +22481,23 @@
   i32.const 2560
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $3
-  local.get $25
+  local.set $171
+  local.get $151
   call $~lib/rt/pure/__release
-  local.get $3
-  local.set $25
-  local.get $25
+  local.get $171
+  local.set $151
+  local.get $151
   i32.const 2
   global.get $~lib/builtins/i32.MAX_VALUE
   call $~lib/array/Array<i32>#splice
-  local.tee $3
+  local.tee $172
   i32.const 3
   i32.const 2
   i32.const 3
   i32.const 2608
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $18
+  local.tee $175
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -21521,14 +22509,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $25
+  local.get $151
   i32.const 2
   i32.const 2
   i32.const 3
   i32.const 2640
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $17
+  local.tee $178
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -21546,23 +22534,23 @@
   i32.const 2672
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $2
-  local.get $25
+  local.set $181
+  local.get $151
   call $~lib/rt/pure/__release
-  local.get $2
-  local.set $25
-  local.get $25
+  local.get $181
+  local.set $151
+  local.get $151
   i32.const 2
   i32.const 2
   call $~lib/array/Array<i32>#splice
-  local.tee $2
+  local.tee $182
   i32.const 2
   i32.const 2
   i32.const 3
   i32.const 2720
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $16
+  local.tee $185
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -21574,14 +22562,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $25
+  local.get $151
   i32.const 3
   i32.const 2
   i32.const 3
   i32.const 2752
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $15
+  local.tee $188
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -21599,23 +22587,23 @@
   i32.const 2784
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $0
-  local.get $25
+  local.set $191
+  local.get $151
   call $~lib/rt/pure/__release
-  local.get $0
-  local.set $25
-  local.get $25
+  local.get $191
+  local.set $151
+  local.get $151
   i32.const 0
   i32.const 1
   call $~lib/array/Array<i32>#splice
-  local.tee $0
+  local.tee $192
   i32.const 1
   i32.const 2
   i32.const 3
   i32.const 2832
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $14
+  local.tee $195
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -21627,14 +22615,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $25
+  local.get $151
   i32.const 4
   i32.const 2
   i32.const 3
   i32.const 2864
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $13
+  local.tee $198
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -21652,23 +22640,23 @@
   i32.const 2896
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $4
-  local.get $25
+  local.set $201
+  local.get $151
   call $~lib/rt/pure/__release
-  local.get $4
-  local.set $25
-  local.get $25
+  local.get $201
+  local.set $151
+  local.get $151
   i32.const -1
   global.get $~lib/builtins/i32.MAX_VALUE
   call $~lib/array/Array<i32>#splice
-  local.tee $4
+  local.tee $202
   i32.const 1
   i32.const 2
   i32.const 3
   i32.const 2944
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $12
+  local.tee $205
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -21680,14 +22668,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $25
+  local.get $151
   i32.const 4
   i32.const 2
   i32.const 3
   i32.const 2976
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $11
+  local.tee $208
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -21705,23 +22693,23 @@
   i32.const 3008
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $1
-  local.get $25
+  local.set $211
+  local.get $151
   call $~lib/rt/pure/__release
-  local.get $1
-  local.set $25
-  local.get $25
+  local.get $211
+  local.set $151
+  local.get $151
   i32.const -2
   global.get $~lib/builtins/i32.MAX_VALUE
   call $~lib/array/Array<i32>#splice
-  local.tee $1
+  local.tee $212
   i32.const 2
   i32.const 2
   i32.const 3
   i32.const 3056
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $10
+  local.tee $215
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -21733,14 +22721,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $25
+  local.get $151
   i32.const 3
   i32.const 2
   i32.const 3
   i32.const 3088
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $9
+  local.tee $218
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -21758,23 +22746,23 @@
   i32.const 3120
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $5
-  local.get $25
+  local.set $221
+  local.get $151
   call $~lib/rt/pure/__release
-  local.get $5
-  local.set $25
-  local.get $25
+  local.get $221
+  local.set $151
+  local.get $151
   i32.const -2
   i32.const 1
   call $~lib/array/Array<i32>#splice
-  local.tee $5
+  local.tee $222
   i32.const 1
   i32.const 2
   i32.const 3
   i32.const 3168
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $8
+  local.tee $225
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -21786,14 +22774,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $25
+  local.get $151
   i32.const 4
   i32.const 2
   i32.const 3
   i32.const 3200
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $7
+  local.tee $228
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -21811,23 +22799,23 @@
   i32.const 3232
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $6
-  local.get $25
+  local.set $231
+  local.get $151
   call $~lib/rt/pure/__release
-  local.get $6
-  local.set $25
-  local.get $25
+  local.get $231
+  local.set $151
+  local.get $151
   i32.const -7
   i32.const 1
   call $~lib/array/Array<i32>#splice
-  local.tee $6
+  local.tee $232
   i32.const 1
   i32.const 2
   i32.const 3
   i32.const 3280
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $27
+  local.tee $235
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -21839,14 +22827,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $25
+  local.get $151
   i32.const 4
   i32.const 2
   i32.const 3
   i32.const 3312
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $28
+  local.tee $238
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -21864,23 +22852,23 @@
   i32.const 3344
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $26
-  local.get $25
+  local.set $241
+  local.get $151
   call $~lib/rt/pure/__release
-  local.get $26
-  local.set $25
-  local.get $25
+  local.get $241
+  local.set $151
+  local.get $151
   i32.const -2
   i32.const -1
   call $~lib/array/Array<i32>#splice
-  local.tee $26
+  local.tee $242
   i32.const 0
   i32.const 2
   i32.const 3
   i32.const 3392
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $30
+  local.tee $245
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -21892,14 +22880,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $25
+  local.get $151
   i32.const 5
   i32.const 2
   i32.const 3
   i32.const 3408
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $31
+  local.tee $248
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -21917,23 +22905,23 @@
   i32.const 3456
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $29
-  local.get $25
+  local.set $251
+  local.get $151
   call $~lib/rt/pure/__release
-  local.get $29
-  local.set $25
-  local.get $25
+  local.get $251
+  local.set $151
+  local.get $151
   i32.const 1
   i32.const -2
   call $~lib/array/Array<i32>#splice
-  local.tee $29
+  local.tee $252
   i32.const 0
   i32.const 2
   i32.const 3
   i32.const 3504
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $33
+  local.tee $255
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -21945,14 +22933,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $25
+  local.get $151
   i32.const 5
   i32.const 2
   i32.const 3
   i32.const 3520
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $34
+  local.tee $258
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -21970,23 +22958,23 @@
   i32.const 3568
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $32
-  local.get $25
+  local.set $261
+  local.get $151
   call $~lib/rt/pure/__release
-  local.get $32
-  local.set $25
-  local.get $25
+  local.get $261
+  local.set $151
+  local.get $151
   i32.const 4
   i32.const 0
   call $~lib/array/Array<i32>#splice
-  local.tee $32
+  local.tee $262
   i32.const 0
   i32.const 2
   i32.const 3
   i32.const 3616
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $36
+  local.tee $265
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -21998,14 +22986,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $25
+  local.get $151
   i32.const 5
   i32.const 2
   i32.const 3
   i32.const 3632
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $37
+  local.tee $268
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -22023,23 +23011,23 @@
   i32.const 3680
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $35
-  local.get $25
+  local.set $271
+  local.get $151
   call $~lib/rt/pure/__release
-  local.get $35
-  local.set $25
-  local.get $25
+  local.get $271
+  local.set $151
+  local.get $151
   i32.const 7
   i32.const 0
   call $~lib/array/Array<i32>#splice
-  local.tee $35
+  local.tee $272
   i32.const 0
   i32.const 2
   i32.const 3
   i32.const 3728
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $39
+  local.tee $275
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -22051,14 +23039,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $25
+  local.get $151
   i32.const 5
   i32.const 2
   i32.const 3
   i32.const 3744
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $40
+  local.tee $278
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -22076,23 +23064,23 @@
   i32.const 3792
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $38
-  local.get $25
+  local.set $281
+  local.get $151
   call $~lib/rt/pure/__release
-  local.get $38
-  local.set $25
-  local.get $25
+  local.get $281
+  local.set $151
+  local.get $151
   i32.const 7
   i32.const 5
   call $~lib/array/Array<i32>#splice
-  local.tee $38
+  local.tee $282
   i32.const 0
   i32.const 2
   i32.const 3
   i32.const 3840
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $42
+  local.tee $285
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -22104,14 +23092,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $25
+  local.get $151
   i32.const 5
   i32.const 2
   i32.const 3
   i32.const 3856
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $43
+  local.tee $288
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -22129,13 +23117,13 @@
   i32.const 3904
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $45
-  local.get $45
+  local.set $291
+  local.get $291
   i32.const 1
   i32.const 2
   call $~lib/array/Array<std/array/Ref>#splice
-  local.set $46
-  local.get $46
+  local.set $292
+  local.get $292
   call $~lib/array/Array<std/array/Ref>#get:length
   i32.const 0
   i32.eq
@@ -22148,7 +23136,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $45
+  local.get $291
   call $~lib/array/Array<std/array/Ref>#get:length
   i32.const 0
   i32.eq
@@ -22167,51 +23155,51 @@
   i32.const 0
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $44
-  local.get $44
+  local.set $293
+  local.get $293
   i32.load offset=4
-  local.set $41
-  local.get $41
+  local.set $294
+  local.get $294
   i32.const 0
   i32.const 1
   call $std/array/Ref#constructor
   i32.store
-  local.get $41
+  local.get $294
   i32.const 0
   i32.const 2
   call $std/array/Ref#constructor
   i32.store offset=4
-  local.get $41
+  local.get $294
   i32.const 0
   i32.const 3
   call $std/array/Ref#constructor
   i32.store offset=8
-  local.get $41
+  local.get $294
   i32.const 0
   i32.const 4
   call $std/array/Ref#constructor
   i32.store offset=12
-  local.get $41
+  local.get $294
   i32.const 0
   i32.const 5
   call $std/array/Ref#constructor
   i32.store offset=16
-  local.get $44
-  local.set $44
-  local.get $45
+  local.get $293
+  local.set $295
+  local.get $291
   call $~lib/rt/pure/__release
-  local.get $44
-  local.set $45
-  local.get $45
+  local.get $295
+  local.set $291
+  local.get $291
   i32.const 2
   i32.const 2
   call $~lib/array/Array<std/array/Ref>#splice
-  local.set $41
-  local.get $46
+  local.set $296
+  local.get $292
   call $~lib/rt/pure/__release
-  local.get $41
-  local.set $46
-  local.get $46
+  local.get $296
+  local.set $292
+  local.get $292
   call $~lib/array/Array<std/array/Ref>#get:length
   i32.const 2
   i32.eq
@@ -22224,10 +23212,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $46
+  local.get $292
   i32.const 0
   call $~lib/array/Array<std/array/Ref>#__get
-  local.tee $41
+  local.tee $297
   i32.load
   i32.const 3
   i32.eq
@@ -22240,10 +23228,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $46
+  local.get $292
   i32.const 1
   call $~lib/array/Array<std/array/Ref>#__get
-  local.tee $44
+  local.tee $298
   i32.load
   i32.const 4
   i32.eq
@@ -22256,7 +23244,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $45
+  local.get $291
   call $~lib/array/Array<std/array/Ref>#get:length
   i32.const 3
   i32.eq
@@ -22269,10 +23257,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $45
+  local.get $291
   i32.const 0
   call $~lib/array/Array<std/array/Ref>#__get
-  local.tee $47
+  local.tee $299
   i32.load
   i32.const 1
   i32.eq
@@ -22285,10 +23273,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $45
+  local.get $291
   i32.const 1
   call $~lib/array/Array<std/array/Ref>#__get
-  local.tee $48
+  local.tee $300
   i32.load
   i32.const 2
   i32.eq
@@ -22301,10 +23289,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $45
+  local.get $291
   i32.const 2
   call $~lib/array/Array<std/array/Ref>#__get
-  local.tee $49
+  local.tee $301
   i32.load
   i32.const 5
   i32.eq
@@ -22323,32 +23311,32 @@
   i32.const 0
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $50
-  local.get $50
+  local.set $302
+  local.get $302
   i32.load offset=4
-  local.set $51
-  local.get $51
+  local.set $303
+  local.get $303
   i32.const 0
   i32.const 1
   call $std/array/Ref#constructor
   i32.store
-  local.get $51
+  local.get $303
   i32.const 0
   call $~lib/rt/pure/__retain
   i32.store offset=4
-  local.get $51
+  local.get $303
   i32.const 0
   i32.const 2
   call $std/array/Ref#constructor
   i32.store offset=8
-  local.get $50
-  local.set $52
-  local.get $52
+  local.get $302
+  local.set $304
+  local.get $304
   i32.const 0
   i32.const 1
   call $~lib/array/Array<std/array/Ref | null>#splice
-  local.set $53
-  local.get $53
+  local.set $305
+  local.get $305
   call $~lib/array/Array<std/array/Ref | null>#get:length
   i32.const 1
   i32.eq
@@ -22361,13 +23349,13 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $53
+  local.get $305
   i32.const 0
   call $~lib/array/Array<std/array/Ref | null>#__get
-  local.tee $51
-  local.tee $50
+  local.tee $306
+  local.tee $307
   if (result i32)
-   local.get $50
+   local.get $307
   else
    i32.const 0
    i32.const 288
@@ -22388,7 +23376,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $52
+  local.get $304
   call $~lib/array/Array<std/array/Ref | null>#get:length
   i32.const 2
   i32.eq
@@ -22401,10 +23389,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $52
+  local.get $304
   i32.const 0
   call $~lib/array/Array<std/array/Ref | null>#__get
-  local.tee $50
+  local.tee $308
   i32.const 0
   i32.eq
   i32.eqz
@@ -22416,13 +23404,13 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $52
+  local.get $304
   i32.const 1
   call $~lib/array/Array<std/array/Ref | null>#__get
-  local.tee $54
-  local.tee $55
+  local.tee $309
+  local.tee $310
   if (result i32)
-   local.get $55
+   local.get $310
   else
    i32.const 0
    i32.const 288
@@ -22443,107 +23431,107 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $25
+  local.get $151
   call $~lib/rt/pure/__release
-  local.get $20
+  local.get $152
   call $~lib/rt/pure/__release
-  local.get $22
+  local.get $155
   call $~lib/rt/pure/__release
-  local.get $21
+  local.get $158
   call $~lib/rt/pure/__release
-  local.get $24
+  local.get $162
   call $~lib/rt/pure/__release
-  local.get $23
+  local.get $165
   call $~lib/rt/pure/__release
-  local.get $19
+  local.get $168
   call $~lib/rt/pure/__release
-  local.get $3
+  local.get $172
   call $~lib/rt/pure/__release
-  local.get $18
+  local.get $175
   call $~lib/rt/pure/__release
-  local.get $17
+  local.get $178
   call $~lib/rt/pure/__release
-  local.get $2
+  local.get $182
   call $~lib/rt/pure/__release
-  local.get $16
+  local.get $185
   call $~lib/rt/pure/__release
-  local.get $15
+  local.get $188
   call $~lib/rt/pure/__release
-  local.get $0
+  local.get $192
   call $~lib/rt/pure/__release
-  local.get $14
+  local.get $195
   call $~lib/rt/pure/__release
-  local.get $13
+  local.get $198
   call $~lib/rt/pure/__release
-  local.get $4
+  local.get $202
   call $~lib/rt/pure/__release
-  local.get $12
+  local.get $205
   call $~lib/rt/pure/__release
-  local.get $11
+  local.get $208
   call $~lib/rt/pure/__release
-  local.get $1
+  local.get $212
   call $~lib/rt/pure/__release
-  local.get $10
+  local.get $215
   call $~lib/rt/pure/__release
-  local.get $9
+  local.get $218
   call $~lib/rt/pure/__release
-  local.get $5
+  local.get $222
   call $~lib/rt/pure/__release
-  local.get $8
+  local.get $225
   call $~lib/rt/pure/__release
-  local.get $7
+  local.get $228
   call $~lib/rt/pure/__release
-  local.get $6
+  local.get $232
   call $~lib/rt/pure/__release
-  local.get $27
+  local.get $235
   call $~lib/rt/pure/__release
-  local.get $28
+  local.get $238
   call $~lib/rt/pure/__release
-  local.get $26
+  local.get $242
   call $~lib/rt/pure/__release
-  local.get $30
+  local.get $245
   call $~lib/rt/pure/__release
-  local.get $31
+  local.get $248
   call $~lib/rt/pure/__release
-  local.get $29
+  local.get $252
   call $~lib/rt/pure/__release
-  local.get $33
+  local.get $255
   call $~lib/rt/pure/__release
-  local.get $34
+  local.get $258
   call $~lib/rt/pure/__release
-  local.get $32
+  local.get $262
   call $~lib/rt/pure/__release
-  local.get $36
+  local.get $265
   call $~lib/rt/pure/__release
-  local.get $37
+  local.get $268
   call $~lib/rt/pure/__release
-  local.get $35
+  local.get $272
   call $~lib/rt/pure/__release
-  local.get $39
+  local.get $275
   call $~lib/rt/pure/__release
-  local.get $40
+  local.get $278
   call $~lib/rt/pure/__release
-  local.get $38
+  local.get $282
   call $~lib/rt/pure/__release
-  local.get $42
+  local.get $285
   call $~lib/rt/pure/__release
-  local.get $43
+  local.get $288
   call $~lib/rt/pure/__release
-  local.get $41
+  local.get $297
   call $~lib/rt/pure/__release
-  local.get $44
+  local.get $298
   call $~lib/rt/pure/__release
-  local.get $47
+  local.get $299
   call $~lib/rt/pure/__release
-  local.get $48
+  local.get $300
   call $~lib/rt/pure/__release
-  local.get $49
+  local.get $301
   call $~lib/rt/pure/__release
-  local.get $51
+  local.get $306
   call $~lib/rt/pure/__release
-  local.get $50
+  local.get $308
   call $~lib/rt/pure/__release
-  local.get $54
+  local.get $309
   call $~lib/rt/pure/__release
   global.get $std/array/arr
   i32.const 0
@@ -22706,8 +23694,8 @@
   global.get $std/array/arr
   i32.const 7
   call $~lib/array/Array<i32>#every
-  local.set $54
-  local.get $54
+  local.set $311
+  local.get $311
   i32.const 1
   i32.eq
   i32.eqz
@@ -22722,8 +23710,8 @@
   global.get $std/array/arr
   i32.const 8
   call $~lib/array/Array<i32>#every
-  local.set $54
-  local.get $54
+  local.set $311
+  local.get $311
   i32.const 0
   i32.eq
   i32.eqz
@@ -22738,8 +23726,8 @@
   global.get $std/array/arr
   i32.const 9
   call $~lib/array/Array<i32>#every
-  local.set $54
-  local.get $54
+  local.set $311
+  local.get $311
   i32.const 1
   i32.eq
   i32.eqz
@@ -22767,8 +23755,8 @@
   global.get $std/array/arr
   i32.const 10
   call $~lib/array/Array<i32>#every
-  local.set $54
-  local.get $54
+  local.set $311
+  local.get $311
   i32.const 0
   i32.eq
   i32.eqz
@@ -22795,8 +23783,8 @@
   global.get $std/array/arr
   i32.const 11
   call $~lib/array/Array<i32>#every
-  local.set $54
-  local.get $54
+  local.set $311
+  local.get $311
   i32.const 1
   i32.eq
   i32.eqz
@@ -22832,8 +23820,8 @@
   global.get $std/array/arr
   i32.const 12
   call $~lib/array/Array<i32>#some
-  local.set $54
-  local.get $54
+  local.set $312
+  local.get $312
   i32.const 1
   i32.eq
   i32.eqz
@@ -22848,8 +23836,8 @@
   global.get $std/array/arr
   i32.const 13
   call $~lib/array/Array<i32>#some
-  local.set $54
-  local.get $54
+  local.set $312
+  local.get $312
   i32.const 0
   i32.eq
   i32.eqz
@@ -22864,8 +23852,8 @@
   global.get $std/array/arr
   i32.const 14
   call $~lib/array/Array<i32>#some
-  local.set $54
-  local.get $54
+  local.set $312
+  local.get $312
   i32.const 0
   i32.eq
   i32.eqz
@@ -22893,8 +23881,8 @@
   global.get $std/array/arr
   i32.const 15
   call $~lib/array/Array<i32>#some
-  local.set $54
-  local.get $54
+  local.set $312
+  local.get $312
   i32.const 1
   i32.eq
   i32.eqz
@@ -22921,8 +23909,8 @@
   global.get $std/array/arr
   i32.const 16
   call $~lib/array/Array<i32>#some
-  local.set $54
-  local.get $54
+  local.set $312
+  local.get $312
   i32.const 0
   i32.eq
   i32.eqz
@@ -23086,21 +24074,21 @@
    unreachable
   end
   i32.const 0
-  local.set $54
+  local.set $313
   loop $for-loop|0
-   local.get $54
+   local.get $313
    i32.const 100
    i32.lt_s
-   local.set $50
-   local.get $50
+   local.set $314
+   local.get $314
    if
     global.get $std/array/arr
     call $~lib/array/Array<i32>#pop
     drop
-    local.get $54
+    local.get $313
     i32.const 1
     i32.add
-    local.set $54
+    local.set $313
     br $for-loop|0
    end
   end
@@ -23123,8 +24111,8 @@
   global.get $std/array/arr
   i32.const 22
   call $~lib/array/Array<i32>#map<f32>
-  local.set $54
-  local.get $54
+  local.set $315
+  local.get $315
   call $~lib/array/Array<f32>#get:length
   i32.const 4
   i32.eq
@@ -23137,7 +24125,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $54
+  local.get $315
   i32.const 0
   call $~lib/array/Array<f32>#__get
   global.get $std/array/arr
@@ -23254,13 +24242,13 @@
   i32.const 3
   call $~lib/array/Array<i32>#push
   drop
-  local.get $54
+  local.get $315
   call $~lib/rt/pure/__release
   global.get $std/array/arr
   i32.const 26
   call $~lib/array/Array<i32>#filter
-  local.set $54
-  local.get $54
+  local.set $316
+  local.get $316
   call $~lib/array/Array<i32>#get:length
   i32.const 2
   i32.eq
@@ -23373,7 +24361,7 @@
   i32.const 3
   call $~lib/array/Array<i32>#push
   drop
-  local.get $54
+  local.get $316
   call $~lib/rt/pure/__release
   global.get $std/array/arr
   i32.const 30
@@ -23413,8 +24401,8 @@
   i32.const 32
   i32.const 0
   call $~lib/array/Array<i32>#reduce<bool>
-  local.set $54
-  local.get $54
+  local.set $317
+  local.get $317
   i32.const 0
   i32.ne
   i32.const 1
@@ -23432,8 +24420,8 @@
   i32.const 33
   i32.const 0
   call $~lib/array/Array<i32>#reduce<bool>
-  local.set $54
-  local.get $54
+  local.set $317
+  local.get $317
   i32.const 0
   i32.ne
   i32.const 0
@@ -23582,8 +24570,8 @@
   i32.const 39
   i32.const 0
   call $~lib/array/Array<i32>#reduceRight<bool>
-  local.set $54
-  local.get $54
+  local.set $318
+  local.get $318
   i32.const 0
   i32.ne
   i32.const 1
@@ -23601,8 +24589,8 @@
   i32.const 40
   i32.const 0
   call $~lib/array/Array<i32>#reduceRight<bool>
-  local.set $54
-  local.get $54
+  local.set $318
+  local.get $318
   i32.const 0
   i32.ne
   i32.const 0
@@ -23730,21 +24718,21 @@
   i32.const 4272
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $50
-  local.get $50
+  local.set $321
+  local.get $321
   i32.const 0
   global.set $~argumentsLength
   i32.const 0
   call $~lib/array/Array<f32>#sort@varargs
   call $~lib/rt/pure/__release
-  local.get $50
+  local.get $321
   i32.const 8
   i32.const 2
   i32.const 9
   i32.const 4320
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $51
+  local.tee $324
   i32.const 0
   call $std/array/isArraysEqual<f32>
   i32.eqz
@@ -23762,21 +24750,21 @@
   i32.const 4368
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $49
-  local.get $49
+  local.set $327
+  local.get $327
   i32.const 0
   global.set $~argumentsLength
   i32.const 0
   call $~lib/array/Array<f64>#sort@varargs
   call $~lib/rt/pure/__release
-  local.get $49
+  local.get $327
   i32.const 8
   i32.const 3
   i32.const 10
   i32.const 4448
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $48
+  local.tee $330
   i32.const 0
   call $std/array/isArraysEqual<f64>
   i32.eqz
@@ -23794,21 +24782,21 @@
   i32.const 4528
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $47
-  local.get $47
+  local.set $333
+  local.get $333
   i32.const 0
   global.set $~argumentsLength
   i32.const 0
   call $~lib/array/Array<i32>#sort@varargs
   call $~lib/rt/pure/__release
-  local.get $47
+  local.get $333
   i32.const 5
   i32.const 2
   i32.const 3
   i32.const 4576
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $44
+  local.tee $336
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -23826,21 +24814,21 @@
   i32.const 4624
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $41
-  local.get $41
+  local.set $339
+  local.get $339
   i32.const 0
   global.set $~argumentsLength
   i32.const 0
   call $~lib/array/Array<u32>#sort@varargs
   call $~lib/rt/pure/__release
-  local.get $41
+  local.get $339
   i32.const 5
   i32.const 2
   i32.const 7
   i32.const 4672
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $43
+  local.tee $342
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -23858,62 +24846,62 @@
   i32.const 4720
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $42
+  local.set $345
   i32.const 1
   i32.const 2
   i32.const 3
   i32.const 4736
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $38
+  local.set $348
   i32.const 2
   i32.const 2
   i32.const 3
   i32.const 4768
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $40
+  local.set $351
   i32.const 4
   i32.const 2
   i32.const 3
   i32.const 4800
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $39
+  local.set $354
   i32.const 4
   i32.const 2
   i32.const 3
   i32.const 4832
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $35
+  local.set $357
   i32.const 64
   call $std/array/createReverseOrderedArray
-  local.set $54
+  local.set $358
   i32.const 128
   call $std/array/createReverseOrderedArray
-  local.set $37
+  local.set $359
   i32.const 1024
   call $std/array/createReverseOrderedArray
-  local.set $36
+  local.set $360
   i32.const 10000
   call $std/array/createReverseOrderedArray
-  local.set $32
+  local.set $361
   i32.const 512
   call $std/array/createRandomOrderedArray
-  local.set $34
-  local.get $42
+  local.set $362
+  local.get $345
   call $std/array/assertSortedDefault<i32>
-  local.get $38
+  local.get $348
   call $std/array/assertSortedDefault<i32>
-  local.get $38
+  local.get $348
   i32.const 1
   i32.const 2
   i32.const 3
   i32.const 4864
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $29
+  local.tee $365
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -23925,16 +24913,16 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $40
+  local.get $351
   call $std/array/assertSortedDefault<i32>
-  local.get $40
+  local.get $351
   i32.const 2
   i32.const 2
   i32.const 3
   i32.const 4896
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $31
+  local.tee $368
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -23946,10 +24934,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $39
+  local.get $354
   call $std/array/assertSortedDefault<i32>
-  local.get $39
-  local.get $35
+  local.get $354
+  local.get $357
   i32.const 0
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -23961,10 +24949,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $54
+  local.get $358
   call $std/array/assertSortedDefault<i32>
-  local.get $54
-  local.get $35
+  local.get $358
+  local.get $357
   i32.const 4
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -23976,10 +24964,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $37
+  local.get $359
   call $std/array/assertSortedDefault<i32>
-  local.get $37
-  local.get $35
+  local.get $359
+  local.get $357
   i32.const 4
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -23991,10 +24979,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $36
+  local.get $360
   call $std/array/assertSortedDefault<i32>
-  local.get $36
-  local.get $35
+  local.get $360
+  local.get $357
   i32.const 4
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -24006,10 +24994,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $32
+  local.get $361
   call $std/array/assertSortedDefault<i32>
-  local.get $32
-  local.get $35
+  local.get $361
+  local.get $357
   i32.const 4
   call $std/array/isArraysEqual<i32>
   i32.eqz
@@ -24021,85 +25009,85 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $34
+  local.get $362
   call $std/array/assertSortedDefault<i32>
-  local.get $50
+  local.get $321
   call $~lib/rt/pure/__release
-  local.get $51
+  local.get $324
   call $~lib/rt/pure/__release
-  local.get $49
+  local.get $327
   call $~lib/rt/pure/__release
-  local.get $48
+  local.get $330
   call $~lib/rt/pure/__release
-  local.get $47
+  local.get $333
   call $~lib/rt/pure/__release
-  local.get $44
+  local.get $336
   call $~lib/rt/pure/__release
-  local.get $41
+  local.get $339
   call $~lib/rt/pure/__release
-  local.get $43
+  local.get $342
   call $~lib/rt/pure/__release
-  local.get $42
+  local.get $345
   call $~lib/rt/pure/__release
-  local.get $38
+  local.get $348
   call $~lib/rt/pure/__release
-  local.get $40
+  local.get $351
   call $~lib/rt/pure/__release
-  local.get $39
+  local.get $354
   call $~lib/rt/pure/__release
-  local.get $35
+  local.get $357
   call $~lib/rt/pure/__release
-  local.get $54
+  local.get $358
   call $~lib/rt/pure/__release
-  local.get $37
+  local.get $359
   call $~lib/rt/pure/__release
-  local.get $36
+  local.get $360
   call $~lib/rt/pure/__release
-  local.get $32
+  local.get $361
   call $~lib/rt/pure/__release
-  local.get $34
+  local.get $362
   call $~lib/rt/pure/__release
-  local.get $29
+  local.get $365
   call $~lib/rt/pure/__release
-  local.get $31
+  local.get $368
   call $~lib/rt/pure/__release
   i32.const 64
   call $std/array/createRandomOrderedArray
-  local.set $31
+  local.set $369
   i32.const 257
   call $std/array/createRandomOrderedArray
-  local.set $29
-  local.get $31
+  local.set $370
+  local.get $369
   i32.const 49
   call $std/array/assertSorted<i32>
-  local.get $31
+  local.get $369
   i32.const 50
   call $std/array/assertSorted<i32>
-  local.get $29
+  local.get $370
   i32.const 51
   call $std/array/assertSorted<i32>
-  local.get $29
+  local.get $370
   i32.const 52
   call $std/array/assertSorted<i32>
-  local.get $31
+  local.get $369
   call $~lib/rt/pure/__release
-  local.get $29
+  local.get $370
   call $~lib/rt/pure/__release
   i32.const 2
   call $std/array/createReverseOrderedNestedArray
-  local.set $29
-  local.get $29
+  local.set $371
+  local.get $371
   i32.const 53
   call $std/array/assertSorted<~lib/array/Array<i32>>
-  local.get $29
+  local.get $371
   call $~lib/rt/pure/__release
   i32.const 512
   call $std/array/createReverseOrderedElementsArray
-  local.set $29
-  local.get $29
+  local.set $372
+  local.get $372
   i32.const 54
   call $std/array/assertSorted<std/array/Proxy<i32>>
-  local.get $29
+  local.get $372
   call $~lib/rt/pure/__release
   i32.const 7
   i32.const 2
@@ -24107,21 +25095,21 @@
   i32.const 5072
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $31
+  local.set $375
   i32.const 7
   i32.const 2
   i32.const 15
   i32.const 5120
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $34
-  local.get $31
+  local.set $378
+  local.get $375
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
   call $std/array/assertSorted<~lib/string/String | null>@varargs
-  local.get $31
-  local.get $34
+  local.get $375
+  local.get $378
   i32.const 0
   call $std/array/isArraysEqual<~lib/string/String | null>
   i32.eqz
@@ -24135,17 +25123,17 @@
   end
   i32.const 400
   call $std/array/createRandomStringArray
-  local.set $29
-  local.get $29
+  local.set $379
+  local.get $379
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
   call $std/array/assertSorted<~lib/string/String>@varargs
-  local.get $31
+  local.get $375
   call $~lib/rt/pure/__release
-  local.get $34
+  local.get $378
   call $~lib/rt/pure/__release
-  local.get $29
+  local.get $379
   call $~lib/rt/pure/__release
   i32.const 2
   i32.const 0
@@ -24153,10 +25141,10 @@
   i32.const 5200
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $34
+  local.tee $382
   i32.const 5296
   call $~lib/array/Array<bool>#join
-  local.tee $29
+  local.tee $383
   i32.const 5328
   call $~lib/string/String.__eq
   i32.eqz
@@ -24174,10 +25162,10 @@
   i32.const 5376
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $32
+  local.tee $386
   i32.const 5056
   call $~lib/array/Array<i32>#join
-  local.tee $31
+  local.tee $387
   i32.const 5840
   call $~lib/string/String.__eq
   i32.eqz
@@ -24195,10 +25183,10 @@
   i32.const 5872
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $37
+  local.tee $390
   i32.const 5904
   call $~lib/array/Array<u32>#join
-  local.tee $36
+  local.tee $391
   i32.const 5840
   call $~lib/string/String.__eq
   i32.eqz
@@ -24216,10 +25204,10 @@
   i32.const 5936
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $35
+  local.tee $394
   i32.const 5968
   call $~lib/array/Array<i32>#join
-  local.tee $54
+  local.tee $395
   i32.const 6000
   call $~lib/string/String.__eq
   i32.eqz
@@ -24237,10 +25225,10 @@
   i32.const 6064
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $40
+  local.tee $398
   i32.const 6128
   call $~lib/array/Array<f64>#join
-  local.tee $39
+  local.tee $399
   i32.const 7216
   call $~lib/string/String.__eq
   i32.eqz
@@ -24258,10 +25246,10 @@
   i32.const 7344
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $42
+  local.tee $402
   i32.const 5056
   call $~lib/array/Array<~lib/string/String | null>#join
-  local.tee $38
+  local.tee $403
   i32.const 7312
   call $~lib/string/String.__eq
   i32.eqz
@@ -24279,30 +25267,30 @@
   i32.const 0
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $43
-  local.get $43
+  local.set $404
+  local.get $404
   i32.load offset=4
-  local.set $41
-  local.get $41
+  local.set $405
+  local.get $405
   i32.const 0
   i32.const 0
   call $std/array/Ref#constructor
   i32.store
-  local.get $41
+  local.get $405
   i32.const 0
   call $~lib/rt/pure/__retain
   i32.store offset=4
-  local.get $41
+  local.get $405
   i32.const 0
   i32.const 0
   call $std/array/Ref#constructor
   i32.store offset=8
-  local.get $43
-  local.set $41
-  local.get $41
+  local.get $404
+  local.set $406
+  local.get $406
   i32.const 5296
   call $~lib/array/Array<std/array/Ref | null>#join
-  local.tee $43
+  local.tee $407
   i32.const 7424
   call $~lib/string/String.__eq
   i32.eqz
@@ -24320,26 +25308,26 @@
   i32.const 0
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $44
-  local.get $44
+  local.set $408
+  local.get $408
   i32.load offset=4
-  local.set $47
-  local.get $47
+  local.set $409
+  local.get $409
   i32.const 0
   i32.const 0
   call $std/array/Ref#constructor
   i32.store
-  local.get $47
+  local.get $409
   i32.const 0
   i32.const 0
   call $std/array/Ref#constructor
   i32.store offset=4
-  local.get $44
-  local.set $47
-  local.get $47
+  local.get $408
+  local.set $410
+  local.get $410
   i32.const 5296
   call $~lib/array/Array<std/array/Ref>#join
-  local.tee $44
+  local.tee $411
   i32.const 7504
   call $~lib/string/String.__eq
   i32.eqz
@@ -24351,37 +25339,37 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $34
+  local.get $382
   call $~lib/rt/pure/__release
-  local.get $29
+  local.get $383
   call $~lib/rt/pure/__release
-  local.get $32
+  local.get $386
   call $~lib/rt/pure/__release
-  local.get $31
+  local.get $387
   call $~lib/rt/pure/__release
-  local.get $37
+  local.get $390
   call $~lib/rt/pure/__release
-  local.get $36
+  local.get $391
   call $~lib/rt/pure/__release
-  local.get $35
+  local.get $394
   call $~lib/rt/pure/__release
-  local.get $54
+  local.get $395
   call $~lib/rt/pure/__release
-  local.get $40
+  local.get $398
   call $~lib/rt/pure/__release
-  local.get $39
+  local.get $399
   call $~lib/rt/pure/__release
-  local.get $42
+  local.get $402
   call $~lib/rt/pure/__release
-  local.get $38
+  local.get $403
   call $~lib/rt/pure/__release
-  local.get $41
+  local.get $406
   call $~lib/rt/pure/__release
-  local.get $43
+  local.get $407
   call $~lib/rt/pure/__release
-  local.get $47
+  local.get $410
   call $~lib/rt/pure/__release
-  local.get $44
+  local.get $411
   call $~lib/rt/pure/__release
   i32.const 0
   i32.const 2
@@ -24389,31 +25377,31 @@
   i32.const 7584
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $47
+  local.set $414
   i32.const 1
   i32.const 2
   i32.const 3
   i32.const 7600
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $43
+  local.set $417
   i32.const 2
   i32.const 2
   i32.const 3
   i32.const 7632
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $41
+  local.set $420
   i32.const 4
   i32.const 2
   i32.const 3
   i32.const 7664
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $38
-  local.get $47
+  local.set $423
+  local.get $414
   call $~lib/array/Array<i32>#toString
-  local.tee $44
+  local.tee $424
   i32.const 5056
   call $~lib/string/String.__eq
   i32.eqz
@@ -24425,9 +25413,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $43
+  local.get $417
   call $~lib/array/Array<i32>#toString
-  local.tee $42
+  local.tee $425
   i32.const 7312
   call $~lib/string/String.__eq
   i32.eqz
@@ -24439,9 +25427,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $41
+  local.get $420
   call $~lib/array/Array<i32>#toString
-  local.tee $39
+  local.tee $426
   i32.const 7696
   call $~lib/string/String.__eq
   i32.eqz
@@ -24453,9 +25441,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $38
+  local.get $423
   call $~lib/array/Array<i32>#toString
-  local.tee $40
+  local.tee $427
   i32.const 7728
   call $~lib/string/String.__eq
   i32.eqz
@@ -24473,9 +25461,9 @@
   i32.const 7760
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $35
+  local.tee $430
   call $~lib/array/Array<i8>#toString
-  local.tee $54
+  local.tee $431
   i32.const 7792
   call $~lib/string/String.__eq
   i32.eqz
@@ -24493,9 +25481,9 @@
   i32.const 7824
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $37
+  local.tee $434
   call $~lib/array/Array<u16>#toString
-  local.tee $36
+  local.tee $435
   i32.const 7856
   call $~lib/string/String.__eq
   i32.eqz
@@ -24513,9 +25501,9 @@
   i32.const 7904
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $32
+  local.tee $438
   call $~lib/array/Array<u64>#toString
-  local.tee $31
+  local.tee $439
   i32.const 7952
   call $~lib/string/String.__eq
   i32.eqz
@@ -24533,9 +25521,9 @@
   i32.const 8016
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $34
+  local.tee $442
   call $~lib/array/Array<i64>#toString
-  local.tee $29
+  local.tee $443
   i32.const 8064
   call $~lib/string/String.__eq
   i32.eqz
@@ -24553,10 +25541,10 @@
   i32.const 8176
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $49
-  local.get $49
+  local.set $446
+  local.get $446
   call $~lib/array/Array<~lib/string/String | null>#toString
-  local.tee $48
+  local.tee $447
   i32.const 8224
   call $~lib/string/String.__eq
   i32.eqz
@@ -24574,9 +25562,9 @@
   i32.const 8336
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $50
+  local.tee $450
   call $~lib/array/Array<~lib/string/String | null>#toString
-  local.tee $51
+  local.tee $451
   i32.const 8368
   call $~lib/string/String.__eq
   i32.eqz
@@ -24594,11 +25582,11 @@
   i32.const 0
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $33
-  local.get $33
+  local.set $452
+  local.get $452
   i32.load offset=4
-  local.set $30
-  local.get $30
+  local.set $453
+  local.get $453
   i32.const 2
   i32.const 2
   i32.const 3
@@ -24606,7 +25594,7 @@
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
   i32.store
-  local.get $30
+  local.get $453
   i32.const 2
   i32.const 2
   i32.const 3
@@ -24614,11 +25602,11 @@
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
   i32.store offset=4
-  local.get $33
-  local.set $56
-  local.get $56
+  local.get $452
+  local.set $458
+  local.get $458
   call $~lib/array/Array<~lib/array/Array<i32>>#toString
-  local.tee $30
+  local.tee $459
   i32.const 8464
   call $~lib/string/String.__eq
   i32.eqz
@@ -24636,11 +25624,11 @@
   i32.const 0
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $33
-  local.get $33
+  local.set $460
+  local.get $460
   i32.load offset=4
-  local.set $26
-  local.get $26
+  local.set $461
+  local.get $461
   i32.const 2
   i32.const 0
   i32.const 6
@@ -24648,7 +25636,7 @@
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
   i32.store
-  local.get $26
+  local.get $461
   i32.const 2
   i32.const 0
   i32.const 6
@@ -24656,11 +25644,11 @@
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
   i32.store offset=4
-  local.get $33
-  local.set $57
-  local.get $57
+  local.get $460
+  local.set $466
+  local.get $466
   call $~lib/array/Array<~lib/array/Array<u8>>#toString
-  local.tee $26
+  local.tee $467
   i32.const 8464
   call $~lib/string/String.__eq
   i32.eqz
@@ -24678,22 +25666,22 @@
   i32.const 0
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $33
-  local.get $33
+  local.set $468
+  local.get $468
   i32.load offset=4
-  local.set $28
-  local.get $28
+  local.set $469
+  local.get $469
   i32.const 1
   i32.const 2
   i32.const 23
   i32.const 0
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $27
-  local.get $27
+  local.set $470
+  local.get $470
   i32.load offset=4
-  local.set $6
-  local.get $6
+  local.set $471
+  local.get $471
   i32.const 1
   i32.const 2
   i32.const 7
@@ -24701,13 +25689,13 @@
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
   i32.store
-  local.get $27
+  local.get $470
   i32.store
-  local.get $33
-  local.set $58
-  local.get $58
+  local.get $468
+  local.set $474
+  local.get $474
   call $~lib/array/Array<~lib/array/Array<~lib/array/Array<u32>>>#toString
-  local.tee $28
+  local.tee $475
   i32.const 7312
   call $~lib/string/String.__eq
   i32.eqz
@@ -24719,51 +25707,51 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $47
+  local.get $414
   call $~lib/rt/pure/__release
-  local.get $43
+  local.get $417
   call $~lib/rt/pure/__release
-  local.get $41
+  local.get $420
   call $~lib/rt/pure/__release
-  local.get $38
+  local.get $423
   call $~lib/rt/pure/__release
-  local.get $44
+  local.get $424
   call $~lib/rt/pure/__release
-  local.get $42
+  local.get $425
   call $~lib/rt/pure/__release
-  local.get $39
+  local.get $426
   call $~lib/rt/pure/__release
-  local.get $40
+  local.get $427
   call $~lib/rt/pure/__release
-  local.get $35
+  local.get $430
   call $~lib/rt/pure/__release
-  local.get $54
+  local.get $431
   call $~lib/rt/pure/__release
-  local.get $37
+  local.get $434
   call $~lib/rt/pure/__release
-  local.get $36
+  local.get $435
   call $~lib/rt/pure/__release
-  local.get $32
+  local.get $438
   call $~lib/rt/pure/__release
-  local.get $31
+  local.get $439
   call $~lib/rt/pure/__release
-  local.get $34
+  local.get $442
   call $~lib/rt/pure/__release
-  local.get $29
+  local.get $443
   call $~lib/rt/pure/__release
-  local.get $49
+  local.get $446
   call $~lib/rt/pure/__release
-  local.get $48
+  local.get $447
   call $~lib/rt/pure/__release
-  local.get $50
+  local.get $450
   call $~lib/rt/pure/__release
-  local.get $51
+  local.get $451
   call $~lib/rt/pure/__release
-  local.get $30
+  local.get $459
   call $~lib/rt/pure/__release
-  local.get $26
+  local.get $467
   call $~lib/rt/pure/__release
-  local.get $28
+  local.get $475
   call $~lib/rt/pure/__release
   global.get $std/array/arr
   call $~lib/rt/pure/__release
@@ -24773,11 +25761,11 @@
   i32.const 0
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $28
-  local.get $28
+  local.set $476
+  local.get $476
   i32.load offset=4
-  local.set $26
-  local.get $26
+  local.set $477
+  local.get $477
   i32.const 1
   i32.const 2
   i32.const 3
@@ -24785,7 +25773,7 @@
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
   i32.store
-  local.get $26
+  local.get $477
   i32.const 3
   i32.const 2
   i32.const 3
@@ -24793,7 +25781,7 @@
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
   i32.store offset=4
-  local.get $26
+  local.get $477
   i32.const 3
   i32.const 2
   i32.const 3
@@ -24801,7 +25789,7 @@
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
   i32.store offset=8
-  local.get $26
+  local.get $477
   i32.const 3
   i32.const 2
   i32.const 3
@@ -24809,12 +25797,12 @@
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
   i32.store offset=12
-  local.get $28
-  local.set $59
-  local.get $59
+  local.get $476
+  local.set $486
+  local.get $486
   call $~lib/array/Array<~lib/array/Array<i32>>#flat
-  local.set $60
-  local.get $60
+  local.set $487
+  local.get $487
   call $~lib/array/Array<i32>#get:length
   i32.const 10
   i32.eq
@@ -24828,18 +25816,18 @@
    unreachable
   end
   i32.const 0
-  local.set $26
+  local.set $488
   loop $for-loop|1
-   local.get $26
+   local.get $488
    i32.const 10
    i32.lt_s
-   local.set $28
-   local.get $28
+   local.set $489
+   local.get $489
    if
-    local.get $60
-    local.get $26
+    local.get $487
+    local.get $488
     call $~lib/array/Array<i32>#__get
-    local.get $26
+    local.get $488
     i32.eq
     i32.eqz
     if
@@ -24850,10 +25838,10 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $26
+    local.get $488
     i32.const 1
     i32.add
-    local.set $26
+    local.set $488
     br $for-loop|1
    end
   end
@@ -24863,11 +25851,11 @@
   i32.const 0
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $26
-  local.get $26
+  local.set $490
+  local.get $490
   i32.load offset=4
-  local.set $28
-  local.get $28
+  local.set $491
+  local.get $491
   i32.const 1
   i32.const 2
   i32.const 15
@@ -24875,7 +25863,7 @@
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
   i32.store
-  local.get $28
+  local.get $491
   i32.const 3
   i32.const 2
   i32.const 15
@@ -24883,7 +25871,7 @@
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
   i32.store offset=4
-  local.get $28
+  local.get $491
   i32.const 3
   i32.const 2
   i32.const 15
@@ -24891,7 +25879,7 @@
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
   i32.store offset=8
-  local.get $28
+  local.get $491
   i32.const 1
   i32.const 2
   i32.const 15
@@ -24899,19 +25887,19 @@
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
   i32.store offset=12
-  local.get $26
-  local.set $61
-  local.get $61
+  local.get $490
+  local.set $500
+  local.get $500
   call $~lib/array/Array<~lib/array/Array<~lib/string/String | null>>#flat
-  local.set $62
+  local.set $501
   i32.const 8
   i32.const 2
   i32.const 15
   i32.const 9072
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $63
-  local.get $62
+  local.set $504
+  local.get $501
   call $~lib/array/Array<~lib/string/String | null>#get:length
   i32.const 8
   i32.eq
@@ -24925,23 +25913,23 @@
    unreachable
   end
   i32.const 0
-  local.set $26
+  local.set $505
   loop $for-loop|2
-   local.get $26
-   local.get $63
+   local.get $505
+   local.get $504
    call $~lib/array/Array<~lib/string/String | null>#get:length
    i32.lt_s
-   local.set $28
-   local.get $28
+   local.set $506
+   local.get $506
    if
-    local.get $62
-    local.get $26
+    local.get $501
+    local.get $505
     call $~lib/array/Array<~lib/string/String | null>#__get
-    local.tee $30
-    local.get $63
-    local.get $26
+    local.tee $507
+    local.get $504
+    local.get $505
     call $~lib/array/Array<~lib/string/String | null>#__get
-    local.tee $51
+    local.tee $508
     call $~lib/string/String.__eq
     i32.eqz
     if
@@ -24952,14 +25940,14 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $30
+    local.get $507
     call $~lib/rt/pure/__release
-    local.get $51
+    local.get $508
     call $~lib/rt/pure/__release
-    local.get $26
+    local.get $505
     i32.const 1
     i32.add
-    local.set $26
+    local.set $505
     br $for-loop|2
    end
   end
@@ -24969,11 +25957,11 @@
   i32.const 0
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $26
-  local.get $26
+  local.set $509
+  local.get $509
   i32.load offset=4
-  local.set $28
-  local.get $28
+  local.set $510
+  local.get $510
   i32.const 0
   i32.const 2
   i32.const 3
@@ -24981,7 +25969,7 @@
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
   i32.store
-  local.get $28
+  local.get $510
   i32.const 0
   i32.const 2
   i32.const 3
@@ -24989,11 +25977,11 @@
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
   i32.store offset=4
-  local.get $26
-  local.set $28
-  local.get $28
+  local.get $509
+  local.set $515
+  local.get $515
   call $~lib/array/Array<~lib/array/Array<i32>>#flat
-  local.tee $26
+  local.tee $516
   call $~lib/array/Array<i32>#get:length
   i32.const 0
   i32.eq
@@ -25006,33 +25994,33 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $28
+  local.get $515
   call $~lib/rt/pure/__release
-  local.get $26
+  local.get $516
   call $~lib/rt/pure/__release
-  local.get $45
+  local.get $291
   call $~lib/rt/pure/__release
-  local.get $46
+  local.get $292
   call $~lib/rt/pure/__release
-  local.get $52
+  local.get $304
   call $~lib/rt/pure/__release
-  local.get $53
+  local.get $305
   call $~lib/rt/pure/__release
-  local.get $56
+  local.get $458
   call $~lib/rt/pure/__release
-  local.get $57
+  local.get $466
   call $~lib/rt/pure/__release
-  local.get $58
+  local.get $474
   call $~lib/rt/pure/__release
-  local.get $59
+  local.get $486
   call $~lib/rt/pure/__release
-  local.get $60
+  local.get $487
   call $~lib/rt/pure/__release
-  local.get $61
+  local.get $500
   call $~lib/rt/pure/__release
-  local.get $62
+  local.get $501
   call $~lib/rt/pure/__release
-  local.get $63
+  local.get $504
   call $~lib/rt/pure/__release
  )
  (func $~start

--- a/tests/compiler/std/arraybuffer.untouched.wat
+++ b/tests/compiler/std/arraybuffer.untouched.wat
@@ -56,6 +56,15 @@
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
   local.get $1
   i32.load
   local.set $2
@@ -192,59 +201,59 @@
   i32.eq
   if
    local.get $0
-   local.set $11
+   local.set $14
    local.get $4
-   local.set $10
+   local.set $13
    local.get $5
-   local.set $9
+   local.set $12
    local.get $7
-   local.set $8
-   local.get $11
-   local.get $10
+   local.set $11
+   local.get $14
+   local.get $13
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $12
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
+   local.get $11
    i32.store offset=96
    local.get $7
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $16
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $15
+    local.get $16
+    local.get $15
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $17
     local.get $0
-    local.set $8
+    local.set $20
     local.get $4
-    local.set $11
-    local.get $9
+    local.set $19
+    local.get $17
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
-    local.set $10
-    local.get $8
-    local.get $11
+    local.tee $17
+    local.set $18
+    local.get $20
+    local.get $19
     i32.const 2
     i32.shl
     i32.add
-    local.get $10
+    local.get $18
     i32.store offset=4
-    local.get $9
+    local.get $17
     i32.eqz
     if
      local.get $0
@@ -274,6 +283,20 @@
   (local $11 i32)
   (local $12 i32)
   (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local $22 i32)
+  (local $23 i32)
+  (local $24 i32)
+  (local $25 i32)
+  (local $26 i32)
+  (local $27 i32)
   i32.const 1
   drop
   local.get $1
@@ -336,8 +359,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $3
+   local.set $6
+   local.get $6
    i32.const 1073741808
    i32.lt_u
    if
@@ -348,16 +371,16 @@
     local.get $2
     i32.const 3
     i32.and
-    local.get $3
+    local.get $6
     i32.or
     local.tee $2
     i32.store
     local.get $1
-    local.set $6
-    local.get $6
+    local.set $7
+    local.get $7
     i32.const 16
     i32.add
-    local.get $6
+    local.get $7
     i32.load
     i32.const 3
     i32.const -1
@@ -375,18 +398,18 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $8
+   local.get $8
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
+   local.set $9
+   local.get $9
    i32.load
-   local.set $3
+   local.set $10
    i32.const 1
    drop
-   local.get $3
+   local.get $10
    i32.const 1
    i32.and
    i32.eqz
@@ -398,7 +421,7 @@
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $3
+   local.get $10
    i32.const 3
    i32.const -1
    i32.xor
@@ -411,23 +434,23 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $7
+   local.set $11
+   local.get $11
    i32.const 1073741808
    i32.lt_u
    if
     local.get $0
-    local.get $6
+    local.get $9
     call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
+    local.get $9
+    local.get $10
     i32.const 3
     i32.and
-    local.get $7
+    local.get $11
     i32.or
     local.tee $2
     i32.store
-    local.get $6
+    local.get $9
     local.set $1
    end
   end
@@ -441,14 +464,14 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $12
   i32.const 1
   drop
-  local.get $8
+  local.get $12
   i32.const 16
   i32.ge_u
   if (result i32)
-   local.get $8
+   local.get $12
    i32.const 1073741808
    i32.lt_u
   else
@@ -468,7 +491,7 @@
   local.get $1
   i32.const 16
   i32.add
-  local.get $8
+  local.get $12
   i32.add
   local.get $4
   i32.eq
@@ -486,24 +509,24 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $12
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $13
+   local.get $12
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $14
   else
    i32.const 31
-   local.get $8
+   local.get $12
    i32.clz
    i32.sub
-   local.set $9
-   local.get $8
-   local.get $9
+   local.set $13
+   local.get $12
+   local.get $13
    i32.const 4
    i32.sub
    i32.shr_u
@@ -511,21 +534,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $14
+   local.get $13
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $13
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $13
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $14
    i32.const 16
    i32.lt_u
   else
@@ -541,86 +564,86 @@
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
-  local.set $6
-  local.get $7
-  local.get $3
+  local.set $17
+  local.get $13
+  local.set $16
+  local.get $14
+  local.set $15
+  local.get $17
+  local.get $16
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $15
   i32.add
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=96
-  local.set $11
+  local.set $18
   local.get $1
   i32.const 0
   i32.store offset=16
   local.get $1
-  local.get $11
+  local.get $18
   i32.store offset=20
-  local.get $11
+  local.get $18
   if
-   local.get $11
+   local.get $18
    local.get $1
    i32.store offset=16
   end
   local.get $0
-  local.set $12
-  local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
+  local.set $22
+  local.get $13
+  local.set $21
+  local.get $14
+  local.set $20
   local.get $1
-  local.set $6
-  local.get $12
-  local.get $7
+  local.set $19
+  local.get $22
+  local.get $21
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $20
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $19
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $13
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.set $13
-  local.get $9
-  local.set $12
+  local.set $27
+  local.get $13
+  local.set $26
   local.get $0
-  local.set $3
-  local.get $9
-  local.set $6
-  local.get $3
-  local.get $6
+  local.set $24
+  local.get $13
+  local.set $23
+  local.get $24
+  local.get $23
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $14
   i32.shl
   i32.or
-  local.set $7
-  local.get $13
-  local.get $12
+  local.set $25
+  local.get $27
+  local.get $26
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $25
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -631,6 +654,7 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
   i32.const 1
   drop
   local.get $1
@@ -770,11 +794,11 @@
   i32.or
   i32.store
   local.get $0
-  local.set $9
+  local.set $10
   local.get $4
-  local.set $3
+  local.set $9
+  local.get $10
   local.get $9
-  local.get $3
   i32.store offset=1568
   local.get $0
   local.get $8
@@ -794,6 +818,12 @@
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
   global.get $~lib/rt/tlsf/ROOT
   local.set $0
   local.get $0
@@ -850,66 +880,66 @@
    local.get $4
    i32.store offset=1568
    i32.const 0
-   local.set $5
+   local.set $6
    loop $for-loop|0
-    local.get $5
+    local.get $6
     i32.const 23
     i32.lt_u
-    local.set $4
-    local.get $4
+    local.set $7
+    local.get $7
     if
      local.get $0
-     local.set $8
-     local.get $5
-     local.set $7
+     local.set $10
+     local.get $6
+     local.set $9
      i32.const 0
-     local.set $6
-     local.get $8
-     local.get $7
+     local.set $8
+     local.get $10
+     local.get $9
      i32.const 2
      i32.shl
      i32.add
-     local.get $6
+     local.get $8
      i32.store offset=4
      i32.const 0
-     local.set $8
+     local.set $11
      loop $for-loop|1
-      local.get $8
+      local.get $11
       i32.const 16
       i32.lt_u
-      local.set $7
-      local.get $7
+      local.set $12
+      local.get $12
       if
        local.get $0
-       local.set $11
-       local.get $5
-       local.set $10
-       local.get $8
-       local.set $9
-       i32.const 0
-       local.set $6
+       local.set $16
+       local.get $6
+       local.set $15
        local.get $11
-       local.get $10
+       local.set $14
+       i32.const 0
+       local.set $13
+       local.get $16
+       local.get $15
        i32.const 4
        i32.shl
-       local.get $9
+       local.get $14
        i32.add
        i32.const 2
        i32.shl
        i32.add
-       local.get $6
+       local.get $13
        i32.store offset=96
-       local.get $8
+       local.get $11
        i32.const 1
        i32.add
-       local.set $8
+       local.set $11
        br $for-loop|1
       end
      end
-     local.get $5
+     local.get $6
      i32.const 1
      i32.add
-     local.set $5
+     local.set $6
      br $for-loop|0
     end
    end
@@ -922,11 +952,11 @@
    i32.const -1
    i32.xor
    i32.and
-   local.set $5
+   local.set $17
    i32.const 0
    drop
    local.get $0
-   local.get $5
+   local.get $17
    memory.size
    i32.const 16
    i32.shl
@@ -975,6 +1005,14 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
   local.get $1
   i32.const 256
   i32.lt_u
@@ -1048,11 +1086,11 @@
    unreachable
   end
   local.get $0
-  local.set $5
+  local.set $6
   local.get $2
-  local.set $4
+  local.set $5
+  local.get $6
   local.get $5
-  local.get $4
   i32.const 2
   i32.shl
   i32.add
@@ -1063,10 +1101,10 @@
   local.get $3
   i32.shl
   i32.and
-  local.set $6
-  i32.const 0
   local.set $7
-  local.get $6
+  i32.const 0
+  local.set $8
+  local.get $7
   i32.eqz
   if
    local.get $0
@@ -1079,30 +1117,30 @@
    i32.add
    i32.shl
    i32.and
-   local.set $5
-   local.get $5
+   local.set $9
+   local.get $9
    i32.eqz
    if
     i32.const 0
-    local.set $7
+    local.set $8
    else
-    local.get $5
+    local.get $9
     i32.ctz
     local.set $2
     local.get $0
-    local.set $8
+    local.set $11
     local.get $2
-    local.set $4
-    local.get $8
-    local.get $4
+    local.set $10
+    local.get $11
+    local.get $10
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $6
+    local.set $7
     i32.const 1
     drop
-    local.get $6
+    local.get $7
     i32.eqz
     if
      i32.const 0
@@ -1113,45 +1151,45 @@
      unreachable
     end
     local.get $0
-    local.set $9
+    local.set $14
     local.get $2
-    local.set $8
-    local.get $6
+    local.set $13
+    local.get $7
     i32.ctz
-    local.set $4
-    local.get $9
-    local.get $8
+    local.set $12
+    local.get $14
+    local.get $13
     i32.const 4
     i32.shl
-    local.get $4
+    local.get $12
     i32.add
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=96
-    local.set $7
+    local.set $8
    end
   else
    local.get $0
-   local.set $9
+   local.set $17
    local.get $2
-   local.set $8
-   local.get $6
+   local.set $16
+   local.get $7
    i32.ctz
-   local.set $4
-   local.get $9
-   local.get $8
+   local.set $15
+   local.get $17
+   local.get $16
    i32.const 4
    i32.shl
-   local.get $4
+   local.get $15
    i32.add
    i32.const 2
    i32.shl
    i32.add
    i32.load offset=96
-   local.set $7
+   local.set $8
   end
-  local.get $7
+  local.get $8
  )
  (func $~lib/rt/tlsf/growMemory (param $0 i32) (param $1 i32)
   (local $2 i32)
@@ -1160,6 +1198,7 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
   i32.const 0
   drop
   local.get $1
@@ -1206,15 +1245,15 @@
   i32.shr_u
   local.set $4
   local.get $2
-  local.tee $3
-  local.get $4
   local.tee $5
-  local.get $3
+  local.get $4
+  local.tee $6
   local.get $5
+  local.get $6
   i32.gt_s
   select
-  local.set $6
-  local.get $6
+  local.set $7
+  local.get $7
   memory.grow
   i32.const 0
   i32.lt_s
@@ -1228,12 +1267,12 @@
    end
   end
   memory.size
-  local.set $7
+  local.set $8
   local.get $0
   local.get $2
   i32.const 16
   i32.shl
-  local.get $7
+  local.get $8
   i32.const 16
   i32.shl
   call $~lib/rt/tlsf/addMemory
@@ -1243,6 +1282,8 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
   local.get $1
   i32.load
   local.set $3
@@ -1307,11 +1348,11 @@
    i32.and
    i32.store
    local.get $1
-   local.set $5
-   local.get $5
+   local.set $7
+   local.get $7
    i32.const 16
    i32.add
-   local.get $5
+   local.get $7
    i32.load
    i32.const 3
    i32.const -1
@@ -1319,11 +1360,11 @@
    i32.and
    i32.add
    local.get $1
-   local.set $5
-   local.get $5
+   local.set $6
+   local.get $6
    i32.const 16
    i32.add
-   local.get $5
+   local.get $6
    i32.load
    i32.const 3
    i32.const -1
@@ -1793,6 +1834,88 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local $22 i32)
+  (local $23 i32)
+  (local $24 i32)
+  (local $25 i32)
+  (local $26 i32)
+  (local $27 i32)
+  (local $28 i32)
+  (local $29 i32)
+  (local $30 i32)
+  (local $31 i32)
+  (local $32 i32)
+  (local $33 i32)
+  (local $34 i32)
+  (local $35 i32)
+  (local $36 i32)
+  (local $37 i32)
+  (local $38 i32)
+  (local $39 i32)
+  (local $40 i32)
+  (local $41 i32)
+  (local $42 i32)
+  (local $43 i32)
+  (local $44 i32)
+  (local $45 i32)
+  (local $46 i32)
+  (local $47 i32)
+  (local $48 i32)
+  (local $49 i32)
+  (local $50 i32)
+  (local $51 i32)
+  (local $52 i32)
+  (local $53 i32)
+  (local $54 i32)
+  (local $55 i32)
+  (local $56 i32)
+  (local $57 i32)
+  (local $58 i32)
+  (local $59 i32)
+  (local $60 i32)
+  (local $61 i32)
+  (local $62 i32)
+  (local $63 i32)
+  (local $64 i32)
+  (local $65 i32)
+  (local $66 i32)
+  (local $67 i32)
+  (local $68 i32)
+  (local $69 i32)
+  (local $70 i32)
+  (local $71 i32)
+  (local $72 i32)
+  (local $73 i32)
+  (local $74 i32)
+  (local $75 i32)
+  (local $76 i32)
+  (local $77 i32)
+  (local $78 i32)
+  (local $79 i32)
+  (local $80 i32)
+  (local $81 i32)
+  (local $82 i32)
+  (local $83 i32)
+  (local $84 i32)
+  (local $85 i32)
+  (local $86 i32)
+  (local $87 i32)
+  (local $88 i32)
   loop $while-continue|0
    local.get $2
    if (result i32)
@@ -1812,11 +1935,11 @@
     local.set $0
     local.get $6
     local.get $1
-    local.tee $6
+    local.tee $7
     i32.const 1
     i32.add
     local.set $1
-    local.get $6
+    local.get $7
     i32.load8_u
     i32.store8
     local.get $2
@@ -1836,8 +1959,8 @@
     local.get $2
     i32.const 16
     i32.ge_u
-    local.set $5
-    local.get $5
+    local.set $8
+    local.get $8
     if
      local.get $0
      local.get $1
@@ -1946,17 +2069,17 @@
    i32.and
    if
     local.get $0
-    local.tee $5
+    local.tee $9
     i32.const 1
     i32.add
     local.set $0
-    local.get $5
+    local.get $9
     local.get $1
-    local.tee $5
+    local.tee $10
     i32.const 1
     i32.add
     local.set $1
-    local.get $5
+    local.get $10
     i32.load8_u
     i32.store8
    end
@@ -1973,16 +2096,16 @@
        local.get $0
        i32.const 3
        i32.and
-       local.set $5
-       local.get $5
+       local.set $11
+       local.get $11
        i32.const 1
        i32.eq
        br_if $case0|2
-       local.get $5
+       local.get $11
        i32.const 2
        i32.eq
        br_if $case1|2
-       local.get $5
+       local.get $11
        i32.const 3
        i32.eq
        br_if $case2|2
@@ -1992,45 +2115,45 @@
       i32.load
       local.set $3
       local.get $0
-      local.tee $5
+      local.tee $12
       i32.const 1
       i32.add
       local.set $0
-      local.get $5
+      local.get $12
       local.get $1
-      local.tee $5
+      local.tee $13
       i32.const 1
       i32.add
       local.set $1
-      local.get $5
+      local.get $13
       i32.load8_u
       i32.store8
       local.get $0
-      local.tee $5
+      local.tee $14
       i32.const 1
       i32.add
       local.set $0
-      local.get $5
+      local.get $14
       local.get $1
-      local.tee $5
+      local.tee $15
       i32.const 1
       i32.add
       local.set $1
-      local.get $5
+      local.get $15
       i32.load8_u
       i32.store8
       local.get $0
-      local.tee $5
+      local.tee $16
       i32.const 1
       i32.add
       local.set $0
-      local.get $5
+      local.get $16
       local.get $1
-      local.tee $5
+      local.tee $17
       i32.const 1
       i32.add
       local.set $1
-      local.get $5
+      local.get $17
       i32.load8_u
       i32.store8
       local.get $2
@@ -2041,8 +2164,8 @@
        local.get $2
        i32.const 17
        i32.ge_u
-       local.set $5
-       local.get $5
+       local.set $18
+       local.get $18
        if
         local.get $1
         i32.const 1
@@ -2127,31 +2250,31 @@
      i32.load
      local.set $3
      local.get $0
-     local.tee $5
+     local.tee $19
      i32.const 1
      i32.add
      local.set $0
-     local.get $5
+     local.get $19
      local.get $1
-     local.tee $5
+     local.tee $20
      i32.const 1
      i32.add
      local.set $1
-     local.get $5
+     local.get $20
      i32.load8_u
      i32.store8
      local.get $0
-     local.tee $5
+     local.tee $21
      i32.const 1
      i32.add
      local.set $0
-     local.get $5
+     local.get $21
      local.get $1
-     local.tee $5
+     local.tee $22
      i32.const 1
      i32.add
      local.set $1
-     local.get $5
+     local.get $22
      i32.load8_u
      i32.store8
      local.get $2
@@ -2162,8 +2285,8 @@
       local.get $2
       i32.const 18
       i32.ge_u
-      local.set $5
-      local.get $5
+      local.set $23
+      local.get $23
       if
        local.get $1
        i32.const 2
@@ -2248,17 +2371,17 @@
     i32.load
     local.set $3
     local.get $0
-    local.tee $5
+    local.tee $24
     i32.const 1
     i32.add
     local.set $0
-    local.get $5
+    local.get $24
     local.get $1
-    local.tee $5
+    local.tee $25
     i32.const 1
     i32.add
     local.set $1
-    local.get $5
+    local.get $25
     i32.load8_u
     i32.store8
     local.get $2
@@ -2269,8 +2392,8 @@
      local.get $2
      i32.const 19
      i32.ge_u
-     local.set $5
-     local.get $5
+     local.set $26
+     local.get $26
      if
       local.get $1
       i32.const 3
@@ -2357,227 +2480,227 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $27
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $27
    local.get $1
-   local.tee $5
+   local.tee $28
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $28
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $29
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $29
    local.get $1
-   local.tee $5
+   local.tee $30
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $30
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $31
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $31
    local.get $1
-   local.tee $5
+   local.tee $32
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $32
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $33
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $33
    local.get $1
-   local.tee $5
+   local.tee $34
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $34
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $35
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $35
    local.get $1
-   local.tee $5
+   local.tee $36
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $36
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $37
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $37
    local.get $1
-   local.tee $5
+   local.tee $38
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $38
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $39
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $39
    local.get $1
-   local.tee $5
+   local.tee $40
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $40
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $41
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $41
    local.get $1
-   local.tee $5
+   local.tee $42
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $42
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $43
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $43
    local.get $1
-   local.tee $5
+   local.tee $44
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $44
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $45
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $45
    local.get $1
-   local.tee $5
+   local.tee $46
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $46
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $47
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $47
    local.get $1
-   local.tee $5
+   local.tee $48
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $48
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $49
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $49
    local.get $1
-   local.tee $5
+   local.tee $50
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $50
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $51
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $51
    local.get $1
-   local.tee $5
+   local.tee $52
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $52
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $53
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $53
    local.get $1
-   local.tee $5
+   local.tee $54
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $54
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $55
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $55
    local.get $1
-   local.tee $5
+   local.tee $56
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $56
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $57
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $57
    local.get $1
-   local.tee $5
+   local.tee $58
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $58
    i32.load8_u
    i32.store8
   end
@@ -2586,115 +2709,115 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $59
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $59
    local.get $1
-   local.tee $5
+   local.tee $60
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $60
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $61
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $61
    local.get $1
-   local.tee $5
+   local.tee $62
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $62
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $63
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $63
    local.get $1
-   local.tee $5
+   local.tee $64
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $64
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $65
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $65
    local.get $1
-   local.tee $5
+   local.tee $66
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $66
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $67
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $67
    local.get $1
-   local.tee $5
+   local.tee $68
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $68
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $69
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $69
    local.get $1
-   local.tee $5
+   local.tee $70
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $70
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $71
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $71
    local.get $1
-   local.tee $5
+   local.tee $72
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $72
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $73
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $73
    local.get $1
-   local.tee $5
+   local.tee $74
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $74
    i32.load8_u
    i32.store8
   end
@@ -2703,59 +2826,59 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $75
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $75
    local.get $1
-   local.tee $5
+   local.tee $76
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $76
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $77
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $77
    local.get $1
-   local.tee $5
+   local.tee $78
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $78
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $79
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $79
    local.get $1
-   local.tee $5
+   local.tee $80
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $80
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $81
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $81
    local.get $1
-   local.tee $5
+   local.tee $82
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $82
    i32.load8_u
    i32.store8
   end
@@ -2764,31 +2887,31 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $83
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $83
    local.get $1
-   local.tee $5
+   local.tee $84
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $84
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $85
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $85
    local.get $1
-   local.tee $5
+   local.tee $86
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $86
    i32.load8_u
    i32.store8
   end
@@ -2797,17 +2920,17 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $87
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $87
    local.get $1
-   local.tee $5
+   local.tee $88
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $88
    i32.load8_u
    i32.store8
   end
@@ -2818,6 +2941,14 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
   block $~lib/util/memory/memmove|inlined.0
    local.get $0
    local.set $5
@@ -2895,11 +3026,11 @@
        local.set $5
        local.get $7
        local.get $4
-       local.tee $7
+       local.tee $8
        i32.const 1
        i32.add
        local.set $4
-       local.get $7
+       local.get $8
        i32.load8_u
        i32.store8
        br $while-continue|0
@@ -2909,8 +3040,8 @@
       local.get $3
       i32.const 8
       i32.ge_u
-      local.set $6
-      local.get $6
+      local.set $9
+      local.get $9
       if
        local.get $5
        local.get $4
@@ -2934,21 +3065,21 @@
     end
     loop $while-continue|2
      local.get $3
-     local.set $6
-     local.get $6
+     local.set $10
+     local.get $10
      if
       local.get $5
-      local.tee $7
+      local.tee $11
       i32.const 1
       i32.add
       local.set $5
-      local.get $7
+      local.get $11
       local.get $4
-      local.tee $7
+      local.tee $12
       i32.const 1
       i32.add
       local.set $4
-      local.get $7
+      local.get $12
       i32.load8_u
       i32.store8
       local.get $3
@@ -2977,8 +3108,8 @@
       i32.add
       i32.const 7
       i32.and
-      local.set $6
-      local.get $6
+      local.set $13
+      local.get $13
       if
        local.get $3
        i32.eqz
@@ -3003,8 +3134,8 @@
       local.get $3
       i32.const 8
       i32.ge_u
-      local.set $6
-      local.get $6
+      local.set $14
+      local.get $14
       if
        local.get $3
        i32.const 8
@@ -3024,8 +3155,8 @@
     end
     loop $while-continue|5
      local.get $3
-     local.set $6
-     local.get $6
+     local.set $15
+     local.get $15
      if
       local.get $5
       local.get $3
@@ -3050,6 +3181,14 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
   local.get $0
   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
   local.set $3
@@ -3069,11 +3208,11 @@
    select
   else
    local.get $1
-   local.tee $4
+   local.tee $6
    local.get $3
-   local.tee $5
-   local.get $4
-   local.get $5
+   local.tee $7
+   local.get $6
+   local.get $7
    i32.lt_s
    select
   end
@@ -3085,20 +3224,20 @@
    local.get $3
    local.get $2
    i32.add
-   local.tee $4
+   local.tee $8
    i32.const 0
-   local.tee $5
-   local.get $4
-   local.get $5
+   local.tee $9
+   local.get $8
+   local.get $9
    i32.gt_s
    select
   else
    local.get $2
-   local.tee $4
+   local.tee $10
    local.get $3
-   local.tee $5
-   local.get $4
-   local.get $5
+   local.tee $11
+   local.get $10
+   local.get $11
    i32.lt_s
    select
   end
@@ -3106,29 +3245,30 @@
   local.get $2
   local.get $1
   i32.sub
-  local.tee $4
+  local.tee $12
   i32.const 0
-  local.tee $5
-  local.get $4
-  local.get $5
+  local.tee $13
+  local.get $12
+  local.get $13
   i32.gt_s
   select
-  local.set $6
-  local.get $6
+  local.set $14
+  local.get $14
   i32.const 0
   call $~lib/rt/tlsf/__alloc
-  local.set $7
-  local.get $7
+  local.set $15
+  local.get $15
   local.get $0
   local.get $1
   i32.add
-  local.get $6
+  local.get $14
   call $~lib/memory/memory.copy
-  local.get $7
+  local.get $15
   call $~lib/rt/pure/__retain
  )
  (func $~lib/arraybuffer/ArrayBuffer.isView<~lib/array/Array<i32> | null> (param $0 i32) (result i32)
   (local $1 i32)
+  (local $2 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $0
@@ -3170,10 +3310,10 @@
   i32.const 0
   drop
   i32.const 0
-  local.set $1
+  local.set $2
   local.get $0
   call $~lib/rt/pure/__release
-  local.get $1
+  local.get $2
  )
  (func $~lib/arraybuffer/ArrayBuffer.isView<usize> (param $0 i32) (result i32)
   i32.const 0
@@ -3206,6 +3346,7 @@
  )
  (func $~lib/arraybuffer/ArrayBuffer.isView<~lib/typedarray/Uint8Array | null> (param $0 i32) (result i32)
   (local $1 i32)
+  (local $2 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $0
@@ -3227,14 +3368,15 @@
   i32.const 1
   drop
   i32.const 1
-  local.set $1
+  local.set $2
   local.get $0
   call $~lib/rt/pure/__release
-  local.get $1
+  local.get $2
   return
  )
  (func $~lib/arraybuffer/ArrayBuffer.isView<~lib/typedarray/Int32Array | null> (param $0 i32) (result i32)
   (local $1 i32)
+  (local $2 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $0
@@ -3264,14 +3406,15 @@
   i32.const 1
   drop
   i32.const 1
-  local.set $1
+  local.set $2
   local.get $0
   call $~lib/rt/pure/__release
-  local.get $1
+  local.get $2
   return
  )
  (func $~lib/arraybuffer/ArrayBuffer.isView<~lib/dataview/DataView | null> (param $0 i32) (result i32)
   (local $1 i32)
+  (local $2 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $0
@@ -3313,10 +3456,10 @@
   i32.const 1
   drop
   i32.const 1
-  local.set $1
+  local.set $2
   local.get $0
   call $~lib/rt/pure/__release
-  local.get $1
+  local.get $2
   return
  )
  (func $~lib/arraybuffer/ArrayBufferView#constructor (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -3708,6 +3851,15 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
   i32.const 0
   i32.const 8
   call $~lib/arraybuffer/ArrayBuffer#constructor
@@ -3781,10 +3933,10 @@
   i32.const -1
   i32.const 1073741808
   call $~lib/arraybuffer/ArrayBuffer#slice
-  local.set $2
+  local.set $3
   local.get $1
   call $~lib/rt/pure/__release
-  local.get $2
+  local.get $3
   local.set $1
   local.get $1
   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
@@ -3803,10 +3955,10 @@
   i32.const 1
   i32.const 3
   call $~lib/arraybuffer/ArrayBuffer#slice
-  local.set $2
+  local.set $4
   local.get $1
   call $~lib/rt/pure/__release
-  local.get $2
+  local.get $4
   local.set $1
   local.get $1
   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
@@ -3825,10 +3977,10 @@
   i32.const 1
   i32.const -1
   call $~lib/arraybuffer/ArrayBuffer#slice
-  local.set $2
+  local.set $5
   local.get $1
   call $~lib/rt/pure/__release
-  local.get $2
+  local.get $5
   local.set $1
   local.get $1
   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
@@ -3847,10 +3999,10 @@
   i32.const -3
   i32.const -1
   call $~lib/arraybuffer/ArrayBuffer#slice
-  local.set $2
+  local.set $6
   local.get $1
   call $~lib/rt/pure/__release
-  local.get $2
+  local.get $6
   local.set $1
   local.get $1
   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
@@ -3869,10 +4021,10 @@
   i32.const -4
   i32.const 42
   call $~lib/arraybuffer/ArrayBuffer#slice
-  local.set $2
+  local.set $7
   local.get $1
   call $~lib/rt/pure/__release
-  local.get $2
+  local.get $7
   local.set $1
   local.get $1
   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
@@ -3891,10 +4043,10 @@
   i32.const 42
   i32.const 1073741808
   call $~lib/arraybuffer/ArrayBuffer#slice
-  local.set $2
+  local.set $8
   local.get $1
   call $~lib/rt/pure/__release
-  local.get $2
+  local.get $8
   local.set $1
   local.get $1
   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
@@ -3996,14 +4148,14 @@
   i32.const 0
   i32.const 1
   call $~lib/typedarray/Uint8Array#constructor
-  local.set $2
+  local.set $9
   i32.const 2
   i32.const 2
   i32.const 3
   i32.const 368
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $4
+  local.tee $12
   call $~lib/arraybuffer/ArrayBuffer.isView<~lib/array/Array<i32>>
   i32.eqz
   i32.eqz
@@ -4015,7 +4167,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $9
   call $~lib/arraybuffer/ArrayBuffer.isView<~lib/typedarray/Uint8Array>
   i32.eqz
   if
@@ -4029,7 +4181,7 @@
   i32.const 0
   i32.const 1
   call $~lib/typedarray/Int32Array#constructor
-  local.tee $3
+  local.tee $13
   call $~lib/arraybuffer/ArrayBuffer.isView<~lib/typedarray/Int32Array>
   i32.eqz
   if
@@ -4041,14 +4193,14 @@
    unreachable
   end
   i32.const 0
-  local.get $2
+  local.get $9
   i32.load
   i32.const 0
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
   call $~lib/dataview/DataView#constructor@varargs
-  local.tee $5
+  local.tee $14
   call $~lib/arraybuffer/ArrayBuffer.isView<~lib/dataview/DataView>
   i32.eqz
   if
@@ -4063,13 +4215,13 @@
   call $~lib/rt/pure/__release
   local.get $1
   call $~lib/rt/pure/__release
-  local.get $2
+  local.get $9
   call $~lib/rt/pure/__release
-  local.get $4
+  local.get $12
   call $~lib/rt/pure/__release
-  local.get $3
+  local.get $13
   call $~lib/rt/pure/__release
-  local.get $5
+  local.get $14
   call $~lib/rt/pure/__release
  )
  (func $~start

--- a/tests/compiler/std/dataview.untouched.wat
+++ b/tests/compiler/std/dataview.untouched.wat
@@ -64,6 +64,15 @@
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
   local.get $1
   i32.load
   local.set $2
@@ -200,59 +209,59 @@
   i32.eq
   if
    local.get $0
-   local.set $11
+   local.set $14
    local.get $4
-   local.set $10
+   local.set $13
    local.get $5
-   local.set $9
+   local.set $12
    local.get $7
-   local.set $8
-   local.get $11
-   local.get $10
+   local.set $11
+   local.get $14
+   local.get $13
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $12
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
+   local.get $11
    i32.store offset=96
    local.get $7
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $16
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $15
+    local.get $16
+    local.get $15
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $17
     local.get $0
-    local.set $8
+    local.set $20
     local.get $4
-    local.set $11
-    local.get $9
+    local.set $19
+    local.get $17
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
-    local.set $10
-    local.get $8
-    local.get $11
+    local.tee $17
+    local.set $18
+    local.get $20
+    local.get $19
     i32.const 2
     i32.shl
     i32.add
-    local.get $10
+    local.get $18
     i32.store offset=4
-    local.get $9
+    local.get $17
     i32.eqz
     if
      local.get $0
@@ -282,6 +291,20 @@
   (local $11 i32)
   (local $12 i32)
   (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local $22 i32)
+  (local $23 i32)
+  (local $24 i32)
+  (local $25 i32)
+  (local $26 i32)
+  (local $27 i32)
   i32.const 1
   drop
   local.get $1
@@ -344,8 +367,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $3
+   local.set $6
+   local.get $6
    i32.const 1073741808
    i32.lt_u
    if
@@ -356,16 +379,16 @@
     local.get $2
     i32.const 3
     i32.and
-    local.get $3
+    local.get $6
     i32.or
     local.tee $2
     i32.store
     local.get $1
-    local.set $6
-    local.get $6
+    local.set $7
+    local.get $7
     i32.const 16
     i32.add
-    local.get $6
+    local.get $7
     i32.load
     i32.const 3
     i32.const -1
@@ -383,18 +406,18 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $8
+   local.get $8
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
+   local.set $9
+   local.get $9
    i32.load
-   local.set $3
+   local.set $10
    i32.const 1
    drop
-   local.get $3
+   local.get $10
    i32.const 1
    i32.and
    i32.eqz
@@ -406,7 +429,7 @@
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $3
+   local.get $10
    i32.const 3
    i32.const -1
    i32.xor
@@ -419,23 +442,23 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $7
+   local.set $11
+   local.get $11
    i32.const 1073741808
    i32.lt_u
    if
     local.get $0
-    local.get $6
+    local.get $9
     call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
+    local.get $9
+    local.get $10
     i32.const 3
     i32.and
-    local.get $7
+    local.get $11
     i32.or
     local.tee $2
     i32.store
-    local.get $6
+    local.get $9
     local.set $1
    end
   end
@@ -449,14 +472,14 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $12
   i32.const 1
   drop
-  local.get $8
+  local.get $12
   i32.const 16
   i32.ge_u
   if (result i32)
-   local.get $8
+   local.get $12
    i32.const 1073741808
    i32.lt_u
   else
@@ -476,7 +499,7 @@
   local.get $1
   i32.const 16
   i32.add
-  local.get $8
+  local.get $12
   i32.add
   local.get $4
   i32.eq
@@ -494,24 +517,24 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $12
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $13
+   local.get $12
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $14
   else
    i32.const 31
-   local.get $8
+   local.get $12
    i32.clz
    i32.sub
-   local.set $9
-   local.get $8
-   local.get $9
+   local.set $13
+   local.get $12
+   local.get $13
    i32.const 4
    i32.sub
    i32.shr_u
@@ -519,21 +542,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $14
+   local.get $13
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $13
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $13
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $14
    i32.const 16
    i32.lt_u
   else
@@ -549,86 +572,86 @@
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
-  local.set $6
-  local.get $7
-  local.get $3
+  local.set $17
+  local.get $13
+  local.set $16
+  local.get $14
+  local.set $15
+  local.get $17
+  local.get $16
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $15
   i32.add
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=96
-  local.set $11
+  local.set $18
   local.get $1
   i32.const 0
   i32.store offset=16
   local.get $1
-  local.get $11
+  local.get $18
   i32.store offset=20
-  local.get $11
+  local.get $18
   if
-   local.get $11
+   local.get $18
    local.get $1
    i32.store offset=16
   end
   local.get $0
-  local.set $12
-  local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
+  local.set $22
+  local.get $13
+  local.set $21
+  local.get $14
+  local.set $20
   local.get $1
-  local.set $6
-  local.get $12
-  local.get $7
+  local.set $19
+  local.get $22
+  local.get $21
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $20
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $19
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $13
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.set $13
-  local.get $9
-  local.set $12
+  local.set $27
+  local.get $13
+  local.set $26
   local.get $0
-  local.set $3
-  local.get $9
-  local.set $6
-  local.get $3
-  local.get $6
+  local.set $24
+  local.get $13
+  local.set $23
+  local.get $24
+  local.get $23
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $14
   i32.shl
   i32.or
-  local.set $7
-  local.get $13
-  local.get $12
+  local.set $25
+  local.get $27
+  local.get $26
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $25
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -639,6 +662,7 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
   i32.const 1
   drop
   local.get $1
@@ -778,11 +802,11 @@
   i32.or
   i32.store
   local.get $0
-  local.set $9
+  local.set $10
   local.get $4
-  local.set $3
+  local.set $9
+  local.get $10
   local.get $9
-  local.get $3
   i32.store offset=1568
   local.get $0
   local.get $8
@@ -802,6 +826,12 @@
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
   global.get $~lib/rt/tlsf/ROOT
   local.set $0
   local.get $0
@@ -858,66 +888,66 @@
    local.get $4
    i32.store offset=1568
    i32.const 0
-   local.set $5
+   local.set $6
    loop $for-loop|0
-    local.get $5
+    local.get $6
     i32.const 23
     i32.lt_u
-    local.set $4
-    local.get $4
+    local.set $7
+    local.get $7
     if
      local.get $0
-     local.set $8
-     local.get $5
-     local.set $7
+     local.set $10
+     local.get $6
+     local.set $9
      i32.const 0
-     local.set $6
-     local.get $8
-     local.get $7
+     local.set $8
+     local.get $10
+     local.get $9
      i32.const 2
      i32.shl
      i32.add
-     local.get $6
+     local.get $8
      i32.store offset=4
      i32.const 0
-     local.set $8
+     local.set $11
      loop $for-loop|1
-      local.get $8
+      local.get $11
       i32.const 16
       i32.lt_u
-      local.set $7
-      local.get $7
+      local.set $12
+      local.get $12
       if
        local.get $0
-       local.set $11
-       local.get $5
-       local.set $10
-       local.get $8
-       local.set $9
-       i32.const 0
-       local.set $6
+       local.set $16
+       local.get $6
+       local.set $15
        local.get $11
-       local.get $10
+       local.set $14
+       i32.const 0
+       local.set $13
+       local.get $16
+       local.get $15
        i32.const 4
        i32.shl
-       local.get $9
+       local.get $14
        i32.add
        i32.const 2
        i32.shl
        i32.add
-       local.get $6
+       local.get $13
        i32.store offset=96
-       local.get $8
+       local.get $11
        i32.const 1
        i32.add
-       local.set $8
+       local.set $11
        br $for-loop|1
       end
      end
-     local.get $5
+     local.get $6
      i32.const 1
      i32.add
-     local.set $5
+     local.set $6
      br $for-loop|0
     end
    end
@@ -930,11 +960,11 @@
    i32.const -1
    i32.xor
    i32.and
-   local.set $5
+   local.set $17
    i32.const 0
    drop
    local.get $0
-   local.get $5
+   local.get $17
    memory.size
    i32.const 16
    i32.shl
@@ -983,6 +1013,14 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
   local.get $1
   i32.const 256
   i32.lt_u
@@ -1056,11 +1094,11 @@
    unreachable
   end
   local.get $0
-  local.set $5
+  local.set $6
   local.get $2
-  local.set $4
+  local.set $5
+  local.get $6
   local.get $5
-  local.get $4
   i32.const 2
   i32.shl
   i32.add
@@ -1071,10 +1109,10 @@
   local.get $3
   i32.shl
   i32.and
-  local.set $6
-  i32.const 0
   local.set $7
-  local.get $6
+  i32.const 0
+  local.set $8
+  local.get $7
   i32.eqz
   if
    local.get $0
@@ -1087,30 +1125,30 @@
    i32.add
    i32.shl
    i32.and
-   local.set $5
-   local.get $5
+   local.set $9
+   local.get $9
    i32.eqz
    if
     i32.const 0
-    local.set $7
+    local.set $8
    else
-    local.get $5
+    local.get $9
     i32.ctz
     local.set $2
     local.get $0
-    local.set $8
+    local.set $11
     local.get $2
-    local.set $4
-    local.get $8
-    local.get $4
+    local.set $10
+    local.get $11
+    local.get $10
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $6
+    local.set $7
     i32.const 1
     drop
-    local.get $6
+    local.get $7
     i32.eqz
     if
      i32.const 0
@@ -1121,45 +1159,45 @@
      unreachable
     end
     local.get $0
-    local.set $9
+    local.set $14
     local.get $2
-    local.set $8
-    local.get $6
+    local.set $13
+    local.get $7
     i32.ctz
-    local.set $4
-    local.get $9
-    local.get $8
+    local.set $12
+    local.get $14
+    local.get $13
     i32.const 4
     i32.shl
-    local.get $4
+    local.get $12
     i32.add
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=96
-    local.set $7
+    local.set $8
    end
   else
    local.get $0
-   local.set $9
+   local.set $17
    local.get $2
-   local.set $8
-   local.get $6
+   local.set $16
+   local.get $7
    i32.ctz
-   local.set $4
-   local.get $9
-   local.get $8
+   local.set $15
+   local.get $17
+   local.get $16
    i32.const 4
    i32.shl
-   local.get $4
+   local.get $15
    i32.add
    i32.const 2
    i32.shl
    i32.add
    i32.load offset=96
-   local.set $7
+   local.set $8
   end
-  local.get $7
+  local.get $8
  )
  (func $~lib/rt/tlsf/growMemory (param $0 i32) (param $1 i32)
   (local $2 i32)
@@ -1168,6 +1206,7 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
   i32.const 0
   drop
   local.get $1
@@ -1214,15 +1253,15 @@
   i32.shr_u
   local.set $4
   local.get $2
-  local.tee $3
-  local.get $4
   local.tee $5
-  local.get $3
+  local.get $4
+  local.tee $6
   local.get $5
+  local.get $6
   i32.gt_s
   select
-  local.set $6
-  local.get $6
+  local.set $7
+  local.get $7
   memory.grow
   i32.const 0
   i32.lt_s
@@ -1236,12 +1275,12 @@
    end
   end
   memory.size
-  local.set $7
+  local.set $8
   local.get $0
   local.get $2
   i32.const 16
   i32.shl
-  local.get $7
+  local.get $8
   i32.const 16
   i32.shl
   call $~lib/rt/tlsf/addMemory
@@ -1251,6 +1290,8 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
   local.get $1
   i32.load
   local.set $3
@@ -1315,11 +1356,11 @@
    i32.and
    i32.store
    local.get $1
-   local.set $5
-   local.get $5
+   local.set $7
+   local.get $7
    i32.const 16
    i32.add
-   local.get $5
+   local.get $7
    i32.load
    i32.const 3
    i32.const -1
@@ -1327,11 +1368,11 @@
    i32.and
    i32.add
    local.get $1
-   local.set $5
-   local.get $5
+   local.set $6
+   local.get $6
    i32.const 16
    i32.add
-   local.get $5
+   local.get $6
    i32.load
    i32.const 3
    i32.const -1

--- a/tests/compiler/std/date.untouched.wat
+++ b/tests/compiler/std/date.untouched.wat
@@ -28,6 +28,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   memory.size
   local.set $1
   local.get $1
@@ -58,8 +59,8 @@
    local.get $5
    i32.gt_s
    select
-   local.set $4
-   local.get $4
+   local.set $6
+   local.get $6
    memory.grow
    i32.const 0
    i32.lt_s
@@ -170,6 +171,20 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i64)
+  (local $7 i64)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i64)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
   i32.const 1970
   local.set $2
   i32.const 0
@@ -206,26 +221,26 @@
    unreachable
   end
   i32.const 1970
-  local.set $5
+  local.set $13
   i32.const 0
-  local.set $4
+  local.set $12
   i32.const 1
-  local.set $3
+  local.set $11
   i32.const 0
-  local.set $2
+  local.set $10
   i32.const 0
-  local.set $1
+  local.set $9
   i32.const 0
-  local.set $0
+  local.set $8
   i64.const 0
-  local.set $6
-  local.get $5
-  local.get $4
-  local.get $3
-  local.get $2
-  local.get $1
-  local.get $0
-  local.get $6
+  local.set $7
+  local.get $13
+  local.get $12
+  local.get $11
+  local.get $10
+  local.get $9
+  local.get $8
+  local.get $7
   f64.convert_i64_s
   call $~lib/bindings/Date/UTC
   i64.trunc_f64_s
@@ -241,26 +256,26 @@
    unreachable
   end
   i32.const 2018
-  local.set $5
+  local.set $20
   i32.const 10
-  local.set $4
+  local.set $19
   i32.const 10
-  local.set $3
+  local.set $18
   i32.const 11
-  local.set $2
+  local.set $17
   i32.const 0
-  local.set $1
+  local.set $16
   i32.const 0
-  local.set $0
+  local.set $15
   i64.const 1
-  local.set $6
-  local.get $5
-  local.get $4
-  local.get $3
-  local.get $2
-  local.get $1
-  local.get $0
-  local.get $6
+  local.set $14
+  local.get $20
+  local.get $19
+  local.get $18
+  local.get $17
+  local.get $16
+  local.get $15
+  local.get $14
   f64.convert_i64_s
   call $~lib/bindings/Date/UTC
   i64.trunc_f64_s

--- a/tests/compiler/std/hash.untouched.wat
+++ b/tests/compiler/std/hash.untouched.wat
@@ -30,6 +30,7 @@
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
   local.get $0
   call $~lib/rt/stub/__retain
   local.set $0
@@ -71,10 +72,10 @@
    end
   end
   local.get $1
-  local.set $3
+  local.set $5
   local.get $0
   call $~lib/rt/stub/__release
-  local.get $3
+  local.get $5
  )
  (func $std/hash/check (param $0 i32) (result i32)
   i32.const 1
@@ -212,8 +213,26 @@
  (func $start:std/hash
   (local $0 i32)
   (local $1 i32)
-  (local $2 f32)
-  (local $3 f64)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 f32)
+  (local $11 f32)
+  (local $12 f32)
+  (local $13 f32)
+  (local $14 f32)
+  (local $15 f32)
+  (local $16 f64)
+  (local $17 f64)
+  (local $18 f64)
+  (local $19 f64)
+  (local $20 f64)
+  (local $21 f64)
   block $~lib/util/hash/HASH<~lib/string/String | null>|inlined.0 (result i32)
    i32.const 0
    call $~lib/rt/stub/__retain
@@ -232,67 +251,67 @@
   drop
   block $~lib/util/hash/HASH<~lib/string/String>|inlined.0 (result i32)
    i32.const 32
-   local.set $1
+   local.set $2
    i32.const 1
    drop
-   local.get $1
+   local.get $2
    call $~lib/util/hash/hashStr
-   local.set $0
-   local.get $1
+   local.set $3
+   local.get $2
    call $~lib/rt/stub/__release
-   local.get $0
+   local.get $3
    br $~lib/util/hash/HASH<~lib/string/String>|inlined.0
   end
   call $std/hash/check
   drop
   block $~lib/util/hash/HASH<~lib/string/String>|inlined.1 (result i32)
    i32.const 48
-   local.set $0
+   local.set $4
    i32.const 1
    drop
-   local.get $0
+   local.get $4
    call $~lib/util/hash/hashStr
-   local.set $1
-   local.get $0
+   local.set $5
+   local.get $4
    call $~lib/rt/stub/__release
-   local.get $1
+   local.get $5
    br $~lib/util/hash/HASH<~lib/string/String>|inlined.1
   end
   call $std/hash/check
   drop
   block $~lib/util/hash/HASH<~lib/string/String>|inlined.2 (result i32)
    i32.const 80
-   local.set $1
+   local.set $6
    i32.const 1
    drop
-   local.get $1
+   local.get $6
    call $~lib/util/hash/hashStr
-   local.set $0
-   local.get $1
+   local.set $7
+   local.get $6
    call $~lib/rt/stub/__release
-   local.get $0
+   local.get $7
    br $~lib/util/hash/HASH<~lib/string/String>|inlined.2
   end
   call $std/hash/check
   drop
   block $~lib/util/hash/HASH<~lib/string/String>|inlined.3 (result i32)
    i32.const 112
-   local.set $0
+   local.set $8
    i32.const 1
    drop
-   local.get $0
+   local.get $8
    call $~lib/util/hash/hashStr
-   local.set $1
-   local.get $0
+   local.set $9
+   local.get $8
    call $~lib/rt/stub/__release
-   local.get $1
+   local.get $9
    br $~lib/util/hash/HASH<~lib/string/String>|inlined.3
   end
   call $std/hash/check
   drop
   block $~lib/util/hash/HASH<f32>|inlined.0 (result i32)
    f32.const 0
-   local.set $2
+   local.set $10
    i32.const 0
    drop
    i32.const 0
@@ -303,7 +322,7 @@
    i32.const 4
    i32.eq
    drop
-   local.get $2
+   local.get $10
    i32.reinterpret_f32
    call $~lib/util/hash/hash32
    br $~lib/util/hash/HASH<f32>|inlined.0
@@ -312,7 +331,7 @@
   drop
   block $~lib/util/hash/HASH<f32>|inlined.1 (result i32)
    f32.const 1
-   local.set $2
+   local.set $11
    i32.const 0
    drop
    i32.const 0
@@ -323,7 +342,7 @@
    i32.const 4
    i32.eq
    drop
-   local.get $2
+   local.get $11
    i32.reinterpret_f32
    call $~lib/util/hash/hash32
    br $~lib/util/hash/HASH<f32>|inlined.1
@@ -332,7 +351,7 @@
   drop
   block $~lib/util/hash/HASH<f32>|inlined.2 (result i32)
    f32.const 1.100000023841858
-   local.set $2
+   local.set $12
    i32.const 0
    drop
    i32.const 0
@@ -343,7 +362,7 @@
    i32.const 4
    i32.eq
    drop
-   local.get $2
+   local.get $12
    i32.reinterpret_f32
    call $~lib/util/hash/hash32
    br $~lib/util/hash/HASH<f32>|inlined.2
@@ -352,7 +371,7 @@
   drop
   block $~lib/util/hash/HASH<f32>|inlined.3 (result i32)
    f32.const 0
-   local.set $2
+   local.set $13
    i32.const 0
    drop
    i32.const 0
@@ -363,7 +382,7 @@
    i32.const 4
    i32.eq
    drop
-   local.get $2
+   local.get $13
    i32.reinterpret_f32
    call $~lib/util/hash/hash32
    br $~lib/util/hash/HASH<f32>|inlined.3
@@ -372,7 +391,7 @@
   drop
   block $~lib/util/hash/HASH<f32>|inlined.4 (result i32)
    f32.const inf
-   local.set $2
+   local.set $14
    i32.const 0
    drop
    i32.const 0
@@ -383,7 +402,7 @@
    i32.const 4
    i32.eq
    drop
-   local.get $2
+   local.get $14
    i32.reinterpret_f32
    call $~lib/util/hash/hash32
    br $~lib/util/hash/HASH<f32>|inlined.4
@@ -392,7 +411,7 @@
   drop
   block $~lib/util/hash/HASH<f32>|inlined.5 (result i32)
    f32.const nan:0x400000
-   local.set $2
+   local.set $15
    i32.const 0
    drop
    i32.const 0
@@ -403,7 +422,7 @@
    i32.const 4
    i32.eq
    drop
-   local.get $2
+   local.get $15
    i32.reinterpret_f32
    call $~lib/util/hash/hash32
    br $~lib/util/hash/HASH<f32>|inlined.5
@@ -412,7 +431,7 @@
   drop
   block $~lib/util/hash/HASH<f64>|inlined.0 (result i32)
    f64.const 0
-   local.set $3
+   local.set $16
    i32.const 0
    drop
    i32.const 0
@@ -427,7 +446,7 @@
    i32.const 8
    i32.eq
    drop
-   local.get $3
+   local.get $16
    i64.reinterpret_f64
    call $~lib/util/hash/hash64
    br $~lib/util/hash/HASH<f64>|inlined.0
@@ -436,7 +455,7 @@
   drop
   block $~lib/util/hash/HASH<f64>|inlined.1 (result i32)
    f64.const 1
-   local.set $3
+   local.set $17
    i32.const 0
    drop
    i32.const 0
@@ -451,7 +470,7 @@
    i32.const 8
    i32.eq
    drop
-   local.get $3
+   local.get $17
    i64.reinterpret_f64
    call $~lib/util/hash/hash64
    br $~lib/util/hash/HASH<f64>|inlined.1
@@ -460,7 +479,7 @@
   drop
   block $~lib/util/hash/HASH<f64>|inlined.2 (result i32)
    f64.const 1.1
-   local.set $3
+   local.set $18
    i32.const 0
    drop
    i32.const 0
@@ -475,7 +494,7 @@
    i32.const 8
    i32.eq
    drop
-   local.get $3
+   local.get $18
    i64.reinterpret_f64
    call $~lib/util/hash/hash64
    br $~lib/util/hash/HASH<f64>|inlined.2
@@ -484,7 +503,7 @@
   drop
   block $~lib/util/hash/HASH<f64>|inlined.3 (result i32)
    f64.const 0
-   local.set $3
+   local.set $19
    i32.const 0
    drop
    i32.const 0
@@ -499,7 +518,7 @@
    i32.const 8
    i32.eq
    drop
-   local.get $3
+   local.get $19
    i64.reinterpret_f64
    call $~lib/util/hash/hash64
    br $~lib/util/hash/HASH<f64>|inlined.3
@@ -508,7 +527,7 @@
   drop
   block $~lib/util/hash/HASH<f64>|inlined.4 (result i32)
    f64.const inf
-   local.set $3
+   local.set $20
    i32.const 0
    drop
    i32.const 0
@@ -523,7 +542,7 @@
    i32.const 8
    i32.eq
    drop
-   local.get $3
+   local.get $20
    i64.reinterpret_f64
    call $~lib/util/hash/hash64
    br $~lib/util/hash/HASH<f64>|inlined.4
@@ -532,7 +551,7 @@
   drop
   block $~lib/util/hash/HASH<f64>|inlined.5 (result i32)
    f64.const nan:0x8000000000000
-   local.set $3
+   local.set $21
    i32.const 0
    drop
    i32.const 0
@@ -547,7 +566,7 @@
    i32.const 8
    i32.eq
    drop
-   local.get $3
+   local.get $21
    i64.reinterpret_f64
    call $~lib/util/hash/hash64
    br $~lib/util/hash/HASH<f64>|inlined.5

--- a/tests/compiler/std/math.optimized.wat
+++ b/tests/compiler/std/math.optimized.wat
@@ -38401,10 +38401,8 @@
   call $~lib/bindings/Math/random
   i64.reinterpret_f64
   call $~lib/math/NativeMath.seedRandom
-  i32.const 0
-  local.set $2
   loop $for-loop|1
-   local.get $2
+   local.get $5
    f64.convert_i32_s
    f64.const 1e6
    f64.lt
@@ -38417,11 +38415,11 @@
      call $~lib/math/NativeMath.seedRandom
     end
     global.get $~lib/math/random_state0_32
-    local.tee $5
+    local.tee $2
     global.get $~lib/math/random_state1_32
     i32.xor
     local.tee $6
-    local.get $5
+    local.get $2
     i32.const 26
     i32.rotl
     i32.xor
@@ -38434,7 +38432,7 @@
     i32.const 13
     i32.rotl
     global.set $~lib/math/random_state1_32
-    local.get $5
+    local.get $2
     i32.const -1640531525
     i32.mul
     i32.const 5
@@ -38465,10 +38463,10 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $2
+    local.get $5
     i32.const 1
     i32.add
-    local.set $2
+    local.set $5
     br $for-loop|1
    end
   end

--- a/tests/compiler/std/math.untouched.wat
+++ b/tests/compiler/std/math.untouched.wat
@@ -156,6 +156,8 @@
   (local $2 f64)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   local.get $0
   local.set $2
   local.get $1
@@ -222,11 +224,11 @@
      i32.add
      i32.const 53
      i32.sub
-     local.tee $3
+     local.tee $5
      i32.const -1022
-     local.tee $4
-     local.get $3
-     local.get $4
+     local.tee $6
+     local.get $5
+     local.get $6
      i32.gt_s
      select
      local.set $1
@@ -245,6 +247,7 @@
  )
  (func $std/math/ulperr (param $0 f64) (param $1 f64) (param $2 f64) (result f64)
   (local $3 f64)
+  (local $4 f64)
   local.get $0
   local.get $0
   f64.ne
@@ -277,14 +280,14 @@
    i32.const 0
    i32.ne
    local.get $1
-   local.set $3
-   local.get $3
+   local.set $4
+   local.get $4
    i64.reinterpret_f64
    i64.const 63
    i64.shr_u
    i32.wrap_i64
-   local.get $3
-   local.get $3
+   local.get $4
+   local.get $4
    f64.eq
    i32.and
    i32.const 0
@@ -391,6 +394,8 @@
   (local $2 f32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   local.get $0
   local.set $2
   local.get $1
@@ -457,11 +462,11 @@
      i32.add
      i32.const 24
      i32.sub
-     local.tee $3
+     local.tee $5
      i32.const -126
-     local.tee $4
-     local.get $3
-     local.get $4
+     local.tee $6
+     local.get $5
+     local.get $6
      i32.gt_s
      select
      local.set $1
@@ -479,6 +484,7 @@
  )
  (func $std/math/ulperrf (param $0 f32) (param $1 f32) (param $2 f32) (result f32)
   (local $3 f32)
+  (local $4 f32)
   local.get $0
   local.get $0
   f32.ne
@@ -510,13 +516,13 @@
    i32.const 0
    i32.ne
    local.get $1
-   local.set $3
-   local.get $3
+   local.set $4
+   local.get $4
    i32.reinterpret_f32
    i32.const 31
    i32.shr_u
-   local.get $3
-   local.get $3
+   local.get $4
+   local.get $4
    f32.eq
    i32.and
    i32.const 0
@@ -1314,6 +1320,15 @@
   (local $16 i64)
   (local $17 f64)
   (local $18 f64)
+  (local $19 f64)
+  (local $20 f64)
+  (local $21 f64)
+  (local $22 f64)
+  (local $23 f64)
+  (local $24 f64)
+  (local $25 f64)
+  (local $26 f64)
+  (local $27 f64)
   i32.const 0
   i32.const 1
   i32.lt_s
@@ -1532,7 +1547,7 @@
    i32.shl
    i32.add
    f64.load
-   local.set $11
+   local.set $17
    i32.const 56
    local.get $14
    i32.const 1
@@ -1541,10 +1556,10 @@
    i32.shl
    i32.add
    f64.load offset=8
-   local.set $10
+   local.set $18
    local.get $16
    f64.reinterpret_i64
-   local.set $9
+   local.set $19
    i32.const 2104
    local.get $14
    i32.const 1
@@ -1553,7 +1568,7 @@
    i32.shl
    i32.add
    f64.load
-   local.set $8
+   local.set $20
    i32.const 2104
    local.get $14
    i32.const 1
@@ -1562,58 +1577,58 @@
    i32.shl
    i32.add
    f64.load offset=8
-   local.set $7
-   local.get $9
-   local.get $8
+   local.set $21
+   local.get $19
+   local.get $20
    f64.sub
-   local.get $7
+   local.get $21
    f64.sub
-   local.get $11
+   local.get $17
    f64.mul
-   local.set $6
+   local.set $22
    local.get $15
    f64.convert_i64_s
-   local.set $5
-   local.get $5
+   local.set $23
+   local.get $23
    f64.const 0.6931471805598903
    f64.mul
-   local.get $10
+   local.get $18
    f64.add
-   local.set $4
-   local.get $4
-   local.get $6
+   local.set $24
+   local.get $24
+   local.get $22
    f64.add
-   local.set $3
-   local.get $4
-   local.get $3
+   local.set $25
+   local.get $24
+   local.get $25
    f64.sub
-   local.get $6
+   local.get $22
    f64.add
-   local.get $5
+   local.get $23
    f64.const 5.497923018708371e-14
    f64.mul
    f64.add
-   local.set $17
-   local.get $6
-   local.get $6
+   local.set $26
+   local.get $22
+   local.get $22
    f64.mul
-   local.set $18
-   local.get $17
-   local.get $18
+   local.set $27
+   local.get $26
+   local.get $27
    f64.const -0.5000000000000001
    f64.mul
    f64.add
-   local.get $6
-   local.get $18
+   local.get $22
+   local.get $27
    f64.mul
    f64.const 0.33333333331825593
-   local.get $6
+   local.get $22
    f64.const -0.2499999999622955
    f64.mul
    f64.add
-   local.get $18
+   local.get $27
    f64.const 0.20000304511814496
-   local.get $6
+   local.get $22
    f64.const -0.16667054827627667
    f64.mul
    f64.add
@@ -1621,7 +1636,7 @@
    f64.add
    f64.mul
    f64.add
-   local.get $3
+   local.get $25
    f64.add
   end
   return
@@ -3329,6 +3344,8 @@
   (local $8 i32)
   (local $9 f64)
   (local $10 f64)
+  (local $11 f64)
+  (local $12 i32)
   local.get $1
   local.get $1
   f64.ne
@@ -3506,15 +3523,15 @@
     else
      f64.const 0
     end
-    local.set $9
+    local.set $10
     local.get $7
     i32.const 1
     i32.and
     if (result f64)
-     local.get $9
+     local.get $10
      f64.neg
     else
-     local.get $9
+     local.get $10
     end
     return
    end
@@ -3566,14 +3583,14 @@
   end
   if
    f64.const 0
-   local.set $10
+   local.set $11
   else
    local.get $0
    local.get $1
    f64.div
    f64.abs
    call $~lib/math/NativeMath.atan
-   local.set $10
+   local.set $11
   end
   block $break|1
    block $case3|1
@@ -3581,40 +3598,40 @@
      block $case1|1
       block $case0|1
        local.get $7
-       local.set $8
-       local.get $8
+       local.set $12
+       local.get $12
        i32.const 0
        i32.eq
        br_if $case0|1
-       local.get $8
+       local.get $12
        i32.const 1
        i32.eq
        br_if $case1|1
-       local.get $8
+       local.get $12
        i32.const 2
        i32.eq
        br_if $case2|1
-       local.get $8
+       local.get $12
        i32.const 3
        i32.eq
        br_if $case3|1
        br $break|1
       end
-      local.get $10
+      local.get $11
       return
      end
-     local.get $10
+     local.get $11
      f64.neg
      return
     end
     global.get $~lib/math/NativeMath.PI
-    local.get $10
+    local.get $11
     f64.const 1.2246467991473532e-16
     f64.sub
     f64.sub
     return
    end
-   local.get $10
+   local.get $11
    f64.const 1.2246467991473532e-16
    f64.sub
    global.get $~lib/math/NativeMath.PI
@@ -3656,6 +3673,8 @@
   (local $5 i32)
   (local $6 f32)
   (local $7 f32)
+  (local $8 f32)
+  (local $9 i32)
   local.get $1
   local.get $1
   f32.ne
@@ -3808,15 +3827,15 @@
     else
      f32.const 0
     end
-    local.set $6
+    local.set $7
     local.get $4
     i32.const 1
     i32.and
     if (result f32)
-     local.get $6
+     local.get $7
      f32.neg
     else
-     local.get $6
+     local.get $7
     end
     return
    end
@@ -3868,14 +3887,14 @@
   end
   if
    f32.const 0
-   local.set $7
+   local.set $8
   else
    local.get $0
    local.get $1
    f32.div
    f32.abs
    call $~lib/math/NativeMathf.atan
-   local.set $7
+   local.set $8
   end
   block $break|1
    block $case3|1
@@ -3883,40 +3902,40 @@
      block $case1|1
       block $case0|1
        local.get $4
-       local.set $5
-       local.get $5
+       local.set $9
+       local.get $9
        i32.const 0
        i32.eq
        br_if $case0|1
-       local.get $5
+       local.get $9
        i32.const 1
        i32.eq
        br_if $case1|1
-       local.get $5
+       local.get $9
        i32.const 2
        i32.eq
        br_if $case2|1
-       local.get $5
+       local.get $9
        i32.const 3
        i32.eq
        br_if $case3|1
        br $break|1
       end
-      local.get $7
+      local.get $8
       return
      end
-     local.get $7
+     local.get $8
      f32.neg
      return
     end
     f32.const 3.1415927410125732
-    local.get $7
+    local.get $8
     f32.const -8.742277657347586e-08
     f32.sub
     f32.sub
     return
    end
-   local.get $7
+   local.get $8
    f32.const -8.742277657347586e-08
    f32.sub
    f32.const 3.1415927410125732
@@ -4299,7 +4318,21 @@
   (local $33 i64)
   (local $34 i64)
   (local $35 i64)
-  (local $36 f64)
+  (local $36 i64)
+  (local $37 i64)
+  (local $38 i64)
+  (local $39 i64)
+  (local $40 i64)
+  (local $41 i64)
+  (local $42 i64)
+  (local $43 i64)
+  (local $44 i64)
+  (local $45 i64)
+  (local $46 i64)
+  (local $47 i64)
+  (local $48 i64)
+  (local $49 i64)
+  (local $50 f64)
   local.get $1
   i64.const 9223372036854775807
   i64.and
@@ -4383,75 +4416,75 @@
   i64.or
   local.set $14
   local.get $7
-  local.set $13
-  local.get $14
-  local.set $12
-  local.get $13
-  i64.const 4294967295
-  i64.and
-  local.set $15
-  local.get $12
-  i64.const 4294967295
-  i64.and
   local.set $16
-  local.get $13
-  i64.const 32
-  i64.shr_u
-  local.set $13
-  local.get $12
-  i64.const 32
-  i64.shr_u
-  local.set $12
-  local.get $15
+  local.get $14
+  local.set $15
   local.get $16
-  i64.mul
-  local.set $19
-  local.get $19
   i64.const 4294967295
   i64.and
   local.set $17
-  local.get $13
+  local.get $15
+  i64.const 4294967295
+  i64.and
+  local.set $18
   local.get $16
+  i64.const 32
+  i64.shr_u
+  local.set $16
+  local.get $15
+  i64.const 32
+  i64.shr_u
+  local.set $15
+  local.get $17
+  local.get $18
   i64.mul
-  local.get $19
+  local.set $21
+  local.get $21
+  i64.const 4294967295
+  i64.and
+  local.set $19
+  local.get $16
+  local.get $18
+  i64.mul
+  local.get $21
   i64.const 32
   i64.shr_u
   i64.add
-  local.set $19
-  local.get $19
+  local.set $21
+  local.get $21
   i64.const 32
   i64.shr_u
-  local.set $18
+  local.set $20
+  local.get $17
   local.get $15
-  local.get $12
   i64.mul
-  local.get $19
+  local.get $21
   i64.const 4294967295
   i64.and
   i64.add
-  local.set $19
-  local.get $13
-  local.get $12
+  local.set $21
+  local.get $16
+  local.get $15
   i64.mul
-  local.get $18
+  local.get $20
   i64.add
-  local.get $19
+  local.get $21
   i64.const 32
   i64.shr_u
   i64.add
   global.set $~lib/math/res128_hi
-  local.get $19
+  local.get $21
   i64.const 32
   i64.shl
-  local.get $17
+  local.get $19
   i64.add
-  local.set $20
+  local.set $22
   global.get $~lib/math/res128_hi
-  local.set $21
+  local.set $23
   local.get $6
   local.get $14
   i64.mul
-  local.set $22
+  local.set $24
   local.get $8
   i64.const 32
   i64.shr_u
@@ -4459,207 +4492,207 @@
   i64.const 32
   i64.shr_s
   i64.mul
-  local.set $23
-  local.get $20
-  local.get $23
-  i64.add
-  local.set $24
+  local.set $25
   local.get $22
-  local.get $21
+  local.get $25
   i64.add
+  local.set $26
   local.get $24
   local.get $23
+  i64.add
+  local.get $26
+  local.get $25
   i64.lt_u
   i64.extend_i32_u
   i64.add
-  local.set $25
-  local.get $24
+  local.set $27
+  local.get $26
   i64.const 2
   i64.shl
-  local.set $26
-  local.get $25
+  local.set $28
+  local.get $27
   i64.const 2
   i64.shl
-  local.get $24
+  local.get $26
   i64.const 62
   i64.shr_u
   i64.or
-  local.set $27
-  local.get $27
+  local.set $29
+  local.get $29
   i64.const 63
   i64.shr_s
-  local.set $28
-  local.get $28
+  local.set $30
+  local.get $30
   i64.const 1
   i64.shr_s
-  local.set $29
-  local.get $25
+  local.set $31
+  local.get $27
   i64.const 62
   i64.shr_s
-  local.get $28
+  local.get $30
   i64.sub
-  local.set $30
+  local.set $32
   i64.const 4372995238176751616
-  local.get $26
   local.get $28
+  local.get $30
   i64.xor
-  local.set $13
-  local.get $27
+  local.set $34
   local.get $29
+  local.get $31
   i64.xor
-  local.set $12
-  local.get $12
+  local.set $33
+  local.get $33
   i64.clz
-  local.set $19
-  local.get $12
-  local.get $19
+  local.set $35
+  local.get $33
+  local.get $35
   i64.shl
-  local.get $13
+  local.get $34
   i64.const 64
-  local.get $19
+  local.get $35
   i64.sub
   i64.shr_u
   i64.or
-  local.set $12
-  local.get $13
-  local.get $19
+  local.set $33
+  local.get $34
+  local.get $35
   i64.shl
-  local.set $13
+  local.set $34
   i64.const -3958705157555305932
-  local.set $16
-  local.get $12
-  local.set $15
-  local.get $16
+  local.set $37
+  local.get $33
+  local.set $36
+  local.get $37
   i64.const 4294967295
   i64.and
-  local.set $18
-  local.get $15
+  local.set $38
+  local.get $36
   i64.const 4294967295
   i64.and
-  local.set $17
-  local.get $16
+  local.set $39
+  local.get $37
   i64.const 32
   i64.shr_u
-  local.set $16
-  local.get $15
+  local.set $37
+  local.get $36
   i64.const 32
   i64.shr_u
-  local.set $15
-  local.get $18
-  local.get $17
+  local.set $36
+  local.get $38
+  local.get $39
   i64.mul
-  local.set $33
-  local.get $33
+  local.set $42
+  local.get $42
   i64.const 4294967295
   i64.and
-  local.set $31
-  local.get $16
-  local.get $17
+  local.set $40
+  local.get $37
+  local.get $39
   i64.mul
-  local.get $33
+  local.get $42
   i64.const 32
   i64.shr_u
   i64.add
-  local.set $33
-  local.get $33
+  local.set $42
+  local.get $42
   i64.const 32
   i64.shr_u
-  local.set $32
-  local.get $18
-  local.get $15
+  local.set $41
+  local.get $38
+  local.get $36
   i64.mul
-  local.get $33
+  local.get $42
   i64.const 4294967295
   i64.and
   i64.add
-  local.set $33
-  local.get $16
-  local.get $15
+  local.set $42
+  local.get $37
+  local.get $36
   i64.mul
-  local.get $32
+  local.get $41
   i64.add
-  local.get $33
+  local.get $42
   i64.const 32
   i64.shr_u
   i64.add
   global.set $~lib/math/res128_hi
-  local.get $33
+  local.get $42
   i64.const 32
   i64.shl
-  local.get $31
+  local.get $40
   i64.add
-  local.set $33
+  local.set $43
   global.get $~lib/math/res128_hi
-  local.set $32
-  local.get $32
+  local.set $44
+  local.get $44
   i64.const 11
   i64.shr_u
-  local.set $31
-  local.get $33
+  local.set $45
+  local.get $43
   i64.const 11
   i64.shr_u
-  local.get $32
+  local.get $44
   i64.const 53
   i64.shl
   i64.or
-  local.set $17
+  local.set $46
   f64.const 2.6469779601696886e-23
   i64.const -4267615245585081135
   f64.convert_i64_u
   f64.mul
-  local.get $12
+  local.get $33
   f64.convert_i64_u
   f64.mul
   f64.const 2.6469779601696886e-23
   i64.const -3958705157555305932
   f64.convert_i64_u
   f64.mul
-  local.get $13
+  local.get $34
   f64.convert_i64_u
   f64.mul
   f64.add
   i64.trunc_f64_u
-  local.set $18
-  local.get $31
-  local.get $33
-  local.get $18
+  local.set $47
+  local.get $45
+  local.get $43
+  local.get $47
   i64.lt_u
   i64.extend_i32_u
   i64.add
   f64.convert_i64_u
   global.set $~lib/math/rempio2_y0
   f64.const 5.421010862427522e-20
-  local.get $17
-  local.get $18
+  local.get $46
+  local.get $47
   i64.add
   f64.convert_i64_u
   f64.mul
   global.set $~lib/math/rempio2_y1
-  local.get $19
+  local.get $35
   i64.const 52
   i64.shl
   i64.sub
-  local.set $34
+  local.set $48
   local.get $1
-  local.get $27
+  local.get $29
   i64.xor
   i64.const -9223372036854775808
   i64.and
-  local.set $35
-  local.get $34
-  local.get $35
+  local.set $49
+  local.get $48
+  local.get $49
   i64.or
   f64.reinterpret_i64
-  local.set $36
+  local.set $50
   global.get $~lib/math/rempio2_y0
-  local.get $36
+  local.get $50
   f64.mul
   global.set $~lib/math/rempio2_y0
   global.get $~lib/math/rempio2_y1
-  local.get $36
+  local.get $50
   f64.mul
   global.set $~lib/math/rempio2_y1
-  local.get $30
+  local.get $32
   i32.wrap_i64
  )
  (func $~lib/math/NativeMath.cos (param $0 f64) (result f64)
@@ -4674,14 +4707,39 @@
   (local $9 f64)
   (local $10 i32)
   (local $11 i64)
-  (local $12 i32)
+  (local $12 f64)
   (local $13 i32)
   (local $14 i32)
-  (local $15 i32)
+  (local $15 f64)
   (local $16 f64)
-  (local $17 i32)
+  (local $17 f64)
   (local $18 f64)
   (local $19 f64)
+  (local $20 f64)
+  (local $21 i32)
+  (local $22 f64)
+  (local $23 i32)
+  (local $24 i32)
+  (local $25 f64)
+  (local $26 f64)
+  (local $27 f64)
+  (local $28 i32)
+  (local $29 i32)
+  (local $30 f64)
+  (local $31 f64)
+  (local $32 i32)
+  (local $33 f64)
+  (local $34 f64)
+  (local $35 f64)
+  (local $36 f64)
+  (local $37 f64)
+  (local $38 f64)
+  (local $39 f64)
+  (local $40 f64)
+  (local $41 f64)
+  (local $42 f64)
+  (local $43 f64)
+  (local $44 f64)
   local.get $0
   i64.reinterpret_f64
   local.set $1
@@ -4783,7 +4841,7 @@
   end
   block $~lib/math/rempio2|inlined.0 (result i32)
    local.get $0
-   local.set $4
+   local.set $12
    local.get $1
    local.set $11
    local.get $3
@@ -4794,312 +4852,312 @@
    i32.wrap_i64
    i32.const 2147483647
    i32.and
-   local.set $12
+   local.set $13
    i32.const 0
    i32.const 1
    i32.lt_s
    drop
-   local.get $12
+   local.get $13
    i32.const 1073928572
    i32.lt_u
    if
     i32.const 1
-    local.set $13
+    local.set $14
     local.get $10
     i32.eqz
     if
-     local.get $4
+     local.get $12
      f64.const 1.5707963267341256
      f64.sub
-     local.set $9
-     local.get $12
+     local.set $15
+     local.get $13
      i32.const 1073291771
      i32.ne
      if
-      local.get $9
+      local.get $15
       f64.const 6.077100506506192e-11
       f64.sub
-      local.set $8
-      local.get $9
-      local.get $8
+      local.set $16
+      local.get $15
+      local.get $16
       f64.sub
       f64.const 6.077100506506192e-11
       f64.sub
-      local.set $7
+      local.set $17
      else
-      local.get $9
+      local.get $15
       f64.const 6.077100506303966e-11
       f64.sub
-      local.set $9
-      local.get $9
+      local.set $15
+      local.get $15
       f64.const 2.0222662487959506e-21
       f64.sub
-      local.set $8
-      local.get $9
-      local.get $8
+      local.set $16
+      local.get $15
+      local.get $16
       f64.sub
       f64.const 2.0222662487959506e-21
       f64.sub
-      local.set $7
+      local.set $17
      end
     else
-     local.get $4
+     local.get $12
      f64.const 1.5707963267341256
      f64.add
-     local.set $9
-     local.get $12
+     local.set $15
+     local.get $13
      i32.const 1073291771
      i32.ne
      if
-      local.get $9
+      local.get $15
       f64.const 6.077100506506192e-11
       f64.add
-      local.set $8
-      local.get $9
-      local.get $8
+      local.set $16
+      local.get $15
+      local.get $16
       f64.sub
       f64.const 6.077100506506192e-11
       f64.add
-      local.set $7
+      local.set $17
      else
-      local.get $9
+      local.get $15
       f64.const 6.077100506303966e-11
       f64.add
-      local.set $9
-      local.get $9
+      local.set $15
+      local.get $15
       f64.const 2.0222662487959506e-21
       f64.add
-      local.set $8
-      local.get $9
-      local.get $8
+      local.set $16
+      local.get $15
+      local.get $16
       f64.sub
       f64.const 2.0222662487959506e-21
       f64.add
-      local.set $7
+      local.set $17
      end
      i32.const -1
-     local.set $13
+     local.set $14
     end
-    local.get $8
+    local.get $16
     global.set $~lib/math/rempio2_y0
-    local.get $7
+    local.get $17
     global.set $~lib/math/rempio2_y1
-    local.get $13
+    local.get $14
     br $~lib/math/rempio2|inlined.0
    end
-   local.get $12
+   local.get $13
    i32.const 1094263291
    i32.lt_u
    if
-    local.get $4
+    local.get $12
     f64.const 0.6366197723675814
     f64.mul
     f64.nearest
-    local.set $7
-    local.get $4
-    local.get $7
+    local.set $18
+    local.get $12
+    local.get $18
     f64.const 1.5707963267341256
     f64.mul
     f64.sub
-    local.set $8
-    local.get $7
+    local.set $19
+    local.get $18
     f64.const 6.077100506506192e-11
     f64.mul
-    local.set $9
-    local.get $12
+    local.set $20
+    local.get $13
     i32.const 20
     i32.shr_u
-    local.set $13
-    local.get $8
-    local.get $9
+    local.set $21
+    local.get $19
+    local.get $20
     f64.sub
-    local.set $6
-    local.get $6
+    local.set $22
+    local.get $22
     i64.reinterpret_f64
     i64.const 32
     i64.shr_u
     i32.wrap_i64
-    local.set $14
-    local.get $13
-    local.get $14
+    local.set $23
+    local.get $21
+    local.get $23
     i32.const 20
     i32.shr_u
     i32.const 2047
     i32.and
     i32.sub
-    local.set $15
-    local.get $15
+    local.set $24
+    local.get $24
     i32.const 16
     i32.gt_u
     if
-     local.get $8
-     local.set $5
-     local.get $7
+     local.get $19
+     local.set $25
+     local.get $18
      f64.const 6.077100506303966e-11
      f64.mul
-     local.set $9
-     local.get $5
-     local.get $9
+     local.set $20
+     local.get $25
+     local.get $20
      f64.sub
-     local.set $8
-     local.get $7
+     local.set $19
+     local.get $18
      f64.const 2.0222662487959506e-21
      f64.mul
-     local.get $5
-     local.get $8
+     local.get $25
+     local.get $19
      f64.sub
-     local.get $9
+     local.get $20
      f64.sub
      f64.sub
-     local.set $9
-     local.get $8
-     local.get $9
+     local.set $20
+     local.get $19
+     local.get $20
      f64.sub
-     local.set $6
-     local.get $6
+     local.set $22
+     local.get $22
      i64.reinterpret_f64
      i64.const 32
      i64.shr_u
      i32.wrap_i64
-     local.set $14
-     local.get $13
-     local.get $14
+     local.set $23
+     local.get $21
+     local.get $23
      i32.const 20
      i32.shr_u
      i32.const 2047
      i32.and
      i32.sub
-     local.set $15
-     local.get $15
+     local.set $24
+     local.get $24
      i32.const 49
      i32.gt_u
      if
-      local.get $8
-      local.set $16
-      local.get $7
+      local.get $19
+      local.set $26
+      local.get $18
       f64.const 2.0222662487111665e-21
       f64.mul
-      local.set $9
-      local.get $16
-      local.get $9
+      local.set $20
+      local.get $26
+      local.get $20
       f64.sub
-      local.set $8
-      local.get $7
+      local.set $19
+      local.get $18
       f64.const 8.4784276603689e-32
       f64.mul
-      local.get $16
-      local.get $8
+      local.get $26
+      local.get $19
       f64.sub
-      local.get $9
+      local.get $20
       f64.sub
       f64.sub
-      local.set $9
-      local.get $8
-      local.get $9
+      local.set $20
+      local.get $19
+      local.get $20
       f64.sub
-      local.set $6
+      local.set $22
      end
     end
-    local.get $8
-    local.get $6
+    local.get $19
+    local.get $22
     f64.sub
-    local.get $9
+    local.get $20
     f64.sub
-    local.set $5
-    local.get $6
+    local.set $27
+    local.get $22
     global.set $~lib/math/rempio2_y0
-    local.get $5
+    local.get $27
     global.set $~lib/math/rempio2_y1
-    local.get $7
+    local.get $18
     i32.trunc_f64_s
     br $~lib/math/rempio2|inlined.0
    end
-   local.get $4
+   local.get $12
    local.get $11
    call $~lib/math/pio2_large_quot
-   local.set $15
+   local.set $28
    i32.const 0
-   local.get $15
+   local.get $28
    i32.sub
-   local.get $15
+   local.get $28
    local.get $10
    select
   end
-  local.set $17
+  local.set $29
   global.get $~lib/math/rempio2_y0
-  local.set $18
+  local.set $30
   global.get $~lib/math/rempio2_y1
-  local.set $19
-  local.get $17
+  local.set $31
+  local.get $29
   i32.const 1
   i32.and
   if (result f64)
    block $~lib/math/sin_kern|inlined.0 (result f64)
-    local.get $18
-    local.set $7
-    local.get $19
-    local.set $16
+    local.get $30
+    local.set $34
+    local.get $31
+    local.set $33
     i32.const 1
-    local.set $13
-    local.get $7
-    local.get $7
+    local.set $32
+    local.get $34
+    local.get $34
     f64.mul
-    local.set $4
-    local.get $4
-    local.get $4
+    local.set $35
+    local.get $35
+    local.get $35
     f64.mul
-    local.set $5
+    local.set $36
     f64.const 0.00833333333332249
-    local.get $4
+    local.get $35
     f64.const -1.984126982985795e-04
-    local.get $4
+    local.get $35
     f64.const 2.7557313707070068e-06
     f64.mul
     f64.add
     f64.mul
     f64.add
-    local.get $4
-    local.get $5
+    local.get $35
+    local.get $36
     f64.mul
     f64.const -2.5050760253406863e-08
-    local.get $4
+    local.get $35
     f64.const 1.58969099521155e-10
     f64.mul
     f64.add
     f64.mul
     f64.add
-    local.set $6
-    local.get $4
-    local.get $7
+    local.set $37
+    local.get $35
+    local.get $34
     f64.mul
-    local.set $9
-    local.get $13
+    local.set $38
+    local.get $32
     i32.eqz
     if
-     local.get $7
-     local.get $9
+     local.get $34
+     local.get $38
      f64.const -0.16666666666666632
-     local.get $4
-     local.get $6
+     local.get $35
+     local.get $37
      f64.mul
      f64.add
      f64.mul
      f64.add
      br $~lib/math/sin_kern|inlined.0
     else
-     local.get $7
-     local.get $4
+     local.get $34
+     local.get $35
      f64.const 0.5
-     local.get $16
+     local.get $33
      f64.mul
-     local.get $9
-     local.get $6
+     local.get $38
+     local.get $37
      f64.mul
      f64.sub
      f64.mul
-     local.get $16
+     local.get $33
      f64.sub
-     local.get $9
+     local.get $38
      f64.const -0.16666666666666632
      f64.mul
      f64.sub
@@ -5109,36 +5167,36 @@
     unreachable
    end
   else
-   local.get $18
-   local.set $16
-   local.get $19
-   local.set $8
-   local.get $16
-   local.get $16
+   local.get $30
+   local.set $40
+   local.get $31
+   local.set $39
+   local.get $40
+   local.get $40
    f64.mul
-   local.set $9
-   local.get $9
-   local.get $9
+   local.set $41
+   local.get $41
+   local.get $41
    f64.mul
-   local.set $6
-   local.get $9
+   local.set $42
+   local.get $41
    f64.const 0.0416666666666666
-   local.get $9
+   local.get $41
    f64.const -0.001388888888887411
-   local.get $9
+   local.get $41
    f64.const 2.480158728947673e-05
    f64.mul
    f64.add
    f64.mul
    f64.add
    f64.mul
-   local.get $6
-   local.get $6
+   local.get $42
+   local.get $42
    f64.mul
    f64.const -2.7557314351390663e-07
-   local.get $9
+   local.get $41
    f64.const 2.087572321298175e-09
-   local.get $9
+   local.get $41
    f64.const -1.1359647557788195e-11
    f64.mul
    f64.add
@@ -5146,33 +5204,33 @@
    f64.add
    f64.mul
    f64.add
-   local.set $5
+   local.set $43
    f64.const 0.5
-   local.get $9
+   local.get $41
    f64.mul
-   local.set $4
+   local.set $44
    f64.const 1
-   local.get $4
+   local.get $44
    f64.sub
-   local.set $6
-   local.get $6
+   local.set $42
+   local.get $42
    f64.const 1
-   local.get $6
+   local.get $42
    f64.sub
-   local.get $4
+   local.get $44
    f64.sub
-   local.get $9
-   local.get $5
+   local.get $41
+   local.get $43
    f64.mul
-   local.get $16
-   local.get $8
+   local.get $40
+   local.get $39
    f64.mul
    f64.sub
    f64.add
    f64.add
   end
   local.set $0
-  local.get $17
+  local.get $29
   i32.const 1
   i32.add
   i32.const 2
@@ -5216,25 +5274,64 @@
   (local $5 f64)
   (local $6 f64)
   (local $7 f64)
-  (local $8 i32)
-  (local $9 i32)
-  (local $10 f32)
-  (local $11 i32)
-  (local $12 f32)
-  (local $13 i32)
-  (local $14 i64)
-  (local $15 i32)
-  (local $16 i64)
-  (local $17 i64)
-  (local $18 i64)
-  (local $19 i64)
-  (local $20 i64)
-  (local $21 i64)
-  (local $22 i64)
-  (local $23 i32)
-  (local $24 i32)
+  (local $8 f64)
+  (local $9 f64)
+  (local $10 f64)
+  (local $11 f64)
+  (local $12 f64)
+  (local $13 f64)
+  (local $14 f64)
+  (local $15 f64)
+  (local $16 f64)
+  (local $17 f64)
+  (local $18 f64)
+  (local $19 f64)
+  (local $20 f64)
+  (local $21 f64)
+  (local $22 f64)
+  (local $23 f64)
+  (local $24 f64)
   (local $25 f64)
-  (local $26 f32)
+  (local $26 f64)
+  (local $27 f64)
+  (local $28 f64)
+  (local $29 f64)
+  (local $30 f64)
+  (local $31 f64)
+  (local $32 f64)
+  (local $33 f64)
+  (local $34 f64)
+  (local $35 i32)
+  (local $36 i32)
+  (local $37 f32)
+  (local $38 f64)
+  (local $39 i32)
+  (local $40 f32)
+  (local $41 i32)
+  (local $42 i64)
+  (local $43 i32)
+  (local $44 i64)
+  (local $45 i64)
+  (local $46 i64)
+  (local $47 i64)
+  (local $48 i64)
+  (local $49 i64)
+  (local $50 i64)
+  (local $51 i64)
+  (local $52 i32)
+  (local $53 i32)
+  (local $54 i32)
+  (local $55 f64)
+  (local $56 f64)
+  (local $57 f64)
+  (local $58 f64)
+  (local $59 f64)
+  (local $60 f64)
+  (local $61 f64)
+  (local $62 f64)
+  (local $63 f64)
+  (local $64 f64)
+  (local $65 f32)
   local.get $0
   i32.reinterpret_f32
   local.set $1
@@ -5317,35 +5414,35 @@
      f64.const 3.141592653589793
      f64.sub
     end
-    local.set $3
-    local.get $3
-    local.get $3
+    local.set $7
+    local.get $7
+    local.get $7
     f64.mul
-    local.set $6
-    local.get $6
-    local.get $6
+    local.set $8
+    local.get $8
+    local.get $8
     f64.mul
-    local.set $5
+    local.set $9
     f64.const -0.001388676377460993
-    local.get $6
+    local.get $8
     f64.const 2.439044879627741e-05
     f64.mul
     f64.add
-    local.set $4
+    local.set $10
     f32.const 1
     f64.promote_f32
-    local.get $6
+    local.get $8
     f64.const -0.499999997251031
     f64.mul
     f64.add
-    local.get $5
+    local.get $9
     f64.const 0.04166662332373906
     f64.mul
     f64.add
-    local.get $5
-    local.get $6
+    local.get $9
+    local.get $8
     f64.mul
-    local.get $4
+    local.get $10
     f64.mul
     f64.add
     f32.demote_f64
@@ -5358,38 +5455,38 @@
      f64.promote_f32
      f64.const 1.5707963267948966
      f64.add
-     local.set $3
-     local.get $3
-     local.get $3
+     local.set $11
+     local.get $11
+     local.get $11
      f64.mul
-     local.set $4
-     local.get $4
-     local.get $4
+     local.set $12
+     local.get $12
+     local.get $12
      f64.mul
-     local.set $5
+     local.set $13
      f64.const -1.9839334836096632e-04
-     local.get $4
+     local.get $12
      f64.const 2.718311493989822e-06
      f64.mul
      f64.add
-     local.set $6
-     local.get $4
-     local.get $3
+     local.set $14
+     local.get $12
+     local.get $11
      f64.mul
-     local.set $7
-     local.get $3
-     local.get $7
+     local.set $15
+     local.get $11
+     local.get $15
      f64.const -0.16666666641626524
-     local.get $4
+     local.get $12
      f64.const 0.008333329385889463
      f64.mul
      f64.add
      f64.mul
      f64.add
-     local.get $7
-     local.get $5
+     local.get $15
+     local.get $13
      f64.mul
-     local.get $6
+     local.get $14
      f64.mul
      f64.add
      f32.demote_f64
@@ -5398,38 +5495,38 @@
      local.get $0
      f64.promote_f32
      f64.sub
-     local.set $3
-     local.get $3
-     local.get $3
+     local.set $16
+     local.get $16
+     local.get $16
      f64.mul
-     local.set $7
-     local.get $7
-     local.get $7
+     local.set $17
+     local.get $17
+     local.get $17
      f64.mul
-     local.set $6
+     local.set $18
      f64.const -1.9839334836096632e-04
-     local.get $7
+     local.get $17
      f64.const 2.718311493989822e-06
      f64.mul
      f64.add
-     local.set $5
-     local.get $7
-     local.get $3
+     local.set $19
+     local.get $17
+     local.get $16
      f64.mul
-     local.set $4
-     local.get $3
-     local.get $4
+     local.set $20
+     local.get $16
+     local.get $20
      f64.const -0.16666666641626524
-     local.get $7
+     local.get $17
      f64.const 0.008333329385889463
      f64.mul
      f64.add
      f64.mul
      f64.add
-     local.get $4
-     local.get $6
+     local.get $20
+     local.get $18
      f64.mul
-     local.get $5
+     local.get $19
      f64.mul
      f64.add
      f32.demote_f64
@@ -5458,35 +5555,35 @@
      f64.const 6.283185307179586
      f64.sub
     end
-    local.set $3
-    local.get $3
-    local.get $3
+    local.set $21
+    local.get $21
+    local.get $21
     f64.mul
-    local.set $4
-    local.get $4
-    local.get $4
+    local.set $22
+    local.get $22
+    local.get $22
     f64.mul
-    local.set $5
+    local.set $23
     f64.const -0.001388676377460993
-    local.get $4
+    local.get $22
     f64.const 2.439044879627741e-05
     f64.mul
     f64.add
-    local.set $6
+    local.set $24
     f32.const 1
     f64.promote_f32
-    local.get $4
+    local.get $22
     f64.const -0.499999997251031
     f64.mul
     f64.add
-    local.get $5
+    local.get $23
     f64.const 0.04166662332373906
     f64.mul
     f64.add
-    local.get $5
-    local.get $4
+    local.get $23
+    local.get $22
     f64.mul
-    local.get $6
+    local.get $24
     f64.mul
     f64.add
     f32.demote_f64
@@ -5499,38 +5596,38 @@
      f64.promote_f32
      f64.const 4.71238898038469
      f64.sub
-     local.set $7
-     local.get $7
-     local.get $7
+     local.set $25
+     local.get $25
+     local.get $25
      f64.mul
-     local.set $6
-     local.get $6
-     local.get $6
+     local.set $26
+     local.get $26
+     local.get $26
      f64.mul
-     local.set $5
+     local.set $27
      f64.const -1.9839334836096632e-04
-     local.get $6
+     local.get $26
      f64.const 2.718311493989822e-06
      f64.mul
      f64.add
-     local.set $4
-     local.get $6
-     local.get $7
+     local.set $28
+     local.get $26
+     local.get $25
      f64.mul
-     local.set $3
-     local.get $7
-     local.get $3
+     local.set $29
+     local.get $25
+     local.get $29
      f64.const -0.16666666641626524
-     local.get $6
+     local.get $26
      f64.const 0.008333329385889463
      f64.mul
      f64.add
      f64.mul
      f64.add
-     local.get $3
-     local.get $5
+     local.get $29
+     local.get $27
      f64.mul
-     local.get $4
+     local.get $28
      f64.mul
      f64.add
      f32.demote_f64
@@ -5539,38 +5636,38 @@
      f64.promote_f32
      f64.const 4.71238898038469
      f64.sub
-     local.set $7
-     local.get $7
-     local.get $7
+     local.set $30
+     local.get $30
+     local.get $30
      f64.mul
-     local.set $3
-     local.get $3
-     local.get $3
+     local.set $31
+     local.get $31
+     local.get $31
      f64.mul
-     local.set $4
+     local.set $32
      f64.const -1.9839334836096632e-04
-     local.get $3
+     local.get $31
      f64.const 2.718311493989822e-06
      f64.mul
      f64.add
-     local.set $5
-     local.get $3
-     local.get $7
+     local.set $33
+     local.get $31
+     local.get $30
      f64.mul
-     local.set $6
-     local.get $7
-     local.get $6
+     local.set $34
+     local.get $30
+     local.get $34
      f64.const -0.16666666641626524
-     local.get $3
+     local.get $31
      f64.const 0.008333329385889463
      f64.mul
      f64.add
      f64.mul
      f64.add
-     local.get $6
-     local.get $4
+     local.get $34
+     local.get $32
      f64.mul
-     local.get $5
+     local.get $33
      f64.mul
      f64.add
      f32.demote_f64
@@ -5590,240 +5687,240 @@
   end
   block $~lib/math/rempio2f|inlined.0 (result i32)
    local.get $0
-   local.set $10
+   local.set $37
    local.get $1
-   local.set $9
+   local.set $36
    local.get $2
-   local.set $8
-   local.get $9
+   local.set $35
+   local.get $36
    i32.const 1305022427
    i32.lt_u
    if
-    local.get $10
+    local.get $37
     f64.promote_f32
     f64.const 0.6366197723675814
     f64.mul
     f64.nearest
-    local.set $6
-    local.get $10
+    local.set $38
+    local.get $37
     f64.promote_f32
-    local.get $6
+    local.get $38
     f64.const 1.5707963109016418
     f64.mul
     f64.sub
-    local.get $6
+    local.get $38
     f64.const 1.5893254773528196e-08
     f64.mul
     f64.sub
     global.set $~lib/math/rempio2f_y
-    local.get $6
+    local.get $38
     i32.trunc_f64_s
     br $~lib/math/rempio2f|inlined.0
    end
-   local.get $10
-   local.set $12
-   local.get $9
-   local.set $11
-   local.get $11
+   local.get $37
+   local.set $40
+   local.get $36
+   local.set $39
+   local.get $39
    i32.const 23
    i32.shr_s
    i32.const 152
    i32.sub
-   local.set $13
-   local.get $13
+   local.set $41
+   local.get $41
    i32.const 63
    i32.and
    i64.extend_i32_s
-   local.set $14
+   local.set $42
    i32.const 4600
-   local.get $13
+   local.get $41
    i32.const 6
    i32.shr_s
    i32.const 3
    i32.shl
    i32.add
-   local.set $15
-   local.get $15
+   local.set $43
+   local.get $43
    i64.load
-   local.set $16
-   local.get $15
+   local.set $44
+   local.get $43
    i64.load offset=8
-   local.set $17
-   local.get $14
+   local.set $45
+   local.get $42
    i64.const 32
    i64.gt_u
    if
-    local.get $15
+    local.get $43
     i64.load offset=16
-    local.set $19
-    local.get $19
+    local.set $47
+    local.get $47
     i64.const 96
-    local.get $14
+    local.get $42
     i64.sub
     i64.shr_u
-    local.set $18
-    local.get $18
-    local.get $17
-    local.get $14
+    local.set $46
+    local.get $46
+    local.get $45
+    local.get $42
     i64.const 32
     i64.sub
     i64.shl
     i64.or
-    local.set $18
+    local.set $46
    else
-    local.get $17
+    local.get $45
     i64.const 32
-    local.get $14
+    local.get $42
     i64.sub
     i64.shr_u
-    local.set $18
+    local.set $46
    end
-   local.get $17
+   local.get $45
    i64.const 64
-   local.get $14
+   local.get $42
    i64.sub
    i64.shr_u
-   local.get $16
-   local.get $14
+   local.get $44
+   local.get $42
    i64.shl
    i64.or
-   local.set $19
-   local.get $11
+   local.set $48
+   local.get $39
    i32.const 8388607
    i32.and
    i32.const 8388608
    i32.or
    i64.extend_i32_s
-   local.set $20
-   local.get $20
-   local.get $19
+   local.set $49
+   local.get $49
+   local.get $48
    i64.mul
-   local.get $20
-   local.get $18
+   local.get $49
+   local.get $46
    i64.mul
    i64.const 32
    i64.shr_u
    i64.add
-   local.set $21
-   local.get $21
+   local.set $50
+   local.get $50
    i64.const 2
    i64.shl
-   local.set $22
-   local.get $21
+   local.set $51
+   local.get $50
    i64.const 62
    i64.shr_u
-   local.get $22
+   local.get $51
    i64.const 63
    i64.shr_u
    i64.add
    i32.wrap_i64
-   local.set $23
+   local.set $52
    f64.const 8.515303950216386e-20
-   local.get $12
+   local.get $40
    f64.promote_f32
    f64.copysign
-   local.get $22
+   local.get $51
    f64.convert_i64_s
    f64.mul
    global.set $~lib/math/rempio2f_y
-   local.get $23
-   local.set $23
+   local.get $52
+   local.set $53
    i32.const 0
-   local.get $23
+   local.get $53
    i32.sub
-   local.get $23
-   local.get $8
+   local.get $53
+   local.get $35
    select
   end
-  local.set $24
+  local.set $54
   global.get $~lib/math/rempio2f_y
-  local.set $25
-  local.get $24
+  local.set $55
+  local.get $54
   i32.const 1
   i32.and
   if (result f32)
-   local.get $25
-   local.set $7
-   local.get $7
-   local.get $7
+   local.get $55
+   local.set $56
+   local.get $56
+   local.get $56
    f64.mul
-   local.set $6
-   local.get $6
-   local.get $6
+   local.set $57
+   local.get $57
+   local.get $57
    f64.mul
-   local.set $5
+   local.set $58
    f64.const -1.9839334836096632e-04
-   local.get $6
+   local.get $57
    f64.const 2.718311493989822e-06
    f64.mul
    f64.add
-   local.set $4
-   local.get $6
-   local.get $7
+   local.set $59
+   local.get $57
+   local.get $56
    f64.mul
-   local.set $3
-   local.get $7
-   local.get $3
+   local.set $60
+   local.get $56
+   local.get $60
    f64.const -0.16666666641626524
-   local.get $6
+   local.get $57
    f64.const 0.008333329385889463
    f64.mul
    f64.add
    f64.mul
    f64.add
-   local.get $3
-   local.get $5
+   local.get $60
+   local.get $58
    f64.mul
-   local.get $4
+   local.get $59
    f64.mul
    f64.add
    f32.demote_f64
   else
-   local.get $25
-   local.set $7
-   local.get $7
-   local.get $7
+   local.get $55
+   local.set $61
+   local.get $61
+   local.get $61
    f64.mul
-   local.set $3
-   local.get $3
-   local.get $3
+   local.set $62
+   local.get $62
+   local.get $62
    f64.mul
-   local.set $4
+   local.set $63
    f64.const -0.001388676377460993
-   local.get $3
+   local.get $62
    f64.const 2.439044879627741e-05
    f64.mul
    f64.add
-   local.set $5
+   local.set $64
    f32.const 1
    f64.promote_f32
-   local.get $3
+   local.get $62
    f64.const -0.499999997251031
    f64.mul
    f64.add
-   local.get $4
+   local.get $63
    f64.const 0.04166662332373906
    f64.mul
    f64.add
-   local.get $4
-   local.get $3
+   local.get $63
+   local.get $62
    f64.mul
-   local.get $5
+   local.get $64
    f64.mul
    f64.add
    f32.demote_f64
   end
-  local.set $26
-  local.get $24
+  local.set $65
+  local.get $54
   i32.const 1
   i32.add
   i32.const 2
   i32.and
   if (result f32)
-   local.get $26
+   local.get $65
    f32.neg
   else
-   local.get $26
+   local.get $65
   end
  )
  (func $std/math/test_cosf (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
@@ -6169,6 +6266,7 @@
   (local $19 f64)
   (local $20 f64)
   (local $21 f64)
+  (local $22 f64)
   i32.const 0
   i32.const 1
   i32.lt_s
@@ -6420,9 +6518,9 @@
    end
    local.get $11
    f64.reinterpret_i64
-   local.set $18
-   local.get $18
-   local.get $18
+   local.set $22
+   local.get $22
+   local.get $22
    local.get $13
    f64.mul
    f64.add
@@ -6980,6 +7078,8 @@
   (local $1 i32)
   (local $2 f32)
   (local $3 f32)
+  (local $4 f32)
+  (local $5 f32)
   local.get $0
   i32.reinterpret_f32
   local.set $1
@@ -7027,18 +7127,18 @@
   if
    local.get $0
    call $~lib/math/NativeMathf.exp
-   local.set $2
+   local.set $3
    f32.const 0.5
-   local.get $2
+   local.get $3
    f32.mul
    f32.const 0.5
-   local.get $2
+   local.get $3
    f32.div
    f32.add
    return
   end
   local.get $0
-  local.set $2
+  local.set $4
   i32.const 127
   i32.const 235
   i32.const 1
@@ -7047,14 +7147,14 @@
   i32.const 23
   i32.shl
   f32.reinterpret_i32
-  local.set $3
-  local.get $2
+  local.set $5
+  local.get $4
   f32.const 162.88958740234375
   f32.sub
   call $~lib/math/NativeMathf.exp
-  local.get $3
+  local.get $5
   f32.mul
-  local.get $3
+  local.get $5
   f32.mul
  )
  (func $std/math/test_coshf (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
@@ -7149,6 +7249,7 @@
   (local $17 f64)
   (local $18 f64)
   (local $19 f64)
+  (local $20 f64)
   block $~lib/util/math/exp2_lut|inlined.0 (result f64)
    local.get $0
    local.set $1
@@ -7388,11 +7489,11 @@
    end
    local.get $10
    f64.reinterpret_i64
-   local.set $17
-   local.get $17
+   local.set $20
+   local.get $20
    local.get $12
    f64.mul
-   local.get $17
+   local.get $20
    f64.add
   end
  )
@@ -8518,6 +8619,15 @@
   (local $21 f64)
   (local $22 f64)
   (local $23 f64)
+  (local $24 f64)
+  (local $25 f64)
+  (local $26 f64)
+  (local $27 f64)
+  (local $28 f64)
+  (local $29 f64)
+  (local $30 f64)
+  (local $31 f64)
+  (local $32 f64)
   i32.const 0
   i32.const 1
   i32.lt_s
@@ -8727,7 +8837,7 @@
    i32.shl
    i32.add
    f64.load
-   local.set $11
+   local.set $17
    i32.const 6936
    local.get $14
    i32.const 1
@@ -8736,13 +8846,13 @@
    i32.shl
    i32.add
    f64.load offset=8
-   local.set $10
+   local.set $18
    local.get $16
    f64.reinterpret_i64
-   local.set $9
+   local.set $19
    local.get $15
    f64.convert_i64_s
-   local.set $8
+   local.set $20
    i32.const 7960
    local.get $14
    i32.const 1
@@ -8751,7 +8861,7 @@
    i32.shl
    i32.add
    f64.load
-   local.set $7
+   local.set $21
    i32.const 7960
    local.get $14
    i32.const 1
@@ -8760,87 +8870,87 @@
    i32.shl
    i32.add
    f64.load offset=8
-   local.set $6
-   local.get $9
-   local.get $7
+   local.set $22
+   local.get $19
+   local.get $21
    f64.sub
-   local.get $6
+   local.get $22
    f64.sub
-   local.get $11
+   local.get $17
    f64.mul
-   local.set $5
-   local.get $5
+   local.set $23
+   local.get $23
    i64.reinterpret_f64
    i64.const -4294967296
    i64.and
    f64.reinterpret_i64
-   local.set $4
-   local.get $5
-   local.get $4
+   local.set $24
+   local.get $23
+   local.get $24
    f64.sub
-   local.set $3
-   local.get $4
+   local.set $25
+   local.get $24
    f64.const 1.4426950407214463
    f64.mul
-   local.set $17
-   local.get $3
+   local.set $26
+   local.get $25
    f64.const 1.4426950407214463
    f64.mul
-   local.get $5
+   local.get $23
    f64.const 1.6751713164886512e-10
    f64.mul
    f64.add
-   local.set $18
-   local.get $8
-   local.get $10
-   f64.add
-   local.set $19
-   local.get $19
-   local.get $17
-   f64.add
-   local.set $20
-   local.get $19
+   local.set $27
    local.get $20
-   f64.sub
-   local.get $17
-   f64.add
    local.get $18
    f64.add
-   local.set $21
-   local.get $5
-   local.get $5
+   local.set $28
+   local.get $28
+   local.get $26
+   f64.add
+   local.set $29
+   local.get $28
+   local.get $29
+   f64.sub
+   local.get $26
+   f64.add
+   local.get $27
+   f64.add
+   local.set $30
+   local.get $23
+   local.get $23
    f64.mul
-   local.set $22
+   local.set $31
    f64.const -0.7213475204444882
-   local.get $5
+   local.get $23
    f64.const 0.4808983469629985
    f64.mul
    f64.add
-   local.get $22
+   local.get $31
    f64.const -0.36067375954075914
-   local.get $5
+   local.get $23
    f64.const 0.2885390073180969
    f64.mul
    f64.add
    f64.mul
    f64.add
-   local.get $22
-   local.get $22
+   local.get $31
+   local.get $31
    f64.mul
    f64.const -0.2404693555628422
-   local.get $5
+   local.get $23
    f64.const 0.2061202382173603
    f64.mul
    f64.add
    f64.mul
    f64.add
-   local.set $23
-   local.get $21
-   local.get $22
-   local.get $23
+   local.set $32
+   local.get $30
+   local.get $31
+   local.get $32
    f64.mul
    f64.add
-   local.get $20
+   local.get $29
    f64.add
   end
   return
@@ -9692,18 +9802,18 @@
   (local $7 i64)
   (local $8 i64)
   (local $9 i64)
-  (local $10 f64)
-  (local $11 i64)
-  (local $12 i32)
+  (local $10 i64)
+  (local $11 f64)
+  (local $12 i64)
   (local $13 i64)
   (local $14 i64)
-  (local $15 f64)
-  (local $16 f64)
-  (local $17 f64)
-  (local $18 f64)
-  (local $19 f64)
-  (local $20 f64)
-  (local $21 f64)
+  (local $15 i64)
+  (local $16 i32)
+  (local $17 i64)
+  (local $18 i64)
+  (local $19 i32)
+  (local $20 i64)
+  (local $21 i64)
   (local $22 f64)
   (local $23 f64)
   (local $24 f64)
@@ -9721,12 +9831,52 @@
   (local $36 f64)
   (local $37 f64)
   (local $38 f64)
-  (local $39 i32)
-  (local $40 i32)
-  (local $41 i32)
-  (local $42 i32)
-  (local $43 i64)
-  (local $44 i64)
+  (local $39 f64)
+  (local $40 f64)
+  (local $41 f64)
+  (local $42 f64)
+  (local $43 f64)
+  (local $44 f64)
+  (local $45 f64)
+  (local $46 f64)
+  (local $47 f64)
+  (local $48 f64)
+  (local $49 f64)
+  (local $50 f64)
+  (local $51 f64)
+  (local $52 f64)
+  (local $53 f64)
+  (local $54 f64)
+  (local $55 i32)
+  (local $56 f64)
+  (local $57 f64)
+  (local $58 i32)
+  (local $59 i64)
+  (local $60 i64)
+  (local $61 i64)
+  (local $62 i32)
+  (local $63 f64)
+  (local $64 f64)
+  (local $65 f64)
+  (local $66 f64)
+  (local $67 f64)
+  (local $68 f64)
+  (local $69 f64)
+  (local $70 i64)
+  (local $71 i32)
+  (local $72 f64)
+  (local $73 i32)
+  (local $74 i32)
+  (local $75 f64)
+  (local $76 i32)
+  (local $77 i64)
+  (local $78 i64)
+  (local $79 f64)
+  (local $80 f64)
+  (local $81 f64)
+  (local $82 f64)
+  (local $83 f64)
+  (local $84 f64)
   local.get $1
   f64.abs
   f64.const 2
@@ -9905,8 +10055,8 @@
      br $~lib/util/math/pow_lut|inlined.0
     end
     local.get $5
-    local.set $9
-    local.get $9
+    local.set $10
+    local.get $10
     i64.const 1
     i64.shl
     i64.const 1
@@ -9919,7 +10069,7 @@
      local.get $3
      local.get $3
      f64.mul
-     local.set $10
+     local.set $11
      local.get $5
      i64.const 63
      i64.shr_u
@@ -9927,21 +10077,21 @@
      if (result i32)
       block $~lib/util/math/checkint|inlined.0 (result i32)
        local.get $6
-       local.set $9
-       local.get $9
+       local.set $12
+       local.get $12
        i64.const 52
        i64.shr_u
        i64.const 2047
        i64.and
-       local.set $11
-       local.get $11
+       local.set $13
+       local.get $13
        i64.const 1023
        i64.lt_u
        if
         i32.const 0
         br $~lib/util/math/checkint|inlined.0
        end
-       local.get $11
+       local.get $13
        i64.const 1023
        i64.const 52
        i64.add
@@ -9954,12 +10104,12 @@
        i64.const 1023
        i64.const 52
        i64.add
-       local.get $11
+       local.get $13
        i64.sub
        i64.shl
-       local.set $11
-       local.get $9
-       local.get $11
+       local.set $13
+       local.get $12
+       local.get $13
        i64.const 1
        i64.sub
        i64.and
@@ -9969,8 +10119,8 @@
         i32.const 0
         br $~lib/util/math/checkint|inlined.0
        end
-       local.get $9
-       local.get $11
+       local.get $12
+       local.get $13
        i64.and
        i64.const 0
        i64.ne
@@ -9986,9 +10136,9 @@
       i32.const 0
      end
      if
-      local.get $10
+      local.get $11
       f64.neg
-      local.set $10
+      local.set $11
      end
      local.get $6
      i64.const 63
@@ -9997,10 +10147,10 @@
      i64.ne
      if (result f64)
       f64.const 1
-      local.get $10
+      local.get $11
       f64.div
      else
-      local.get $10
+      local.get $11
      end
      br $~lib/util/math/pow_lut|inlined.0
     end
@@ -10012,21 +10162,21 @@
     if
      block $~lib/util/math/checkint|inlined.1 (result i32)
       local.get $6
-      local.set $9
-      local.get $9
+      local.set $14
+      local.get $14
       i64.const 52
       i64.shr_u
       i64.const 2047
       i64.and
-      local.set $11
-      local.get $11
+      local.set $15
+      local.get $15
       i64.const 1023
       i64.lt_u
       if
        i32.const 0
        br $~lib/util/math/checkint|inlined.1
       end
-      local.get $11
+      local.get $15
       i64.const 1023
       i64.const 52
       i64.add
@@ -10039,12 +10189,12 @@
       i64.const 1023
       i64.const 52
       i64.add
-      local.get $11
+      local.get $15
       i64.sub
       i64.shl
-      local.set $11
-      local.get $9
-      local.get $11
+      local.set $15
+      local.get $14
+      local.get $15
       i64.const 1
       i64.sub
       i64.and
@@ -10054,8 +10204,8 @@
        i32.const 0
        br $~lib/util/math/checkint|inlined.1
       end
-      local.get $9
-      local.get $11
+      local.get $14
+      local.get $15
       i64.and
       i64.const 0
       i64.ne
@@ -10065,8 +10215,8 @@
       end
       i32.const 2
      end
-     local.set $12
-     local.get $12
+     local.set $16
+     local.get $16
      i32.const 0
      i32.eq
      if
@@ -10079,7 +10229,7 @@
       f64.div
       br $~lib/util/math/pow_lut|inlined.0
      end
-     local.get $12
+     local.get $16
      i32.const 1
      i32.eq
      if
@@ -10157,12 +10307,12 @@
     end
    end
    local.get $5
-   local.set $9
-   local.get $9
+   local.set $17
+   local.get $17
    i64.const 4604531861337669632
    i64.sub
-   local.set $11
-   local.get $11
+   local.set $18
+   local.get $18
    i64.const 52
    i64.const 7
    i64.sub
@@ -10170,150 +10320,150 @@
    i64.const 127
    i64.and
    i32.wrap_i64
-   local.set $12
-   local.get $11
+   local.set $19
+   local.get $18
    i64.const 52
    i64.shr_s
-   local.set $13
-   local.get $9
-   local.get $11
+   local.set $20
+   local.get $17
+   local.get $18
    i64.const 4095
    i64.const 52
    i64.shl
    i64.and
    i64.sub
-   local.set $14
-   local.get $14
+   local.set $21
+   local.get $21
    f64.reinterpret_i64
-   local.set $10
-   local.get $13
+   local.set $22
+   local.get $20
    f64.convert_i64_s
-   local.set $15
+   local.set $23
    i32.const 9240
-   local.get $12
+   local.get $19
    i32.const 2
    i32.const 3
    i32.add
    i32.shl
    i32.add
    f64.load
-   local.set $16
+   local.set $24
    i32.const 9240
-   local.get $12
+   local.get $19
    i32.const 2
    i32.const 3
    i32.add
    i32.shl
    i32.add
    f64.load offset=16
-   local.set $17
+   local.set $25
    i32.const 9240
-   local.get $12
+   local.get $19
    i32.const 2
    i32.const 3
    i32.add
    i32.shl
    i32.add
    f64.load offset=24
-   local.set $18
-   local.get $14
+   local.set $26
+   local.get $21
    i64.const 2147483648
    i64.add
    i64.const -4294967296
    i64.and
    f64.reinterpret_i64
-   local.set $19
-   local.get $10
-   local.get $19
+   local.set $27
+   local.get $22
+   local.get $27
    f64.sub
-   local.set $20
-   local.get $19
-   local.get $16
+   local.set $28
+   local.get $27
+   local.get $24
    f64.mul
    f64.const 1
    f64.sub
-   local.set $21
-   local.get $20
-   local.get $16
-   f64.mul
-   local.set $22
-   local.get $21
-   local.get $22
-   f64.add
-   local.set $23
-   local.get $15
-   f64.const 0.6931471805598903
-   f64.mul
-   local.get $17
-   f64.add
-   local.set $24
-   local.get $24
-   local.get $23
-   f64.add
-   local.set $25
-   local.get $15
-   f64.const 5.497923018708371e-14
-   f64.mul
-   local.get $18
-   f64.add
-   local.set $26
-   local.get $24
-   local.get $25
-   f64.sub
-   local.get $23
-   f64.add
-   local.set $27
-   f64.const -0.5
-   local.get $23
-   f64.mul
-   local.set $28
-   local.get $23
-   local.get $28
-   f64.mul
    local.set $29
-   local.get $23
-   local.get $29
+   local.get $28
+   local.get $24
    f64.mul
    local.set $30
-   f64.const -0.5
-   local.get $21
-   f64.mul
+   local.get $29
+   local.get $30
+   f64.add
    local.set $31
-   local.get $21
-   local.get $31
+   local.get $23
+   f64.const 0.6931471805598903
    f64.mul
-   local.set $32
    local.get $25
+   f64.add
+   local.set $32
    local.get $32
+   local.get $31
    f64.add
    local.set $33
-   local.get $22
-   local.get $28
-   local.get $31
-   f64.add
+   local.get $23
+   f64.const 5.497923018708371e-14
    f64.mul
+   local.get $26
+   f64.add
    local.set $34
-   local.get $25
+   local.get $32
    local.get $33
    f64.sub
-   local.get $32
+   local.get $31
    f64.add
    local.set $35
+   f64.const -0.5
+   local.get $31
+   f64.mul
+   local.set $36
+   local.get $31
+   local.get $36
+   f64.mul
+   local.set $37
+   local.get $31
+   local.get $37
+   f64.mul
+   local.set $38
+   f64.const -0.5
+   local.get $29
+   f64.mul
+   local.set $39
+   local.get $29
+   local.get $39
+   f64.mul
+   local.set $40
+   local.get $33
+   local.get $40
+   f64.add
+   local.set $41
    local.get $30
+   local.get $36
+   local.get $39
+   f64.add
+   f64.mul
+   local.set $42
+   local.get $33
+   local.get $41
+   f64.sub
+   local.get $40
+   f64.add
+   local.set $43
+   local.get $38
    f64.const -0.6666666666666679
-   local.get $23
+   local.get $31
    f64.const 0.5000000000000007
    f64.mul
    f64.add
-   local.get $29
+   local.get $37
    f64.const 0.7999999995323976
-   local.get $23
+   local.get $31
    f64.const -0.6666666663487739
    f64.mul
    f64.add
-   local.get $29
+   local.get $37
    f64.const -1.142909628459501
-   local.get $23
+   local.get $31
    f64.const 1.0000415263675542
    f64.mul
    f64.add
@@ -10322,88 +10472,88 @@
    f64.mul
    f64.add
    f64.mul
-   local.set $36
-   local.get $26
-   local.get $27
-   f64.add
+   local.set $44
    local.get $34
-   f64.add
    local.get $35
    f64.add
-   local.get $36
+   local.get $42
    f64.add
-   local.set $37
-   local.get $33
-   local.get $37
+   local.get $43
    f64.add
-   local.set $38
-   local.get $33
-   local.get $38
+   local.get $44
+   f64.add
+   local.set $45
+   local.get $41
+   local.get $45
+   f64.add
+   local.set $46
+   local.get $41
+   local.get $46
    f64.sub
-   local.get $37
+   local.get $45
    f64.add
    global.set $~lib/util/math/log_tail
-   local.get $38
-   local.set $38
+   local.get $46
+   local.set $47
    global.get $~lib/util/math/log_tail
-   local.set $37
+   local.set $48
    local.get $6
    i64.const -134217728
    i64.and
    f64.reinterpret_i64
-   local.set $34
+   local.set $51
    local.get $2
-   local.get $34
+   local.get $51
    f64.sub
-   local.set $33
-   local.get $38
+   local.set $52
+   local.get $47
    i64.reinterpret_f64
    i64.const -134217728
    i64.and
    f64.reinterpret_i64
-   local.set $32
-   local.get $38
-   local.get $32
+   local.set $53
+   local.get $47
+   local.get $53
    f64.sub
-   local.get $37
+   local.get $48
    f64.add
-   local.set $31
-   local.get $34
-   local.get $32
+   local.set $54
+   local.get $51
+   local.get $53
    f64.mul
-   local.set $36
-   local.get $33
-   local.get $32
+   local.set $49
+   local.get $52
+   local.get $53
    f64.mul
    local.get $2
-   local.get $31
+   local.get $54
    f64.mul
    f64.add
-   local.set $35
+   local.set $50
    block $~lib/util/math/exp_inline|inlined.0 (result f64)
-    local.get $36
-    local.set $15
-    local.get $35
-    local.set $10
+    local.get $49
+    local.set $57
+    local.get $50
+    local.set $56
     local.get $4
-    local.set $12
-    local.get $15
+    local.set $55
+    local.get $57
     i64.reinterpret_f64
-    local.set $9
-    local.get $9
+    local.set $70
+    local.get $70
     i64.const 52
     i64.shr_u
     i32.wrap_i64
     i32.const 2047
     i32.and
-    local.set $39
-    local.get $39
+    local.set $58
+    local.get $58
     i32.const 969
     i32.sub
     i32.const 63
     i32.ge_u
     if
-     local.get $39
+     local.get $58
      i32.const 969
      i32.sub
      i32.const -2147483648
@@ -10411,252 +10561,252 @@
      if
       f64.const -1
       f64.const 1
-      local.get $12
+      local.get $55
       select
       br $~lib/util/math/exp_inline|inlined.0
      end
-     local.get $39
+     local.get $58
      i32.const 1033
      i32.ge_u
      if
-      local.get $9
+      local.get $70
       i64.const 63
       i64.shr_u
       i64.const 0
       i64.ne
       if (result f64)
-       local.get $12
-       local.set $41
-       local.get $41
-       local.set $42
+       local.get $55
+       local.set $71
+       local.get $71
+       local.set $73
        i64.const 1152921504606846976
        f64.reinterpret_i64
-       local.set $16
-       local.get $16
+       local.set $72
+       local.get $72
        f64.neg
-       local.get $16
-       local.get $42
+       local.get $72
+       local.get $73
        select
-       local.get $16
+       local.get $72
        f64.mul
       else
-       local.get $12
-       local.set $42
-       local.get $42
-       local.set $41
+       local.get $55
+       local.set $74
+       local.get $74
+       local.set $76
        i64.const 8070450532247928832
        f64.reinterpret_i64
-       local.set $17
-       local.get $17
+       local.set $75
+       local.get $75
        f64.neg
-       local.get $17
-       local.get $41
+       local.get $75
+       local.get $76
        select
-       local.get $17
+       local.get $75
        f64.mul
       end
       br $~lib/util/math/exp_inline|inlined.0
      end
      i32.const 0
-     local.set $39
+     local.set $58
     end
     f64.const 184.6649652337873
-    local.get $15
+    local.get $57
     f64.mul
-    local.set $29
-    local.get $29
+    local.set $64
+    local.get $64
     f64.const 6755399441055744
     f64.add
-    local.set $30
-    local.get $30
+    local.set $63
+    local.get $63
     i64.reinterpret_f64
-    local.set $14
-    local.get $30
+    local.set $59
+    local.get $63
     f64.const 6755399441055744
     f64.sub
-    local.set $30
-    local.get $15
-    local.get $30
+    local.set $63
+    local.get $57
+    local.get $63
     f64.const -0.005415212348111709
     f64.mul
     f64.add
-    local.get $30
+    local.get $63
     f64.const -1.2864023111638346e-14
     f64.mul
     f64.add
-    local.set $28
-    local.get $28
-    local.get $10
+    local.set $65
+    local.get $65
+    local.get $56
     f64.add
-    local.set $28
-    local.get $14
+    local.set $65
+    local.get $59
     i64.const 127
     i64.and
     i64.const 1
     i64.shl
     i32.wrap_i64
-    local.set $40
-    local.get $14
-    local.get $12
+    local.set $62
+    local.get $59
+    local.get $55
     i64.extend_i32_u
     i64.add
     i64.const 52
     i64.const 7
     i64.sub
     i64.shl
-    local.set $13
+    local.set $60
     i32.const 4632
-    local.get $40
+    local.get $62
     i32.const 3
     i32.shl
     i32.add
     i64.load
     f64.reinterpret_i64
-    local.set $25
+    local.set $68
     i32.const 4632
-    local.get $40
+    local.get $62
     i32.const 3
     i32.shl
     i32.add
     i64.load offset=8
-    local.get $13
+    local.get $60
     i64.add
-    local.set $11
-    local.get $28
-    local.get $28
+    local.set $61
+    local.get $65
+    local.get $65
     f64.mul
-    local.set $27
-    local.get $25
-    local.get $28
+    local.set $66
+    local.get $68
+    local.get $65
     f64.add
-    local.get $27
+    local.get $66
     f64.const 0.49999999999996786
-    local.get $28
+    local.get $65
     f64.const 0.16666666666665886
     f64.mul
     f64.add
     f64.mul
     f64.add
-    local.get $27
-    local.get $27
+    local.get $66
+    local.get $66
     f64.mul
     f64.const 0.0416666808410674
-    local.get $28
+    local.get $65
     f64.const 0.008333335853059549
     f64.mul
     f64.add
     f64.mul
     f64.add
-    local.set $24
-    local.get $39
+    local.set $69
+    local.get $58
     i32.const 0
     i32.eq
     if
      block $~lib/util/math/specialcase|inlined.1 (result f64)
-      local.get $24
-      local.set $18
-      local.get $11
-      local.set $44
-      local.get $14
-      local.set $43
-      local.get $43
+      local.get $69
+      local.set $79
+      local.get $61
+      local.set $78
+      local.get $59
+      local.set $77
+      local.get $77
       i64.const 2147483648
       i64.and
       i64.const 0
       i64.ne
       i32.eqz
       if
-       local.get $44
+       local.get $78
        i64.const 1009
        i64.const 52
        i64.shl
        i64.sub
-       local.set $44
-       local.get $44
+       local.set $78
+       local.get $78
        f64.reinterpret_i64
-       local.set $17
+       local.set $80
        f64.const 5486124068793688683255936e279
-       local.get $17
-       local.get $17
-       local.get $18
+       local.get $80
+       local.get $80
+       local.get $79
        f64.mul
        f64.add
        f64.mul
        br $~lib/util/math/specialcase|inlined.1
       end
-      local.get $44
+      local.get $78
       i64.const 1022
       i64.const 52
       i64.shl
       i64.add
-      local.set $44
-      local.get $44
+      local.set $78
+      local.get $78
       f64.reinterpret_i64
-      local.set $17
-      local.get $17
-      local.get $17
-      local.get $18
+      local.set $80
+      local.get $80
+      local.get $80
+      local.get $79
       f64.mul
       f64.add
-      local.set $16
-      local.get $16
+      local.set $81
+      local.get $81
       f64.abs
       f64.const 1
       f64.lt
       if
        f64.const 1
-       local.get $16
+       local.get $81
        f64.copysign
-       local.set $23
-       local.get $17
-       local.get $16
+       local.set $82
+       local.get $80
+       local.get $81
        f64.sub
-       local.get $17
-       local.get $18
+       local.get $80
+       local.get $79
        f64.mul
        f64.add
-       local.set $22
-       local.get $23
-       local.get $16
+       local.set $83
+       local.get $82
+       local.get $81
        f64.add
-       local.set $21
-       local.get $23
-       local.get $21
+       local.set $84
+       local.get $82
+       local.get $84
        f64.sub
-       local.get $16
+       local.get $81
        f64.add
-       local.get $22
+       local.get $83
        f64.add
-       local.set $22
-       local.get $21
-       local.get $22
+       local.set $83
+       local.get $84
+       local.get $83
        f64.add
-       local.get $23
+       local.get $82
        f64.sub
-       local.set $16
-       local.get $16
+       local.set $81
+       local.get $81
        f64.const 0
        f64.eq
        if
-        local.get $44
+        local.get $78
         i64.const -9223372036854775808
         i64.and
         f64.reinterpret_i64
-        local.set $16
+        local.set $81
        end
       end
-      local.get $16
+      local.get $81
       f64.const 2.2250738585072014e-308
       f64.mul
      end
      br $~lib/util/math/exp_inline|inlined.0
     end
-    local.get $11
+    local.get $61
     f64.reinterpret_i64
-    local.set $26
-    local.get $26
-    local.get $26
-    local.get $24
+    local.set $67
+    local.get $67
+    local.get $67
+    local.get $69
     f64.mul
     f64.add
    end
@@ -10697,22 +10847,44 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
-  (local $9 f32)
-  (local $10 i32)
+  (local $9 i32)
+  (local $10 f32)
   (local $11 i32)
   (local $12 i32)
   (local $13 i32)
   (local $14 i32)
-  (local $15 f64)
-  (local $16 f64)
-  (local $17 f64)
-  (local $18 f64)
-  (local $19 f64)
-  (local $20 f64)
-  (local $21 f64)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
   (local $22 f64)
-  (local $23 i64)
-  (local $24 i64)
+  (local $23 f64)
+  (local $24 f64)
+  (local $25 f64)
+  (local $26 f64)
+  (local $27 f64)
+  (local $28 f64)
+  (local $29 f64)
+  (local $30 f64)
+  (local $31 f64)
+  (local $32 i32)
+  (local $33 f32)
+  (local $34 i32)
+  (local $35 i32)
+  (local $36 f32)
+  (local $37 i32)
+  (local $38 i32)
+  (local $39 f64)
+  (local $40 f64)
+  (local $41 i64)
+  (local $42 f64)
+  (local $43 i64)
+  (local $44 f64)
+  (local $45 f64)
+  (local $46 f64)
   local.get $1
   f32.abs
   f32.const 2
@@ -10885,8 +11057,8 @@
      br $~lib/util/math/powf_lut|inlined.0
     end
     local.get $5
-    local.set $8
-    local.get $8
+    local.set $9
+    local.get $9
     i32.const 1
     i32.shl
     i32.const 1
@@ -10901,28 +11073,28 @@
      local.get $3
      local.get $3
      f32.mul
-     local.set $9
+     local.set $10
      local.get $5
      i32.const 31
      i32.shr_u
      if (result i32)
       block $~lib/util/math/checkintf|inlined.0 (result i32)
        local.get $6
-       local.set $8
-       local.get $8
+       local.set $11
+       local.get $11
        i32.const 23
        i32.shr_u
        i32.const 255
        i32.and
-       local.set $10
-       local.get $10
+       local.set $12
+       local.get $12
        i32.const 127
        i32.lt_u
        if
         i32.const 0
         br $~lib/util/math/checkintf|inlined.0
        end
-       local.get $10
+       local.get $12
        i32.const 127
        i32.const 23
        i32.add
@@ -10935,12 +11107,12 @@
        i32.const 127
        i32.const 23
        i32.add
-       local.get $10
+       local.get $12
        i32.sub
        i32.shl
-       local.set $10
-       local.get $8
-       local.get $10
+       local.set $12
+       local.get $11
+       local.get $12
        i32.const 1
        i32.sub
        i32.and
@@ -10948,8 +11120,8 @@
         i32.const 0
         br $~lib/util/math/checkintf|inlined.0
        end
-       local.get $8
-       local.get $10
+       local.get $11
+       local.get $12
        i32.and
        if
         i32.const 1
@@ -10963,19 +11135,19 @@
       i32.const 0
      end
      if
-      local.get $9
+      local.get $10
       f32.neg
-      local.set $9
+      local.set $10
      end
      local.get $6
      i32.const 31
      i32.shr_u
      if (result f32)
       f32.const 1
-      local.get $9
+      local.get $10
       f32.div
      else
-      local.get $9
+      local.get $10
      end
      br $~lib/util/math/powf_lut|inlined.0
     end
@@ -10985,21 +11157,21 @@
     if
      block $~lib/util/math/checkintf|inlined.1 (result i32)
       local.get $6
-      local.set $8
-      local.get $8
+      local.set $13
+      local.get $13
       i32.const 23
       i32.shr_u
       i32.const 255
       i32.and
-      local.set $10
-      local.get $10
+      local.set $14
+      local.get $14
       i32.const 127
       i32.lt_u
       if
        i32.const 0
        br $~lib/util/math/checkintf|inlined.1
       end
-      local.get $10
+      local.get $14
       i32.const 127
       i32.const 23
       i32.add
@@ -11012,12 +11184,12 @@
       i32.const 127
       i32.const 23
       i32.add
-      local.get $10
+      local.get $14
       i32.sub
       i32.shl
-      local.set $10
-      local.get $8
-      local.get $10
+      local.set $14
+      local.get $13
+      local.get $14
       i32.const 1
       i32.sub
       i32.and
@@ -11025,8 +11197,8 @@
        i32.const 0
        br $~lib/util/math/checkintf|inlined.1
       end
-      local.get $8
-      local.get $10
+      local.get $13
+      local.get $14
       i32.and
       if
        i32.const 1
@@ -11034,8 +11206,8 @@
       end
       i32.const 2
      end
-     local.set $10
-     local.get $10
+     local.set $15
+     local.get $15
      i32.const 0
      i32.eq
      if
@@ -11048,7 +11220,7 @@
       f32.div
       br $~lib/util/math/powf_lut|inlined.0
      end
-     local.get $10
+     local.get $15
      i32.const 1
      i32.eq
      if
@@ -11082,108 +11254,108 @@
     end
    end
    local.get $5
-   local.set $8
-   local.get $8
+   local.set $16
+   local.get $16
    i32.const 1060306944
    i32.sub
-   local.set $10
-   local.get $10
+   local.set $17
+   local.get $17
    i32.const 23
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 15
    i32.and
-   local.set $11
-   local.get $10
+   local.set $18
+   local.get $17
    i32.const -8388608
    i32.and
-   local.set $12
-   local.get $8
-   local.get $12
+   local.set $19
+   local.get $16
+   local.get $19
    i32.sub
-   local.set $13
-   local.get $12
+   local.set $20
+   local.get $19
    i32.const 23
    i32.shr_s
-   local.set $14
+   local.set $21
    i32.const 8984
-   local.get $11
+   local.get $18
    i32.const 1
    i32.const 3
    i32.add
    i32.shl
    i32.add
    f64.load
-   local.set $15
+   local.set $22
    i32.const 8984
-   local.get $11
+   local.get $18
    i32.const 1
    i32.const 3
    i32.add
    i32.shl
    i32.add
    f64.load offset=8
-   local.set $16
-   local.get $13
+   local.set $23
+   local.get $20
    f32.reinterpret_i32
    f64.promote_f32
-   local.set $17
-   local.get $17
-   local.get $15
+   local.set $24
+   local.get $24
+   local.get $22
    f64.mul
    f64.const 1
    f64.sub
-   local.set $18
-   local.get $16
-   local.get $14
+   local.set $25
+   local.get $23
+   local.get $21
    f64.convert_i32_s
    f64.add
-   local.set $19
+   local.set $26
    f64.const 0.288457581109214
-   local.get $18
+   local.get $25
    f64.mul
    f64.const -0.36092606229713164
    f64.add
-   local.set $20
+   local.set $27
    f64.const 0.480898481472577
-   local.get $18
+   local.get $25
    f64.mul
    f64.const -0.7213474675006291
    f64.add
-   local.set $21
+   local.set $28
    f64.const 1.4426950408774342
-   local.get $18
+   local.get $25
    f64.mul
-   local.get $19
+   local.get $26
    f64.add
-   local.set $22
-   local.get $18
-   local.get $18
+   local.set $29
+   local.get $25
+   local.get $25
    f64.mul
-   local.set $18
-   local.get $22
-   local.get $21
-   local.get $18
+   local.set $25
+   local.get $29
+   local.get $28
+   local.get $25
    f64.mul
    f64.add
-   local.set $22
-   local.get $20
-   local.get $18
-   local.get $18
+   local.set $29
+   local.get $27
+   local.get $25
+   local.get $25
    f64.mul
    f64.mul
-   local.get $22
+   local.get $29
    f64.add
-   local.set $20
-   local.get $20
-   local.set $22
+   local.set $27
+   local.get $27
+   local.set $30
    local.get $2
    f64.promote_f32
-   local.get $22
+   local.get $30
    f64.mul
-   local.set $21
-   local.get $21
+   local.set $31
+   local.get $31
    i64.reinterpret_f64
    i64.const 47
    i64.shr_u
@@ -11192,66 +11364,66 @@
    i64.const 32959
    i64.ge_u
    if
-    local.get $21
+    local.get $31
     f64.const 127.99999995700433
     f64.gt
     if
      local.get $4
-     local.set $8
-     local.get $8
-     local.set $10
+     local.set $32
+     local.get $32
+     local.set $34
      i32.const 1879048192
      f32.reinterpret_i32
-     local.set $9
-     local.get $9
+     local.set $33
+     local.get $33
      f32.neg
-     local.get $9
-     local.get $10
+     local.get $33
+     local.get $34
      select
-     local.get $9
+     local.get $33
      f32.mul
      br $~lib/util/math/powf_lut|inlined.0
     end
-    local.get $21
+    local.get $31
     f64.const -150
     f64.le
     if
      local.get $4
-     local.set $11
-     local.get $11
-     local.set $12
+     local.set $35
+     local.get $35
+     local.set $37
      i32.const 268435456
      f32.reinterpret_i32
-     local.set $9
-     local.get $9
+     local.set $36
+     local.get $36
      f32.neg
-     local.get $9
-     local.get $12
+     local.get $36
+     local.get $37
      select
-     local.get $9
+     local.get $36
      f32.mul
      br $~lib/util/math/powf_lut|inlined.0
     end
    end
-   local.get $21
-   local.set $15
+   local.get $31
+   local.set $39
    local.get $4
-   local.set $13
-   local.get $15
+   local.set $38
+   local.get $39
    f64.const 211106232532992
    f64.add
-   local.set $20
-   local.get $20
+   local.set $40
+   local.get $40
    i64.reinterpret_f64
-   local.set $23
-   local.get $15
-   local.get $20
+   local.set $41
+   local.get $39
+   local.get $40
    f64.const 211106232532992
    f64.sub
    f64.sub
-   local.set $19
+   local.set $42
    i32.const 6680
-   local.get $23
+   local.get $41
    i32.wrap_i64
    i32.const 31
    i32.and
@@ -11259,10 +11431,10 @@
    i32.shl
    i32.add
    i64.load
-   local.set $24
-   local.get $24
-   local.get $23
-   local.get $13
+   local.set $43
+   local.get $43
+   local.get $41
+   local.get $38
    i64.extend_i32_u
    i64.add
    i64.const 52
@@ -11270,35 +11442,35 @@
    i64.sub
    i64.shl
    i64.add
-   local.set $24
-   local.get $24
+   local.set $43
+   local.get $43
    f64.reinterpret_i64
-   local.set $16
+   local.set $46
    f64.const 0.05550361559341535
-   local.get $19
+   local.get $42
    f64.mul
    f64.const 0.2402284522445722
    f64.add
-   local.set $18
+   local.set $44
    f64.const 0.6931471806916203
-   local.get $19
+   local.get $42
    f64.mul
    f64.const 1
    f64.add
-   local.set $17
-   local.get $17
-   local.get $18
-   local.get $19
-   local.get $19
+   local.set $45
+   local.get $45
+   local.get $44
+   local.get $42
+   local.get $42
    f64.mul
    f64.mul
    f64.add
-   local.set $17
-   local.get $17
-   local.get $16
+   local.set $45
+   local.get $45
+   local.get $46
    f64.mul
-   local.set $17
-   local.get $17
+   local.set $45
+   local.get $45
    f32.demote_f64
   end
   return
@@ -11979,7 +12151,8 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
-  (local $10 f32)
+  (local $10 i32)
+  (local $11 f32)
   local.get $0
   i32.reinterpret_f32
   local.set $2
@@ -12184,13 +12357,13 @@
      i32.const 8
      i32.shl
      i32.clz
-     local.set $9
+     local.set $10
      local.get $4
-     local.get $9
+     local.get $10
      i32.sub
      local.set $4
      local.get $7
-     local.get $9
+     local.get $10
      i32.shl
      local.set $7
     end
@@ -12233,7 +12406,7 @@
   local.get $0
   local.get $0
   f32.add
-  local.set $10
+  local.set $11
   local.get $4
   local.get $5
   i32.eq
@@ -12246,13 +12419,13 @@
    local.get $5
    i32.eq
    if (result i32)
-    local.get $10
+    local.get $11
     local.get $1
     f32.gt
     if (result i32)
      i32.const 1
     else
-     local.get $10
+     local.get $11
      local.get $1
      f32.eq
      if (result i32)
@@ -12301,15 +12474,41 @@
   (local $8 f64)
   (local $9 f64)
   (local $10 f64)
-  (local $11 i64)
-  (local $12 i32)
-  (local $13 i32)
+  (local $11 i32)
+  (local $12 i64)
+  (local $13 f64)
   (local $14 i32)
   (local $15 i32)
   (local $16 f64)
-  (local $17 i32)
+  (local $17 f64)
   (local $18 f64)
   (local $19 f64)
+  (local $20 f64)
+  (local $21 f64)
+  (local $22 i32)
+  (local $23 f64)
+  (local $24 i32)
+  (local $25 i32)
+  (local $26 f64)
+  (local $27 f64)
+  (local $28 f64)
+  (local $29 i32)
+  (local $30 i32)
+  (local $31 f64)
+  (local $32 f64)
+  (local $33 f64)
+  (local $34 f64)
+  (local $35 f64)
+  (local $36 f64)
+  (local $37 f64)
+  (local $38 f64)
+  (local $39 i32)
+  (local $40 f64)
+  (local $41 f64)
+  (local $42 f64)
+  (local $43 f64)
+  (local $44 f64)
+  (local $45 f64)
   local.get $0
   i64.reinterpret_f64
   local.set $1
@@ -12424,287 +12623,287 @@
   end
   block $~lib/math/rempio2|inlined.1 (result i32)
    local.get $0
-   local.set $5
+   local.set $13
    local.get $1
-   local.set $11
+   local.set $12
    local.get $3
-   local.set $4
-   local.get $11
+   local.set $11
+   local.get $12
    i64.const 32
    i64.shr_u
    i32.wrap_i64
    i32.const 2147483647
    i32.and
-   local.set $12
+   local.set $14
    i32.const 0
    i32.const 1
    i32.lt_s
    drop
-   local.get $12
+   local.get $14
    i32.const 1073928572
    i32.lt_u
    if
     i32.const 1
-    local.set $13
-    local.get $4
+    local.set $15
+    local.get $11
     i32.eqz
     if
-     local.get $5
+     local.get $13
      f64.const 1.5707963267341256
      f64.sub
-     local.set $10
-     local.get $12
+     local.set $16
+     local.get $14
      i32.const 1073291771
      i32.ne
      if
-      local.get $10
+      local.get $16
       f64.const 6.077100506506192e-11
       f64.sub
-      local.set $9
-      local.get $10
-      local.get $9
+      local.set $17
+      local.get $16
+      local.get $17
       f64.sub
       f64.const 6.077100506506192e-11
       f64.sub
-      local.set $8
+      local.set $18
      else
-      local.get $10
+      local.get $16
       f64.const 6.077100506303966e-11
       f64.sub
-      local.set $10
-      local.get $10
+      local.set $16
+      local.get $16
       f64.const 2.0222662487959506e-21
       f64.sub
-      local.set $9
-      local.get $10
-      local.get $9
+      local.set $17
+      local.get $16
+      local.get $17
       f64.sub
       f64.const 2.0222662487959506e-21
       f64.sub
-      local.set $8
+      local.set $18
      end
     else
-     local.get $5
+     local.get $13
      f64.const 1.5707963267341256
      f64.add
-     local.set $10
-     local.get $12
+     local.set $16
+     local.get $14
      i32.const 1073291771
      i32.ne
      if
-      local.get $10
+      local.get $16
       f64.const 6.077100506506192e-11
       f64.add
-      local.set $9
-      local.get $10
-      local.get $9
+      local.set $17
+      local.get $16
+      local.get $17
       f64.sub
       f64.const 6.077100506506192e-11
       f64.add
-      local.set $8
+      local.set $18
      else
-      local.get $10
+      local.get $16
       f64.const 6.077100506303966e-11
       f64.add
-      local.set $10
-      local.get $10
+      local.set $16
+      local.get $16
       f64.const 2.0222662487959506e-21
       f64.add
-      local.set $9
-      local.get $10
-      local.get $9
+      local.set $17
+      local.get $16
+      local.get $17
       f64.sub
       f64.const 2.0222662487959506e-21
       f64.add
-      local.set $8
+      local.set $18
      end
      i32.const -1
-     local.set $13
+     local.set $15
     end
-    local.get $9
+    local.get $17
     global.set $~lib/math/rempio2_y0
-    local.get $8
+    local.get $18
     global.set $~lib/math/rempio2_y1
-    local.get $13
+    local.get $15
     br $~lib/math/rempio2|inlined.1
    end
-   local.get $12
+   local.get $14
    i32.const 1094263291
    i32.lt_u
    if
-    local.get $5
+    local.get $13
     f64.const 0.6366197723675814
     f64.mul
     f64.nearest
-    local.set $8
-    local.get $5
-    local.get $8
+    local.set $19
+    local.get $13
+    local.get $19
     f64.const 1.5707963267341256
     f64.mul
     f64.sub
-    local.set $9
-    local.get $8
+    local.set $20
+    local.get $19
     f64.const 6.077100506506192e-11
     f64.mul
-    local.set $10
-    local.get $12
+    local.set $21
+    local.get $14
     i32.const 20
     i32.shr_u
-    local.set $13
-    local.get $9
-    local.get $10
+    local.set $22
+    local.get $20
+    local.get $21
     f64.sub
-    local.set $7
-    local.get $7
+    local.set $23
+    local.get $23
     i64.reinterpret_f64
     i64.const 32
     i64.shr_u
     i32.wrap_i64
-    local.set $14
-    local.get $13
-    local.get $14
+    local.set $24
+    local.get $22
+    local.get $24
     i32.const 20
     i32.shr_u
     i32.const 2047
     i32.and
     i32.sub
-    local.set $15
-    local.get $15
+    local.set $25
+    local.get $25
     i32.const 16
     i32.gt_u
     if
-     local.get $9
-     local.set $6
-     local.get $8
+     local.get $20
+     local.set $26
+     local.get $19
      f64.const 6.077100506303966e-11
      f64.mul
-     local.set $10
-     local.get $6
-     local.get $10
+     local.set $21
+     local.get $26
+     local.get $21
      f64.sub
-     local.set $9
-     local.get $8
+     local.set $20
+     local.get $19
      f64.const 2.0222662487959506e-21
      f64.mul
-     local.get $6
-     local.get $9
+     local.get $26
+     local.get $20
      f64.sub
-     local.get $10
+     local.get $21
      f64.sub
      f64.sub
-     local.set $10
-     local.get $9
-     local.get $10
+     local.set $21
+     local.get $20
+     local.get $21
      f64.sub
-     local.set $7
-     local.get $7
+     local.set $23
+     local.get $23
      i64.reinterpret_f64
      i64.const 32
      i64.shr_u
      i32.wrap_i64
-     local.set $14
-     local.get $13
-     local.get $14
+     local.set $24
+     local.get $22
+     local.get $24
      i32.const 20
      i32.shr_u
      i32.const 2047
      i32.and
      i32.sub
-     local.set $15
-     local.get $15
+     local.set $25
+     local.get $25
      i32.const 49
      i32.gt_u
      if
-      local.get $9
-      local.set $16
-      local.get $8
+      local.get $20
+      local.set $27
+      local.get $19
       f64.const 2.0222662487111665e-21
       f64.mul
-      local.set $10
-      local.get $16
-      local.get $10
+      local.set $21
+      local.get $27
+      local.get $21
       f64.sub
-      local.set $9
-      local.get $8
+      local.set $20
+      local.get $19
       f64.const 8.4784276603689e-32
       f64.mul
-      local.get $16
-      local.get $9
+      local.get $27
+      local.get $20
       f64.sub
-      local.get $10
+      local.get $21
       f64.sub
       f64.sub
-      local.set $10
-      local.get $9
-      local.get $10
+      local.set $21
+      local.get $20
+      local.get $21
       f64.sub
-      local.set $7
+      local.set $23
      end
     end
-    local.get $9
-    local.get $7
+    local.get $20
+    local.get $23
     f64.sub
-    local.get $10
+    local.get $21
     f64.sub
-    local.set $6
-    local.get $7
+    local.set $28
+    local.get $23
     global.set $~lib/math/rempio2_y0
-    local.get $6
+    local.get $28
     global.set $~lib/math/rempio2_y1
-    local.get $8
+    local.get $19
     i32.trunc_f64_s
     br $~lib/math/rempio2|inlined.1
    end
-   local.get $5
-   local.get $11
+   local.get $13
+   local.get $12
    call $~lib/math/pio2_large_quot
-   local.set $15
+   local.set $29
    i32.const 0
-   local.get $15
+   local.get $29
    i32.sub
-   local.get $15
-   local.get $4
+   local.get $29
+   local.get $11
    select
   end
-  local.set $17
+  local.set $30
   global.get $~lib/math/rempio2_y0
-  local.set $18
+  local.set $31
   global.get $~lib/math/rempio2_y1
-  local.set $19
-  local.get $17
+  local.set $32
+  local.get $30
   i32.const 1
   i32.and
   if (result f64)
-   local.get $18
-   local.set $8
-   local.get $19
-   local.set $16
-   local.get $8
-   local.get $8
+   local.get $31
+   local.set $34
+   local.get $32
+   local.set $33
+   local.get $34
+   local.get $34
    f64.mul
-   local.set $5
-   local.get $5
-   local.get $5
+   local.set $35
+   local.get $35
+   local.get $35
    f64.mul
-   local.set $6
-   local.get $5
+   local.set $36
+   local.get $35
    f64.const 0.0416666666666666
-   local.get $5
+   local.get $35
    f64.const -0.001388888888887411
-   local.get $5
+   local.get $35
    f64.const 2.480158728947673e-05
    f64.mul
    f64.add
    f64.mul
    f64.add
    f64.mul
-   local.get $6
-   local.get $6
+   local.get $36
+   local.get $36
    f64.mul
    f64.const -2.7557314351390663e-07
-   local.get $5
+   local.get $35
    f64.const 2.087572321298175e-09
-   local.get $5
+   local.get $35
    f64.const -1.1359647557788195e-11
    f64.mul
    f64.add
@@ -12712,97 +12911,97 @@
    f64.add
    f64.mul
    f64.add
-   local.set $7
+   local.set $37
    f64.const 0.5
-   local.get $5
+   local.get $35
    f64.mul
-   local.set $10
+   local.set $38
    f64.const 1
-   local.get $10
+   local.get $38
    f64.sub
-   local.set $6
-   local.get $6
+   local.set $36
+   local.get $36
    f64.const 1
-   local.get $6
+   local.get $36
    f64.sub
-   local.get $10
+   local.get $38
    f64.sub
-   local.get $5
-   local.get $7
+   local.get $35
+   local.get $37
    f64.mul
-   local.get $8
-   local.get $16
+   local.get $34
+   local.get $33
    f64.mul
    f64.sub
    f64.add
    f64.add
   else
    block $~lib/math/sin_kern|inlined.2 (result f64)
-    local.get $18
-    local.set $16
-    local.get $19
-    local.set $9
+    local.get $31
+    local.set $41
+    local.get $32
+    local.set $40
     i32.const 1
-    local.set $13
-    local.get $16
-    local.get $16
+    local.set $39
+    local.get $41
+    local.get $41
     f64.mul
-    local.set $10
-    local.get $10
-    local.get $10
+    local.set $42
+    local.get $42
+    local.get $42
     f64.mul
-    local.set $7
+    local.set $43
     f64.const 0.00833333333332249
-    local.get $10
+    local.get $42
     f64.const -1.984126982985795e-04
-    local.get $10
+    local.get $42
     f64.const 2.7557313707070068e-06
     f64.mul
     f64.add
     f64.mul
     f64.add
-    local.get $10
-    local.get $7
+    local.get $42
+    local.get $43
     f64.mul
     f64.const -2.5050760253406863e-08
-    local.get $10
+    local.get $42
     f64.const 1.58969099521155e-10
     f64.mul
     f64.add
     f64.mul
     f64.add
-    local.set $6
-    local.get $10
-    local.get $16
+    local.set $44
+    local.get $42
+    local.get $41
     f64.mul
-    local.set $5
-    local.get $13
+    local.set $45
+    local.get $39
     i32.eqz
     if
-     local.get $16
-     local.get $5
+     local.get $41
+     local.get $45
      f64.const -0.16666666666666632
-     local.get $10
-     local.get $6
+     local.get $42
+     local.get $44
      f64.mul
      f64.add
      f64.mul
      f64.add
      br $~lib/math/sin_kern|inlined.2
     else
-     local.get $16
-     local.get $10
+     local.get $41
+     local.get $42
      f64.const 0.5
-     local.get $9
+     local.get $40
      f64.mul
-     local.get $5
-     local.get $6
+     local.get $45
+     local.get $44
      f64.mul
      f64.sub
      f64.mul
-     local.get $9
+     local.get $40
      f64.sub
-     local.get $5
+     local.get $45
      f64.const -0.16666666666666632
      f64.mul
      f64.sub
@@ -12813,7 +13012,7 @@
    end
   end
   local.set $0
-  local.get $17
+  local.get $30
   i32.const 2
   i32.and
   if (result f64)
@@ -12855,25 +13054,63 @@
   (local $5 f64)
   (local $6 f64)
   (local $7 f64)
-  (local $8 i32)
-  (local $9 i32)
-  (local $10 f32)
-  (local $11 i32)
-  (local $12 f32)
-  (local $13 i32)
-  (local $14 i64)
-  (local $15 i32)
-  (local $16 i64)
-  (local $17 i64)
-  (local $18 i64)
-  (local $19 i64)
-  (local $20 i64)
-  (local $21 i64)
-  (local $22 i64)
-  (local $23 i32)
-  (local $24 i32)
+  (local $8 f64)
+  (local $9 f64)
+  (local $10 f64)
+  (local $11 f64)
+  (local $12 f64)
+  (local $13 f64)
+  (local $14 f64)
+  (local $15 f64)
+  (local $16 f64)
+  (local $17 f64)
+  (local $18 f64)
+  (local $19 f64)
+  (local $20 f64)
+  (local $21 f64)
+  (local $22 f64)
+  (local $23 f64)
+  (local $24 f64)
   (local $25 f64)
-  (local $26 f32)
+  (local $26 f64)
+  (local $27 f64)
+  (local $28 f64)
+  (local $29 f64)
+  (local $30 f64)
+  (local $31 f64)
+  (local $32 f64)
+  (local $33 f64)
+  (local $34 i32)
+  (local $35 i32)
+  (local $36 f32)
+  (local $37 f64)
+  (local $38 i32)
+  (local $39 f32)
+  (local $40 i32)
+  (local $41 i64)
+  (local $42 i32)
+  (local $43 i64)
+  (local $44 i64)
+  (local $45 i64)
+  (local $46 i64)
+  (local $47 i64)
+  (local $48 i64)
+  (local $49 i64)
+  (local $50 i64)
+  (local $51 i32)
+  (local $52 i32)
+  (local $53 i32)
+  (local $54 f64)
+  (local $55 f64)
+  (local $56 f64)
+  (local $57 f64)
+  (local $58 f64)
+  (local $59 f64)
+  (local $60 f64)
+  (local $61 f64)
+  (local $62 f64)
+  (local $63 f64)
+  (local $64 f32)
   local.get $0
   i32.reinterpret_f32
   local.set $1
@@ -12953,35 +13190,35 @@
      f64.promote_f32
      f64.const 1.5707963267948966
      f64.add
-     local.set $3
-     local.get $3
-     local.get $3
+     local.set $8
+     local.get $8
+     local.get $8
      f64.mul
-     local.set $7
-     local.get $7
-     local.get $7
+     local.set $9
+     local.get $9
+     local.get $9
      f64.mul
-     local.set $6
+     local.set $10
      f64.const -0.001388676377460993
-     local.get $7
+     local.get $9
      f64.const 2.439044879627741e-05
      f64.mul
      f64.add
-     local.set $5
+     local.set $11
      f32.const 1
      f64.promote_f32
-     local.get $7
+     local.get $9
      f64.const -0.499999997251031
      f64.mul
      f64.add
-     local.get $6
+     local.get $10
      f64.const 0.04166662332373906
      f64.mul
      f64.add
-     local.get $6
-     local.get $7
+     local.get $10
+     local.get $9
      f64.mul
-     local.get $5
+     local.get $11
      f64.mul
      f64.add
      f32.demote_f64
@@ -12991,35 +13228,35 @@
      f64.promote_f32
      f64.const 1.5707963267948966
      f64.sub
-     local.set $4
-     local.get $4
-     local.get $4
+     local.set $12
+     local.get $12
+     local.get $12
      f64.mul
-     local.set $5
-     local.get $5
-     local.get $5
+     local.set $13
+     local.get $13
+     local.get $13
      f64.mul
-     local.set $6
+     local.set $14
      f64.const -0.001388676377460993
-     local.get $5
+     local.get $13
      f64.const 2.439044879627741e-05
      f64.mul
      f64.add
-     local.set $7
+     local.set $15
      f32.const 1
      f64.promote_f32
-     local.get $5
+     local.get $13
      f64.const -0.499999997251031
      f64.mul
      f64.add
-     local.get $6
+     local.get $14
      f64.const 0.04166662332373906
      f64.mul
      f64.add
-     local.get $6
-     local.get $5
+     local.get $14
+     local.get $13
      f64.mul
-     local.get $7
+     local.get $15
      f64.mul
      f64.add
      f32.demote_f64
@@ -13039,38 +13276,38 @@
     f64.sub
    end
    f64.neg
-   local.set $3
-   local.get $3
-   local.get $3
+   local.set $16
+   local.get $16
+   local.get $16
    f64.mul
-   local.set $7
-   local.get $7
-   local.get $7
+   local.set $17
+   local.get $17
+   local.get $17
    f64.mul
-   local.set $6
+   local.set $18
    f64.const -1.9839334836096632e-04
-   local.get $7
+   local.get $17
    f64.const 2.718311493989822e-06
    f64.mul
    f64.add
-   local.set $5
-   local.get $7
-   local.get $3
+   local.set $19
+   local.get $17
+   local.get $16
    f64.mul
-   local.set $4
-   local.get $3
-   local.get $4
+   local.set $20
+   local.get $16
+   local.get $20
    f64.const -0.16666666641626524
-   local.get $7
+   local.get $17
    f64.const 0.008333329385889463
    f64.mul
    f64.add
    f64.mul
    f64.add
-   local.get $4
-   local.get $6
+   local.get $20
+   local.get $18
    f64.mul
-   local.get $5
+   local.get $19
    f64.mul
    f64.add
    f32.demote_f64
@@ -13090,35 +13327,35 @@
      f64.promote_f32
      f64.const 4.71238898038469
      f64.add
-     local.set $3
-     local.get $3
-     local.get $3
+     local.set $21
+     local.get $21
+     local.get $21
      f64.mul
-     local.set $4
-     local.get $4
-     local.get $4
+     local.set $22
+     local.get $22
+     local.get $22
      f64.mul
-     local.set $5
+     local.set $23
      f64.const -0.001388676377460993
-     local.get $4
+     local.get $22
      f64.const 2.439044879627741e-05
      f64.mul
      f64.add
-     local.set $6
+     local.set $24
      f32.const 1
      f64.promote_f32
-     local.get $4
+     local.get $22
      f64.const -0.499999997251031
      f64.mul
      f64.add
-     local.get $5
+     local.get $23
      f64.const 0.04166662332373906
      f64.mul
      f64.add
-     local.get $5
-     local.get $4
+     local.get $23
+     local.get $22
      f64.mul
-     local.get $6
+     local.get $24
      f64.mul
      f64.add
      f32.demote_f64
@@ -13127,35 +13364,35 @@
      f64.promote_f32
      f64.const 4.71238898038469
      f64.sub
-     local.set $7
-     local.get $7
-     local.get $7
+     local.set $25
+     local.get $25
+     local.get $25
      f64.mul
-     local.set $6
-     local.get $6
-     local.get $6
+     local.set $26
+     local.get $26
+     local.get $26
      f64.mul
-     local.set $5
+     local.set $27
      f64.const -0.001388676377460993
-     local.get $6
+     local.get $26
      f64.const 2.439044879627741e-05
      f64.mul
      f64.add
-     local.set $4
+     local.set $28
      f32.const 1
      f64.promote_f32
-     local.get $6
+     local.get $26
      f64.const -0.499999997251031
      f64.mul
      f64.add
-     local.get $5
+     local.get $27
      f64.const 0.04166662332373906
      f64.mul
      f64.add
-     local.get $5
-     local.get $6
+     local.get $27
+     local.get $26
      f64.mul
-     local.get $4
+     local.get $28
      f64.mul
      f64.add
      f32.demote_f64
@@ -13175,38 +13412,38 @@
     f64.const 6.283185307179586
     f64.sub
    end
-   local.set $3
-   local.get $3
-   local.get $3
+   local.set $29
+   local.get $29
+   local.get $29
    f64.mul
-   local.set $4
-   local.get $4
-   local.get $4
+   local.set $30
+   local.get $30
+   local.get $30
    f64.mul
-   local.set $5
+   local.set $31
    f64.const -1.9839334836096632e-04
-   local.get $4
+   local.get $30
    f64.const 2.718311493989822e-06
    f64.mul
    f64.add
-   local.set $6
-   local.get $4
-   local.get $3
+   local.set $32
+   local.get $30
+   local.get $29
    f64.mul
-   local.set $7
-   local.get $3
-   local.get $7
+   local.set $33
+   local.get $29
+   local.get $33
    f64.const -0.16666666641626524
-   local.get $4
+   local.get $30
    f64.const 0.008333329385889463
    f64.mul
    f64.add
    f64.mul
    f64.add
-   local.get $7
-   local.get $5
+   local.get $33
+   local.get $31
    f64.mul
-   local.get $6
+   local.get $32
    f64.mul
    f64.add
    f32.demote_f64
@@ -13223,238 +13460,238 @@
   end
   block $~lib/math/rempio2f|inlined.1 (result i32)
    local.get $0
-   local.set $10
+   local.set $36
    local.get $1
-   local.set $9
+   local.set $35
    local.get $2
-   local.set $8
-   local.get $9
+   local.set $34
+   local.get $35
    i32.const 1305022427
    i32.lt_u
    if
-    local.get $10
+    local.get $36
     f64.promote_f32
     f64.const 0.6366197723675814
     f64.mul
     f64.nearest
-    local.set $7
-    local.get $10
+    local.set $37
+    local.get $36
     f64.promote_f32
-    local.get $7
+    local.get $37
     f64.const 1.5707963109016418
     f64.mul
     f64.sub
-    local.get $7
+    local.get $37
     f64.const 1.5893254773528196e-08
     f64.mul
     f64.sub
     global.set $~lib/math/rempio2f_y
-    local.get $7
+    local.get $37
     i32.trunc_f64_s
     br $~lib/math/rempio2f|inlined.1
    end
-   local.get $10
-   local.set $12
-   local.get $9
-   local.set $11
-   local.get $11
+   local.get $36
+   local.set $39
+   local.get $35
+   local.set $38
+   local.get $38
    i32.const 23
    i32.shr_s
    i32.const 152
    i32.sub
-   local.set $13
-   local.get $13
+   local.set $40
+   local.get $40
    i32.const 63
    i32.and
    i64.extend_i32_s
-   local.set $14
+   local.set $41
    i32.const 4600
-   local.get $13
+   local.get $40
    i32.const 6
    i32.shr_s
    i32.const 3
    i32.shl
    i32.add
-   local.set $15
-   local.get $15
+   local.set $42
+   local.get $42
    i64.load
-   local.set $16
-   local.get $15
+   local.set $43
+   local.get $42
    i64.load offset=8
-   local.set $17
-   local.get $14
+   local.set $44
+   local.get $41
    i64.const 32
    i64.gt_u
    if
-    local.get $15
+    local.get $42
     i64.load offset=16
-    local.set $19
-    local.get $19
+    local.set $46
+    local.get $46
     i64.const 96
-    local.get $14
+    local.get $41
     i64.sub
     i64.shr_u
-    local.set $18
-    local.get $18
-    local.get $17
-    local.get $14
+    local.set $45
+    local.get $45
+    local.get $44
+    local.get $41
     i64.const 32
     i64.sub
     i64.shl
     i64.or
-    local.set $18
+    local.set $45
    else
-    local.get $17
+    local.get $44
     i64.const 32
-    local.get $14
+    local.get $41
     i64.sub
     i64.shr_u
-    local.set $18
+    local.set $45
    end
-   local.get $17
+   local.get $44
    i64.const 64
-   local.get $14
+   local.get $41
    i64.sub
    i64.shr_u
-   local.get $16
-   local.get $14
+   local.get $43
+   local.get $41
    i64.shl
    i64.or
-   local.set $19
-   local.get $11
+   local.set $47
+   local.get $38
    i32.const 8388607
    i32.and
    i32.const 8388608
    i32.or
    i64.extend_i32_s
-   local.set $20
-   local.get $20
-   local.get $19
+   local.set $48
+   local.get $48
+   local.get $47
    i64.mul
-   local.get $20
-   local.get $18
+   local.get $48
+   local.get $45
    i64.mul
    i64.const 32
    i64.shr_u
    i64.add
-   local.set $21
-   local.get $21
+   local.set $49
+   local.get $49
    i64.const 2
    i64.shl
-   local.set $22
-   local.get $21
+   local.set $50
+   local.get $49
    i64.const 62
    i64.shr_u
-   local.get $22
+   local.get $50
    i64.const 63
    i64.shr_u
    i64.add
    i32.wrap_i64
-   local.set $23
+   local.set $51
    f64.const 8.515303950216386e-20
-   local.get $12
+   local.get $39
    f64.promote_f32
    f64.copysign
-   local.get $22
+   local.get $50
    f64.convert_i64_s
    f64.mul
    global.set $~lib/math/rempio2f_y
-   local.get $23
-   local.set $23
+   local.get $51
+   local.set $52
    i32.const 0
-   local.get $23
+   local.get $52
    i32.sub
-   local.get $23
-   local.get $8
+   local.get $52
+   local.get $34
    select
   end
-  local.set $24
+  local.set $53
   global.get $~lib/math/rempio2f_y
-  local.set $25
-  local.get $24
+  local.set $54
+  local.get $53
   i32.const 1
   i32.and
   if (result f32)
-   local.get $25
-   local.set $3
-   local.get $3
-   local.get $3
+   local.get $54
+   local.set $55
+   local.get $55
+   local.get $55
    f64.mul
-   local.set $7
-   local.get $7
-   local.get $7
+   local.set $56
+   local.get $56
+   local.get $56
    f64.mul
-   local.set $6
+   local.set $57
    f64.const -0.001388676377460993
-   local.get $7
+   local.get $56
    f64.const 2.439044879627741e-05
    f64.mul
    f64.add
-   local.set $5
+   local.set $58
    f32.const 1
    f64.promote_f32
-   local.get $7
+   local.get $56
    f64.const -0.499999997251031
    f64.mul
    f64.add
-   local.get $6
+   local.get $57
    f64.const 0.04166662332373906
    f64.mul
    f64.add
-   local.get $6
-   local.get $7
+   local.get $57
+   local.get $56
    f64.mul
-   local.get $5
+   local.get $58
    f64.mul
    f64.add
    f32.demote_f64
   else
-   local.get $25
-   local.set $4
-   local.get $4
-   local.get $4
+   local.get $54
+   local.set $59
+   local.get $59
+   local.get $59
    f64.mul
-   local.set $5
-   local.get $5
-   local.get $5
+   local.set $60
+   local.get $60
+   local.get $60
    f64.mul
-   local.set $6
+   local.set $61
    f64.const -1.9839334836096632e-04
-   local.get $5
+   local.get $60
    f64.const 2.718311493989822e-06
    f64.mul
    f64.add
-   local.set $7
-   local.get $5
-   local.get $4
+   local.set $62
+   local.get $60
+   local.get $59
    f64.mul
-   local.set $3
-   local.get $4
-   local.get $3
+   local.set $63
+   local.get $59
+   local.get $63
    f64.const -0.16666666641626524
-   local.get $5
+   local.get $60
    f64.const 0.008333329385889463
    f64.mul
    f64.add
    f64.mul
    f64.add
-   local.get $3
-   local.get $6
+   local.get $63
+   local.get $61
    f64.mul
-   local.get $7
+   local.get $62
    f64.mul
    f64.add
    f32.demote_f64
   end
-  local.set $26
-  local.get $24
+  local.set $64
+  local.get $53
   i32.const 2
   i32.and
   if (result f32)
-   local.get $26
+   local.get $64
    f32.neg
   else
-   local.get $26
+   local.get $64
   end
  )
  (func $std/math/test_sinf (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
@@ -13956,11 +14193,17 @@
   (local $10 f64)
   (local $11 f64)
   (local $12 f64)
-  (local $13 i32)
-  (local $14 i32)
-  (local $15 f64)
+  (local $13 f64)
+  (local $14 f64)
+  (local $15 i32)
   (local $16 f64)
   (local $17 i32)
+  (local $18 i32)
+  (local $19 f64)
+  (local $20 f64)
+  (local $21 f64)
+  (local $22 i32)
+  (local $23 i32)
   local.get $0
   i64.reinterpret_f64
   local.set $1
@@ -14117,141 +14360,141 @@
     f64.const 0.6366197723675814
     f64.mul
     f64.nearest
-    local.set $11
+    local.set $12
     local.get $6
-    local.get $11
+    local.get $12
     f64.const 1.5707963267341256
     f64.mul
     f64.sub
-    local.set $10
-    local.get $11
+    local.set $13
+    local.get $12
     f64.const 6.077100506506192e-11
     f64.mul
-    local.set $9
+    local.set $14
     local.get $7
     i32.const 20
     i32.shr_u
-    local.set $8
-    local.get $10
-    local.get $9
+    local.set $15
+    local.get $13
+    local.get $14
     f64.sub
-    local.set $12
-    local.get $12
+    local.set $16
+    local.get $16
     i64.reinterpret_f64
     i64.const 32
     i64.shr_u
     i32.wrap_i64
-    local.set $13
-    local.get $8
-    local.get $13
+    local.set $17
+    local.get $15
+    local.get $17
     i32.const 20
     i32.shr_u
     i32.const 2047
     i32.and
     i32.sub
-    local.set $14
-    local.get $14
+    local.set $18
+    local.get $18
     i32.const 16
     i32.gt_u
     if
-     local.get $10
-     local.set $15
-     local.get $11
+     local.get $13
+     local.set $19
+     local.get $12
      f64.const 6.077100506303966e-11
      f64.mul
-     local.set $9
-     local.get $15
-     local.get $9
+     local.set $14
+     local.get $19
+     local.get $14
      f64.sub
-     local.set $10
-     local.get $11
+     local.set $13
+     local.get $12
      f64.const 2.0222662487959506e-21
      f64.mul
-     local.get $15
-     local.get $10
+     local.get $19
+     local.get $13
      f64.sub
-     local.get $9
+     local.get $14
      f64.sub
      f64.sub
-     local.set $9
-     local.get $10
-     local.get $9
+     local.set $14
+     local.get $13
+     local.get $14
      f64.sub
-     local.set $12
-     local.get $12
+     local.set $16
+     local.get $16
      i64.reinterpret_f64
      i64.const 32
      i64.shr_u
      i32.wrap_i64
-     local.set $13
-     local.get $8
-     local.get $13
+     local.set $17
+     local.get $15
+     local.get $17
      i32.const 20
      i32.shr_u
      i32.const 2047
      i32.and
      i32.sub
-     local.set $14
-     local.get $14
+     local.set $18
+     local.get $18
      i32.const 49
      i32.gt_u
      if
-      local.get $10
-      local.set $16
-      local.get $11
+      local.get $13
+      local.set $20
+      local.get $12
       f64.const 2.0222662487111665e-21
       f64.mul
-      local.set $9
-      local.get $16
-      local.get $9
+      local.set $14
+      local.get $20
+      local.get $14
       f64.sub
-      local.set $10
-      local.get $11
+      local.set $13
+      local.get $12
       f64.const 8.4784276603689e-32
       f64.mul
-      local.get $16
-      local.get $10
+      local.get $20
+      local.get $13
       f64.sub
-      local.get $9
+      local.get $14
       f64.sub
       f64.sub
-      local.set $9
-      local.get $10
-      local.get $9
+      local.set $14
+      local.get $13
+      local.get $14
       f64.sub
-      local.set $12
+      local.set $16
      end
     end
-    local.get $10
-    local.get $12
+    local.get $13
+    local.get $16
     f64.sub
-    local.get $9
+    local.get $14
     f64.sub
-    local.set $15
-    local.get $12
+    local.set $21
+    local.get $16
     global.set $~lib/math/rempio2_y0
-    local.get $15
+    local.get $21
     global.set $~lib/math/rempio2_y1
-    local.get $11
+    local.get $12
     i32.trunc_f64_s
     br $~lib/math/rempio2|inlined.2
    end
    local.get $6
    local.get $5
    call $~lib/math/pio2_large_quot
-   local.set $14
+   local.set $22
    i32.const 0
-   local.get $14
+   local.get $22
    i32.sub
-   local.get $14
+   local.get $22
    local.get $4
    select
   end
-  local.set $17
+  local.set $23
   global.get $~lib/math/rempio2_y0
   global.get $~lib/math/rempio2_y1
   i32.const 1
-  local.get $17
+  local.get $23
   i32.const 1
   i32.and
   i32.const 1
@@ -14295,22 +14538,66 @@
   (local $9 f64)
   (local $10 f64)
   (local $11 i32)
-  (local $12 f32)
-  (local $13 i32)
-  (local $14 f32)
-  (local $15 i32)
-  (local $16 i64)
-  (local $17 i32)
-  (local $18 i64)
-  (local $19 i64)
-  (local $20 i64)
-  (local $21 i64)
-  (local $22 i64)
-  (local $23 i64)
-  (local $24 i64)
-  (local $25 i32)
-  (local $26 i32)
-  (local $27 f64)
+  (local $12 f64)
+  (local $13 f64)
+  (local $14 f64)
+  (local $15 f64)
+  (local $16 f64)
+  (local $17 f64)
+  (local $18 f64)
+  (local $19 i32)
+  (local $20 f64)
+  (local $21 f64)
+  (local $22 f64)
+  (local $23 f64)
+  (local $24 f64)
+  (local $25 f64)
+  (local $26 f64)
+  (local $27 i32)
+  (local $28 f64)
+  (local $29 f64)
+  (local $30 f64)
+  (local $31 f64)
+  (local $32 f64)
+  (local $33 f64)
+  (local $34 f64)
+  (local $35 i32)
+  (local $36 f64)
+  (local $37 f64)
+  (local $38 f64)
+  (local $39 f64)
+  (local $40 f64)
+  (local $41 f64)
+  (local $42 f64)
+  (local $43 i32)
+  (local $44 i32)
+  (local $45 f32)
+  (local $46 f64)
+  (local $47 i32)
+  (local $48 f32)
+  (local $49 i32)
+  (local $50 i64)
+  (local $51 i32)
+  (local $52 i64)
+  (local $53 i64)
+  (local $54 i64)
+  (local $55 i64)
+  (local $56 i64)
+  (local $57 i64)
+  (local $58 i64)
+  (local $59 i64)
+  (local $60 i32)
+  (local $61 i32)
+  (local $62 i32)
+  (local $63 f64)
+  (local $64 i32)
+  (local $65 f64)
+  (local $66 f64)
+  (local $67 f64)
+  (local $68 f64)
+  (local $69 f64)
+  (local $70 f64)
+  (local $71 f64)
   local.get $0
   i32.reinterpret_f32
   local.set $1
@@ -14420,63 +14707,63 @@
      f64.const 1.5707963267948966
      f64.sub
     end
-    local.set $4
+    local.set $12
     i32.const 1
-    local.set $3
-    local.get $4
-    local.get $4
+    local.set $11
+    local.get $12
+    local.get $12
     f64.mul
-    local.set $10
+    local.set $13
     f64.const 0.002974357433599673
-    local.get $10
+    local.get $13
     f64.const 0.009465647849436732
     f64.mul
     f64.add
-    local.set $9
+    local.set $14
     f64.const 0.05338123784456704
-    local.get $10
+    local.get $13
     f64.const 0.024528318116654728
     f64.mul
     f64.add
-    local.set $8
-    local.get $10
-    local.get $10
+    local.set $15
+    local.get $13
+    local.get $13
     f64.mul
-    local.set $7
-    local.get $10
-    local.get $4
+    local.set $16
+    local.get $13
+    local.get $12
     f64.mul
-    local.set $6
+    local.set $17
     f64.const 0.3333313950307914
-    local.get $10
+    local.get $13
     f64.const 0.13339200271297674
     f64.mul
     f64.add
-    local.set $5
-    local.get $4
-    local.get $6
-    local.get $5
+    local.set $18
+    local.get $12
+    local.get $17
+    local.get $18
     f64.mul
     f64.add
-    local.get $6
-    local.get $7
+    local.get $17
+    local.get $16
     f64.mul
-    local.get $8
-    local.get $7
-    local.get $9
-    f64.mul
-    f64.add
+    local.get $15
+    local.get $16
+    local.get $14
     f64.mul
     f64.add
-    local.set $9
-    local.get $3
+    f64.mul
+    f64.add
+    local.set $14
+    local.get $11
     if (result f64)
      f32.const -1
      f64.promote_f32
-     local.get $9
+     local.get $14
      f64.div
     else
-     local.get $9
+     local.get $14
     end
     f32.demote_f64
     return
@@ -14493,63 +14780,63 @@
      f64.const 3.141592653589793
      f64.sub
     end
-    local.set $4
+    local.set $20
     i32.const 0
-    local.set $3
-    local.get $4
-    local.get $4
+    local.set $19
+    local.get $20
+    local.get $20
     f64.mul
-    local.set $5
+    local.set $21
     f64.const 0.002974357433599673
-    local.get $5
+    local.get $21
     f64.const 0.009465647849436732
     f64.mul
     f64.add
-    local.set $6
+    local.set $22
     f64.const 0.05338123784456704
-    local.get $5
+    local.get $21
     f64.const 0.024528318116654728
     f64.mul
     f64.add
-    local.set $7
-    local.get $5
-    local.get $5
+    local.set $23
+    local.get $21
+    local.get $21
     f64.mul
-    local.set $8
-    local.get $5
-    local.get $4
+    local.set $24
+    local.get $21
+    local.get $20
     f64.mul
-    local.set $9
+    local.set $25
     f64.const 0.3333313950307914
-    local.get $5
+    local.get $21
     f64.const 0.13339200271297674
     f64.mul
     f64.add
-    local.set $10
-    local.get $4
-    local.get $9
-    local.get $10
+    local.set $26
+    local.get $20
+    local.get $25
+    local.get $26
     f64.mul
     f64.add
-    local.get $9
-    local.get $8
+    local.get $25
+    local.get $24
     f64.mul
-    local.get $7
-    local.get $8
-    local.get $6
-    f64.mul
-    f64.add
+    local.get $23
+    local.get $24
+    local.get $22
     f64.mul
     f64.add
-    local.set $6
-    local.get $3
+    f64.mul
+    f64.add
+    local.set $22
+    local.get $19
     if (result f64)
      f32.const -1
      f64.promote_f32
-     local.get $6
+     local.get $22
      f64.div
     else
-     local.get $6
+     local.get $22
     end
     f32.demote_f64
     return
@@ -14576,63 +14863,63 @@
      f64.const 4.71238898038469
      f64.sub
     end
-    local.set $4
+    local.set $28
     i32.const 1
-    local.set $3
-    local.get $4
-    local.get $4
+    local.set $27
+    local.get $28
+    local.get $28
     f64.mul
-    local.set $10
+    local.set $29
     f64.const 0.002974357433599673
-    local.get $10
+    local.get $29
     f64.const 0.009465647849436732
     f64.mul
     f64.add
-    local.set $9
+    local.set $30
     f64.const 0.05338123784456704
-    local.get $10
+    local.get $29
     f64.const 0.024528318116654728
     f64.mul
     f64.add
-    local.set $8
-    local.get $10
-    local.get $10
+    local.set $31
+    local.get $29
+    local.get $29
     f64.mul
-    local.set $7
-    local.get $10
-    local.get $4
+    local.set $32
+    local.get $29
+    local.get $28
     f64.mul
-    local.set $6
+    local.set $33
     f64.const 0.3333313950307914
-    local.get $10
+    local.get $29
     f64.const 0.13339200271297674
     f64.mul
     f64.add
-    local.set $5
-    local.get $4
-    local.get $6
-    local.get $5
+    local.set $34
+    local.get $28
+    local.get $33
+    local.get $34
     f64.mul
     f64.add
-    local.get $6
-    local.get $7
+    local.get $33
+    local.get $32
     f64.mul
-    local.get $8
-    local.get $7
-    local.get $9
-    f64.mul
-    f64.add
+    local.get $31
+    local.get $32
+    local.get $30
     f64.mul
     f64.add
-    local.set $9
-    local.get $3
+    f64.mul
+    f64.add
+    local.set $30
+    local.get $27
     if (result f64)
      f32.const -1
      f64.promote_f32
-     local.get $9
+     local.get $30
      f64.div
     else
-     local.get $9
+     local.get $30
     end
     f32.demote_f64
     return
@@ -14649,63 +14936,63 @@
      f64.const 6.283185307179586
      f64.sub
     end
-    local.set $4
+    local.set $36
     i32.const 0
-    local.set $3
-    local.get $4
-    local.get $4
+    local.set $35
+    local.get $36
+    local.get $36
     f64.mul
-    local.set $5
+    local.set $37
     f64.const 0.002974357433599673
-    local.get $5
+    local.get $37
     f64.const 0.009465647849436732
     f64.mul
     f64.add
-    local.set $6
+    local.set $38
     f64.const 0.05338123784456704
-    local.get $5
+    local.get $37
     f64.const 0.024528318116654728
     f64.mul
     f64.add
-    local.set $7
-    local.get $5
-    local.get $5
+    local.set $39
+    local.get $37
+    local.get $37
     f64.mul
-    local.set $8
-    local.get $5
-    local.get $4
+    local.set $40
+    local.get $37
+    local.get $36
     f64.mul
-    local.set $9
+    local.set $41
     f64.const 0.3333313950307914
-    local.get $5
+    local.get $37
     f64.const 0.13339200271297674
     f64.mul
     f64.add
-    local.set $10
-    local.get $4
-    local.get $9
-    local.get $10
+    local.set $42
+    local.get $36
+    local.get $41
+    local.get $42
     f64.mul
     f64.add
-    local.get $9
-    local.get $8
+    local.get $41
+    local.get $40
     f64.mul
-    local.get $7
-    local.get $8
-    local.get $6
-    f64.mul
-    f64.add
+    local.get $39
+    local.get $40
+    local.get $38
     f64.mul
     f64.add
-    local.set $6
-    local.get $3
+    f64.mul
+    f64.add
+    local.set $38
+    local.get $35
     if (result f64)
      f32.const -1
      f64.promote_f32
-     local.get $6
+     local.get $38
      f64.div
     else
-     local.get $6
+     local.get $38
     end
     f32.demote_f64
     return
@@ -14723,214 +15010,214 @@
   end
   block $~lib/math/rempio2f|inlined.2 (result i32)
    local.get $0
-   local.set $12
+   local.set $45
    local.get $1
-   local.set $11
+   local.set $44
    local.get $2
-   local.set $3
-   local.get $11
+   local.set $43
+   local.get $44
    i32.const 1305022427
    i32.lt_u
    if
-    local.get $12
+    local.get $45
     f64.promote_f32
     f64.const 0.6366197723675814
     f64.mul
     f64.nearest
-    local.set $10
-    local.get $12
+    local.set $46
+    local.get $45
     f64.promote_f32
-    local.get $10
+    local.get $46
     f64.const 1.5707963109016418
     f64.mul
     f64.sub
-    local.get $10
+    local.get $46
     f64.const 1.5893254773528196e-08
     f64.mul
     f64.sub
     global.set $~lib/math/rempio2f_y
-    local.get $10
+    local.get $46
     i32.trunc_f64_s
     br $~lib/math/rempio2f|inlined.2
    end
-   local.get $12
-   local.set $14
-   local.get $11
-   local.set $13
-   local.get $13
+   local.get $45
+   local.set $48
+   local.get $44
+   local.set $47
+   local.get $47
    i32.const 23
    i32.shr_s
    i32.const 152
    i32.sub
-   local.set $15
-   local.get $15
+   local.set $49
+   local.get $49
    i32.const 63
    i32.and
    i64.extend_i32_s
-   local.set $16
+   local.set $50
    i32.const 4600
-   local.get $15
+   local.get $49
    i32.const 6
    i32.shr_s
    i32.const 3
    i32.shl
    i32.add
-   local.set $17
-   local.get $17
+   local.set $51
+   local.get $51
    i64.load
-   local.set $18
-   local.get $17
+   local.set $52
+   local.get $51
    i64.load offset=8
-   local.set $19
-   local.get $16
+   local.set $53
+   local.get $50
    i64.const 32
    i64.gt_u
    if
-    local.get $17
+    local.get $51
     i64.load offset=16
-    local.set $21
-    local.get $21
+    local.set $55
+    local.get $55
     i64.const 96
-    local.get $16
+    local.get $50
     i64.sub
     i64.shr_u
-    local.set $20
-    local.get $20
-    local.get $19
-    local.get $16
+    local.set $54
+    local.get $54
+    local.get $53
+    local.get $50
     i64.const 32
     i64.sub
     i64.shl
     i64.or
-    local.set $20
+    local.set $54
    else
-    local.get $19
+    local.get $53
     i64.const 32
-    local.get $16
+    local.get $50
     i64.sub
     i64.shr_u
-    local.set $20
+    local.set $54
    end
-   local.get $19
+   local.get $53
    i64.const 64
-   local.get $16
+   local.get $50
    i64.sub
    i64.shr_u
-   local.get $18
-   local.get $16
+   local.get $52
+   local.get $50
    i64.shl
    i64.or
-   local.set $21
-   local.get $13
+   local.set $56
+   local.get $47
    i32.const 8388607
    i32.and
    i32.const 8388608
    i32.or
    i64.extend_i32_s
-   local.set $22
-   local.get $22
-   local.get $21
+   local.set $57
+   local.get $57
+   local.get $56
    i64.mul
-   local.get $22
-   local.get $20
+   local.get $57
+   local.get $54
    i64.mul
    i64.const 32
    i64.shr_u
    i64.add
-   local.set $23
-   local.get $23
+   local.set $58
+   local.get $58
    i64.const 2
    i64.shl
-   local.set $24
-   local.get $23
+   local.set $59
+   local.get $58
    i64.const 62
    i64.shr_u
-   local.get $24
+   local.get $59
    i64.const 63
    i64.shr_u
    i64.add
    i32.wrap_i64
-   local.set $25
+   local.set $60
    f64.const 8.515303950216386e-20
-   local.get $14
+   local.get $48
    f64.promote_f32
    f64.copysign
-   local.get $24
+   local.get $59
    f64.convert_i64_s
    f64.mul
    global.set $~lib/math/rempio2f_y
-   local.get $25
-   local.set $25
+   local.get $60
+   local.set $61
    i32.const 0
-   local.get $25
+   local.get $61
    i32.sub
-   local.get $25
-   local.get $3
+   local.get $61
+   local.get $43
    select
   end
-  local.set $26
+  local.set $62
   global.get $~lib/math/rempio2f_y
-  local.set $27
-  local.get $27
-  local.set $4
-  local.get $26
+  local.set $63
+  local.get $63
+  local.set $65
+  local.get $62
   i32.const 1
   i32.and
-  local.set $13
-  local.get $4
-  local.get $4
+  local.set $64
+  local.get $65
+  local.get $65
   f64.mul
-  local.set $10
+  local.set $66
   f64.const 0.002974357433599673
-  local.get $10
+  local.get $66
   f64.const 0.009465647849436732
   f64.mul
   f64.add
-  local.set $9
+  local.set $67
   f64.const 0.05338123784456704
-  local.get $10
+  local.get $66
   f64.const 0.024528318116654728
   f64.mul
   f64.add
-  local.set $8
-  local.get $10
-  local.get $10
+  local.set $68
+  local.get $66
+  local.get $66
   f64.mul
-  local.set $7
-  local.get $10
-  local.get $4
+  local.set $69
+  local.get $66
+  local.get $65
   f64.mul
-  local.set $6
+  local.set $70
   f64.const 0.3333313950307914
-  local.get $10
+  local.get $66
   f64.const 0.13339200271297674
   f64.mul
   f64.add
-  local.set $5
-  local.get $4
-  local.get $6
-  local.get $5
+  local.set $71
+  local.get $65
+  local.get $70
+  local.get $71
   f64.mul
   f64.add
-  local.get $6
-  local.get $7
+  local.get $70
+  local.get $69
   f64.mul
-  local.get $8
-  local.get $7
-  local.get $9
-  f64.mul
-  f64.add
+  local.get $68
+  local.get $69
+  local.get $67
   f64.mul
   f64.add
-  local.set $9
-  local.get $13
+  f64.mul
+  f64.add
+  local.set $67
+  local.get $64
   if (result f64)
    f32.const -1
    f64.promote_f32
-   local.get $9
+   local.get $67
    f64.div
   else
-   local.get $9
+   local.get $67
   end
   f32.demote_f64
  )
@@ -15201,19 +15488,52 @@
   (local $8 f64)
   (local $9 f64)
   (local $10 f64)
-  (local $11 i64)
-  (local $12 i32)
-  (local $13 i32)
-  (local $14 i32)
-  (local $15 i32)
+  (local $11 f64)
+  (local $12 f64)
+  (local $13 f64)
+  (local $14 f64)
+  (local $15 f64)
   (local $16 f64)
-  (local $17 i32)
-  (local $18 f64)
-  (local $19 f64)
+  (local $17 f64)
+  (local $18 i32)
+  (local $19 i64)
   (local $20 f64)
-  (local $21 f64)
-  (local $22 f64)
+  (local $21 i32)
+  (local $22 i32)
   (local $23 f64)
+  (local $24 f64)
+  (local $25 f64)
+  (local $26 f64)
+  (local $27 f64)
+  (local $28 f64)
+  (local $29 i32)
+  (local $30 f64)
+  (local $31 i32)
+  (local $32 i32)
+  (local $33 f64)
+  (local $34 f64)
+  (local $35 f64)
+  (local $36 i32)
+  (local $37 i32)
+  (local $38 f64)
+  (local $39 f64)
+  (local $40 i32)
+  (local $41 f64)
+  (local $42 f64)
+  (local $43 f64)
+  (local $44 f64)
+  (local $45 f64)
+  (local $46 f64)
+  (local $47 f64)
+  (local $48 f64)
+  (local $49 f64)
+  (local $50 f64)
+  (local $51 f64)
+  (local $52 f64)
+  (local $53 f64)
+  (local $54 f64)
+  (local $55 f64)
+  (local $56 f64)
   local.get $0
   i64.reinterpret_f64
   local.set $1
@@ -15320,35 +15640,35 @@
    end
    global.set $~lib/math/NativeMath.sincos_sin
    local.get $0
-   local.set $6
+   local.set $12
    f64.const 0
-   local.set $5
-   local.get $6
-   local.get $6
+   local.set $11
+   local.get $12
+   local.get $12
    f64.mul
-   local.set $10
-   local.get $10
-   local.get $10
+   local.set $13
+   local.get $13
+   local.get $13
    f64.mul
-   local.set $9
-   local.get $10
+   local.set $14
+   local.get $13
    f64.const 0.0416666666666666
-   local.get $10
+   local.get $13
    f64.const -0.001388888888887411
-   local.get $10
+   local.get $13
    f64.const 2.480158728947673e-05
    f64.mul
    f64.add
    f64.mul
    f64.add
    f64.mul
-   local.get $9
-   local.get $9
+   local.get $14
+   local.get $14
    f64.mul
    f64.const -2.7557314351390663e-07
-   local.get $10
+   local.get $13
    f64.const 2.087572321298175e-09
-   local.get $10
+   local.get $13
    f64.const -1.1359647557788195e-11
    f64.mul
    f64.add
@@ -15356,26 +15676,26 @@
    f64.add
    f64.mul
    f64.add
-   local.set $8
+   local.set $15
    f64.const 0.5
-   local.get $10
+   local.get $13
    f64.mul
-   local.set $7
+   local.set $16
    f64.const 1
-   local.get $7
+   local.get $16
    f64.sub
-   local.set $9
-   local.get $9
+   local.set $14
+   local.get $14
    f64.const 1
-   local.get $9
+   local.get $14
    f64.sub
-   local.get $7
+   local.get $16
    f64.sub
-   local.get $10
-   local.get $8
+   local.get $13
+   local.get $15
    f64.mul
-   local.get $6
-   local.get $5
+   local.get $12
+   local.get $11
    f64.mul
    f64.sub
    f64.add
@@ -15390,328 +15710,328 @@
    local.get $0
    local.get $0
    f64.sub
-   local.set $7
-   local.get $7
+   local.set $17
+   local.get $17
    global.set $~lib/math/NativeMath.sincos_sin
-   local.get $7
+   local.get $17
    global.set $~lib/math/NativeMath.sincos_cos
    return
   end
   block $~lib/math/rempio2|inlined.3 (result i32)
    local.get $0
-   local.set $5
+   local.set $20
    local.get $1
-   local.set $11
+   local.set $19
    local.get $3
-   local.set $4
-   local.get $11
+   local.set $18
+   local.get $19
    i64.const 32
    i64.shr_u
    i32.wrap_i64
    i32.const 2147483647
    i32.and
-   local.set $12
+   local.set $21
    i32.const 0
    i32.const 1
    i32.lt_s
    drop
-   local.get $12
+   local.get $21
    i32.const 1073928572
    i32.lt_u
    if
     i32.const 1
-    local.set $13
-    local.get $4
+    local.set $22
+    local.get $18
     i32.eqz
     if
-     local.get $5
+     local.get $20
      f64.const 1.5707963267341256
      f64.sub
-     local.set $7
-     local.get $12
+     local.set $23
+     local.get $21
      i32.const 1073291771
      i32.ne
      if
-      local.get $7
+      local.get $23
       f64.const 6.077100506506192e-11
       f64.sub
-      local.set $8
-      local.get $7
-      local.get $8
+      local.set $24
+      local.get $23
+      local.get $24
       f64.sub
       f64.const 6.077100506506192e-11
       f64.sub
-      local.set $9
+      local.set $25
      else
-      local.get $7
+      local.get $23
       f64.const 6.077100506303966e-11
       f64.sub
-      local.set $7
-      local.get $7
+      local.set $23
+      local.get $23
       f64.const 2.0222662487959506e-21
       f64.sub
-      local.set $8
-      local.get $7
-      local.get $8
+      local.set $24
+      local.get $23
+      local.get $24
       f64.sub
       f64.const 2.0222662487959506e-21
       f64.sub
-      local.set $9
+      local.set $25
      end
     else
-     local.get $5
+     local.get $20
      f64.const 1.5707963267341256
      f64.add
-     local.set $7
-     local.get $12
+     local.set $23
+     local.get $21
      i32.const 1073291771
      i32.ne
      if
-      local.get $7
+      local.get $23
       f64.const 6.077100506506192e-11
       f64.add
-      local.set $8
-      local.get $7
-      local.get $8
+      local.set $24
+      local.get $23
+      local.get $24
       f64.sub
       f64.const 6.077100506506192e-11
       f64.add
-      local.set $9
+      local.set $25
      else
-      local.get $7
+      local.get $23
       f64.const 6.077100506303966e-11
       f64.add
-      local.set $7
-      local.get $7
+      local.set $23
+      local.get $23
       f64.const 2.0222662487959506e-21
       f64.add
-      local.set $8
-      local.get $7
-      local.get $8
+      local.set $24
+      local.get $23
+      local.get $24
       f64.sub
       f64.const 2.0222662487959506e-21
       f64.add
-      local.set $9
+      local.set $25
      end
      i32.const -1
-     local.set $13
+     local.set $22
     end
-    local.get $8
+    local.get $24
     global.set $~lib/math/rempio2_y0
-    local.get $9
+    local.get $25
     global.set $~lib/math/rempio2_y1
-    local.get $13
+    local.get $22
     br $~lib/math/rempio2|inlined.3
    end
-   local.get $12
+   local.get $21
    i32.const 1094263291
    i32.lt_u
    if
-    local.get $5
+    local.get $20
     f64.const 0.6366197723675814
     f64.mul
     f64.nearest
-    local.set $9
-    local.get $5
-    local.get $9
+    local.set $26
+    local.get $20
+    local.get $26
     f64.const 1.5707963267341256
     f64.mul
     f64.sub
-    local.set $8
-    local.get $9
+    local.set $27
+    local.get $26
     f64.const 6.077100506506192e-11
     f64.mul
-    local.set $7
-    local.get $12
+    local.set $28
+    local.get $21
     i32.const 20
     i32.shr_u
-    local.set $13
-    local.get $8
-    local.get $7
+    local.set $29
+    local.get $27
+    local.get $28
     f64.sub
-    local.set $10
-    local.get $10
+    local.set $30
+    local.get $30
     i64.reinterpret_f64
     i64.const 32
     i64.shr_u
     i32.wrap_i64
-    local.set $14
-    local.get $13
-    local.get $14
+    local.set $31
+    local.get $29
+    local.get $31
     i32.const 20
     i32.shr_u
     i32.const 2047
     i32.and
     i32.sub
-    local.set $15
-    local.get $15
+    local.set $32
+    local.get $32
     i32.const 16
     i32.gt_u
     if
-     local.get $8
-     local.set $6
-     local.get $9
+     local.get $27
+     local.set $33
+     local.get $26
      f64.const 6.077100506303966e-11
      f64.mul
-     local.set $7
-     local.get $6
-     local.get $7
+     local.set $28
+     local.get $33
+     local.get $28
      f64.sub
-     local.set $8
-     local.get $9
+     local.set $27
+     local.get $26
      f64.const 2.0222662487959506e-21
      f64.mul
-     local.get $6
-     local.get $8
+     local.get $33
+     local.get $27
      f64.sub
-     local.get $7
+     local.get $28
      f64.sub
      f64.sub
-     local.set $7
-     local.get $8
-     local.get $7
+     local.set $28
+     local.get $27
+     local.get $28
      f64.sub
-     local.set $10
-     local.get $10
+     local.set $30
+     local.get $30
      i64.reinterpret_f64
      i64.const 32
      i64.shr_u
      i32.wrap_i64
-     local.set $14
-     local.get $13
-     local.get $14
+     local.set $31
+     local.get $29
+     local.get $31
      i32.const 20
      i32.shr_u
      i32.const 2047
      i32.and
      i32.sub
-     local.set $15
-     local.get $15
+     local.set $32
+     local.get $32
      i32.const 49
      i32.gt_u
      if
-      local.get $8
-      local.set $16
-      local.get $9
+      local.get $27
+      local.set $34
+      local.get $26
       f64.const 2.0222662487111665e-21
       f64.mul
-      local.set $7
-      local.get $16
-      local.get $7
+      local.set $28
+      local.get $34
+      local.get $28
       f64.sub
-      local.set $8
-      local.get $9
+      local.set $27
+      local.get $26
       f64.const 8.4784276603689e-32
       f64.mul
-      local.get $16
-      local.get $8
+      local.get $34
+      local.get $27
       f64.sub
-      local.get $7
+      local.get $28
       f64.sub
       f64.sub
-      local.set $7
-      local.get $8
-      local.get $7
+      local.set $28
+      local.get $27
+      local.get $28
       f64.sub
-      local.set $10
+      local.set $30
      end
     end
-    local.get $8
-    local.get $10
+    local.get $27
+    local.get $30
     f64.sub
-    local.get $7
+    local.get $28
     f64.sub
-    local.set $6
-    local.get $10
+    local.set $35
+    local.get $30
     global.set $~lib/math/rempio2_y0
-    local.get $6
+    local.get $35
     global.set $~lib/math/rempio2_y1
-    local.get $9
+    local.get $26
     i32.trunc_f64_s
     br $~lib/math/rempio2|inlined.3
    end
-   local.get $5
-   local.get $11
+   local.get $20
+   local.get $19
    call $~lib/math/pio2_large_quot
-   local.set $15
+   local.set $36
    i32.const 0
-   local.get $15
+   local.get $36
    i32.sub
-   local.get $15
-   local.get $4
+   local.get $36
+   local.get $18
    select
   end
-  local.set $17
+  local.set $37
   global.get $~lib/math/rempio2_y0
-  local.set $18
+  local.set $38
   global.get $~lib/math/rempio2_y1
-  local.set $19
+  local.set $39
   block $~lib/math/sin_kern|inlined.4 (result f64)
-   local.get $18
-   local.set $9
-   local.get $19
-   local.set $16
+   local.get $38
+   local.set $42
+   local.get $39
+   local.set $41
    i32.const 1
-   local.set $13
-   local.get $9
-   local.get $9
+   local.set $40
+   local.get $42
+   local.get $42
    f64.mul
-   local.set $5
-   local.get $5
-   local.get $5
+   local.set $43
+   local.get $43
+   local.get $43
    f64.mul
-   local.set $6
+   local.set $44
    f64.const 0.00833333333332249
-   local.get $5
+   local.get $43
    f64.const -1.984126982985795e-04
-   local.get $5
+   local.get $43
    f64.const 2.7557313707070068e-06
    f64.mul
    f64.add
    f64.mul
    f64.add
-   local.get $5
-   local.get $6
+   local.get $43
+   local.get $44
    f64.mul
    f64.const -2.5050760253406863e-08
-   local.get $5
+   local.get $43
    f64.const 1.58969099521155e-10
    f64.mul
    f64.add
    f64.mul
    f64.add
-   local.set $10
-   local.get $5
-   local.get $9
+   local.set $45
+   local.get $43
+   local.get $42
    f64.mul
-   local.set $7
-   local.get $13
+   local.set $46
+   local.get $40
    i32.eqz
    if
-    local.get $9
-    local.get $7
+    local.get $42
+    local.get $46
     f64.const -0.16666666666666632
-    local.get $5
-    local.get $10
+    local.get $43
+    local.get $45
     f64.mul
     f64.add
     f64.mul
     f64.add
     br $~lib/math/sin_kern|inlined.4
    else
-    local.get $9
-    local.get $5
+    local.get $42
+    local.get $43
     f64.const 0.5
-    local.get $16
+    local.get $41
     f64.mul
-    local.get $7
-    local.get $10
+    local.get $46
+    local.get $45
     f64.mul
     f64.sub
     f64.mul
-    local.get $16
+    local.get $41
     f64.sub
-    local.get $7
+    local.get $46
     f64.const -0.16666666666666632
     f64.mul
     f64.sub
@@ -15720,37 +16040,37 @@
    end
    unreachable
   end
-  local.set $20
-  local.get $18
-  local.set $16
-  local.get $19
-  local.set $8
-  local.get $16
-  local.get $16
+  local.set $47
+  local.get $38
+  local.set $49
+  local.get $39
+  local.set $48
+  local.get $49
+  local.get $49
   f64.mul
-  local.set $7
-  local.get $7
-  local.get $7
+  local.set $50
+  local.get $50
+  local.get $50
   f64.mul
-  local.set $10
-  local.get $7
+  local.set $51
+  local.get $50
   f64.const 0.0416666666666666
-  local.get $7
+  local.get $50
   f64.const -0.001388888888887411
-  local.get $7
+  local.get $50
   f64.const 2.480158728947673e-05
   f64.mul
   f64.add
   f64.mul
   f64.add
   f64.mul
-  local.get $10
-  local.get $10
+  local.get $51
+  local.get $51
   f64.mul
   f64.const -2.7557314351390663e-07
-  local.get $7
+  local.get $50
   f64.const 2.087572321298175e-09
-  local.get $7
+  local.get $50
   f64.const -1.1359647557788195e-11
   f64.mul
   f64.add
@@ -15758,59 +16078,59 @@
   f64.add
   f64.mul
   f64.add
-  local.set $6
+  local.set $52
   f64.const 0.5
-  local.get $7
+  local.get $50
   f64.mul
-  local.set $5
+  local.set $53
   f64.const 1
-  local.get $5
+  local.get $53
   f64.sub
-  local.set $10
-  local.get $10
+  local.set $51
+  local.get $51
   f64.const 1
-  local.get $10
+  local.get $51
   f64.sub
-  local.get $5
+  local.get $53
   f64.sub
-  local.get $7
-  local.get $6
+  local.get $50
+  local.get $52
   f64.mul
-  local.get $16
-  local.get $8
+  local.get $49
+  local.get $48
   f64.mul
   f64.sub
   f64.add
   f64.add
-  local.set $21
-  local.get $20
-  local.set $22
-  local.get $21
-  local.set $23
-  local.get $17
+  local.set $54
+  local.get $47
+  local.set $55
+  local.get $54
+  local.set $56
+  local.get $37
   i32.const 1
   i32.and
   if
-   local.get $21
-   local.set $22
-   local.get $20
+   local.get $54
+   local.set $55
+   local.get $47
    f64.neg
-   local.set $23
+   local.set $56
   end
-  local.get $17
+  local.get $37
   i32.const 2
   i32.and
   if
-   local.get $22
+   local.get $55
    f64.neg
-   local.set $22
-   local.get $23
+   local.set $55
+   local.get $56
    f64.neg
-   local.set $23
+   local.set $56
   end
-  local.get $22
+  local.get $55
   global.set $~lib/math/NativeMath.sincos_sin
-  local.get $23
+  local.get $56
   global.set $~lib/math/NativeMath.sincos_cos
  )
  (func $std/math/test_sincos (param $0 i64) (param $1 i64) (param $2 i64) (param $3 i64) (param $4 i64) (param $5 i32) (result i32)
@@ -15974,6 +16294,8 @@
   (local $2 i64)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   i64.const 1
   local.set $2
   i32.const 0
@@ -16022,8 +16344,8 @@
   local.get $1
   i32.clz
   i32.sub
-  local.set $3
-  local.get $3
+  local.set $4
+  local.get $4
   i32.const 6
   i32.le_s
   if
@@ -16034,29 +16356,29 @@
        block $case2|1
         block $case1|1
          block $case0|1
-          local.get $3
-          local.set $4
           local.get $4
+          local.set $5
+          local.get $5
           i32.const 6
           i32.eq
           br_if $case0|1
-          local.get $4
+          local.get $5
           i32.const 5
           i32.eq
           br_if $case1|1
-          local.get $4
+          local.get $5
           i32.const 4
           i32.eq
           br_if $case2|1
-          local.get $4
+          local.get $5
           i32.const 3
           i32.eq
           br_if $case3|1
-          local.get $4
+          local.get $5
           i32.const 2
           i32.eq
           br_if $case4|1
-          local.get $4
+          local.get $5
           i32.const 1
           i32.eq
           br_if $case5|1
@@ -16169,8 +16491,8 @@
    local.get $1
    i32.const 0
    i32.gt_s
-   local.set $3
-   local.get $3
+   local.set $6
+   local.get $6
    if
     local.get $1
     i32.const 1
@@ -16296,10 +16618,39 @@
  )
  (func $start:std/math
   (local $0 f64)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i64)
-  (local $4 f32)
+  (local $1 f64)
+  (local $2 f64)
+  (local $3 f64)
+  (local $4 f64)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 f64)
+  (local $8 i64)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 f32)
+  (local $12 f64)
+  (local $13 f64)
+  (local $14 f64)
+  (local $15 f64)
+  (local $16 f64)
+  (local $17 f64)
+  (local $18 f64)
+  (local $19 f64)
+  (local $20 f32)
+  (local $21 f32)
+  (local $22 f32)
+  (local $23 f32)
+  (local $24 f32)
+  (local $25 f32)
+  (local $26 f32)
+  (local $27 f32)
+  (local $28 f32)
+  (local $29 f32)
+  (local $30 f32)
+  (local $31 f64)
+  (local $32 f64)
+  (local $33 f64)
   global.get $~lib/math/NativeMath.E
   global.get $~lib/math/NativeMath.E
   f64.eq
@@ -43272,8 +43623,8 @@
   f64.const nan:0x8000000000000
   f64.const -1
   call $~lib/math/NativeMath.pow
-  local.tee $0
-  local.get $0
+  local.tee $1
+  local.get $1
   f64.ne
   i32.eqz
   if
@@ -43386,8 +43737,8 @@
   f64.const nan:0x8000000000000
   f64.const 2
   call $~lib/math/NativeMath.pow
-  local.tee $0
-  local.get $0
+  local.tee $2
+  local.get $2
   f64.ne
   i32.eqz
   if
@@ -43429,8 +43780,8 @@
   f64.const -1
   f64.const 0.5
   call $~lib/math/NativeMath.pow
-  local.tee $0
-  local.get $0
+  local.tee $3
+  local.get $3
   f64.ne
   i32.eqz
   if
@@ -43501,8 +43852,8 @@
   f64.const nan:0x8000000000000
   f64.const 0.5
   call $~lib/math/NativeMath.pow
-  local.tee $0
-  local.get $0
+  local.tee $4
+  local.get $4
   f64.ne
   i32.eqz
   if
@@ -47201,22 +47552,22 @@
   i64.reinterpret_f64
   call $~lib/math/NativeMath.seedRandom
   i32.const 0
-  local.set $1
+  local.set $5
   loop $for-loop|0
-   local.get $1
+   local.get $5
    f64.convert_i32_s
    f64.const 1e6
    f64.lt
-   local.set $2
-   local.get $2
+   local.set $6
+   local.get $6
    if
     call $~lib/math/NativeMath.random
-    local.set $0
-    local.get $0
+    local.set $7
+    local.get $7
     f64.const 0
     f64.ge
     if (result i32)
-     local.get $0
+     local.get $7
      f64.const 1
      f64.lt
     else
@@ -47231,35 +47582,35 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $1
+    local.get $5
     i32.const 1
     i32.add
-    local.set $1
+    local.set $5
     br $for-loop|0
    end
   end
   call $~lib/bindings/Math/random
   i64.reinterpret_f64
-  local.set $3
-  local.get $3
+  local.set $8
+  local.get $8
   call $~lib/math/NativeMath.seedRandom
   i32.const 0
-  local.set $1
+  local.set $9
   loop $for-loop|1
-   local.get $1
+   local.get $9
    f64.convert_i32_s
    f64.const 1e6
    f64.lt
-   local.set $2
-   local.get $2
+   local.set $10
+   local.get $10
    if
     call $~lib/math/NativeMathf.random
-    local.set $4
-    local.get $4
+    local.set $11
+    local.get $11
     f32.const 0
     f32.ge
     if (result i32)
-     local.get $4
+     local.get $11
      f32.const 1
      f32.lt
     else
@@ -47274,10 +47625,10 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $1
+    local.get $9
     i32.const 1
     i32.add
-    local.set $1
+    local.set $9
     br $for-loop|1
    end
   end
@@ -48296,14 +48647,14 @@
    unreachable
   end
   f64.const 0
-  local.set $0
-  local.get $0
+  local.set $12
+  local.get $12
   i64.reinterpret_f64
   i64.const 63
   i64.shr_u
   i32.wrap_i64
-  local.get $0
-  local.get $0
+  local.get $12
+  local.get $12
   f64.eq
   i32.and
   i32.const 0
@@ -48312,14 +48663,14 @@
   i32.eq
   drop
   f64.const -0
-  local.set $0
-  local.get $0
+  local.set $13
+  local.get $13
   i64.reinterpret_f64
   i64.const 63
   i64.shr_u
   i32.wrap_i64
-  local.get $0
-  local.get $0
+  local.get $13
+  local.get $13
   f64.eq
   i32.and
   i32.const 0
@@ -48328,14 +48679,14 @@
   i32.eq
   drop
   f64.const 1
-  local.set $0
-  local.get $0
+  local.set $14
+  local.get $14
   i64.reinterpret_f64
   i64.const 63
   i64.shr_u
   i32.wrap_i64
-  local.get $0
-  local.get $0
+  local.get $14
+  local.get $14
   f64.eq
   i32.and
   i32.const 0
@@ -48344,14 +48695,14 @@
   i32.eq
   drop
   f64.const -1
-  local.set $0
-  local.get $0
+  local.set $15
+  local.get $15
   i64.reinterpret_f64
   i64.const 63
   i64.shr_u
   i32.wrap_i64
-  local.get $0
-  local.get $0
+  local.get $15
+  local.get $15
   f64.eq
   i32.and
   i32.const 0
@@ -48360,14 +48711,14 @@
   i32.eq
   drop
   f64.const nan:0x8000000000000
-  local.set $0
-  local.get $0
+  local.set $16
+  local.get $16
   i64.reinterpret_f64
   i64.const 63
   i64.shr_u
   i32.wrap_i64
-  local.get $0
-  local.get $0
+  local.get $16
+  local.get $16
   f64.eq
   i32.and
   i32.const 0
@@ -48377,14 +48728,14 @@
   drop
   f64.const nan:0x8000000000000
   f64.neg
-  local.set $0
-  local.get $0
+  local.set $17
+  local.get $17
   i64.reinterpret_f64
   i64.const 63
   i64.shr_u
   i32.wrap_i64
-  local.get $0
-  local.get $0
+  local.get $17
+  local.get $17
   f64.eq
   i32.and
   i32.const 0
@@ -48393,14 +48744,14 @@
   i32.eq
   drop
   f64.const inf
-  local.set $0
-  local.get $0
+  local.set $18
+  local.get $18
   i64.reinterpret_f64
   i64.const 63
   i64.shr_u
   i32.wrap_i64
-  local.get $0
-  local.get $0
+  local.get $18
+  local.get $18
   f64.eq
   i32.and
   i32.const 0
@@ -48410,14 +48761,14 @@
   drop
   f64.const inf
   f64.neg
-  local.set $0
-  local.get $0
+  local.set $19
+  local.get $19
   i64.reinterpret_f64
   i64.const 63
   i64.shr_u
   i32.wrap_i64
-  local.get $0
-  local.get $0
+  local.get $19
+  local.get $19
   f64.eq
   i32.and
   i32.const 0
@@ -48426,13 +48777,13 @@
   i32.eq
   drop
   f32.const 0
-  local.set $4
-  local.get $4
+  local.set $20
+  local.get $20
   i32.reinterpret_f32
   i32.const 31
   i32.shr_u
-  local.get $4
-  local.get $4
+  local.get $20
+  local.get $20
   f32.eq
   i32.and
   i32.const 0
@@ -48441,13 +48792,13 @@
   i32.eq
   drop
   f32.const -0
-  local.set $4
-  local.get $4
+  local.set $21
+  local.get $21
   i32.reinterpret_f32
   i32.const 31
   i32.shr_u
-  local.get $4
-  local.get $4
+  local.get $21
+  local.get $21
   f32.eq
   i32.and
   i32.const 0
@@ -48456,13 +48807,13 @@
   i32.eq
   drop
   f32.const 1
-  local.set $4
-  local.get $4
+  local.set $22
+  local.get $22
   i32.reinterpret_f32
   i32.const 31
   i32.shr_u
-  local.get $4
-  local.get $4
+  local.get $22
+  local.get $22
   f32.eq
   i32.and
   i32.const 0
@@ -48471,13 +48822,13 @@
   i32.eq
   drop
   f32.const -1
-  local.set $4
-  local.get $4
+  local.set $23
+  local.get $23
   i32.reinterpret_f32
   i32.const 31
   i32.shr_u
-  local.get $4
-  local.get $4
+  local.get $23
+  local.get $23
   f32.eq
   i32.and
   i32.const 0
@@ -48486,13 +48837,13 @@
   i32.eq
   drop
   f32.const nan:0x400000
-  local.set $4
-  local.get $4
+  local.set $24
+  local.get $24
   i32.reinterpret_f32
   i32.const 31
   i32.shr_u
-  local.get $4
-  local.get $4
+  local.get $24
+  local.get $24
   f32.eq
   i32.and
   i32.const 0
@@ -48502,13 +48853,13 @@
   drop
   f32.const nan:0x400000
   f32.neg
-  local.set $4
-  local.get $4
+  local.set $25
+  local.get $25
   i32.reinterpret_f32
   i32.const 31
   i32.shr_u
-  local.get $4
-  local.get $4
+  local.get $25
+  local.get $25
   f32.eq
   i32.and
   i32.const 0
@@ -48517,13 +48868,13 @@
   i32.eq
   drop
   f32.const inf
-  local.set $4
-  local.get $4
+  local.set $26
+  local.get $26
   i32.reinterpret_f32
   i32.const 31
   i32.shr_u
-  local.get $4
-  local.get $4
+  local.get $26
+  local.get $26
   f32.eq
   i32.and
   i32.const 0
@@ -48533,13 +48884,13 @@
   drop
   f32.const inf
   f32.neg
-  local.set $4
-  local.get $4
+  local.set $27
+  local.get $27
   i32.reinterpret_f32
   i32.const 31
   i32.shr_u
-  local.get $4
-  local.get $4
+  local.get $27
+  local.get $27
   f32.eq
   i32.and
   i32.const 0
@@ -58746,8 +59097,8 @@
   f32.const nan:0x400000
   i32.const 1
   call $~lib/math/ipow32f
-  local.tee $4
-  local.get $4
+  local.tee $28
+  local.get $28
   f32.ne
   i32.eqz
   if
@@ -58761,8 +59112,8 @@
   f32.const nan:0x400000
   i32.const -1
   call $~lib/math/ipow32f
-  local.tee $4
-  local.get $4
+  local.tee $29
+  local.get $29
   f32.ne
   i32.eqz
   if
@@ -58776,8 +59127,8 @@
   f32.const nan:0x400000
   i32.const 2
   call $~lib/math/ipow32f
-  local.tee $4
-  local.get $4
+  local.tee $30
+  local.get $30
   f32.ne
   i32.eqz
   if
@@ -58977,8 +59328,8 @@
   f64.const nan:0x8000000000000
   i32.const 1
   call $~lib/math/ipow64f
-  local.tee $0
-  local.get $0
+  local.tee $31
+  local.get $31
   f64.ne
   i32.eqz
   if
@@ -58992,8 +59343,8 @@
   f64.const nan:0x8000000000000
   i32.const -1
   call $~lib/math/ipow64f
-  local.tee $0
-  local.get $0
+  local.tee $32
+  local.get $32
   f64.ne
   i32.eqz
   if
@@ -59007,8 +59358,8 @@
   f64.const nan:0x8000000000000
   i32.const 2
   call $~lib/math/ipow64f
-  local.tee $0
-  local.get $0
+  local.tee $33
+  local.get $33
   f64.ne
   i32.eqz
   if

--- a/tests/compiler/std/new.untouched.wat
+++ b/tests/compiler/std/new.untouched.wat
@@ -19,6 +19,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   memory.size
   local.set $1
   local.get $1
@@ -49,8 +50,8 @@
    local.get $5
    i32.gt_s
    select
-   local.set $4
-   local.get $4
+   local.set $6
+   local.get $6
    memory.grow
    i32.const 0
    i32.lt_s

--- a/tests/compiler/std/object.untouched.wat
+++ b/tests/compiler/std/object.untouched.wat
@@ -111,6 +111,9 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
   local.get $0
   call $~lib/rt/stub/__retain
   local.set $0
@@ -182,33 +185,33 @@
   end
   loop $while-continue|1
    local.get $4
-   local.tee $7
+   local.tee $8
    i32.const 1
    i32.sub
    local.set $4
-   local.get $7
-   local.set $7
-   local.get $7
+   local.get $8
+   local.set $9
+   local.get $9
    if
     local.get $5
     i32.load16_u
-    local.set $8
+    local.set $10
     local.get $6
     i32.load16_u
-    local.set $9
-    local.get $8
-    local.get $9
+    local.set $11
+    local.get $10
+    local.get $11
     i32.ne
     if
-     local.get $8
-     local.get $9
+     local.get $10
+     local.get $11
      i32.sub
-     local.set $10
+     local.set $12
      local.get $0
      call $~lib/rt/stub/__release
      local.get $2
      call $~lib/rt/stub/__release
-     local.get $10
+     local.get $12
      return
     end
     local.get $5
@@ -223,16 +226,19 @@
    end
   end
   i32.const 0
-  local.set $7
+  local.set $13
   local.get $0
   call $~lib/rt/stub/__release
   local.get $2
   call $~lib/rt/stub/__release
-  local.get $7
+  local.get $13
  )
  (func $~lib/string/String.__eq (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   local.get $0
   call $~lib/rt/stub/__retain
   local.set $0
@@ -264,44 +270,44 @@
   end
   if
    i32.const 0
-   local.set $2
+   local.set $3
    local.get $0
    call $~lib/rt/stub/__release
    local.get $1
    call $~lib/rt/stub/__release
-   local.get $2
+   local.get $3
    return
   end
   local.get $0
   call $~lib/string/String#get:length
-  local.set $3
-  local.get $3
+  local.set $4
+  local.get $4
   local.get $1
   call $~lib/string/String#get:length
   i32.ne
   if
    i32.const 0
-   local.set $2
+   local.set $5
    local.get $0
    call $~lib/rt/stub/__release
    local.get $1
    call $~lib/rt/stub/__release
-   local.get $2
+   local.get $5
    return
   end
   local.get $0
   i32.const 0
   local.get $1
   i32.const 0
-  local.get $3
+  local.get $4
   call $~lib/util/string/compareImpl
   i32.eqz
-  local.set $2
+  local.set $6
   local.get $0
   call $~lib/rt/stub/__release
   local.get $1
   call $~lib/rt/stub/__release
-  local.get $2
+  local.get $6
  )
  (func $~lib/object/Object.is<~lib/string/String> (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)

--- a/tests/compiler/std/operator-overloading.untouched.wat
+++ b/tests/compiler/std/operator-overloading.untouched.wat
@@ -92,6 +92,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   memory.size
   local.set $1
   local.get $1
@@ -122,8 +123,8 @@
    local.get $5
    i32.gt_s
    select
-   local.set $4
-   local.get $4
+   local.set $6
+   local.get $6
    memory.grow
    i32.const 0
    i32.lt_s
@@ -363,18 +364,18 @@
   (local $7 i64)
   (local $8 i64)
   (local $9 i64)
-  (local $10 f64)
-  (local $11 i64)
-  (local $12 i32)
+  (local $10 i64)
+  (local $11 f64)
+  (local $12 i64)
   (local $13 i64)
   (local $14 i64)
-  (local $15 f64)
-  (local $16 f64)
-  (local $17 f64)
-  (local $18 f64)
-  (local $19 f64)
-  (local $20 f64)
-  (local $21 f64)
+  (local $15 i64)
+  (local $16 i32)
+  (local $17 i64)
+  (local $18 i64)
+  (local $19 i32)
+  (local $20 i64)
+  (local $21 i64)
   (local $22 f64)
   (local $23 f64)
   (local $24 f64)
@@ -392,12 +393,52 @@
   (local $36 f64)
   (local $37 f64)
   (local $38 f64)
-  (local $39 i32)
-  (local $40 i32)
-  (local $41 i32)
-  (local $42 i32)
-  (local $43 i64)
-  (local $44 i64)
+  (local $39 f64)
+  (local $40 f64)
+  (local $41 f64)
+  (local $42 f64)
+  (local $43 f64)
+  (local $44 f64)
+  (local $45 f64)
+  (local $46 f64)
+  (local $47 f64)
+  (local $48 f64)
+  (local $49 f64)
+  (local $50 f64)
+  (local $51 f64)
+  (local $52 f64)
+  (local $53 f64)
+  (local $54 f64)
+  (local $55 i32)
+  (local $56 f64)
+  (local $57 f64)
+  (local $58 i32)
+  (local $59 i64)
+  (local $60 i64)
+  (local $61 i64)
+  (local $62 i32)
+  (local $63 f64)
+  (local $64 f64)
+  (local $65 f64)
+  (local $66 f64)
+  (local $67 f64)
+  (local $68 f64)
+  (local $69 f64)
+  (local $70 i64)
+  (local $71 i32)
+  (local $72 f64)
+  (local $73 i32)
+  (local $74 i32)
+  (local $75 f64)
+  (local $76 i32)
+  (local $77 i64)
+  (local $78 i64)
+  (local $79 f64)
+  (local $80 f64)
+  (local $81 f64)
+  (local $82 f64)
+  (local $83 f64)
+  (local $84 f64)
   local.get $1
   f64.abs
   f64.const 2
@@ -576,8 +617,8 @@
      br $~lib/util/math/pow_lut|inlined.0
     end
     local.get $5
-    local.set $9
-    local.get $9
+    local.set $10
+    local.get $10
     i64.const 1
     i64.shl
     i64.const 1
@@ -590,7 +631,7 @@
      local.get $3
      local.get $3
      f64.mul
-     local.set $10
+     local.set $11
      local.get $5
      i64.const 63
      i64.shr_u
@@ -598,21 +639,21 @@
      if (result i32)
       block $~lib/util/math/checkint|inlined.0 (result i32)
        local.get $6
-       local.set $9
-       local.get $9
+       local.set $12
+       local.get $12
        i64.const 52
        i64.shr_u
        i64.const 2047
        i64.and
-       local.set $11
-       local.get $11
+       local.set $13
+       local.get $13
        i64.const 1023
        i64.lt_u
        if
         i32.const 0
         br $~lib/util/math/checkint|inlined.0
        end
-       local.get $11
+       local.get $13
        i64.const 1023
        i64.const 52
        i64.add
@@ -625,12 +666,12 @@
        i64.const 1023
        i64.const 52
        i64.add
-       local.get $11
+       local.get $13
        i64.sub
        i64.shl
-       local.set $11
-       local.get $9
-       local.get $11
+       local.set $13
+       local.get $12
+       local.get $13
        i64.const 1
        i64.sub
        i64.and
@@ -640,8 +681,8 @@
         i32.const 0
         br $~lib/util/math/checkint|inlined.0
        end
-       local.get $9
-       local.get $11
+       local.get $12
+       local.get $13
        i64.and
        i64.const 0
        i64.ne
@@ -657,9 +698,9 @@
       i32.const 0
      end
      if
-      local.get $10
+      local.get $11
       f64.neg
-      local.set $10
+      local.set $11
      end
      local.get $6
      i64.const 63
@@ -668,10 +709,10 @@
      i64.ne
      if (result f64)
       f64.const 1
-      local.get $10
+      local.get $11
       f64.div
      else
-      local.get $10
+      local.get $11
      end
      br $~lib/util/math/pow_lut|inlined.0
     end
@@ -683,21 +724,21 @@
     if
      block $~lib/util/math/checkint|inlined.1 (result i32)
       local.get $6
-      local.set $9
-      local.get $9
+      local.set $14
+      local.get $14
       i64.const 52
       i64.shr_u
       i64.const 2047
       i64.and
-      local.set $11
-      local.get $11
+      local.set $15
+      local.get $15
       i64.const 1023
       i64.lt_u
       if
        i32.const 0
        br $~lib/util/math/checkint|inlined.1
       end
-      local.get $11
+      local.get $15
       i64.const 1023
       i64.const 52
       i64.add
@@ -710,12 +751,12 @@
       i64.const 1023
       i64.const 52
       i64.add
-      local.get $11
+      local.get $15
       i64.sub
       i64.shl
-      local.set $11
-      local.get $9
-      local.get $11
+      local.set $15
+      local.get $14
+      local.get $15
       i64.const 1
       i64.sub
       i64.and
@@ -725,8 +766,8 @@
        i32.const 0
        br $~lib/util/math/checkint|inlined.1
       end
-      local.get $9
-      local.get $11
+      local.get $14
+      local.get $15
       i64.and
       i64.const 0
       i64.ne
@@ -736,8 +777,8 @@
       end
       i32.const 2
      end
-     local.set $12
-     local.get $12
+     local.set $16
+     local.get $16
      i32.const 0
      i32.eq
      if
@@ -750,7 +791,7 @@
       f64.div
       br $~lib/util/math/pow_lut|inlined.0
      end
-     local.get $12
+     local.get $16
      i32.const 1
      i32.eq
      if
@@ -828,12 +869,12 @@
     end
    end
    local.get $5
-   local.set $9
-   local.get $9
+   local.set $17
+   local.get $17
    i64.const 4604531861337669632
    i64.sub
-   local.set $11
-   local.get $11
+   local.set $18
+   local.get $18
    i64.const 52
    i64.const 7
    i64.sub
@@ -841,150 +882,150 @@
    i64.const 127
    i64.and
    i32.wrap_i64
-   local.set $12
-   local.get $11
+   local.set $19
+   local.get $18
    i64.const 52
    i64.shr_s
-   local.set $13
-   local.get $9
-   local.get $11
+   local.set $20
+   local.get $17
+   local.get $18
    i64.const 4095
    i64.const 52
    i64.shl
    i64.and
    i64.sub
-   local.set $14
-   local.get $14
+   local.set $21
+   local.get $21
    f64.reinterpret_i64
-   local.set $10
-   local.get $13
+   local.set $22
+   local.get $20
    f64.convert_i64_s
-   local.set $15
+   local.set $23
    i32.const 88
-   local.get $12
+   local.get $19
    i32.const 2
    i32.const 3
    i32.add
    i32.shl
    i32.add
    f64.load
-   local.set $16
+   local.set $24
    i32.const 88
-   local.get $12
+   local.get $19
    i32.const 2
    i32.const 3
    i32.add
    i32.shl
    i32.add
    f64.load offset=16
-   local.set $17
+   local.set $25
    i32.const 88
-   local.get $12
+   local.get $19
    i32.const 2
    i32.const 3
    i32.add
    i32.shl
    i32.add
    f64.load offset=24
-   local.set $18
-   local.get $14
+   local.set $26
+   local.get $21
    i64.const 2147483648
    i64.add
    i64.const -4294967296
    i64.and
    f64.reinterpret_i64
-   local.set $19
-   local.get $10
-   local.get $19
+   local.set $27
+   local.get $22
+   local.get $27
    f64.sub
-   local.set $20
-   local.get $19
-   local.get $16
+   local.set $28
+   local.get $27
+   local.get $24
    f64.mul
    f64.const 1
    f64.sub
-   local.set $21
-   local.get $20
-   local.get $16
-   f64.mul
-   local.set $22
-   local.get $21
-   local.get $22
-   f64.add
-   local.set $23
-   local.get $15
-   f64.const 0.6931471805598903
-   f64.mul
-   local.get $17
-   f64.add
-   local.set $24
-   local.get $24
-   local.get $23
-   f64.add
-   local.set $25
-   local.get $15
-   f64.const 5.497923018708371e-14
-   f64.mul
-   local.get $18
-   f64.add
-   local.set $26
-   local.get $24
-   local.get $25
-   f64.sub
-   local.get $23
-   f64.add
-   local.set $27
-   f64.const -0.5
-   local.get $23
-   f64.mul
-   local.set $28
-   local.get $23
-   local.get $28
-   f64.mul
    local.set $29
-   local.get $23
-   local.get $29
+   local.get $28
+   local.get $24
    f64.mul
    local.set $30
-   f64.const -0.5
-   local.get $21
-   f64.mul
+   local.get $29
+   local.get $30
+   f64.add
    local.set $31
-   local.get $21
-   local.get $31
+   local.get $23
+   f64.const 0.6931471805598903
    f64.mul
-   local.set $32
    local.get $25
+   f64.add
+   local.set $32
    local.get $32
+   local.get $31
    f64.add
    local.set $33
-   local.get $22
-   local.get $28
-   local.get $31
-   f64.add
+   local.get $23
+   f64.const 5.497923018708371e-14
    f64.mul
+   local.get $26
+   f64.add
    local.set $34
-   local.get $25
+   local.get $32
    local.get $33
    f64.sub
-   local.get $32
+   local.get $31
    f64.add
    local.set $35
+   f64.const -0.5
+   local.get $31
+   f64.mul
+   local.set $36
+   local.get $31
+   local.get $36
+   f64.mul
+   local.set $37
+   local.get $31
+   local.get $37
+   f64.mul
+   local.set $38
+   f64.const -0.5
+   local.get $29
+   f64.mul
+   local.set $39
+   local.get $29
+   local.get $39
+   f64.mul
+   local.set $40
+   local.get $33
+   local.get $40
+   f64.add
+   local.set $41
    local.get $30
+   local.get $36
+   local.get $39
+   f64.add
+   f64.mul
+   local.set $42
+   local.get $33
+   local.get $41
+   f64.sub
+   local.get $40
+   f64.add
+   local.set $43
+   local.get $38
    f64.const -0.6666666666666679
-   local.get $23
+   local.get $31
    f64.const 0.5000000000000007
    f64.mul
    f64.add
-   local.get $29
+   local.get $37
    f64.const 0.7999999995323976
-   local.get $23
+   local.get $31
    f64.const -0.6666666663487739
    f64.mul
    f64.add
-   local.get $29
+   local.get $37
    f64.const -1.142909628459501
-   local.get $23
+   local.get $31
    f64.const 1.0000415263675542
    f64.mul
    f64.add
@@ -993,88 +1034,88 @@
    f64.mul
    f64.add
    f64.mul
-   local.set $36
-   local.get $26
-   local.get $27
-   f64.add
+   local.set $44
    local.get $34
-   f64.add
    local.get $35
    f64.add
-   local.get $36
+   local.get $42
    f64.add
-   local.set $37
-   local.get $33
-   local.get $37
+   local.get $43
    f64.add
-   local.set $38
-   local.get $33
-   local.get $38
+   local.get $44
+   f64.add
+   local.set $45
+   local.get $41
+   local.get $45
+   f64.add
+   local.set $46
+   local.get $41
+   local.get $46
    f64.sub
-   local.get $37
+   local.get $45
    f64.add
    global.set $~lib/util/math/log_tail
-   local.get $38
-   local.set $38
+   local.get $46
+   local.set $47
    global.get $~lib/util/math/log_tail
-   local.set $37
+   local.set $48
    local.get $6
    i64.const -134217728
    i64.and
    f64.reinterpret_i64
-   local.set $34
+   local.set $51
    local.get $2
-   local.get $34
+   local.get $51
    f64.sub
-   local.set $33
-   local.get $38
+   local.set $52
+   local.get $47
    i64.reinterpret_f64
    i64.const -134217728
    i64.and
    f64.reinterpret_i64
-   local.set $32
-   local.get $38
-   local.get $32
+   local.set $53
+   local.get $47
+   local.get $53
    f64.sub
-   local.get $37
+   local.get $48
    f64.add
-   local.set $31
-   local.get $34
-   local.get $32
+   local.set $54
+   local.get $51
+   local.get $53
    f64.mul
-   local.set $36
-   local.get $33
-   local.get $32
+   local.set $49
+   local.get $52
+   local.get $53
    f64.mul
    local.get $2
-   local.get $31
+   local.get $54
    f64.mul
    f64.add
-   local.set $35
+   local.set $50
    block $~lib/util/math/exp_inline|inlined.0 (result f64)
-    local.get $36
-    local.set $15
-    local.get $35
-    local.set $10
+    local.get $49
+    local.set $57
+    local.get $50
+    local.set $56
     local.get $4
-    local.set $12
-    local.get $15
+    local.set $55
+    local.get $57
     i64.reinterpret_f64
-    local.set $9
-    local.get $9
+    local.set $70
+    local.get $70
     i64.const 52
     i64.shr_u
     i32.wrap_i64
     i32.const 2047
     i32.and
-    local.set $39
-    local.get $39
+    local.set $58
+    local.get $58
     i32.const 969
     i32.sub
     i32.const 63
     i32.ge_u
     if
-     local.get $39
+     local.get $58
      i32.const 969
      i32.sub
      i32.const -2147483648
@@ -1082,252 +1123,252 @@
      if
       f64.const -1
       f64.const 1
-      local.get $12
+      local.get $55
       select
       br $~lib/util/math/exp_inline|inlined.0
      end
-     local.get $39
+     local.get $58
      i32.const 1033
      i32.ge_u
      if
-      local.get $9
+      local.get $70
       i64.const 63
       i64.shr_u
       i64.const 0
       i64.ne
       if (result f64)
-       local.get $12
-       local.set $41
-       local.get $41
-       local.set $42
+       local.get $55
+       local.set $71
+       local.get $71
+       local.set $73
        i64.const 1152921504606846976
        f64.reinterpret_i64
-       local.set $16
-       local.get $16
+       local.set $72
+       local.get $72
        f64.neg
-       local.get $16
-       local.get $42
+       local.get $72
+       local.get $73
        select
-       local.get $16
+       local.get $72
        f64.mul
       else
-       local.get $12
-       local.set $42
-       local.get $42
-       local.set $41
+       local.get $55
+       local.set $74
+       local.get $74
+       local.set $76
        i64.const 8070450532247928832
        f64.reinterpret_i64
-       local.set $17
-       local.get $17
+       local.set $75
+       local.get $75
        f64.neg
-       local.get $17
-       local.get $41
+       local.get $75
+       local.get $76
        select
-       local.get $17
+       local.get $75
        f64.mul
       end
       br $~lib/util/math/exp_inline|inlined.0
      end
      i32.const 0
-     local.set $39
+     local.set $58
     end
     f64.const 184.6649652337873
-    local.get $15
+    local.get $57
     f64.mul
-    local.set $29
-    local.get $29
+    local.set $64
+    local.get $64
     f64.const 6755399441055744
     f64.add
-    local.set $30
-    local.get $30
+    local.set $63
+    local.get $63
     i64.reinterpret_f64
-    local.set $14
-    local.get $30
+    local.set $59
+    local.get $63
     f64.const 6755399441055744
     f64.sub
-    local.set $30
-    local.get $15
-    local.get $30
+    local.set $63
+    local.get $57
+    local.get $63
     f64.const -0.005415212348111709
     f64.mul
     f64.add
-    local.get $30
+    local.get $63
     f64.const -1.2864023111638346e-14
     f64.mul
     f64.add
-    local.set $28
-    local.get $28
-    local.get $10
+    local.set $65
+    local.get $65
+    local.get $56
     f64.add
-    local.set $28
-    local.get $14
+    local.set $65
+    local.get $59
     i64.const 127
     i64.and
     i64.const 1
     i64.shl
     i32.wrap_i64
-    local.set $40
-    local.get $14
-    local.get $12
+    local.set $62
+    local.get $59
+    local.get $55
     i64.extend_i32_u
     i64.add
     i64.const 52
     i64.const 7
     i64.sub
     i64.shl
-    local.set $13
+    local.set $60
     i32.const 4184
-    local.get $40
+    local.get $62
     i32.const 3
     i32.shl
     i32.add
     i64.load
     f64.reinterpret_i64
-    local.set $25
+    local.set $68
     i32.const 4184
-    local.get $40
+    local.get $62
     i32.const 3
     i32.shl
     i32.add
     i64.load offset=8
-    local.get $13
+    local.get $60
     i64.add
-    local.set $11
-    local.get $28
-    local.get $28
+    local.set $61
+    local.get $65
+    local.get $65
     f64.mul
-    local.set $27
-    local.get $25
-    local.get $28
+    local.set $66
+    local.get $68
+    local.get $65
     f64.add
-    local.get $27
+    local.get $66
     f64.const 0.49999999999996786
-    local.get $28
+    local.get $65
     f64.const 0.16666666666665886
     f64.mul
     f64.add
     f64.mul
     f64.add
-    local.get $27
-    local.get $27
+    local.get $66
+    local.get $66
     f64.mul
     f64.const 0.0416666808410674
-    local.get $28
+    local.get $65
     f64.const 0.008333335853059549
     f64.mul
     f64.add
     f64.mul
     f64.add
-    local.set $24
-    local.get $39
+    local.set $69
+    local.get $58
     i32.const 0
     i32.eq
     if
      block $~lib/util/math/specialcase|inlined.0 (result f64)
-      local.get $24
-      local.set $18
-      local.get $11
-      local.set $44
-      local.get $14
-      local.set $43
-      local.get $43
+      local.get $69
+      local.set $79
+      local.get $61
+      local.set $78
+      local.get $59
+      local.set $77
+      local.get $77
       i64.const 2147483648
       i64.and
       i64.const 0
       i64.ne
       i32.eqz
       if
-       local.get $44
+       local.get $78
        i64.const 1009
        i64.const 52
        i64.shl
        i64.sub
-       local.set $44
-       local.get $44
+       local.set $78
+       local.get $78
        f64.reinterpret_i64
-       local.set $17
+       local.set $80
        f64.const 5486124068793688683255936e279
-       local.get $17
-       local.get $17
-       local.get $18
+       local.get $80
+       local.get $80
+       local.get $79
        f64.mul
        f64.add
        f64.mul
        br $~lib/util/math/specialcase|inlined.0
       end
-      local.get $44
+      local.get $78
       i64.const 1022
       i64.const 52
       i64.shl
       i64.add
-      local.set $44
-      local.get $44
+      local.set $78
+      local.get $78
       f64.reinterpret_i64
-      local.set $17
-      local.get $17
-      local.get $17
-      local.get $18
+      local.set $80
+      local.get $80
+      local.get $80
+      local.get $79
       f64.mul
       f64.add
-      local.set $16
-      local.get $16
+      local.set $81
+      local.get $81
       f64.abs
       f64.const 1
       f64.lt
       if
        f64.const 1
-       local.get $16
+       local.get $81
        f64.copysign
-       local.set $23
-       local.get $17
-       local.get $16
+       local.set $82
+       local.get $80
+       local.get $81
        f64.sub
-       local.get $17
-       local.get $18
+       local.get $80
+       local.get $79
        f64.mul
        f64.add
-       local.set $22
-       local.get $23
-       local.get $16
+       local.set $83
+       local.get $82
+       local.get $81
        f64.add
-       local.set $21
-       local.get $23
-       local.get $21
+       local.set $84
+       local.get $82
+       local.get $84
        f64.sub
-       local.get $16
+       local.get $81
        f64.add
-       local.get $22
+       local.get $83
        f64.add
-       local.set $22
-       local.get $21
-       local.get $22
+       local.set $83
+       local.get $84
+       local.get $83
        f64.add
-       local.get $23
+       local.get $82
        f64.sub
-       local.set $16
-       local.get $16
+       local.set $81
+       local.get $81
        f64.const 0
        f64.eq
        if
-        local.get $44
+        local.get $78
         i64.const -9223372036854775808
         i64.and
         f64.reinterpret_i64
-        local.set $16
+        local.set $81
        end
       end
-      local.get $16
+      local.get $81
       f64.const 2.2250738585072014e-308
       f64.mul
      end
      br $~lib/util/math/exp_inline|inlined.0
     end
-    local.get $11
+    local.get $61
     f64.reinterpret_i64
-    local.set $26
-    local.get $26
-    local.get $26
-    local.get $24
+    local.set $67
+    local.get $67
+    local.get $67
+    local.get $69
     f64.mul
     f64.add
    end
@@ -1876,6 +1917,33 @@
   (local $22 i32)
   (local $23 i32)
   (local $24 i32)
+  (local $25 i32)
+  (local $26 i32)
+  (local $27 i32)
+  (local $28 i32)
+  (local $29 i32)
+  (local $30 i32)
+  (local $31 i32)
+  (local $32 i32)
+  (local $33 i32)
+  (local $34 i32)
+  (local $35 i32)
+  (local $36 i32)
+  (local $37 i32)
+  (local $38 i32)
+  (local $39 i32)
+  (local $40 i32)
+  (local $41 i32)
+  (local $42 i32)
+  (local $43 i32)
+  (local $44 i32)
+  (local $45 i32)
+  (local $46 i32)
+  (local $47 i32)
+  (local $48 i32)
+  (local $49 i32)
+  (local $50 i32)
+  (local $51 i32)
   global.get $~lib/heap/__heap_base
   i32.const 15
   i32.add
@@ -2521,7 +2589,7 @@
   global.set $std/operator-overloading/pos
   global.get $std/operator-overloading/pos
   call $std/operator-overloading/Tester.pos
-  local.tee $12
+  local.tee $14
   call $~lib/rt/stub/__retain
   global.set $std/operator-overloading/pres
   global.get $std/operator-overloading/pres
@@ -2554,7 +2622,7 @@
   global.set $std/operator-overloading/neg
   global.get $std/operator-overloading/neg
   call $std/operator-overloading/Tester.neg
-  local.tee $13
+  local.tee $15
   call $~lib/rt/stub/__retain
   global.set $std/operator-overloading/nres
   global.get $std/operator-overloading/nres
@@ -2591,7 +2659,7 @@
   global.set $std/operator-overloading/not
   global.get $std/operator-overloading/not
   call $std/operator-overloading/Tester.not
-  local.tee $14
+  local.tee $16
   call $~lib/rt/stub/__retain
   global.set $std/operator-overloading/res
   global.get $std/operator-overloading/res
@@ -2669,19 +2737,19 @@
   global.set $std/operator-overloading/incdec
   global.get $std/operator-overloading/incdec
   call $std/operator-overloading/Tester#inc
-  local.tee $15
-  local.tee $16
-  global.get $std/operator-overloading/incdec
   local.tee $17
+  local.tee $18
+  global.get $std/operator-overloading/incdec
+  local.tee $19
   i32.ne
   if
-   local.get $16
+   local.get $18
    call $~lib/rt/stub/__retain
-   local.set $16
-   local.get $17
+   local.set $18
+   local.get $19
    call $~lib/rt/stub/__release
   end
-  local.get $16
+  local.get $18
   global.set $std/operator-overloading/incdec
   global.get $std/operator-overloading/incdec
   i32.load
@@ -2706,19 +2774,19 @@
   end
   global.get $std/operator-overloading/incdec
   call $std/operator-overloading/Tester#dec
-  local.tee $16
-  local.tee $17
+  local.tee $20
+  local.tee $21
   global.get $std/operator-overloading/incdec
-  local.tee $18
+  local.tee $22
   i32.ne
   if
-   local.get $17
+   local.get $21
    call $~lib/rt/stub/__retain
-   local.set $17
-   local.get $18
+   local.set $21
+   local.get $22
    call $~lib/rt/stub/__release
   end
-  local.get $17
+  local.get $21
   global.set $std/operator-overloading/incdec
   global.get $std/operator-overloading/incdec
   i32.load
@@ -2745,29 +2813,29 @@
   i32.const 0
   i32.const 1
   call $std/operator-overloading/Tester#constructor
-  local.set $18
+  local.set $23
   global.get $std/operator-overloading/incdec
   call $~lib/rt/stub/__release
-  local.get $18
+  local.get $23
   global.set $std/operator-overloading/incdec
   global.get $std/operator-overloading/incdec
-  local.tee $18
+  local.tee $24
   call $std/operator-overloading/Tester#postInc
-  local.tee $17
-  local.tee $19
+  local.tee $25
+  local.tee $26
   global.get $std/operator-overloading/incdec
-  local.tee $20
+  local.tee $27
   i32.ne
   if
-   local.get $19
+   local.get $26
    call $~lib/rt/stub/__retain
-   local.set $19
-   local.get $20
+   local.set $26
+   local.get $27
    call $~lib/rt/stub/__release
   end
-  local.get $19
+  local.get $26
   global.set $std/operator-overloading/incdec
-  local.get $18
+  local.get $24
   call $~lib/rt/stub/__retain
   global.set $std/operator-overloading/tmp
   global.get $std/operator-overloading/tmp
@@ -2813,35 +2881,35 @@
    unreachable
   end
   global.get $std/operator-overloading/incdec
-  local.tee $18
+  local.tee $28
   call $std/operator-overloading/Tester#postDec
-  local.tee $19
-  local.tee $20
+  local.tee $29
+  local.tee $30
   global.get $std/operator-overloading/incdec
-  local.tee $21
+  local.tee $31
   i32.ne
   if
-   local.get $20
+   local.get $30
    call $~lib/rt/stub/__retain
-   local.set $20
-   local.get $21
+   local.set $30
+   local.get $31
    call $~lib/rt/stub/__release
   end
-  local.get $20
+  local.get $30
   global.set $std/operator-overloading/incdec
-  local.get $18
-  local.tee $21
+  local.get $28
+  local.tee $32
   global.get $std/operator-overloading/tmp
-  local.tee $18
+  local.tee $33
   i32.ne
   if
-   local.get $21
+   local.get $32
    call $~lib/rt/stub/__retain
-   local.set $21
-   local.get $18
+   local.set $32
+   local.get $33
    call $~lib/rt/stub/__release
   end
-  local.get $21
+  local.get $32
   global.set $std/operator-overloading/tmp
   global.get $std/operator-overloading/tmp
   i32.load
@@ -2892,34 +2960,34 @@
   global.set $std/operator-overloading/ais1
   global.get $std/operator-overloading/ais1
   call $~lib/rt/stub/__retain
-  local.set $20
+  local.set $35
   i32.const 0
-  local.get $20
+  local.get $35
   i32.load
   i32.const 1
   i32.add
-  local.get $20
+  local.get $35
   i32.load offset=4
   i32.const 1
   i32.add
   call $std/operator-overloading/TesterInlineStatic#constructor
-  local.set $21
-  local.get $20
+  local.set $36
+  local.get $35
   call $~lib/rt/stub/__release
-  local.get $21
-  local.tee $20
-  local.tee $18
+  local.get $36
+  local.tee $37
+  local.tee $38
   global.get $std/operator-overloading/ais1
-  local.tee $21
+  local.tee $39
   i32.ne
   if
-   local.get $18
+   local.get $38
    call $~lib/rt/stub/__retain
-   local.set $18
-   local.get $21
+   local.set $38
+   local.get $39
    call $~lib/rt/stub/__release
   end
-  local.get $18
+  local.get $38
   global.set $std/operator-overloading/ais1
   i32.const 0
   i32.const 2
@@ -2928,29 +2996,29 @@
   global.set $std/operator-overloading/ais2
   global.get $std/operator-overloading/ais1
   call $~lib/rt/stub/__retain
-  local.set $18
+  local.set $41
   global.get $std/operator-overloading/ais2
   call $~lib/rt/stub/__retain
-  local.set $21
+  local.set $40
   i32.const 0
-  local.get $18
+  local.get $41
   i32.load
-  local.get $21
+  local.get $40
   i32.load
   i32.add
-  local.get $18
+  local.get $41
   i32.load offset=4
-  local.get $21
+  local.get $40
   i32.load offset=4
   i32.add
   call $std/operator-overloading/TesterInlineStatic#constructor
-  local.set $22
-  local.get $21
+  local.set $42
+  local.get $40
   call $~lib/rt/stub/__release
-  local.get $18
+  local.get $41
   call $~lib/rt/stub/__release
-  local.get $22
-  local.tee $18
+  local.get $42
+  local.tee $43
   call $~lib/rt/stub/__retain
   global.set $std/operator-overloading/ais
   global.get $std/operator-overloading/ais
@@ -2980,30 +3048,30 @@
   call $std/operator-overloading/TesterInlineInstance#constructor
   global.set $std/operator-overloading/aii1
   global.get $std/operator-overloading/aii1
-  local.set $22
+  local.set $44
   i32.const 0
-  local.get $22
+  local.get $44
   i32.load
   i32.const 1
   i32.add
-  local.get $22
+  local.get $44
   i32.load offset=4
   i32.const 1
   i32.add
   call $std/operator-overloading/TesterInlineInstance#constructor
-  local.tee $22
-  local.tee $21
+  local.tee $45
+  local.tee $46
   global.get $std/operator-overloading/aii1
-  local.tee $23
+  local.tee $47
   i32.ne
   if
-   local.get $21
+   local.get $46
    call $~lib/rt/stub/__retain
-   local.set $21
-   local.get $23
+   local.set $46
+   local.get $47
    call $~lib/rt/stub/__release
   end
-  local.get $21
+  local.get $46
   global.set $std/operator-overloading/aii1
   i32.const 0
   i32.const 2
@@ -3011,27 +3079,27 @@
   call $std/operator-overloading/TesterInlineInstance#constructor
   global.set $std/operator-overloading/aii2
   global.get $std/operator-overloading/aii1
-  local.set $21
+  local.set $49
   global.get $std/operator-overloading/aii2
   call $~lib/rt/stub/__retain
-  local.set $23
+  local.set $48
   i32.const 0
-  local.get $21
+  local.get $49
   i32.load
-  local.get $23
+  local.get $48
   i32.load
   i32.add
-  local.get $21
+  local.get $49
   i32.load offset=4
-  local.get $23
+  local.get $48
   i32.load offset=4
   i32.add
   call $std/operator-overloading/TesterInlineInstance#constructor
-  local.set $24
-  local.get $23
+  local.set $50
+  local.get $48
   call $~lib/rt/stub/__release
-  local.get $24
-  local.tee $21
+  local.get $50
+  local.tee $51
   call $~lib/rt/stub/__retain
   global.set $std/operator-overloading/aii
   global.get $std/operator-overloading/aii
@@ -3079,10 +3147,6 @@
   call $~lib/rt/stub/__release
   local.get $11
   call $~lib/rt/stub/__release
-  local.get $12
-  call $~lib/rt/stub/__release
-  local.get $13
-  call $~lib/rt/stub/__release
   local.get $14
   call $~lib/rt/stub/__release
   local.get $15
@@ -3091,15 +3155,19 @@
   call $~lib/rt/stub/__release
   local.get $17
   call $~lib/rt/stub/__release
-  local.get $18
-  call $~lib/rt/stub/__release
-  local.get $19
-  call $~lib/rt/stub/__release
   local.get $20
   call $~lib/rt/stub/__release
-  local.get $21
+  local.get $25
   call $~lib/rt/stub/__release
-  local.get $22
+  local.get $29
+  call $~lib/rt/stub/__release
+  local.get $37
+  call $~lib/rt/stub/__release
+  local.get $43
+  call $~lib/rt/stub/__release
+  local.get $45
+  call $~lib/rt/stub/__release
+  local.get $51
   call $~lib/rt/stub/__release
  )
  (func $~start

--- a/tests/compiler/std/pointer.untouched.wat
+++ b/tests/compiler/std/pointer.untouched.wat
@@ -237,6 +237,88 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local $22 i32)
+  (local $23 i32)
+  (local $24 i32)
+  (local $25 i32)
+  (local $26 i32)
+  (local $27 i32)
+  (local $28 i32)
+  (local $29 i32)
+  (local $30 i32)
+  (local $31 i32)
+  (local $32 i32)
+  (local $33 i32)
+  (local $34 i32)
+  (local $35 i32)
+  (local $36 i32)
+  (local $37 i32)
+  (local $38 i32)
+  (local $39 i32)
+  (local $40 i32)
+  (local $41 i32)
+  (local $42 i32)
+  (local $43 i32)
+  (local $44 i32)
+  (local $45 i32)
+  (local $46 i32)
+  (local $47 i32)
+  (local $48 i32)
+  (local $49 i32)
+  (local $50 i32)
+  (local $51 i32)
+  (local $52 i32)
+  (local $53 i32)
+  (local $54 i32)
+  (local $55 i32)
+  (local $56 i32)
+  (local $57 i32)
+  (local $58 i32)
+  (local $59 i32)
+  (local $60 i32)
+  (local $61 i32)
+  (local $62 i32)
+  (local $63 i32)
+  (local $64 i32)
+  (local $65 i32)
+  (local $66 i32)
+  (local $67 i32)
+  (local $68 i32)
+  (local $69 i32)
+  (local $70 i32)
+  (local $71 i32)
+  (local $72 i32)
+  (local $73 i32)
+  (local $74 i32)
+  (local $75 i32)
+  (local $76 i32)
+  (local $77 i32)
+  (local $78 i32)
+  (local $79 i32)
+  (local $80 i32)
+  (local $81 i32)
+  (local $82 i32)
+  (local $83 i32)
+  (local $84 i32)
+  (local $85 i32)
+  (local $86 i32)
+  (local $87 i32)
+  (local $88 i32)
   loop $while-continue|0
    local.get $2
    if (result i32)
@@ -256,11 +338,11 @@
     local.set $0
     local.get $6
     local.get $1
-    local.tee $6
+    local.tee $7
     i32.const 1
     i32.add
     local.set $1
-    local.get $6
+    local.get $7
     i32.load8_u
     i32.store8
     local.get $2
@@ -280,8 +362,8 @@
     local.get $2
     i32.const 16
     i32.ge_u
-    local.set $5
-    local.get $5
+    local.set $8
+    local.get $8
     if
      local.get $0
      local.get $1
@@ -390,17 +472,17 @@
    i32.and
    if
     local.get $0
-    local.tee $5
+    local.tee $9
     i32.const 1
     i32.add
     local.set $0
-    local.get $5
+    local.get $9
     local.get $1
-    local.tee $5
+    local.tee $10
     i32.const 1
     i32.add
     local.set $1
-    local.get $5
+    local.get $10
     i32.load8_u
     i32.store8
    end
@@ -417,16 +499,16 @@
        local.get $0
        i32.const 3
        i32.and
-       local.set $5
-       local.get $5
+       local.set $11
+       local.get $11
        i32.const 1
        i32.eq
        br_if $case0|2
-       local.get $5
+       local.get $11
        i32.const 2
        i32.eq
        br_if $case1|2
-       local.get $5
+       local.get $11
        i32.const 3
        i32.eq
        br_if $case2|2
@@ -436,45 +518,45 @@
       i32.load
       local.set $3
       local.get $0
-      local.tee $5
+      local.tee $12
       i32.const 1
       i32.add
       local.set $0
-      local.get $5
+      local.get $12
       local.get $1
-      local.tee $5
+      local.tee $13
       i32.const 1
       i32.add
       local.set $1
-      local.get $5
+      local.get $13
       i32.load8_u
       i32.store8
       local.get $0
-      local.tee $5
+      local.tee $14
       i32.const 1
       i32.add
       local.set $0
-      local.get $5
+      local.get $14
       local.get $1
-      local.tee $5
+      local.tee $15
       i32.const 1
       i32.add
       local.set $1
-      local.get $5
+      local.get $15
       i32.load8_u
       i32.store8
       local.get $0
-      local.tee $5
+      local.tee $16
       i32.const 1
       i32.add
       local.set $0
-      local.get $5
+      local.get $16
       local.get $1
-      local.tee $5
+      local.tee $17
       i32.const 1
       i32.add
       local.set $1
-      local.get $5
+      local.get $17
       i32.load8_u
       i32.store8
       local.get $2
@@ -485,8 +567,8 @@
        local.get $2
        i32.const 17
        i32.ge_u
-       local.set $5
-       local.get $5
+       local.set $18
+       local.get $18
        if
         local.get $1
         i32.const 1
@@ -571,31 +653,31 @@
      i32.load
      local.set $3
      local.get $0
-     local.tee $5
+     local.tee $19
      i32.const 1
      i32.add
      local.set $0
-     local.get $5
+     local.get $19
      local.get $1
-     local.tee $5
+     local.tee $20
      i32.const 1
      i32.add
      local.set $1
-     local.get $5
+     local.get $20
      i32.load8_u
      i32.store8
      local.get $0
-     local.tee $5
+     local.tee $21
      i32.const 1
      i32.add
      local.set $0
-     local.get $5
+     local.get $21
      local.get $1
-     local.tee $5
+     local.tee $22
      i32.const 1
      i32.add
      local.set $1
-     local.get $5
+     local.get $22
      i32.load8_u
      i32.store8
      local.get $2
@@ -606,8 +688,8 @@
       local.get $2
       i32.const 18
       i32.ge_u
-      local.set $5
-      local.get $5
+      local.set $23
+      local.get $23
       if
        local.get $1
        i32.const 2
@@ -692,17 +774,17 @@
     i32.load
     local.set $3
     local.get $0
-    local.tee $5
+    local.tee $24
     i32.const 1
     i32.add
     local.set $0
-    local.get $5
+    local.get $24
     local.get $1
-    local.tee $5
+    local.tee $25
     i32.const 1
     i32.add
     local.set $1
-    local.get $5
+    local.get $25
     i32.load8_u
     i32.store8
     local.get $2
@@ -713,8 +795,8 @@
      local.get $2
      i32.const 19
      i32.ge_u
-     local.set $5
-     local.get $5
+     local.set $26
+     local.get $26
      if
       local.get $1
       i32.const 3
@@ -801,227 +883,227 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $27
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $27
    local.get $1
-   local.tee $5
+   local.tee $28
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $28
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $29
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $29
    local.get $1
-   local.tee $5
+   local.tee $30
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $30
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $31
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $31
    local.get $1
-   local.tee $5
+   local.tee $32
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $32
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $33
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $33
    local.get $1
-   local.tee $5
+   local.tee $34
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $34
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $35
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $35
    local.get $1
-   local.tee $5
+   local.tee $36
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $36
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $37
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $37
    local.get $1
-   local.tee $5
+   local.tee $38
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $38
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $39
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $39
    local.get $1
-   local.tee $5
+   local.tee $40
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $40
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $41
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $41
    local.get $1
-   local.tee $5
+   local.tee $42
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $42
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $43
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $43
    local.get $1
-   local.tee $5
+   local.tee $44
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $44
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $45
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $45
    local.get $1
-   local.tee $5
+   local.tee $46
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $46
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $47
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $47
    local.get $1
-   local.tee $5
+   local.tee $48
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $48
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $49
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $49
    local.get $1
-   local.tee $5
+   local.tee $50
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $50
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $51
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $51
    local.get $1
-   local.tee $5
+   local.tee $52
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $52
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $53
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $53
    local.get $1
-   local.tee $5
+   local.tee $54
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $54
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $55
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $55
    local.get $1
-   local.tee $5
+   local.tee $56
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $56
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $57
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $57
    local.get $1
-   local.tee $5
+   local.tee $58
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $58
    i32.load8_u
    i32.store8
   end
@@ -1030,115 +1112,115 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $59
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $59
    local.get $1
-   local.tee $5
+   local.tee $60
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $60
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $61
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $61
    local.get $1
-   local.tee $5
+   local.tee $62
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $62
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $63
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $63
    local.get $1
-   local.tee $5
+   local.tee $64
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $64
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $65
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $65
    local.get $1
-   local.tee $5
+   local.tee $66
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $66
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $67
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $67
    local.get $1
-   local.tee $5
+   local.tee $68
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $68
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $69
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $69
    local.get $1
-   local.tee $5
+   local.tee $70
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $70
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $71
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $71
    local.get $1
-   local.tee $5
+   local.tee $72
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $72
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $73
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $73
    local.get $1
-   local.tee $5
+   local.tee $74
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $74
    i32.load8_u
    i32.store8
   end
@@ -1147,59 +1229,59 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $75
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $75
    local.get $1
-   local.tee $5
+   local.tee $76
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $76
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $77
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $77
    local.get $1
-   local.tee $5
+   local.tee $78
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $78
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $79
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $79
    local.get $1
-   local.tee $5
+   local.tee $80
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $80
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $81
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $81
    local.get $1
-   local.tee $5
+   local.tee $82
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $82
    i32.load8_u
    i32.store8
   end
@@ -1208,31 +1290,31 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $83
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $83
    local.get $1
-   local.tee $5
+   local.tee $84
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $84
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $85
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $85
    local.get $1
-   local.tee $5
+   local.tee $86
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $86
    i32.load8_u
    i32.store8
   end
@@ -1241,17 +1323,17 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $87
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $87
    local.get $1
-   local.tee $5
+   local.tee $88
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $88
    i32.load8_u
    i32.store8
   end
@@ -1262,6 +1344,14 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
   block $~lib/util/memory/memmove|inlined.0
    local.get $0
    local.set $5
@@ -1339,11 +1429,11 @@
        local.set $5
        local.get $7
        local.get $4
-       local.tee $7
+       local.tee $8
        i32.const 1
        i32.add
        local.set $4
-       local.get $7
+       local.get $8
        i32.load8_u
        i32.store8
        br $while-continue|0
@@ -1353,8 +1443,8 @@
       local.get $3
       i32.const 8
       i32.ge_u
-      local.set $6
-      local.get $6
+      local.set $9
+      local.get $9
       if
        local.get $5
        local.get $4
@@ -1378,21 +1468,21 @@
     end
     loop $while-continue|2
      local.get $3
-     local.set $6
-     local.get $6
+     local.set $10
+     local.get $10
      if
       local.get $5
-      local.tee $7
+      local.tee $11
       i32.const 1
       i32.add
       local.set $5
-      local.get $7
+      local.get $11
       local.get $4
-      local.tee $7
+      local.tee $12
       i32.const 1
       i32.add
       local.set $4
-      local.get $7
+      local.get $12
       i32.load8_u
       i32.store8
       local.get $3
@@ -1421,8 +1511,8 @@
       i32.add
       i32.const 7
       i32.and
-      local.set $6
-      local.get $6
+      local.set $13
+      local.get $13
       if
        local.get $3
        i32.eqz
@@ -1447,8 +1537,8 @@
       local.get $3
       i32.const 8
       i32.ge_u
-      local.set $6
-      local.get $6
+      local.set $14
+      local.get $14
       if
        local.get $3
        i32.const 8
@@ -1468,8 +1558,8 @@
     end
     loop $while-continue|5
      local.get $3
-     local.set $6
-     local.get $6
+     local.set $15
+     local.get $15
      if
       local.get $5
       local.get $3
@@ -1492,7 +1582,64 @@
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
-  (local $3 f32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local $22 i32)
+  (local $23 i32)
+  (local $24 i32)
+  (local $25 i32)
+  (local $26 i32)
+  (local $27 i32)
+  (local $28 i32)
+  (local $29 i32)
+  (local $30 i32)
+  (local $31 i32)
+  (local $32 i32)
+  (local $33 i32)
+  (local $34 i32)
+  (local $35 i32)
+  (local $36 i32)
+  (local $37 f32)
+  (local $38 i32)
+  (local $39 i32)
+  (local $40 f32)
+  (local $41 i32)
+  (local $42 i32)
+  (local $43 i32)
+  (local $44 i32)
+  (local $45 i32)
+  (local $46 i32)
+  (local $47 i32)
+  (local $48 i32)
+  (local $49 i32)
+  (local $50 i32)
+  (local $51 f32)
+  (local $52 i32)
+  (local $53 i32)
+  (local $54 i32)
+  (local $55 i32)
+  (local $56 i32)
+  (local $57 i32)
+  (local $58 f32)
+  (local $59 i32)
+  (local $60 i32)
   i32.const 0
   local.set $1
   i32.const 8
@@ -1504,18 +1651,18 @@
   local.get $2
   global.set $std/pointer/one
   i32.const 0
-  local.set $0
+  local.set $4
   i32.const 24
-  local.set $2
-  local.get $2
-  local.set $1
-  local.get $0
+  local.set $3
+  local.get $3
+  local.set $5
+  local.get $4
   call $~lib/rt/stub/__release
-  local.get $1
+  local.get $5
   global.set $std/pointer/two
   global.get $std/pointer/one
-  local.set $1
-  local.get $1
+  local.set $6
+  local.get $6
   i32.const 8
   i32.eq
   i32.eqz
@@ -1528,8 +1675,8 @@
    unreachable
   end
   global.get $std/pointer/two
-  local.set $2
-  local.get $2
+  local.set $7
+  local.get $7
   i32.const 24
   i32.eq
   i32.eqz
@@ -1543,30 +1690,30 @@
   end
   block $std/pointer/Pointer<std/pointer/Entry>#get:value|inlined.0 (result i32)
    global.get $std/pointer/one
-   local.set $0
+   local.set $8
    i32.const 1
    drop
-   local.get $0
+   local.get $8
    br $std/pointer/Pointer<std/pointer/Entry>#get:value|inlined.0
   end
   i32.const 1
   i32.store
   block $std/pointer/Pointer<std/pointer/Entry>#get:value|inlined.1 (result i32)
    global.get $std/pointer/one
-   local.set $1
+   local.set $9
    i32.const 1
    drop
-   local.get $1
+   local.get $9
    br $std/pointer/Pointer<std/pointer/Entry>#get:value|inlined.1
   end
   i32.const 2
   i32.store offset=4
   block $std/pointer/Pointer<std/pointer/Entry>#get:value|inlined.2 (result i32)
    global.get $std/pointer/one
-   local.set $2
+   local.set $10
    i32.const 1
    drop
-   local.get $2
+   local.get $10
    br $std/pointer/Pointer<std/pointer/Entry>#get:value|inlined.2
   end
   i32.load
@@ -1583,10 +1730,10 @@
   end
   block $std/pointer/Pointer<std/pointer/Entry>#get:value|inlined.3 (result i32)
    global.get $std/pointer/one
-   local.set $0
+   local.set $11
    i32.const 1
    drop
-   local.get $0
+   local.get $11
    br $std/pointer/Pointer<std/pointer/Entry>#get:value|inlined.3
   end
   i32.load offset=4
@@ -1602,16 +1749,16 @@
    unreachable
   end
   global.get $std/pointer/one
-  local.set $2
+  local.set $13
   global.get $std/pointer/two
-  local.set $1
-  local.get $2
-  local.get $1
+  local.set $12
+  local.get $13
+  local.get $12
   i32.add
   global.set $std/pointer/add
   global.get $std/pointer/add
-  local.set $0
-  local.get $0
+  local.set $14
+  local.get $14
   i32.const 32
   i32.eq
   i32.eqz
@@ -1624,16 +1771,16 @@
    unreachable
   end
   global.get $std/pointer/two
-  local.set $2
+  local.set $16
   global.get $std/pointer/one
-  local.set $1
-  local.get $2
-  local.get $1
+  local.set $15
+  local.get $16
+  local.get $15
   i32.sub
   global.set $std/pointer/sub
   global.get $std/pointer/sub
-  local.set $0
-  local.get $0
+  local.set $17
+  local.get $17
   i32.const 16
   i32.eq
   i32.eqz
@@ -1646,8 +1793,8 @@
    unreachable
   end
   global.get $std/pointer/one
-  local.set $1
-  local.get $1
+  local.set $18
+  local.get $18
   i32.const 8
   i32.eq
   i32.eqz
@@ -1660,8 +1807,8 @@
    unreachable
   end
   global.get $std/pointer/one
-  local.set $2
-  local.get $2
+  local.set $19
+  local.get $19
   i32.const 8
   i32.add
   global.set $std/pointer/one
@@ -1680,8 +1827,8 @@
    unreachable
   end
   global.get $std/pointer/one
-  local.set $0
-  local.get $0
+  local.set $20
+  local.get $20
   i32.const 16
   i32.eq
   i32.eqz
@@ -1694,8 +1841,8 @@
    unreachable
   end
   global.get $std/pointer/two
-  local.set $1
-  local.get $1
+  local.set $21
+  local.get $21
   i32.const 24
   i32.eq
   i32.eqz
@@ -1708,20 +1855,20 @@
    unreachable
   end
   global.get $std/pointer/two
-  local.set $2
-  local.get $2
+  local.set $22
+  local.get $22
   i32.const 8
   i32.sub
   global.set $std/pointer/two
   global.get $std/pointer/two
-  local.set $0
-  local.get $0
+  local.set $23
+  local.get $23
   i32.const 8
   i32.sub
   global.set $std/pointer/two
   global.get $std/pointer/two
-  local.set $1
-  local.get $1
+  local.set $24
+  local.get $24
   i32.const 8
   i32.eq
   i32.eqz
@@ -1735,10 +1882,10 @@
   end
   block $std/pointer/Pointer<std/pointer/Entry>#get:value|inlined.4 (result i32)
    global.get $std/pointer/two
-   local.set $2
+   local.set $25
    i32.const 1
    drop
-   local.get $2
+   local.get $25
    br $std/pointer/Pointer<std/pointer/Entry>#get:value|inlined.4
   end
   i32.load
@@ -1755,10 +1902,10 @@
   end
   block $std/pointer/Pointer<std/pointer/Entry>#get:value|inlined.5 (result i32)
    global.get $std/pointer/two
-   local.set $0
+   local.set $26
    i32.const 1
    drop
-   local.get $0
+   local.get $26
    br $std/pointer/Pointer<std/pointer/Entry>#get:value|inlined.5
   end
   i32.load offset=4
@@ -1774,40 +1921,40 @@
    unreachable
   end
   global.get $std/pointer/one
-  local.set $0
+  local.set $29
   block $std/pointer/Pointer<std/pointer/Entry>#get:value|inlined.6 (result i32)
    global.get $std/pointer/two
-   local.set $1
+   local.set $27
    i32.const 1
    drop
-   local.get $1
+   local.get $27
    br $std/pointer/Pointer<std/pointer/Entry>#get:value|inlined.6
   end
-  local.set $2
+  local.set $28
   i32.const 1
   drop
   i32.const 0
   drop
-  local.get $2
+  local.get $28
   i32.const 0
   i32.eq
   if
-   local.get $0
+   local.get $29
    i32.const 0
    i32.const 8
    call $~lib/memory/memory.fill
   else
-   local.get $0
-   local.get $2
+   local.get $29
+   local.get $28
    i32.const 8
    call $~lib/memory/memory.copy
   end
   global.get $std/pointer/one
-  local.set $1
-  local.get $1
+  local.set $30
+  local.get $30
   global.get $std/pointer/two
-  local.set $2
-  local.get $2
+  local.set $31
+  local.get $31
   i32.ne
   i32.eqz
   if
@@ -1820,10 +1967,10 @@
   end
   block $std/pointer/Pointer<std/pointer/Entry>#get:value|inlined.7 (result i32)
    global.get $std/pointer/one
-   local.set $0
+   local.set $32
    i32.const 1
    drop
-   local.get $0
+   local.get $32
    br $std/pointer/Pointer<std/pointer/Entry>#get:value|inlined.7
   end
   i32.load
@@ -1840,10 +1987,10 @@
   end
   block $std/pointer/Pointer<std/pointer/Entry>#get:value|inlined.8 (result i32)
    global.get $std/pointer/one
-   local.set $1
+   local.set $33
    i32.const 1
    drop
-   local.get $1
+   local.get $33
    br $std/pointer/Pointer<std/pointer/Entry>#get:value|inlined.8
   end
   i32.load offset=4
@@ -1859,47 +2006,47 @@
    unreachable
   end
   i32.const 0
-  local.set $0
+  local.set $35
   i32.const 0
-  local.set $2
-  local.get $2
-  local.set $1
-  local.get $0
+  local.set $34
+  local.get $34
+  local.set $36
+  local.get $35
   call $~lib/rt/stub/__release
-  local.get $1
+  local.get $36
   global.set $std/pointer/buf
   global.get $std/pointer/buf
-  local.set $2
+  local.set $39
   i32.const 0
-  local.set $1
+  local.set $38
   f32.const 1.100000023841858
-  local.set $3
-  local.get $2
-  local.get $1
+  local.set $37
+  local.get $39
+  local.get $38
   i32.const 4
   i32.mul
   i32.add
-  local.get $3
+  local.get $37
   f32.store
   global.get $std/pointer/buf
-  local.set $1
+  local.set $42
   i32.const 1
-  local.set $0
+  local.set $41
   f32.const 1.2000000476837158
-  local.set $3
-  local.get $1
-  local.get $0
+  local.set $40
+  local.get $42
+  local.get $41
   i32.const 4
   i32.mul
   i32.add
-  local.get $3
+  local.get $40
   f32.store
   global.get $std/pointer/buf
-  local.set $0
+  local.set $44
   i32.const 0
-  local.set $2
-  local.get $0
-  local.get $2
+  local.set $43
+  local.get $44
+  local.get $43
   i32.const 4
   i32.mul
   i32.add
@@ -1916,11 +2063,11 @@
    unreachable
   end
   global.get $std/pointer/buf
-  local.set $2
+  local.set $46
   i32.const 1
-  local.set $1
-  local.get $2
-  local.get $1
+  local.set $45
+  local.get $46
+  local.get $45
   i32.const 4
   i32.mul
   i32.add
@@ -1937,11 +2084,11 @@
    unreachable
   end
   global.get $std/pointer/buf
-  local.set $1
+  local.set $48
   i32.const 0
-  local.set $0
-  local.get $1
-  local.get $0
+  local.set $47
+  local.get $48
+  local.get $47
   i32.const 4
   i32.mul
   i32.add
@@ -1958,11 +2105,11 @@
    unreachable
   end
   global.get $std/pointer/buf
-  local.set $0
+  local.set $50
   i32.const 1
-  local.set $2
-  local.get $0
-  local.get $2
+  local.set $49
+  local.get $50
+  local.get $49
   i32.const 4
   i32.mul
   i32.add
@@ -2005,24 +2152,24 @@
    unreachable
   end
   global.get $std/pointer/buf
-  local.set $2
+  local.set $53
   i32.const 2
-  local.set $1
+  local.set $52
   f32.const 1.2999999523162842
-  local.set $3
-  local.get $2
-  local.get $1
+  local.set $51
+  local.get $53
+  local.get $52
   i32.const 4
   i32.mul
   i32.add
-  local.get $3
+  local.get $51
   f32.store
   global.get $std/pointer/buf
-  local.set $1
+  local.set $55
   i32.const 2
-  local.set $0
-  local.get $1
-  local.get $0
+  local.set $54
+  local.get $55
+  local.get $54
   i32.const 4
   i32.mul
   i32.add
@@ -2039,11 +2186,11 @@
    unreachable
   end
   global.get $std/pointer/buf
-  local.set $0
+  local.set $57
   i32.const 2
-  local.set $2
-  local.get $0
-  local.get $2
+  local.set $56
+  local.get $57
+  local.get $56
   i32.const 4
   i32.mul
   i32.add
@@ -2073,20 +2220,20 @@
    unreachable
   end
   global.get $std/pointer/buf
-  local.set $1
+  local.set $59
   f32.const 1.399999976158142
-  local.set $3
+  local.set $58
   i32.const 0
   drop
-  local.get $1
-  local.get $3
+  local.get $59
+  local.get $58
   f32.store
   block $std/pointer/Pointer<f32>#get:value|inlined.0 (result f32)
    global.get $std/pointer/buf
-   local.set $2
+   local.set $60
    i32.const 0
    drop
-   local.get $2
+   local.get $60
    f32.load
    br $std/pointer/Pointer<f32>#get:value|inlined.0
   end

--- a/tests/compiler/std/static-array.untouched.wat
+++ b/tests/compiler/std/static-array.untouched.wat
@@ -78,6 +78,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   memory.size
   local.set $1
   local.get $1
@@ -108,8 +109,8 @@
    local.get $5
    i32.gt_s
    select
-   local.set $4
-   local.get $4
+   local.set $6
+   local.get $6
    memory.grow
    i32.const 0
    i32.lt_s
@@ -186,6 +187,88 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local $22 i32)
+  (local $23 i32)
+  (local $24 i32)
+  (local $25 i32)
+  (local $26 i32)
+  (local $27 i32)
+  (local $28 i32)
+  (local $29 i32)
+  (local $30 i32)
+  (local $31 i32)
+  (local $32 i32)
+  (local $33 i32)
+  (local $34 i32)
+  (local $35 i32)
+  (local $36 i32)
+  (local $37 i32)
+  (local $38 i32)
+  (local $39 i32)
+  (local $40 i32)
+  (local $41 i32)
+  (local $42 i32)
+  (local $43 i32)
+  (local $44 i32)
+  (local $45 i32)
+  (local $46 i32)
+  (local $47 i32)
+  (local $48 i32)
+  (local $49 i32)
+  (local $50 i32)
+  (local $51 i32)
+  (local $52 i32)
+  (local $53 i32)
+  (local $54 i32)
+  (local $55 i32)
+  (local $56 i32)
+  (local $57 i32)
+  (local $58 i32)
+  (local $59 i32)
+  (local $60 i32)
+  (local $61 i32)
+  (local $62 i32)
+  (local $63 i32)
+  (local $64 i32)
+  (local $65 i32)
+  (local $66 i32)
+  (local $67 i32)
+  (local $68 i32)
+  (local $69 i32)
+  (local $70 i32)
+  (local $71 i32)
+  (local $72 i32)
+  (local $73 i32)
+  (local $74 i32)
+  (local $75 i32)
+  (local $76 i32)
+  (local $77 i32)
+  (local $78 i32)
+  (local $79 i32)
+  (local $80 i32)
+  (local $81 i32)
+  (local $82 i32)
+  (local $83 i32)
+  (local $84 i32)
+  (local $85 i32)
+  (local $86 i32)
+  (local $87 i32)
+  (local $88 i32)
   loop $while-continue|0
    local.get $2
    if (result i32)
@@ -205,11 +288,11 @@
     local.set $0
     local.get $6
     local.get $1
-    local.tee $6
+    local.tee $7
     i32.const 1
     i32.add
     local.set $1
-    local.get $6
+    local.get $7
     i32.load8_u
     i32.store8
     local.get $2
@@ -229,8 +312,8 @@
     local.get $2
     i32.const 16
     i32.ge_u
-    local.set $5
-    local.get $5
+    local.set $8
+    local.get $8
     if
      local.get $0
      local.get $1
@@ -339,17 +422,17 @@
    i32.and
    if
     local.get $0
-    local.tee $5
+    local.tee $9
     i32.const 1
     i32.add
     local.set $0
-    local.get $5
+    local.get $9
     local.get $1
-    local.tee $5
+    local.tee $10
     i32.const 1
     i32.add
     local.set $1
-    local.get $5
+    local.get $10
     i32.load8_u
     i32.store8
    end
@@ -366,16 +449,16 @@
        local.get $0
        i32.const 3
        i32.and
-       local.set $5
-       local.get $5
+       local.set $11
+       local.get $11
        i32.const 1
        i32.eq
        br_if $case0|2
-       local.get $5
+       local.get $11
        i32.const 2
        i32.eq
        br_if $case1|2
-       local.get $5
+       local.get $11
        i32.const 3
        i32.eq
        br_if $case2|2
@@ -385,45 +468,45 @@
       i32.load
       local.set $3
       local.get $0
-      local.tee $5
+      local.tee $12
       i32.const 1
       i32.add
       local.set $0
-      local.get $5
+      local.get $12
       local.get $1
-      local.tee $5
+      local.tee $13
       i32.const 1
       i32.add
       local.set $1
-      local.get $5
+      local.get $13
       i32.load8_u
       i32.store8
       local.get $0
-      local.tee $5
+      local.tee $14
       i32.const 1
       i32.add
       local.set $0
-      local.get $5
+      local.get $14
       local.get $1
-      local.tee $5
+      local.tee $15
       i32.const 1
       i32.add
       local.set $1
-      local.get $5
+      local.get $15
       i32.load8_u
       i32.store8
       local.get $0
-      local.tee $5
+      local.tee $16
       i32.const 1
       i32.add
       local.set $0
-      local.get $5
+      local.get $16
       local.get $1
-      local.tee $5
+      local.tee $17
       i32.const 1
       i32.add
       local.set $1
-      local.get $5
+      local.get $17
       i32.load8_u
       i32.store8
       local.get $2
@@ -434,8 +517,8 @@
        local.get $2
        i32.const 17
        i32.ge_u
-       local.set $5
-       local.get $5
+       local.set $18
+       local.get $18
        if
         local.get $1
         i32.const 1
@@ -520,31 +603,31 @@
      i32.load
      local.set $3
      local.get $0
-     local.tee $5
+     local.tee $19
      i32.const 1
      i32.add
      local.set $0
-     local.get $5
+     local.get $19
      local.get $1
-     local.tee $5
+     local.tee $20
      i32.const 1
      i32.add
      local.set $1
-     local.get $5
+     local.get $20
      i32.load8_u
      i32.store8
      local.get $0
-     local.tee $5
+     local.tee $21
      i32.const 1
      i32.add
      local.set $0
-     local.get $5
+     local.get $21
      local.get $1
-     local.tee $5
+     local.tee $22
      i32.const 1
      i32.add
      local.set $1
-     local.get $5
+     local.get $22
      i32.load8_u
      i32.store8
      local.get $2
@@ -555,8 +638,8 @@
       local.get $2
       i32.const 18
       i32.ge_u
-      local.set $5
-      local.get $5
+      local.set $23
+      local.get $23
       if
        local.get $1
        i32.const 2
@@ -641,17 +724,17 @@
     i32.load
     local.set $3
     local.get $0
-    local.tee $5
+    local.tee $24
     i32.const 1
     i32.add
     local.set $0
-    local.get $5
+    local.get $24
     local.get $1
-    local.tee $5
+    local.tee $25
     i32.const 1
     i32.add
     local.set $1
-    local.get $5
+    local.get $25
     i32.load8_u
     i32.store8
     local.get $2
@@ -662,8 +745,8 @@
      local.get $2
      i32.const 19
      i32.ge_u
-     local.set $5
-     local.get $5
+     local.set $26
+     local.get $26
      if
       local.get $1
       i32.const 3
@@ -750,227 +833,227 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $27
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $27
    local.get $1
-   local.tee $5
+   local.tee $28
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $28
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $29
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $29
    local.get $1
-   local.tee $5
+   local.tee $30
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $30
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $31
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $31
    local.get $1
-   local.tee $5
+   local.tee $32
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $32
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $33
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $33
    local.get $1
-   local.tee $5
+   local.tee $34
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $34
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $35
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $35
    local.get $1
-   local.tee $5
+   local.tee $36
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $36
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $37
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $37
    local.get $1
-   local.tee $5
+   local.tee $38
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $38
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $39
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $39
    local.get $1
-   local.tee $5
+   local.tee $40
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $40
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $41
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $41
    local.get $1
-   local.tee $5
+   local.tee $42
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $42
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $43
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $43
    local.get $1
-   local.tee $5
+   local.tee $44
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $44
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $45
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $45
    local.get $1
-   local.tee $5
+   local.tee $46
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $46
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $47
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $47
    local.get $1
-   local.tee $5
+   local.tee $48
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $48
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $49
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $49
    local.get $1
-   local.tee $5
+   local.tee $50
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $50
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $51
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $51
    local.get $1
-   local.tee $5
+   local.tee $52
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $52
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $53
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $53
    local.get $1
-   local.tee $5
+   local.tee $54
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $54
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $55
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $55
    local.get $1
-   local.tee $5
+   local.tee $56
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $56
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $57
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $57
    local.get $1
-   local.tee $5
+   local.tee $58
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $58
    i32.load8_u
    i32.store8
   end
@@ -979,115 +1062,115 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $59
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $59
    local.get $1
-   local.tee $5
+   local.tee $60
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $60
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $61
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $61
    local.get $1
-   local.tee $5
+   local.tee $62
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $62
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $63
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $63
    local.get $1
-   local.tee $5
+   local.tee $64
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $64
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $65
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $65
    local.get $1
-   local.tee $5
+   local.tee $66
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $66
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $67
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $67
    local.get $1
-   local.tee $5
+   local.tee $68
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $68
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $69
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $69
    local.get $1
-   local.tee $5
+   local.tee $70
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $70
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $71
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $71
    local.get $1
-   local.tee $5
+   local.tee $72
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $72
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $73
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $73
    local.get $1
-   local.tee $5
+   local.tee $74
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $74
    i32.load8_u
    i32.store8
   end
@@ -1096,59 +1179,59 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $75
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $75
    local.get $1
-   local.tee $5
+   local.tee $76
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $76
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $77
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $77
    local.get $1
-   local.tee $5
+   local.tee $78
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $78
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $79
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $79
    local.get $1
-   local.tee $5
+   local.tee $80
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $80
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $81
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $81
    local.get $1
-   local.tee $5
+   local.tee $82
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $82
    i32.load8_u
    i32.store8
   end
@@ -1157,31 +1240,31 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $83
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $83
    local.get $1
-   local.tee $5
+   local.tee $84
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $84
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $85
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $85
    local.get $1
-   local.tee $5
+   local.tee $86
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $86
    i32.load8_u
    i32.store8
   end
@@ -1190,17 +1273,17 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $87
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $87
    local.get $1
-   local.tee $5
+   local.tee $88
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $88
    i32.load8_u
    i32.store8
   end
@@ -1211,6 +1294,14 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
   block $~lib/util/memory/memmove|inlined.0
    local.get $0
    local.set $5
@@ -1288,11 +1379,11 @@
        local.set $5
        local.get $7
        local.get $4
-       local.tee $7
+       local.tee $8
        i32.const 1
        i32.add
        local.set $4
-       local.get $7
+       local.get $8
        i32.load8_u
        i32.store8
        br $while-continue|0
@@ -1302,8 +1393,8 @@
       local.get $3
       i32.const 8
       i32.ge_u
-      local.set $6
-      local.get $6
+      local.set $9
+      local.get $9
       if
        local.get $5
        local.get $4
@@ -1327,21 +1418,21 @@
     end
     loop $while-continue|2
      local.get $3
-     local.set $6
-     local.get $6
+     local.set $10
+     local.get $10
      if
       local.get $5
-      local.tee $7
+      local.tee $11
       i32.const 1
       i32.add
       local.set $5
-      local.get $7
+      local.get $11
       local.get $4
-      local.tee $7
+      local.tee $12
       i32.const 1
       i32.add
       local.set $4
-      local.get $7
+      local.get $12
       i32.load8_u
       i32.store8
       local.get $3
@@ -1370,8 +1461,8 @@
       i32.add
       i32.const 7
       i32.and
-      local.set $6
-      local.get $6
+      local.set $13
+      local.get $13
       if
        local.get $3
        i32.eqz
@@ -1396,8 +1487,8 @@
       local.get $3
       i32.const 8
       i32.ge_u
-      local.set $6
-      local.get $6
+      local.set $14
+      local.get $14
       if
        local.get $3
        i32.const 8
@@ -1417,8 +1508,8 @@
     end
     loop $while-continue|5
      local.get $3
-     local.set $6
-     local.get $6
+     local.set $15
+     local.get $15
      if
       local.get $5
       local.get $3
@@ -1444,6 +1535,7 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
   local.get $0
   i32.const 0
   i32.ne
@@ -1533,13 +1625,13 @@
     local.get $2
     i32.load offset=8
     call $~lib/rt/stub/__alloc
-    local.set $6
-    local.get $6
+    local.set $8
+    local.get $8
     local.get $0
     local.get $2
     i32.load offset=12
     call $~lib/memory/memory.copy
-    local.get $6
+    local.get $8
     local.tee $0
     i32.const 16
     i32.sub
@@ -2129,6 +2221,12 @@
  (func $start:std/static-array
   (local $0 i32)
   (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
   global.get $std/static-array/i
   call $~lib/array/Array<i32>#get:length
   i32.const 2

--- a/tests/compiler/std/staticarray.untouched.wat
+++ b/tests/compiler/std/staticarray.untouched.wat
@@ -115,6 +115,15 @@
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
   local.get $1
   i32.load
   local.set $2
@@ -251,59 +260,59 @@
   i32.eq
   if
    local.get $0
-   local.set $11
+   local.set $14
    local.get $4
-   local.set $10
+   local.set $13
    local.get $5
-   local.set $9
+   local.set $12
    local.get $7
-   local.set $8
-   local.get $11
-   local.get $10
+   local.set $11
+   local.get $14
+   local.get $13
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $12
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
+   local.get $11
    i32.store offset=96
    local.get $7
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $16
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $15
+    local.get $16
+    local.get $15
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $17
     local.get $0
-    local.set $8
+    local.set $20
     local.get $4
-    local.set $11
-    local.get $9
+    local.set $19
+    local.get $17
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
-    local.set $10
-    local.get $8
-    local.get $11
+    local.tee $17
+    local.set $18
+    local.get $20
+    local.get $19
     i32.const 2
     i32.shl
     i32.add
-    local.get $10
+    local.get $18
     i32.store offset=4
-    local.get $9
+    local.get $17
     i32.eqz
     if
      local.get $0
@@ -333,6 +342,20 @@
   (local $11 i32)
   (local $12 i32)
   (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local $22 i32)
+  (local $23 i32)
+  (local $24 i32)
+  (local $25 i32)
+  (local $26 i32)
+  (local $27 i32)
   i32.const 1
   drop
   local.get $1
@@ -395,8 +418,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $3
+   local.set $6
+   local.get $6
    i32.const 1073741808
    i32.lt_u
    if
@@ -407,16 +430,16 @@
     local.get $2
     i32.const 3
     i32.and
-    local.get $3
+    local.get $6
     i32.or
     local.tee $2
     i32.store
     local.get $1
-    local.set $6
-    local.get $6
+    local.set $7
+    local.get $7
     i32.const 16
     i32.add
-    local.get $6
+    local.get $7
     i32.load
     i32.const 3
     i32.const -1
@@ -434,18 +457,18 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $8
+   local.get $8
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
+   local.set $9
+   local.get $9
    i32.load
-   local.set $3
+   local.set $10
    i32.const 1
    drop
-   local.get $3
+   local.get $10
    i32.const 1
    i32.and
    i32.eqz
@@ -457,7 +480,7 @@
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $3
+   local.get $10
    i32.const 3
    i32.const -1
    i32.xor
@@ -470,23 +493,23 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $7
+   local.set $11
+   local.get $11
    i32.const 1073741808
    i32.lt_u
    if
     local.get $0
-    local.get $6
+    local.get $9
     call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
+    local.get $9
+    local.get $10
     i32.const 3
     i32.and
-    local.get $7
+    local.get $11
     i32.or
     local.tee $2
     i32.store
-    local.get $6
+    local.get $9
     local.set $1
    end
   end
@@ -500,14 +523,14 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $12
   i32.const 1
   drop
-  local.get $8
+  local.get $12
   i32.const 16
   i32.ge_u
   if (result i32)
-   local.get $8
+   local.get $12
    i32.const 1073741808
    i32.lt_u
   else
@@ -527,7 +550,7 @@
   local.get $1
   i32.const 16
   i32.add
-  local.get $8
+  local.get $12
   i32.add
   local.get $4
   i32.eq
@@ -545,24 +568,24 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $12
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $13
+   local.get $12
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $14
   else
    i32.const 31
-   local.get $8
+   local.get $12
    i32.clz
    i32.sub
-   local.set $9
-   local.get $8
-   local.get $9
+   local.set $13
+   local.get $12
+   local.get $13
    i32.const 4
    i32.sub
    i32.shr_u
@@ -570,21 +593,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $14
+   local.get $13
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $13
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $13
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $14
    i32.const 16
    i32.lt_u
   else
@@ -600,86 +623,86 @@
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
-  local.set $6
-  local.get $7
-  local.get $3
+  local.set $17
+  local.get $13
+  local.set $16
+  local.get $14
+  local.set $15
+  local.get $17
+  local.get $16
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $15
   i32.add
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=96
-  local.set $11
+  local.set $18
   local.get $1
   i32.const 0
   i32.store offset=16
   local.get $1
-  local.get $11
+  local.get $18
   i32.store offset=20
-  local.get $11
+  local.get $18
   if
-   local.get $11
+   local.get $18
    local.get $1
    i32.store offset=16
   end
   local.get $0
-  local.set $12
-  local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
+  local.set $22
+  local.get $13
+  local.set $21
+  local.get $14
+  local.set $20
   local.get $1
-  local.set $6
-  local.get $12
-  local.get $7
+  local.set $19
+  local.get $22
+  local.get $21
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $20
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $19
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $13
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.set $13
-  local.get $9
-  local.set $12
+  local.set $27
+  local.get $13
+  local.set $26
   local.get $0
-  local.set $3
-  local.get $9
-  local.set $6
-  local.get $3
-  local.get $6
+  local.set $24
+  local.get $13
+  local.set $23
+  local.get $24
+  local.get $23
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $14
   i32.shl
   i32.or
-  local.set $7
-  local.get $13
-  local.get $12
+  local.set $25
+  local.get $27
+  local.get $26
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $25
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -690,6 +713,7 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
   i32.const 1
   drop
   local.get $1
@@ -829,11 +853,11 @@
   i32.or
   i32.store
   local.get $0
-  local.set $9
+  local.set $10
   local.get $4
-  local.set $3
+  local.set $9
+  local.get $10
   local.get $9
-  local.get $3
   i32.store offset=1568
   local.get $0
   local.get $8
@@ -853,6 +877,12 @@
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
   global.get $~lib/rt/tlsf/ROOT
   local.set $0
   local.get $0
@@ -909,66 +939,66 @@
    local.get $4
    i32.store offset=1568
    i32.const 0
-   local.set $5
+   local.set $6
    loop $for-loop|0
-    local.get $5
+    local.get $6
     i32.const 23
     i32.lt_u
-    local.set $4
-    local.get $4
+    local.set $7
+    local.get $7
     if
      local.get $0
-     local.set $8
-     local.get $5
-     local.set $7
+     local.set $10
+     local.get $6
+     local.set $9
      i32.const 0
-     local.set $6
-     local.get $8
-     local.get $7
+     local.set $8
+     local.get $10
+     local.get $9
      i32.const 2
      i32.shl
      i32.add
-     local.get $6
+     local.get $8
      i32.store offset=4
      i32.const 0
-     local.set $8
+     local.set $11
      loop $for-loop|1
-      local.get $8
+      local.get $11
       i32.const 16
       i32.lt_u
-      local.set $7
-      local.get $7
+      local.set $12
+      local.get $12
       if
        local.get $0
-       local.set $11
-       local.get $5
-       local.set $10
-       local.get $8
-       local.set $9
-       i32.const 0
-       local.set $6
+       local.set $16
+       local.get $6
+       local.set $15
        local.get $11
-       local.get $10
+       local.set $14
+       i32.const 0
+       local.set $13
+       local.get $16
+       local.get $15
        i32.const 4
        i32.shl
-       local.get $9
+       local.get $14
        i32.add
        i32.const 2
        i32.shl
        i32.add
-       local.get $6
+       local.get $13
        i32.store offset=96
-       local.get $8
+       local.get $11
        i32.const 1
        i32.add
-       local.set $8
+       local.set $11
        br $for-loop|1
       end
      end
-     local.get $5
+     local.get $6
      i32.const 1
      i32.add
-     local.set $5
+     local.set $6
      br $for-loop|0
     end
    end
@@ -981,11 +1011,11 @@
    i32.const -1
    i32.xor
    i32.and
-   local.set $5
+   local.set $17
    i32.const 0
    drop
    local.get $0
-   local.get $5
+   local.get $17
    memory.size
    i32.const 16
    i32.shl
@@ -1034,6 +1064,14 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
   local.get $1
   i32.const 256
   i32.lt_u
@@ -1107,11 +1145,11 @@
    unreachable
   end
   local.get $0
-  local.set $5
+  local.set $6
   local.get $2
-  local.set $4
+  local.set $5
+  local.get $6
   local.get $5
-  local.get $4
   i32.const 2
   i32.shl
   i32.add
@@ -1122,10 +1160,10 @@
   local.get $3
   i32.shl
   i32.and
-  local.set $6
-  i32.const 0
   local.set $7
-  local.get $6
+  i32.const 0
+  local.set $8
+  local.get $7
   i32.eqz
   if
    local.get $0
@@ -1138,30 +1176,30 @@
    i32.add
    i32.shl
    i32.and
-   local.set $5
-   local.get $5
+   local.set $9
+   local.get $9
    i32.eqz
    if
     i32.const 0
-    local.set $7
+    local.set $8
    else
-    local.get $5
+    local.get $9
     i32.ctz
     local.set $2
     local.get $0
-    local.set $8
+    local.set $11
     local.get $2
-    local.set $4
-    local.get $8
-    local.get $4
+    local.set $10
+    local.get $11
+    local.get $10
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $6
+    local.set $7
     i32.const 1
     drop
-    local.get $6
+    local.get $7
     i32.eqz
     if
      i32.const 0
@@ -1172,45 +1210,45 @@
      unreachable
     end
     local.get $0
-    local.set $9
+    local.set $14
     local.get $2
-    local.set $8
-    local.get $6
+    local.set $13
+    local.get $7
     i32.ctz
-    local.set $4
-    local.get $9
-    local.get $8
+    local.set $12
+    local.get $14
+    local.get $13
     i32.const 4
     i32.shl
-    local.get $4
+    local.get $12
     i32.add
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=96
-    local.set $7
+    local.set $8
    end
   else
    local.get $0
-   local.set $9
+   local.set $17
    local.get $2
-   local.set $8
-   local.get $6
+   local.set $16
+   local.get $7
    i32.ctz
-   local.set $4
-   local.get $9
-   local.get $8
+   local.set $15
+   local.get $17
+   local.get $16
    i32.const 4
    i32.shl
-   local.get $4
+   local.get $15
    i32.add
    i32.const 2
    i32.shl
    i32.add
    i32.load offset=96
-   local.set $7
+   local.set $8
   end
-  local.get $7
+  local.get $8
  )
  (func $~lib/rt/tlsf/growMemory (param $0 i32) (param $1 i32)
   (local $2 i32)
@@ -1219,6 +1257,7 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
   i32.const 0
   drop
   local.get $1
@@ -1265,15 +1304,15 @@
   i32.shr_u
   local.set $4
   local.get $2
-  local.tee $3
-  local.get $4
   local.tee $5
-  local.get $3
+  local.get $4
+  local.tee $6
   local.get $5
+  local.get $6
   i32.gt_s
   select
-  local.set $6
-  local.get $6
+  local.set $7
+  local.get $7
   memory.grow
   i32.const 0
   i32.lt_s
@@ -1287,12 +1326,12 @@
    end
   end
   memory.size
-  local.set $7
+  local.set $8
   local.get $0
   local.get $2
   i32.const 16
   i32.shl
-  local.get $7
+  local.get $8
   i32.const 16
   i32.shl
   call $~lib/rt/tlsf/addMemory
@@ -1302,6 +1341,8 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
   local.get $1
   i32.load
   local.set $3
@@ -1366,11 +1407,11 @@
    i32.and
    i32.store
    local.get $1
-   local.set $5
-   local.get $5
+   local.set $7
+   local.get $7
    i32.const 16
    i32.add
-   local.get $5
+   local.get $7
    i32.load
    i32.const 3
    i32.const -1
@@ -1378,11 +1419,11 @@
    i32.and
    i32.add
    local.get $1
-   local.set $5
-   local.get $5
+   local.set $6
+   local.get $6
    i32.const 16
    i32.add
-   local.get $5
+   local.get $6
    i32.load
    i32.const 3
    i32.const -1
@@ -1537,6 +1578,88 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local $22 i32)
+  (local $23 i32)
+  (local $24 i32)
+  (local $25 i32)
+  (local $26 i32)
+  (local $27 i32)
+  (local $28 i32)
+  (local $29 i32)
+  (local $30 i32)
+  (local $31 i32)
+  (local $32 i32)
+  (local $33 i32)
+  (local $34 i32)
+  (local $35 i32)
+  (local $36 i32)
+  (local $37 i32)
+  (local $38 i32)
+  (local $39 i32)
+  (local $40 i32)
+  (local $41 i32)
+  (local $42 i32)
+  (local $43 i32)
+  (local $44 i32)
+  (local $45 i32)
+  (local $46 i32)
+  (local $47 i32)
+  (local $48 i32)
+  (local $49 i32)
+  (local $50 i32)
+  (local $51 i32)
+  (local $52 i32)
+  (local $53 i32)
+  (local $54 i32)
+  (local $55 i32)
+  (local $56 i32)
+  (local $57 i32)
+  (local $58 i32)
+  (local $59 i32)
+  (local $60 i32)
+  (local $61 i32)
+  (local $62 i32)
+  (local $63 i32)
+  (local $64 i32)
+  (local $65 i32)
+  (local $66 i32)
+  (local $67 i32)
+  (local $68 i32)
+  (local $69 i32)
+  (local $70 i32)
+  (local $71 i32)
+  (local $72 i32)
+  (local $73 i32)
+  (local $74 i32)
+  (local $75 i32)
+  (local $76 i32)
+  (local $77 i32)
+  (local $78 i32)
+  (local $79 i32)
+  (local $80 i32)
+  (local $81 i32)
+  (local $82 i32)
+  (local $83 i32)
+  (local $84 i32)
+  (local $85 i32)
+  (local $86 i32)
+  (local $87 i32)
+  (local $88 i32)
   loop $while-continue|0
    local.get $2
    if (result i32)
@@ -1556,11 +1679,11 @@
     local.set $0
     local.get $6
     local.get $1
-    local.tee $6
+    local.tee $7
     i32.const 1
     i32.add
     local.set $1
-    local.get $6
+    local.get $7
     i32.load8_u
     i32.store8
     local.get $2
@@ -1580,8 +1703,8 @@
     local.get $2
     i32.const 16
     i32.ge_u
-    local.set $5
-    local.get $5
+    local.set $8
+    local.get $8
     if
      local.get $0
      local.get $1
@@ -1690,17 +1813,17 @@
    i32.and
    if
     local.get $0
-    local.tee $5
+    local.tee $9
     i32.const 1
     i32.add
     local.set $0
-    local.get $5
+    local.get $9
     local.get $1
-    local.tee $5
+    local.tee $10
     i32.const 1
     i32.add
     local.set $1
-    local.get $5
+    local.get $10
     i32.load8_u
     i32.store8
    end
@@ -1717,16 +1840,16 @@
        local.get $0
        i32.const 3
        i32.and
-       local.set $5
-       local.get $5
+       local.set $11
+       local.get $11
        i32.const 1
        i32.eq
        br_if $case0|2
-       local.get $5
+       local.get $11
        i32.const 2
        i32.eq
        br_if $case1|2
-       local.get $5
+       local.get $11
        i32.const 3
        i32.eq
        br_if $case2|2
@@ -1736,45 +1859,45 @@
       i32.load
       local.set $3
       local.get $0
-      local.tee $5
+      local.tee $12
       i32.const 1
       i32.add
       local.set $0
-      local.get $5
+      local.get $12
       local.get $1
-      local.tee $5
+      local.tee $13
       i32.const 1
       i32.add
       local.set $1
-      local.get $5
+      local.get $13
       i32.load8_u
       i32.store8
       local.get $0
-      local.tee $5
+      local.tee $14
       i32.const 1
       i32.add
       local.set $0
-      local.get $5
+      local.get $14
       local.get $1
-      local.tee $5
+      local.tee $15
       i32.const 1
       i32.add
       local.set $1
-      local.get $5
+      local.get $15
       i32.load8_u
       i32.store8
       local.get $0
-      local.tee $5
+      local.tee $16
       i32.const 1
       i32.add
       local.set $0
-      local.get $5
+      local.get $16
       local.get $1
-      local.tee $5
+      local.tee $17
       i32.const 1
       i32.add
       local.set $1
-      local.get $5
+      local.get $17
       i32.load8_u
       i32.store8
       local.get $2
@@ -1785,8 +1908,8 @@
        local.get $2
        i32.const 17
        i32.ge_u
-       local.set $5
-       local.get $5
+       local.set $18
+       local.get $18
        if
         local.get $1
         i32.const 1
@@ -1871,31 +1994,31 @@
      i32.load
      local.set $3
      local.get $0
-     local.tee $5
+     local.tee $19
      i32.const 1
      i32.add
      local.set $0
-     local.get $5
+     local.get $19
      local.get $1
-     local.tee $5
+     local.tee $20
      i32.const 1
      i32.add
      local.set $1
-     local.get $5
+     local.get $20
      i32.load8_u
      i32.store8
      local.get $0
-     local.tee $5
+     local.tee $21
      i32.const 1
      i32.add
      local.set $0
-     local.get $5
+     local.get $21
      local.get $1
-     local.tee $5
+     local.tee $22
      i32.const 1
      i32.add
      local.set $1
-     local.get $5
+     local.get $22
      i32.load8_u
      i32.store8
      local.get $2
@@ -1906,8 +2029,8 @@
       local.get $2
       i32.const 18
       i32.ge_u
-      local.set $5
-      local.get $5
+      local.set $23
+      local.get $23
       if
        local.get $1
        i32.const 2
@@ -1992,17 +2115,17 @@
     i32.load
     local.set $3
     local.get $0
-    local.tee $5
+    local.tee $24
     i32.const 1
     i32.add
     local.set $0
-    local.get $5
+    local.get $24
     local.get $1
-    local.tee $5
+    local.tee $25
     i32.const 1
     i32.add
     local.set $1
-    local.get $5
+    local.get $25
     i32.load8_u
     i32.store8
     local.get $2
@@ -2013,8 +2136,8 @@
      local.get $2
      i32.const 19
      i32.ge_u
-     local.set $5
-     local.get $5
+     local.set $26
+     local.get $26
      if
       local.get $1
       i32.const 3
@@ -2101,227 +2224,227 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $27
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $27
    local.get $1
-   local.tee $5
+   local.tee $28
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $28
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $29
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $29
    local.get $1
-   local.tee $5
+   local.tee $30
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $30
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $31
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $31
    local.get $1
-   local.tee $5
+   local.tee $32
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $32
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $33
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $33
    local.get $1
-   local.tee $5
+   local.tee $34
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $34
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $35
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $35
    local.get $1
-   local.tee $5
+   local.tee $36
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $36
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $37
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $37
    local.get $1
-   local.tee $5
+   local.tee $38
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $38
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $39
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $39
    local.get $1
-   local.tee $5
+   local.tee $40
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $40
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $41
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $41
    local.get $1
-   local.tee $5
+   local.tee $42
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $42
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $43
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $43
    local.get $1
-   local.tee $5
+   local.tee $44
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $44
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $45
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $45
    local.get $1
-   local.tee $5
+   local.tee $46
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $46
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $47
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $47
    local.get $1
-   local.tee $5
+   local.tee $48
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $48
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $49
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $49
    local.get $1
-   local.tee $5
+   local.tee $50
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $50
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $51
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $51
    local.get $1
-   local.tee $5
+   local.tee $52
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $52
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $53
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $53
    local.get $1
-   local.tee $5
+   local.tee $54
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $54
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $55
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $55
    local.get $1
-   local.tee $5
+   local.tee $56
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $56
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $57
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $57
    local.get $1
-   local.tee $5
+   local.tee $58
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $58
    i32.load8_u
    i32.store8
   end
@@ -2330,115 +2453,115 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $59
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $59
    local.get $1
-   local.tee $5
+   local.tee $60
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $60
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $61
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $61
    local.get $1
-   local.tee $5
+   local.tee $62
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $62
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $63
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $63
    local.get $1
-   local.tee $5
+   local.tee $64
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $64
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $65
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $65
    local.get $1
-   local.tee $5
+   local.tee $66
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $66
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $67
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $67
    local.get $1
-   local.tee $5
+   local.tee $68
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $68
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $69
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $69
    local.get $1
-   local.tee $5
+   local.tee $70
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $70
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $71
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $71
    local.get $1
-   local.tee $5
+   local.tee $72
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $72
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $73
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $73
    local.get $1
-   local.tee $5
+   local.tee $74
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $74
    i32.load8_u
    i32.store8
   end
@@ -2447,59 +2570,59 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $75
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $75
    local.get $1
-   local.tee $5
+   local.tee $76
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $76
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $77
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $77
    local.get $1
-   local.tee $5
+   local.tee $78
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $78
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $79
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $79
    local.get $1
-   local.tee $5
+   local.tee $80
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $80
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $81
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $81
    local.get $1
-   local.tee $5
+   local.tee $82
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $82
    i32.load8_u
    i32.store8
   end
@@ -2508,31 +2631,31 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $83
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $83
    local.get $1
-   local.tee $5
+   local.tee $84
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $84
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $85
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $85
    local.get $1
-   local.tee $5
+   local.tee $86
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $86
    i32.load8_u
    i32.store8
   end
@@ -2541,17 +2664,17 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $87
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $87
    local.get $1
-   local.tee $5
+   local.tee $88
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $88
    i32.load8_u
    i32.store8
   end
@@ -2562,6 +2685,14 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
   block $~lib/util/memory/memmove|inlined.0
    local.get $0
    local.set $5
@@ -2639,11 +2770,11 @@
        local.set $5
        local.get $7
        local.get $4
-       local.tee $7
+       local.tee $8
        i32.const 1
        i32.add
        local.set $4
-       local.get $7
+       local.get $8
        i32.load8_u
        i32.store8
        br $while-continue|0
@@ -2653,8 +2784,8 @@
       local.get $3
       i32.const 8
       i32.ge_u
-      local.set $6
-      local.get $6
+      local.set $9
+      local.get $9
       if
        local.get $5
        local.get $4
@@ -2678,21 +2809,21 @@
     end
     loop $while-continue|2
      local.get $3
-     local.set $6
-     local.get $6
+     local.set $10
+     local.get $10
      if
       local.get $5
-      local.tee $7
+      local.tee $11
       i32.const 1
       i32.add
       local.set $5
-      local.get $7
+      local.get $11
       local.get $4
-      local.tee $7
+      local.tee $12
       i32.const 1
       i32.add
       local.set $4
-      local.get $7
+      local.get $12
       i32.load8_u
       i32.store8
       local.get $3
@@ -2721,8 +2852,8 @@
       i32.add
       i32.const 7
       i32.and
-      local.set $6
-      local.get $6
+      local.set $13
+      local.get $13
       if
        local.get $3
        i32.eqz
@@ -2747,8 +2878,8 @@
       local.get $3
       i32.const 8
       i32.ge_u
-      local.set $6
-      local.get $6
+      local.set $14
+      local.get $14
       if
        local.get $3
        i32.const 8
@@ -2768,8 +2899,8 @@
     end
     loop $while-continue|5
      local.get $3
-     local.set $6
-     local.get $6
+     local.set $15
+     local.get $15
      if
       local.get $5
       local.get $3
@@ -2902,6 +3033,12 @@
  (func $start:std/staticarray
   (local $0 i32)
   (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
   global.get $std/staticarray/arr1
   i32.const 1
   call $~lib/staticarray/StaticArray<i32>#__get
@@ -3068,10 +3205,10 @@
    unreachable
   end
   call $std/staticarray/test
-  local.set $0
+  local.set $2
   global.get $std/staticarray/arr3
   call $~lib/rt/pure/__release
-  local.get $0
+  local.get $2
   global.set $std/staticarray/arr3
   global.get $std/staticarray/arr3
   i32.const 1
@@ -3092,44 +3229,44 @@
   i32.const 0
   call $~lib/rt/__allocBuffer
   call $~lib/rt/pure/__retain
-  local.set $0
-  local.get $0
+  local.set $3
+  local.get $3
   i32.const 0
   call $std/staticarray/Ref#constructor
   i32.store
-  local.get $0
+  local.get $3
   i32.const 0
   call $std/staticarray/Ref#constructor
   i32.store offset=4
-  local.get $0
+  local.get $3
   global.set $std/staticarray/arr4
   i32.const 0
-  local.tee $0
+  local.tee $4
   global.get $std/staticarray/arr3
-  local.tee $1
+  local.tee $5
   i32.ne
   if
-   local.get $0
+   local.get $4
    call $~lib/rt/pure/__retain
-   local.set $0
-   local.get $1
+   local.set $4
+   local.get $5
    call $~lib/rt/pure/__release
   end
-  local.get $0
+  local.get $4
   global.set $std/staticarray/arr3
   i32.const 0
-  local.tee $1
+  local.tee $6
   global.get $std/staticarray/arr4
-  local.tee $0
+  local.tee $7
   i32.ne
   if
-   local.get $1
+   local.get $6
    call $~lib/rt/pure/__retain
-   local.set $1
-   local.get $0
+   local.set $6
+   local.get $7
    call $~lib/rt/pure/__release
   end
-  local.get $1
+  local.get $6
   global.set $std/staticarray/arr4
  )
  (func $~start

--- a/tests/compiler/std/string-casemapping.untouched.wat
+++ b/tests/compiler/std/string-casemapping.untouched.wat
@@ -288,6 +288,15 @@
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
   local.get $1
   i32.load
   local.set $2
@@ -424,59 +433,59 @@
   i32.eq
   if
    local.get $0
-   local.set $11
+   local.set $14
    local.get $4
-   local.set $10
+   local.set $13
    local.get $5
-   local.set $9
+   local.set $12
    local.get $7
-   local.set $8
-   local.get $11
-   local.get $10
+   local.set $11
+   local.get $14
+   local.get $13
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $12
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
+   local.get $11
    i32.store offset=96
    local.get $7
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $16
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $15
+    local.get $16
+    local.get $15
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $17
     local.get $0
-    local.set $8
+    local.set $20
     local.get $4
-    local.set $11
-    local.get $9
+    local.set $19
+    local.get $17
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
-    local.set $10
-    local.get $8
-    local.get $11
+    local.tee $17
+    local.set $18
+    local.get $20
+    local.get $19
     i32.const 2
     i32.shl
     i32.add
-    local.get $10
+    local.get $18
     i32.store offset=4
-    local.get $9
+    local.get $17
     i32.eqz
     if
      local.get $0
@@ -506,6 +515,20 @@
   (local $11 i32)
   (local $12 i32)
   (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local $22 i32)
+  (local $23 i32)
+  (local $24 i32)
+  (local $25 i32)
+  (local $26 i32)
+  (local $27 i32)
   i32.const 1
   drop
   local.get $1
@@ -568,8 +591,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $3
+   local.set $6
+   local.get $6
    i32.const 1073741808
    i32.lt_u
    if
@@ -580,16 +603,16 @@
     local.get $2
     i32.const 3
     i32.and
-    local.get $3
+    local.get $6
     i32.or
     local.tee $2
     i32.store
     local.get $1
-    local.set $6
-    local.get $6
+    local.set $7
+    local.get $7
     i32.const 16
     i32.add
-    local.get $6
+    local.get $7
     i32.load
     i32.const 3
     i32.const -1
@@ -607,18 +630,18 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $8
+   local.get $8
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
+   local.set $9
+   local.get $9
    i32.load
-   local.set $3
+   local.set $10
    i32.const 1
    drop
-   local.get $3
+   local.get $10
    i32.const 1
    i32.and
    i32.eqz
@@ -630,7 +653,7 @@
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $3
+   local.get $10
    i32.const 3
    i32.const -1
    i32.xor
@@ -643,23 +666,23 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $7
+   local.set $11
+   local.get $11
    i32.const 1073741808
    i32.lt_u
    if
     local.get $0
-    local.get $6
+    local.get $9
     call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
+    local.get $9
+    local.get $10
     i32.const 3
     i32.and
-    local.get $7
+    local.get $11
     i32.or
     local.tee $2
     i32.store
-    local.get $6
+    local.get $9
     local.set $1
    end
   end
@@ -673,14 +696,14 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $12
   i32.const 1
   drop
-  local.get $8
+  local.get $12
   i32.const 16
   i32.ge_u
   if (result i32)
-   local.get $8
+   local.get $12
    i32.const 1073741808
    i32.lt_u
   else
@@ -700,7 +723,7 @@
   local.get $1
   i32.const 16
   i32.add
-  local.get $8
+  local.get $12
   i32.add
   local.get $4
   i32.eq
@@ -718,24 +741,24 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $12
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $13
+   local.get $12
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $14
   else
    i32.const 31
-   local.get $8
+   local.get $12
    i32.clz
    i32.sub
-   local.set $9
-   local.get $8
-   local.get $9
+   local.set $13
+   local.get $12
+   local.get $13
    i32.const 4
    i32.sub
    i32.shr_u
@@ -743,21 +766,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $14
+   local.get $13
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $13
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $13
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $14
    i32.const 16
    i32.lt_u
   else
@@ -773,86 +796,86 @@
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
-  local.set $6
-  local.get $7
-  local.get $3
+  local.set $17
+  local.get $13
+  local.set $16
+  local.get $14
+  local.set $15
+  local.get $17
+  local.get $16
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $15
   i32.add
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=96
-  local.set $11
+  local.set $18
   local.get $1
   i32.const 0
   i32.store offset=16
   local.get $1
-  local.get $11
+  local.get $18
   i32.store offset=20
-  local.get $11
+  local.get $18
   if
-   local.get $11
+   local.get $18
    local.get $1
    i32.store offset=16
   end
   local.get $0
-  local.set $12
-  local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
+  local.set $22
+  local.get $13
+  local.set $21
+  local.get $14
+  local.set $20
   local.get $1
-  local.set $6
-  local.get $12
-  local.get $7
+  local.set $19
+  local.get $22
+  local.get $21
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $20
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $19
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $13
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.set $13
-  local.get $9
-  local.set $12
+  local.set $27
+  local.get $13
+  local.set $26
   local.get $0
-  local.set $3
-  local.get $9
-  local.set $6
-  local.get $3
-  local.get $6
+  local.set $24
+  local.get $13
+  local.set $23
+  local.get $24
+  local.get $23
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $14
   i32.shl
   i32.or
-  local.set $7
-  local.get $13
-  local.get $12
+  local.set $25
+  local.get $27
+  local.get $26
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $25
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -863,6 +886,7 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
   i32.const 1
   drop
   local.get $1
@@ -1002,11 +1026,11 @@
   i32.or
   i32.store
   local.get $0
-  local.set $9
+  local.set $10
   local.get $4
-  local.set $3
+  local.set $9
+  local.get $10
   local.get $9
-  local.get $3
   i32.store offset=1568
   local.get $0
   local.get $8
@@ -1026,6 +1050,12 @@
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
   global.get $~lib/rt/tlsf/ROOT
   local.set $0
   local.get $0
@@ -1082,66 +1112,66 @@
    local.get $4
    i32.store offset=1568
    i32.const 0
-   local.set $5
+   local.set $6
    loop $for-loop|0
-    local.get $5
+    local.get $6
     i32.const 23
     i32.lt_u
-    local.set $4
-    local.get $4
+    local.set $7
+    local.get $7
     if
      local.get $0
-     local.set $8
-     local.get $5
-     local.set $7
+     local.set $10
+     local.get $6
+     local.set $9
      i32.const 0
-     local.set $6
-     local.get $8
-     local.get $7
+     local.set $8
+     local.get $10
+     local.get $9
      i32.const 2
      i32.shl
      i32.add
-     local.get $6
+     local.get $8
      i32.store offset=4
      i32.const 0
-     local.set $8
+     local.set $11
      loop $for-loop|1
-      local.get $8
+      local.get $11
       i32.const 16
       i32.lt_u
-      local.set $7
-      local.get $7
+      local.set $12
+      local.get $12
       if
        local.get $0
-       local.set $11
-       local.get $5
-       local.set $10
-       local.get $8
-       local.set $9
-       i32.const 0
-       local.set $6
+       local.set $16
+       local.get $6
+       local.set $15
        local.get $11
-       local.get $10
+       local.set $14
+       i32.const 0
+       local.set $13
+       local.get $16
+       local.get $15
        i32.const 4
        i32.shl
-       local.get $9
+       local.get $14
        i32.add
        i32.const 2
        i32.shl
        i32.add
-       local.get $6
+       local.get $13
        i32.store offset=96
-       local.get $8
+       local.get $11
        i32.const 1
        i32.add
-       local.set $8
+       local.set $11
        br $for-loop|1
       end
      end
-     local.get $5
+     local.get $6
      i32.const 1
      i32.add
-     local.set $5
+     local.set $6
      br $for-loop|0
     end
    end
@@ -1154,11 +1184,11 @@
    i32.const -1
    i32.xor
    i32.and
-   local.set $5
+   local.set $17
    i32.const 0
    drop
    local.get $0
-   local.get $5
+   local.get $17
    memory.size
    i32.const 16
    i32.shl
@@ -1207,6 +1237,14 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
   local.get $1
   i32.const 256
   i32.lt_u
@@ -1280,11 +1318,11 @@
    unreachable
   end
   local.get $0
-  local.set $5
+  local.set $6
   local.get $2
-  local.set $4
+  local.set $5
+  local.get $6
   local.get $5
-  local.get $4
   i32.const 2
   i32.shl
   i32.add
@@ -1295,10 +1333,10 @@
   local.get $3
   i32.shl
   i32.and
-  local.set $6
-  i32.const 0
   local.set $7
-  local.get $6
+  i32.const 0
+  local.set $8
+  local.get $7
   i32.eqz
   if
    local.get $0
@@ -1311,30 +1349,30 @@
    i32.add
    i32.shl
    i32.and
-   local.set $5
-   local.get $5
+   local.set $9
+   local.get $9
    i32.eqz
    if
     i32.const 0
-    local.set $7
+    local.set $8
    else
-    local.get $5
+    local.get $9
     i32.ctz
     local.set $2
     local.get $0
-    local.set $8
+    local.set $11
     local.get $2
-    local.set $4
-    local.get $8
-    local.get $4
+    local.set $10
+    local.get $11
+    local.get $10
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $6
+    local.set $7
     i32.const 1
     drop
-    local.get $6
+    local.get $7
     i32.eqz
     if
      i32.const 0
@@ -1345,45 +1383,45 @@
      unreachable
     end
     local.get $0
-    local.set $9
+    local.set $14
     local.get $2
-    local.set $8
-    local.get $6
+    local.set $13
+    local.get $7
     i32.ctz
-    local.set $4
-    local.get $9
-    local.get $8
+    local.set $12
+    local.get $14
+    local.get $13
     i32.const 4
     i32.shl
-    local.get $4
+    local.get $12
     i32.add
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=96
-    local.set $7
+    local.set $8
    end
   else
    local.get $0
-   local.set $9
+   local.set $17
    local.get $2
-   local.set $8
-   local.get $6
+   local.set $16
+   local.get $7
    i32.ctz
-   local.set $4
-   local.get $9
-   local.get $8
+   local.set $15
+   local.get $17
+   local.get $16
    i32.const 4
    i32.shl
-   local.get $4
+   local.get $15
    i32.add
    i32.const 2
    i32.shl
    i32.add
    i32.load offset=96
-   local.set $7
+   local.set $8
   end
-  local.get $7
+  local.get $8
  )
  (func $~lib/rt/tlsf/growMemory (param $0 i32) (param $1 i32)
   (local $2 i32)
@@ -1392,6 +1430,7 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
   i32.const 0
   drop
   local.get $1
@@ -1438,15 +1477,15 @@
   i32.shr_u
   local.set $4
   local.get $2
-  local.tee $3
-  local.get $4
   local.tee $5
-  local.get $3
+  local.get $4
+  local.tee $6
   local.get $5
+  local.get $6
   i32.gt_s
   select
-  local.set $6
-  local.get $6
+  local.set $7
+  local.get $7
   memory.grow
   i32.const 0
   i32.lt_s
@@ -1460,12 +1499,12 @@
    end
   end
   memory.size
-  local.set $7
+  local.set $8
   local.get $0
   local.get $2
   i32.const 16
   i32.shl
-  local.get $7
+  local.get $8
   i32.const 16
   i32.shl
   call $~lib/rt/tlsf/addMemory
@@ -1475,6 +1514,8 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
   local.get $1
   i32.load
   local.set $3
@@ -1539,11 +1580,11 @@
    i32.and
    i32.store
    local.get $1
-   local.set $5
-   local.get $5
+   local.set $7
+   local.get $7
    i32.const 16
    i32.add
-   local.get $5
+   local.get $7
    i32.load
    i32.const 3
    i32.const -1
@@ -1551,11 +1592,11 @@
    i32.and
    i32.add
    local.get $1
-   local.set $5
-   local.get $5
+   local.set $6
+   local.get $6
    i32.const 16
    i32.add
-   local.get $5
+   local.get $6
    i32.load
    i32.const 3
    i32.const -1
@@ -1956,6 +1997,88 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local $22 i32)
+  (local $23 i32)
+  (local $24 i32)
+  (local $25 i32)
+  (local $26 i32)
+  (local $27 i32)
+  (local $28 i32)
+  (local $29 i32)
+  (local $30 i32)
+  (local $31 i32)
+  (local $32 i32)
+  (local $33 i32)
+  (local $34 i32)
+  (local $35 i32)
+  (local $36 i32)
+  (local $37 i32)
+  (local $38 i32)
+  (local $39 i32)
+  (local $40 i32)
+  (local $41 i32)
+  (local $42 i32)
+  (local $43 i32)
+  (local $44 i32)
+  (local $45 i32)
+  (local $46 i32)
+  (local $47 i32)
+  (local $48 i32)
+  (local $49 i32)
+  (local $50 i32)
+  (local $51 i32)
+  (local $52 i32)
+  (local $53 i32)
+  (local $54 i32)
+  (local $55 i32)
+  (local $56 i32)
+  (local $57 i32)
+  (local $58 i32)
+  (local $59 i32)
+  (local $60 i32)
+  (local $61 i32)
+  (local $62 i32)
+  (local $63 i32)
+  (local $64 i32)
+  (local $65 i32)
+  (local $66 i32)
+  (local $67 i32)
+  (local $68 i32)
+  (local $69 i32)
+  (local $70 i32)
+  (local $71 i32)
+  (local $72 i32)
+  (local $73 i32)
+  (local $74 i32)
+  (local $75 i32)
+  (local $76 i32)
+  (local $77 i32)
+  (local $78 i32)
+  (local $79 i32)
+  (local $80 i32)
+  (local $81 i32)
+  (local $82 i32)
+  (local $83 i32)
+  (local $84 i32)
+  (local $85 i32)
+  (local $86 i32)
+  (local $87 i32)
+  (local $88 i32)
   loop $while-continue|0
    local.get $2
    if (result i32)
@@ -1975,11 +2098,11 @@
     local.set $0
     local.get $6
     local.get $1
-    local.tee $6
+    local.tee $7
     i32.const 1
     i32.add
     local.set $1
-    local.get $6
+    local.get $7
     i32.load8_u
     i32.store8
     local.get $2
@@ -1999,8 +2122,8 @@
     local.get $2
     i32.const 16
     i32.ge_u
-    local.set $5
-    local.get $5
+    local.set $8
+    local.get $8
     if
      local.get $0
      local.get $1
@@ -2109,17 +2232,17 @@
    i32.and
    if
     local.get $0
-    local.tee $5
+    local.tee $9
     i32.const 1
     i32.add
     local.set $0
-    local.get $5
+    local.get $9
     local.get $1
-    local.tee $5
+    local.tee $10
     i32.const 1
     i32.add
     local.set $1
-    local.get $5
+    local.get $10
     i32.load8_u
     i32.store8
    end
@@ -2136,16 +2259,16 @@
        local.get $0
        i32.const 3
        i32.and
-       local.set $5
-       local.get $5
+       local.set $11
+       local.get $11
        i32.const 1
        i32.eq
        br_if $case0|2
-       local.get $5
+       local.get $11
        i32.const 2
        i32.eq
        br_if $case1|2
-       local.get $5
+       local.get $11
        i32.const 3
        i32.eq
        br_if $case2|2
@@ -2155,45 +2278,45 @@
       i32.load
       local.set $3
       local.get $0
-      local.tee $5
+      local.tee $12
       i32.const 1
       i32.add
       local.set $0
-      local.get $5
+      local.get $12
       local.get $1
-      local.tee $5
+      local.tee $13
       i32.const 1
       i32.add
       local.set $1
-      local.get $5
+      local.get $13
       i32.load8_u
       i32.store8
       local.get $0
-      local.tee $5
+      local.tee $14
       i32.const 1
       i32.add
       local.set $0
-      local.get $5
+      local.get $14
       local.get $1
-      local.tee $5
+      local.tee $15
       i32.const 1
       i32.add
       local.set $1
-      local.get $5
+      local.get $15
       i32.load8_u
       i32.store8
       local.get $0
-      local.tee $5
+      local.tee $16
       i32.const 1
       i32.add
       local.set $0
-      local.get $5
+      local.get $16
       local.get $1
-      local.tee $5
+      local.tee $17
       i32.const 1
       i32.add
       local.set $1
-      local.get $5
+      local.get $17
       i32.load8_u
       i32.store8
       local.get $2
@@ -2204,8 +2327,8 @@
        local.get $2
        i32.const 17
        i32.ge_u
-       local.set $5
-       local.get $5
+       local.set $18
+       local.get $18
        if
         local.get $1
         i32.const 1
@@ -2290,31 +2413,31 @@
      i32.load
      local.set $3
      local.get $0
-     local.tee $5
+     local.tee $19
      i32.const 1
      i32.add
      local.set $0
-     local.get $5
+     local.get $19
      local.get $1
-     local.tee $5
+     local.tee $20
      i32.const 1
      i32.add
      local.set $1
-     local.get $5
+     local.get $20
      i32.load8_u
      i32.store8
      local.get $0
-     local.tee $5
+     local.tee $21
      i32.const 1
      i32.add
      local.set $0
-     local.get $5
+     local.get $21
      local.get $1
-     local.tee $5
+     local.tee $22
      i32.const 1
      i32.add
      local.set $1
-     local.get $5
+     local.get $22
      i32.load8_u
      i32.store8
      local.get $2
@@ -2325,8 +2448,8 @@
       local.get $2
       i32.const 18
       i32.ge_u
-      local.set $5
-      local.get $5
+      local.set $23
+      local.get $23
       if
        local.get $1
        i32.const 2
@@ -2411,17 +2534,17 @@
     i32.load
     local.set $3
     local.get $0
-    local.tee $5
+    local.tee $24
     i32.const 1
     i32.add
     local.set $0
-    local.get $5
+    local.get $24
     local.get $1
-    local.tee $5
+    local.tee $25
     i32.const 1
     i32.add
     local.set $1
-    local.get $5
+    local.get $25
     i32.load8_u
     i32.store8
     local.get $2
@@ -2432,8 +2555,8 @@
      local.get $2
      i32.const 19
      i32.ge_u
-     local.set $5
-     local.get $5
+     local.set $26
+     local.get $26
      if
       local.get $1
       i32.const 3
@@ -2520,227 +2643,227 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $27
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $27
    local.get $1
-   local.tee $5
+   local.tee $28
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $28
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $29
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $29
    local.get $1
-   local.tee $5
+   local.tee $30
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $30
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $31
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $31
    local.get $1
-   local.tee $5
+   local.tee $32
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $32
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $33
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $33
    local.get $1
-   local.tee $5
+   local.tee $34
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $34
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $35
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $35
    local.get $1
-   local.tee $5
+   local.tee $36
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $36
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $37
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $37
    local.get $1
-   local.tee $5
+   local.tee $38
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $38
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $39
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $39
    local.get $1
-   local.tee $5
+   local.tee $40
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $40
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $41
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $41
    local.get $1
-   local.tee $5
+   local.tee $42
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $42
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $43
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $43
    local.get $1
-   local.tee $5
+   local.tee $44
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $44
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $45
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $45
    local.get $1
-   local.tee $5
+   local.tee $46
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $46
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $47
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $47
    local.get $1
-   local.tee $5
+   local.tee $48
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $48
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $49
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $49
    local.get $1
-   local.tee $5
+   local.tee $50
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $50
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $51
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $51
    local.get $1
-   local.tee $5
+   local.tee $52
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $52
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $53
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $53
    local.get $1
-   local.tee $5
+   local.tee $54
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $54
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $55
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $55
    local.get $1
-   local.tee $5
+   local.tee $56
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $56
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $57
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $57
    local.get $1
-   local.tee $5
+   local.tee $58
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $58
    i32.load8_u
    i32.store8
   end
@@ -2749,115 +2872,115 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $59
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $59
    local.get $1
-   local.tee $5
+   local.tee $60
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $60
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $61
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $61
    local.get $1
-   local.tee $5
+   local.tee $62
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $62
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $63
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $63
    local.get $1
-   local.tee $5
+   local.tee $64
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $64
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $65
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $65
    local.get $1
-   local.tee $5
+   local.tee $66
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $66
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $67
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $67
    local.get $1
-   local.tee $5
+   local.tee $68
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $68
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $69
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $69
    local.get $1
-   local.tee $5
+   local.tee $70
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $70
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $71
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $71
    local.get $1
-   local.tee $5
+   local.tee $72
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $72
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $73
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $73
    local.get $1
-   local.tee $5
+   local.tee $74
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $74
    i32.load8_u
    i32.store8
   end
@@ -2866,59 +2989,59 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $75
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $75
    local.get $1
-   local.tee $5
+   local.tee $76
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $76
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $77
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $77
    local.get $1
-   local.tee $5
+   local.tee $78
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $78
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $79
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $79
    local.get $1
-   local.tee $5
+   local.tee $80
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $80
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $81
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $81
    local.get $1
-   local.tee $5
+   local.tee $82
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $82
    i32.load8_u
    i32.store8
   end
@@ -2927,31 +3050,31 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $83
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $83
    local.get $1
-   local.tee $5
+   local.tee $84
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $84
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $85
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $85
    local.get $1
-   local.tee $5
+   local.tee $86
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $86
    i32.load8_u
    i32.store8
   end
@@ -2960,17 +3083,17 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $87
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $87
    local.get $1
-   local.tee $5
+   local.tee $88
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $88
    i32.load8_u
    i32.store8
   end
@@ -2981,6 +3104,14 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
   block $~lib/util/memory/memmove|inlined.0
    local.get $0
    local.set $5
@@ -3058,11 +3189,11 @@
        local.set $5
        local.get $7
        local.get $4
-       local.tee $7
+       local.tee $8
        i32.const 1
        i32.add
        local.set $4
-       local.get $7
+       local.get $8
        i32.load8_u
        i32.store8
        br $while-continue|0
@@ -3072,8 +3203,8 @@
       local.get $3
       i32.const 8
       i32.ge_u
-      local.set $6
-      local.get $6
+      local.set $9
+      local.get $9
       if
        local.get $5
        local.get $4
@@ -3097,21 +3228,21 @@
     end
     loop $while-continue|2
      local.get $3
-     local.set $6
-     local.get $6
+     local.set $10
+     local.get $10
      if
       local.get $5
-      local.tee $7
+      local.tee $11
       i32.const 1
       i32.add
       local.set $5
-      local.get $7
+      local.get $11
       local.get $4
-      local.tee $7
+      local.tee $12
       i32.const 1
       i32.add
       local.set $4
-      local.get $7
+      local.get $12
       i32.load8_u
       i32.store8
       local.get $3
@@ -3140,8 +3271,8 @@
       i32.add
       i32.const 7
       i32.and
-      local.set $6
-      local.get $6
+      local.set $13
+      local.get $13
       if
        local.get $3
        i32.eqz
@@ -3166,8 +3297,8 @@
       local.get $3
       i32.const 8
       i32.ge_u
-      local.set $6
-      local.get $6
+      local.set $14
+      local.get $14
       if
        local.get $3
        i32.const 8
@@ -3187,8 +3318,8 @@
     end
     loop $while-continue|5
      local.get $3
-     local.set $6
-     local.get $6
+     local.set $15
+     local.get $15
      if
       local.get $5
       local.get $3
@@ -3232,6 +3363,7 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
   local.get $2
   call $~lib/rt/tlsf/prepareSize
   local.set $3
@@ -3289,8 +3421,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $5
-   local.get $5
+   local.set $8
+   local.get $8
    local.get $3
    i32.ge_u
    if
@@ -3301,7 +3433,7 @@
     local.get $4
     i32.const 3
     i32.and
-    local.get $5
+    local.get $8
     i32.or
     i32.store
     local.get $1
@@ -3320,12 +3452,12 @@
   local.get $1
   i32.load offset=8
   call $~lib/rt/tlsf/allocateBlock
-  local.set $8
-  local.get $8
+  local.set $9
+  local.get $9
   local.get $1
   i32.load offset=4
   i32.store offset=4
-  local.get $8
+  local.get $9
   i32.const 16
   i32.add
   local.get $1
@@ -3340,13 +3472,13 @@
    i32.const 1
    drop
    local.get $1
-   local.get $8
+   local.get $9
    call $~lib/rt/rtrace/onrealloc
    local.get $0
    local.get $1
    call $~lib/rt/tlsf/freeBlock
   end
-  local.get $8
+  local.get $9
  )
  (func $~lib/rt/tlsf/__realloc (param $0 i32) (param $1 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
@@ -3374,6 +3506,15 @@
   (local $14 i32)
   (local $15 i32)
   (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local $22 i32)
+  (local $23 i32)
+  (local $24 i32)
+  (local $25 i32)
   local.get $0
   call $~lib/string/String#get:length
   local.set $1
@@ -3430,13 +3571,13 @@
       i32.add
       block $~lib/util/string/toUpper8|inlined.0 (result i32)
        local.get $8
-       local.set $9
+       local.set $10
        i32.const 0
        i32.const 0
        i32.gt_s
        drop
        i32.const 1024
-       local.get $9
+       local.get $10
        i32.add
        i32.load8_u
        br $~lib/util/string/toUpper8|inlined.0
@@ -3466,8 +3607,8 @@
        i32.shl
        i32.add
        i32.load16_u offset=2
-       local.set $9
-       local.get $9
+       local.set $11
+       local.get $11
        i32.const 56319
        i32.sub
        i32.const 57344
@@ -3476,13 +3617,13 @@
        i32.lt_u
        if
         local.get $8
-        local.set $10
+        local.set $12
         local.get $8
         i32.const 1023
         i32.and
         i32.const 10
         i32.shl
-        local.get $9
+        local.get $11
         i32.const 1023
         i32.and
         i32.or
@@ -3502,8 +3643,8 @@
          i32.const 1
          i32.shl
          i32.add
-         local.get $10
-         local.get $9
+         local.get $12
+         local.get $11
          i32.const 16
          i32.shl
          i32.or
@@ -3535,7 +3676,7 @@
        i32.store16
       else
        i32.const -1
-       local.set $9
+       local.set $13
        local.get $8
        i32.const 223
        i32.sub
@@ -3546,57 +3687,57 @@
        if
         block $~lib/util/casemap/bsearch|inlined.0 (result i32)
          local.get $8
-         local.set $12
+         local.set $16
          local.get $3
-         local.set $11
+         local.set $15
          local.get $4
-         local.set $10
+         local.set $14
          i32.const 0
-         local.set $13
+         local.set $17
          loop $while-continue|1
-          local.get $13
-          local.get $10
-          i32.le_s
-          local.set $14
+          local.get $17
           local.get $14
+          i32.le_s
+          local.set $18
+          local.get $18
           if
-           local.get $13
-           local.get $10
+           local.get $17
+           local.get $14
            i32.add
            i32.const 3
            i32.shr_u
            i32.const 2
            i32.shl
-           local.set $15
-           local.get $11
+           local.set $19
            local.get $15
+           local.get $19
            i32.const 1
            i32.shl
            i32.add
            i32.load16_u
-           local.get $12
-           i32.sub
-           local.set $16
            local.get $16
+           i32.sub
+           local.set $20
+           local.get $20
            i32.const 0
            i32.eq
            if
-            local.get $15
+            local.get $19
             br $~lib/util/casemap/bsearch|inlined.0
            else
-            local.get $16
+            local.get $20
             i32.const 31
             i32.shr_u
             if
-             local.get $15
+             local.get $19
              i32.const 4
              i32.add
-             local.set $13
+             local.set $17
             else
-             local.get $15
+             local.get $19
              i32.const 4
              i32.sub
-             local.set $10
+             local.set $14
             end
            end
            br $while-continue|1
@@ -3604,43 +3745,43 @@
          end
          i32.const -1
         end
-        local.set $9
+        local.set $13
        end
-       local.get $9
+       local.get $13
        i32.const -1
        i32.xor
        if
         local.get $3
-        local.get $9
+        local.get $13
         i32.const 1
         i32.shl
         i32.add
         i32.load offset=2
-        local.set $13
+        local.set $21
         local.get $3
-        local.get $9
+        local.get $13
         i32.const 1
         i32.shl
         i32.add
         i32.load16_u offset=6
-        local.set $12
+        local.set $22
         local.get $2
         local.get $5
         i32.const 1
         i32.shl
         i32.add
-        local.get $13
+        local.get $21
         i32.store
         local.get $2
         local.get $5
         i32.const 1
         i32.shl
         i32.add
-        local.get $12
+        local.get $22
         i32.store16 offset=4
         local.get $5
         i32.const 1
-        local.get $12
+        local.get $22
         i32.const 0
         i32.ne
         i32.add
@@ -3652,8 +3793,8 @@
         call $~lib/util/casemap/casemap
         i32.const 2097151
         i32.and
-        local.set $12
-        local.get $12
+        local.set $23
+        local.get $23
         i32.const 65536
         i32.lt_s
         if
@@ -3662,32 +3803,32 @@
          i32.const 1
          i32.shl
          i32.add
-         local.get $12
+         local.get $23
          i32.store16
         else
-         local.get $12
+         local.get $23
          i32.const 65536
          i32.sub
-         local.set $12
-         local.get $12
+         local.set $23
+         local.get $23
          i32.const 10
          i32.shr_u
          i32.const 55296
          i32.or
-         local.set $13
-         local.get $12
+         local.set $24
+         local.get $23
          i32.const 1023
          i32.and
          i32.const 56320
          i32.or
-         local.set $11
+         local.set $25
          local.get $2
          local.get $5
          i32.const 1
          i32.shl
          i32.add
-         local.get $13
-         local.get $11
+         local.get $24
+         local.get $25
          i32.const 16
          i32.shl
          i32.or
@@ -3739,6 +3880,9 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $0
@@ -3810,33 +3954,33 @@
   end
   loop $while-continue|1
    local.get $4
-   local.tee $7
+   local.tee $8
    i32.const 1
    i32.sub
    local.set $4
-   local.get $7
-   local.set $7
-   local.get $7
+   local.get $8
+   local.set $9
+   local.get $9
    if
     local.get $5
     i32.load16_u
-    local.set $8
+    local.set $10
     local.get $6
     i32.load16_u
-    local.set $9
-    local.get $8
-    local.get $9
+    local.set $11
+    local.get $10
+    local.get $11
     i32.ne
     if
-     local.get $8
-     local.get $9
+     local.get $10
+     local.get $11
      i32.sub
-     local.set $10
+     local.set $12
      local.get $0
      call $~lib/rt/pure/__release
      local.get $2
      call $~lib/rt/pure/__release
-     local.get $10
+     local.get $12
      return
     end
     local.get $5
@@ -3851,16 +3995,19 @@
    end
   end
   i32.const 0
-  local.set $7
+  local.set $13
   local.get $0
   call $~lib/rt/pure/__release
   local.get $2
   call $~lib/rt/pure/__release
-  local.get $7
+  local.get $13
  )
  (func $~lib/string/String.__eq (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $0
@@ -3892,44 +4039,44 @@
   end
   if
    i32.const 0
-   local.set $2
+   local.set $3
    local.get $0
    call $~lib/rt/pure/__release
    local.get $1
    call $~lib/rt/pure/__release
-   local.get $2
+   local.get $3
    return
   end
   local.get $0
   call $~lib/string/String#get:length
-  local.set $3
-  local.get $3
+  local.set $4
+  local.get $4
   local.get $1
   call $~lib/string/String#get:length
   i32.ne
   if
    i32.const 0
-   local.set $2
+   local.set $5
    local.get $0
    call $~lib/rt/pure/__release
    local.get $1
    call $~lib/rt/pure/__release
-   local.get $2
+   local.get $5
    return
   end
   local.get $0
   i32.const 0
   local.get $1
   i32.const 0
-  local.get $3
+  local.get $4
   call $~lib/util/string/compareImpl
   i32.eqz
-  local.set $2
+  local.set $6
   local.get $0
   call $~lib/rt/pure/__release
   local.get $1
   call $~lib/rt/pure/__release
-  local.get $2
+  local.get $6
  )
  (func $~lib/util/string/stagedBinaryLookup (param $0 i32) (param $1 i32) (result i32)
   local.get $0
@@ -3975,6 +4122,26 @@
   (local $16 i32)
   (local $17 i32)
   (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local $22 i32)
+  (local $23 i32)
+  (local $24 i32)
+  (local $25 i32)
+  (local $26 i32)
+  (local $27 i32)
+  (local $28 i32)
+  (local $29 i32)
+  (local $30 i32)
+  (local $31 i32)
+  (local $32 i32)
+  (local $33 i32)
+  (local $34 i32)
+  (local $35 i32)
+  (local $36 i32)
+  (local $37 i32)
+  (local $38 i32)
   local.get $0
   call $~lib/string/String#get:length
   local.set $1
@@ -4026,13 +4193,13 @@
       i32.add
       block $~lib/util/string/toLower8|inlined.0 (result i32)
        local.get $6
-       local.set $7
+       local.set $8
        i32.const 0
        i32.const 0
        i32.gt_s
        drop
        i32.const 5778
-       local.get $7
+       local.get $8
        i32.add
        i32.load8_u
        br $~lib/util/string/toLower8|inlined.0
@@ -4062,8 +4229,8 @@
        i32.shl
        i32.add
        i32.load16_u offset=2
-       local.set $7
-       local.get $7
+       local.set $9
+       local.get $9
        i32.const 56319
        i32.sub
        i32.const 57344
@@ -4072,13 +4239,13 @@
        i32.lt_u
        if
         local.get $6
-        local.set $8
+        local.set $10
         local.get $6
         i32.const 1023
         i32.and
         i32.const 10
         i32.shl
-        local.get $7
+        local.get $9
         i32.const 1023
         i32.and
         i32.or
@@ -4098,8 +4265,8 @@
          i32.const 1
          i32.shl
          i32.add
-         local.get $8
-         local.get $7
+         local.get $10
+         local.get $9
          i32.const 16
          i32.shl
          i32.or
@@ -4137,94 +4304,94 @@
        i32.eq
        if
         i32.const 963
-        local.set $7
+        local.set $11
         local.get $1
         i32.const 1
         i32.gt_u
         if (result i32)
          block $~lib/util/string/isFinalSigma|inlined.0 (result i32)
           local.get $0
-          local.set $10
+          local.set $14
           local.get $4
-          local.set $9
+          local.set $13
           local.get $1
-          local.set $8
-          i32.const 0
-          local.set $11
-          local.get $9
           local.set $12
           i32.const 0
-          local.tee $13
-          local.get $12
+          local.set $15
+          local.get $13
+          local.set $16
+          i32.const 0
+          local.tee $17
+          local.get $16
           i32.const 30
           i32.sub
-          local.tee $14
-          local.get $13
-          local.get $14
+          local.tee $18
+          local.get $17
+          local.get $18
           i32.gt_s
           select
-          local.set $13
+          local.set $19
           loop $while-continue|1
-           local.get $12
-           local.get $13
+           local.get $16
+           local.get $19
            i32.gt_s
-           local.set $14
-           local.get $14
+           local.set $20
+           local.get $20
            if
             block $~lib/util/string/codePointBefore|inlined.0 (result i32)
-             local.get $10
-             local.set $16
-             local.get $12
-             local.set $15
-             local.get $15
+             local.get $14
+             local.set $22
+             local.get $16
+             local.set $21
+             local.get $21
              i32.const 0
              i32.le_s
              if
               i32.const -1
               br $~lib/util/string/codePointBefore|inlined.0
              end
-             local.get $16
-             local.get $15
+             local.get $22
+             local.get $21
              i32.const 1
              i32.sub
              i32.const 1
              i32.shl
              i32.add
              i32.load16_u
-             local.set $17
-             local.get $17
+             local.set $23
+             local.get $23
              i32.const 64512
              i32.and
              i32.const 56320
              i32.eq
-             local.get $15
+             local.get $21
              i32.const 2
              i32.sub
              i32.const 0
              i32.ge_s
              i32.and
              if
-              local.get $16
-              local.get $15
+              local.get $22
+              local.get $21
               i32.const 2
               i32.sub
               i32.const 1
               i32.shl
               i32.add
               i32.load16_u
-              local.set $18
-              local.get $18
+              local.set $24
+              local.get $24
               i32.const 64512
               i32.and
               i32.const 55296
               i32.eq
               if
-               local.get $18
+               local.get $24
                i32.const 1023
                i32.and
                i32.const 10
                i32.shl
-               local.get $17
+               local.get $23
                i32.const 1023
                i32.and
                i32.add
@@ -4233,7 +4400,7 @@
                br $~lib/util/string/codePointBefore|inlined.0
               end
              end
-             local.get $17
+             local.get $23
              i32.const 63488
              i32.and
              i32.const 55296
@@ -4241,151 +4408,151 @@
              if (result i32)
               i32.const 65533
              else
-              local.get $17
+              local.get $23
              end
             end
-            local.set $17
-            local.get $17
-            local.set $18
-            local.get $18
+            local.set $25
+            local.get $25
+            local.set $26
+            local.get $26
             i32.const 918000
             i32.lt_u
             if (result i32)
              i32.const 5906
-             local.get $18
+             local.get $26
              call $~lib/util/string/stagedBinaryLookup
             else
              i32.const 0
             end
             i32.eqz
             if
-             local.get $17
-             local.set $15
-             local.get $15
+             local.get $25
+             local.set $27
+             local.get $27
              i32.const 127370
              i32.lt_u
              if (result i32)
               i32.const 8914
-              local.get $15
+              local.get $27
               call $~lib/util/string/stagedBinaryLookup
              else
               i32.const 0
              end
              if
               i32.const 1
-              local.set $11
+              local.set $15
              else
               i32.const 0
               br $~lib/util/string/isFinalSigma|inlined.0
              end
             end
-            local.get $12
-            local.get $17
+            local.get $16
+            local.get $25
             i32.const 65536
             i32.ge_s
             i32.const 1
             i32.add
             i32.sub
-            local.set $12
+            local.set $16
             br $while-continue|1
            end
           end
-          local.get $11
+          local.get $15
           i32.eqz
           if
            i32.const 0
            br $~lib/util/string/isFinalSigma|inlined.0
           end
-          local.get $9
+          local.get $13
           i32.const 1
           i32.add
-          local.set $12
-          local.get $12
+          local.set $16
+          local.get $16
           i32.const 30
           i32.add
-          local.tee $14
-          local.get $8
-          local.tee $15
-          local.get $14
-          local.get $15
+          local.tee $28
+          local.get $12
+          local.tee $29
+          local.get $28
+          local.get $29
           i32.lt_s
           select
-          local.set $14
+          local.set $30
           loop $while-continue|2
-           local.get $12
-           local.get $14
+           local.get $16
+           local.get $30
            i32.lt_s
-           local.set $15
-           local.get $15
+           local.set $31
+           local.get $31
            if
-            local.get $10
-            local.get $12
+            local.get $14
+            local.get $16
             i32.const 1
             i32.shl
             i32.add
             i32.load16_u
-            local.set $18
-            local.get $18
+            local.set $32
+            local.get $32
             i32.const 64512
             i32.and
             i32.const 55296
             i32.eq
-            local.get $12
+            local.get $16
             i32.const 1
             i32.add
-            local.get $8
+            local.get $12
             i32.ne
             i32.and
             if
-             local.get $10
-             local.get $12
+             local.get $14
+             local.get $16
              i32.const 1
              i32.shl
              i32.add
              i32.load16_u offset=2
-             local.set $16
-             local.get $16
+             local.set $33
+             local.get $33
              i32.const 64512
              i32.and
              i32.const 56320
              i32.eq
              if
-              local.get $18
+              local.get $32
               i32.const 55296
               i32.sub
               i32.const 10
               i32.shl
-              local.get $16
+              local.get $33
               i32.const 56320
               i32.sub
               i32.add
               i32.const 65536
               i32.add
-              local.set $18
+              local.set $32
              end
             end
-            local.get $18
-            local.set $16
-            local.get $16
+            local.get $32
+            local.set $34
+            local.get $34
             i32.const 918000
             i32.lt_u
             if (result i32)
              i32.const 5906
-             local.get $16
+             local.get $34
              call $~lib/util/string/stagedBinaryLookup
             else
              i32.const 0
             end
             i32.eqz
             if
-             local.get $18
-             local.set $16
-             local.get $16
+             local.get $32
+             local.set $35
+             local.get $35
              i32.const 127370
              i32.lt_u
              if (result i32)
               i32.const 8914
-              local.get $16
+              local.get $35
               call $~lib/util/string/stagedBinaryLookup
              else
               i32.const 0
@@ -4393,14 +4560,14 @@
              i32.eqz
              br $~lib/util/string/isFinalSigma|inlined.0
             end
-            local.get $12
-            local.get $18
+            local.get $16
+            local.get $32
             i32.const 65536
             i32.ge_u
             i32.const 1
             i32.add
             i32.add
-            local.set $12
+            local.set $16
             br $while-continue|2
            end
           end
@@ -4411,14 +4578,14 @@
         end
         if
          i32.const 962
-         local.set $7
+         local.set $11
         end
         local.get $2
         local.get $3
         i32.const 1
         i32.shl
         i32.add
-        local.get $7
+        local.get $11
         i32.store16
        else
         local.get $6
@@ -4444,8 +4611,8 @@
          call $~lib/util/casemap/casemap
          i32.const 2097151
          i32.and
-         local.set $7
-         local.get $7
+         local.set $36
+         local.get $36
          i32.const 65536
          i32.lt_s
          if
@@ -4454,32 +4621,32 @@
           i32.const 1
           i32.shl
           i32.add
-          local.get $7
+          local.get $36
           i32.store16
          else
-          local.get $7
+          local.get $36
           i32.const 65536
           i32.sub
-          local.set $7
-          local.get $7
+          local.set $36
+          local.get $36
           i32.const 10
           i32.shr_u
           i32.const 55296
           i32.or
-          local.set $14
-          local.get $7
+          local.set $37
+          local.get $36
           i32.const 1023
           i32.and
           i32.const 56320
           i32.or
-          local.set $13
+          local.set $38
           local.get $2
           local.get $3
           i32.const 1
           i32.shl
           i32.add
-          local.get $14
-          local.get $13
+          local.get $37
+          local.get $38
           i32.const 16
           i32.shl
           i32.or
@@ -4707,6 +4874,9 @@
   (local $9 i64)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
   loop $while-continue|0
    local.get $1
    i32.const 10000
@@ -4771,30 +4941,30 @@
    local.get $1
    i32.const 100
    i32.div_u
-   local.set $3
+   local.set $10
    local.get $1
    i32.const 100
    i32.rem_u
-   local.set $10
-   local.get $3
+   local.set $11
+   local.get $10
    local.set $1
    local.get $2
    i32.const 2
    i32.sub
    local.set $2
    i32.const 17556
-   local.get $10
+   local.get $11
    i32.const 2
    i32.shl
    i32.add
    i32.load
-   local.set $11
+   local.set $12
    local.get $0
    local.get $2
    i32.const 1
    i32.shl
    i32.add
-   local.get $11
+   local.get $12
    i32.store
   end
   local.get $1
@@ -4811,13 +4981,13 @@
    i32.shl
    i32.add
    i32.load
-   local.set $11
+   local.set $13
    local.get $0
    local.get $2
    i32.const 1
    i32.shl
    i32.add
-   local.get $11
+   local.get $13
    i32.store
   else
    local.get $2
@@ -4827,13 +4997,13 @@
    i32.const 48
    local.get $1
    i32.add
-   local.set $11
+   local.set $14
    local.get $0
    local.get $2
    i32.const 1
    i32.shl
    i32.add
-   local.get $11
+   local.get $14
    i32.store16
   end
  )
@@ -5026,7 +5196,10 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i64)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i64)
+  (local $10 i32)
   local.get $0
   i64.const 0
   i64.ne
@@ -5069,26 +5242,26 @@
   else
    local.get $0
    call $~lib/util/number/decimalCount64High
-   local.set $3
-   local.get $3
+   local.set $7
+   local.get $7
    i32.const 1
    i32.shl
    i32.const 1
    call $~lib/rt/tlsf/__alloc
    local.set $1
    local.get $1
-   local.set $5
+   local.set $10
    local.get $0
-   local.set $7
-   local.get $3
-   local.set $4
+   local.set $9
+   local.get $7
+   local.set $8
    i32.const 0
    i32.const 1
    i32.ge_s
    drop
-   local.get $5
-   local.get $7
-   local.get $4
+   local.get $10
+   local.get $9
+   local.get $8
    call $~lib/util/number/utoa64_lut
   end
   local.get $1
@@ -5119,6 +5292,8 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
   local.get $1
   call $~lib/rt/pure/__retain
   local.set $1
@@ -5161,32 +5336,32 @@
   if
    i32.const 32
    call $~lib/rt/pure/__retain
-   local.set $2
+   local.set $7
    local.get $1
    call $~lib/rt/pure/__release
-   local.get $2
+   local.get $7
    return
   end
   local.get $6
   i32.const 1
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
-  local.set $7
-  local.get $7
+  local.set $8
+  local.get $8
   local.get $0
   local.get $4
   call $~lib/memory/memory.copy
-  local.get $7
+  local.get $8
   local.get $4
   i32.add
   local.get $1
   local.get $5
   call $~lib/memory/memory.copy
-  local.get $7
-  local.set $2
+  local.get $8
+  local.set $9
   local.get $1
   call $~lib/rt/pure/__release
-  local.get $2
+  local.get $9
  )
  (func $~lib/string/String.__concat (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
@@ -5313,6 +5488,10 @@
   (local $98 i32)
   (local $99 i32)
   (local $100 i32)
+  (local $101 i32)
+  (local $102 i32)
+  (local $103 i32)
+  (local $104 i32)
   i32.const 32
   call $~lib/string/String#toUpperCase
   local.tee $0
@@ -6679,9 +6858,9 @@
      i32.const 18160
      local.get $94
      call $~lib/number/U64#toString
-     local.tee $100
+     local.tee $101
      call $~lib/string/String.__concat
-     local.tee $99
+     local.tee $102
      i32.const 0
      f64.const 0
      f64.const 0
@@ -6692,9 +6871,9 @@
      i32.const 18224
      local.get $96
      call $~lib/number/U64#toString
-     local.tee $98
+     local.tee $103
      call $~lib/string/String.__concat
-     local.tee $97
+     local.tee $104
      i32.const 0
      f64.const 0
      f64.const 0
@@ -6702,13 +6881,13 @@
      f64.const 0
      f64.const 0
      call $~lib/builtins/trace
-     local.get $100
+     local.get $101
      call $~lib/rt/pure/__release
-     local.get $99
+     local.get $102
      call $~lib/rt/pure/__release
-     local.get $98
+     local.get $103
      call $~lib/rt/pure/__release
-     local.get $97
+     local.get $104
      call $~lib/rt/pure/__release
     end
     local.get $88

--- a/tests/compiler/std/string-encoding.untouched.wat
+++ b/tests/compiler/std/string-encoding.untouched.wat
@@ -159,6 +159,15 @@
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
   local.get $1
   i32.load
   local.set $2
@@ -295,59 +304,59 @@
   i32.eq
   if
    local.get $0
-   local.set $11
+   local.set $14
    local.get $4
-   local.set $10
+   local.set $13
    local.get $5
-   local.set $9
+   local.set $12
    local.get $7
-   local.set $8
-   local.get $11
-   local.get $10
+   local.set $11
+   local.get $14
+   local.get $13
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $12
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
+   local.get $11
    i32.store offset=96
    local.get $7
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $16
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $15
+    local.get $16
+    local.get $15
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $17
     local.get $0
-    local.set $8
+    local.set $20
     local.get $4
-    local.set $11
-    local.get $9
+    local.set $19
+    local.get $17
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
-    local.set $10
-    local.get $8
-    local.get $11
+    local.tee $17
+    local.set $18
+    local.get $20
+    local.get $19
     i32.const 2
     i32.shl
     i32.add
-    local.get $10
+    local.get $18
     i32.store offset=4
-    local.get $9
+    local.get $17
     i32.eqz
     if
      local.get $0
@@ -377,6 +386,20 @@
   (local $11 i32)
   (local $12 i32)
   (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local $22 i32)
+  (local $23 i32)
+  (local $24 i32)
+  (local $25 i32)
+  (local $26 i32)
+  (local $27 i32)
   i32.const 1
   drop
   local.get $1
@@ -439,8 +462,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $3
+   local.set $6
+   local.get $6
    i32.const 1073741808
    i32.lt_u
    if
@@ -451,16 +474,16 @@
     local.get $2
     i32.const 3
     i32.and
-    local.get $3
+    local.get $6
     i32.or
     local.tee $2
     i32.store
     local.get $1
-    local.set $6
-    local.get $6
+    local.set $7
+    local.get $7
     i32.const 16
     i32.add
-    local.get $6
+    local.get $7
     i32.load
     i32.const 3
     i32.const -1
@@ -478,18 +501,18 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $8
+   local.get $8
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
+   local.set $9
+   local.get $9
    i32.load
-   local.set $3
+   local.set $10
    i32.const 1
    drop
-   local.get $3
+   local.get $10
    i32.const 1
    i32.and
    i32.eqz
@@ -501,7 +524,7 @@
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $3
+   local.get $10
    i32.const 3
    i32.const -1
    i32.xor
@@ -514,23 +537,23 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $7
+   local.set $11
+   local.get $11
    i32.const 1073741808
    i32.lt_u
    if
     local.get $0
-    local.get $6
+    local.get $9
     call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
+    local.get $9
+    local.get $10
     i32.const 3
     i32.and
-    local.get $7
+    local.get $11
     i32.or
     local.tee $2
     i32.store
-    local.get $6
+    local.get $9
     local.set $1
    end
   end
@@ -544,14 +567,14 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $12
   i32.const 1
   drop
-  local.get $8
+  local.get $12
   i32.const 16
   i32.ge_u
   if (result i32)
-   local.get $8
+   local.get $12
    i32.const 1073741808
    i32.lt_u
   else
@@ -571,7 +594,7 @@
   local.get $1
   i32.const 16
   i32.add
-  local.get $8
+  local.get $12
   i32.add
   local.get $4
   i32.eq
@@ -589,24 +612,24 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $12
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $13
+   local.get $12
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $14
   else
    i32.const 31
-   local.get $8
+   local.get $12
    i32.clz
    i32.sub
-   local.set $9
-   local.get $8
-   local.get $9
+   local.set $13
+   local.get $12
+   local.get $13
    i32.const 4
    i32.sub
    i32.shr_u
@@ -614,21 +637,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $14
+   local.get $13
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $13
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $13
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $14
    i32.const 16
    i32.lt_u
   else
@@ -644,86 +667,86 @@
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
-  local.set $6
-  local.get $7
-  local.get $3
+  local.set $17
+  local.get $13
+  local.set $16
+  local.get $14
+  local.set $15
+  local.get $17
+  local.get $16
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $15
   i32.add
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=96
-  local.set $11
+  local.set $18
   local.get $1
   i32.const 0
   i32.store offset=16
   local.get $1
-  local.get $11
+  local.get $18
   i32.store offset=20
-  local.get $11
+  local.get $18
   if
-   local.get $11
+   local.get $18
    local.get $1
    i32.store offset=16
   end
   local.get $0
-  local.set $12
-  local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
+  local.set $22
+  local.get $13
+  local.set $21
+  local.get $14
+  local.set $20
   local.get $1
-  local.set $6
-  local.get $12
-  local.get $7
+  local.set $19
+  local.get $22
+  local.get $21
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $20
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $19
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $13
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.set $13
-  local.get $9
-  local.set $12
+  local.set $27
+  local.get $13
+  local.set $26
   local.get $0
-  local.set $3
-  local.get $9
-  local.set $6
-  local.get $3
-  local.get $6
+  local.set $24
+  local.get $13
+  local.set $23
+  local.get $24
+  local.get $23
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $14
   i32.shl
   i32.or
-  local.set $7
-  local.get $13
-  local.get $12
+  local.set $25
+  local.get $27
+  local.get $26
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $25
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -734,6 +757,7 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
   i32.const 1
   drop
   local.get $1
@@ -873,11 +897,11 @@
   i32.or
   i32.store
   local.get $0
-  local.set $9
+  local.set $10
   local.get $4
-  local.set $3
+  local.set $9
+  local.get $10
   local.get $9
-  local.get $3
   i32.store offset=1568
   local.get $0
   local.get $8
@@ -897,6 +921,12 @@
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
   global.get $~lib/rt/tlsf/ROOT
   local.set $0
   local.get $0
@@ -953,66 +983,66 @@
    local.get $4
    i32.store offset=1568
    i32.const 0
-   local.set $5
+   local.set $6
    loop $for-loop|0
-    local.get $5
+    local.get $6
     i32.const 23
     i32.lt_u
-    local.set $4
-    local.get $4
+    local.set $7
+    local.get $7
     if
      local.get $0
-     local.set $8
-     local.get $5
-     local.set $7
+     local.set $10
+     local.get $6
+     local.set $9
      i32.const 0
-     local.set $6
-     local.get $8
-     local.get $7
+     local.set $8
+     local.get $10
+     local.get $9
      i32.const 2
      i32.shl
      i32.add
-     local.get $6
+     local.get $8
      i32.store offset=4
      i32.const 0
-     local.set $8
+     local.set $11
      loop $for-loop|1
-      local.get $8
+      local.get $11
       i32.const 16
       i32.lt_u
-      local.set $7
-      local.get $7
+      local.set $12
+      local.get $12
       if
        local.get $0
-       local.set $11
-       local.get $5
-       local.set $10
-       local.get $8
-       local.set $9
-       i32.const 0
-       local.set $6
+       local.set $16
+       local.get $6
+       local.set $15
        local.get $11
-       local.get $10
+       local.set $14
+       i32.const 0
+       local.set $13
+       local.get $16
+       local.get $15
        i32.const 4
        i32.shl
-       local.get $9
+       local.get $14
        i32.add
        i32.const 2
        i32.shl
        i32.add
-       local.get $6
+       local.get $13
        i32.store offset=96
-       local.get $8
+       local.get $11
        i32.const 1
        i32.add
-       local.set $8
+       local.set $11
        br $for-loop|1
       end
      end
-     local.get $5
+     local.get $6
      i32.const 1
      i32.add
-     local.set $5
+     local.set $6
      br $for-loop|0
     end
    end
@@ -1025,11 +1055,11 @@
    i32.const -1
    i32.xor
    i32.and
-   local.set $5
+   local.set $17
    i32.const 0
    drop
    local.get $0
-   local.get $5
+   local.get $17
    memory.size
    i32.const 16
    i32.shl
@@ -1078,6 +1108,14 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
   local.get $1
   i32.const 256
   i32.lt_u
@@ -1151,11 +1189,11 @@
    unreachable
   end
   local.get $0
-  local.set $5
+  local.set $6
   local.get $2
-  local.set $4
+  local.set $5
+  local.get $6
   local.get $5
-  local.get $4
   i32.const 2
   i32.shl
   i32.add
@@ -1166,10 +1204,10 @@
   local.get $3
   i32.shl
   i32.and
-  local.set $6
-  i32.const 0
   local.set $7
-  local.get $6
+  i32.const 0
+  local.set $8
+  local.get $7
   i32.eqz
   if
    local.get $0
@@ -1182,30 +1220,30 @@
    i32.add
    i32.shl
    i32.and
-   local.set $5
-   local.get $5
+   local.set $9
+   local.get $9
    i32.eqz
    if
     i32.const 0
-    local.set $7
+    local.set $8
    else
-    local.get $5
+    local.get $9
     i32.ctz
     local.set $2
     local.get $0
-    local.set $8
+    local.set $11
     local.get $2
-    local.set $4
-    local.get $8
-    local.get $4
+    local.set $10
+    local.get $11
+    local.get $10
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $6
+    local.set $7
     i32.const 1
     drop
-    local.get $6
+    local.get $7
     i32.eqz
     if
      i32.const 0
@@ -1216,45 +1254,45 @@
      unreachable
     end
     local.get $0
-    local.set $9
+    local.set $14
     local.get $2
-    local.set $8
-    local.get $6
+    local.set $13
+    local.get $7
     i32.ctz
-    local.set $4
-    local.get $9
-    local.get $8
+    local.set $12
+    local.get $14
+    local.get $13
     i32.const 4
     i32.shl
-    local.get $4
+    local.get $12
     i32.add
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=96
-    local.set $7
+    local.set $8
    end
   else
    local.get $0
-   local.set $9
+   local.set $17
    local.get $2
-   local.set $8
-   local.get $6
+   local.set $16
+   local.get $7
    i32.ctz
-   local.set $4
-   local.get $9
-   local.get $8
+   local.set $15
+   local.get $17
+   local.get $16
    i32.const 4
    i32.shl
-   local.get $4
+   local.get $15
    i32.add
    i32.const 2
    i32.shl
    i32.add
    i32.load offset=96
-   local.set $7
+   local.set $8
   end
-  local.get $7
+  local.get $8
  )
  (func $~lib/rt/tlsf/growMemory (param $0 i32) (param $1 i32)
   (local $2 i32)
@@ -1263,6 +1301,7 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
   i32.const 0
   drop
   local.get $1
@@ -1309,15 +1348,15 @@
   i32.shr_u
   local.set $4
   local.get $2
-  local.tee $3
-  local.get $4
   local.tee $5
-  local.get $3
+  local.get $4
+  local.tee $6
   local.get $5
+  local.get $6
   i32.gt_s
   select
-  local.set $6
-  local.get $6
+  local.set $7
+  local.get $7
   memory.grow
   i32.const 0
   i32.lt_s
@@ -1331,12 +1370,12 @@
    end
   end
   memory.size
-  local.set $7
+  local.set $8
   local.get $0
   local.get $2
   i32.const 16
   i32.shl
-  local.get $7
+  local.get $8
   i32.const 16
   i32.shl
   call $~lib/rt/tlsf/addMemory
@@ -1346,6 +1385,8 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
   local.get $1
   i32.load
   local.set $3
@@ -1410,11 +1451,11 @@
    i32.and
    i32.store
    local.get $1
-   local.set $5
-   local.get $5
+   local.set $7
+   local.get $7
    i32.const 16
    i32.add
-   local.get $5
+   local.get $7
    i32.load
    i32.const 3
    i32.const -1
@@ -1422,11 +1463,11 @@
    i32.and
    i32.add
    local.get $1
-   local.set $5
-   local.get $5
+   local.set $6
+   local.get $6
    i32.const 16
    i32.add
-   local.get $5
+   local.get $6
    i32.load
    i32.const 3
    i32.const -1
@@ -1589,6 +1630,88 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local $22 i32)
+  (local $23 i32)
+  (local $24 i32)
+  (local $25 i32)
+  (local $26 i32)
+  (local $27 i32)
+  (local $28 i32)
+  (local $29 i32)
+  (local $30 i32)
+  (local $31 i32)
+  (local $32 i32)
+  (local $33 i32)
+  (local $34 i32)
+  (local $35 i32)
+  (local $36 i32)
+  (local $37 i32)
+  (local $38 i32)
+  (local $39 i32)
+  (local $40 i32)
+  (local $41 i32)
+  (local $42 i32)
+  (local $43 i32)
+  (local $44 i32)
+  (local $45 i32)
+  (local $46 i32)
+  (local $47 i32)
+  (local $48 i32)
+  (local $49 i32)
+  (local $50 i32)
+  (local $51 i32)
+  (local $52 i32)
+  (local $53 i32)
+  (local $54 i32)
+  (local $55 i32)
+  (local $56 i32)
+  (local $57 i32)
+  (local $58 i32)
+  (local $59 i32)
+  (local $60 i32)
+  (local $61 i32)
+  (local $62 i32)
+  (local $63 i32)
+  (local $64 i32)
+  (local $65 i32)
+  (local $66 i32)
+  (local $67 i32)
+  (local $68 i32)
+  (local $69 i32)
+  (local $70 i32)
+  (local $71 i32)
+  (local $72 i32)
+  (local $73 i32)
+  (local $74 i32)
+  (local $75 i32)
+  (local $76 i32)
+  (local $77 i32)
+  (local $78 i32)
+  (local $79 i32)
+  (local $80 i32)
+  (local $81 i32)
+  (local $82 i32)
+  (local $83 i32)
+  (local $84 i32)
+  (local $85 i32)
+  (local $86 i32)
+  (local $87 i32)
+  (local $88 i32)
   loop $while-continue|0
    local.get $2
    if (result i32)
@@ -1608,11 +1731,11 @@
     local.set $0
     local.get $6
     local.get $1
-    local.tee $6
+    local.tee $7
     i32.const 1
     i32.add
     local.set $1
-    local.get $6
+    local.get $7
     i32.load8_u
     i32.store8
     local.get $2
@@ -1632,8 +1755,8 @@
     local.get $2
     i32.const 16
     i32.ge_u
-    local.set $5
-    local.get $5
+    local.set $8
+    local.get $8
     if
      local.get $0
      local.get $1
@@ -1742,17 +1865,17 @@
    i32.and
    if
     local.get $0
-    local.tee $5
+    local.tee $9
     i32.const 1
     i32.add
     local.set $0
-    local.get $5
+    local.get $9
     local.get $1
-    local.tee $5
+    local.tee $10
     i32.const 1
     i32.add
     local.set $1
-    local.get $5
+    local.get $10
     i32.load8_u
     i32.store8
    end
@@ -1769,16 +1892,16 @@
        local.get $0
        i32.const 3
        i32.and
-       local.set $5
-       local.get $5
+       local.set $11
+       local.get $11
        i32.const 1
        i32.eq
        br_if $case0|2
-       local.get $5
+       local.get $11
        i32.const 2
        i32.eq
        br_if $case1|2
-       local.get $5
+       local.get $11
        i32.const 3
        i32.eq
        br_if $case2|2
@@ -1788,45 +1911,45 @@
       i32.load
       local.set $3
       local.get $0
-      local.tee $5
+      local.tee $12
       i32.const 1
       i32.add
       local.set $0
-      local.get $5
+      local.get $12
       local.get $1
-      local.tee $5
+      local.tee $13
       i32.const 1
       i32.add
       local.set $1
-      local.get $5
+      local.get $13
       i32.load8_u
       i32.store8
       local.get $0
-      local.tee $5
+      local.tee $14
       i32.const 1
       i32.add
       local.set $0
-      local.get $5
+      local.get $14
       local.get $1
-      local.tee $5
+      local.tee $15
       i32.const 1
       i32.add
       local.set $1
-      local.get $5
+      local.get $15
       i32.load8_u
       i32.store8
       local.get $0
-      local.tee $5
+      local.tee $16
       i32.const 1
       i32.add
       local.set $0
-      local.get $5
+      local.get $16
       local.get $1
-      local.tee $5
+      local.tee $17
       i32.const 1
       i32.add
       local.set $1
-      local.get $5
+      local.get $17
       i32.load8_u
       i32.store8
       local.get $2
@@ -1837,8 +1960,8 @@
        local.get $2
        i32.const 17
        i32.ge_u
-       local.set $5
-       local.get $5
+       local.set $18
+       local.get $18
        if
         local.get $1
         i32.const 1
@@ -1923,31 +2046,31 @@
      i32.load
      local.set $3
      local.get $0
-     local.tee $5
+     local.tee $19
      i32.const 1
      i32.add
      local.set $0
-     local.get $5
+     local.get $19
      local.get $1
-     local.tee $5
+     local.tee $20
      i32.const 1
      i32.add
      local.set $1
-     local.get $5
+     local.get $20
      i32.load8_u
      i32.store8
      local.get $0
-     local.tee $5
+     local.tee $21
      i32.const 1
      i32.add
      local.set $0
-     local.get $5
+     local.get $21
      local.get $1
-     local.tee $5
+     local.tee $22
      i32.const 1
      i32.add
      local.set $1
-     local.get $5
+     local.get $22
      i32.load8_u
      i32.store8
      local.get $2
@@ -1958,8 +2081,8 @@
       local.get $2
       i32.const 18
       i32.ge_u
-      local.set $5
-      local.get $5
+      local.set $23
+      local.get $23
       if
        local.get $1
        i32.const 2
@@ -2044,17 +2167,17 @@
     i32.load
     local.set $3
     local.get $0
-    local.tee $5
+    local.tee $24
     i32.const 1
     i32.add
     local.set $0
-    local.get $5
+    local.get $24
     local.get $1
-    local.tee $5
+    local.tee $25
     i32.const 1
     i32.add
     local.set $1
-    local.get $5
+    local.get $25
     i32.load8_u
     i32.store8
     local.get $2
@@ -2065,8 +2188,8 @@
      local.get $2
      i32.const 19
      i32.ge_u
-     local.set $5
-     local.get $5
+     local.set $26
+     local.get $26
      if
       local.get $1
       i32.const 3
@@ -2153,227 +2276,227 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $27
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $27
    local.get $1
-   local.tee $5
+   local.tee $28
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $28
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $29
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $29
    local.get $1
-   local.tee $5
+   local.tee $30
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $30
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $31
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $31
    local.get $1
-   local.tee $5
+   local.tee $32
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $32
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $33
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $33
    local.get $1
-   local.tee $5
+   local.tee $34
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $34
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $35
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $35
    local.get $1
-   local.tee $5
+   local.tee $36
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $36
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $37
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $37
    local.get $1
-   local.tee $5
+   local.tee $38
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $38
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $39
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $39
    local.get $1
-   local.tee $5
+   local.tee $40
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $40
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $41
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $41
    local.get $1
-   local.tee $5
+   local.tee $42
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $42
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $43
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $43
    local.get $1
-   local.tee $5
+   local.tee $44
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $44
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $45
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $45
    local.get $1
-   local.tee $5
+   local.tee $46
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $46
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $47
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $47
    local.get $1
-   local.tee $5
+   local.tee $48
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $48
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $49
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $49
    local.get $1
-   local.tee $5
+   local.tee $50
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $50
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $51
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $51
    local.get $1
-   local.tee $5
+   local.tee $52
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $52
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $53
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $53
    local.get $1
-   local.tee $5
+   local.tee $54
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $54
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $55
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $55
    local.get $1
-   local.tee $5
+   local.tee $56
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $56
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $57
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $57
    local.get $1
-   local.tee $5
+   local.tee $58
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $58
    i32.load8_u
    i32.store8
   end
@@ -2382,115 +2505,115 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $59
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $59
    local.get $1
-   local.tee $5
+   local.tee $60
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $60
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $61
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $61
    local.get $1
-   local.tee $5
+   local.tee $62
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $62
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $63
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $63
    local.get $1
-   local.tee $5
+   local.tee $64
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $64
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $65
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $65
    local.get $1
-   local.tee $5
+   local.tee $66
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $66
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $67
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $67
    local.get $1
-   local.tee $5
+   local.tee $68
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $68
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $69
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $69
    local.get $1
-   local.tee $5
+   local.tee $70
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $70
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $71
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $71
    local.get $1
-   local.tee $5
+   local.tee $72
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $72
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $73
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $73
    local.get $1
-   local.tee $5
+   local.tee $74
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $74
    i32.load8_u
    i32.store8
   end
@@ -2499,59 +2622,59 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $75
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $75
    local.get $1
-   local.tee $5
+   local.tee $76
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $76
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $77
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $77
    local.get $1
-   local.tee $5
+   local.tee $78
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $78
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $79
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $79
    local.get $1
-   local.tee $5
+   local.tee $80
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $80
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $81
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $81
    local.get $1
-   local.tee $5
+   local.tee $82
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $82
    i32.load8_u
    i32.store8
   end
@@ -2560,31 +2683,31 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $83
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $83
    local.get $1
-   local.tee $5
+   local.tee $84
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $84
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $85
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $85
    local.get $1
-   local.tee $5
+   local.tee $86
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $86
    i32.load8_u
    i32.store8
   end
@@ -2593,17 +2716,17 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $87
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $87
    local.get $1
-   local.tee $5
+   local.tee $88
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $88
    i32.load8_u
    i32.store8
   end
@@ -2614,6 +2737,14 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
   block $~lib/util/memory/memmove|inlined.0
    local.get $0
    local.set $5
@@ -2691,11 +2822,11 @@
        local.set $5
        local.get $7
        local.get $4
-       local.tee $7
+       local.tee $8
        i32.const 1
        i32.add
        local.set $4
-       local.get $7
+       local.get $8
        i32.load8_u
        i32.store8
        br $while-continue|0
@@ -2705,8 +2836,8 @@
       local.get $3
       i32.const 8
       i32.ge_u
-      local.set $6
-      local.get $6
+      local.set $9
+      local.get $9
       if
        local.get $5
        local.get $4
@@ -2730,21 +2861,21 @@
     end
     loop $while-continue|2
      local.get $3
-     local.set $6
-     local.get $6
+     local.set $10
+     local.get $10
      if
       local.get $5
-      local.tee $7
+      local.tee $11
       i32.const 1
       i32.add
       local.set $5
-      local.get $7
+      local.get $11
       local.get $4
-      local.tee $7
+      local.tee $12
       i32.const 1
       i32.add
       local.set $4
-      local.get $7
+      local.get $12
       i32.load8_u
       i32.store8
       local.get $3
@@ -2773,8 +2904,8 @@
       i32.add
       i32.const 7
       i32.and
-      local.set $6
-      local.get $6
+      local.set $13
+      local.get $13
       if
        local.get $3
        i32.eqz
@@ -2799,8 +2930,8 @@
       local.get $3
       i32.const 8
       i32.ge_u
-      local.set $6
-      local.get $6
+      local.set $14
+      local.get $14
       if
        local.get $3
        i32.const 8
@@ -2820,8 +2951,8 @@
     end
     loop $while-continue|5
      local.get $3
-     local.set $6
-     local.get $6
+     local.set $15
+     local.get $15
      if
       local.get $5
       local.get $3
@@ -3101,6 +3232,9 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $0
@@ -3172,33 +3306,33 @@
   end
   loop $while-continue|1
    local.get $4
-   local.tee $7
+   local.tee $8
    i32.const 1
    i32.sub
    local.set $4
-   local.get $7
-   local.set $7
-   local.get $7
+   local.get $8
+   local.set $9
+   local.get $9
    if
     local.get $5
     i32.load16_u
-    local.set $8
+    local.set $10
     local.get $6
     i32.load16_u
-    local.set $9
-    local.get $8
-    local.get $9
+    local.set $11
+    local.get $10
+    local.get $11
     i32.ne
     if
-     local.get $8
-     local.get $9
+     local.get $10
+     local.get $11
      i32.sub
-     local.set $10
+     local.set $12
      local.get $0
      call $~lib/rt/pure/__release
      local.get $2
      call $~lib/rt/pure/__release
-     local.get $10
+     local.get $12
      return
     end
     local.get $5
@@ -3213,16 +3347,19 @@
    end
   end
   i32.const 0
-  local.set $7
+  local.set $13
   local.get $0
   call $~lib/rt/pure/__release
   local.get $2
   call $~lib/rt/pure/__release
-  local.get $7
+  local.get $13
  )
  (func $~lib/string/String.__eq (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $0
@@ -3254,44 +3391,44 @@
   end
   if
    i32.const 0
-   local.set $2
+   local.set $3
    local.get $0
    call $~lib/rt/pure/__release
    local.get $1
    call $~lib/rt/pure/__release
-   local.get $2
+   local.get $3
    return
   end
   local.get $0
   call $~lib/string/String#get:length
-  local.set $3
-  local.get $3
+  local.set $4
+  local.get $4
   local.get $1
   call $~lib/string/String#get:length
   i32.ne
   if
    i32.const 0
-   local.set $2
+   local.set $5
    local.get $0
    call $~lib/rt/pure/__release
    local.get $1
    call $~lib/rt/pure/__release
-   local.get $2
+   local.get $5
    return
   end
   local.get $0
   i32.const 0
   local.get $1
   i32.const 0
-  local.get $3
+  local.get $4
   call $~lib/util/string/compareImpl
   i32.eqz
-  local.set $2
+  local.set $6
   local.get $0
   call $~lib/rt/pure/__release
   local.get $1
   call $~lib/rt/pure/__release
-  local.get $2
+  local.get $6
  )
  (func $std/string-encoding/testUTF16Decode
   (local $0 i32)
@@ -3473,6 +3610,7 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $0
@@ -3573,10 +3711,10 @@
    end
   end
   local.get $4
-  local.set $5
+  local.set $7
   local.get $0
   call $~lib/rt/pure/__release
-  local.get $5
+  local.get $7
  )
  (func $std/string-encoding/testUTF8Length
   global.get $std/string-encoding/str
@@ -3618,6 +3756,12 @@
   (local $10 i32)
   (local $11 i32)
   (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
   local.get $0
   local.get $1
   i32.const 1
@@ -3693,8 +3837,8 @@
       if
        local.get $0
        i32.load16_u offset=2
-       local.set $9
-       local.get $9
+       local.set $10
+       local.get $10
        i32.const 64512
        i32.and
        i32.const 56320
@@ -3707,7 +3851,7 @@
         i32.const 10
         i32.shl
         i32.add
-        local.get $9
+        local.get $10
         i32.const 1023
         i32.and
         i32.or
@@ -3717,7 +3861,7 @@
         i32.shr_u
         i32.const 240
         i32.or
-        local.set $8
+        local.set $11
         local.get $7
         i32.const 12
         i32.shr_u
@@ -3725,7 +3869,7 @@
         i32.and
         i32.const 128
         i32.or
-        local.set $10
+        local.set $12
         local.get $7
         i32.const 6
         i32.shr_u
@@ -3733,26 +3877,26 @@
         i32.and
         i32.const 128
         i32.or
-        local.set $11
+        local.set $13
         local.get $7
         i32.const 63
         i32.and
         i32.const 128
         i32.or
-        local.set $12
+        local.set $14
         local.get $5
-        local.get $12
+        local.get $14
         i32.const 24
         i32.shl
-        local.get $11
+        local.get $13
         i32.const 16
         i32.shl
         i32.or
-        local.get $10
+        local.get $12
         i32.const 8
         i32.shl
         i32.or
-        local.get $8
+        local.get $11
         i32.or
         i32.store
         local.get $5
@@ -3771,7 +3915,7 @@
       i32.shr_u
       i32.const 224
       i32.or
-      local.set $9
+      local.set $15
       local.get $7
       i32.const 6
       i32.shr_u
@@ -3779,22 +3923,22 @@
       i32.and
       i32.const 128
       i32.or
-      local.set $12
+      local.set $16
       local.get $7
       i32.const 63
       i32.and
       i32.const 128
       i32.or
-      local.set $11
+      local.set $17
       local.get $5
-      local.get $12
+      local.get $16
       i32.const 8
       i32.shl
-      local.get $9
+      local.get $15
       i32.or
       i32.store16
       local.get $5
-      local.get $11
+      local.get $17
       i32.store8 offset=2
       local.get $5
       i32.const 3
@@ -3812,11 +3956,11 @@
   local.get $3
   if
    local.get $5
-   local.tee $6
+   local.tee $18
    i32.const 1
    i32.add
    local.set $5
-   local.get $6
+   local.get $18
    i32.const 0
    i32.store8
   end
@@ -4246,6 +4390,7 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
   local.get $2
   call $~lib/rt/tlsf/prepareSize
   local.set $3
@@ -4303,8 +4448,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $5
-   local.get $5
+   local.set $8
+   local.get $8
    local.get $3
    i32.ge_u
    if
@@ -4315,7 +4460,7 @@
     local.get $4
     i32.const 3
     i32.and
-    local.get $5
+    local.get $8
     i32.or
     i32.store
     local.get $1
@@ -4334,12 +4479,12 @@
   local.get $1
   i32.load offset=8
   call $~lib/rt/tlsf/allocateBlock
-  local.set $8
-  local.get $8
+  local.set $9
+  local.get $9
   local.get $1
   i32.load offset=4
   i32.store offset=4
-  local.get $8
+  local.get $9
   i32.const 16
   i32.add
   local.get $1
@@ -4354,13 +4499,13 @@
    i32.const 1
    drop
    local.get $1
-   local.get $8
+   local.get $9
    call $~lib/rt/rtrace/onrealloc
    local.get $0
    local.get $1
    call $~lib/rt/tlsf/freeBlock
   end
-  local.get $8
+  local.get $9
  )
  (func $~lib/rt/tlsf/__realloc (param $0 i32) (param $1 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize

--- a/tests/compiler/std/string.optimized.wat
+++ b/tests/compiler/std/string.optimized.wat
@@ -3221,33 +3221,32 @@
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
-  (local $5 i32)
-  (local $6 i64)
-  (local $7 i32)
-  (local $8 i32)
-  (local $9 i64)
+  (local $5 i64)
+  (local $6 i32)
+  (local $7 i64)
+  (local $8 i64)
+  (local $9 f64)
   (local $10 i64)
   (local $11 f64)
-  (local $12 i64)
-  (local $13 f64)
+  (local $12 i32)
+  (local $13 i32)
   (local $14 i32)
-  (local $15 i32)
-  (local $16 i64)
+  (local $15 i64)
   block $folding-inner0
    local.get $0
    call $~lib/string/String#get:length
-   local.tee $5
+   local.tee $4
    i32.eqz
    br_if $folding-inner0
    local.get $0
    i32.load16_u
-   local.set $7
+   local.set $6
    f64.const 1
-   local.set $13
+   local.set $11
    loop $while-continue|0
-    local.get $5
+    local.get $4
     if (result i32)
-     local.get $7
+     local.get $6
      call $~lib/util/string/isSpace
     else
      i32.const 0
@@ -3258,43 +3257,43 @@
      i32.add
      local.tee $0
      i32.load16_u
-     local.set $7
-     local.get $5
+     local.set $6
+     local.get $4
      i32.const 1
      i32.sub
-     local.set $5
+     local.set $4
      br $while-continue|0
     end
    end
-   local.get $5
+   local.get $4
    i32.eqz
    br_if $folding-inner0
-   local.get $7
+   local.get $6
    i32.const 45
    i32.eq
    if (result i32)
-    local.get $5
+    local.get $4
     i32.const 1
     i32.sub
-    local.tee $5
+    local.tee $4
     i32.eqz
     br_if $folding-inner0
     f64.const -1
-    local.set $13
+    local.set $11
     local.get $0
     i32.const 2
     i32.add
     local.tee $0
     i32.load16_u
    else
-    local.get $7
+    local.get $6
     i32.const 43
     i32.eq
     if (result i32)
-     local.get $5
+     local.get $4
      i32.const 1
      i32.sub
-     local.tee $5
+     local.tee $4
      i32.eqz
      br_if $folding-inner0
      local.get $0
@@ -3303,14 +3302,14 @@
      local.tee $0
      i32.load16_u
     else
-     local.get $7
+     local.get $6
     end
    end
-   local.tee $7
+   local.tee $6
    i32.const 73
    i32.eq
    i32.const 0
-   local.get $5
+   local.get $4
    i32.const 8
    i32.ge_s
    select
@@ -3329,27 +3328,27 @@
     end
     if
      f64.const inf
-     local.get $13
+     local.get $11
      f64.copysign
      return
     end
     br $folding-inner0
    end
-   local.get $7
+   local.get $6
    i32.const 48
    i32.sub
    i32.const 10
    i32.ge_u
    i32.const 0
-   local.get $7
+   local.get $6
    i32.const 46
    i32.ne
    select
    br_if $folding-inner0
    local.get $0
-   local.set $4
+   local.set $3
    loop $while-continue|1
-    local.get $7
+    local.get $6
     i32.const 48
     i32.eq
     if
@@ -3358,57 +3357,57 @@
      i32.add
      local.tee $0
      i32.load16_u
-     local.set $7
-     local.get $5
+     local.set $6
+     local.get $4
      i32.const 1
      i32.sub
-     local.set $5
+     local.set $4
      br $while-continue|1
     end
    end
-   local.get $5
+   local.get $4
    i32.const 0
    i32.le_s
    if
     f64.const 0
     return
    end
-   local.get $7
+   local.get $6
    i32.const 46
    i32.eq
    if
-    local.get $4
+    local.get $3
     local.get $0
     i32.sub
     i32.eqz
-    local.set $4
+    local.set $3
     local.get $0
     i32.const 2
     i32.add
     local.set $0
-    local.get $5
+    local.get $4
     i32.const 1
     i32.sub
-    local.tee $5
+    local.tee $4
     if (result i32)
      i32.const 0
     else
-     local.get $4
+     local.get $3
     end
     br_if $folding-inner0
     i32.const 1
-    local.set $14
+    local.set $12
     loop $for-loop|2
      local.get $0
      i32.load16_u
-     local.tee $7
+     local.tee $6
      i32.const 48
      i32.eq
      if
-      local.get $5
+      local.get $4
       i32.const 1
       i32.sub
-      local.set $5
+      local.set $4
       local.get $2
       i32.const 1
       i32.sub
@@ -3420,57 +3419,57 @@
       br $for-loop|2
      end
     end
-    local.get $5
+    local.get $4
     i32.const 0
     i32.le_s
     if
      f64.const 0
      return
     end
-    local.get $7
+    local.get $6
     i32.const 48
     i32.sub
     i32.const 10
     i32.ge_u
     i32.const 0
     i32.const 0
-    local.get $4
+    local.get $3
     local.get $2
     select
     select
     br_if $folding-inner0
    end
-   local.get $7
+   local.get $6
    i32.const 48
    i32.sub
-   local.set $8
+   local.set $3
    loop $for-loop|3
     i32.const 1
-    local.get $14
+    local.get $12
     i32.eqz
     i32.const 0
-    local.get $7
+    local.get $6
     i32.const 46
     i32.eq
     select
-    local.get $8
+    local.get $3
     i32.const 10
     i32.lt_u
     select
     if
      block $for-break3
-      local.get $8
+      local.get $3
       i32.const 10
       i32.lt_u
       if
-       local.get $8
+       local.get $3
        i64.extend_i32_u
-       local.get $6
+       local.get $5
        i64.const 10
        i64.mul
        i64.add
-       local.get $6
-       local.get $8
+       local.get $5
+       local.get $3
        i32.eqz
        i32.eqz
        i64.extend_i32_u
@@ -3479,7 +3478,7 @@
        i32.const 19
        i32.lt_s
        select
-       local.set $6
+       local.set $5
        local.get $1
        i32.const 1
        i32.add
@@ -3488,12 +3487,12 @@
        local.get $1
        local.set $2
        i32.const 1
-       local.set $14
+       local.set $12
       end
-      local.get $5
+      local.get $4
       i32.const 1
       i32.sub
-      local.tee $5
+      local.tee $4
       i32.eqz
       br_if $for-break3
       local.get $0
@@ -3501,17 +3500,17 @@
       i32.add
       local.tee $0
       i32.load16_u
-      local.tee $7
+      local.tee $6
       i32.const 48
       i32.sub
-      local.set $8
+      local.set $3
       br $for-loop|3
      end
     end
    end
    local.get $2
    local.get $1
-   local.get $14
+   local.get $12
    select
    i32.const 19
    local.get $1
@@ -3520,138 +3519,138 @@
    i32.lt_s
    select
    i32.sub
-   local.set $4
+   local.set $3
    i32.const 1
-   local.set $1
+   local.set $2
    block $~lib/util/string/parseExp|inlined.0
     local.get $0
-    local.tee $2
+    local.tee $1
     i32.load16_u
     i32.const 32
     i32.or
     i32.const 101
     i32.ne
     br_if $~lib/util/string/parseExp|inlined.0
-    local.get $2
+    local.get $1
     i32.const 2
     i32.add
-    local.tee $8
-    i32.load16_u
     local.tee $0
+    i32.load16_u
+    local.tee $1
     i32.const 45
     i32.eq
     if (result i32)
-     local.get $5
+     local.get $4
      i32.const 1
      i32.sub
-     local.tee $5
+     local.tee $4
      i32.eqz
      br_if $~lib/util/string/parseExp|inlined.0
      i32.const -1
-     local.set $1
-     local.get $8
+     local.set $2
+     local.get $0
      i32.const 2
      i32.add
-     local.tee $8
+     local.tee $0
      i32.load16_u
     else
-     local.get $0
+     local.get $1
      i32.const 43
      i32.eq
      if (result i32)
-      local.get $5
+      local.get $4
       i32.const 1
       i32.sub
-      local.tee $5
+      local.tee $4
       i32.eqz
       br_if $~lib/util/string/parseExp|inlined.0
-      local.get $8
+      local.get $0
       i32.const 2
       i32.add
-      local.tee $8
+      local.tee $0
       i32.load16_u
      else
-      local.get $0
+      local.get $1
      end
     end
-    local.set $0
+    local.set $1
     loop $while-continue|4
-     local.get $0
+     local.get $1
      i32.const 48
      i32.eq
      if
-      local.get $5
+      local.get $4
       i32.const 1
       i32.sub
-      local.tee $5
+      local.tee $4
       i32.eqz
       br_if $~lib/util/string/parseExp|inlined.0
-      local.get $8
+      local.get $0
       i32.const 2
       i32.add
-      local.tee $8
+      local.tee $0
       i32.load16_u
-      local.set $0
+      local.set $1
       br $while-continue|4
      end
     end
-    local.get $0
+    local.get $1
     i32.const 48
     i32.sub
-    local.set $0
+    local.set $1
     loop $for-loop|5
-     local.get $0
+     local.get $1
      i32.const 10
      i32.lt_u
      i32.const 0
-     local.get $5
+     local.get $4
      select
      if
-      local.get $3
+      local.get $13
       i32.const 3200
       i32.ge_s
       if
-       local.get $1
+       local.get $2
        i32.const 3200
        i32.mul
-       local.set $15
+       local.set $14
        br $~lib/util/string/parseExp|inlined.0
       end
-      local.get $0
-      local.get $3
+      local.get $1
+      local.get $13
       i32.const 10
       i32.mul
       i32.add
-      local.set $3
-      local.get $5
+      local.set $13
+      local.get $4
       i32.const 1
       i32.sub
-      local.set $5
-      local.get $8
+      local.set $4
+      local.get $0
       i32.const 2
       i32.add
-      local.tee $8
+      local.tee $0
       i32.load16_u
       i32.const 48
       i32.sub
-      local.set $0
+      local.set $1
       br $for-loop|5
      end
     end
-    local.get $1
-    local.get $3
+    local.get $2
+    local.get $13
     i32.mul
-    local.set $15
+    local.set $14
    end
    block $~lib/util/string/scientific|inlined.0
     i32.const 1
-    local.get $4
-    local.get $15
+    local.get $3
+    local.get $14
     i32.add
     local.tee $0
     i32.const -342
     i32.lt_s
-    local.get $6
+    local.get $5
     i64.eqz
     select
     br_if $~lib/util/string/scientific|inlined.0
@@ -3660,12 +3659,12 @@
     i32.gt_s
     if
      f64.const inf
-     local.set $11
+     local.set $9
      br $~lib/util/string/scientific|inlined.0
     end
-    local.get $6
+    local.get $5
     f64.convert_i64_u
-    local.set $11
+    local.set $9
     local.get $0
     i32.eqz
     br_if $~lib/util/string/scientific|inlined.0
@@ -3678,7 +3677,7 @@
     i32.gt_s
     select
     if
-     local.get $11
+     local.get $9
      local.get $0
      i32.const 3
      i32.shl
@@ -3686,11 +3685,11 @@
      i32.add
      f64.load
      f64.mul
-     local.set $11
+     local.set $9
      i32.const 22
      local.set $0
     end
-    local.get $6
+    local.get $5
     i64.const 9007199254740991
     i64.le_u
     if (result i32)
@@ -3712,7 +3711,7 @@
      i32.const 0
      i32.gt_s
      if
-      local.get $11
+      local.get $9
       local.get $0
       i32.const 3
       i32.shl
@@ -3720,10 +3719,10 @@
       i32.add
       f64.load
       f64.mul
-      local.set $11
+      local.set $9
       br $~lib/util/string/scientific|inlined.0
      end
-     local.get $11
+     local.get $9
      i32.const 0
      local.get $0
      i32.sub
@@ -3738,33 +3737,33 @@
      i32.const 0
      i32.lt_s
      if (result f64)
-      local.get $6
-      local.get $6
+      local.get $5
+      local.get $5
       i64.clz
-      local.tee $9
+      local.tee $7
       i64.shl
-      local.set $6
+      local.set $5
       local.get $0
       local.tee $1
       i64.extend_i32_s
-      local.get $9
+      local.get $7
       i64.sub
-      local.set $9
+      local.set $7
       loop $for-loop|6
        local.get $1
        i32.const -14
        i32.le_s
        if
         f64.const 0.00004294967296
-        local.get $6
+        local.get $5
         i64.const 6103515625
         i64.rem_u
-        local.get $6
+        local.get $5
         i64.const 6103515625
         i64.div_u
-        local.tee $12
-        i64.clz
         local.tee $10
+        i64.clz
+        local.tee $8
         i64.const 18
         i64.sub
         i64.shl
@@ -3772,15 +3771,15 @@
         f64.mul
         f64.nearest
         i64.trunc_f64_u
-        local.get $12
         local.get $10
+        local.get $8
         i64.shl
         i64.add
-        local.set $6
-        local.get $9
-        local.get $10
+        local.set $5
+        local.get $7
+        local.get $8
         i64.sub
-        local.set $9
+        local.set $7
         local.get $1
         i32.const 14
         i32.add
@@ -3788,75 +3787,75 @@
         br $for-loop|6
        end
       end
-      local.get $6
+      local.get $5
       i32.const 0
       local.get $1
       i32.sub
       call $~lib/math/ipow32
       i64.extend_i32_s
-      local.tee $12
+      local.tee $10
       i64.div_u
-      local.tee $16
+      local.tee $15
       i64.clz
-      local.set $10
-      local.get $6
-      local.get $12
+      local.set $8
+      local.get $5
+      local.get $10
       i64.rem_u
       f64.convert_i64_u
       i64.reinterpret_f64
-      local.get $10
+      local.get $8
       i64.const 52
       i64.shl
       i64.add
       f64.reinterpret_i64
-      local.get $12
+      local.get $10
       f64.convert_i64_u
       f64.div
       i64.trunc_f64_u
-      local.get $16
-      local.get $10
+      local.get $15
+      local.get $8
       i64.shl
       i64.add
       f64.convert_i64_u
-      local.get $9
-      local.get $10
+      local.get $7
+      local.get $8
       i64.sub
       i32.wrap_i64
       call $~lib/math/NativeMath.scalbn
      else
-      local.get $6
-      local.get $6
+      local.get $5
+      local.get $5
       i64.ctz
-      local.tee $9
+      local.tee $7
       i64.shr_u
-      local.set $6
-      local.get $9
+      local.set $5
+      local.get $7
       local.get $0
-      local.tee $3
+      local.tee $1
       i64.extend_i32_s
       i64.add
       global.set $~lib/util/string/__fixmulShift
       loop $for-loop|7
-       local.get $3
+       local.get $1
        i32.const 13
        i32.ge_s
        if
         i64.const 32
-        local.get $6
+        local.get $5
         i64.const 32
         i64.shr_u
         i64.const 1220703125
         i64.mul
-        local.get $6
+        local.get $5
         i64.const 4294967295
         i64.and
         i64.const 1220703125
         i64.mul
-        local.tee $6
+        local.tee $5
         i64.const 32
         i64.shr_u
         i64.add
-        local.tee $9
+        local.tee $7
         i64.const 32
         i64.shr_u
         i32.wrap_i64
@@ -3864,11 +3863,11 @@
         local.tee $0
         i64.extend_i32_u
         i64.sub
-        local.tee $10
+        local.tee $8
         global.get $~lib/util/string/__fixmulShift
         i64.add
         global.set $~lib/util/string/__fixmulShift
-        local.get $6
+        local.get $5
         local.get $0
         i64.extend_i32_u
         i64.shl
@@ -3876,46 +3875,46 @@
         i64.shr_u
         i64.const 1
         i64.and
-        local.get $9
+        local.get $7
         local.get $0
         i64.extend_i32_u
         i64.shl
-        local.get $6
+        local.get $5
         i64.const 4294967295
         i64.and
-        local.get $10
+        local.get $8
         i64.shr_u
         i64.or
         i64.add
-        local.set $6
-        local.get $3
+        local.set $5
+        local.get $1
         i32.const 13
         i32.sub
-        local.set $3
+        local.set $1
         br $for-loop|7
        end
       end
-      local.get $3
+      local.get $1
       call $~lib/math/ipow32
       local.tee $0
       i64.extend_i32_u
-      local.get $6
+      local.get $5
       i64.const 4294967295
       i64.and
       i64.mul
-      local.set $9
+      local.set $7
       i64.const 32
       local.get $0
       i64.extend_i32_u
-      local.get $6
+      local.get $5
       i64.const 32
       i64.shr_u
       i64.mul
-      local.get $9
+      local.get $7
       i64.const 32
       i64.shr_u
       i64.add
-      local.tee $6
+      local.tee $5
       i64.const 32
       i64.shr_u
       i32.wrap_i64
@@ -3923,11 +3922,11 @@
       local.tee $0
       i64.extend_i32_u
       i64.sub
-      local.tee $10
+      local.tee $8
       global.get $~lib/util/string/__fixmulShift
       i64.add
       global.set $~lib/util/string/__fixmulShift
-      local.get $9
+      local.get $7
       local.get $0
       i64.extend_i32_u
       i64.shl
@@ -3935,14 +3934,14 @@
       i64.shr_u
       i64.const 1
       i64.and
-      local.get $6
+      local.get $5
       local.get $0
       i64.extend_i32_u
       i64.shl
-      local.get $9
+      local.get $7
       i64.const 4294967295
       i64.and
-      local.get $10
+      local.get $8
       i64.shr_u
       i64.or
       i64.add
@@ -3952,10 +3951,10 @@
       call $~lib/math/NativeMath.scalbn
      end
     end
-    local.set $11
+    local.set $9
    end
+   local.get $9
    local.get $11
-   local.get $13
    f64.copysign
    return
   end
@@ -6084,8 +6083,6 @@
    global.get $~lib/util/number/_K
    i32.add
    global.set $~lib/util/number/_K
-   local.get $8
-   local.set $1
    local.get $9
    i32.const 0
    local.get $4
@@ -6096,7 +6093,7 @@
    i32.add
    i64.load32_u
    i64.mul
-   local.set $3
+   local.set $1
    local.get $0
    local.get $6
    i32.const 1
@@ -6109,30 +6106,30 @@
    local.set $4
    loop $while-continue|6
     i32.const 1
-    local.get $3
     local.get $1
+    local.get $8
     i64.sub
-    local.get $1
+    local.get $8
     local.get $11
     i64.add
-    local.get $3
+    local.get $1
     i64.sub
     i64.gt_u
-    local.get $1
+    local.get $8
     local.get $11
     i64.add
-    local.get $3
+    local.get $1
     i64.lt_u
     select
     i32.const 0
     local.get $5
-    local.get $1
+    local.get $8
     i64.sub
     local.get $11
     i64.ge_u
     i32.const 0
+    local.get $8
     local.get $1
-    local.get $3
     i64.lt_u
     select
     select
@@ -6141,10 +6138,10 @@
      i32.const 1
      i32.sub
      local.set $4
-     local.get $1
+     local.get $8
      local.get $11
      i64.add
-     local.set $1
+     local.set $8
      br $while-continue|6
     end
    end
@@ -13864,15 +13861,15 @@
   call $~lib/rt/pure/__release
   local.get $76
   call $~lib/rt/pure/__release
-  local.get $80
-  call $~lib/rt/pure/__release
-  local.get $81
-  call $~lib/rt/pure/__release
-  local.get $79
+  local.get $77
   call $~lib/rt/pure/__release
   local.get $78
   call $~lib/rt/pure/__release
-  local.get $77
+  local.get $79
+  call $~lib/rt/pure/__release
+  local.get $80
+  call $~lib/rt/pure/__release
+  local.get $81
   call $~lib/rt/pure/__release
   local.get $82
   call $~lib/rt/pure/__release
@@ -14006,9 +14003,9 @@
   call $~lib/rt/pure/__release
   local.get $147
   call $~lib/rt/pure/__release
-  local.get $149
-  call $~lib/rt/pure/__release
   local.get $148
+  call $~lib/rt/pure/__release
+  local.get $149
   call $~lib/rt/pure/__release
   local.get $150
   call $~lib/rt/pure/__release

--- a/tests/compiler/std/string.untouched.wat
+++ b/tests/compiler/std/string.untouched.wat
@@ -498,6 +498,9 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $0
@@ -569,33 +572,33 @@
   end
   loop $while-continue|1
    local.get $4
-   local.tee $7
+   local.tee $8
    i32.const 1
    i32.sub
    local.set $4
-   local.get $7
-   local.set $7
-   local.get $7
+   local.get $8
+   local.set $9
+   local.get $9
    if
     local.get $5
     i32.load16_u
-    local.set $8
+    local.set $10
     local.get $6
     i32.load16_u
-    local.set $9
-    local.get $8
-    local.get $9
+    local.set $11
+    local.get $10
+    local.get $11
     i32.ne
     if
-     local.get $8
-     local.get $9
+     local.get $10
+     local.get $11
      i32.sub
-     local.set $10
+     local.set $12
      local.get $0
      call $~lib/rt/pure/__release
      local.get $2
      call $~lib/rt/pure/__release
-     local.get $10
+     local.get $12
      return
     end
     local.get $5
@@ -610,16 +613,19 @@
    end
   end
   i32.const 0
-  local.set $7
+  local.set $13
   local.get $0
   call $~lib/rt/pure/__release
   local.get $2
   call $~lib/rt/pure/__release
-  local.get $7
+  local.get $13
  )
  (func $~lib/string/String.__eq (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $0
@@ -651,44 +657,44 @@
   end
   if
    i32.const 0
-   local.set $2
+   local.set $3
    local.get $0
    call $~lib/rt/pure/__release
    local.get $1
    call $~lib/rt/pure/__release
-   local.get $2
+   local.get $3
    return
   end
   local.get $0
   call $~lib/string/String#get:length
-  local.set $3
-  local.get $3
+  local.set $4
+  local.get $4
   local.get $1
   call $~lib/string/String#get:length
   i32.ne
   if
    i32.const 0
-   local.set $2
+   local.set $5
    local.get $0
    call $~lib/rt/pure/__release
    local.get $1
    call $~lib/rt/pure/__release
-   local.get $2
+   local.get $5
    return
   end
   local.get $0
   i32.const 0
   local.get $1
   i32.const 0
-  local.get $3
+  local.get $4
   call $~lib/util/string/compareImpl
   i32.eqz
-  local.set $2
+  local.set $6
   local.get $0
   call $~lib/rt/pure/__release
   local.get $1
   call $~lib/rt/pure/__release
-  local.get $2
+  local.get $6
  )
  (func $~lib/string/String#charCodeAt (param $0 i32) (param $1 i32) (result i32)
   local.get $1
@@ -737,6 +743,15 @@
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
   local.get $1
   i32.load
   local.set $2
@@ -873,59 +888,59 @@
   i32.eq
   if
    local.get $0
-   local.set $11
+   local.set $14
    local.get $4
-   local.set $10
+   local.set $13
    local.get $5
-   local.set $9
+   local.set $12
    local.get $7
-   local.set $8
-   local.get $11
-   local.get $10
+   local.set $11
+   local.get $14
+   local.get $13
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $12
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
+   local.get $11
    i32.store offset=96
    local.get $7
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $16
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $15
+    local.get $16
+    local.get $15
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $17
     local.get $0
-    local.set $8
+    local.set $20
     local.get $4
-    local.set $11
-    local.get $9
+    local.set $19
+    local.get $17
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
-    local.set $10
-    local.get $8
-    local.get $11
+    local.tee $17
+    local.set $18
+    local.get $20
+    local.get $19
     i32.const 2
     i32.shl
     i32.add
-    local.get $10
+    local.get $18
     i32.store offset=4
-    local.get $9
+    local.get $17
     i32.eqz
     if
      local.get $0
@@ -955,6 +970,20 @@
   (local $11 i32)
   (local $12 i32)
   (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local $22 i32)
+  (local $23 i32)
+  (local $24 i32)
+  (local $25 i32)
+  (local $26 i32)
+  (local $27 i32)
   i32.const 1
   drop
   local.get $1
@@ -1017,8 +1046,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $3
+   local.set $6
+   local.get $6
    i32.const 1073741808
    i32.lt_u
    if
@@ -1029,16 +1058,16 @@
     local.get $2
     i32.const 3
     i32.and
-    local.get $3
+    local.get $6
     i32.or
     local.tee $2
     i32.store
     local.get $1
-    local.set $6
-    local.get $6
+    local.set $7
+    local.get $7
     i32.const 16
     i32.add
-    local.get $6
+    local.get $7
     i32.load
     i32.const 3
     i32.const -1
@@ -1056,18 +1085,18 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $8
+   local.get $8
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
+   local.set $9
+   local.get $9
    i32.load
-   local.set $3
+   local.set $10
    i32.const 1
    drop
-   local.get $3
+   local.get $10
    i32.const 1
    i32.and
    i32.eqz
@@ -1079,7 +1108,7 @@
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $3
+   local.get $10
    i32.const 3
    i32.const -1
    i32.xor
@@ -1092,23 +1121,23 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $7
+   local.set $11
+   local.get $11
    i32.const 1073741808
    i32.lt_u
    if
     local.get $0
-    local.get $6
+    local.get $9
     call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
+    local.get $9
+    local.get $10
     i32.const 3
     i32.and
-    local.get $7
+    local.get $11
     i32.or
     local.tee $2
     i32.store
-    local.get $6
+    local.get $9
     local.set $1
    end
   end
@@ -1122,14 +1151,14 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $12
   i32.const 1
   drop
-  local.get $8
+  local.get $12
   i32.const 16
   i32.ge_u
   if (result i32)
-   local.get $8
+   local.get $12
    i32.const 1073741808
    i32.lt_u
   else
@@ -1149,7 +1178,7 @@
   local.get $1
   i32.const 16
   i32.add
-  local.get $8
+  local.get $12
   i32.add
   local.get $4
   i32.eq
@@ -1167,24 +1196,24 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $12
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $13
+   local.get $12
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $14
   else
    i32.const 31
-   local.get $8
+   local.get $12
    i32.clz
    i32.sub
-   local.set $9
-   local.get $8
-   local.get $9
+   local.set $13
+   local.get $12
+   local.get $13
    i32.const 4
    i32.sub
    i32.shr_u
@@ -1192,21 +1221,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $14
+   local.get $13
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $13
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $13
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $14
    i32.const 16
    i32.lt_u
   else
@@ -1222,86 +1251,86 @@
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
-  local.set $6
-  local.get $7
-  local.get $3
+  local.set $17
+  local.get $13
+  local.set $16
+  local.get $14
+  local.set $15
+  local.get $17
+  local.get $16
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $15
   i32.add
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=96
-  local.set $11
+  local.set $18
   local.get $1
   i32.const 0
   i32.store offset=16
   local.get $1
-  local.get $11
+  local.get $18
   i32.store offset=20
-  local.get $11
+  local.get $18
   if
-   local.get $11
+   local.get $18
    local.get $1
    i32.store offset=16
   end
   local.get $0
-  local.set $12
-  local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
+  local.set $22
+  local.get $13
+  local.set $21
+  local.get $14
+  local.set $20
   local.get $1
-  local.set $6
-  local.get $12
-  local.get $7
+  local.set $19
+  local.get $22
+  local.get $21
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $20
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $19
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $13
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.set $13
-  local.get $9
-  local.set $12
+  local.set $27
+  local.get $13
+  local.set $26
   local.get $0
-  local.set $3
-  local.get $9
-  local.set $6
-  local.get $3
-  local.get $6
+  local.set $24
+  local.get $13
+  local.set $23
+  local.get $24
+  local.get $23
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $14
   i32.shl
   i32.or
-  local.set $7
-  local.get $13
-  local.get $12
+  local.set $25
+  local.get $27
+  local.get $26
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $25
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -1312,6 +1341,7 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
   i32.const 1
   drop
   local.get $1
@@ -1451,11 +1481,11 @@
   i32.or
   i32.store
   local.get $0
-  local.set $9
+  local.set $10
   local.get $4
-  local.set $3
+  local.set $9
+  local.get $10
   local.get $9
-  local.get $3
   i32.store offset=1568
   local.get $0
   local.get $8
@@ -1475,6 +1505,12 @@
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
   global.get $~lib/rt/tlsf/ROOT
   local.set $0
   local.get $0
@@ -1531,66 +1567,66 @@
    local.get $4
    i32.store offset=1568
    i32.const 0
-   local.set $5
+   local.set $6
    loop $for-loop|0
-    local.get $5
+    local.get $6
     i32.const 23
     i32.lt_u
-    local.set $4
-    local.get $4
+    local.set $7
+    local.get $7
     if
      local.get $0
-     local.set $8
-     local.get $5
-     local.set $7
+     local.set $10
+     local.get $6
+     local.set $9
      i32.const 0
-     local.set $6
-     local.get $8
-     local.get $7
+     local.set $8
+     local.get $10
+     local.get $9
      i32.const 2
      i32.shl
      i32.add
-     local.get $6
+     local.get $8
      i32.store offset=4
      i32.const 0
-     local.set $8
+     local.set $11
      loop $for-loop|1
-      local.get $8
+      local.get $11
       i32.const 16
       i32.lt_u
-      local.set $7
-      local.get $7
+      local.set $12
+      local.get $12
       if
        local.get $0
-       local.set $11
-       local.get $5
-       local.set $10
-       local.get $8
-       local.set $9
-       i32.const 0
-       local.set $6
+       local.set $16
+       local.get $6
+       local.set $15
        local.get $11
-       local.get $10
+       local.set $14
+       i32.const 0
+       local.set $13
+       local.get $16
+       local.get $15
        i32.const 4
        i32.shl
-       local.get $9
+       local.get $14
        i32.add
        i32.const 2
        i32.shl
        i32.add
-       local.get $6
+       local.get $13
        i32.store offset=96
-       local.get $8
+       local.get $11
        i32.const 1
        i32.add
-       local.set $8
+       local.set $11
        br $for-loop|1
       end
      end
-     local.get $5
+     local.get $6
      i32.const 1
      i32.add
-     local.set $5
+     local.set $6
      br $for-loop|0
     end
    end
@@ -1603,11 +1639,11 @@
    i32.const -1
    i32.xor
    i32.and
-   local.set $5
+   local.set $17
    i32.const 0
    drop
    local.get $0
-   local.get $5
+   local.get $17
    memory.size
    i32.const 16
    i32.shl
@@ -1656,6 +1692,14 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
   local.get $1
   i32.const 256
   i32.lt_u
@@ -1729,11 +1773,11 @@
    unreachable
   end
   local.get $0
-  local.set $5
+  local.set $6
   local.get $2
-  local.set $4
+  local.set $5
+  local.get $6
   local.get $5
-  local.get $4
   i32.const 2
   i32.shl
   i32.add
@@ -1744,10 +1788,10 @@
   local.get $3
   i32.shl
   i32.and
-  local.set $6
-  i32.const 0
   local.set $7
-  local.get $6
+  i32.const 0
+  local.set $8
+  local.get $7
   i32.eqz
   if
    local.get $0
@@ -1760,30 +1804,30 @@
    i32.add
    i32.shl
    i32.and
-   local.set $5
-   local.get $5
+   local.set $9
+   local.get $9
    i32.eqz
    if
     i32.const 0
-    local.set $7
+    local.set $8
    else
-    local.get $5
+    local.get $9
     i32.ctz
     local.set $2
     local.get $0
-    local.set $8
+    local.set $11
     local.get $2
-    local.set $4
-    local.get $8
-    local.get $4
+    local.set $10
+    local.get $11
+    local.get $10
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $6
+    local.set $7
     i32.const 1
     drop
-    local.get $6
+    local.get $7
     i32.eqz
     if
      i32.const 0
@@ -1794,45 +1838,45 @@
      unreachable
     end
     local.get $0
-    local.set $9
+    local.set $14
     local.get $2
-    local.set $8
-    local.get $6
+    local.set $13
+    local.get $7
     i32.ctz
-    local.set $4
-    local.get $9
-    local.get $8
+    local.set $12
+    local.get $14
+    local.get $13
     i32.const 4
     i32.shl
-    local.get $4
+    local.get $12
     i32.add
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=96
-    local.set $7
+    local.set $8
    end
   else
    local.get $0
-   local.set $9
+   local.set $17
    local.get $2
-   local.set $8
-   local.get $6
+   local.set $16
+   local.get $7
    i32.ctz
-   local.set $4
-   local.get $9
-   local.get $8
+   local.set $15
+   local.get $17
+   local.get $16
    i32.const 4
    i32.shl
-   local.get $4
+   local.get $15
    i32.add
    i32.const 2
    i32.shl
    i32.add
    i32.load offset=96
-   local.set $7
+   local.set $8
   end
-  local.get $7
+  local.get $8
  )
  (func $~lib/rt/tlsf/growMemory (param $0 i32) (param $1 i32)
   (local $2 i32)
@@ -1841,6 +1885,7 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
   i32.const 0
   drop
   local.get $1
@@ -1887,15 +1932,15 @@
   i32.shr_u
   local.set $4
   local.get $2
-  local.tee $3
-  local.get $4
   local.tee $5
-  local.get $3
+  local.get $4
+  local.tee $6
   local.get $5
+  local.get $6
   i32.gt_s
   select
-  local.set $6
-  local.get $6
+  local.set $7
+  local.get $7
   memory.grow
   i32.const 0
   i32.lt_s
@@ -1909,12 +1954,12 @@
    end
   end
   memory.size
-  local.set $7
+  local.set $8
   local.get $0
   local.get $2
   i32.const 16
   i32.shl
-  local.get $7
+  local.get $8
   i32.const 16
   i32.shl
   call $~lib/rt/tlsf/addMemory
@@ -1924,6 +1969,8 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
   local.get $1
   i32.load
   local.set $3
@@ -1988,11 +2035,11 @@
    i32.and
    i32.store
    local.get $1
-   local.set $5
-   local.get $5
+   local.set $7
+   local.get $7
    i32.const 16
    i32.add
-   local.get $5
+   local.get $7
    i32.load
    i32.const 3
    i32.const -1
@@ -2000,11 +2047,11 @@
    i32.and
    i32.add
    local.get $1
-   local.set $5
-   local.get $5
+   local.set $6
+   local.get $6
    i32.const 16
    i32.add
-   local.get $5
+   local.get $6
    i32.load
    i32.const 3
    i32.const -1
@@ -2268,6 +2315,12 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
   local.get $1
   call $~lib/rt/pure/__retain
   local.set $1
@@ -2294,54 +2347,59 @@
   call $~lib/string/String#get:length
   local.set $5
   local.get $2
-  local.tee $3
+  local.tee $6
   i32.const 0
-  local.tee $4
-  local.get $3
-  local.get $4
+  local.tee $7
+  local.get $6
+  local.get $7
   i32.gt_s
   select
-  local.tee $3
+  local.tee $8
   local.get $5
-  local.tee $4
-  local.get $3
-  local.get $4
+  local.tee $9
+  local.get $8
+  local.get $9
   i32.lt_s
   select
-  local.set $6
+  local.set $10
   local.get $1
   call $~lib/string/String#get:length
-  local.set $7
-  local.get $7
-  local.get $6
+  local.set $11
+  local.get $11
+  local.get $10
   i32.add
   local.get $5
   i32.gt_s
   if
    i32.const 0
-   local.set $3
+   local.set $12
    local.get $1
    call $~lib/rt/pure/__release
-   local.get $3
+   local.get $12
    return
   end
   local.get $0
-  local.get $6
+  local.get $10
   local.get $1
   i32.const 0
-  local.get $7
+  local.get $11
   call $~lib/util/string/compareImpl
   i32.eqz
-  local.set $3
+  local.set $13
   local.get $1
   call $~lib/rt/pure/__release
-  local.get $3
+  local.get $13
  )
  (func $~lib/string/String#endsWith (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
   local.get $1
   call $~lib/rt/pure/__retain
   local.set $1
@@ -2357,51 +2415,51 @@
    return
   end
   local.get $2
-  local.tee $3
-  i32.const 0
   local.tee $4
-  local.get $3
+  i32.const 0
+  local.tee $5
   local.get $4
+  local.get $5
   i32.gt_s
   select
-  local.tee $3
+  local.tee $6
   local.get $0
   call $~lib/string/String#get:length
-  local.tee $4
-  local.get $3
-  local.get $4
+  local.tee $7
+  local.get $6
+  local.get $7
   i32.lt_s
   select
   local.set $2
   local.get $1
   call $~lib/string/String#get:length
-  local.set $5
+  local.set $8
   local.get $2
-  local.get $5
+  local.get $8
   i32.sub
-  local.set $6
-  local.get $6
+  local.set $9
+  local.get $9
   i32.const 0
   i32.lt_s
   if
    i32.const 0
-   local.set $3
+   local.set $10
    local.get $1
    call $~lib/rt/pure/__release
-   local.get $3
+   local.get $10
    return
   end
   local.get $0
-  local.get $6
+  local.get $9
   local.get $1
   i32.const 0
-  local.get $5
+  local.get $8
   call $~lib/util/string/compareImpl
   i32.eqz
-  local.set $3
+  local.set $11
   local.get $1
   call $~lib/rt/pure/__release
-  local.get $3
+  local.get $11
  )
  (func $~lib/string/String#indexOf (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
@@ -2409,6 +2467,13 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
   local.get $1
   call $~lib/rt/pure/__retain
   local.set $1
@@ -2432,66 +2497,66 @@
   i32.eqz
   if
    i32.const -1
-   local.set $4
+   local.set $6
    local.get $1
    call $~lib/rt/pure/__release
-   local.get $4
+   local.get $6
    return
   end
   local.get $2
-  local.tee $4
+  local.tee $7
   i32.const 0
-  local.tee $6
-  local.get $4
-  local.get $6
+  local.tee $8
+  local.get $7
+  local.get $8
   i32.gt_s
   select
-  local.tee $4
+  local.tee $9
   local.get $5
-  local.tee $6
-  local.get $4
-  local.get $6
+  local.tee $10
+  local.get $9
+  local.get $10
   i32.lt_s
   select
-  local.set $7
+  local.set $11
   local.get $5
   local.get $3
   i32.sub
   local.set $5
   loop $for-loop|0
-   local.get $7
+   local.get $11
    local.get $5
    i32.le_s
-   local.set $4
-   local.get $4
+   local.set $12
+   local.get $12
    if
     local.get $0
-    local.get $7
+    local.get $11
     local.get $1
     i32.const 0
     local.get $3
     call $~lib/util/string/compareImpl
     i32.eqz
     if
-     local.get $7
-     local.set $6
+     local.get $11
+     local.set $13
      local.get $1
      call $~lib/rt/pure/__release
-     local.get $6
+     local.get $13
      return
     end
-    local.get $7
+    local.get $11
     i32.const 1
     i32.add
-    local.set $7
+    local.set $11
     br $for-loop|0
    end
   end
   i32.const -1
-  local.set $4
+  local.set $14
   local.get $1
   call $~lib/rt/pure/__release
-  local.get $4
+  local.get $14
  )
  (func $~lib/string/String#includes (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
@@ -2514,6 +2579,88 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local $22 i32)
+  (local $23 i32)
+  (local $24 i32)
+  (local $25 i32)
+  (local $26 i32)
+  (local $27 i32)
+  (local $28 i32)
+  (local $29 i32)
+  (local $30 i32)
+  (local $31 i32)
+  (local $32 i32)
+  (local $33 i32)
+  (local $34 i32)
+  (local $35 i32)
+  (local $36 i32)
+  (local $37 i32)
+  (local $38 i32)
+  (local $39 i32)
+  (local $40 i32)
+  (local $41 i32)
+  (local $42 i32)
+  (local $43 i32)
+  (local $44 i32)
+  (local $45 i32)
+  (local $46 i32)
+  (local $47 i32)
+  (local $48 i32)
+  (local $49 i32)
+  (local $50 i32)
+  (local $51 i32)
+  (local $52 i32)
+  (local $53 i32)
+  (local $54 i32)
+  (local $55 i32)
+  (local $56 i32)
+  (local $57 i32)
+  (local $58 i32)
+  (local $59 i32)
+  (local $60 i32)
+  (local $61 i32)
+  (local $62 i32)
+  (local $63 i32)
+  (local $64 i32)
+  (local $65 i32)
+  (local $66 i32)
+  (local $67 i32)
+  (local $68 i32)
+  (local $69 i32)
+  (local $70 i32)
+  (local $71 i32)
+  (local $72 i32)
+  (local $73 i32)
+  (local $74 i32)
+  (local $75 i32)
+  (local $76 i32)
+  (local $77 i32)
+  (local $78 i32)
+  (local $79 i32)
+  (local $80 i32)
+  (local $81 i32)
+  (local $82 i32)
+  (local $83 i32)
+  (local $84 i32)
+  (local $85 i32)
+  (local $86 i32)
+  (local $87 i32)
+  (local $88 i32)
   loop $while-continue|0
    local.get $2
    if (result i32)
@@ -2533,11 +2680,11 @@
     local.set $0
     local.get $6
     local.get $1
-    local.tee $6
+    local.tee $7
     i32.const 1
     i32.add
     local.set $1
-    local.get $6
+    local.get $7
     i32.load8_u
     i32.store8
     local.get $2
@@ -2557,8 +2704,8 @@
     local.get $2
     i32.const 16
     i32.ge_u
-    local.set $5
-    local.get $5
+    local.set $8
+    local.get $8
     if
      local.get $0
      local.get $1
@@ -2667,17 +2814,17 @@
    i32.and
    if
     local.get $0
-    local.tee $5
+    local.tee $9
     i32.const 1
     i32.add
     local.set $0
-    local.get $5
+    local.get $9
     local.get $1
-    local.tee $5
+    local.tee $10
     i32.const 1
     i32.add
     local.set $1
-    local.get $5
+    local.get $10
     i32.load8_u
     i32.store8
    end
@@ -2694,16 +2841,16 @@
        local.get $0
        i32.const 3
        i32.and
-       local.set $5
-       local.get $5
+       local.set $11
+       local.get $11
        i32.const 1
        i32.eq
        br_if $case0|2
-       local.get $5
+       local.get $11
        i32.const 2
        i32.eq
        br_if $case1|2
-       local.get $5
+       local.get $11
        i32.const 3
        i32.eq
        br_if $case2|2
@@ -2713,45 +2860,45 @@
       i32.load
       local.set $3
       local.get $0
-      local.tee $5
+      local.tee $12
       i32.const 1
       i32.add
       local.set $0
-      local.get $5
+      local.get $12
       local.get $1
-      local.tee $5
+      local.tee $13
       i32.const 1
       i32.add
       local.set $1
-      local.get $5
+      local.get $13
       i32.load8_u
       i32.store8
       local.get $0
-      local.tee $5
+      local.tee $14
       i32.const 1
       i32.add
       local.set $0
-      local.get $5
+      local.get $14
       local.get $1
-      local.tee $5
+      local.tee $15
       i32.const 1
       i32.add
       local.set $1
-      local.get $5
+      local.get $15
       i32.load8_u
       i32.store8
       local.get $0
-      local.tee $5
+      local.tee $16
       i32.const 1
       i32.add
       local.set $0
-      local.get $5
+      local.get $16
       local.get $1
-      local.tee $5
+      local.tee $17
       i32.const 1
       i32.add
       local.set $1
-      local.get $5
+      local.get $17
       i32.load8_u
       i32.store8
       local.get $2
@@ -2762,8 +2909,8 @@
        local.get $2
        i32.const 17
        i32.ge_u
-       local.set $5
-       local.get $5
+       local.set $18
+       local.get $18
        if
         local.get $1
         i32.const 1
@@ -2848,31 +2995,31 @@
      i32.load
      local.set $3
      local.get $0
-     local.tee $5
+     local.tee $19
      i32.const 1
      i32.add
      local.set $0
-     local.get $5
+     local.get $19
      local.get $1
-     local.tee $5
+     local.tee $20
      i32.const 1
      i32.add
      local.set $1
-     local.get $5
+     local.get $20
      i32.load8_u
      i32.store8
      local.get $0
-     local.tee $5
+     local.tee $21
      i32.const 1
      i32.add
      local.set $0
-     local.get $5
+     local.get $21
      local.get $1
-     local.tee $5
+     local.tee $22
      i32.const 1
      i32.add
      local.set $1
-     local.get $5
+     local.get $22
      i32.load8_u
      i32.store8
      local.get $2
@@ -2883,8 +3030,8 @@
       local.get $2
       i32.const 18
       i32.ge_u
-      local.set $5
-      local.get $5
+      local.set $23
+      local.get $23
       if
        local.get $1
        i32.const 2
@@ -2969,17 +3116,17 @@
     i32.load
     local.set $3
     local.get $0
-    local.tee $5
+    local.tee $24
     i32.const 1
     i32.add
     local.set $0
-    local.get $5
+    local.get $24
     local.get $1
-    local.tee $5
+    local.tee $25
     i32.const 1
     i32.add
     local.set $1
-    local.get $5
+    local.get $25
     i32.load8_u
     i32.store8
     local.get $2
@@ -2990,8 +3137,8 @@
      local.get $2
      i32.const 19
      i32.ge_u
-     local.set $5
-     local.get $5
+     local.set $26
+     local.get $26
      if
       local.get $1
       i32.const 3
@@ -3078,227 +3225,227 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $27
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $27
    local.get $1
-   local.tee $5
+   local.tee $28
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $28
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $29
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $29
    local.get $1
-   local.tee $5
+   local.tee $30
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $30
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $31
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $31
    local.get $1
-   local.tee $5
+   local.tee $32
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $32
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $33
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $33
    local.get $1
-   local.tee $5
+   local.tee $34
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $34
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $35
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $35
    local.get $1
-   local.tee $5
+   local.tee $36
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $36
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $37
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $37
    local.get $1
-   local.tee $5
+   local.tee $38
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $38
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $39
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $39
    local.get $1
-   local.tee $5
+   local.tee $40
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $40
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $41
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $41
    local.get $1
-   local.tee $5
+   local.tee $42
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $42
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $43
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $43
    local.get $1
-   local.tee $5
+   local.tee $44
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $44
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $45
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $45
    local.get $1
-   local.tee $5
+   local.tee $46
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $46
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $47
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $47
    local.get $1
-   local.tee $5
+   local.tee $48
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $48
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $49
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $49
    local.get $1
-   local.tee $5
+   local.tee $50
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $50
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $51
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $51
    local.get $1
-   local.tee $5
+   local.tee $52
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $52
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $53
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $53
    local.get $1
-   local.tee $5
+   local.tee $54
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $54
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $55
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $55
    local.get $1
-   local.tee $5
+   local.tee $56
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $56
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $57
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $57
    local.get $1
-   local.tee $5
+   local.tee $58
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $58
    i32.load8_u
    i32.store8
   end
@@ -3307,115 +3454,115 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $59
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $59
    local.get $1
-   local.tee $5
+   local.tee $60
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $60
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $61
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $61
    local.get $1
-   local.tee $5
+   local.tee $62
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $62
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $63
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $63
    local.get $1
-   local.tee $5
+   local.tee $64
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $64
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $65
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $65
    local.get $1
-   local.tee $5
+   local.tee $66
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $66
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $67
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $67
    local.get $1
-   local.tee $5
+   local.tee $68
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $68
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $69
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $69
    local.get $1
-   local.tee $5
+   local.tee $70
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $70
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $71
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $71
    local.get $1
-   local.tee $5
+   local.tee $72
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $72
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $73
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $73
    local.get $1
-   local.tee $5
+   local.tee $74
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $74
    i32.load8_u
    i32.store8
   end
@@ -3424,59 +3571,59 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $75
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $75
    local.get $1
-   local.tee $5
+   local.tee $76
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $76
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $77
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $77
    local.get $1
-   local.tee $5
+   local.tee $78
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $78
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $79
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $79
    local.get $1
-   local.tee $5
+   local.tee $80
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $80
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $81
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $81
    local.get $1
-   local.tee $5
+   local.tee $82
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $82
    i32.load8_u
    i32.store8
   end
@@ -3485,31 +3632,31 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $83
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $83
    local.get $1
-   local.tee $5
+   local.tee $84
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $84
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $85
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $85
    local.get $1
-   local.tee $5
+   local.tee $86
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $86
    i32.load8_u
    i32.store8
   end
@@ -3518,17 +3665,17 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $87
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $87
    local.get $1
-   local.tee $5
+   local.tee $88
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $88
    i32.load8_u
    i32.store8
   end
@@ -3539,6 +3686,14 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
   block $~lib/util/memory/memmove|inlined.0
    local.get $0
    local.set $5
@@ -3616,11 +3771,11 @@
        local.set $5
        local.get $7
        local.get $4
-       local.tee $7
+       local.tee $8
        i32.const 1
        i32.add
        local.set $4
-       local.get $7
+       local.get $8
        i32.load8_u
        i32.store8
        br $while-continue|0
@@ -3630,8 +3785,8 @@
       local.get $3
       i32.const 8
       i32.ge_u
-      local.set $6
-      local.get $6
+      local.set $9
+      local.get $9
       if
        local.get $5
        local.get $4
@@ -3655,21 +3810,21 @@
     end
     loop $while-continue|2
      local.get $3
-     local.set $6
-     local.get $6
+     local.set $10
+     local.get $10
      if
       local.get $5
-      local.tee $7
+      local.tee $11
       i32.const 1
       i32.add
       local.set $5
-      local.get $7
+      local.get $11
       local.get $4
-      local.tee $7
+      local.tee $12
       i32.const 1
       i32.add
       local.set $4
-      local.get $7
+      local.get $12
       i32.load8_u
       i32.store8
       local.get $3
@@ -3698,8 +3853,8 @@
       i32.add
       i32.const 7
       i32.and
-      local.set $6
-      local.get $6
+      local.set $13
+      local.get $13
       if
        local.get $3
        i32.eqz
@@ -3724,8 +3879,8 @@
       local.get $3
       i32.const 8
       i32.ge_u
-      local.set $6
-      local.get $6
+      local.set $14
+      local.get $14
       if
        local.get $3
        i32.const 8
@@ -3745,8 +3900,8 @@
     end
     loop $while-continue|5
      local.get $3
-     local.set $6
-     local.get $6
+     local.set $15
+     local.get $15
      if
       local.get $5
       local.get $3
@@ -3805,6 +3960,8 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
   local.get $2
   call $~lib/rt/pure/__retain
   local.set $2
@@ -3857,25 +4014,25 @@
    i32.sub
    local.get $5
    i32.div_u
-   local.set $6
-   local.get $6
+   local.set $9
+   local.get $9
    local.get $5
    i32.mul
-   local.set $9
-   local.get $7
-   local.get $9
-   i32.sub
    local.set $10
+   local.get $7
+   local.get $10
+   i32.sub
+   local.set $11
    local.get $8
    local.get $2
    local.get $5
-   local.get $6
+   local.get $9
    call $~lib/memory/memory.repeat
    local.get $8
-   local.get $9
+   local.get $10
    i32.add
    local.get $2
-   local.get $10
+   local.get $11
    call $~lib/memory/memory.copy
   else
    local.get $8
@@ -3891,10 +4048,10 @@
   call $~lib/memory/memory.copy
   local.get $8
   call $~lib/rt/pure/__retain
-  local.set $10
+  local.set $12
   local.get $2
   call $~lib/rt/pure/__release
-  local.get $10
+  local.get $12
  )
  (func $~lib/string/String#padEnd (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
@@ -3905,6 +4062,8 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
   local.get $2
   call $~lib/rt/pure/__retain
   local.set $2
@@ -3961,29 +4120,29 @@
    i32.sub
    local.get $5
    i32.div_u
-   local.set $6
-   local.get $6
+   local.set $9
+   local.get $9
    local.get $5
    i32.mul
-   local.set $9
-   local.get $7
-   local.get $9
-   i32.sub
    local.set $10
+   local.get $7
+   local.get $10
+   i32.sub
+   local.set $11
    local.get $8
    local.get $3
    i32.add
    local.get $2
    local.get $5
-   local.get $6
+   local.get $9
    call $~lib/memory/memory.repeat
    local.get $8
    local.get $3
    i32.add
-   local.get $9
+   local.get $10
    i32.add
    local.get $2
-   local.get $10
+   local.get $11
    call $~lib/memory/memory.copy
   else
    local.get $8
@@ -3995,10 +4154,10 @@
   end
   local.get $8
   call $~lib/rt/pure/__retain
-  local.set $10
+  local.set $12
   local.get $2
   call $~lib/rt/pure/__release
-  local.get $10
+  local.get $12
  )
  (func $~lib/string/String#lastIndexOf (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
@@ -4006,6 +4165,13 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
   local.get $1
   call $~lib/rt/pure/__retain
   local.set $1
@@ -4030,69 +4196,72 @@
   i32.eqz
   if
    i32.const -1
-   local.set $4
+   local.set $6
    local.get $1
    call $~lib/rt/pure/__release
-   local.get $4
+   local.get $6
    return
   end
   local.get $2
-  local.tee $4
+  local.tee $7
   i32.const 0
-  local.tee $6
-  local.get $4
-  local.get $6
+  local.tee $8
+  local.get $7
+  local.get $8
   i32.gt_s
   select
-  local.tee $4
+  local.tee $9
   local.get $5
   local.get $3
   i32.sub
-  local.tee $6
-  local.get $4
-  local.get $6
+  local.tee $10
+  local.get $9
+  local.get $10
   i32.lt_s
   select
-  local.set $7
+  local.set $11
   loop $for-loop|0
-   local.get $7
+   local.get $11
    i32.const 0
    i32.ge_s
-   local.set $4
-   local.get $4
+   local.set $12
+   local.get $12
    if
     local.get $0
-    local.get $7
+    local.get $11
     local.get $1
     i32.const 0
     local.get $3
     call $~lib/util/string/compareImpl
     i32.eqz
     if
-     local.get $7
-     local.set $6
+     local.get $11
+     local.set $13
      local.get $1
      call $~lib/rt/pure/__release
-     local.get $6
+     local.get $13
      return
     end
-    local.get $7
+    local.get $11
     i32.const 1
     i32.sub
-    local.set $7
+    local.set $11
     br $for-loop|0
    end
   end
   i32.const -1
-  local.set $4
+  local.set $14
   local.get $1
   call $~lib/rt/pure/__release
-  local.get $4
+  local.get $14
  )
  (func $~lib/string/String#localeCompare (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
   local.get $1
   call $~lib/rt/pure/__retain
   local.set $1
@@ -4123,20 +4292,20 @@
    local.get $4
    i32.gt_s
    select
-   local.set $2
+   local.set $5
    local.get $1
    call $~lib/rt/pure/__release
-   local.get $2
+   local.get $5
    return
   end
   local.get $4
   i32.eqz
   if
    i32.const 0
-   local.set $2
+   local.set $6
    local.get $1
    call $~lib/rt/pure/__release
-   local.get $2
+   local.get $6
    return
   end
   local.get $0
@@ -4145,10 +4314,10 @@
   i32.const 0
   local.get $4
   call $~lib/util/string/compareImpl
-  local.set $2
+  local.set $7
   local.get $1
   call $~lib/rt/pure/__release
-  local.get $2
+  local.get $7
  )
  (func $~lib/util/string/isSpace (param $0 i32) (result i32)
   (local $1 i32)
@@ -4366,6 +4535,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   local.get $0
   call $~lib/string/String#get:length
   local.set $1
@@ -4411,8 +4581,8 @@
    else
     i32.const 0
    end
-   local.set $3
-   local.get $3
+   local.set $5
+   local.get $5
    if
     local.get $4
     i32.const 2
@@ -4451,14 +4621,14 @@
   local.get $2
   i32.const 1
   call $~lib/rt/tlsf/__alloc
-  local.set $5
-  local.get $5
+  local.set $6
+  local.get $6
   local.get $0
   local.get $4
   i32.add
   local.get $2
   call $~lib/memory/memory.copy
-  local.get $5
+  local.get $6
   call $~lib/rt/pure/__retain
  )
  (func $~lib/util/string/strtol<f64> (param $0 i32) (param $1 i32) (result f64)
@@ -4469,6 +4639,13 @@
   (local $6 f64)
   (local $7 i32)
   (local $8 f64)
+  (local $9 f64)
+  (local $10 i32)
+  (local $11 f64)
+  (local $12 f64)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 f64)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $0
@@ -4526,10 +4703,10 @@
     i32.const 1
     drop
     f64.const nan:0x8000000000000
-    local.set $3
+    local.set $8
     local.get $0
     call $~lib/rt/pure/__release
-    local.get $3
+    local.get $8
     return
    end
    local.get $4
@@ -4554,10 +4731,10 @@
      i32.const 1
      drop
      f64.const nan:0x8000000000000
-     local.set $3
+     local.set $9
      local.get $0
      call $~lib/rt/pure/__release
-     local.get $3
+     local.get $9
      return
     end
     local.get $4
@@ -4593,16 +4770,16 @@
          i32.load16_u
          i32.const 32
          i32.or
-         local.set $7
-         local.get $7
+         local.set $10
+         local.get $10
          i32.const 98
          i32.eq
          br_if $case0|1
-         local.get $7
+         local.get $10
          i32.const 111
          i32.eq
          br_if $case1|1
-         local.get $7
+         local.get $10
          i32.const 120
          i32.eq
          br_if $case2|1
@@ -4666,25 +4843,25 @@
     i32.const 1
     drop
     f64.const nan:0x8000000000000
-    local.set $3
+    local.set $11
     local.get $0
     call $~lib/rt/pure/__release
-    local.get $3
+    local.get $11
     return
    end
   end
   f64.const 0
-  local.set $8
+  local.set $12
   block $while-break|2
    loop $while-continue|2
     local.get $2
-    local.tee $7
+    local.tee $13
     i32.const 1
     i32.sub
     local.set $2
-    local.get $7
-    local.set $7
-    local.get $7
+    local.get $13
+    local.set $14
+    local.get $14
     if
      local.get $4
      i32.load16_u
@@ -4740,14 +4917,14 @@
      if
       br $while-break|2
      end
-     local.get $8
+     local.get $12
      local.get $1
      f64.convert_i32_s
      f64.mul
      local.get $5
      f64.convert_i32_u
      f64.add
-     local.set $8
+     local.set $12
      local.get $4
      i32.const 2
      i32.add
@@ -4757,12 +4934,12 @@
    end
   end
   local.get $6
-  local.get $8
+  local.get $12
   f64.mul
-  local.set $3
+  local.set $15
   local.get $0
   call $~lib/rt/pure/__release
-  local.get $3
+  local.get $15
  )
  (func $~lib/string/parseInt (param $0 i32) (param $1 i32) (result f64)
   (local $2 f64)
@@ -4784,6 +4961,14 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $0
@@ -4812,8 +4997,8 @@
   loop $while-continue|0
    local.get $5
    call $~lib/util/string/isSpace
-   local.set $3
-   local.get $3
+   local.set $7
+   local.get $7
    if
     local.get $4
     i32.const 2
@@ -4841,10 +5026,10 @@
     i32.const 0
     drop
     i32.const 0
-    local.set $3
+    local.set $8
     local.get $0
     call $~lib/rt/pure/__release
-    local.get $3
+    local.get $8
     return
    end
    local.get $4
@@ -4869,10 +5054,10 @@
      i32.const 0
      drop
      i32.const 0
-     local.set $3
+     local.set $9
      local.get $0
      call $~lib/rt/pure/__release
-     local.get $3
+     local.get $9
      return
     end
     local.get $4
@@ -4908,16 +5093,16 @@
          i32.load16_u
          i32.const 32
          i32.or
-         local.set $3
-         local.get $3
+         local.set $10
+         local.get $10
          i32.const 98
          i32.eq
          br_if $case0|1
-         local.get $3
+         local.get $10
          i32.const 111
          i32.eq
          br_if $case1|1
-         local.get $3
+         local.get $10
          i32.const 120
          i32.eq
          br_if $case2|1
@@ -4981,25 +5166,25 @@
     i32.const 0
     drop
     i32.const 0
-    local.set $3
+    local.set $11
     local.get $0
     call $~lib/rt/pure/__release
-    local.get $3
+    local.get $11
     return
    end
   end
   i32.const 0
-  local.set $7
+  local.set $12
   block $while-break|2
    loop $while-continue|2
     local.get $2
-    local.tee $3
+    local.tee $13
     i32.const 1
     i32.sub
     local.set $2
-    local.get $3
-    local.set $3
-    local.get $3
+    local.get $13
+    local.set $14
+    local.get $14
     if
      local.get $4
      i32.load16_u
@@ -5055,12 +5240,12 @@
      if
       br $while-break|2
      end
-     local.get $7
+     local.get $12
      local.get $1
      i32.mul
      local.get $5
      i32.add
-     local.set $7
+     local.set $12
      local.get $4
      i32.const 2
      i32.add
@@ -5070,12 +5255,12 @@
    end
   end
   local.get $6
-  local.get $7
+  local.get $12
   i32.mul
-  local.set $3
+  local.set $15
   local.get $0
   call $~lib/rt/pure/__release
-  local.get $3
+  local.get $15
  )
  (func $~lib/number/I32.parseInt (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
@@ -5098,6 +5283,13 @@
   (local $6 i64)
   (local $7 i32)
   (local $8 i64)
+  (local $9 i64)
+  (local $10 i32)
+  (local $11 i64)
+  (local $12 i64)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i64)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $0
@@ -5155,10 +5347,10 @@
     i32.const 0
     drop
     i64.const 0
-    local.set $3
+    local.set $8
     local.get $0
     call $~lib/rt/pure/__release
-    local.get $3
+    local.get $8
     return
    end
    local.get $4
@@ -5183,10 +5375,10 @@
      i32.const 0
      drop
      i64.const 0
-     local.set $3
+     local.set $9
      local.get $0
      call $~lib/rt/pure/__release
-     local.get $3
+     local.get $9
      return
     end
     local.get $4
@@ -5222,16 +5414,16 @@
          i32.load16_u
          i32.const 32
          i32.or
-         local.set $7
-         local.get $7
+         local.set $10
+         local.get $10
          i32.const 98
          i32.eq
          br_if $case0|1
-         local.get $7
+         local.get $10
          i32.const 111
          i32.eq
          br_if $case1|1
-         local.get $7
+         local.get $10
          i32.const 120
          i32.eq
          br_if $case2|1
@@ -5295,25 +5487,25 @@
     i32.const 0
     drop
     i64.const 0
-    local.set $3
+    local.set $11
     local.get $0
     call $~lib/rt/pure/__release
-    local.get $3
+    local.get $11
     return
    end
   end
   i64.const 0
-  local.set $8
+  local.set $12
   block $while-break|2
    loop $while-continue|2
     local.get $2
-    local.tee $7
+    local.tee $13
     i32.const 1
     i32.sub
     local.set $2
-    local.get $7
-    local.set $7
-    local.get $7
+    local.get $13
+    local.set $14
+    local.get $14
     if
      local.get $4
      i32.load16_u
@@ -5369,14 +5561,14 @@
      if
       br $while-break|2
      end
-     local.get $8
+     local.get $12
      local.get $1
      i64.extend_i32_s
      i64.mul
      local.get $5
      i64.extend_i32_u
      i64.add
-     local.set $8
+     local.set $12
      local.get $4
      i32.const 2
      i32.add
@@ -5386,12 +5578,12 @@
    end
   end
   local.get $6
-  local.get $8
+  local.get $12
   i64.mul
-  local.set $3
+  local.set $15
   local.get $0
   call $~lib/rt/pure/__release
-  local.get $3
+  local.get $15
  )
  (func $~lib/number/I64.parseInt (param $0 i32) (param $1 i32) (result i64)
   (local $2 i64)
@@ -5410,6 +5602,8 @@
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   i32.const 1
   local.set $2
   i32.const 0
@@ -5458,8 +5652,8 @@
   local.get $1
   i32.clz
   i32.sub
-  local.set $3
-  local.get $3
+  local.set $4
+  local.get $4
   i32.const 5
   i32.le_s
   if
@@ -5469,25 +5663,25 @@
       block $case2|1
        block $case1|1
         block $case0|1
-         local.get $3
-         local.set $4
          local.get $4
+         local.set $5
+         local.get $5
          i32.const 5
          i32.eq
          br_if $case0|1
-         local.get $4
+         local.get $5
          i32.const 4
          i32.eq
          br_if $case1|1
-         local.get $4
+         local.get $5
          i32.const 3
          i32.eq
          br_if $case2|1
-         local.get $4
+         local.get $5
          i32.const 2
          i32.eq
          br_if $case3|1
-         local.get $4
+         local.get $5
          i32.const 1
          i32.eq
          br_if $case4|1
@@ -5582,8 +5776,8 @@
    local.get $1
    i32.const 0
    i32.gt_s
-   local.set $3
-   local.get $3
+   local.set $6
+   local.get $6
    if
     local.get $1
     i32.const 1
@@ -5611,6 +5805,8 @@
   (local $2 f64)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   local.get $0
   local.set $2
   local.get $1
@@ -5677,11 +5873,11 @@
      i32.add
      i32.const 53
      i32.sub
-     local.tee $3
+     local.tee $5
      i32.const -1022
-     local.tee $4
-     local.get $3
-     local.get $4
+     local.tee $6
+     local.get $5
+     local.get $6
      i32.gt_s
      select
      local.set $1
@@ -5705,24 +5901,74 @@
   (local $4 i32)
   (local $5 f64)
   (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  (local $9 i32)
-  (local $10 i32)
-  (local $11 i64)
-  (local $12 i32)
+  (local $7 f64)
+  (local $8 f64)
+  (local $9 f64)
+  (local $10 f64)
+  (local $11 f64)
+  (local $12 f64)
   (local $13 i32)
   (local $14 i32)
-  (local $15 i32)
+  (local $15 f64)
   (local $16 i32)
   (local $17 i32)
-  (local $18 i64)
+  (local $18 i32)
   (local $19 i64)
-  (local $20 i64)
-  (local $21 i64)
-  (local $22 i64)
-  (local $23 i64)
-  (local $24 i64)
+  (local $20 i32)
+  (local $21 f64)
+  (local $22 i32)
+  (local $23 f64)
+  (local $24 f64)
+  (local $25 i32)
+  (local $26 i32)
+  (local $27 i32)
+  (local $28 i32)
+  (local $29 i32)
+  (local $30 i32)
+  (local $31 i32)
+  (local $32 i32)
+  (local $33 i32)
+  (local $34 i32)
+  (local $35 i32)
+  (local $36 i32)
+  (local $37 i32)
+  (local $38 i64)
+  (local $39 f64)
+  (local $40 i32)
+  (local $41 i32)
+  (local $42 i32)
+  (local $43 i32)
+  (local $44 i32)
+  (local $45 i32)
+  (local $46 i64)
+  (local $47 i64)
+  (local $48 i32)
+  (local $49 i64)
+  (local $50 i64)
+  (local $51 i64)
+  (local $52 i64)
+  (local $53 i64)
+  (local $54 i64)
+  (local $55 i64)
+  (local $56 i32)
+  (local $57 i64)
+  (local $58 i64)
+  (local $59 i32)
+  (local $60 i32)
+  (local $61 i64)
+  (local $62 i64)
+  (local $63 i64)
+  (local $64 i32)
+  (local $65 i32)
+  (local $66 i64)
+  (local $67 i32)
+  (local $68 i64)
+  (local $69 i64)
+  (local $70 i64)
+  (local $71 i32)
+  (local $72 i32)
+  (local $73 i64)
+  (local $74 f64)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $0
@@ -5774,10 +6020,10 @@
   i32.eqz
   if
    f64.const nan:0x8000000000000
-   local.set $2
+   local.set $7
    local.get $0
    call $~lib/rt/pure/__release
-   local.get $2
+   local.get $7
    return
   end
   local.get $4
@@ -5791,10 +6037,10 @@
    i32.eqz
    if
     f64.const nan:0x8000000000000
-    local.set $2
+    local.set $8
     local.get $0
     call $~lib/rt/pure/__release
-    local.get $2
+    local.get $8
     return
    end
    local.get $3
@@ -5817,10 +6063,10 @@
     i32.eqz
     if
      f64.const nan:0x8000000000000
-     local.set $2
+     local.set $9
      local.get $0
      call $~lib/rt/pure/__release
-     local.get $2
+     local.get $9
      return
     end
     local.get $3
@@ -5858,17 +6104,17 @@
     f64.const inf
     local.get $5
     f64.copysign
-    local.set $2
+    local.set $10
     local.get $0
     call $~lib/rt/pure/__release
-    local.get $2
+    local.get $10
     return
    end
    f64.const nan:0x8000000000000
-   local.set $2
+   local.set $11
    local.get $0
    call $~lib/rt/pure/__release
-   local.get $2
+   local.get $11
    return
   end
   local.get $4
@@ -5885,20 +6131,20 @@
   end
   if
    f64.const nan:0x8000000000000
-   local.set $2
+   local.set $12
    local.get $0
    call $~lib/rt/pure/__release
-   local.get $2
+   local.get $12
    return
   end
   local.get $3
-  local.set $7
+  local.set $13
   loop $while-continue|1
    local.get $4
    i32.const 48
    i32.eq
-   local.set $6
-   local.get $6
+   local.set $14
+   local.get $14
    if
     local.get $3
     i32.const 2
@@ -5918,29 +6164,29 @@
   i32.le_s
   if
    f64.const 0
-   local.set $2
+   local.set $15
    local.get $0
    call $~lib/rt/pure/__release
-   local.get $2
+   local.get $15
    return
   end
   i32.const 0
-  local.set $8
+  local.set $16
   i32.const 0
-  local.set $9
+  local.set $17
   i32.const 0
-  local.set $10
+  local.set $18
   i64.const 0
-  local.set $11
+  local.set $19
   local.get $4
   i32.const 46
   i32.eq
   if
-   local.get $7
+   local.get $13
    local.get $3
    i32.sub
    i32.eqz
-   local.set $6
+   local.set $20
    local.get $3
    i32.const 2
    i32.add
@@ -5952,37 +6198,37 @@
    local.get $1
    i32.eqz
    if (result i32)
-    local.get $6
+    local.get $20
    else
     i32.const 0
    end
    if
     f64.const nan:0x8000000000000
-    local.set $2
+    local.set $21
     local.get $0
     call $~lib/rt/pure/__release
-    local.get $2
+    local.get $21
     return
    end
    i32.const 1
-   local.set $8
+   local.set $16
    loop $for-loop|2
     local.get $3
     i32.load16_u
     local.tee $4
     i32.const 48
     i32.eq
-    local.set $12
-    local.get $12
+    local.set $22
+    local.get $22
     if
      local.get $1
      i32.const 1
      i32.sub
      local.set $1
-     local.get $10
+     local.get $18
      i32.const 1
      i32.sub
-     local.set $10
+     local.set $18
      local.get $3
      i32.const 2
      i32.add
@@ -5995,16 +6241,16 @@
    i32.le_s
    if
     f64.const 0
-    local.set $2
+    local.set $23
     local.get $0
     call $~lib/rt/pure/__release
-    local.get $2
+    local.get $23
     return
    end
-   local.get $10
+   local.get $18
    i32.eqz
    if (result i32)
-    local.get $6
+    local.get $20
    else
     i32.const 0
    end
@@ -6019,20 +6265,20 @@
    end
    if
     f64.const nan:0x8000000000000
-    local.set $2
+    local.set $24
     local.get $0
     call $~lib/rt/pure/__release
-    local.get $2
+    local.get $24
     return
    end
   end
   local.get $4
   i32.const 48
   i32.sub
-  local.set $6
+  local.set $25
   block $for-break3
    loop $for-loop|3
-    local.get $6
+    local.get $25
     i32.const 10
     i32.lt_u
     if (result i32)
@@ -6042,47 +6288,47 @@
      i32.const 46
      i32.eq
      if (result i32)
-      local.get $8
+      local.get $16
       i32.eqz
      else
       i32.const 0
      end
     end
-    local.set $12
-    local.get $12
+    local.set $26
+    local.get $26
     if
-     local.get $6
+     local.get $25
      i32.const 10
      i32.lt_u
      if
-      local.get $9
+      local.get $17
       i32.const 19
       i32.lt_s
       if (result i64)
        i64.const 10
-       local.get $11
+       local.get $19
        i64.mul
-       local.get $6
+       local.get $25
        i64.extend_i32_u
        i64.add
       else
-       local.get $11
-       local.get $6
+       local.get $19
+       local.get $25
        i32.eqz
        i32.eqz
        i64.extend_i32_u
        i64.or
       end
-      local.set $11
-      local.get $9
+      local.set $19
+      local.get $17
       i32.const 1
       i32.add
-      local.set $9
+      local.set $17
      else
-      local.get $9
-      local.set $10
+      local.get $17
+      local.set $18
       i32.const 1
-      local.set $8
+      local.set $16
      end
      local.get $1
      i32.const 1
@@ -6101,43 +6347,43 @@
      local.get $4
      i32.const 48
      i32.sub
-     local.set $6
+     local.set $25
      br $for-loop|3
     end
    end
   end
-  local.get $8
+  local.get $16
   i32.eqz
   if
-   local.get $9
-   local.set $10
+   local.get $17
+   local.set $18
   end
   block $~lib/util/string/scientific|inlined.0 (result f64)
-   local.get $11
-   local.set $18
-   local.get $10
+   local.get $19
+   local.set $38
+   local.get $18
    i32.const 19
-   local.tee $6
-   local.get $9
-   local.tee $12
-   local.get $6
-   local.get $12
+   local.tee $27
+   local.get $17
+   local.tee $28
+   local.get $27
+   local.get $28
    i32.lt_s
    select
    i32.sub
    block $~lib/util/string/parseExp|inlined.0 (result i32)
     local.get $3
-    local.set $6
+    local.set $30
     local.get $1
-    local.set $12
+    local.set $29
     i32.const 1
-    local.set $13
+    local.set $31
     i32.const 0
-    local.set $14
-    local.get $6
+    local.set $32
+    local.get $30
     i32.load16_u
-    local.set $15
-    local.get $15
+    local.set $33
+    local.get $33
     i32.const 32
     i32.or
     i32.const 101
@@ -6146,142 +6392,142 @@
      i32.const 0
      br $~lib/util/string/parseExp|inlined.0
     end
-    local.get $6
+    local.get $30
     i32.const 2
     i32.add
-    local.tee $6
+    local.tee $30
     i32.load16_u
-    local.set $15
-    local.get $15
+    local.set $33
+    local.get $33
     i32.const 45
     i32.eq
     if
-     local.get $12
+     local.get $29
      i32.const 1
      i32.sub
-     local.tee $12
+     local.tee $29
      i32.eqz
      if
       i32.const 0
       br $~lib/util/string/parseExp|inlined.0
      end
-     local.get $6
+     local.get $30
      i32.const 2
      i32.add
-     local.tee $6
+     local.tee $30
      i32.load16_u
-     local.set $15
+     local.set $33
      i32.const -1
-     local.set $13
+     local.set $31
     else
-     local.get $15
+     local.get $33
      i32.const 43
      i32.eq
      if
-      local.get $12
+      local.get $29
       i32.const 1
       i32.sub
-      local.tee $12
+      local.tee $29
       i32.eqz
       if
        i32.const 0
        br $~lib/util/string/parseExp|inlined.0
       end
-      local.get $6
+      local.get $30
       i32.const 2
       i32.add
-      local.tee $6
+      local.tee $30
       i32.load16_u
-      local.set $15
+      local.set $33
      end
     end
     loop $while-continue|4
-     local.get $15
+     local.get $33
      i32.const 48
      i32.eq
-     local.set $16
-     local.get $16
+     local.set $34
+     local.get $34
      if
-      local.get $12
+      local.get $29
       i32.const 1
       i32.sub
-      local.tee $12
+      local.tee $29
       i32.eqz
       if
        i32.const 0
        br $~lib/util/string/parseExp|inlined.0
       end
-      local.get $6
+      local.get $30
       i32.const 2
       i32.add
-      local.tee $6
+      local.tee $30
       i32.load16_u
-      local.set $15
+      local.set $33
       br $while-continue|4
      end
     end
-    local.get $15
+    local.get $33
     i32.const 48
     i32.sub
-    local.set $16
+    local.set $35
     loop $for-loop|5
-     local.get $12
+     local.get $29
      if (result i32)
-      local.get $16
+      local.get $35
       i32.const 10
       i32.lt_u
      else
       i32.const 0
      end
-     local.set $17
-     local.get $17
+     local.set $36
+     local.get $36
      if
-      local.get $14
+      local.get $32
       i32.const 3200
       i32.ge_s
       if
-       local.get $13
+       local.get $31
        i32.const 3200
        i32.mul
        br $~lib/util/string/parseExp|inlined.0
       end
       i32.const 10
-      local.get $14
+      local.get $32
       i32.mul
-      local.get $16
+      local.get $35
       i32.add
-      local.set $14
-      local.get $6
+      local.set $32
+      local.get $30
       i32.const 2
       i32.add
-      local.tee $6
+      local.tee $30
       i32.load16_u
-      local.set $15
-      local.get $12
+      local.set $33
+      local.get $29
       i32.const 1
       i32.sub
-      local.set $12
-      local.get $15
+      local.set $29
+      local.get $33
       i32.const 48
       i32.sub
-      local.set $16
+      local.set $35
       br $for-loop|5
      end
     end
-    local.get $13
-    local.get $14
+    local.get $31
+    local.get $32
     i32.mul
    end
    i32.add
-   local.set $17
-   local.get $18
+   local.set $37
+   local.get $38
    i64.const 0
    i64.ne
    i32.eqz
    if (result i32)
     i32.const 1
    else
-    local.get $17
+    local.get $37
     i32.const -342
     i32.lt_s
    end
@@ -6289,27 +6535,27 @@
     f64.const 0
     br $~lib/util/string/scientific|inlined.0
    end
-   local.get $17
+   local.get $37
    i32.const 308
    i32.gt_s
    if
     f64.const inf
     br $~lib/util/string/scientific|inlined.0
    end
-   local.get $18
+   local.get $38
    f64.convert_i64_u
-   local.set $2
-   local.get $17
+   local.set $39
+   local.get $37
    i32.eqz
    if
-    local.get $2
+    local.get $39
     br $~lib/util/string/scientific|inlined.0
    end
-   local.get $17
+   local.get $37
    i32.const 22
    i32.gt_s
    if (result i32)
-    local.get $17
+    local.get $37
     i32.const 22
     i32.const 15
     i32.add
@@ -6318,34 +6564,34 @@
     i32.const 0
    end
    if
-    local.get $2
-    local.get $17
+    local.get $39
+    local.get $37
     i32.const 22
     i32.sub
-    local.set $16
+    local.set $40
     i32.const 1992
-    local.get $16
+    local.get $40
     i32.const 3
     i32.shl
     i32.add
     f64.load
     f64.mul
-    local.set $2
+    local.set $39
     i32.const 22
-    local.set $17
+    local.set $37
    end
-   local.get $18
+   local.get $38
    i64.const 9007199254740991
    i64.le_u
    if (result i32)
-    local.get $17
-    local.tee $16
+    local.get $37
+    local.tee $41
     i32.const 31
     i32.shr_s
-    local.tee $15
-    local.get $16
+    local.tee $42
+    local.get $41
     i32.add
-    local.get $15
+    local.get $42
     i32.xor
     i32.const 22
     i32.le_s
@@ -6353,15 +6599,15 @@
     i32.const 0
    end
    if
-    local.get $17
+    local.get $37
     i32.const 0
     i32.gt_s
     if
-     local.get $2
-     local.get $17
-     local.set $12
+     local.get $39
+     local.get $37
+     local.set $43
      i32.const 1992
-     local.get $12
+     local.get $43
      i32.const 3
      i32.shl
      i32.add
@@ -6369,13 +6615,13 @@
      f64.mul
      br $~lib/util/string/scientific|inlined.0
     end
-    local.get $2
+    local.get $39
     i32.const 0
-    local.get $17
+    local.get $37
     i32.sub
-    local.set $6
+    local.set $44
     i32.const 1992
-    local.get $6
+    local.get $44
     i32.const 3
     i32.shl
     i32.add
@@ -6383,50 +6629,50 @@
     f64.div
     br $~lib/util/string/scientific|inlined.0
    else
-    local.get $17
+    local.get $37
     i32.const 0
     i32.lt_s
     if
-     local.get $18
-     local.set $19
-     local.get $17
-     local.set $13
-     local.get $19
+     local.get $38
+     local.set $46
+     local.get $37
+     local.set $45
+     local.get $46
      i64.clz
-     local.set $20
-     local.get $19
-     local.get $20
+     local.set $47
+     local.get $46
+     local.get $47
      i64.shl
-     local.set $19
-     local.get $13
+     local.set $46
+     local.get $45
      i64.extend_i32_s
-     local.get $20
+     local.get $47
      i64.sub
-     local.set $20
+     local.set $47
      loop $for-loop|6
-      local.get $13
+      local.get $45
       i32.const -14
       i32.le_s
-      local.set $6
-      local.get $6
+      local.set $48
+      local.get $48
       if
-       local.get $19
+       local.get $46
        i64.const 6103515625
        i64.div_u
-       local.set $21
-       local.get $19
+       local.set $49
+       local.get $46
        i64.const 6103515625
        i64.rem_u
-       local.set $22
-       local.get $21
+       local.set $50
+       local.get $49
        i64.clz
-       local.set $23
-       local.get $21
-       local.get $23
+       local.set $51
+       local.get $49
+       local.get $51
        i64.shl
        f64.const 0.00004294967296
-       local.get $22
-       local.get $23
+       local.get $50
+       local.get $51
        i64.const 18
        i64.sub
        i64.shl
@@ -6435,140 +6681,140 @@
        f64.nearest
        i64.trunc_f64_u
        i64.add
-       local.set $19
-       local.get $20
-       local.get $23
+       local.set $46
+       local.get $47
+       local.get $51
        i64.sub
-       local.set $20
-       local.get $13
+       local.set $47
+       local.get $45
        i32.const 14
        i32.add
-       local.set $13
+       local.set $45
        br $for-loop|6
       end
      end
      i32.const 5
      i32.const 0
-     local.get $13
+     local.get $45
      i32.sub
      call $~lib/math/ipow32
      i64.extend_i32_s
-     local.set $23
-     local.get $19
-     local.get $23
+     local.set $52
+     local.get $46
+     local.get $52
      i64.div_u
-     local.set $22
-     local.get $19
-     local.get $23
+     local.set $53
+     local.get $46
+     local.get $52
      i64.rem_u
-     local.set $21
-     local.get $22
+     local.set $54
+     local.get $53
      i64.clz
-     local.set $24
-     local.get $22
-     local.get $24
+     local.set $55
+     local.get $53
+     local.get $55
      i64.shl
-     local.get $21
+     local.get $54
      f64.convert_i64_u
      i64.reinterpret_f64
-     local.get $24
+     local.get $55
      i64.const 52
      i64.shl
      i64.add
      f64.reinterpret_i64
-     local.get $23
+     local.get $52
      f64.convert_i64_u
      f64.div
      i64.trunc_f64_u
      i64.add
-     local.set $19
-     local.get $20
-     local.get $24
+     local.set $46
+     local.get $47
+     local.get $55
      i64.sub
-     local.set $20
-     local.get $19
+     local.set $47
+     local.get $46
      f64.convert_i64_u
-     local.get $20
+     local.get $47
      i32.wrap_i64
      call $~lib/math/NativeMath.scalbn
      br $~lib/util/string/scientific|inlined.0
     else
-     local.get $18
-     local.set $19
-     local.get $17
-     local.set $14
-     local.get $19
+     local.get $38
+     local.set $57
+     local.get $37
+     local.set $56
+     local.get $57
      i64.ctz
-     local.set $24
-     local.get $19
-     local.get $24
+     local.set $58
+     local.get $57
+     local.get $58
      i64.shr_u
-     local.set $19
-     local.get $24
-     local.get $14
+     local.set $57
+     local.get $58
+     local.get $56
      i64.extend_i32_s
      i64.add
-     local.set $24
-     local.get $24
+     local.set $58
+     local.get $58
      global.set $~lib/util/string/__fixmulShift
      loop $for-loop|7
-      local.get $14
+      local.get $56
       i32.const 13
       i32.ge_s
-      local.set $13
-      local.get $13
+      local.set $59
+      local.get $59
       if
-       local.get $19
-       local.set $20
+       local.get $57
+       local.set $61
        i32.const 1220703125
-       local.set $15
-       local.get $20
+       local.set $60
+       local.get $61
        i64.const 4294967295
        i64.and
-       local.get $15
+       local.get $60
        i64.extend_i32_u
        i64.mul
-       local.set $21
-       local.get $20
+       local.set $62
+       local.get $61
        i64.const 32
        i64.shr_u
-       local.get $15
+       local.get $60
        i64.extend_i32_u
        i64.mul
-       local.get $21
+       local.get $62
        i64.const 32
        i64.shr_u
        i64.add
-       local.set $22
-       local.get $22
+       local.set $63
+       local.get $63
        i64.const 32
        i64.shr_u
        i32.wrap_i64
-       local.set $6
-       local.get $6
+       local.set $64
+       local.get $64
        i32.clz
-       local.set $12
+       local.set $65
        i64.const 32
-       local.get $12
+       local.get $65
        i64.extend_i32_u
        i64.sub
-       local.set $23
+       local.set $66
        global.get $~lib/util/string/__fixmulShift
-       local.get $23
+       local.get $66
        i64.add
        global.set $~lib/util/string/__fixmulShift
-       local.get $22
-       local.get $12
+       local.get $63
+       local.get $65
        i64.extend_i32_u
        i64.shl
-       local.get $21
+       local.get $62
        i64.const 4294967295
        i64.and
-       local.get $23
+       local.get $66
        i64.shr_u
        i64.or
-       local.get $21
-       local.get $12
+       local.get $62
+       local.get $65
        i64.extend_i32_u
        i64.shl
        i64.const 31
@@ -6576,67 +6822,67 @@
        i64.const 1
        i64.and
        i64.add
-       local.set $19
-       local.get $14
+       local.set $57
+       local.get $56
        i32.const 13
        i32.sub
-       local.set $14
+       local.set $56
        br $for-loop|7
       end
      end
-     local.get $19
-     local.set $20
+     local.get $57
+     local.set $68
      i32.const 5
-     local.get $14
+     local.get $56
      call $~lib/math/ipow32
-     local.set $16
-     local.get $20
+     local.set $67
+     local.get $68
      i64.const 4294967295
      i64.and
-     local.get $16
+     local.get $67
      i64.extend_i32_u
      i64.mul
-     local.set $23
-     local.get $20
+     local.set $69
+     local.get $68
      i64.const 32
      i64.shr_u
-     local.get $16
+     local.get $67
      i64.extend_i32_u
      i64.mul
-     local.get $23
+     local.get $69
      i64.const 32
      i64.shr_u
      i64.add
-     local.set $22
-     local.get $22
+     local.set $70
+     local.get $70
      i64.const 32
      i64.shr_u
      i32.wrap_i64
-     local.set $13
-     local.get $13
+     local.set $71
+     local.get $71
      i32.clz
-     local.set $12
+     local.set $72
      i64.const 32
-     local.get $12
+     local.get $72
      i64.extend_i32_u
      i64.sub
-     local.set $21
+     local.set $73
      global.get $~lib/util/string/__fixmulShift
-     local.get $21
+     local.get $73
      i64.add
      global.set $~lib/util/string/__fixmulShift
-     local.get $22
-     local.get $12
+     local.get $70
+     local.get $72
      i64.extend_i32_u
      i64.shl
-     local.get $23
+     local.get $69
      i64.const 4294967295
      i64.and
-     local.get $21
+     local.get $73
      i64.shr_u
      i64.or
-     local.get $23
-     local.get $12
+     local.get $69
+     local.get $72
      i64.extend_i32_u
      i64.shl
      i64.const 31
@@ -6644,12 +6890,12 @@
      i64.const 1
      i64.and
      i64.add
-     local.set $19
+     local.set $57
      global.get $~lib/util/string/__fixmulShift
-     local.set $24
-     local.get $19
+     local.set $58
+     local.get $57
      f64.convert_i64_u
-     local.get $24
+     local.get $58
      i32.wrap_i64
      call $~lib/math/NativeMath.scalbn
      br $~lib/util/string/scientific|inlined.0
@@ -6660,10 +6906,10 @@
   end
   local.get $5
   f64.copysign
-  local.set $2
+  local.set $74
   local.get $0
   call $~lib/rt/pure/__release
-  local.get $2
+  local.get $74
  )
  (func $~lib/string/parseFloat (param $0 i32) (result f64)
   (local $1 f64)
@@ -6684,6 +6930,8 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
   local.get $1
   call $~lib/rt/pure/__retain
   local.set $1
@@ -6726,32 +6974,32 @@
   if
    i32.const 272
    call $~lib/rt/pure/__retain
-   local.set $2
+   local.set $7
    local.get $1
    call $~lib/rt/pure/__release
-   local.get $2
+   local.get $7
    return
   end
   local.get $6
   i32.const 1
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
-  local.set $7
-  local.get $7
+  local.set $8
+  local.get $8
   local.get $0
   local.get $4
   call $~lib/memory/memory.copy
-  local.get $7
+  local.get $8
   local.get $4
   i32.add
   local.get $1
   local.get $5
   call $~lib/memory/memory.copy
-  local.get $7
-  local.set $2
+  local.get $8
+  local.set $9
   local.get $1
   call $~lib/rt/pure/__release
-  local.get $2
+  local.get $9
  )
  (func $~lib/string/String.__concat (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
@@ -6800,6 +7048,10 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $0
@@ -6840,27 +7092,27 @@
   i32.eqz
   if
    i32.const 0
-   local.set $2
+   local.set $4
    local.get $0
    call $~lib/rt/pure/__release
    local.get $1
    call $~lib/rt/pure/__release
-   local.get $2
+   local.get $4
    return
   end
   local.get $1
   call $~lib/string/String#get:length
-  local.set $4
-  local.get $4
+  local.set $5
+  local.get $5
   i32.eqz
   if
    i32.const 1
-   local.set $2
+   local.set $6
    local.get $0
    call $~lib/rt/pure/__release
    local.get $1
    call $~lib/rt/pure/__release
-   local.get $2
+   local.get $6
    return
   end
   local.get $0
@@ -6868,28 +7120,32 @@
   local.get $1
   i32.const 0
   local.get $3
-  local.tee $2
-  local.get $4
-  local.tee $5
-  local.get $2
+  local.tee $7
   local.get $5
+  local.tee $8
+  local.get $7
+  local.get $8
   i32.lt_s
   select
   call $~lib/util/string/compareImpl
   i32.const 0
   i32.gt_s
-  local.set $2
+  local.set $9
   local.get $0
   call $~lib/rt/pure/__release
   local.get $1
   call $~lib/rt/pure/__release
-  local.get $2
+  local.get $9
  )
  (func $~lib/string/String.__lt (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $0
@@ -6930,50 +7186,50 @@
   i32.eqz
   if
    i32.const 0
-   local.set $2
+   local.set $4
    local.get $0
    call $~lib/rt/pure/__release
    local.get $1
    call $~lib/rt/pure/__release
-   local.get $2
+   local.get $4
    return
   end
   local.get $0
   call $~lib/string/String#get:length
-  local.set $4
-  local.get $4
+  local.set $5
+  local.get $5
   i32.eqz
   if
    i32.const 1
-   local.set $2
+   local.set $6
    local.get $0
    call $~lib/rt/pure/__release
    local.get $1
    call $~lib/rt/pure/__release
-   local.get $2
+   local.get $6
    return
   end
   local.get $0
   i32.const 0
   local.get $1
   i32.const 0
-  local.get $4
-  local.tee $2
-  local.get $3
-  local.tee $5
-  local.get $2
   local.get $5
+  local.tee $7
+  local.get $3
+  local.tee $8
+  local.get $7
+  local.get $8
   i32.lt_s
   select
   call $~lib/util/string/compareImpl
   i32.const 0
   i32.lt_s
-  local.set $2
+  local.set $9
   local.get $0
   call $~lib/rt/pure/__release
   local.get $1
   call $~lib/rt/pure/__release
-  local.get $2
+  local.get $9
  )
  (func $~lib/string/String.__gte (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
@@ -7091,6 +7347,8 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
   local.get $1
   call $~lib/rt/pure/__retain
   local.set $1
@@ -7141,42 +7399,42 @@
   if
    local.get $2
    call $~lib/string/String#get:length
-   local.set $5
+   local.set $7
    local.get $3
    local.get $4
    i32.sub
    local.set $3
    local.get $3
-   local.get $5
-   i32.add
-   local.set $7
    local.get $7
+   i32.add
+   local.set $8
+   local.get $8
    if
-    local.get $7
+    local.get $8
     i32.const 1
     i32.shl
     i32.const 1
     call $~lib/rt/tlsf/__alloc
-    local.set $8
-    local.get $8
+    local.set $9
+    local.get $9
     local.get $0
     local.get $6
     i32.const 1
     i32.shl
     call $~lib/memory/memory.copy
-    local.get $8
+    local.get $9
     local.get $6
     i32.const 1
     i32.shl
     i32.add
     local.get $2
-    local.get $5
+    local.get $7
     i32.const 1
     i32.shl
     call $~lib/memory/memory.copy
-    local.get $8
+    local.get $9
     local.get $6
-    local.get $5
+    local.get $7
     i32.add
     i32.const 1
     i32.shl
@@ -7194,25 +7452,25 @@
     i32.const 1
     i32.shl
     call $~lib/memory/memory.copy
-    local.get $8
+    local.get $9
     call $~lib/rt/pure/__retain
-    local.set $9
+    local.set $10
     local.get $1
     call $~lib/rt/pure/__release
     local.get $2
     call $~lib/rt/pure/__release
-    local.get $9
+    local.get $10
     return
    end
   end
   local.get $0
   call $~lib/rt/pure/__retain
-  local.set $7
+  local.set $11
   local.get $1
   call $~lib/rt/pure/__release
   local.get $2
   call $~lib/rt/pure/__release
-  local.get $7
+  local.get $11
  )
  (func $~lib/rt/tlsf/checkUsedBlock (param $0 i32) (result i32)
   (local $1 i32)
@@ -7287,6 +7545,7 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
   local.get $2
   call $~lib/rt/tlsf/prepareSize
   local.set $3
@@ -7344,8 +7603,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $5
-   local.get $5
+   local.set $8
+   local.get $8
    local.get $3
    i32.ge_u
    if
@@ -7356,7 +7615,7 @@
     local.get $4
     i32.const 3
     i32.and
-    local.get $5
+    local.get $8
     i32.or
     i32.store
     local.get $1
@@ -7375,12 +7634,12 @@
   local.get $1
   i32.load offset=8
   call $~lib/rt/tlsf/allocateBlock
-  local.set $8
-  local.get $8
+  local.set $9
+  local.get $9
   local.get $1
   i32.load offset=4
   i32.store offset=4
-  local.get $8
+  local.get $9
   i32.const 16
   i32.add
   local.get $1
@@ -7395,13 +7654,13 @@
    i32.const 1
    drop
    local.get $1
-   local.get $8
+   local.get $9
    call $~lib/rt/rtrace/onrealloc
    local.get $0
    local.get $1
    call $~lib/rt/tlsf/freeBlock
   end
-  local.get $8
+  local.get $9
  )
  (func $~lib/rt/tlsf/__realloc (param $0 i32) (param $1 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
@@ -7426,6 +7685,20 @@
   (local $13 i32)
   (local $14 i32)
   (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local $22 i32)
+  (local $23 i32)
+  (local $24 i32)
+  (local $25 i32)
+  (local $26 i32)
+  (local $27 i32)
+  (local $28 i32)
+  (local $29 i32)
   local.get $1
   call $~lib/rt/pure/__retain
   local.set $1
@@ -7476,12 +7749,12 @@
    if
     local.get $0
     call $~lib/rt/pure/__retain
-    local.set $5
+    local.set $7
     local.get $1
     call $~lib/rt/pure/__release
     local.get $2
     call $~lib/rt/pure/__release
-    local.get $5
+    local.get $7
     return
    end
    local.get $3
@@ -7495,43 +7768,43 @@
    i32.shl
    i32.const 1
    call $~lib/rt/tlsf/__alloc
-   local.set $5
-   local.get $5
+   local.set $8
+   local.get $8
    local.get $2
    local.get $6
    i32.const 1
    i32.shl
    call $~lib/memory/memory.copy
    local.get $6
-   local.set $7
+   local.set $9
    i32.const 0
-   local.set $8
+   local.set $10
    loop $for-loop|0
-    local.get $8
+    local.get $10
     local.get $3
     i32.lt_u
-    local.set $9
-    local.get $9
+    local.set $11
+    local.get $11
     if
-     local.get $5
-     local.get $7
-     local.tee $10
+     local.get $8
+     local.get $9
+     local.tee $12
      i32.const 1
      i32.add
-     local.set $7
-     local.get $10
+     local.set $9
+     local.get $12
      i32.const 1
      i32.shl
      i32.add
      local.get $0
-     local.get $8
+     local.get $10
      i32.const 1
      i32.shl
      i32.add
      i32.load16_u
      i32.store16
-     local.get $5
-     local.get $7
+     local.get $8
+     local.get $9
      i32.const 1
      i32.shl
      i32.add
@@ -7540,31 +7813,31 @@
      i32.const 1
      i32.shl
      call $~lib/memory/memory.copy
-     local.get $7
+     local.get $9
      local.get $6
      i32.add
-     local.set $7
-     local.get $8
+     local.set $9
+     local.get $10
      i32.const 1
      i32.add
-     local.set $8
+     local.set $10
      br $for-loop|0
     end
    end
-   local.get $5
+   local.get $8
    call $~lib/rt/pure/__retain
-   local.set $8
+   local.set $13
    local.get $1
    call $~lib/rt/pure/__release
    local.get $2
    call $~lib/rt/pure/__release
-   local.get $8
+   local.get $13
    return
   end
   i32.const 0
-  local.set $11
+  local.set $14
   i32.const 0
-  local.set $12
+  local.set $15
   local.get $4
   local.get $6
   i32.eq
@@ -7572,28 +7845,28 @@
    local.get $3
    i32.const 1
    i32.shl
-   local.set $7
-   local.get $7
+   local.set $16
+   local.get $16
    i32.const 1
    call $~lib/rt/tlsf/__alloc
-   local.set $5
-   local.get $5
+   local.set $17
+   local.get $17
    local.get $0
-   local.get $7
+   local.get $16
    call $~lib/memory/memory.copy
    loop $while-continue|1
     local.get $0
     local.get $1
-    local.get $11
+    local.get $14
     call $~lib/string/String#indexOf
-    local.tee $12
+    local.tee $15
     i32.const -1
     i32.xor
-    local.set $8
-    local.get $8
+    local.set $18
+    local.get $18
     if
-     local.get $5
-     local.get $12
+     local.get $17
+     local.get $15
      i32.const 1
      i32.shl
      i32.add
@@ -7602,41 +7875,41 @@
      i32.const 1
      i32.shl
      call $~lib/memory/memory.copy
-     local.get $12
+     local.get $15
      local.get $4
      i32.add
-     local.set $11
+     local.set $14
      br $while-continue|1
     end
    end
-   local.get $5
+   local.get $17
    call $~lib/rt/pure/__retain
-   local.set $8
+   local.set $19
    local.get $1
    call $~lib/rt/pure/__release
    local.get $2
    call $~lib/rt/pure/__release
-   local.get $8
+   local.get $19
    return
   end
   i32.const 0
-  local.set $13
+  local.set $20
   i32.const 0
-  local.set $14
+  local.set $21
   local.get $3
-  local.set $15
+  local.set $22
   loop $while-continue|2
    local.get $0
    local.get $1
-   local.get $11
+   local.get $14
    call $~lib/string/String#indexOf
-   local.tee $12
+   local.tee $15
    i32.const -1
    i32.xor
-   local.set $5
-   local.get $5
+   local.set $23
+   local.get $23
    if
-    local.get $13
+    local.get $20
     i32.eqz
     if
      local.get $3
@@ -7644,49 +7917,49 @@
      i32.shl
      i32.const 1
      call $~lib/rt/tlsf/__alloc
-     local.set $13
+     local.set $20
     end
-    local.get $14
-    local.get $15
+    local.get $21
+    local.get $22
     i32.gt_u
     if
-     local.get $15
+     local.get $22
      i32.const 1
      i32.shl
-     local.set $7
-     local.get $13
-     local.get $7
+     local.set $24
+     local.get $20
+     local.get $24
      i32.const 1
      i32.shl
      call $~lib/rt/tlsf/__realloc
-     local.set $13
-     local.get $7
-     local.set $15
+     local.set $20
+     local.get $24
+     local.set $22
     end
-    local.get $12
-    local.get $11
-    i32.sub
-    local.set $7
-    local.get $13
+    local.get $15
     local.get $14
+    i32.sub
+    local.set $25
+    local.get $20
+    local.get $21
     i32.const 1
     i32.shl
     i32.add
     local.get $0
-    local.get $11
+    local.get $14
     i32.const 1
     i32.shl
     i32.add
-    local.get $7
+    local.get $25
     i32.const 1
     i32.shl
     call $~lib/memory/memory.copy
-    local.get $14
-    local.get $7
+    local.get $21
+    local.get $25
     i32.add
-    local.set $14
-    local.get $13
-    local.get $14
+    local.set $21
+    local.get $20
+    local.get $21
     i32.const 1
     i32.shl
     i32.add
@@ -7695,96 +7968,102 @@
     i32.const 1
     i32.shl
     call $~lib/memory/memory.copy
-    local.get $14
+    local.get $21
     local.get $6
     i32.add
-    local.set $14
-    local.get $12
+    local.set $21
+    local.get $15
     local.get $4
     i32.add
-    local.set $11
+    local.set $14
     br $while-continue|2
    end
   end
-  local.get $14
+  local.get $21
   if
-   local.get $14
-   local.get $15
+   local.get $21
+   local.get $22
    i32.gt_u
    if
-    local.get $15
+    local.get $22
     i32.const 1
     i32.shl
-    local.set $5
-    local.get $13
-    local.get $5
+    local.set $26
+    local.get $20
+    local.get $26
     i32.const 1
     i32.shl
     call $~lib/rt/tlsf/__realloc
-    local.set $13
-    local.get $5
-    local.set $15
+    local.set $20
+    local.get $26
+    local.set $22
    end
    local.get $3
-   local.get $11
+   local.get $14
    i32.sub
-   local.set $5
-   local.get $5
+   local.set $27
+   local.get $27
    if
-    local.get $13
-    local.get $14
+    local.get $20
+    local.get $21
     i32.const 1
     i32.shl
     i32.add
     local.get $0
-    local.get $11
+    local.get $14
     i32.const 1
     i32.shl
     i32.add
-    local.get $5
+    local.get $27
     i32.const 1
     i32.shl
     call $~lib/memory/memory.copy
    end
-   local.get $5
-   local.get $14
+   local.get $27
+   local.get $21
    i32.add
-   local.set $5
-   local.get $15
-   local.get $5
+   local.set $27
+   local.get $22
+   local.get $27
    i32.gt_u
    if
-    local.get $13
-    local.get $5
+    local.get $20
+    local.get $27
     i32.const 1
     i32.shl
     call $~lib/rt/tlsf/__realloc
-    local.set $13
+    local.set $20
    end
-   local.get $13
+   local.get $20
    call $~lib/rt/pure/__retain
-   local.set $8
+   local.set $28
    local.get $1
    call $~lib/rt/pure/__release
    local.get $2
    call $~lib/rt/pure/__release
-   local.get $8
+   local.get $28
    return
   end
   local.get $0
   call $~lib/rt/pure/__retain
-  local.set $5
+  local.set $29
   local.get $1
   call $~lib/rt/pure/__release
   local.get $2
   call $~lib/rt/pure/__release
-  local.get $5
+  local.get $29
  )
  (func $~lib/string/String#slice (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
   local.get $0
   call $~lib/string/String#get:length
   local.set $3
@@ -7804,11 +8083,11 @@
    select
   else
    local.get $1
-   local.tee $4
+   local.tee $6
    local.get $3
-   local.tee $5
-   local.get $4
-   local.get $5
+   local.tee $7
+   local.get $6
+   local.get $7
    i32.lt_s
    select
   end
@@ -7820,20 +8099,20 @@
    local.get $2
    local.get $3
    i32.add
-   local.tee $4
+   local.tee $8
    i32.const 0
-   local.tee $5
-   local.get $4
-   local.get $5
+   local.tee $9
+   local.get $8
+   local.get $9
    i32.gt_s
    select
   else
    local.get $2
-   local.tee $4
+   local.tee $10
    local.get $3
-   local.tee $5
-   local.get $4
-   local.get $5
+   local.tee $11
+   local.get $10
+   local.get $11
    i32.lt_s
    select
   end
@@ -7855,8 +8134,8 @@
   i32.shl
   i32.const 1
   call $~lib/rt/tlsf/__alloc
-  local.set $6
-  local.get $6
+  local.set $12
+  local.get $12
   local.get $0
   local.get $1
   i32.const 1
@@ -7866,7 +8145,7 @@
   i32.const 1
   i32.shl
   call $~lib/memory/memory.copy
-  local.get $6
+  local.get $12
   call $~lib/rt/pure/__retain
  )
  (func $~lib/string/String#substr (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -7877,6 +8156,10 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
   local.get $1
   local.set $3
   local.get $2
@@ -7901,26 +8184,26 @@
    local.set $3
   end
   local.get $4
-  local.tee $6
+  local.tee $8
   i32.const 0
-  local.tee $7
-  local.get $6
-  local.get $7
+  local.tee $9
+  local.get $8
+  local.get $9
   i32.gt_s
   select
-  local.tee $6
+  local.tee $10
   local.get $5
   local.get $3
   i32.sub
-  local.tee $7
-  local.get $6
-  local.get $7
+  local.tee $11
+  local.get $10
+  local.get $11
   i32.lt_s
   select
   i32.const 1
   i32.shl
-  local.set $8
-  local.get $8
+  local.set $12
+  local.get $12
   i32.const 0
   i32.le_s
   if
@@ -7928,19 +8211,19 @@
    call $~lib/rt/pure/__retain
    return
   end
-  local.get $8
+  local.get $12
   i32.const 1
   call $~lib/rt/tlsf/__alloc
-  local.set $9
-  local.get $9
+  local.set $13
+  local.get $13
   local.get $0
   local.get $3
   i32.const 1
   i32.shl
   i32.add
-  local.get $8
+  local.get $12
   call $~lib/memory/memory.copy
-  local.get $9
+  local.get $13
   call $~lib/rt/pure/__retain
  )
  (func $~lib/string/String#substring (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -7953,6 +8236,16 @@
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
   local.get $0
   call $~lib/string/String#get:length
   local.set $3
@@ -7964,67 +8257,67 @@
   local.get $5
   i32.gt_s
   select
-  local.tee $4
+  local.tee $6
   local.get $3
-  local.tee $5
-  local.get $4
-  local.get $5
-  i32.lt_s
-  select
-  local.set $6
-  local.get $2
-  local.tee $4
-  i32.const 0
-  local.tee $5
-  local.get $4
-  local.get $5
-  i32.gt_s
-  select
-  local.tee $4
-  local.get $3
-  local.tee $5
-  local.get $4
-  local.get $5
-  i32.lt_s
-  select
-  local.set $7
+  local.tee $7
   local.get $6
-  local.tee $4
   local.get $7
-  local.tee $5
-  local.get $4
-  local.get $5
   i32.lt_s
   select
-  i32.const 1
-  i32.shl
   local.set $8
-  local.get $6
-  local.tee $4
-  local.get $7
-  local.tee $5
-  local.get $4
-  local.get $5
+  local.get $2
+  local.tee $9
+  i32.const 0
+  local.tee $10
+  local.get $9
+  local.get $10
+  i32.gt_s
+  select
+  local.tee $11
+  local.get $3
+  local.tee $12
+  local.get $11
+  local.get $12
+  i32.lt_s
+  select
+  local.set $13
+  local.get $8
+  local.tee $14
+  local.get $13
+  local.tee $15
+  local.get $14
+  local.get $15
+  i32.lt_s
+  select
+  i32.const 1
+  i32.shl
+  local.set $16
+  local.get $8
+  local.tee $17
+  local.get $13
+  local.tee $18
+  local.get $17
+  local.get $18
   i32.gt_s
   select
   i32.const 1
   i32.shl
-  local.set $9
-  local.get $9
-  local.get $8
+  local.set $19
+  local.get $19
+  local.get $16
   i32.sub
-  local.set $10
-  local.get $10
+  local.set $20
+  local.get $20
   i32.eqz
   if
    i32.const 272
    call $~lib/rt/pure/__retain
    return
   end
-  local.get $8
+  local.get $16
   i32.eqz
   if (result i32)
-   local.get $9
+   local.get $19
    local.get $3
    i32.const 1
    i32.shl
@@ -8037,17 +8330,17 @@
    call $~lib/rt/pure/__retain
    return
   end
-  local.get $10
+  local.get $20
   i32.const 1
   call $~lib/rt/tlsf/__alloc
-  local.set $11
-  local.get $11
+  local.set $21
+  local.get $21
   local.get $0
-  local.get $8
+  local.get $16
   i32.add
-  local.get $10
+  local.get $20
   call $~lib/memory/memory.copy
-  local.get $11
+  local.get $21
   call $~lib/rt/pure/__retain
  )
  (func $~lib/rt/__allocBuffer (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -8423,6 +8716,23 @@
   (local $12 i32)
   (local $13 i32)
   (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local $22 i32)
+  (local $23 i32)
+  (local $24 i32)
+  (local $25 i32)
+  (local $26 i32)
+  (local $27 i32)
+  (local $28 i32)
+  (local $29 i32)
+  (local $30 i32)
+  (local $31 i32)
   local.get $1
   call $~lib/rt/pure/__retain
   local.set $1
@@ -8451,27 +8761,27 @@
    i32.const 0
    call $~lib/rt/__allocArray
    call $~lib/rt/pure/__retain
-   local.set $3
-   local.get $3
-   i32.load offset=4
    local.set $4
    local.get $4
+   i32.load offset=4
+   local.set $5
+   local.get $5
    local.get $0
    call $~lib/rt/pure/__retain
    i32.store
-   local.get $3
-   local.set $4
+   local.get $4
+   local.set $6
    local.get $1
    call $~lib/rt/pure/__release
-   local.get $4
+   local.get $6
    return
   end
   local.get $0
   call $~lib/string/String#get:length
-  local.set $5
+  local.set $7
   local.get $1
   call $~lib/string/String#get:length
-  local.set $6
+  local.set $8
   local.get $2
   i32.const 0
   i32.lt_s
@@ -8479,10 +8789,10 @@
    global.get $~lib/builtins/i32.MAX_VALUE
    local.set $2
   end
-  local.get $6
+  local.get $8
   i32.eqz
   if
-   local.get $5
+   local.get $7
    i32.eqz
    if
     i32.const 0
@@ -8491,79 +8801,79 @@
     i32.const 0
     call $~lib/rt/__allocArray
     call $~lib/rt/pure/__retain
-    local.set $4
+    local.set $9
     local.get $1
     call $~lib/rt/pure/__release
-    local.get $4
+    local.get $9
     return
    end
-   local.get $5
-   local.tee $4
+   local.get $7
+   local.tee $10
    local.get $2
-   local.tee $3
-   local.get $4
-   local.get $3
+   local.tee $11
+   local.get $10
+   local.get $11
    i32.lt_s
    select
-   local.set $5
-   local.get $5
+   local.set $7
+   local.get $7
    i32.const 2
    i32.const 3
    i32.const 0
    call $~lib/rt/__allocArray
    call $~lib/rt/pure/__retain
-   local.set $4
-   local.get $4
+   local.set $12
+   local.get $12
    i32.load offset=4
-   local.set $3
+   local.set $13
    i32.const 0
-   local.set $7
+   local.set $14
    loop $for-loop|0
+    local.get $14
     local.get $7
-    local.get $5
     i32.lt_s
-    local.set $8
-    local.get $8
+    local.set $15
+    local.get $15
     if
      i32.const 2
      i32.const 1
      call $~lib/rt/tlsf/__alloc
-     local.set $9
-     local.get $9
+     local.set $16
+     local.get $16
      local.get $0
-     local.get $7
+     local.get $14
      i32.const 1
      i32.shl
      i32.add
      i32.load16_u
      i32.store16
-     local.get $3
-     local.get $7
+     local.get $13
+     local.get $14
      i32.const 2
      i32.shl
      i32.add
-     local.get $9
+     local.get $16
      i32.store
      i32.const 1
      drop
-     local.get $9
+     local.get $16
      call $~lib/rt/pure/__retain
      drop
-     local.get $7
+     local.get $14
      i32.const 1
      i32.add
-     local.set $7
+     local.set $14
      br $for-loop|0
     end
    end
-   local.get $4
-   local.set $7
+   local.get $12
+   local.set $17
    local.get $1
    call $~lib/rt/pure/__release
-   local.get $7
+   local.get $17
    return
   else
-   local.get $5
+   local.get $7
    i32.eqz
    if
     i32.const 1
@@ -8572,16 +8882,16 @@
     i32.const 0
     call $~lib/rt/__allocArray
     call $~lib/rt/pure/__retain
-    local.set $3
-    local.get $3
+    local.set $18
+    local.get $18
     i32.load offset=4
     i32.const 272
     i32.store
-    local.get $3
-    local.set $4
+    local.get $18
+    local.set $19
     local.get $1
     call $~lib/rt/pure/__release
-    local.get $4
+    local.get $19
     return
    end
   end
@@ -8591,132 +8901,132 @@
   i32.const 0
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $10
+  local.set $20
   i32.const 0
-  local.set $11
+  local.set $21
   i32.const 0
-  local.set $12
+  local.set $22
   i32.const 0
-  local.set $13
+  local.set $23
   loop $while-continue|1
    local.get $0
    local.get $1
-   local.get $12
+   local.get $22
    call $~lib/string/String#indexOf
-   local.tee $11
+   local.tee $21
    i32.const -1
    i32.xor
-   local.set $3
-   local.get $3
+   local.set $24
+   local.get $24
    if
-    local.get $11
-    local.get $12
+    local.get $21
+    local.get $22
     i32.sub
-    local.set $4
-    local.get $4
+    local.set $25
+    local.get $25
     i32.const 0
     i32.gt_s
     if
-     local.get $4
+     local.get $25
      i32.const 1
      i32.shl
      i32.const 1
      call $~lib/rt/tlsf/__alloc
-     local.set $7
-     local.get $7
+     local.set $26
+     local.get $26
      local.get $0
-     local.get $12
+     local.get $22
      i32.const 1
      i32.shl
      i32.add
-     local.get $4
+     local.get $25
      i32.const 1
      i32.shl
      call $~lib/memory/memory.copy
-     local.get $10
-     local.get $7
+     local.get $20
+     local.get $26
      call $~lib/array/Array<~lib/string/String>#push
      drop
     else
-     local.get $10
+     local.get $20
      i32.const 272
      call $~lib/array/Array<~lib/string/String>#push
      drop
     end
-    local.get $13
+    local.get $23
     i32.const 1
     i32.add
-    local.tee $13
+    local.tee $23
     local.get $2
     i32.eq
     if
-     local.get $10
-     local.set $7
+     local.get $20
+     local.set $27
      local.get $1
      call $~lib/rt/pure/__release
-     local.get $7
+     local.get $27
      return
     end
-    local.get $11
-    local.get $6
+    local.get $21
+    local.get $8
     i32.add
-    local.set $12
+    local.set $22
     br $while-continue|1
    end
   end
-  local.get $12
+  local.get $22
   i32.eqz
   if
-   local.get $10
+   local.get $20
    local.get $0
    call $~lib/array/Array<~lib/string/String>#push
    drop
-   local.get $10
-   local.set $3
+   local.get $20
+   local.set $28
    local.get $1
    call $~lib/rt/pure/__release
-   local.get $3
+   local.get $28
    return
   end
-  local.get $5
-  local.get $12
+  local.get $7
+  local.get $22
   i32.sub
-  local.set $14
-  local.get $14
+  local.set $29
+  local.get $29
   i32.const 0
   i32.gt_s
   if
-   local.get $14
+   local.get $29
    i32.const 1
    i32.shl
    i32.const 1
    call $~lib/rt/tlsf/__alloc
-   local.set $3
-   local.get $3
+   local.set $30
+   local.get $30
    local.get $0
-   local.get $12
+   local.get $22
    i32.const 1
    i32.shl
    i32.add
-   local.get $14
+   local.get $29
    i32.const 1
    i32.shl
    call $~lib/memory/memory.copy
-   local.get $10
-   local.get $3
+   local.get $20
+   local.get $30
    call $~lib/array/Array<~lib/string/String>#push
    drop
   else
-   local.get $10
+   local.get $20
    i32.const 272
    call $~lib/array/Array<~lib/string/String>#push
    drop
   end
-  local.get $10
-  local.set $3
+  local.get $20
+  local.set $31
   local.get $1
   call $~lib/rt/pure/__release
-  local.get $3
+  local.get $31
  )
  (func $~lib/array/Array<~lib/string/String>#get:length (param $0 i32) (result i32)
   local.get $0
@@ -8834,6 +9144,9 @@
   (local $9 i64)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
   loop $while-continue|0
    local.get $1
    i32.const 10000
@@ -8898,30 +9211,30 @@
    local.get $1
    i32.const 100
    i32.div_u
-   local.set $3
+   local.set $10
    local.get $1
    i32.const 100
    i32.rem_u
-   local.set $10
-   local.get $3
+   local.set $11
+   local.get $10
    local.set $1
    local.get $2
    i32.const 2
    i32.sub
    local.set $2
    i32.const 12524
-   local.get $10
+   local.get $11
    i32.const 2
    i32.shl
    i32.add
    i32.load
-   local.set $11
+   local.set $12
    local.get $0
    local.get $2
    i32.const 1
    i32.shl
    i32.add
-   local.get $11
+   local.get $12
    i32.store
   end
   local.get $1
@@ -8938,13 +9251,13 @@
    i32.shl
    i32.add
    i32.load
-   local.set $11
+   local.set $13
    local.get $0
    local.get $2
    i32.const 1
    i32.shl
    i32.add
-   local.get $11
+   local.get $13
    i32.store
   else
    local.get $2
@@ -8954,13 +9267,13 @@
    i32.const 48
    local.get $1
    i32.add
-   local.set $11
+   local.set $14
    local.get $0
    local.get $2
    i32.const 1
    i32.shl
    i32.add
-   local.get $11
+   local.get $14
    i32.store16
   end
  )
@@ -9249,7 +9562,10 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i64)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i64)
+  (local $10 i32)
   local.get $0
   i64.const 0
   i64.ne
@@ -9292,26 +9608,26 @@
   else
    local.get $0
    call $~lib/util/number/decimalCount64High
-   local.set $3
-   local.get $3
+   local.set $7
+   local.get $7
    i32.const 1
    i32.shl
    i32.const 1
    call $~lib/rt/tlsf/__alloc
    local.set $1
    local.get $1
-   local.set $5
+   local.set $10
    local.get $0
-   local.set $7
-   local.get $3
-   local.set $4
+   local.set $9
+   local.get $7
+   local.set $8
    i32.const 0
    i32.const 1
    i32.ge_s
    drop
-   local.get $5
-   local.get $7
-   local.get $4
+   local.get $10
+   local.get $9
+   local.get $8
    call $~lib/util/number/utoa64_lut
   end
   local.get $1
@@ -9325,7 +9641,10 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i64)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i64)
+  (local $11 i32)
   local.get $0
   i64.const 0
   i64.ne
@@ -9384,26 +9703,26 @@
    call $~lib/util/number/decimalCount64High
    local.get $1
    i32.add
-   local.set $4
-   local.get $4
+   local.set $8
+   local.get $8
    i32.const 1
    i32.shl
    i32.const 1
    call $~lib/rt/tlsf/__alloc
    local.set $2
    local.get $2
-   local.set $6
+   local.set $11
    local.get $0
-   local.set $8
-   local.get $4
-   local.set $5
+   local.set $10
+   local.get $8
+   local.set $9
    i32.const 0
    i32.const 1
    i32.ge_s
    drop
-   local.get $6
-   local.get $8
-   local.get $5
+   local.get $11
+   local.get $10
+   local.get $9
    call $~lib/util/number/utoa64_lut
   end
   local.get $1
@@ -9428,16 +9747,31 @@
   (local $16 i32)
   (local $17 i32)
   (local $18 i32)
-  (local $19 i64)
+  (local $19 i32)
   (local $20 i64)
   (local $21 i64)
   (local $22 i64)
   (local $23 i64)
-  (local $24 i32)
+  (local $24 i64)
   (local $25 i32)
   (local $26 i32)
   (local $27 i32)
-  (local $28 i64)
+  (local $28 i32)
+  (local $29 i32)
+  (local $30 i32)
+  (local $31 i32)
+  (local $32 i64)
+  (local $33 i32)
+  (local $34 i64)
+  (local $35 i64)
+  (local $36 i64)
+  (local $37 i64)
+  (local $38 i32)
+  (local $39 i32)
+  (local $40 i32)
+  (local $41 i32)
+  (local $42 i32)
+  (local $43 i32)
   i32.const 0
   local.get $4
   i32.sub
@@ -9641,11 +9975,11 @@
     if
      local.get $0
      local.get $15
-     local.tee $18
+     local.tee $19
      i32.const 1
      i32.add
      local.set $15
-     local.get $18
+     local.get $19
      i32.const 1
      i32.shl
      i32.add
@@ -9667,8 +10001,8 @@
     i64.shl
     local.get $13
     i64.add
-    local.set $19
-    local.get $19
+    local.set $20
+    local.get $20
     local.get $5
     i64.le_u
     if
@@ -9677,13 +10011,13 @@
      i32.add
      global.set $~lib/util/number/_K
      local.get $0
-     local.set $24
+     local.set $26
      local.get $15
-     local.set $18
+     local.set $25
      local.get $5
+     local.set $24
+     local.get $20
      local.set $23
-     local.get $19
-     local.set $22
      i32.const 15592
      local.get $14
      i32.const 2
@@ -9693,71 +10027,71 @@
      local.get $7
      i64.extend_i32_s
      i64.shl
-     local.set $21
+     local.set $22
      local.get $10
-     local.set $20
-     local.get $24
-     local.get $18
+     local.set $21
+     local.get $26
+     local.get $25
      i32.const 1
      i32.sub
      i32.const 1
      i32.shl
      i32.add
-     local.set $25
-     local.get $25
+     local.set $27
+     local.get $27
      i32.load16_u
-     local.set $26
+     local.set $28
      loop $while-continue|3
-      local.get $22
-      local.get $20
+      local.get $23
+      local.get $21
       i64.lt_u
       if (result i32)
+       local.get $24
        local.get $23
-       local.get $22
        i64.sub
-       local.get $21
+       local.get $22
        i64.ge_u
       else
        i32.const 0
       end
       if (result i32)
+       local.get $23
        local.get $22
-       local.get $21
        i64.add
-       local.get $20
+       local.get $21
        i64.lt_u
        if (result i32)
         i32.const 1
        else
-        local.get $20
-        local.get $22
-        i64.sub
-        local.get $22
         local.get $21
+        local.get $23
+        i64.sub
+        local.get $23
+        local.get $22
         i64.add
-        local.get $20
+        local.get $21
         i64.sub
         i64.gt_u
        end
       else
        i32.const 0
       end
-      local.set $27
-      local.get $27
+      local.set $30
+      local.get $30
       if
-       local.get $26
+       local.get $28
        i32.const 1
        i32.sub
-       local.set $26
+       local.set $28
+       local.get $23
        local.get $22
-       local.get $21
        i64.add
-       local.set $22
+       local.set $23
        br $while-continue|3
       end
      end
-     local.get $25
-     local.get $26
+     local.get $27
+     local.get $28
      i32.store16
      local.get $15
      return
@@ -9767,8 +10101,8 @@
   end
   loop $while-continue|4
    i32.const 1
-   local.set $16
-   local.get $16
+   local.set $31
+   local.get $31
    if
     local.get $13
     i64.const 10
@@ -9782,8 +10116,8 @@
     local.get $7
     i64.extend_i32_s
     i64.shr_u
-    local.set $23
-    local.get $23
+    local.set $32
+    local.get $32
     local.get $15
     i64.extend_i32_s
     i64.or
@@ -9792,16 +10126,16 @@
     if
      local.get $0
      local.get $15
-     local.tee $26
+     local.tee $33
      i32.const 1
      i32.add
      local.set $15
-     local.get $26
+     local.get $33
      i32.const 1
      i32.shl
      i32.add
      i32.const 48
-     local.get $23
+     local.get $32
      i32.wrap_i64
      i32.const 65535
      i32.and
@@ -9836,79 +10170,79 @@
      i64.mul
      local.set $10
      local.get $0
-     local.set $18
+     local.set $39
      local.get $15
-     local.set $27
+     local.set $38
      local.get $5
-     local.set $28
+     local.set $37
      local.get $13
-     local.set $22
+     local.set $36
      local.get $8
-     local.set $21
+     local.set $35
      local.get $10
-     local.set $20
-     local.get $18
-     local.get $27
+     local.set $34
+     local.get $39
+     local.get $38
      i32.const 1
      i32.sub
      i32.const 1
      i32.shl
      i32.add
-     local.set $26
-     local.get $26
+     local.set $40
+     local.get $40
      i32.load16_u
-     local.set $25
+     local.set $41
      loop $while-continue|6
-      local.get $22
-      local.get $20
+      local.get $36
+      local.get $34
       i64.lt_u
       if (result i32)
-       local.get $28
-       local.get $22
+       local.get $37
+       local.get $36
        i64.sub
-       local.get $21
+       local.get $35
        i64.ge_u
       else
        i32.const 0
       end
       if (result i32)
-       local.get $22
-       local.get $21
+       local.get $36
+       local.get $35
        i64.add
-       local.get $20
+       local.get $34
        i64.lt_u
        if (result i32)
         i32.const 1
        else
-        local.get $20
-        local.get $22
+        local.get $34
+        local.get $36
         i64.sub
-        local.get $22
-        local.get $21
+        local.get $36
+        local.get $35
         i64.add
-        local.get $20
+        local.get $34
         i64.sub
         i64.gt_u
        end
       else
        i32.const 0
       end
-      local.set $24
-      local.get $24
+      local.set $43
+      local.get $43
       if
-       local.get $25
+       local.get $41
        i32.const 1
        i32.sub
-       local.set $25
-       local.get $22
-       local.get $21
+       local.set $41
+       local.get $36
+       local.get $35
        i64.add
-       local.set $22
+       local.set $36
        br $while-continue|6
       end
      end
-     local.get $26
-     local.get $25
+     local.get $40
+     local.get $41
      i32.store16
      local.get $15
      return
@@ -9928,6 +10262,19 @@
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local $22 i32)
+  (local $23 i32)
+  (local $24 i32)
   local.get $2
   i32.eqz
   if
@@ -10017,11 +10364,11 @@
     i32.const 1
     i32.shl
     i32.add
-    local.set $4
-    local.get $4
+    local.set $6
+    local.get $6
     i32.const 2
     i32.add
-    local.get $4
+    local.get $6
     i32.const 0
     local.get $2
     i32.sub
@@ -10054,9 +10401,9 @@
      i32.const 2
      local.get $3
      i32.sub
-     local.set $4
+     local.set $7
      local.get $0
-     local.get $4
+     local.get $7
      i32.const 1
      i32.shl
      i32.add
@@ -10073,30 +10420,30 @@
      i32.or
      i32.store
      i32.const 2
-     local.set $5
+     local.set $8
      loop $for-loop|1
-      local.get $5
-      local.get $4
+      local.get $8
+      local.get $7
       i32.lt_s
-      local.set $6
-      local.get $6
+      local.set $9
+      local.get $9
       if
        local.get $0
-       local.get $5
+       local.get $8
        i32.const 1
        i32.shl
        i32.add
        i32.const 48
        i32.store16
-       local.get $5
+       local.get $8
        i32.const 1
        i32.add
-       local.set $5
+       local.set $8
        br $for-loop|1
       end
      end
      local.get $1
-     local.get $4
+     local.get $7
      i32.add
      return
     else
@@ -10110,48 +10457,48 @@
       local.get $0
       i32.const 4
       i32.add
-      local.set $5
+      local.set $11
       local.get $3
       i32.const 1
       i32.sub
-      local.set $6
-      local.get $6
+      local.set $10
+      local.get $10
       i32.const 0
       i32.lt_s
-      local.set $4
-      local.get $4
+      local.set $12
+      local.get $12
       if
        i32.const 0
-       local.get $6
+       local.get $10
        i32.sub
-       local.set $6
+       local.set $10
       end
-      local.get $6
+      local.get $10
       call $~lib/util/number/decimalCount32
       i32.const 1
       i32.add
-      local.set $7
-      local.get $5
-      local.set $10
-      local.get $6
-      local.set $9
-      local.get $7
-      local.set $8
+      local.set $13
+      local.get $11
+      local.set $16
+      local.get $10
+      local.set $15
+      local.get $13
+      local.set $14
       i32.const 0
       i32.const 1
       i32.ge_s
       drop
-      local.get $10
-      local.get $9
-      local.get $8
+      local.get $16
+      local.get $15
+      local.get $14
       call $~lib/util/number/utoa32_lut
-      local.get $5
+      local.get $11
       i32.const 45
       i32.const 43
-      local.get $4
+      local.get $12
       select
       i32.store16
-      local.get $7
+      local.get $13
       local.set $1
       local.get $1
       i32.const 2
@@ -10161,14 +10508,14 @@
       local.get $1
       i32.const 1
       i32.shl
-      local.set $7
+      local.set $17
       local.get $0
       i32.const 4
       i32.add
       local.get $0
       i32.const 2
       i32.add
-      local.get $7
+      local.get $17
       i32.const 2
       i32.sub
       call $~lib/memory/memory.copy
@@ -10176,58 +10523,58 @@
       i32.const 46
       i32.store16 offset=2
       local.get $0
-      local.get $7
+      local.get $17
       i32.add
       i32.const 101
       i32.store16 offset=2
       local.get $1
       local.get $0
-      local.get $7
+      local.get $17
       i32.add
       i32.const 4
       i32.add
-      local.set $9
+      local.set $19
       local.get $3
       i32.const 1
       i32.sub
-      local.set $8
-      local.get $8
+      local.set $18
+      local.get $18
       i32.const 0
       i32.lt_s
-      local.set $4
-      local.get $4
+      local.set $20
+      local.get $20
       if
        i32.const 0
-       local.get $8
+       local.get $18
        i32.sub
-       local.set $8
+       local.set $18
       end
-      local.get $8
+      local.get $18
       call $~lib/util/number/decimalCount32
       i32.const 1
       i32.add
-      local.set $5
-      local.get $9
-      local.set $11
-      local.get $8
-      local.set $6
-      local.get $5
-      local.set $10
+      local.set $21
+      local.get $19
+      local.set $24
+      local.get $18
+      local.set $23
+      local.get $21
+      local.set $22
       i32.const 0
       i32.const 1
       i32.ge_s
       drop
-      local.get $11
-      local.get $6
-      local.get $10
+      local.get $24
+      local.get $23
+      local.get $22
       call $~lib/util/number/utoa32_lut
-      local.get $9
+      local.get $19
       i32.const 45
       i32.const 43
-      local.get $4
+      local.get $20
       select
       i32.store16
-      local.get $5
+      local.get $21
       i32.add
       local.set $1
       local.get $1
@@ -10258,19 +10605,51 @@
   (local $13 i32)
   (local $14 i32)
   (local $15 i32)
-  (local $16 f64)
-  (local $17 i64)
-  (local $18 i64)
-  (local $19 i64)
-  (local $20 i64)
+  (local $16 i32)
+  (local $17 f64)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
   (local $21 i64)
-  (local $22 i64)
+  (local $22 i32)
   (local $23 i64)
   (local $24 i64)
   (local $25 i64)
-  (local $26 i32)
+  (local $26 i64)
   (local $27 i64)
-  (local $28 i32)
+  (local $28 i64)
+  (local $29 i64)
+  (local $30 i64)
+  (local $31 i64)
+  (local $32 i64)
+  (local $33 i32)
+  (local $34 i32)
+  (local $35 i32)
+  (local $36 i64)
+  (local $37 i64)
+  (local $38 i64)
+  (local $39 i64)
+  (local $40 i64)
+  (local $41 i64)
+  (local $42 i64)
+  (local $43 i64)
+  (local $44 i64)
+  (local $45 i64)
+  (local $46 i32)
+  (local $47 i32)
+  (local $48 i32)
+  (local $49 i64)
+  (local $50 i64)
+  (local $51 i64)
+  (local $52 i64)
+  (local $53 i64)
+  (local $54 i64)
+  (local $55 i64)
+  (local $56 i64)
+  (local $57 i64)
+  (local $58 i64)
+  (local $59 i64)
+  (local $60 i32)
   local.get $1
   f64.const 0
   f64.lt
@@ -10374,47 +10753,47 @@
   local.get $13
   global.set $~lib/util/number/_exp
   global.get $~lib/util/number/_exp
-  local.set $10
+  local.set $16
   i32.const -61
-  local.get $10
+  local.get $16
   i32.sub
   f64.convert_i32_s
   f64.const 0.30102999566398114
   f64.mul
   f64.const 347
   f64.add
-  local.set $16
-  local.get $16
+  local.set $17
+  local.get $17
   i32.trunc_f64_s
-  local.set $15
-  local.get $15
-  local.get $15
+  local.set $18
+  local.get $18
+  local.get $18
   f64.convert_i32_s
-  local.get $16
+  local.get $17
   f64.ne
   i32.add
-  local.set $15
-  local.get $15
+  local.set $18
+  local.get $18
   i32.const 3
   i32.shr_s
   i32.const 1
   i32.add
-  local.set $14
+  local.set $19
   i32.const 348
-  local.get $14
+  local.get $19
   i32.const 3
   i32.shl
   i32.sub
   global.set $~lib/util/number/_K
   i32.const 14720
-  local.get $14
+  local.get $19
   i32.const 3
   i32.shl
   i32.add
   i64.load
   global.set $~lib/util/number/_frc_pow
   i32.const 15416
-  local.get $14
+  local.get $19
   i32.const 1
   i32.shl
   i32.add
@@ -10423,249 +10802,249 @@
   local.get $9
   i64.clz
   i32.wrap_i64
-  local.set $14
+  local.set $20
   local.get $9
-  local.get $14
+  local.get $20
   i64.extend_i32_s
   i64.shl
   local.set $9
   local.get $7
-  local.get $14
+  local.get $20
   i32.sub
   local.set $7
   global.get $~lib/util/number/_frc_pow
-  local.set $12
+  local.set $21
   global.get $~lib/util/number/_exp_pow
-  local.set $15
+  local.set $22
   local.get $9
-  local.set $17
-  local.get $12
-  local.set $11
-  local.get $17
-  i64.const 4294967295
-  i64.and
-  local.set $18
-  local.get $11
-  i64.const 4294967295
-  i64.and
-  local.set $19
-  local.get $17
-  i64.const 32
-  i64.shr_u
-  local.set $20
-  local.get $11
-  i64.const 32
-  i64.shr_u
-  local.set $21
-  local.get $18
-  local.get $19
-  i64.mul
-  local.set $22
-  local.get $20
-  local.get $19
-  i64.mul
-  local.get $22
-  i64.const 32
-  i64.shr_u
-  i64.add
-  local.set $23
-  local.get $18
+  local.set $24
   local.get $21
-  i64.mul
+  local.set $23
+  local.get $24
+  i64.const 4294967295
+  i64.and
+  local.set $25
   local.get $23
   i64.const 4294967295
   i64.and
-  i64.add
-  local.set $24
+  local.set $26
   local.get $24
+  i64.const 32
+  i64.shr_u
+  local.set $27
+  local.get $23
+  i64.const 32
+  i64.shr_u
+  local.set $28
+  local.get $25
+  local.get $26
+  i64.mul
+  local.set $29
+  local.get $27
+  local.get $26
+  i64.mul
+  local.get $29
+  i64.const 32
+  i64.shr_u
+  i64.add
+  local.set $30
+  local.get $25
+  local.get $28
+  i64.mul
+  local.get $30
+  i64.const 4294967295
+  i64.and
+  i64.add
+  local.set $31
+  local.get $31
   i64.const 2147483647
   i64.add
-  local.set $24
-  local.get $23
+  local.set $31
+  local.get $30
   i64.const 32
   i64.shr_u
-  local.set $23
-  local.get $24
+  local.set $30
+  local.get $31
   i64.const 32
   i64.shr_u
-  local.set $24
-  local.get $20
-  local.get $21
+  local.set $31
+  local.get $27
+  local.get $28
   i64.mul
-  local.get $23
+  local.get $30
   i64.add
-  local.get $24
+  local.get $31
   i64.add
-  local.set $24
+  local.set $32
   local.get $7
-  local.set $10
-  local.get $15
-  local.set $13
-  local.get $10
-  local.get $13
+  local.set $34
+  local.get $22
+  local.set $33
+  local.get $34
+  local.get $33
   i32.add
   i32.const 64
   i32.add
-  local.set $10
+  local.set $35
   global.get $~lib/util/number/_frc_plus
-  local.set $17
-  local.get $12
-  local.set $11
-  local.get $17
-  i64.const 4294967295
-  i64.and
-  local.set $23
-  local.get $11
-  i64.const 4294967295
-  i64.and
-  local.set $22
-  local.get $17
-  i64.const 32
-  i64.shr_u
-  local.set $21
-  local.get $11
-  i64.const 32
-  i64.shr_u
-  local.set $20
-  local.get $23
-  local.get $22
-  i64.mul
-  local.set $19
+  local.set $37
   local.get $21
-  local.get $22
+  local.set $36
+  local.get $37
+  i64.const 4294967295
+  i64.and
+  local.set $38
+  local.get $36
+  i64.const 4294967295
+  i64.and
+  local.set $39
+  local.get $37
+  i64.const 32
+  i64.shr_u
+  local.set $40
+  local.get $36
+  i64.const 32
+  i64.shr_u
+  local.set $41
+  local.get $38
+  local.get $39
   i64.mul
-  local.get $19
+  local.set $42
+  local.get $40
+  local.get $39
+  i64.mul
+  local.get $42
   i64.const 32
   i64.shr_u
   i64.add
-  local.set $18
-  local.get $23
-  local.get $20
+  local.set $43
+  local.get $38
+  local.get $41
   i64.mul
-  local.get $18
+  local.get $43
   i64.const 4294967295
   i64.and
   i64.add
-  local.set $25
-  local.get $25
+  local.set $44
+  local.get $44
   i64.const 2147483647
   i64.add
-  local.set $25
-  local.get $18
+  local.set $44
+  local.get $43
   i64.const 32
   i64.shr_u
-  local.set $18
-  local.get $25
+  local.set $43
+  local.get $44
   i64.const 32
   i64.shr_u
-  local.set $25
-  local.get $21
-  local.get $20
+  local.set $44
+  local.get $40
+  local.get $41
   i64.mul
-  local.get $18
+  local.get $43
   i64.add
-  local.get $25
+  local.get $44
   i64.add
   i64.const 1
   i64.sub
-  local.set $25
+  local.set $45
   global.get $~lib/util/number/_exp
-  local.set $26
-  local.get $15
-  local.set $13
-  local.get $26
-  local.get $13
+  local.set $47
+  local.get $22
+  local.set $46
+  local.get $47
+  local.get $46
   i32.add
   i32.const 64
   i32.add
-  local.set $26
+  local.set $48
   global.get $~lib/util/number/_frc_minus
-  local.set $17
-  local.get $12
-  local.set $11
-  local.get $17
-  i64.const 4294967295
-  i64.and
-  local.set $18
-  local.get $11
-  i64.const 4294967295
-  i64.and
-  local.set $19
-  local.get $17
-  i64.const 32
-  i64.shr_u
-  local.set $20
-  local.get $11
-  i64.const 32
-  i64.shr_u
-  local.set $21
-  local.get $18
-  local.get $19
-  i64.mul
-  local.set $22
-  local.get $20
-  local.get $19
-  i64.mul
-  local.get $22
-  i64.const 32
-  i64.shr_u
-  i64.add
-  local.set $23
-  local.get $18
+  local.set $50
   local.get $21
+  local.set $49
+  local.get $50
+  i64.const 4294967295
+  i64.and
+  local.set $51
+  local.get $49
+  i64.const 4294967295
+  i64.and
+  local.set $52
+  local.get $50
+  i64.const 32
+  i64.shr_u
+  local.set $53
+  local.get $49
+  i64.const 32
+  i64.shr_u
+  local.set $54
+  local.get $51
+  local.get $52
   i64.mul
-  local.get $23
+  local.set $55
+  local.get $53
+  local.get $52
+  i64.mul
+  local.get $55
+  i64.const 32
+  i64.shr_u
+  i64.add
+  local.set $56
+  local.get $51
+  local.get $54
+  i64.mul
+  local.get $56
   i64.const 4294967295
   i64.and
   i64.add
-  local.set $27
-  local.get $27
+  local.set $57
+  local.get $57
   i64.const 2147483647
   i64.add
-  local.set $27
-  local.get $23
+  local.set $57
+  local.get $56
   i64.const 32
   i64.shr_u
-  local.set $23
-  local.get $27
+  local.set $56
+  local.get $57
   i64.const 32
   i64.shr_u
-  local.set $27
-  local.get $20
-  local.get $21
+  local.set $57
+  local.get $53
+  local.get $54
   i64.mul
-  local.get $23
+  local.get $56
   i64.add
-  local.get $27
+  local.get $57
   i64.add
   i64.const 1
   i64.add
-  local.set $27
-  local.get $25
-  local.get $27
+  local.set $58
+  local.get $45
+  local.get $58
   i64.sub
-  local.set $23
+  local.set $59
   local.get $4
-  local.get $24
-  local.get $10
-  local.get $25
-  local.get $26
-  local.get $23
+  local.get $32
+  local.get $35
+  local.get $45
+  local.get $48
+  local.get $59
   local.get $3
   call $~lib/util/number/genDigits
-  local.set $28
+  local.set $60
   local.get $0
   local.get $2
   i32.const 1
   i32.shl
   i32.add
-  local.get $28
+  local.get $60
   local.get $2
   i32.sub
   global.get $~lib/util/number/_K
   call $~lib/util/number/prettify
-  local.set $28
-  local.get $28
+  local.set $60
+  local.get $60
   local.get $2
   i32.add
  )
@@ -10770,30 +11149,30 @@
   (local $30 i32)
   (local $31 i32)
   (local $32 f64)
-  (local $33 i32)
-  (local $34 i32)
-  (local $35 i32)
-  (local $36 i32)
-  (local $37 i32)
-  (local $38 i32)
-  (local $39 i32)
-  (local $40 i32)
-  (local $41 i32)
-  (local $42 i32)
-  (local $43 i32)
-  (local $44 i32)
-  (local $45 i32)
-  (local $46 i32)
-  (local $47 i32)
-  (local $48 i32)
-  (local $49 i32)
-  (local $50 i32)
-  (local $51 i32)
+  (local $33 f64)
+  (local $34 f64)
+  (local $35 f64)
+  (local $36 f64)
+  (local $37 f64)
+  (local $38 f64)
+  (local $39 f64)
+  (local $40 f64)
+  (local $41 f64)
+  (local $42 f64)
+  (local $43 f64)
+  (local $44 f64)
+  (local $45 f64)
+  (local $46 f64)
+  (local $47 f64)
+  (local $48 f64)
+  (local $49 f64)
+  (local $50 f64)
+  (local $51 f64)
   (local $52 i32)
   (local $53 i32)
   (local $54 i32)
   (local $55 i32)
-  (local $56 i32)
+  (local $56 f64)
   (local $57 i32)
   (local $58 i32)
   (local $59 i32)
@@ -10949,6 +11328,121 @@
   (local $209 i32)
   (local $210 i32)
   (local $211 i32)
+  (local $212 i32)
+  (local $213 i32)
+  (local $214 i32)
+  (local $215 i32)
+  (local $216 i32)
+  (local $217 i32)
+  (local $218 i32)
+  (local $219 i32)
+  (local $220 i32)
+  (local $221 i32)
+  (local $222 i32)
+  (local $223 i32)
+  (local $224 i32)
+  (local $225 i32)
+  (local $226 i32)
+  (local $227 i32)
+  (local $228 i32)
+  (local $229 i32)
+  (local $230 i32)
+  (local $231 i32)
+  (local $232 i32)
+  (local $233 i32)
+  (local $234 i32)
+  (local $235 i32)
+  (local $236 i32)
+  (local $237 i32)
+  (local $238 i32)
+  (local $239 i32)
+  (local $240 i32)
+  (local $241 i32)
+  (local $242 i32)
+  (local $243 i32)
+  (local $244 i32)
+  (local $245 i32)
+  (local $246 i32)
+  (local $247 i32)
+  (local $248 i32)
+  (local $249 i32)
+  (local $250 i32)
+  (local $251 i32)
+  (local $252 i32)
+  (local $253 i32)
+  (local $254 i32)
+  (local $255 i32)
+  (local $256 i32)
+  (local $257 i32)
+  (local $258 i32)
+  (local $259 i32)
+  (local $260 i32)
+  (local $261 i32)
+  (local $262 i32)
+  (local $263 i32)
+  (local $264 i32)
+  (local $265 i32)
+  (local $266 i32)
+  (local $267 i32)
+  (local $268 i32)
+  (local $269 i32)
+  (local $270 i32)
+  (local $271 i32)
+  (local $272 i32)
+  (local $273 i32)
+  (local $274 i32)
+  (local $275 i32)
+  (local $276 i32)
+  (local $277 i32)
+  (local $278 i32)
+  (local $279 i32)
+  (local $280 i32)
+  (local $281 i32)
+  (local $282 i32)
+  (local $283 i32)
+  (local $284 i32)
+  (local $285 i32)
+  (local $286 i32)
+  (local $287 i32)
+  (local $288 i32)
+  (local $289 i32)
+  (local $290 i32)
+  (local $291 i32)
+  (local $292 i32)
+  (local $293 i32)
+  (local $294 i32)
+  (local $295 i32)
+  (local $296 i32)
+  (local $297 i32)
+  (local $298 i32)
+  (local $299 i32)
+  (local $300 i32)
+  (local $301 i32)
+  (local $302 i32)
+  (local $303 i32)
+  (local $304 i32)
+  (local $305 i32)
+  (local $306 i32)
+  (local $307 i32)
+  (local $308 i32)
+  (local $309 i32)
+  (local $310 i32)
+  (local $311 i32)
+  (local $312 i32)
+  (local $313 i32)
+  (local $314 i32)
+  (local $315 i32)
+  (local $316 i32)
+  (local $317 i32)
+  (local $318 i32)
+  (local $319 i32)
+  (local $320 i32)
+  (local $321 i32)
+  (local $322 i32)
+  (local $323 i32)
+  (local $324 i32)
+  (local $325 i32)
+  (local $326 i32)
   global.get $std/string/str
   i32.const 32
   i32.eq
@@ -13243,8 +13737,8 @@
   end
   i32.const 4544
   call $~lib/string/parseFloat
-  local.tee $32
-  local.get $32
+  local.tee $33
+  local.get $33
   f64.ne
   i32.eqz
   if
@@ -13257,8 +13751,8 @@
   end
   i32.const 4576
   call $~lib/string/parseFloat
-  local.tee $32
-  local.get $32
+  local.tee $34
+  local.get $34
   f64.ne
   i32.eqz
   if
@@ -13271,8 +13765,8 @@
   end
   i32.const 4608
   call $~lib/string/parseFloat
-  local.tee $32
-  local.get $32
+  local.tee $35
+  local.get $35
   f64.ne
   i32.eqz
   if
@@ -13285,8 +13779,8 @@
   end
   i32.const 4640
   call $~lib/string/parseFloat
-  local.tee $32
-  local.get $32
+  local.tee $36
+  local.get $36
   f64.ne
   i32.eqz
   if
@@ -13299,8 +13793,8 @@
   end
   i32.const 4672
   call $~lib/string/parseFloat
-  local.tee $32
-  local.get $32
+  local.tee $37
+  local.get $37
   f64.ne
   i32.eqz
   if
@@ -13313,8 +13807,8 @@
   end
   i32.const 4704
   call $~lib/string/parseFloat
-  local.tee $32
-  local.get $32
+  local.tee $38
+  local.get $38
   f64.ne
   i32.eqz
   if
@@ -13327,8 +13821,8 @@
   end
   i32.const 4736
   call $~lib/string/parseFloat
-  local.tee $32
-  local.get $32
+  local.tee $39
+  local.get $39
   f64.ne
   i32.eqz
   if
@@ -13341,8 +13835,8 @@
   end
   i32.const 4768
   call $~lib/string/parseFloat
-  local.tee $32
-  local.get $32
+  local.tee $40
+  local.get $40
   f64.ne
   i32.eqz
   if
@@ -13355,8 +13849,8 @@
   end
   i32.const 4800
   call $~lib/string/parseFloat
-  local.tee $32
-  local.get $32
+  local.tee $41
+  local.get $41
   f64.ne
   i32.eqz
   if
@@ -13369,8 +13863,8 @@
   end
   i32.const 4832
   call $~lib/string/parseFloat
-  local.tee $32
-  local.get $32
+  local.tee $42
+  local.get $42
   f64.ne
   i32.eqz
   if
@@ -13383,8 +13877,8 @@
   end
   i32.const 4864
   call $~lib/string/parseFloat
-  local.tee $32
-  local.get $32
+  local.tee $43
+  local.get $43
   f64.ne
   i32.eqz
   if
@@ -13397,8 +13891,8 @@
   end
   i32.const 4896
   call $~lib/string/parseFloat
-  local.tee $32
-  local.get $32
+  local.tee $44
+  local.get $44
   f64.ne
   i32.eqz
   if
@@ -13411,8 +13905,8 @@
   end
   i32.const 4928
   call $~lib/string/parseFloat
-  local.tee $32
-  local.get $32
+  local.tee $45
+  local.get $45
   f64.ne
   i32.eqz
   if
@@ -13425,8 +13919,8 @@
   end
   i32.const 4960
   call $~lib/string/parseFloat
-  local.tee $32
-  local.get $32
+  local.tee $46
+  local.get $46
   f64.ne
   i32.eqz
   if
@@ -13439,8 +13933,8 @@
   end
   i32.const 4992
   call $~lib/string/parseFloat
-  local.tee $32
-  local.get $32
+  local.tee $47
+  local.get $47
   f64.ne
   i32.eqz
   if
@@ -13453,8 +13947,8 @@
   end
   i32.const 5024
   call $~lib/string/parseFloat
-  local.tee $32
-  local.get $32
+  local.tee $48
+  local.get $48
   f64.ne
   i32.eqz
   if
@@ -13794,8 +14288,8 @@
   end
   i32.const 6160
   call $~lib/string/parseFloat
-  local.tee $32
-  local.get $32
+  local.tee $49
+  local.get $49
   f64.ne
   i32.eqz
   if
@@ -13808,8 +14302,8 @@
   end
   i32.const 6192
   call $~lib/string/parseFloat
-  local.tee $32
-  local.get $32
+  local.tee $50
+  local.get $50
   f64.ne
   i32.eqz
   if
@@ -13822,8 +14316,8 @@
   end
   i32.const 6224
   call $~lib/string/parseFloat
-  local.tee $32
-  local.get $32
+  local.tee $51
+  local.get $51
   f64.ne
   i32.eqz
   if
@@ -13876,16 +14370,16 @@
   i32.const 6832
   i32.const 6992
   call $~lib/string/String.__concat
-  local.tee $33
+  local.tee $52
   i32.const 7152
   call $~lib/string/String.__concat
-  local.tee $34
+  local.tee $53
   i32.const 7312
   call $~lib/string/String.__concat
-  local.tee $35
+  local.tee $54
   i32.const 7472
   call $~lib/string/String.__concat
-  local.tee $36
+  local.tee $55
   call $~lib/string/parseFloat
   global.get $~lib/builtins/f64.MAX_VALUE
   f64.eq
@@ -14212,8 +14706,8 @@
   end
   i32.const 10320
   call $~lib/string/parseFloat
-  local.tee $32
-  local.get $32
+  local.tee $56
+  local.get $56
   f64.ne
   i32.eqz
   if
@@ -14240,10 +14734,10 @@
   i32.const 320
   i32.const 10384
   call $~lib/string/String.__concat
-  local.tee $37
+  local.tee $57
   call $~lib/rt/pure/__retain
-  local.set $38
-  local.get $38
+  local.set $58
+  local.get $58
   i32.const 10416
   call $~lib/string/String.__eq
   i32.eqz
@@ -14255,7 +14749,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $38
+  local.get $58
   i32.const 320
   call $~lib/string/String.__ne
   i32.eqz
@@ -14267,9 +14761,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $37
+  local.get $57
   call $~lib/rt/pure/__release
-  local.get $38
+  local.get $58
   call $~lib/rt/pure/__release
   i32.const 272
   i32.const 272
@@ -14628,19 +15122,19 @@
   end
   i32.const 65377
   call $~lib/string/String.fromCodePoint
-  local.set $38
+  local.set $59
   i32.const 55296
   call $~lib/string/String.fromCodePoint
-  local.tee $37
+  local.tee $60
   i32.const 56322
   call $~lib/string/String.fromCodePoint
-  local.tee $39
+  local.tee $61
   call $~lib/string/String.__concat
-  local.tee $40
+  local.tee $62
   call $~lib/rt/pure/__retain
-  local.set $41
-  local.get $38
-  local.get $41
+  local.set $63
+  local.get $59
+  local.get $63
   call $~lib/string/String.__gt
   i32.eqz
   if
@@ -14651,15 +15145,15 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $38
+  local.get $59
   call $~lib/rt/pure/__release
-  local.get $37
+  local.get $60
   call $~lib/rt/pure/__release
-  local.get $39
+  local.get $61
   call $~lib/rt/pure/__release
-  local.get $40
+  local.get $62
   call $~lib/rt/pure/__release
-  local.get $41
+  local.get $63
   call $~lib/rt/pure/__release
   i32.const 864
   call $~lib/string/String#get:length
@@ -14677,7 +15171,7 @@
   i32.const 272
   i32.const 100
   call $~lib/string/String#repeat
-  local.tee $41
+  local.tee $64
   i32.const 272
   call $~lib/string/String.__eq
   i32.eqz
@@ -14692,7 +15186,7 @@
   i32.const 320
   i32.const 0
   call $~lib/string/String#repeat
-  local.tee $40
+  local.tee $65
   i32.const 272
   call $~lib/string/String.__eq
   i32.eqz
@@ -14707,7 +15201,7 @@
   i32.const 320
   i32.const 1
   call $~lib/string/String#repeat
-  local.tee $39
+  local.tee $66
   i32.const 320
   call $~lib/string/String.__eq
   i32.eqz
@@ -14722,7 +15216,7 @@
   i32.const 320
   i32.const 2
   call $~lib/string/String#repeat
-  local.tee $37
+  local.tee $67
   i32.const 10832
   call $~lib/string/String.__eq
   i32.eqz
@@ -14737,7 +15231,7 @@
   i32.const 320
   i32.const 3
   call $~lib/string/String#repeat
-  local.tee $38
+  local.tee $68
   i32.const 10912
   call $~lib/string/String.__eq
   i32.eqz
@@ -14752,7 +15246,7 @@
   i32.const 10416
   i32.const 4
   call $~lib/string/String#repeat
-  local.tee $42
+  local.tee $69
   i32.const 10944
   call $~lib/string/String.__eq
   i32.eqz
@@ -14767,7 +15261,7 @@
   i32.const 320
   i32.const 5
   call $~lib/string/String#repeat
-  local.tee $43
+  local.tee $70
   i32.const 10976
   call $~lib/string/String.__eq
   i32.eqz
@@ -14782,7 +15276,7 @@
   i32.const 320
   i32.const 6
   call $~lib/string/String#repeat
-  local.tee $44
+  local.tee $71
   i32.const 11008
   call $~lib/string/String.__eq
   i32.eqz
@@ -14797,7 +15291,7 @@
   i32.const 320
   i32.const 7
   call $~lib/string/String#repeat
-  local.tee $45
+  local.tee $72
   i32.const 11040
   call $~lib/string/String.__eq
   i32.eqz
@@ -14813,7 +15307,7 @@
   i32.const 272
   i32.const 272
   call $~lib/string/String#replace
-  local.tee $46
+  local.tee $73
   i32.const 272
   call $~lib/string/String.__eq
   i32.eqz
@@ -14829,7 +15323,7 @@
   i32.const 272
   i32.const 4544
   call $~lib/string/String#replace
-  local.tee $47
+  local.tee $74
   i32.const 4544
   call $~lib/string/String.__eq
   i32.eqz
@@ -14845,7 +15339,7 @@
   i32.const 4544
   i32.const 272
   call $~lib/string/String#replace
-  local.tee $48
+  local.tee $75
   i32.const 272
   call $~lib/string/String.__eq
   i32.eqz
@@ -14861,7 +15355,7 @@
   i32.const 272
   i32.const 272
   call $~lib/string/String#replace
-  local.tee $49
+  local.tee $76
   i32.const 4544
   call $~lib/string/String.__eq
   i32.eqz
@@ -14877,7 +15371,7 @@
   i32.const 4576
   i32.const 4544
   call $~lib/string/String#replace
-  local.tee $50
+  local.tee $77
   i32.const 800
   call $~lib/string/String.__eq
   i32.eqz
@@ -14893,7 +15387,7 @@
   i32.const 800
   i32.const 4544
   call $~lib/string/String#replace
-  local.tee $51
+  local.tee $78
   i32.const 4544
   call $~lib/string/String.__eq
   i32.eqz
@@ -14909,7 +15403,7 @@
   i32.const 1248
   i32.const 4544
   call $~lib/string/String#replace
-  local.tee $52
+  local.tee $79
   i32.const 800
   call $~lib/string/String.__eq
   i32.eqz
@@ -14925,7 +15419,7 @@
   i32.const 10416
   i32.const 10416
   call $~lib/string/String#replace
-  local.tee $53
+  local.tee $80
   i32.const 800
   call $~lib/string/String.__eq
   i32.eqz
@@ -14941,7 +15435,7 @@
   i32.const 4576
   i32.const 4544
   call $~lib/string/String#replace
-  local.tee $54
+  local.tee $81
   i32.const 11104
   call $~lib/string/String.__eq
   i32.eqz
@@ -14957,7 +15451,7 @@
   i32.const 272
   i32.const 4544
   call $~lib/string/String#replace
-  local.tee $55
+  local.tee $82
   i32.const 11136
   call $~lib/string/String.__eq
   i32.eqz
@@ -14973,7 +15467,7 @@
   i32.const 11200
   i32.const 4544
   call $~lib/string/String#replace
-  local.tee $56
+  local.tee $83
   i32.const 11136
   call $~lib/string/String.__eq
   i32.eqz
@@ -14989,7 +15483,7 @@
   i32.const 11232
   i32.const 11264
   call $~lib/string/String#replace
-  local.tee $57
+  local.tee $84
   i32.const 11296
   call $~lib/string/String.__eq
   i32.eqz
@@ -15005,7 +15499,7 @@
   i32.const 11232
   i32.const 272
   call $~lib/string/String#replace
-  local.tee $58
+  local.tee $85
   i32.const 10416
   call $~lib/string/String.__eq
   i32.eqz
@@ -15021,7 +15515,7 @@
   i32.const 272
   i32.const 800
   call $~lib/string/String#replaceAll
-  local.tee $59
+  local.tee $86
   i32.const 800
   call $~lib/string/String.__eq
   i32.eqz
@@ -15037,7 +15531,7 @@
   i32.const 4576
   i32.const 4544
   call $~lib/string/String#replaceAll
-  local.tee $60
+  local.tee $87
   i32.const 800
   call $~lib/string/String.__eq
   i32.eqz
@@ -15053,7 +15547,7 @@
   i32.const 800
   i32.const 4544
   call $~lib/string/String#replaceAll
-  local.tee $61
+  local.tee $88
   i32.const 11264
   call $~lib/string/String.__eq
   i32.eqz
@@ -15069,7 +15563,7 @@
   i32.const 800
   i32.const 4544
   call $~lib/string/String#replaceAll
-  local.tee $62
+  local.tee $89
   i32.const 11376
   call $~lib/string/String.__eq
   i32.eqz
@@ -15085,7 +15579,7 @@
   i32.const 10416
   i32.const 10416
   call $~lib/string/String#replaceAll
-  local.tee $63
+  local.tee $90
   i32.const 992
   call $~lib/string/String.__eq
   i32.eqz
@@ -15101,7 +15595,7 @@
   i32.const 320
   i32.const 11376
   call $~lib/string/String#replaceAll
-  local.tee $64
+  local.tee $91
   i32.const 11440
   call $~lib/string/String.__eq
   i32.eqz
@@ -15117,7 +15611,7 @@
   i32.const 10416
   i32.const 11264
   call $~lib/string/String#replaceAll
-  local.tee $65
+  local.tee $92
   i32.const 11488
   call $~lib/string/String.__eq
   i32.eqz
@@ -15133,7 +15627,7 @@
   i32.const 11552
   i32.const 11264
   call $~lib/string/String#replaceAll
-  local.tee $66
+  local.tee $93
   i32.const 11584
   call $~lib/string/String.__eq
   i32.eqz
@@ -15149,7 +15643,7 @@
   i32.const 1248
   i32.const 4544
   call $~lib/string/String#replaceAll
-  local.tee $67
+  local.tee $94
   i32.const 800
   call $~lib/string/String.__eq
   i32.eqz
@@ -15165,7 +15659,7 @@
   i32.const 11616
   i32.const 11264
   call $~lib/string/String#replaceAll
-  local.tee $68
+  local.tee $95
   i32.const 1248
   call $~lib/string/String.__eq
   i32.eqz
@@ -15181,7 +15675,7 @@
   i32.const 11648
   i32.const 4544
   call $~lib/string/String#replaceAll
-  local.tee $69
+  local.tee $96
   i32.const 11680
   call $~lib/string/String.__eq
   i32.eqz
@@ -15197,7 +15691,7 @@
   i32.const 10416
   i32.const 4544
   call $~lib/string/String#replaceAll
-  local.tee $70
+  local.tee $97
   i32.const 4544
   call $~lib/string/String.__eq
   i32.eqz
@@ -15213,7 +15707,7 @@
   i32.const 4576
   i32.const 4544
   call $~lib/string/String#replaceAll
-  local.tee $71
+  local.tee $98
   i32.const 11712
   call $~lib/string/String.__eq
   i32.eqz
@@ -15229,7 +15723,7 @@
   i32.const 272
   i32.const 272
   call $~lib/string/String#replaceAll
-  local.tee $72
+  local.tee $99
   i32.const 272
   call $~lib/string/String.__eq
   i32.eqz
@@ -15245,7 +15739,7 @@
   i32.const 272
   i32.const 4544
   call $~lib/string/String#replaceAll
-  local.tee $73
+  local.tee $100
   i32.const 4544
   call $~lib/string/String.__eq
   i32.eqz
@@ -15261,7 +15755,7 @@
   i32.const 4544
   i32.const 272
   call $~lib/string/String#replaceAll
-  local.tee $74
+  local.tee $101
   i32.const 272
   call $~lib/string/String.__eq
   i32.eqz
@@ -15277,7 +15771,7 @@
   i32.const 272
   i32.const 272
   call $~lib/string/String#replaceAll
-  local.tee $75
+  local.tee $102
   i32.const 4544
   call $~lib/string/String.__eq
   i32.eqz
@@ -15293,7 +15787,7 @@
   i32.const 800
   i32.const 4576
   call $~lib/string/String#replaceAll
-  local.tee $76
+  local.tee $103
   i32.const 4576
   call $~lib/string/String.__eq
   i32.eqz
@@ -15309,7 +15803,7 @@
   i32.const 1216
   i32.const 4576
   call $~lib/string/String#replaceAll
-  local.tee $77
+  local.tee $104
   i32.const 800
   call $~lib/string/String.__eq
   i32.eqz
@@ -15325,7 +15819,7 @@
   i32.const 272
   i32.const 4544
   call $~lib/string/String#replaceAll
-  local.tee $78
+  local.tee $105
   i32.const 11744
   call $~lib/string/String.__eq
   i32.eqz
@@ -15341,7 +15835,7 @@
   i32.const 272
   i32.const 272
   call $~lib/string/String#replaceAll
-  local.tee $79
+  local.tee $106
   i32.const 800
   call $~lib/string/String.__eq
   i32.eqz
@@ -15354,16 +15848,16 @@
    unreachable
   end
   i32.const 11776
-  local.set $80
+  local.set $107
   global.get $std/string/str
   call $~lib/rt/pure/__release
-  local.get $80
+  local.get $107
   global.set $std/string/str
   global.get $std/string/str
   i32.const 0
   global.get $~lib/builtins/i32.MAX_VALUE
   call $~lib/string/String#slice
-  local.tee $80
+  local.tee $108
   i32.const 11776
   call $~lib/string/String.__eq
   i32.eqz
@@ -15379,7 +15873,7 @@
   i32.const -1
   global.get $~lib/builtins/i32.MAX_VALUE
   call $~lib/string/String#slice
-  local.tee $81
+  local.tee $109
   i32.const 11824
   call $~lib/string/String.__eq
   i32.eqz
@@ -15395,7 +15889,7 @@
   i32.const -5
   global.get $~lib/builtins/i32.MAX_VALUE
   call $~lib/string/String#slice
-  local.tee $82
+  local.tee $110
   i32.const 11856
   call $~lib/string/String.__eq
   i32.eqz
@@ -15411,7 +15905,7 @@
   i32.const 2
   i32.const 7
   call $~lib/string/String#slice
-  local.tee $83
+  local.tee $111
   i32.const 11888
   call $~lib/string/String.__eq
   i32.eqz
@@ -15427,7 +15921,7 @@
   i32.const -11
   i32.const -6
   call $~lib/string/String#slice
-  local.tee $84
+  local.tee $112
   i32.const 11920
   call $~lib/string/String.__eq
   i32.eqz
@@ -15443,7 +15937,7 @@
   i32.const 4
   i32.const 3
   call $~lib/string/String#slice
-  local.tee $85
+  local.tee $113
   i32.const 272
   call $~lib/string/String.__eq
   i32.eqz
@@ -15459,7 +15953,7 @@
   i32.const 0
   i32.const -1
   call $~lib/string/String#slice
-  local.tee $86
+  local.tee $114
   i32.const 11952
   call $~lib/string/String.__eq
   i32.eqz
@@ -15475,7 +15969,7 @@
   i32.const 0
   global.get $~lib/builtins/i32.MAX_VALUE
   call $~lib/string/String#substr
-  local.tee $87
+  local.tee $115
   i32.const 11776
   call $~lib/string/String.__eq
   i32.eqz
@@ -15491,7 +15985,7 @@
   i32.const -1
   global.get $~lib/builtins/i32.MAX_VALUE
   call $~lib/string/String#substr
-  local.tee $88
+  local.tee $116
   i32.const 11824
   call $~lib/string/String.__eq
   i32.eqz
@@ -15507,7 +16001,7 @@
   i32.const -5
   global.get $~lib/builtins/i32.MAX_VALUE
   call $~lib/string/String#substr
-  local.tee $89
+  local.tee $117
   i32.const 11856
   call $~lib/string/String.__eq
   i32.eqz
@@ -15523,7 +16017,7 @@
   i32.const 2
   i32.const 7
   call $~lib/string/String#substr
-  local.tee $90
+  local.tee $118
   i32.const 12000
   call $~lib/string/String.__eq
   i32.eqz
@@ -15539,7 +16033,7 @@
   i32.const -11
   i32.const -6
   call $~lib/string/String#substr
-  local.tee $91
+  local.tee $119
   i32.const 272
   call $~lib/string/String.__eq
   i32.eqz
@@ -15555,7 +16049,7 @@
   i32.const 4
   i32.const 3
   call $~lib/string/String#substr
-  local.tee $92
+  local.tee $120
   i32.const 12032
   call $~lib/string/String.__eq
   i32.eqz
@@ -15571,7 +16065,7 @@
   i32.const 0
   i32.const -1
   call $~lib/string/String#substr
-  local.tee $93
+  local.tee $121
   i32.const 272
   call $~lib/string/String.__eq
   i32.eqz
@@ -15587,7 +16081,7 @@
   i32.const 0
   i32.const 100
   call $~lib/string/String#substr
-  local.tee $94
+  local.tee $122
   i32.const 11776
   call $~lib/string/String.__eq
   i32.eqz
@@ -15603,7 +16097,7 @@
   i32.const 4
   i32.const 4
   call $~lib/string/String#substr
-  local.tee $95
+  local.tee $123
   i32.const 12064
   call $~lib/string/String.__eq
   i32.eqz
@@ -15619,7 +16113,7 @@
   i32.const 4
   i32.const -3
   call $~lib/string/String#substr
-  local.tee $96
+  local.tee $124
   i32.const 272
   call $~lib/string/String.__eq
   i32.eqz
@@ -15635,7 +16129,7 @@
   i32.const 0
   global.get $~lib/builtins/i32.MAX_VALUE
   call $~lib/string/String#substring
-  local.tee $97
+  local.tee $125
   i32.const 11776
   call $~lib/string/String.__eq
   i32.eqz
@@ -15651,7 +16145,7 @@
   i32.const -1
   global.get $~lib/builtins/i32.MAX_VALUE
   call $~lib/string/String#substring
-  local.tee $98
+  local.tee $126
   i32.const 11776
   call $~lib/string/String.__eq
   i32.eqz
@@ -15667,7 +16161,7 @@
   i32.const -5
   global.get $~lib/builtins/i32.MAX_VALUE
   call $~lib/string/String#substring
-  local.tee $99
+  local.tee $127
   i32.const 11776
   call $~lib/string/String.__eq
   i32.eqz
@@ -15683,7 +16177,7 @@
   i32.const 2
   i32.const 7
   call $~lib/string/String#substring
-  local.tee $100
+  local.tee $128
   i32.const 11888
   call $~lib/string/String.__eq
   i32.eqz
@@ -15699,7 +16193,7 @@
   i32.const -11
   i32.const -6
   call $~lib/string/String#substring
-  local.tee $101
+  local.tee $129
   i32.const 272
   call $~lib/string/String.__eq
   i32.eqz
@@ -15715,7 +16209,7 @@
   i32.const 4
   i32.const 3
   call $~lib/string/String#substring
-  local.tee $102
+  local.tee $130
   i32.const 12096
   call $~lib/string/String.__eq
   i32.eqz
@@ -15731,7 +16225,7 @@
   i32.const 0
   i32.const -1
   call $~lib/string/String#substring
-  local.tee $103
+  local.tee $131
   i32.const 272
   call $~lib/string/String.__eq
   i32.eqz
@@ -15747,7 +16241,7 @@
   i32.const 0
   i32.const 100
   call $~lib/string/String#substring
-  local.tee $104
+  local.tee $132
   i32.const 11776
   call $~lib/string/String.__eq
   i32.eqz
@@ -15763,7 +16257,7 @@
   i32.const 4
   i32.const 4
   call $~lib/string/String#substring
-  local.tee $105
+  local.tee $133
   i32.const 272
   call $~lib/string/String.__eq
   i32.eqz
@@ -15779,7 +16273,7 @@
   i32.const 4
   i32.const -3
   call $~lib/string/String#substring
-  local.tee $106
+  local.tee $134
   i32.const 1248
   call $~lib/string/String.__eq
   i32.eqz
@@ -15792,31 +16286,31 @@
    unreachable
   end
   i32.const 0
-  local.set $107
+  local.set $135
   i32.const 272
   i32.const 0
   global.get $~lib/builtins/i32.MAX_VALUE
   call $~lib/string/String#split
-  local.set $108
-  local.get $107
+  local.set $136
+  local.get $135
   call $~lib/rt/pure/__release
-  local.get $108
-  local.set $107
-  local.get $107
+  local.get $136
+  local.set $135
+  local.get $135
   call $~lib/array/Array<~lib/string/String>#get:length
   i32.const 1
   i32.eq
   if (result i32)
-   local.get $107
+   local.get $135
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $108
+   local.tee $137
    i32.const 272
    call $~lib/string/String.__eq
-   local.set $109
-   local.get $108
+   local.set $138
+   local.get $137
    call $~lib/rt/pure/__release
-   local.get $109
+   local.get $138
   else
    i32.const 0
   end
@@ -15835,12 +16329,12 @@
   i32.const 272
   global.get $~lib/builtins/i32.MAX_VALUE
   call $~lib/string/String#split
-  local.set $109
-  local.get $107
+  local.set $139
+  local.get $135
   call $~lib/rt/pure/__release
-  local.get $109
-  local.set $107
-  local.get $107
+  local.get $139
+  local.set $135
+  local.get $135
   call $~lib/array/Array<~lib/string/String>#get:length
   i32.const 0
   i32.eq
@@ -15857,26 +16351,26 @@
   i32.const 1056
   global.get $~lib/builtins/i32.MAX_VALUE
   call $~lib/string/String#split
-  local.set $108
-  local.get $107
+  local.set $140
+  local.get $135
   call $~lib/rt/pure/__release
-  local.get $108
-  local.set $107
-  local.get $107
+  local.get $140
+  local.set $135
+  local.get $135
   call $~lib/array/Array<~lib/string/String>#get:length
   i32.const 1
   i32.eq
   if (result i32)
-   local.get $107
+   local.get $135
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $108
+   local.tee $141
    i32.const 272
    call $~lib/string/String.__eq
-   local.set $109
-   local.get $108
+   local.set $142
+   local.get $141
    call $~lib/rt/pure/__release
-   local.get $109
+   local.get $142
   else
    i32.const 0
   end
@@ -15895,26 +16389,26 @@
   i32.const 4736
   global.get $~lib/builtins/i32.MAX_VALUE
   call $~lib/string/String#split
-  local.set $109
-  local.get $107
+  local.set $143
+  local.get $135
   call $~lib/rt/pure/__release
-  local.get $109
-  local.set $107
-  local.get $107
+  local.get $143
+  local.set $135
+  local.get $135
   call $~lib/array/Array<~lib/string/String>#get:length
   i32.const 1
   i32.eq
   if (result i32)
-   local.get $107
+   local.get $135
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $109
+   local.tee $144
    i32.const 12352
    call $~lib/string/String.__eq
-   local.set $108
-   local.get $109
+   local.set $145
+   local.get $144
    call $~lib/rt/pure/__release
-   local.get $108
+   local.get $145
   else
    i32.const 0
   end
@@ -15933,58 +16427,58 @@
   i32.const 1056
   global.get $~lib/builtins/i32.MAX_VALUE
   call $~lib/string/String#split
-  local.set $108
-  local.get $107
+  local.set $146
+  local.get $135
   call $~lib/rt/pure/__release
-  local.get $108
-  local.set $107
-  local.get $107
+  local.get $146
+  local.set $135
+  local.get $135
   call $~lib/array/Array<~lib/string/String>#get:length
   i32.const 3
   i32.eq
   if (result i32)
-   local.get $107
+   local.get $135
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $108
+   local.tee $147
    i32.const 320
    call $~lib/string/String.__eq
-   local.set $109
-   local.get $108
+   local.set $148
+   local.get $147
    call $~lib/rt/pure/__release
-   local.get $109
+   local.get $148
   else
    i32.const 0
   end
   i32.const 0
   i32.ne
   if (result i32)
-   local.get $107
+   local.get $135
    i32.const 1
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $108
+   local.tee $149
    i32.const 10384
    call $~lib/string/String.__eq
-   local.set $109
-   local.get $108
+   local.set $150
+   local.get $149
    call $~lib/rt/pure/__release
-   local.get $109
+   local.get $150
   else
    i32.const 0
   end
   i32.const 0
   i32.ne
   if (result i32)
-   local.get $107
+   local.get $135
    i32.const 2
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $108
+   local.tee $151
    i32.const 11232
    call $~lib/string/String.__eq
-   local.set $109
-   local.get $108
+   local.set $152
+   local.get $151
    call $~lib/rt/pure/__release
-   local.get $109
+   local.get $152
   else
    i32.const 0
   end
@@ -16003,58 +16497,58 @@
   i32.const 12416
   global.get $~lib/builtins/i32.MAX_VALUE
   call $~lib/string/String#split
-  local.set $109
-  local.get $107
+  local.set $153
+  local.get $135
   call $~lib/rt/pure/__release
-  local.get $109
-  local.set $107
-  local.get $107
+  local.get $153
+  local.set $135
+  local.get $135
   call $~lib/array/Array<~lib/string/String>#get:length
   i32.const 3
   i32.eq
   if (result i32)
-   local.get $107
+   local.get $135
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $109
+   local.tee $154
    i32.const 320
    call $~lib/string/String.__eq
-   local.set $108
-   local.get $109
+   local.set $155
+   local.get $154
    call $~lib/rt/pure/__release
-   local.get $108
+   local.get $155
   else
    i32.const 0
   end
   i32.const 0
   i32.ne
   if (result i32)
-   local.get $107
+   local.get $135
    i32.const 1
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $109
+   local.tee $156
    i32.const 10384
    call $~lib/string/String.__eq
-   local.set $108
-   local.get $109
+   local.set $157
+   local.get $156
    call $~lib/rt/pure/__release
-   local.get $108
+   local.get $157
   else
    i32.const 0
   end
   i32.const 0
   i32.ne
   if (result i32)
-   local.get $107
+   local.get $135
    i32.const 2
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $109
+   local.tee $158
    i32.const 11232
    call $~lib/string/String.__eq
-   local.set $108
-   local.get $109
+   local.set $159
+   local.get $158
    call $~lib/rt/pure/__release
-   local.get $108
+   local.get $159
   else
    i32.const 0
   end
@@ -16073,74 +16567,74 @@
   i32.const 1056
   global.get $~lib/builtins/i32.MAX_VALUE
   call $~lib/string/String#split
-  local.set $108
-  local.get $107
+  local.set $160
+  local.get $135
   call $~lib/rt/pure/__release
-  local.get $108
-  local.set $107
-  local.get $107
+  local.get $160
+  local.set $135
+  local.get $135
   call $~lib/array/Array<~lib/string/String>#get:length
   i32.const 4
   i32.eq
   if (result i32)
-   local.get $107
+   local.get $135
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $108
+   local.tee $161
    i32.const 320
    call $~lib/string/String.__eq
-   local.set $109
-   local.get $108
+   local.set $162
+   local.get $161
    call $~lib/rt/pure/__release
-   local.get $109
+   local.get $162
   else
    i32.const 0
   end
   i32.const 0
   i32.ne
   if (result i32)
-   local.get $107
+   local.get $135
    i32.const 1
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $108
+   local.tee $163
    i32.const 10384
    call $~lib/string/String.__eq
-   local.set $109
-   local.get $108
+   local.set $164
+   local.get $163
    call $~lib/rt/pure/__release
-   local.get $109
+   local.get $164
   else
    i32.const 0
   end
   i32.const 0
   i32.ne
   if (result i32)
-   local.get $107
+   local.get $135
    i32.const 2
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $108
+   local.tee $165
    i32.const 272
    call $~lib/string/String.__eq
-   local.set $109
-   local.get $108
+   local.set $166
+   local.get $165
    call $~lib/rt/pure/__release
-   local.get $109
+   local.get $166
   else
    i32.const 0
   end
   i32.const 0
   i32.ne
   if (result i32)
-   local.get $107
+   local.get $135
    i32.const 3
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $108
+   local.tee $167
    i32.const 11232
    call $~lib/string/String.__eq
-   local.set $109
-   local.get $108
+   local.set $168
+   local.get $167
    call $~lib/rt/pure/__release
-   local.get $109
+   local.get $168
   else
    i32.const 0
   end
@@ -16159,74 +16653,74 @@
   i32.const 1056
   global.get $~lib/builtins/i32.MAX_VALUE
   call $~lib/string/String#split
-  local.set $109
-  local.get $107
+  local.set $169
+  local.get $135
   call $~lib/rt/pure/__release
-  local.get $109
-  local.set $107
-  local.get $107
+  local.get $169
+  local.set $135
+  local.get $135
   call $~lib/array/Array<~lib/string/String>#get:length
   i32.const 4
   i32.eq
   if (result i32)
-   local.get $107
+   local.get $135
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $109
+   local.tee $170
    i32.const 272
    call $~lib/string/String.__eq
-   local.set $108
-   local.get $109
+   local.set $171
+   local.get $170
    call $~lib/rt/pure/__release
-   local.get $108
+   local.get $171
   else
    i32.const 0
   end
   i32.const 0
   i32.ne
   if (result i32)
-   local.get $107
+   local.get $135
    i32.const 1
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $109
+   local.tee $172
    i32.const 320
    call $~lib/string/String.__eq
-   local.set $108
-   local.get $109
+   local.set $173
+   local.get $172
    call $~lib/rt/pure/__release
-   local.get $108
+   local.get $173
   else
    i32.const 0
   end
   i32.const 0
   i32.ne
   if (result i32)
-   local.get $107
+   local.get $135
    i32.const 2
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $109
+   local.tee $174
    i32.const 10384
    call $~lib/string/String.__eq
-   local.set $108
-   local.get $109
+   local.set $175
+   local.get $174
    call $~lib/rt/pure/__release
-   local.get $108
+   local.get $175
   else
    i32.const 0
   end
   i32.const 0
   i32.ne
   if (result i32)
-   local.get $107
+   local.get $135
    i32.const 3
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $109
+   local.tee $176
    i32.const 11232
    call $~lib/string/String.__eq
-   local.set $108
-   local.get $109
+   local.set $177
+   local.get $176
    call $~lib/rt/pure/__release
-   local.get $108
+   local.get $177
   else
    i32.const 0
   end
@@ -16245,74 +16739,74 @@
   i32.const 1056
   global.get $~lib/builtins/i32.MAX_VALUE
   call $~lib/string/String#split
-  local.set $108
-  local.get $107
+  local.set $178
+  local.get $135
   call $~lib/rt/pure/__release
-  local.get $108
-  local.set $107
-  local.get $107
+  local.get $178
+  local.set $135
+  local.get $135
   call $~lib/array/Array<~lib/string/String>#get:length
   i32.const 4
   i32.eq
   if (result i32)
-   local.get $107
+   local.get $135
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $108
+   local.tee $179
    i32.const 320
    call $~lib/string/String.__eq
-   local.set $109
-   local.get $108
+   local.set $180
+   local.get $179
    call $~lib/rt/pure/__release
-   local.get $109
+   local.get $180
   else
    i32.const 0
   end
   i32.const 0
   i32.ne
   if (result i32)
-   local.get $107
+   local.get $135
    i32.const 1
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $108
+   local.tee $181
    i32.const 10384
    call $~lib/string/String.__eq
-   local.set $109
-   local.get $108
+   local.set $182
+   local.get $181
    call $~lib/rt/pure/__release
-   local.get $109
+   local.get $182
   else
    i32.const 0
   end
   i32.const 0
   i32.ne
   if (result i32)
-   local.get $107
+   local.get $135
    i32.const 2
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $108
+   local.tee $183
    i32.const 11232
    call $~lib/string/String.__eq
-   local.set $109
-   local.get $108
+   local.set $184
+   local.get $183
    call $~lib/rt/pure/__release
-   local.get $109
+   local.get $184
   else
    i32.const 0
   end
   i32.const 0
   i32.ne
   if (result i32)
-   local.get $107
+   local.get $135
    i32.const 3
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $108
+   local.tee $185
    i32.const 272
    call $~lib/string/String.__eq
-   local.set $109
-   local.get $108
+   local.set $186
+   local.get $185
    call $~lib/rt/pure/__release
-   local.get $109
+   local.get $186
   else
    i32.const 0
   end
@@ -16331,58 +16825,58 @@
   i32.const 272
   global.get $~lib/builtins/i32.MAX_VALUE
   call $~lib/string/String#split
-  local.set $109
-  local.get $107
+  local.set $187
+  local.get $135
   call $~lib/rt/pure/__release
-  local.get $109
-  local.set $107
-  local.get $107
+  local.get $187
+  local.set $135
+  local.get $135
   call $~lib/array/Array<~lib/string/String>#get:length
   i32.const 3
   i32.eq
   if (result i32)
-   local.get $107
+   local.get $135
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $109
+   local.tee $188
    i32.const 320
    call $~lib/string/String.__eq
-   local.set $108
-   local.get $109
+   local.set $189
+   local.get $188
    call $~lib/rt/pure/__release
-   local.get $108
+   local.get $189
   else
    i32.const 0
   end
   i32.const 0
   i32.ne
   if (result i32)
-   local.get $107
+   local.get $135
    i32.const 1
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $109
+   local.tee $190
    i32.const 10384
    call $~lib/string/String.__eq
-   local.set $108
-   local.get $109
+   local.set $191
+   local.get $190
    call $~lib/rt/pure/__release
-   local.get $108
+   local.get $191
   else
    i32.const 0
   end
   i32.const 0
   i32.ne
   if (result i32)
-   local.get $107
+   local.get $135
    i32.const 2
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $109
+   local.tee $192
    i32.const 11232
    call $~lib/string/String.__eq
-   local.set $108
-   local.get $109
+   local.set $193
+   local.get $192
    call $~lib/rt/pure/__release
-   local.get $108
+   local.get $193
   else
    i32.const 0
   end
@@ -16401,12 +16895,12 @@
   i32.const 272
   i32.const 0
   call $~lib/string/String#split
-  local.set $108
-  local.get $107
+  local.set $194
+  local.get $135
   call $~lib/rt/pure/__release
-  local.get $108
-  local.set $107
-  local.get $107
+  local.get $194
+  local.set $135
+  local.get $135
   call $~lib/array/Array<~lib/string/String>#get:length
   i32.const 0
   i32.eq
@@ -16423,26 +16917,26 @@
   i32.const 272
   i32.const 1
   call $~lib/string/String#split
-  local.set $109
-  local.get $107
+  local.set $195
+  local.get $135
   call $~lib/rt/pure/__release
-  local.get $109
-  local.set $107
-  local.get $107
+  local.get $195
+  local.set $135
+  local.get $135
   call $~lib/array/Array<~lib/string/String>#get:length
   i32.const 1
   i32.eq
   if (result i32)
-   local.get $107
+   local.get $135
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $109
+   local.tee $196
    i32.const 320
    call $~lib/string/String.__eq
-   local.set $108
-   local.get $109
+   local.set $197
+   local.get $196
    call $~lib/rt/pure/__release
-   local.get $108
+   local.get $197
   else
    i32.const 0
   end
@@ -16461,26 +16955,26 @@
   i32.const 1056
   i32.const 1
   call $~lib/string/String#split
-  local.set $108
-  local.get $107
+  local.set $198
+  local.get $135
   call $~lib/rt/pure/__release
-  local.get $108
-  local.set $107
-  local.get $107
+  local.get $198
+  local.set $135
+  local.get $135
   call $~lib/array/Array<~lib/string/String>#get:length
   i32.const 1
   i32.eq
   if (result i32)
-   local.get $107
+   local.get $135
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $108
+   local.tee $199
    i32.const 320
    call $~lib/string/String.__eq
-   local.set $109
-   local.get $108
+   local.set $200
+   local.get $199
    call $~lib/rt/pure/__release
-   local.get $109
+   local.get $200
   else
    i32.const 0
   end
@@ -16499,58 +16993,58 @@
   i32.const 272
   i32.const 4
   call $~lib/string/String#split
-  local.set $109
-  local.get $107
+  local.set $201
+  local.get $135
   call $~lib/rt/pure/__release
-  local.get $109
-  local.set $107
-  local.get $107
+  local.get $201
+  local.set $135
+  local.get $135
   call $~lib/array/Array<~lib/string/String>#get:length
   i32.const 3
   i32.eq
   if (result i32)
-   local.get $107
+   local.get $135
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $109
+   local.tee $202
    i32.const 320
    call $~lib/string/String.__eq
-   local.set $108
-   local.get $109
+   local.set $203
+   local.get $202
    call $~lib/rt/pure/__release
-   local.get $108
+   local.get $203
   else
    i32.const 0
   end
   i32.const 0
   i32.ne
   if (result i32)
-   local.get $107
+   local.get $135
    i32.const 1
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $109
+   local.tee $204
    i32.const 10384
    call $~lib/string/String.__eq
-   local.set $108
-   local.get $109
+   local.set $205
+   local.get $204
    call $~lib/rt/pure/__release
-   local.get $108
+   local.get $205
   else
    i32.const 0
   end
   i32.const 0
   i32.ne
   if (result i32)
-   local.get $107
+   local.get $135
    i32.const 2
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $109
+   local.tee $206
    i32.const 11232
    call $~lib/string/String.__eq
-   local.set $108
-   local.get $109
+   local.set $207
+   local.get $206
    call $~lib/rt/pure/__release
-   local.get $108
+   local.get $207
   else
    i32.const 0
   end
@@ -16569,58 +17063,58 @@
   i32.const 272
   i32.const -1
   call $~lib/string/String#split
-  local.set $108
-  local.get $107
+  local.set $208
+  local.get $135
   call $~lib/rt/pure/__release
-  local.get $108
-  local.set $107
-  local.get $107
+  local.get $208
+  local.set $135
+  local.get $135
   call $~lib/array/Array<~lib/string/String>#get:length
   i32.const 3
   i32.eq
   if (result i32)
-   local.get $107
+   local.get $135
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $108
+   local.tee $209
    i32.const 320
    call $~lib/string/String.__eq
-   local.set $109
-   local.get $108
+   local.set $210
+   local.get $209
    call $~lib/rt/pure/__release
-   local.get $109
+   local.get $210
   else
    i32.const 0
   end
   i32.const 0
   i32.ne
   if (result i32)
-   local.get $107
+   local.get $135
    i32.const 1
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $108
+   local.tee $211
    i32.const 10384
    call $~lib/string/String.__eq
-   local.set $109
-   local.get $108
+   local.set $212
+   local.get $211
    call $~lib/rt/pure/__release
-   local.get $109
+   local.get $212
   else
    i32.const 0
   end
   i32.const 0
   i32.ne
   if (result i32)
-   local.get $107
+   local.get $135
    i32.const 2
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $108
+   local.tee $213
    i32.const 11232
    call $~lib/string/String.__eq
-   local.set $109
-   local.get $108
+   local.set $214
+   local.get $213
    call $~lib/rt/pure/__release
-   local.get $109
+   local.get $214
   else
    i32.const 0
   end
@@ -16639,58 +17133,58 @@
   i32.const 1056
   i32.const -1
   call $~lib/string/String#split
-  local.set $109
-  local.get $107
+  local.set $215
+  local.get $135
   call $~lib/rt/pure/__release
-  local.get $109
-  local.set $107
-  local.get $107
+  local.get $215
+  local.set $135
+  local.get $135
   call $~lib/array/Array<~lib/string/String>#get:length
   i32.const 3
   i32.eq
   if (result i32)
-   local.get $107
+   local.get $135
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $109
+   local.tee $216
    i32.const 320
    call $~lib/string/String.__eq
-   local.set $108
-   local.get $109
+   local.set $217
+   local.get $216
    call $~lib/rt/pure/__release
-   local.get $108
+   local.get $217
   else
    i32.const 0
   end
   i32.const 0
   i32.ne
   if (result i32)
-   local.get $107
+   local.get $135
    i32.const 1
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $109
+   local.tee $218
    i32.const 10384
    call $~lib/string/String.__eq
-   local.set $108
-   local.get $109
+   local.set $219
+   local.get $218
    call $~lib/rt/pure/__release
-   local.get $108
+   local.get $219
   else
    i32.const 0
   end
   i32.const 0
   i32.ne
   if (result i32)
-   local.get $107
+   local.get $135
    i32.const 2
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $109
+   local.tee $220
    i32.const 11232
    call $~lib/string/String.__eq
-   local.set $108
-   local.get $109
+   local.set $221
+   local.get $220
    call $~lib/rt/pure/__release
-   local.get $108
+   local.get $221
   else
    i32.const 0
   end
@@ -16705,11 +17199,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $107
+  local.get $135
   call $~lib/rt/pure/__release
   i32.const 0
   call $~lib/util/number/itoa32
-  local.tee $107
+  local.tee $222
   i32.const 1424
   call $~lib/string/String.__eq
   i32.eqz
@@ -16723,7 +17217,7 @@
   end
   i32.const 1
   call $~lib/util/number/itoa32
-  local.tee $109
+  local.tee $223
   i32.const 1488
   call $~lib/string/String.__eq
   i32.eqz
@@ -16737,7 +17231,7 @@
   end
   i32.const 8
   call $~lib/util/number/itoa32
-  local.tee $108
+  local.tee $224
   i32.const 12944
   call $~lib/string/String.__eq
   i32.eqz
@@ -16751,7 +17245,7 @@
   end
   i32.const 12
   call $~lib/util/number/itoa32
-  local.tee $110
+  local.tee $225
   i32.const 12976
   call $~lib/string/String.__eq
   i32.eqz
@@ -16765,7 +17259,7 @@
   end
   i32.const 123
   call $~lib/util/number/itoa32
-  local.tee $111
+  local.tee $226
   i32.const 864
   call $~lib/string/String.__eq
   i32.eqz
@@ -16779,7 +17273,7 @@
   end
   i32.const -1000
   call $~lib/util/number/itoa32
-  local.tee $112
+  local.tee $227
   i32.const 13008
   call $~lib/string/String.__eq
   i32.eqz
@@ -16793,7 +17287,7 @@
   end
   i32.const 1234
   call $~lib/util/number/itoa32
-  local.tee $113
+  local.tee $228
   i32.const 13040
   call $~lib/string/String.__eq
   i32.eqz
@@ -16807,7 +17301,7 @@
   end
   i32.const 12345
   call $~lib/util/number/itoa32
-  local.tee $114
+  local.tee $229
   i32.const 13072
   call $~lib/string/String.__eq
   i32.eqz
@@ -16821,7 +17315,7 @@
   end
   i32.const 123456
   call $~lib/util/number/itoa32
-  local.tee $115
+  local.tee $230
   i32.const 13104
   call $~lib/string/String.__eq
   i32.eqz
@@ -16835,7 +17329,7 @@
   end
   i32.const 1111111
   call $~lib/util/number/itoa32
-  local.tee $116
+  local.tee $231
   i32.const 13136
   call $~lib/string/String.__eq
   i32.eqz
@@ -16849,7 +17343,7 @@
   end
   i32.const 1234567
   call $~lib/util/number/itoa32
-  local.tee $117
+  local.tee $232
   i32.const 13168
   call $~lib/string/String.__eq
   i32.eqz
@@ -16863,7 +17357,7 @@
   end
   i32.const 12345678
   call $~lib/util/number/itoa32
-  local.tee $118
+  local.tee $233
   i32.const 13200
   call $~lib/string/String.__eq
   i32.eqz
@@ -16877,7 +17371,7 @@
   end
   i32.const 123456789
   call $~lib/util/number/itoa32
-  local.tee $119
+  local.tee $234
   i32.const 13232
   call $~lib/string/String.__eq
   i32.eqz
@@ -16891,7 +17385,7 @@
   end
   i32.const 2147483646
   call $~lib/util/number/itoa32
-  local.tee $120
+  local.tee $235
   i32.const 13280
   call $~lib/string/String.__eq
   i32.eqz
@@ -16905,7 +17399,7 @@
   end
   i32.const 2147483647
   call $~lib/util/number/itoa32
-  local.tee $121
+  local.tee $236
   i32.const 13328
   call $~lib/string/String.__eq
   i32.eqz
@@ -16919,7 +17413,7 @@
   end
   i32.const -2147483648
   call $~lib/util/number/itoa32
-  local.tee $122
+  local.tee $237
   i32.const 13376
   call $~lib/string/String.__eq
   i32.eqz
@@ -16933,7 +17427,7 @@
   end
   i32.const -1
   call $~lib/util/number/itoa32
-  local.tee $123
+  local.tee $238
   i32.const 13424
   call $~lib/string/String.__eq
   i32.eqz
@@ -16947,7 +17441,7 @@
   end
   i32.const 0
   call $~lib/util/number/utoa32
-  local.tee $124
+  local.tee $239
   i32.const 1424
   call $~lib/string/String.__eq
   i32.eqz
@@ -16961,7 +17455,7 @@
   end
   i32.const 1000
   call $~lib/util/number/utoa32
-  local.tee $125
+  local.tee $240
   i32.const 13456
   call $~lib/string/String.__eq
   i32.eqz
@@ -16975,7 +17469,7 @@
   end
   i32.const 2147483647
   call $~lib/util/number/utoa32
-  local.tee $126
+  local.tee $241
   i32.const 13328
   call $~lib/string/String.__eq
   i32.eqz
@@ -16989,7 +17483,7 @@
   end
   i32.const -2147483648
   call $~lib/util/number/utoa32
-  local.tee $127
+  local.tee $242
   i32.const 13488
   call $~lib/string/String.__eq
   i32.eqz
@@ -17003,7 +17497,7 @@
   end
   global.get $~lib/builtins/u32.MAX_VALUE
   call $~lib/util/number/utoa32
-  local.tee $128
+  local.tee $243
   i32.const 13536
   call $~lib/string/String.__eq
   i32.eqz
@@ -17017,7 +17511,7 @@
   end
   i64.const 0
   call $~lib/util/number/utoa64
-  local.tee $129
+  local.tee $244
   i32.const 1424
   call $~lib/string/String.__eq
   i32.eqz
@@ -17031,7 +17525,7 @@
   end
   i64.const 12
   call $~lib/util/number/utoa64
-  local.tee $130
+  local.tee $245
   i32.const 12976
   call $~lib/string/String.__eq
   i32.eqz
@@ -17045,7 +17539,7 @@
   end
   i64.const 123
   call $~lib/util/number/utoa64
-  local.tee $131
+  local.tee $246
   i32.const 864
   call $~lib/string/String.__eq
   i32.eqz
@@ -17059,7 +17553,7 @@
   end
   i64.const 1234
   call $~lib/util/number/utoa64
-  local.tee $132
+  local.tee $247
   i32.const 13040
   call $~lib/string/String.__eq
   i32.eqz
@@ -17073,7 +17567,7 @@
   end
   i64.const 12345
   call $~lib/util/number/utoa64
-  local.tee $133
+  local.tee $248
   i32.const 13072
   call $~lib/string/String.__eq
   i32.eqz
@@ -17087,7 +17581,7 @@
   end
   i64.const 123456
   call $~lib/util/number/utoa64
-  local.tee $134
+  local.tee $249
   i32.const 13104
   call $~lib/string/String.__eq
   i32.eqz
@@ -17101,7 +17595,7 @@
   end
   i64.const 1234567
   call $~lib/util/number/utoa64
-  local.tee $135
+  local.tee $250
   i32.const 13168
   call $~lib/string/String.__eq
   i32.eqz
@@ -17115,7 +17609,7 @@
   end
   i64.const 99999999
   call $~lib/util/number/utoa64
-  local.tee $136
+  local.tee $251
   i32.const 13584
   call $~lib/string/String.__eq
   i32.eqz
@@ -17129,7 +17623,7 @@
   end
   i64.const 100000000
   call $~lib/util/number/utoa64
-  local.tee $137
+  local.tee $252
   i32.const 13616
   call $~lib/string/String.__eq
   i32.eqz
@@ -17143,7 +17637,7 @@
   end
   i64.const 4294967295
   call $~lib/util/number/utoa64
-  local.tee $138
+  local.tee $253
   i32.const 13536
   call $~lib/string/String.__eq
   i32.eqz
@@ -17157,7 +17651,7 @@
   end
   i64.const 4294967297
   call $~lib/util/number/utoa64
-  local.tee $139
+  local.tee $254
   i32.const 13664
   call $~lib/string/String.__eq
   i32.eqz
@@ -17171,7 +17665,7 @@
   end
   i64.const 68719476735
   call $~lib/util/number/utoa64
-  local.tee $140
+  local.tee $255
   i32.const 13712
   call $~lib/string/String.__eq
   i32.eqz
@@ -17185,7 +17679,7 @@
   end
   i64.const 868719476735
   call $~lib/util/number/utoa64
-  local.tee $141
+  local.tee $256
   i32.const 13760
   call $~lib/string/String.__eq
   i32.eqz
@@ -17199,7 +17693,7 @@
   end
   i64.const 8687194767350
   call $~lib/util/number/utoa64
-  local.tee $142
+  local.tee $257
   i32.const 13808
   call $~lib/string/String.__eq
   i32.eqz
@@ -17213,7 +17707,7 @@
   end
   i64.const 86871947673501
   call $~lib/util/number/utoa64
-  local.tee $143
+  local.tee $258
   i32.const 13856
   call $~lib/string/String.__eq
   i32.eqz
@@ -17227,7 +17721,7 @@
   end
   i64.const 999868719476735
   call $~lib/util/number/utoa64
-  local.tee $144
+  local.tee $259
   i32.const 13904
   call $~lib/string/String.__eq
   i32.eqz
@@ -17241,7 +17735,7 @@
   end
   i64.const 9999868719476735
   call $~lib/util/number/utoa64
-  local.tee $145
+  local.tee $260
   i32.const 13952
   call $~lib/string/String.__eq
   i32.eqz
@@ -17255,7 +17749,7 @@
   end
   i64.const 19999868719476735
   call $~lib/util/number/utoa64
-  local.tee $146
+  local.tee $261
   i32.const 14000
   call $~lib/string/String.__eq
   i32.eqz
@@ -17269,7 +17763,7 @@
   end
   i64.const 129999868719476735
   call $~lib/util/number/utoa64
-  local.tee $147
+  local.tee $262
   i32.const 14064
   call $~lib/string/String.__eq
   i32.eqz
@@ -17283,7 +17777,7 @@
   end
   i64.const 1239999868719476735
   call $~lib/util/number/utoa64
-  local.tee $148
+  local.tee $263
   i32.const 14128
   call $~lib/string/String.__eq
   i32.eqz
@@ -17297,7 +17791,7 @@
   end
   global.get $~lib/builtins/u64.MAX_VALUE
   call $~lib/util/number/utoa64
-  local.tee $149
+  local.tee $264
   i32.const 14192
   call $~lib/string/String.__eq
   i32.eqz
@@ -17311,7 +17805,7 @@
   end
   i64.const 0
   call $~lib/util/number/itoa64
-  local.tee $150
+  local.tee $265
   i32.const 1424
   call $~lib/string/String.__eq
   i32.eqz
@@ -17325,7 +17819,7 @@
   end
   i64.const -1234
   call $~lib/util/number/itoa64
-  local.tee $151
+  local.tee $266
   i32.const 14256
   call $~lib/string/String.__eq
   i32.eqz
@@ -17339,7 +17833,7 @@
   end
   i64.const 4294967295
   call $~lib/util/number/itoa64
-  local.tee $152
+  local.tee $267
   i32.const 13536
   call $~lib/string/String.__eq
   i32.eqz
@@ -17353,7 +17847,7 @@
   end
   i64.const 4294967297
   call $~lib/util/number/itoa64
-  local.tee $153
+  local.tee $268
   i32.const 13664
   call $~lib/string/String.__eq
   i32.eqz
@@ -17367,7 +17861,7 @@
   end
   i64.const -4294967295
   call $~lib/util/number/itoa64
-  local.tee $154
+  local.tee $269
   i32.const 14288
   call $~lib/string/String.__eq
   i32.eqz
@@ -17381,7 +17875,7 @@
   end
   i64.const 68719476735
   call $~lib/util/number/itoa64
-  local.tee $155
+  local.tee $270
   i32.const 13712
   call $~lib/string/String.__eq
   i32.eqz
@@ -17395,7 +17889,7 @@
   end
   i64.const -68719476735
   call $~lib/util/number/itoa64
-  local.tee $156
+  local.tee $271
   i32.const 14336
   call $~lib/string/String.__eq
   i32.eqz
@@ -17409,7 +17903,7 @@
   end
   i64.const -868719476735
   call $~lib/util/number/itoa64
-  local.tee $157
+  local.tee $272
   i32.const 14384
   call $~lib/string/String.__eq
   i32.eqz
@@ -17423,7 +17917,7 @@
   end
   i64.const -999868719476735
   call $~lib/util/number/itoa64
-  local.tee $158
+  local.tee $273
   i32.const 14432
   call $~lib/string/String.__eq
   i32.eqz
@@ -17437,7 +17931,7 @@
   end
   i64.const -19999868719476735
   call $~lib/util/number/itoa64
-  local.tee $159
+  local.tee $274
   i32.const 14480
   call $~lib/string/String.__eq
   i32.eqz
@@ -17451,7 +17945,7 @@
   end
   global.get $~lib/builtins/i64.MAX_VALUE
   call $~lib/util/number/itoa64
-  local.tee $160
+  local.tee $275
   i32.const 14544
   call $~lib/string/String.__eq
   i32.eqz
@@ -17465,7 +17959,7 @@
   end
   global.get $~lib/builtins/i64.MIN_VALUE
   call $~lib/util/number/itoa64
-  local.tee $161
+  local.tee $276
   i32.const 14608
   call $~lib/string/String.__eq
   i32.eqz
@@ -17479,7 +17973,7 @@
   end
   f64.const 0
   call $~lib/util/number/dtoa
-  local.tee $162
+  local.tee $277
   i32.const 14672
   call $~lib/string/String.__eq
   i32.eqz
@@ -17493,7 +17987,7 @@
   end
   f64.const -0
   call $~lib/util/number/dtoa
-  local.tee $163
+  local.tee $278
   i32.const 14672
   call $~lib/string/String.__eq
   i32.eqz
@@ -17507,7 +18001,7 @@
   end
   f64.const nan:0x8000000000000
   call $~lib/util/number/dtoa
-  local.tee $164
+  local.tee $279
   i32.const 4800
   call $~lib/string/String.__eq
   i32.eqz
@@ -17521,7 +18015,7 @@
   end
   f64.const inf
   call $~lib/util/number/dtoa
-  local.tee $165
+  local.tee $280
   i32.const 14704
   call $~lib/string/String.__eq
   i32.eqz
@@ -17536,7 +18030,7 @@
   f64.const inf
   f64.neg
   call $~lib/util/number/dtoa
-  local.tee $166
+  local.tee $281
   i32.const 6016
   call $~lib/string/String.__eq
   i32.eqz
@@ -17550,7 +18044,7 @@
   end
   global.get $~lib/builtins/f64.EPSILON
   call $~lib/util/number/dtoa
-  local.tee $167
+  local.tee $282
   i32.const 5312
   call $~lib/string/String.__eq
   i32.eqz
@@ -17565,7 +18059,7 @@
   global.get $~lib/builtins/f64.EPSILON
   f64.neg
   call $~lib/util/number/dtoa
-  local.tee $168
+  local.tee $283
   i32.const 15648
   call $~lib/string/String.__eq
   i32.eqz
@@ -17579,7 +18073,7 @@
   end
   global.get $~lib/builtins/f64.MAX_VALUE
   call $~lib/util/number/dtoa
-  local.tee $169
+  local.tee $284
   i32.const 5376
   call $~lib/string/String.__eq
   i32.eqz
@@ -17594,7 +18088,7 @@
   global.get $~lib/builtins/f64.MAX_VALUE
   f64.neg
   call $~lib/util/number/dtoa
-  local.tee $170
+  local.tee $285
   i32.const 15712
   call $~lib/string/String.__eq
   i32.eqz
@@ -17608,7 +18102,7 @@
   end
   f64.const 4185580496821356722454785e274
   call $~lib/util/number/dtoa
-  local.tee $171
+  local.tee $286
   i32.const 15776
   call $~lib/string/String.__eq
   i32.eqz
@@ -17622,7 +18116,7 @@
   end
   f64.const 2.2250738585072014e-308
   call $~lib/util/number/dtoa
-  local.tee $172
+  local.tee $287
   i32.const 15840
   call $~lib/string/String.__eq
   i32.eqz
@@ -17636,7 +18130,7 @@
   end
   f64.const 4.940656e-318
   call $~lib/util/number/dtoa
-  local.tee $173
+  local.tee $288
   i32.const 15904
   call $~lib/string/String.__eq
   i32.eqz
@@ -17650,7 +18144,7 @@
   end
   f64.const 9060801153433600
   call $~lib/util/number/dtoa
-  local.tee $174
+  local.tee $289
   i32.const 15952
   call $~lib/string/String.__eq
   i32.eqz
@@ -17664,7 +18158,7 @@
   end
   f64.const 4708356024711512064
   call $~lib/util/number/dtoa
-  local.tee $175
+  local.tee $290
   i32.const 16016
   call $~lib/string/String.__eq
   i32.eqz
@@ -17678,7 +18172,7 @@
   end
   f64.const 9409340012568248320
   call $~lib/util/number/dtoa
-  local.tee $176
+  local.tee $291
   i32.const 16080
   call $~lib/string/String.__eq
   i32.eqz
@@ -17692,7 +18186,7 @@
   end
   f64.const 5e-324
   call $~lib/util/number/dtoa
-  local.tee $177
+  local.tee $292
   i32.const 5440
   call $~lib/string/String.__eq
   i32.eqz
@@ -17706,7 +18200,7 @@
   end
   f64.const 1
   call $~lib/util/number/dtoa
-  local.tee $178
+  local.tee $293
   i32.const 16144
   call $~lib/string/String.__eq
   i32.eqz
@@ -17720,7 +18214,7 @@
   end
   f64.const 0.1
   call $~lib/util/number/dtoa
-  local.tee $179
+  local.tee $294
   i32.const 2448
   call $~lib/string/String.__eq
   i32.eqz
@@ -17734,7 +18228,7 @@
   end
   f64.const -1
   call $~lib/util/number/dtoa
-  local.tee $180
+  local.tee $295
   i32.const 16176
   call $~lib/string/String.__eq
   i32.eqz
@@ -17748,7 +18242,7 @@
   end
   f64.const -0.1
   call $~lib/util/number/dtoa
-  local.tee $181
+  local.tee $296
   i32.const 16208
   call $~lib/string/String.__eq
   i32.eqz
@@ -17762,7 +18256,7 @@
   end
   f64.const 1e6
   call $~lib/util/number/dtoa
-  local.tee $182
+  local.tee $297
   i32.const 16240
   call $~lib/string/String.__eq
   i32.eqz
@@ -17776,7 +18270,7 @@
   end
   f64.const 1e-06
   call $~lib/util/number/dtoa
-  local.tee $183
+  local.tee $298
   i32.const 16288
   call $~lib/string/String.__eq
   i32.eqz
@@ -17790,7 +18284,7 @@
   end
   f64.const -1e6
   call $~lib/util/number/dtoa
-  local.tee $184
+  local.tee $299
   i32.const 16320
   call $~lib/string/String.__eq
   i32.eqz
@@ -17804,7 +18298,7 @@
   end
   f64.const -1e-06
   call $~lib/util/number/dtoa
-  local.tee $185
+  local.tee $300
   i32.const 16368
   call $~lib/string/String.__eq
   i32.eqz
@@ -17818,7 +18312,7 @@
   end
   f64.const 1e7
   call $~lib/util/number/dtoa
-  local.tee $186
+  local.tee $301
   i32.const 16416
   call $~lib/string/String.__eq
   i32.eqz
@@ -17832,7 +18326,7 @@
   end
   f64.const 1e-07
   call $~lib/util/number/dtoa
-  local.tee $187
+  local.tee $302
   i32.const 16464
   call $~lib/string/String.__eq
   i32.eqz
@@ -17846,7 +18340,7 @@
   end
   f64.const 1.e+308
   call $~lib/util/number/dtoa
-  local.tee $188
+  local.tee $303
   i32.const 2672
   call $~lib/string/String.__eq
   i32.eqz
@@ -17860,7 +18354,7 @@
   end
   f64.const -1.e+308
   call $~lib/util/number/dtoa
-  local.tee $189
+  local.tee $304
   i32.const 16496
   call $~lib/string/String.__eq
   i32.eqz
@@ -17874,7 +18368,7 @@
   end
   f64.const inf
   call $~lib/util/number/dtoa
-  local.tee $190
+  local.tee $305
   i32.const 14704
   call $~lib/string/String.__eq
   i32.eqz
@@ -17888,7 +18382,7 @@
   end
   f64.const -inf
   call $~lib/util/number/dtoa
-  local.tee $191
+  local.tee $306
   i32.const 6016
   call $~lib/string/String.__eq
   i32.eqz
@@ -17902,7 +18396,7 @@
   end
   f64.const 1e-308
   call $~lib/util/number/dtoa
-  local.tee $192
+  local.tee $307
   i32.const 16528
   call $~lib/string/String.__eq
   i32.eqz
@@ -17916,7 +18410,7 @@
   end
   f64.const -1e-308
   call $~lib/util/number/dtoa
-  local.tee $193
+  local.tee $308
   i32.const 16560
   call $~lib/string/String.__eq
   i32.eqz
@@ -17930,7 +18424,7 @@
   end
   f64.const 1e-323
   call $~lib/util/number/dtoa
-  local.tee $194
+  local.tee $309
   i32.const 16592
   call $~lib/string/String.__eq
   i32.eqz
@@ -17944,7 +18438,7 @@
   end
   f64.const -1e-323
   call $~lib/util/number/dtoa
-  local.tee $195
+  local.tee $310
   i32.const 16624
   call $~lib/string/String.__eq
   i32.eqz
@@ -17958,7 +18452,7 @@
   end
   f64.const 0
   call $~lib/util/number/dtoa
-  local.tee $196
+  local.tee $311
   i32.const 14672
   call $~lib/string/String.__eq
   i32.eqz
@@ -17972,7 +18466,7 @@
   end
   f64.const 4294967272
   call $~lib/util/number/dtoa
-  local.tee $197
+  local.tee $312
   i32.const 16656
   call $~lib/string/String.__eq
   i32.eqz
@@ -17986,7 +18480,7 @@
   end
   f64.const 1.2312145673456234e-08
   call $~lib/util/number/dtoa
-  local.tee $198
+  local.tee $313
   i32.const 16704
   call $~lib/string/String.__eq
   i32.eqz
@@ -18000,7 +18494,7 @@
   end
   f64.const 555555555.5555556
   call $~lib/util/number/dtoa
-  local.tee $199
+  local.tee $314
   i32.const 16768
   call $~lib/string/String.__eq
   i32.eqz
@@ -18014,7 +18508,7 @@
   end
   f64.const 0.9999999999999999
   call $~lib/util/number/dtoa
-  local.tee $200
+  local.tee $315
   i32.const 16832
   call $~lib/string/String.__eq
   i32.eqz
@@ -18028,7 +18522,7 @@
   end
   f64.const 1
   call $~lib/util/number/dtoa
-  local.tee $201
+  local.tee $316
   i32.const 16144
   call $~lib/string/String.__eq
   i32.eqz
@@ -18042,7 +18536,7 @@
   end
   f64.const 12.34
   call $~lib/util/number/dtoa
-  local.tee $202
+  local.tee $317
   i32.const 16896
   call $~lib/string/String.__eq
   i32.eqz
@@ -18058,7 +18552,7 @@
   f64.const 3
   f64.div
   call $~lib/util/number/dtoa
-  local.tee $203
+  local.tee $318
   i32.const 16928
   call $~lib/string/String.__eq
   i32.eqz
@@ -18072,7 +18566,7 @@
   end
   f64.const 1234e17
   call $~lib/util/number/dtoa
-  local.tee $204
+  local.tee $319
   i32.const 16992
   call $~lib/string/String.__eq
   i32.eqz
@@ -18086,7 +18580,7 @@
   end
   f64.const 1234e18
   call $~lib/util/number/dtoa
-  local.tee $205
+  local.tee $320
   i32.const 17056
   call $~lib/string/String.__eq
   i32.eqz
@@ -18100,7 +18594,7 @@
   end
   f64.const 2.71828
   call $~lib/util/number/dtoa
-  local.tee $206
+  local.tee $321
   i32.const 17104
   call $~lib/string/String.__eq
   i32.eqz
@@ -18114,7 +18608,7 @@
   end
   f64.const 0.0271828
   call $~lib/util/number/dtoa
-  local.tee $207
+  local.tee $322
   i32.const 17136
   call $~lib/string/String.__eq
   i32.eqz
@@ -18128,7 +18622,7 @@
   end
   f64.const 271.828
   call $~lib/util/number/dtoa
-  local.tee $208
+  local.tee $323
   i32.const 17184
   call $~lib/string/String.__eq
   i32.eqz
@@ -18142,7 +18636,7 @@
   end
   f64.const 1.1e+128
   call $~lib/util/number/dtoa
-  local.tee $209
+  local.tee $324
   i32.const 17216
   call $~lib/string/String.__eq
   i32.eqz
@@ -18156,7 +18650,7 @@
   end
   f64.const 1.1e-64
   call $~lib/util/number/dtoa
-  local.tee $210
+  local.tee $325
   i32.const 17248
   call $~lib/string/String.__eq
   i32.eqz
@@ -18170,7 +18664,7 @@
   end
   f64.const 0.000035689
   call $~lib/util/number/dtoa
-  local.tee $211
+  local.tee $326
   i32.const 17280
   call $~lib/string/String.__eq
   i32.eqz
@@ -18248,44 +18742,6 @@
   call $~lib/rt/pure/__release
   local.get $31
   call $~lib/rt/pure/__release
-  local.get $33
-  call $~lib/rt/pure/__release
-  local.get $34
-  call $~lib/rt/pure/__release
-  local.get $35
-  call $~lib/rt/pure/__release
-  local.get $36
-  call $~lib/rt/pure/__release
-  local.get $37
-  call $~lib/rt/pure/__release
-  local.get $38
-  call $~lib/rt/pure/__release
-  local.get $39
-  call $~lib/rt/pure/__release
-  local.get $40
-  call $~lib/rt/pure/__release
-  local.get $41
-  call $~lib/rt/pure/__release
-  local.get $42
-  call $~lib/rt/pure/__release
-  local.get $43
-  call $~lib/rt/pure/__release
-  local.get $44
-  call $~lib/rt/pure/__release
-  local.get $45
-  call $~lib/rt/pure/__release
-  local.get $46
-  call $~lib/rt/pure/__release
-  local.get $47
-  call $~lib/rt/pure/__release
-  local.get $48
-  call $~lib/rt/pure/__release
-  local.get $49
-  call $~lib/rt/pure/__release
-  local.get $50
-  call $~lib/rt/pure/__release
-  local.get $51
-  call $~lib/rt/pure/__release
   local.get $52
   call $~lib/rt/pure/__release
   local.get $53
@@ -18293,22 +18749,6 @@
   local.get $54
   call $~lib/rt/pure/__release
   local.get $55
-  call $~lib/rt/pure/__release
-  local.get $56
-  call $~lib/rt/pure/__release
-  local.get $57
-  call $~lib/rt/pure/__release
-  local.get $58
-  call $~lib/rt/pure/__release
-  local.get $59
-  call $~lib/rt/pure/__release
-  local.get $60
-  call $~lib/rt/pure/__release
-  local.get $61
-  call $~lib/rt/pure/__release
-  local.get $62
-  call $~lib/rt/pure/__release
-  local.get $63
   call $~lib/rt/pure/__release
   local.get $64
   call $~lib/rt/pure/__release
@@ -18396,8 +18836,6 @@
   call $~lib/rt/pure/__release
   local.get $106
   call $~lib/rt/pure/__release
-  local.get $107
-  call $~lib/rt/pure/__release
   local.get $108
   call $~lib/rt/pure/__release
   local.get $109
@@ -18452,159 +18890,215 @@
   call $~lib/rt/pure/__release
   local.get $134
   call $~lib/rt/pure/__release
-  local.get $135
+  local.get $222
   call $~lib/rt/pure/__release
-  local.get $136
+  local.get $223
   call $~lib/rt/pure/__release
-  local.get $137
+  local.get $224
   call $~lib/rt/pure/__release
-  local.get $138
+  local.get $225
   call $~lib/rt/pure/__release
-  local.get $139
+  local.get $226
   call $~lib/rt/pure/__release
-  local.get $140
+  local.get $227
   call $~lib/rt/pure/__release
-  local.get $141
+  local.get $228
   call $~lib/rt/pure/__release
-  local.get $142
+  local.get $229
   call $~lib/rt/pure/__release
-  local.get $143
+  local.get $230
   call $~lib/rt/pure/__release
-  local.get $144
+  local.get $231
   call $~lib/rt/pure/__release
-  local.get $145
+  local.get $232
   call $~lib/rt/pure/__release
-  local.get $146
+  local.get $233
   call $~lib/rt/pure/__release
-  local.get $147
+  local.get $234
   call $~lib/rt/pure/__release
-  local.get $148
+  local.get $235
   call $~lib/rt/pure/__release
-  local.get $149
+  local.get $236
   call $~lib/rt/pure/__release
-  local.get $150
+  local.get $237
   call $~lib/rt/pure/__release
-  local.get $151
+  local.get $238
   call $~lib/rt/pure/__release
-  local.get $152
+  local.get $239
   call $~lib/rt/pure/__release
-  local.get $153
+  local.get $240
   call $~lib/rt/pure/__release
-  local.get $154
+  local.get $241
   call $~lib/rt/pure/__release
-  local.get $155
+  local.get $242
   call $~lib/rt/pure/__release
-  local.get $156
+  local.get $243
   call $~lib/rt/pure/__release
-  local.get $157
+  local.get $244
   call $~lib/rt/pure/__release
-  local.get $158
+  local.get $245
   call $~lib/rt/pure/__release
-  local.get $159
+  local.get $246
   call $~lib/rt/pure/__release
-  local.get $160
+  local.get $247
   call $~lib/rt/pure/__release
-  local.get $161
+  local.get $248
   call $~lib/rt/pure/__release
-  local.get $162
+  local.get $249
   call $~lib/rt/pure/__release
-  local.get $163
+  local.get $250
   call $~lib/rt/pure/__release
-  local.get $164
+  local.get $251
   call $~lib/rt/pure/__release
-  local.get $165
+  local.get $252
   call $~lib/rt/pure/__release
-  local.get $166
+  local.get $253
   call $~lib/rt/pure/__release
-  local.get $167
+  local.get $254
   call $~lib/rt/pure/__release
-  local.get $168
+  local.get $255
   call $~lib/rt/pure/__release
-  local.get $169
+  local.get $256
   call $~lib/rt/pure/__release
-  local.get $170
+  local.get $257
   call $~lib/rt/pure/__release
-  local.get $171
+  local.get $258
   call $~lib/rt/pure/__release
-  local.get $172
+  local.get $259
   call $~lib/rt/pure/__release
-  local.get $173
+  local.get $260
   call $~lib/rt/pure/__release
-  local.get $174
+  local.get $261
   call $~lib/rt/pure/__release
-  local.get $175
+  local.get $262
   call $~lib/rt/pure/__release
-  local.get $176
+  local.get $263
   call $~lib/rt/pure/__release
-  local.get $177
+  local.get $264
   call $~lib/rt/pure/__release
-  local.get $178
+  local.get $265
   call $~lib/rt/pure/__release
-  local.get $179
+  local.get $266
   call $~lib/rt/pure/__release
-  local.get $180
+  local.get $267
   call $~lib/rt/pure/__release
-  local.get $181
+  local.get $268
   call $~lib/rt/pure/__release
-  local.get $182
+  local.get $269
   call $~lib/rt/pure/__release
-  local.get $183
+  local.get $270
   call $~lib/rt/pure/__release
-  local.get $184
+  local.get $271
   call $~lib/rt/pure/__release
-  local.get $185
+  local.get $272
   call $~lib/rt/pure/__release
-  local.get $186
+  local.get $273
   call $~lib/rt/pure/__release
-  local.get $187
+  local.get $274
   call $~lib/rt/pure/__release
-  local.get $188
+  local.get $275
   call $~lib/rt/pure/__release
-  local.get $189
+  local.get $276
   call $~lib/rt/pure/__release
-  local.get $190
+  local.get $277
   call $~lib/rt/pure/__release
-  local.get $191
+  local.get $278
   call $~lib/rt/pure/__release
-  local.get $192
+  local.get $279
   call $~lib/rt/pure/__release
-  local.get $193
+  local.get $280
   call $~lib/rt/pure/__release
-  local.get $194
+  local.get $281
   call $~lib/rt/pure/__release
-  local.get $195
+  local.get $282
   call $~lib/rt/pure/__release
-  local.get $196
+  local.get $283
   call $~lib/rt/pure/__release
-  local.get $197
+  local.get $284
   call $~lib/rt/pure/__release
-  local.get $198
+  local.get $285
   call $~lib/rt/pure/__release
-  local.get $199
+  local.get $286
   call $~lib/rt/pure/__release
-  local.get $200
+  local.get $287
   call $~lib/rt/pure/__release
-  local.get $201
+  local.get $288
   call $~lib/rt/pure/__release
-  local.get $202
+  local.get $289
   call $~lib/rt/pure/__release
-  local.get $203
+  local.get $290
   call $~lib/rt/pure/__release
-  local.get $204
+  local.get $291
   call $~lib/rt/pure/__release
-  local.get $205
+  local.get $292
   call $~lib/rt/pure/__release
-  local.get $206
+  local.get $293
   call $~lib/rt/pure/__release
-  local.get $207
+  local.get $294
   call $~lib/rt/pure/__release
-  local.get $208
+  local.get $295
   call $~lib/rt/pure/__release
-  local.get $209
+  local.get $296
   call $~lib/rt/pure/__release
-  local.get $210
+  local.get $297
   call $~lib/rt/pure/__release
-  local.get $211
+  local.get $298
+  call $~lib/rt/pure/__release
+  local.get $299
+  call $~lib/rt/pure/__release
+  local.get $300
+  call $~lib/rt/pure/__release
+  local.get $301
+  call $~lib/rt/pure/__release
+  local.get $302
+  call $~lib/rt/pure/__release
+  local.get $303
+  call $~lib/rt/pure/__release
+  local.get $304
+  call $~lib/rt/pure/__release
+  local.get $305
+  call $~lib/rt/pure/__release
+  local.get $306
+  call $~lib/rt/pure/__release
+  local.get $307
+  call $~lib/rt/pure/__release
+  local.get $308
+  call $~lib/rt/pure/__release
+  local.get $309
+  call $~lib/rt/pure/__release
+  local.get $310
+  call $~lib/rt/pure/__release
+  local.get $311
+  call $~lib/rt/pure/__release
+  local.get $312
+  call $~lib/rt/pure/__release
+  local.get $313
+  call $~lib/rt/pure/__release
+  local.get $314
+  call $~lib/rt/pure/__release
+  local.get $315
+  call $~lib/rt/pure/__release
+  local.get $316
+  call $~lib/rt/pure/__release
+  local.get $317
+  call $~lib/rt/pure/__release
+  local.get $318
+  call $~lib/rt/pure/__release
+  local.get $319
+  call $~lib/rt/pure/__release
+  local.get $320
+  call $~lib/rt/pure/__release
+  local.get $321
+  call $~lib/rt/pure/__release
+  local.get $322
+  call $~lib/rt/pure/__release
+  local.get $323
+  call $~lib/rt/pure/__release
+  local.get $324
+  call $~lib/rt/pure/__release
+  local.get $325
+  call $~lib/rt/pure/__release
+  local.get $326
   call $~lib/rt/pure/__release
  )
  (func $std/string/getString (result i32)

--- a/tests/compiler/std/symbol.untouched.wat
+++ b/tests/compiler/std/symbol.untouched.wat
@@ -66,6 +66,7 @@
  (func $~lib/symbol/Symbol (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
+  (local $3 i32)
   local.get $0
   call $~lib/rt/stub/__retain
   local.set $0
@@ -82,10 +83,10 @@
    unreachable
   end
   local.get $2
-  local.set $1
+  local.set $3
   local.get $0
   call $~lib/rt/stub/__release
-  local.get $1
+  local.get $3
  )
  (func $~lib/rt/stub/maybeGrowMemory (param $0 i32)
   (local $1 i32)
@@ -93,6 +94,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   memory.size
   local.set $1
   local.get $1
@@ -123,8 +125,8 @@
    local.get $5
    i32.gt_s
    select
-   local.set $4
-   local.get $4
+   local.set $6
+   local.get $6
    memory.grow
    i32.const 0
    i32.lt_s
@@ -443,6 +445,8 @@
  (func $~lib/map/Map<~lib/string/String,usize>#clear (param $0 i32)
   (local $1 i32)
   (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
   local.get $0
   local.tee $1
   i32.const 0
@@ -460,15 +464,15 @@
   i32.sub
   i32.store offset=4
   local.get $0
-  local.tee $2
+  local.tee $3
   i32.const 0
   i32.const 48
   call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $1
-  local.get $2
+  local.set $4
+  local.get $3
   i32.load offset=8
   call $~lib/rt/stub/__release
-  local.get $1
+  local.get $4
   i32.store offset=8
   local.get $0
   i32.const 4
@@ -515,6 +519,8 @@
  (func $~lib/map/Map<usize,~lib/string/String>#clear (param $0 i32)
   (local $1 i32)
   (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
   local.get $0
   local.tee $1
   i32.const 0
@@ -532,15 +538,15 @@
   i32.sub
   i32.store offset=4
   local.get $0
-  local.tee $2
+  local.tee $3
   i32.const 0
   i32.const 48
   call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $1
-  local.get $2
+  local.set $4
+  local.get $3
   i32.load offset=8
   call $~lib/rt/stub/__release
-  local.get $1
+  local.get $4
   i32.store offset=8
   local.get $0
   i32.const 4
@@ -597,6 +603,7 @@
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
   local.get $0
   call $~lib/rt/stub/__retain
   local.set $0
@@ -638,10 +645,10 @@
    end
   end
   local.get $1
-  local.set $3
+  local.set $5
   local.get $0
   call $~lib/rt/stub/__release
-  local.get $3
+  local.get $5
  )
  (func $~lib/util/string/compareImpl (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
   (local $5 i32)
@@ -650,6 +657,9 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
   local.get $0
   call $~lib/rt/stub/__retain
   local.set $0
@@ -721,33 +731,33 @@
   end
   loop $while-continue|1
    local.get $4
-   local.tee $7
+   local.tee $8
    i32.const 1
    i32.sub
    local.set $4
-   local.get $7
-   local.set $7
-   local.get $7
+   local.get $8
+   local.set $9
+   local.get $9
    if
     local.get $5
     i32.load16_u
-    local.set $8
+    local.set $10
     local.get $6
     i32.load16_u
-    local.set $9
-    local.get $8
-    local.get $9
+    local.set $11
+    local.get $10
+    local.get $11
     i32.ne
     if
-     local.get $8
-     local.get $9
+     local.get $10
+     local.get $11
      i32.sub
-     local.set $10
+     local.set $12
      local.get $0
      call $~lib/rt/stub/__release
      local.get $2
      call $~lib/rt/stub/__release
-     local.get $10
+     local.get $12
      return
     end
     local.get $5
@@ -762,16 +772,19 @@
    end
   end
   i32.const 0
-  local.set $7
+  local.set $13
   local.get $0
   call $~lib/rt/stub/__release
   local.get $2
   call $~lib/rt/stub/__release
-  local.get $7
+  local.get $13
  )
  (func $~lib/string/String.__eq (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   local.get $0
   call $~lib/rt/stub/__retain
   local.set $0
@@ -803,49 +816,50 @@
   end
   if
    i32.const 0
-   local.set $2
+   local.set $3
    local.get $0
    call $~lib/rt/stub/__release
    local.get $1
    call $~lib/rt/stub/__release
-   local.get $2
+   local.get $3
    return
   end
   local.get $0
   call $~lib/string/String#get:length
-  local.set $3
-  local.get $3
+  local.set $4
+  local.get $4
   local.get $1
   call $~lib/string/String#get:length
   i32.ne
   if
    i32.const 0
-   local.set $2
+   local.set $5
    local.get $0
    call $~lib/rt/stub/__release
    local.get $1
    call $~lib/rt/stub/__release
-   local.get $2
+   local.get $5
    return
   end
   local.get $0
   i32.const 0
   local.get $1
   i32.const 0
-  local.get $3
+  local.get $4
   call $~lib/util/string/compareImpl
   i32.eqz
-  local.set $2
+  local.set $6
   local.get $0
   call $~lib/rt/stub/__release
   local.get $1
   call $~lib/rt/stub/__release
-  local.get $2
+  local.get $6
  )
  (func $~lib/map/Map<~lib/string/String,usize>#find (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   local.get $1
   call $~lib/rt/stub/__retain
   local.set $1
@@ -897,14 +911,15 @@
    end
   end
   i32.const 0
-  local.set $4
+  local.set $6
   local.get $1
   call $~lib/rt/stub/__release
-  local.get $4
+  local.get $6
  )
  (func $~lib/map/Map<~lib/string/String,usize>#has (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
   local.get $1
   call $~lib/rt/stub/__retain
   local.set $1
@@ -927,15 +942,16 @@
   call $~lib/map/Map<~lib/string/String,usize>#find
   i32.const 0
   i32.ne
-  local.set $2
+  local.set $4
   local.get $1
   call $~lib/rt/stub/__release
-  local.get $2
+  local.get $4
  )
  (func $~lib/map/Map<~lib/string/String,usize>#get (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
   local.get $1
   call $~lib/rt/stub/__retain
   local.set $1
@@ -971,10 +987,10 @@
   end
   local.get $4
   i32.load offset=4
-  local.set $2
+  local.set $5
   local.get $1
   call $~lib/rt/stub/__release
-  local.get $2
+  local.get $5
  )
  (func $~lib/map/Map<~lib/string/String,usize>#rehash (param $0 i32) (param $1 i32)
   (local $2 i32)
@@ -989,6 +1005,14 @@
   (local $11 i32)
   (local $12 i32)
   (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
   local.get $1
   i32.const 1
   i32.add
@@ -1065,18 +1089,18 @@
      end
      local.get $1
      i32.and
-     local.set $12
+     local.set $14
      local.get $3
-     local.get $12
+     local.get $14
      i32.const 4
      i32.mul
      i32.add
-     local.set $13
+     local.set $15
      local.get $11
-     local.get $13
+     local.get $15
      i32.load
      i32.store offset=8
-     local.get $13
+     local.get $15
      local.get $8
      i32.store
      local.get $8
@@ -1092,41 +1116,41 @@
    end
   end
   local.get $0
-  local.tee $11
+  local.tee $16
   local.get $3
-  local.tee $12
-  local.get $11
+  local.tee $17
+  local.get $16
   i32.load
-  local.tee $9
+  local.tee $18
   i32.ne
   if
-   local.get $12
+   local.get $17
    call $~lib/rt/stub/__retain
-   local.set $12
-   local.get $9
+   local.set $17
+   local.get $18
    call $~lib/rt/stub/__release
   end
-  local.get $12
+  local.get $17
   i32.store
   local.get $0
   local.get $1
   i32.store offset=4
   local.get $0
-  local.tee $13
+  local.tee $19
   local.get $5
-  local.tee $9
-  local.get $13
+  local.tee $20
+  local.get $19
   i32.load offset=8
-  local.tee $11
+  local.tee $21
   i32.ne
   if
-   local.get $9
+   local.get $20
    call $~lib/rt/stub/__retain
-   local.set $9
-   local.get $11
+   local.set $20
+   local.get $21
    call $~lib/rt/stub/__release
   end
-  local.get $9
+  local.get $20
   i32.store offset=8
   local.get $0
   local.get $4
@@ -1145,6 +1169,10 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
   local.get $1
   call $~lib/rt/stub/__retain
   local.set $1
@@ -1208,16 +1236,16 @@
    local.get $0
    i32.load offset=8
    call $~lib/rt/stub/__retain
-   local.set $3
-   local.get $3
+   local.set $7
+   local.get $7
    local.get $0
    local.get $0
    i32.load offset=16
-   local.tee $4
+   local.tee $8
    i32.const 1
    i32.add
    i32.store offset=16
-   local.get $4
+   local.get $8
    i32.const 12
    i32.mul
    i32.add
@@ -1244,23 +1272,23 @@
    i32.const 4
    i32.mul
    i32.add
-   local.set $4
+   local.set $9
    local.get $6
-   local.get $4
+   local.get $9
    i32.load
    i32.store offset=8
-   local.get $4
+   local.get $9
    local.get $6
    i32.store
-   local.get $3
+   local.get $7
    call $~lib/rt/stub/__release
   end
   local.get $0
   call $~lib/rt/stub/__retain
-  local.set $4
+  local.set $10
   local.get $1
   call $~lib/rt/stub/__release
-  local.get $4
+  local.get $10
  )
  (func $~lib/util/hash/hash32 (param $0 i32) (result i32)
   (local $1 i32)
@@ -1365,6 +1393,13 @@
   (local $11 i32)
   (local $12 i32)
   (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
   local.get $1
   i32.const 1
   i32.add
@@ -1452,18 +1487,18 @@
      end
      local.get $1
      i32.and
-     local.set $12
+     local.set $13
      local.get $3
-     local.get $12
+     local.get $13
      i32.const 4
      i32.mul
      i32.add
-     local.set $13
+     local.set $14
      local.get $11
-     local.get $13
+     local.get $14
      i32.load
      i32.store offset=8
-     local.get $13
+     local.get $14
      local.get $8
      i32.store
      local.get $8
@@ -1479,41 +1514,41 @@
    end
   end
   local.get $0
-  local.tee $11
+  local.tee $15
   local.get $3
-  local.tee $12
-  local.get $11
+  local.tee $16
+  local.get $15
   i32.load
-  local.tee $9
+  local.tee $17
   i32.ne
   if
-   local.get $12
+   local.get $16
    call $~lib/rt/stub/__retain
-   local.set $12
-   local.get $9
+   local.set $16
+   local.get $17
    call $~lib/rt/stub/__release
   end
-  local.get $12
+  local.get $16
   i32.store
   local.get $0
   local.get $1
   i32.store offset=4
   local.get $0
-  local.tee $13
+  local.tee $18
   local.get $5
-  local.tee $9
-  local.get $13
+  local.tee $19
+  local.get $18
   i32.load offset=8
-  local.tee $11
+  local.tee $20
   i32.ne
   if
-   local.get $9
+   local.get $19
    call $~lib/rt/stub/__retain
-   local.set $9
-   local.get $11
+   local.set $19
+   local.get $20
    call $~lib/rt/stub/__release
   end
-  local.get $9
+  local.get $19
   i32.store offset=8
   local.get $0
   local.get $4
@@ -1532,6 +1567,10 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
   local.get $2
   call $~lib/rt/stub/__retain
   local.set $2
@@ -1572,16 +1611,16 @@
    drop
    local.get $5
    i32.load offset=4
-   local.set $3
+   local.set $6
    local.get $2
-   local.get $3
+   local.get $6
    i32.ne
    if
     local.get $5
     local.get $2
     call $~lib/rt/stub/__retain
     i32.store offset=4
-    local.get $3
+    local.get $6
     call $~lib/rt/stub/__release
    end
   else
@@ -1617,16 +1656,16 @@
    local.get $0
    i32.load offset=8
    call $~lib/rt/stub/__retain
-   local.set $3
-   local.get $3
+   local.set $7
+   local.get $7
    local.get $0
    local.get $0
    i32.load offset=16
-   local.tee $6
+   local.tee $8
    i32.const 1
    i32.add
    i32.store offset=16
-   local.get $6
+   local.get $8
    i32.const 12
    i32.mul
    i32.add
@@ -1653,27 +1692,31 @@
    i32.const 4
    i32.mul
    i32.add
-   local.set $6
+   local.set $9
    local.get $5
-   local.get $6
+   local.get $9
    i32.load
    i32.store offset=8
-   local.get $6
+   local.get $9
    local.get $5
    i32.store
-   local.get $3
+   local.get $7
    call $~lib/rt/stub/__release
   end
   local.get $0
   call $~lib/rt/stub/__retain
-  local.set $6
+  local.set $10
   local.get $2
   call $~lib/rt/stub/__release
-  local.get $6
+  local.get $10
  )
  (func $~lib/symbol/_Symbol.for (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   local.get $0
   call $~lib/rt/stub/__retain
   local.set $0
@@ -1689,10 +1732,10 @@
    global.set $~lib/symbol/stringToId
    i32.const 0
    call $~lib/map/Map<usize,~lib/string/String>#constructor
-   local.set $1
+   local.set $2
    global.get $~lib/symbol/idToString
    call $~lib/rt/stub/__release
-   local.get $1
+   local.get $2
    global.set $~lib/symbol/idToString
   else
    global.get $~lib/symbol/stringToId
@@ -1702,40 +1745,40 @@
     global.get $~lib/symbol/stringToId
     local.get $0
     call $~lib/map/Map<~lib/string/String,usize>#get
-    local.set $1
+    local.set $3
     local.get $0
     call $~lib/rt/stub/__release
-    local.get $1
+    local.get $3
     return
    end
   end
   global.get $~lib/symbol/nextId
-  local.tee $1
+  local.tee $4
   i32.const 1
   i32.add
   global.set $~lib/symbol/nextId
-  local.get $1
-  local.set $2
-  local.get $2
+  local.get $4
+  local.set $5
+  local.get $5
   i32.eqz
   if
    unreachable
   end
   global.get $~lib/symbol/stringToId
   local.get $0
-  local.get $2
+  local.get $5
   call $~lib/map/Map<~lib/string/String,usize>#set
   call $~lib/rt/stub/__release
   global.get $~lib/symbol/idToString
-  local.get $2
+  local.get $5
   local.get $0
   call $~lib/map/Map<usize,~lib/string/String>#set
   call $~lib/rt/stub/__release
-  local.get $2
-  local.set $1
+  local.get $5
+  local.set $6
   local.get $0
   call $~lib/rt/stub/__release
-  local.get $1
+  local.get $6
  )
  (func $~lib/map/Map<usize,~lib/string/String>#has (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
@@ -1841,6 +1884,88 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local $22 i32)
+  (local $23 i32)
+  (local $24 i32)
+  (local $25 i32)
+  (local $26 i32)
+  (local $27 i32)
+  (local $28 i32)
+  (local $29 i32)
+  (local $30 i32)
+  (local $31 i32)
+  (local $32 i32)
+  (local $33 i32)
+  (local $34 i32)
+  (local $35 i32)
+  (local $36 i32)
+  (local $37 i32)
+  (local $38 i32)
+  (local $39 i32)
+  (local $40 i32)
+  (local $41 i32)
+  (local $42 i32)
+  (local $43 i32)
+  (local $44 i32)
+  (local $45 i32)
+  (local $46 i32)
+  (local $47 i32)
+  (local $48 i32)
+  (local $49 i32)
+  (local $50 i32)
+  (local $51 i32)
+  (local $52 i32)
+  (local $53 i32)
+  (local $54 i32)
+  (local $55 i32)
+  (local $56 i32)
+  (local $57 i32)
+  (local $58 i32)
+  (local $59 i32)
+  (local $60 i32)
+  (local $61 i32)
+  (local $62 i32)
+  (local $63 i32)
+  (local $64 i32)
+  (local $65 i32)
+  (local $66 i32)
+  (local $67 i32)
+  (local $68 i32)
+  (local $69 i32)
+  (local $70 i32)
+  (local $71 i32)
+  (local $72 i32)
+  (local $73 i32)
+  (local $74 i32)
+  (local $75 i32)
+  (local $76 i32)
+  (local $77 i32)
+  (local $78 i32)
+  (local $79 i32)
+  (local $80 i32)
+  (local $81 i32)
+  (local $82 i32)
+  (local $83 i32)
+  (local $84 i32)
+  (local $85 i32)
+  (local $86 i32)
+  (local $87 i32)
+  (local $88 i32)
   loop $while-continue|0
    local.get $2
    if (result i32)
@@ -1860,11 +1985,11 @@
     local.set $0
     local.get $6
     local.get $1
-    local.tee $6
+    local.tee $7
     i32.const 1
     i32.add
     local.set $1
-    local.get $6
+    local.get $7
     i32.load8_u
     i32.store8
     local.get $2
@@ -1884,8 +2009,8 @@
     local.get $2
     i32.const 16
     i32.ge_u
-    local.set $5
-    local.get $5
+    local.set $8
+    local.get $8
     if
      local.get $0
      local.get $1
@@ -1994,17 +2119,17 @@
    i32.and
    if
     local.get $0
-    local.tee $5
+    local.tee $9
     i32.const 1
     i32.add
     local.set $0
-    local.get $5
+    local.get $9
     local.get $1
-    local.tee $5
+    local.tee $10
     i32.const 1
     i32.add
     local.set $1
-    local.get $5
+    local.get $10
     i32.load8_u
     i32.store8
    end
@@ -2021,16 +2146,16 @@
        local.get $0
        i32.const 3
        i32.and
-       local.set $5
-       local.get $5
+       local.set $11
+       local.get $11
        i32.const 1
        i32.eq
        br_if $case0|2
-       local.get $5
+       local.get $11
        i32.const 2
        i32.eq
        br_if $case1|2
-       local.get $5
+       local.get $11
        i32.const 3
        i32.eq
        br_if $case2|2
@@ -2040,45 +2165,45 @@
       i32.load
       local.set $3
       local.get $0
-      local.tee $5
+      local.tee $12
       i32.const 1
       i32.add
       local.set $0
-      local.get $5
+      local.get $12
       local.get $1
-      local.tee $5
+      local.tee $13
       i32.const 1
       i32.add
       local.set $1
-      local.get $5
+      local.get $13
       i32.load8_u
       i32.store8
       local.get $0
-      local.tee $5
+      local.tee $14
       i32.const 1
       i32.add
       local.set $0
-      local.get $5
+      local.get $14
       local.get $1
-      local.tee $5
+      local.tee $15
       i32.const 1
       i32.add
       local.set $1
-      local.get $5
+      local.get $15
       i32.load8_u
       i32.store8
       local.get $0
-      local.tee $5
+      local.tee $16
       i32.const 1
       i32.add
       local.set $0
-      local.get $5
+      local.get $16
       local.get $1
-      local.tee $5
+      local.tee $17
       i32.const 1
       i32.add
       local.set $1
-      local.get $5
+      local.get $17
       i32.load8_u
       i32.store8
       local.get $2
@@ -2089,8 +2214,8 @@
        local.get $2
        i32.const 17
        i32.ge_u
-       local.set $5
-       local.get $5
+       local.set $18
+       local.get $18
        if
         local.get $1
         i32.const 1
@@ -2175,31 +2300,31 @@
      i32.load
      local.set $3
      local.get $0
-     local.tee $5
+     local.tee $19
      i32.const 1
      i32.add
      local.set $0
-     local.get $5
+     local.get $19
      local.get $1
-     local.tee $5
+     local.tee $20
      i32.const 1
      i32.add
      local.set $1
-     local.get $5
+     local.get $20
      i32.load8_u
      i32.store8
      local.get $0
-     local.tee $5
+     local.tee $21
      i32.const 1
      i32.add
      local.set $0
-     local.get $5
+     local.get $21
      local.get $1
-     local.tee $5
+     local.tee $22
      i32.const 1
      i32.add
      local.set $1
-     local.get $5
+     local.get $22
      i32.load8_u
      i32.store8
      local.get $2
@@ -2210,8 +2335,8 @@
       local.get $2
       i32.const 18
       i32.ge_u
-      local.set $5
-      local.get $5
+      local.set $23
+      local.get $23
       if
        local.get $1
        i32.const 2
@@ -2296,17 +2421,17 @@
     i32.load
     local.set $3
     local.get $0
-    local.tee $5
+    local.tee $24
     i32.const 1
     i32.add
     local.set $0
-    local.get $5
+    local.get $24
     local.get $1
-    local.tee $5
+    local.tee $25
     i32.const 1
     i32.add
     local.set $1
-    local.get $5
+    local.get $25
     i32.load8_u
     i32.store8
     local.get $2
@@ -2317,8 +2442,8 @@
      local.get $2
      i32.const 19
      i32.ge_u
-     local.set $5
-     local.get $5
+     local.set $26
+     local.get $26
      if
       local.get $1
       i32.const 3
@@ -2405,227 +2530,227 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $27
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $27
    local.get $1
-   local.tee $5
+   local.tee $28
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $28
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $29
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $29
    local.get $1
-   local.tee $5
+   local.tee $30
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $30
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $31
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $31
    local.get $1
-   local.tee $5
+   local.tee $32
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $32
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $33
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $33
    local.get $1
-   local.tee $5
+   local.tee $34
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $34
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $35
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $35
    local.get $1
-   local.tee $5
+   local.tee $36
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $36
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $37
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $37
    local.get $1
-   local.tee $5
+   local.tee $38
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $38
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $39
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $39
    local.get $1
-   local.tee $5
+   local.tee $40
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $40
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $41
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $41
    local.get $1
-   local.tee $5
+   local.tee $42
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $42
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $43
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $43
    local.get $1
-   local.tee $5
+   local.tee $44
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $44
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $45
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $45
    local.get $1
-   local.tee $5
+   local.tee $46
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $46
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $47
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $47
    local.get $1
-   local.tee $5
+   local.tee $48
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $48
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $49
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $49
    local.get $1
-   local.tee $5
+   local.tee $50
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $50
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $51
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $51
    local.get $1
-   local.tee $5
+   local.tee $52
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $52
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $53
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $53
    local.get $1
-   local.tee $5
+   local.tee $54
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $54
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $55
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $55
    local.get $1
-   local.tee $5
+   local.tee $56
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $56
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $57
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $57
    local.get $1
-   local.tee $5
+   local.tee $58
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $58
    i32.load8_u
    i32.store8
   end
@@ -2634,115 +2759,115 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $59
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $59
    local.get $1
-   local.tee $5
+   local.tee $60
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $60
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $61
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $61
    local.get $1
-   local.tee $5
+   local.tee $62
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $62
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $63
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $63
    local.get $1
-   local.tee $5
+   local.tee $64
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $64
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $65
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $65
    local.get $1
-   local.tee $5
+   local.tee $66
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $66
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $67
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $67
    local.get $1
-   local.tee $5
+   local.tee $68
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $68
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $69
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $69
    local.get $1
-   local.tee $5
+   local.tee $70
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $70
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $71
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $71
    local.get $1
-   local.tee $5
+   local.tee $72
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $72
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $73
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $73
    local.get $1
-   local.tee $5
+   local.tee $74
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $74
    i32.load8_u
    i32.store8
   end
@@ -2751,59 +2876,59 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $75
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $75
    local.get $1
-   local.tee $5
+   local.tee $76
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $76
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $77
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $77
    local.get $1
-   local.tee $5
+   local.tee $78
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $78
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $79
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $79
    local.get $1
-   local.tee $5
+   local.tee $80
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $80
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $81
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $81
    local.get $1
-   local.tee $5
+   local.tee $82
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $82
    i32.load8_u
    i32.store8
   end
@@ -2812,31 +2937,31 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $83
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $83
    local.get $1
-   local.tee $5
+   local.tee $84
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $84
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $85
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $85
    local.get $1
-   local.tee $5
+   local.tee $86
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $86
    i32.load8_u
    i32.store8
   end
@@ -2845,17 +2970,17 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $87
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $87
    local.get $1
-   local.tee $5
+   local.tee $88
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $88
    i32.load8_u
    i32.store8
   end
@@ -2866,6 +2991,14 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
   block $~lib/util/memory/memmove|inlined.0
    local.get $0
    local.set $5
@@ -2943,11 +3076,11 @@
        local.set $5
        local.get $7
        local.get $4
-       local.tee $7
+       local.tee $8
        i32.const 1
        i32.add
        local.set $4
-       local.get $7
+       local.get $8
        i32.load8_u
        i32.store8
        br $while-continue|0
@@ -2957,8 +3090,8 @@
       local.get $3
       i32.const 8
       i32.ge_u
-      local.set $6
-      local.get $6
+      local.set $9
+      local.get $9
       if
        local.get $5
        local.get $4
@@ -2982,21 +3115,21 @@
     end
     loop $while-continue|2
      local.get $3
-     local.set $6
-     local.get $6
+     local.set $10
+     local.get $10
      if
       local.get $5
-      local.tee $7
+      local.tee $11
       i32.const 1
       i32.add
       local.set $5
-      local.get $7
+      local.get $11
       local.get $4
-      local.tee $7
+      local.tee $12
       i32.const 1
       i32.add
       local.set $4
-      local.get $7
+      local.get $12
       i32.load8_u
       i32.store8
       local.get $3
@@ -3025,8 +3158,8 @@
       i32.add
       i32.const 7
       i32.and
-      local.set $6
-      local.get $6
+      local.set $13
+      local.get $13
       if
        local.get $3
        i32.eqz
@@ -3051,8 +3184,8 @@
       local.get $3
       i32.const 8
       i32.ge_u
-      local.set $6
-      local.get $6
+      local.set $14
+      local.get $14
       if
        local.get $3
        i32.const 8
@@ -3072,8 +3205,8 @@
     end
     loop $while-continue|5
      local.get $3
-     local.set $6
-     local.get $6
+     local.set $15
+     local.get $15
      if
       local.get $5
       local.get $3
@@ -3099,6 +3232,8 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
   local.get $1
   call $~lib/rt/stub/__retain
   local.set $1
@@ -3141,32 +3276,32 @@
   if
    i32.const 336
    call $~lib/rt/stub/__retain
-   local.set $2
+   local.set $7
    local.get $1
    call $~lib/rt/stub/__release
-   local.get $2
+   local.get $7
    return
   end
   local.get $6
   i32.const 1
   call $~lib/rt/stub/__alloc
   call $~lib/rt/stub/__retain
-  local.set $7
-  local.get $7
+  local.set $8
+  local.get $8
   local.get $0
   local.get $4
   call $~lib/memory/memory.copy
-  local.get $7
+  local.get $8
   local.get $4
   i32.add
   local.get $1
   local.get $5
   call $~lib/memory/memory.copy
-  local.get $7
-  local.set $2
+  local.get $8
+  local.set $9
   local.get $1
   call $~lib/rt/stub/__release
-  local.get $2
+  local.get $9
  )
  (func $~lib/string/String.__concat (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
@@ -3197,6 +3332,19 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
   local.get $0
   local.set $1
   i32.const 336
@@ -3263,90 +3411,90 @@
                br $case11|0
               end
               i32.const 352
-              local.set $3
+              local.set $4
               local.get $2
               call $~lib/rt/stub/__release
-              local.get $3
+              local.get $4
               local.set $2
               br $break|0
              end
              i32.const 400
-             local.set $3
+             local.set $5
              local.get $2
              call $~lib/rt/stub/__release
-             local.get $3
+             local.get $5
              local.set $2
              br $break|0
             end
             i32.const 464
-            local.set $3
+            local.set $6
             local.get $2
             call $~lib/rt/stub/__release
-            local.get $3
+            local.get $6
             local.set $2
             br $break|0
            end
            i32.const 496
-           local.set $3
+           local.set $7
            local.get $2
            call $~lib/rt/stub/__release
-           local.get $3
+           local.get $7
            local.set $2
            br $break|0
           end
           i32.const 528
-          local.set $3
+          local.set $8
           local.get $2
           call $~lib/rt/stub/__release
-          local.get $3
+          local.get $8
           local.set $2
           br $break|0
          end
          i32.const 560
-         local.set $3
+         local.set $9
          local.get $2
          call $~lib/rt/stub/__release
-         local.get $3
+         local.get $9
          local.set $2
          br $break|0
         end
         i32.const 592
-        local.set $3
+        local.set $10
         local.get $2
         call $~lib/rt/stub/__release
-        local.get $3
+        local.get $10
         local.set $2
         br $break|0
        end
        i32.const 624
-       local.set $3
+       local.set $11
        local.get $2
        call $~lib/rt/stub/__release
-       local.get $3
+       local.get $11
        local.set $2
        br $break|0
       end
       i32.const 656
-      local.set $3
+      local.set $12
       local.get $2
       call $~lib/rt/stub/__release
-      local.get $3
+      local.get $12
       local.set $2
       br $break|0
      end
      i32.const 704
-     local.set $3
+     local.set $13
      local.get $2
      call $~lib/rt/stub/__release
-     local.get $3
+     local.get $13
      local.set $2
      br $break|0
     end
     i32.const 752
-    local.set $3
+    local.set $14
     local.get $2
     call $~lib/rt/stub/__release
-    local.get $3
+    local.get $14
     local.set $2
     br $break|0
    end
@@ -3364,10 +3512,10 @@
     global.get $~lib/symbol/idToString
     local.get $1
     call $~lib/map/Map<usize,~lib/string/String>#get
-    local.set $3
+    local.set $15
     local.get $2
     call $~lib/rt/stub/__release
-    local.get $3
+    local.get $15
     local.set $2
    end
    br $break|0
@@ -3375,22 +3523,24 @@
   i32.const 800
   local.get $2
   call $~lib/string/String.__concat
-  local.tee $3
+  local.tee $16
   i32.const 864
   call $~lib/string/String.__concat
-  local.tee $4
-  local.set $5
-  local.get $3
+  local.tee $17
+  local.set $18
+  local.get $16
   call $~lib/rt/stub/__release
   local.get $2
   call $~lib/rt/stub/__release
-  local.get $5
+  local.get $18
  )
  (func $start:std/symbol
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
   i32.const 32
   call $~lib/symbol/Symbol
   global.set $std/symbol/sym1
@@ -3484,9 +3634,9 @@
   global.set $std/symbol/key3
   global.get $std/symbol/sym4
   call $~lib/symbol/_Symbol.keyFor
-  local.tee $0
+  local.tee $1
   if (result i32)
-   local.get $0
+   local.get $1
   else
    i32.const 0
    i32.const 64
@@ -3524,7 +3674,7 @@
   i32.const 0
   call $~lib/symbol/Symbol
   call $~lib/symbol/_Symbol#toString
-  local.tee $0
+  local.tee $2
   i32.const 896
   call $~lib/string/String.__eq
   i32.eqz
@@ -3538,7 +3688,7 @@
   end
   global.get $std/symbol/sym3
   call $~lib/symbol/_Symbol#toString
-  local.tee $1
+  local.tee $3
   i32.const 928
   call $~lib/string/String.__eq
   i32.eqz
@@ -3556,7 +3706,7 @@
   global.set $std/symbol/isConcatSpreadable
   global.get $std/symbol/hasInstance
   call $~lib/symbol/_Symbol#toString
-  local.tee $2
+  local.tee $4
   i32.const 976
   call $~lib/string/String.__eq
   i32.eqz
@@ -3570,7 +3720,7 @@
   end
   global.get $std/symbol/isConcatSpreadable
   call $~lib/symbol/_Symbol#toString
-  local.tee $3
+  local.tee $5
   i32.const 1040
   call $~lib/string/String.__eq
   i32.eqz
@@ -3586,13 +3736,13 @@
   drop
   global.get $~lib/symbol/_Symbol.isConcatSpreadable
   drop
-  local.get $0
-  call $~lib/rt/stub/__release
-  local.get $1
-  call $~lib/rt/stub/__release
   local.get $2
   call $~lib/rt/stub/__release
   local.get $3
+  call $~lib/rt/stub/__release
+  local.get $4
+  call $~lib/rt/stub/__release
+  local.get $5
   call $~lib/rt/stub/__release
  )
  (func $~start

--- a/tests/compiler/std/typedarray.optimized.wat
+++ b/tests/compiler/std/typedarray.optimized.wat
@@ -2500,27 +2500,27 @@
   local.get $1
   i32.const 1
   i32.sub
-  local.set $3
+  local.set $2
   loop $for-loop|0
-   local.get $3
+   local.get $2
    i32.const 0
    i32.gt_s
    if
-    local.get $3
-    local.set $2
+    local.get $2
+    local.set $3
     loop $while-continue|1
-     local.get $2
+     local.get $3
      i32.const 1
      i32.and
      local.get $5
-     local.get $2
+     local.get $3
      i32.const 6
      i32.shr_u
      i32.const 2
      i32.shl
      i32.add
      i32.load
-     local.get $2
+     local.get $3
      i32.const 1
      i32.shr_s
      i32.const 31
@@ -2530,25 +2530,25 @@
      i32.and
      i32.eq
      if
-      local.get $2
+      local.get $3
       i32.const 1
       i32.shr_s
-      local.set $2
+      local.set $3
       br $while-continue|1
      end
     end
     local.get $0
-    local.get $2
+    local.get $3
     i32.const 1
     i32.shr_s
-    local.tee $2
+    local.tee $3
     i32.const 3
     i32.shl
     i32.add
     f64.load
     local.set $4
     local.get $0
-    local.get $3
+    local.get $2
     i32.const 3
     i32.shl
     i32.add
@@ -2563,7 +2563,7 @@
     i32.lt_s
     if
      local.get $5
-     local.get $3
+     local.get $2
      i32.const 5
      i32.shr_u
      i32.const 2
@@ -2573,31 +2573,31 @@
      local.get $7
      i32.load
      i32.const 1
-     local.get $3
+     local.get $2
      i32.const 31
      i32.and
      i32.shl
      i32.xor
      i32.store
      local.get $0
-     local.get $3
+     local.get $2
      i32.const 3
      i32.shl
      i32.add
      local.get $4
      f64.store
      local.get $0
-     local.get $2
+     local.get $3
      i32.const 3
      i32.shl
      i32.add
      local.get $6
      f64.store
     end
-    local.get $3
+    local.get $2
     i32.const 1
     i32.sub
-    local.set $3
+    local.set $2
     br $for-loop|0
    end
   end
@@ -8268,22 +8268,23 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   i32.const 2812
   i32.load
   local.tee $1
   call $~lib/typedarray/Int8Array#constructor
-  local.tee $4
-  local.set $2
-  local.get $1
-  call $~lib/typedarray/Int8Array#constructor
   local.tee $5
   local.set $3
+  local.get $1
+  call $~lib/typedarray/Int8Array#constructor
+  local.tee $6
+  local.set $4
   loop $for-loop|0
    local.get $0
    local.get $1
    i32.lt_s
    if
-    local.get $2
+    local.get $3
     local.get $0
     i32.const 2800
     local.get $0
@@ -8293,7 +8294,7 @@
     i32.const 24
     i32.shr_s
     call $~lib/typedarray/Int8Array#__set
-    local.get $3
+    local.get $4
     local.get $0
     i32.const 2800
     local.get $0
@@ -8310,24 +8311,22 @@
     br $for-loop|0
    end
   end
-  local.get $2
+  local.get $3
   call $~lib/typedarray/Int8Array#reverse
   call $~lib/rt/pure/__release
-  i32.const 0
-  local.set $0
   loop $for-loop|1
-   local.get $0
+   local.get $2
    local.get $1
    i32.lt_s
    if
+    local.get $3
     local.get $2
-    local.get $0
     call $~lib/typedarray/Int8Array#__get
     i32.const 2800
     local.get $1
     i32.const 1
     i32.sub
-    local.get $0
+    local.get $2
     i32.sub
     call $~lib/array/Array<i32>#__get
     i32.const 24
@@ -8343,14 +8342,14 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $0
+    local.get $2
     i32.const 1
     i32.add
-    local.set $0
+    local.set $2
     br $for-loop|1
    end
   end
-  local.get $3
+  local.get $4
   i32.const 4
   i32.const 8
   call $~lib/typedarray/Int8Array#subarray
@@ -8408,9 +8407,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
-  call $~lib/rt/pure/__release
   local.get $5
+  call $~lib/rt/pure/__release
+  local.get $6
   call $~lib/rt/pure/__release
   local.get $1
   call $~lib/rt/pure/__release
@@ -8535,22 +8534,23 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   i32.const 2812
   i32.load
   local.tee $1
   call $~lib/typedarray/Uint8Array#constructor
-  local.tee $4
-  local.set $2
-  local.get $1
-  call $~lib/typedarray/Uint8Array#constructor
   local.tee $5
   local.set $3
+  local.get $1
+  call $~lib/typedarray/Uint8Array#constructor
+  local.tee $6
+  local.set $4
   loop $for-loop|0
    local.get $0
    local.get $1
    i32.lt_s
    if
-    local.get $2
+    local.get $3
     local.get $0
     i32.const 2800
     local.get $0
@@ -8558,7 +8558,7 @@
     i32.const 255
     i32.and
     call $~lib/typedarray/Uint8Array#__set
-    local.get $3
+    local.get $4
     local.get $0
     i32.const 2800
     local.get $0
@@ -8573,24 +8573,22 @@
     br $for-loop|0
    end
   end
-  local.get $2
+  local.get $3
   call $~lib/typedarray/Uint8Array#reverse
   call $~lib/rt/pure/__release
-  i32.const 0
-  local.set $0
   loop $for-loop|1
-   local.get $0
+   local.get $2
    local.get $1
    i32.lt_s
    if
+    local.get $3
     local.get $2
-    local.get $0
     call $~lib/typedarray/Uint8Array#__get
     i32.const 2800
     local.get $1
     i32.const 1
     i32.sub
-    local.get $0
+    local.get $2
     i32.sub
     call $~lib/array/Array<i32>#__get
     i32.const 255
@@ -8604,14 +8602,14 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $0
+    local.get $2
     i32.const 1
     i32.add
-    local.set $0
+    local.set $2
     br $for-loop|1
    end
   end
-  local.get $3
+  local.get $4
   i32.const 8
   call $~lib/typedarray/Uint8Array#subarray
   local.tee $1
@@ -8668,9 +8666,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
-  call $~lib/rt/pure/__release
   local.get $5
+  call $~lib/rt/pure/__release
+  local.get $6
   call $~lib/rt/pure/__release
   local.get $1
   call $~lib/rt/pure/__release
@@ -8745,22 +8743,23 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   i32.const 2812
   i32.load
   local.tee $1
   call $~lib/typedarray/Uint8ClampedArray#constructor
-  local.tee $4
-  local.set $2
-  local.get $1
-  call $~lib/typedarray/Uint8ClampedArray#constructor
   local.tee $5
   local.set $3
+  local.get $1
+  call $~lib/typedarray/Uint8ClampedArray#constructor
+  local.tee $6
+  local.set $4
   loop $for-loop|0
    local.get $0
    local.get $1
    i32.lt_s
    if
-    local.get $2
+    local.get $3
     local.get $0
     i32.const 2800
     local.get $0
@@ -8768,7 +8767,7 @@
     i32.const 255
     i32.and
     call $~lib/typedarray/Uint8ClampedArray#__set
-    local.get $3
+    local.get $4
     local.get $0
     i32.const 2800
     local.get $0
@@ -8783,24 +8782,22 @@
     br $for-loop|0
    end
   end
-  local.get $2
+  local.get $3
   call $~lib/typedarray/Uint8Array#reverse
   call $~lib/rt/pure/__release
-  i32.const 0
-  local.set $0
   loop $for-loop|1
-   local.get $0
+   local.get $2
    local.get $1
    i32.lt_s
    if
+    local.get $3
     local.get $2
-    local.get $0
     call $~lib/typedarray/Uint8ClampedArray#__get
     i32.const 2800
     local.get $1
     i32.const 1
     i32.sub
-    local.get $0
+    local.get $2
     i32.sub
     call $~lib/array/Array<i32>#__get
     i32.const 255
@@ -8814,14 +8811,14 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $0
+    local.get $2
     i32.const 1
     i32.add
-    local.set $0
+    local.set $2
     br $for-loop|1
    end
   end
-  local.get $3
+  local.get $4
   i32.const 8
   call $~lib/typedarray/Uint8ClampedArray#subarray
   local.tee $1
@@ -8878,9 +8875,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
-  call $~lib/rt/pure/__release
   local.get $5
+  call $~lib/rt/pure/__release
+  local.get $6
   call $~lib/rt/pure/__release
   local.get $1
   call $~lib/rt/pure/__release
@@ -9017,22 +9014,23 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   i32.const 2812
   i32.load
   local.tee $1
   call $~lib/typedarray/Int16Array#constructor
-  local.tee $4
-  local.set $2
-  local.get $1
-  call $~lib/typedarray/Int16Array#constructor
   local.tee $5
   local.set $3
+  local.get $1
+  call $~lib/typedarray/Int16Array#constructor
+  local.tee $6
+  local.set $4
   loop $for-loop|0
    local.get $0
    local.get $1
    i32.lt_s
    if
-    local.get $2
+    local.get $3
     local.get $0
     i32.const 2800
     local.get $0
@@ -9042,7 +9040,7 @@
     i32.const 16
     i32.shr_s
     call $~lib/typedarray/Int16Array#__set
-    local.get $3
+    local.get $4
     local.get $0
     i32.const 2800
     local.get $0
@@ -9059,24 +9057,22 @@
     br $for-loop|0
    end
   end
-  local.get $2
+  local.get $3
   call $~lib/typedarray/Int16Array#reverse
   call $~lib/rt/pure/__release
-  i32.const 0
-  local.set $0
   loop $for-loop|1
-   local.get $0
+   local.get $2
    local.get $1
    i32.lt_s
    if
+    local.get $3
     local.get $2
-    local.get $0
     call $~lib/typedarray/Int16Array#__get
     i32.const 2800
     local.get $1
     i32.const 1
     i32.sub
-    local.get $0
+    local.get $2
     i32.sub
     call $~lib/array/Array<i32>#__get
     i32.const 16
@@ -9092,14 +9088,14 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $0
+    local.get $2
     i32.const 1
     i32.add
-    local.set $0
+    local.set $2
     br $for-loop|1
    end
   end
-  local.get $3
+  local.get $4
   i32.const 8
   call $~lib/typedarray/Int16Array#subarray
   local.tee $1
@@ -9156,9 +9152,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
-  call $~lib/rt/pure/__release
   local.get $5
+  call $~lib/rt/pure/__release
+  local.get $6
   call $~lib/rt/pure/__release
   local.get $1
   call $~lib/rt/pure/__release
@@ -9295,22 +9291,23 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   i32.const 2812
   i32.load
   local.tee $1
   call $~lib/typedarray/Uint16Array#constructor
-  local.tee $4
-  local.set $2
-  local.get $1
-  call $~lib/typedarray/Uint16Array#constructor
   local.tee $5
   local.set $3
+  local.get $1
+  call $~lib/typedarray/Uint16Array#constructor
+  local.tee $6
+  local.set $4
   loop $for-loop|0
    local.get $0
    local.get $1
    i32.lt_s
    if
-    local.get $2
+    local.get $3
     local.get $0
     i32.const 2800
     local.get $0
@@ -9318,7 +9315,7 @@
     i32.const 65535
     i32.and
     call $~lib/typedarray/Uint16Array#__set
-    local.get $3
+    local.get $4
     local.get $0
     i32.const 2800
     local.get $0
@@ -9333,24 +9330,22 @@
     br $for-loop|0
    end
   end
-  local.get $2
+  local.get $3
   call $~lib/typedarray/Uint16Array#reverse
   call $~lib/rt/pure/__release
-  i32.const 0
-  local.set $0
   loop $for-loop|1
-   local.get $0
+   local.get $2
    local.get $1
    i32.lt_s
    if
+    local.get $3
     local.get $2
-    local.get $0
     call $~lib/typedarray/Uint16Array#__get
     i32.const 2800
     local.get $1
     i32.const 1
     i32.sub
-    local.get $0
+    local.get $2
     i32.sub
     call $~lib/array/Array<i32>#__get
     i32.const 65535
@@ -9364,14 +9359,14 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $0
+    local.get $2
     i32.const 1
     i32.add
-    local.set $0
+    local.set $2
     br $for-loop|1
    end
   end
-  local.get $3
+  local.get $4
   i32.const 8
   call $~lib/typedarray/Uint16Array#subarray
   local.tee $1
@@ -9428,9 +9423,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
-  call $~lib/rt/pure/__release
   local.get $5
+  call $~lib/rt/pure/__release
+  local.get $6
   call $~lib/rt/pure/__release
   local.get $1
   call $~lib/rt/pure/__release
@@ -9500,28 +9495,29 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   i32.const 2812
   i32.load
   local.tee $1
   call $~lib/typedarray/Int32Array#constructor
-  local.tee $4
-  local.set $2
-  local.get $1
-  call $~lib/typedarray/Int32Array#constructor
   local.tee $5
   local.set $3
+  local.get $1
+  call $~lib/typedarray/Int32Array#constructor
+  local.tee $6
+  local.set $4
   loop $for-loop|0
    local.get $0
    local.get $1
    i32.lt_s
    if
-    local.get $2
+    local.get $3
     local.get $0
     i32.const 2800
     local.get $0
     call $~lib/array/Array<i32>#__get
     call $~lib/typedarray/Int32Array#__set
-    local.get $3
+    local.get $4
     local.get $0
     i32.const 2800
     local.get $0
@@ -9534,24 +9530,22 @@
     br $for-loop|0
    end
   end
-  local.get $2
+  local.get $3
   call $~lib/typedarray/Int32Array#reverse
   call $~lib/rt/pure/__release
-  i32.const 0
-  local.set $0
   loop $for-loop|1
-   local.get $0
+   local.get $2
    local.get $1
    i32.lt_s
    if
+    local.get $3
     local.get $2
-    local.get $0
     call $~lib/typedarray/Int32Array#__get
     i32.const 2800
     local.get $1
     i32.const 1
     i32.sub
-    local.get $0
+    local.get $2
     i32.sub
     call $~lib/array/Array<i32>#__get
     i32.ne
@@ -9563,14 +9557,14 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $0
+    local.get $2
     i32.const 1
     i32.add
-    local.set $0
+    local.set $2
     br $for-loop|1
    end
   end
-  local.get $3
+  local.get $4
   i32.const 4
   i32.const 8
   call $~lib/typedarray/Int32Array#subarray
@@ -9628,9 +9622,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
-  call $~lib/rt/pure/__release
   local.get $5
+  call $~lib/rt/pure/__release
+  local.get $6
   call $~lib/rt/pure/__release
   local.get $1
   call $~lib/rt/pure/__release
@@ -9711,28 +9705,29 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   i32.const 2812
   i32.load
   local.tee $1
   call $~lib/typedarray/Uint32Array#constructor
-  local.tee $4
-  local.set $2
-  local.get $1
-  call $~lib/typedarray/Uint32Array#constructor
   local.tee $5
   local.set $3
+  local.get $1
+  call $~lib/typedarray/Uint32Array#constructor
+  local.tee $6
+  local.set $4
   loop $for-loop|0
    local.get $0
    local.get $1
    i32.lt_s
    if
-    local.get $2
+    local.get $3
     local.get $0
     i32.const 2800
     local.get $0
     call $~lib/array/Array<i32>#__get
     call $~lib/typedarray/Uint32Array#__set
-    local.get $3
+    local.get $4
     local.get $0
     i32.const 2800
     local.get $0
@@ -9745,24 +9740,22 @@
     br $for-loop|0
    end
   end
-  local.get $2
+  local.get $3
   call $~lib/typedarray/Int32Array#reverse
   call $~lib/rt/pure/__release
-  i32.const 0
-  local.set $0
   loop $for-loop|1
-   local.get $0
+   local.get $2
    local.get $1
    i32.lt_s
    if
+    local.get $3
     local.get $2
-    local.get $0
     call $~lib/typedarray/Uint32Array#__get
     i32.const 2800
     local.get $1
     i32.const 1
     i32.sub
-    local.get $0
+    local.get $2
     i32.sub
     call $~lib/array/Array<i32>#__get
     i32.ne
@@ -9774,14 +9767,14 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $0
+    local.get $2
     i32.const 1
     i32.add
-    local.set $0
+    local.set $2
     br $for-loop|1
    end
   end
-  local.get $3
+  local.get $4
   i32.const 8
   call $~lib/typedarray/Uint32Array#subarray
   local.tee $1
@@ -9838,9 +9831,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
-  call $~lib/rt/pure/__release
   local.get $5
+  call $~lib/rt/pure/__release
+  local.get $6
   call $~lib/rt/pure/__release
   local.get $1
   call $~lib/rt/pure/__release
@@ -9977,29 +9970,30 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   i32.const 2812
   i32.load
   local.tee $1
   call $~lib/typedarray/Int64Array#constructor
-  local.tee $4
-  local.set $2
-  local.get $1
-  call $~lib/typedarray/Int64Array#constructor
   local.tee $5
   local.set $3
+  local.get $1
+  call $~lib/typedarray/Int64Array#constructor
+  local.tee $6
+  local.set $4
   loop $for-loop|0
    local.get $0
    local.get $1
    i32.lt_s
    if
-    local.get $2
+    local.get $3
     local.get $0
     i32.const 2800
     local.get $0
     call $~lib/array/Array<i32>#__get
     i64.extend_i32_s
     call $~lib/typedarray/Int64Array#__set
-    local.get $3
+    local.get $4
     local.get $0
     i32.const 2800
     local.get $0
@@ -10013,24 +10007,22 @@
     br $for-loop|0
    end
   end
-  local.get $2
+  local.get $3
   call $~lib/typedarray/Int64Array#reverse
   call $~lib/rt/pure/__release
-  i32.const 0
-  local.set $0
   loop $for-loop|1
-   local.get $0
+   local.get $2
    local.get $1
    i32.lt_s
    if
+    local.get $3
     local.get $2
-    local.get $0
     call $~lib/typedarray/Int64Array#__get
     i32.const 2800
     local.get $1
     i32.const 1
     i32.sub
-    local.get $0
+    local.get $2
     i32.sub
     call $~lib/array/Array<i32>#__get
     i64.extend_i32_s
@@ -10043,14 +10035,14 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $0
+    local.get $2
     i32.const 1
     i32.add
-    local.set $0
+    local.set $2
     br $for-loop|1
    end
   end
-  local.get $3
+  local.get $4
   i32.const 8
   call $~lib/typedarray/Int64Array#subarray
   local.tee $1
@@ -10107,9 +10099,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
-  call $~lib/rt/pure/__release
   local.get $5
+  call $~lib/rt/pure/__release
+  local.get $6
   call $~lib/rt/pure/__release
   local.get $1
   call $~lib/rt/pure/__release
@@ -10190,29 +10182,30 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   i32.const 2812
   i32.load
   local.tee $1
   call $~lib/typedarray/Uint64Array#constructor
-  local.tee $4
-  local.set $2
-  local.get $1
-  call $~lib/typedarray/Uint64Array#constructor
   local.tee $5
   local.set $3
+  local.get $1
+  call $~lib/typedarray/Uint64Array#constructor
+  local.tee $6
+  local.set $4
   loop $for-loop|0
    local.get $0
    local.get $1
    i32.lt_s
    if
-    local.get $2
+    local.get $3
     local.get $0
     i32.const 2800
     local.get $0
     call $~lib/array/Array<i32>#__get
     i64.extend_i32_s
     call $~lib/typedarray/Uint64Array#__set
-    local.get $3
+    local.get $4
     local.get $0
     i32.const 2800
     local.get $0
@@ -10226,24 +10219,22 @@
     br $for-loop|0
    end
   end
-  local.get $2
+  local.get $3
   call $~lib/typedarray/Int64Array#reverse
   call $~lib/rt/pure/__release
-  i32.const 0
-  local.set $0
   loop $for-loop|1
-   local.get $0
+   local.get $2
    local.get $1
    i32.lt_s
    if
+    local.get $3
     local.get $2
-    local.get $0
     call $~lib/typedarray/Uint64Array#__get
     i32.const 2800
     local.get $1
     i32.const 1
     i32.sub
-    local.get $0
+    local.get $2
     i32.sub
     call $~lib/array/Array<i32>#__get
     i64.extend_i32_s
@@ -10256,14 +10247,14 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $0
+    local.get $2
     i32.const 1
     i32.add
-    local.set $0
+    local.set $2
     br $for-loop|1
    end
   end
-  local.get $3
+  local.get $4
   i32.const 8
   call $~lib/typedarray/Uint64Array#subarray
   local.tee $1
@@ -10320,9 +10311,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
-  call $~lib/rt/pure/__release
   local.get $5
+  call $~lib/rt/pure/__release
+  local.get $6
   call $~lib/rt/pure/__release
   local.get $1
   call $~lib/rt/pure/__release
@@ -10459,29 +10450,30 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   i32.const 2812
   i32.load
   local.tee $1
   call $~lib/typedarray/Float32Array#constructor
-  local.tee $4
-  local.set $2
-  local.get $1
-  call $~lib/typedarray/Float32Array#constructor
   local.tee $5
   local.set $3
+  local.get $1
+  call $~lib/typedarray/Float32Array#constructor
+  local.tee $6
+  local.set $4
   loop $for-loop|0
    local.get $0
    local.get $1
    i32.lt_s
    if
-    local.get $2
+    local.get $3
     local.get $0
     i32.const 2800
     local.get $0
     call $~lib/array/Array<i32>#__get
     f32.convert_i32_s
     call $~lib/typedarray/Float32Array#__set
-    local.get $3
+    local.get $4
     local.get $0
     i32.const 2800
     local.get $0
@@ -10495,24 +10487,22 @@
     br $for-loop|0
    end
   end
-  local.get $2
+  local.get $3
   call $~lib/typedarray/Float32Array#reverse
   call $~lib/rt/pure/__release
-  i32.const 0
-  local.set $0
   loop $for-loop|1
-   local.get $0
+   local.get $2
    local.get $1
    i32.lt_s
    if
+    local.get $3
     local.get $2
-    local.get $0
     call $~lib/typedarray/Float32Array#__get
     i32.const 2800
     local.get $1
     i32.const 1
     i32.sub
-    local.get $0
+    local.get $2
     i32.sub
     call $~lib/array/Array<i32>#__get
     f32.convert_i32_s
@@ -10525,14 +10515,14 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $0
+    local.get $2
     i32.const 1
     i32.add
-    local.set $0
+    local.set $2
     br $for-loop|1
    end
   end
-  local.get $3
+  local.get $4
   i32.const 8
   call $~lib/typedarray/Float32Array#subarray
   local.tee $1
@@ -10589,9 +10579,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
-  call $~lib/rt/pure/__release
   local.get $5
+  call $~lib/rt/pure/__release
+  local.get $6
   call $~lib/rt/pure/__release
   local.get $1
   call $~lib/rt/pure/__release
@@ -10661,29 +10651,30 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   i32.const 2812
   i32.load
   local.tee $1
   call $~lib/typedarray/Float64Array#constructor
-  local.tee $4
-  local.set $2
-  local.get $1
-  call $~lib/typedarray/Float64Array#constructor
   local.tee $5
   local.set $3
+  local.get $1
+  call $~lib/typedarray/Float64Array#constructor
+  local.tee $6
+  local.set $4
   loop $for-loop|0
    local.get $0
    local.get $1
    i32.lt_s
    if
-    local.get $2
+    local.get $3
     local.get $0
     i32.const 2800
     local.get $0
     call $~lib/array/Array<i32>#__get
     f64.convert_i32_s
     call $~lib/typedarray/Float64Array#__set
-    local.get $3
+    local.get $4
     local.get $0
     i32.const 2800
     local.get $0
@@ -10697,24 +10688,22 @@
     br $for-loop|0
    end
   end
-  local.get $2
+  local.get $3
   call $~lib/typedarray/Float64Array#reverse
   call $~lib/rt/pure/__release
-  i32.const 0
-  local.set $0
   loop $for-loop|1
-   local.get $0
+   local.get $2
    local.get $1
    i32.lt_s
    if
+    local.get $3
     local.get $2
-    local.get $0
     call $~lib/typedarray/Float64Array#__get
     i32.const 2800
     local.get $1
     i32.const 1
     i32.sub
-    local.get $0
+    local.get $2
     i32.sub
     call $~lib/array/Array<i32>#__get
     f64.convert_i32_s
@@ -10727,14 +10716,14 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $0
+    local.get $2
     i32.const 1
     i32.add
-    local.set $0
+    local.set $2
     br $for-loop|1
    end
   end
-  local.get $3
+  local.get $4
   i32.const 4
   i32.const 8
   call $~lib/typedarray/Float64Array#subarray
@@ -10792,9 +10781,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
-  call $~lib/rt/pure/__release
   local.get $5
+  call $~lib/rt/pure/__release
+  local.get $6
   call $~lib/rt/pure/__release
   local.get $1
   call $~lib/rt/pure/__release
@@ -18367,8 +18356,6 @@
    global.get $~lib/util/number/_K
    i32.add
    global.set $~lib/util/number/_K
-   local.get $8
-   local.set $1
    local.get $9
    i32.const 0
    local.get $4
@@ -18379,7 +18366,7 @@
    i32.add
    i64.load32_u
    i64.mul
-   local.set $3
+   local.set $1
    local.get $0
    local.get $6
    i32.const 1
@@ -18392,30 +18379,30 @@
    local.set $4
    loop $while-continue|6
     i32.const 1
-    local.get $3
     local.get $1
+    local.get $8
     i64.sub
-    local.get $1
+    local.get $8
     local.get $11
     i64.add
-    local.get $3
+    local.get $1
     i64.sub
     i64.gt_u
-    local.get $1
+    local.get $8
     local.get $11
     i64.add
-    local.get $3
+    local.get $1
     i64.lt_u
     select
     i32.const 0
     local.get $5
-    local.get $1
+    local.get $8
     i64.sub
     local.get $11
     i64.ge_u
     i32.const 0
+    local.get $8
     local.get $1
-    local.get $3
     i64.lt_u
     select
     select
@@ -18424,10 +18411,10 @@
      i32.const 1
      i32.sub
      local.set $4
-     local.get $1
+     local.get $8
      local.get $11
      i64.add
-     local.set $1
+     local.set $8
      br $while-continue|6
     end
    end

--- a/tests/compiler/std/typedarray.untouched.wat
+++ b/tests/compiler/std/typedarray.untouched.wat
@@ -247,6 +247,15 @@
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
   local.get $1
   i32.load
   local.set $2
@@ -383,59 +392,59 @@
   i32.eq
   if
    local.get $0
-   local.set $11
+   local.set $14
    local.get $4
-   local.set $10
+   local.set $13
    local.get $5
-   local.set $9
+   local.set $12
    local.get $7
-   local.set $8
-   local.get $11
-   local.get $10
+   local.set $11
+   local.get $14
+   local.get $13
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $12
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
+   local.get $11
    i32.store offset=96
    local.get $7
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $16
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $15
+    local.get $16
+    local.get $15
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $17
     local.get $0
-    local.set $8
+    local.set $20
     local.get $4
-    local.set $11
-    local.get $9
+    local.set $19
+    local.get $17
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
-    local.set $10
-    local.get $8
-    local.get $11
+    local.tee $17
+    local.set $18
+    local.get $20
+    local.get $19
     i32.const 2
     i32.shl
     i32.add
-    local.get $10
+    local.get $18
     i32.store offset=4
-    local.get $9
+    local.get $17
     i32.eqz
     if
      local.get $0
@@ -465,6 +474,20 @@
   (local $11 i32)
   (local $12 i32)
   (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local $22 i32)
+  (local $23 i32)
+  (local $24 i32)
+  (local $25 i32)
+  (local $26 i32)
+  (local $27 i32)
   i32.const 1
   drop
   local.get $1
@@ -527,8 +550,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $3
+   local.set $6
+   local.get $6
    i32.const 1073741808
    i32.lt_u
    if
@@ -539,16 +562,16 @@
     local.get $2
     i32.const 3
     i32.and
-    local.get $3
+    local.get $6
     i32.or
     local.tee $2
     i32.store
     local.get $1
-    local.set $6
-    local.get $6
+    local.set $7
+    local.get $7
     i32.const 16
     i32.add
-    local.get $6
+    local.get $7
     i32.load
     i32.const 3
     i32.const -1
@@ -566,18 +589,18 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $8
+   local.get $8
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
+   local.set $9
+   local.get $9
    i32.load
-   local.set $3
+   local.set $10
    i32.const 1
    drop
-   local.get $3
+   local.get $10
    i32.const 1
    i32.and
    i32.eqz
@@ -589,7 +612,7 @@
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $3
+   local.get $10
    i32.const 3
    i32.const -1
    i32.xor
@@ -602,23 +625,23 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $7
+   local.set $11
+   local.get $11
    i32.const 1073741808
    i32.lt_u
    if
     local.get $0
-    local.get $6
+    local.get $9
     call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
+    local.get $9
+    local.get $10
     i32.const 3
     i32.and
-    local.get $7
+    local.get $11
     i32.or
     local.tee $2
     i32.store
-    local.get $6
+    local.get $9
     local.set $1
    end
   end
@@ -632,14 +655,14 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $12
   i32.const 1
   drop
-  local.get $8
+  local.get $12
   i32.const 16
   i32.ge_u
   if (result i32)
-   local.get $8
+   local.get $12
    i32.const 1073741808
    i32.lt_u
   else
@@ -659,7 +682,7 @@
   local.get $1
   i32.const 16
   i32.add
-  local.get $8
+  local.get $12
   i32.add
   local.get $4
   i32.eq
@@ -677,24 +700,24 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $12
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $13
+   local.get $12
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $14
   else
    i32.const 31
-   local.get $8
+   local.get $12
    i32.clz
    i32.sub
-   local.set $9
-   local.get $8
-   local.get $9
+   local.set $13
+   local.get $12
+   local.get $13
    i32.const 4
    i32.sub
    i32.shr_u
@@ -702,21 +725,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $14
+   local.get $13
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $13
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $13
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $14
    i32.const 16
    i32.lt_u
   else
@@ -732,86 +755,86 @@
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
-  local.set $6
-  local.get $7
-  local.get $3
+  local.set $17
+  local.get $13
+  local.set $16
+  local.get $14
+  local.set $15
+  local.get $17
+  local.get $16
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $15
   i32.add
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=96
-  local.set $11
+  local.set $18
   local.get $1
   i32.const 0
   i32.store offset=16
   local.get $1
-  local.get $11
+  local.get $18
   i32.store offset=20
-  local.get $11
+  local.get $18
   if
-   local.get $11
+   local.get $18
    local.get $1
    i32.store offset=16
   end
   local.get $0
-  local.set $12
-  local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
+  local.set $22
+  local.get $13
+  local.set $21
+  local.get $14
+  local.set $20
   local.get $1
-  local.set $6
-  local.get $12
-  local.get $7
+  local.set $19
+  local.get $22
+  local.get $21
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $20
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $19
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $13
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.set $13
-  local.get $9
-  local.set $12
+  local.set $27
+  local.get $13
+  local.set $26
   local.get $0
-  local.set $3
-  local.get $9
-  local.set $6
-  local.get $3
-  local.get $6
+  local.set $24
+  local.get $13
+  local.set $23
+  local.get $24
+  local.get $23
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $14
   i32.shl
   i32.or
-  local.set $7
-  local.get $13
-  local.get $12
+  local.set $25
+  local.get $27
+  local.get $26
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $25
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -822,6 +845,7 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
   i32.const 1
   drop
   local.get $1
@@ -961,11 +985,11 @@
   i32.or
   i32.store
   local.get $0
-  local.set $9
+  local.set $10
   local.get $4
-  local.set $3
+  local.set $9
+  local.get $10
   local.get $9
-  local.get $3
   i32.store offset=1568
   local.get $0
   local.get $8
@@ -985,6 +1009,12 @@
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
   global.get $~lib/rt/tlsf/ROOT
   local.set $0
   local.get $0
@@ -1041,66 +1071,66 @@
    local.get $4
    i32.store offset=1568
    i32.const 0
-   local.set $5
+   local.set $6
    loop $for-loop|0
-    local.get $5
+    local.get $6
     i32.const 23
     i32.lt_u
-    local.set $4
-    local.get $4
+    local.set $7
+    local.get $7
     if
      local.get $0
-     local.set $8
-     local.get $5
-     local.set $7
+     local.set $10
+     local.get $6
+     local.set $9
      i32.const 0
-     local.set $6
-     local.get $8
-     local.get $7
+     local.set $8
+     local.get $10
+     local.get $9
      i32.const 2
      i32.shl
      i32.add
-     local.get $6
+     local.get $8
      i32.store offset=4
      i32.const 0
-     local.set $8
+     local.set $11
      loop $for-loop|1
-      local.get $8
+      local.get $11
       i32.const 16
       i32.lt_u
-      local.set $7
-      local.get $7
+      local.set $12
+      local.get $12
       if
        local.get $0
-       local.set $11
-       local.get $5
-       local.set $10
-       local.get $8
-       local.set $9
-       i32.const 0
-       local.set $6
+       local.set $16
+       local.get $6
+       local.set $15
        local.get $11
-       local.get $10
+       local.set $14
+       i32.const 0
+       local.set $13
+       local.get $16
+       local.get $15
        i32.const 4
        i32.shl
-       local.get $9
+       local.get $14
        i32.add
        i32.const 2
        i32.shl
        i32.add
-       local.get $6
+       local.get $13
        i32.store offset=96
-       local.get $8
+       local.get $11
        i32.const 1
        i32.add
-       local.set $8
+       local.set $11
        br $for-loop|1
       end
      end
-     local.get $5
+     local.get $6
      i32.const 1
      i32.add
-     local.set $5
+     local.set $6
      br $for-loop|0
     end
    end
@@ -1113,11 +1143,11 @@
    i32.const -1
    i32.xor
    i32.and
-   local.set $5
+   local.set $17
    i32.const 0
    drop
    local.get $0
-   local.get $5
+   local.get $17
    memory.size
    i32.const 16
    i32.shl
@@ -1166,6 +1196,14 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
   local.get $1
   i32.const 256
   i32.lt_u
@@ -1239,11 +1277,11 @@
    unreachable
   end
   local.get $0
-  local.set $5
+  local.set $6
   local.get $2
-  local.set $4
+  local.set $5
+  local.get $6
   local.get $5
-  local.get $4
   i32.const 2
   i32.shl
   i32.add
@@ -1254,10 +1292,10 @@
   local.get $3
   i32.shl
   i32.and
-  local.set $6
-  i32.const 0
   local.set $7
-  local.get $6
+  i32.const 0
+  local.set $8
+  local.get $7
   i32.eqz
   if
    local.get $0
@@ -1270,30 +1308,30 @@
    i32.add
    i32.shl
    i32.and
-   local.set $5
-   local.get $5
+   local.set $9
+   local.get $9
    i32.eqz
    if
     i32.const 0
-    local.set $7
+    local.set $8
    else
-    local.get $5
+    local.get $9
     i32.ctz
     local.set $2
     local.get $0
-    local.set $8
+    local.set $11
     local.get $2
-    local.set $4
-    local.get $8
-    local.get $4
+    local.set $10
+    local.get $11
+    local.get $10
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $6
+    local.set $7
     i32.const 1
     drop
-    local.get $6
+    local.get $7
     i32.eqz
     if
      i32.const 0
@@ -1304,45 +1342,45 @@
      unreachable
     end
     local.get $0
-    local.set $9
+    local.set $14
     local.get $2
-    local.set $8
-    local.get $6
+    local.set $13
+    local.get $7
     i32.ctz
-    local.set $4
-    local.get $9
-    local.get $8
+    local.set $12
+    local.get $14
+    local.get $13
     i32.const 4
     i32.shl
-    local.get $4
+    local.get $12
     i32.add
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=96
-    local.set $7
+    local.set $8
    end
   else
    local.get $0
-   local.set $9
+   local.set $17
    local.get $2
-   local.set $8
-   local.get $6
+   local.set $16
+   local.get $7
    i32.ctz
-   local.set $4
-   local.get $9
-   local.get $8
+   local.set $15
+   local.get $17
+   local.get $16
    i32.const 4
    i32.shl
-   local.get $4
+   local.get $15
    i32.add
    i32.const 2
    i32.shl
    i32.add
    i32.load offset=96
-   local.set $7
+   local.set $8
   end
-  local.get $7
+  local.get $8
  )
  (func $~lib/rt/tlsf/growMemory (param $0 i32) (param $1 i32)
   (local $2 i32)
@@ -1351,6 +1389,7 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
   i32.const 0
   drop
   local.get $1
@@ -1397,15 +1436,15 @@
   i32.shr_u
   local.set $4
   local.get $2
-  local.tee $3
-  local.get $4
   local.tee $5
-  local.get $3
+  local.get $4
+  local.tee $6
   local.get $5
+  local.get $6
   i32.gt_s
   select
-  local.set $6
-  local.get $6
+  local.set $7
+  local.get $7
   memory.grow
   i32.const 0
   i32.lt_s
@@ -1419,12 +1458,12 @@
    end
   end
   memory.size
-  local.set $7
+  local.set $8
   local.get $0
   local.get $2
   i32.const 16
   i32.shl
-  local.get $7
+  local.get $8
   i32.const 16
   i32.shl
   call $~lib/rt/tlsf/addMemory
@@ -1434,6 +1473,8 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
   local.get $1
   i32.load
   local.set $3
@@ -1498,11 +1539,11 @@
    i32.and
    i32.store
    local.get $1
-   local.set $5
-   local.get $5
+   local.set $7
+   local.get $7
    i32.const 16
    i32.add
-   local.get $5
+   local.get $7
    i32.load
    i32.const 3
    i32.const -1
@@ -1510,11 +1551,11 @@
    i32.and
    i32.add
    local.get $1
-   local.set $5
-   local.get $5
+   local.set $6
+   local.get $6
    i32.const 16
    i32.add
-   local.get $5
+   local.get $6
    i32.load
    i32.const 3
    i32.const -1
@@ -2854,6 +2895,16 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $5
@@ -2880,11 +2931,11 @@
    select
   else
    local.get $4
-   local.tee $7
+   local.tee $9
    local.get $6
-   local.tee $8
-   local.get $7
-   local.get $8
+   local.tee $10
+   local.get $9
+   local.get $10
    i32.lt_s
    select
   end
@@ -2896,43 +2947,43 @@
    local.get $6
    local.get $3
    i32.add
-   local.tee $7
+   local.tee $11
    i32.const 0
-   local.tee $8
-   local.get $7
-   local.get $8
+   local.tee $12
+   local.get $11
+   local.get $12
    i32.gt_s
    select
   else
    local.get $3
-   local.tee $7
+   local.tee $13
    local.get $6
-   local.tee $8
-   local.get $7
-   local.get $8
+   local.tee $14
+   local.get $13
+   local.get $14
    i32.lt_s
    select
   end
   local.set $3
   local.get $3
-  local.tee $7
+  local.tee $15
   local.get $4
-  local.tee $8
-  local.get $7
-  local.get $8
+  local.tee $16
+  local.get $15
+  local.get $16
   i32.gt_s
   select
   local.set $3
   i32.const 12
   i32.const 8
   call $~lib/rt/tlsf/__alloc
-  local.set $7
-  local.get $7
+  local.set $17
+  local.get $17
   local.get $5
   i32.load
   call $~lib/rt/pure/__retain
   i32.store
-  local.get $7
+  local.get $17
   local.get $5
   i32.load offset=4
   local.get $4
@@ -2940,19 +2991,19 @@
   i32.shl
   i32.add
   i32.store offset=4
-  local.get $7
+  local.get $17
   local.get $3
   local.get $4
   i32.sub
   i32.const 2
   i32.shl
   i32.store offset=8
-  local.get $7
+  local.get $17
   call $~lib/rt/pure/__retain
-  local.set $8
+  local.set $18
   local.get $5
   call $~lib/rt/pure/__release
-  local.get $8
+  local.get $18
  )
  (func $~lib/typedarray/Float64Array#__set (param $0 i32) (param $1 i32) (param $2 f64)
   local.get $1
@@ -2985,6 +3036,16 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $5
@@ -3011,11 +3072,11 @@
    select
   else
    local.get $4
-   local.tee $7
+   local.tee $9
    local.get $6
-   local.tee $8
-   local.get $7
-   local.get $8
+   local.tee $10
+   local.get $9
+   local.get $10
    i32.lt_s
    select
   end
@@ -3027,43 +3088,43 @@
    local.get $6
    local.get $3
    i32.add
-   local.tee $7
+   local.tee $11
    i32.const 0
-   local.tee $8
-   local.get $7
-   local.get $8
+   local.tee $12
+   local.get $11
+   local.get $12
    i32.gt_s
    select
   else
    local.get $3
-   local.tee $7
+   local.tee $13
    local.get $6
-   local.tee $8
-   local.get $7
-   local.get $8
+   local.tee $14
+   local.get $13
+   local.get $14
    i32.lt_s
    select
   end
   local.set $3
   local.get $3
-  local.tee $7
+  local.tee $15
   local.get $4
-  local.tee $8
-  local.get $7
-  local.get $8
+  local.tee $16
+  local.get $15
+  local.get $16
   i32.gt_s
   select
   local.set $3
   i32.const 12
   i32.const 13
   call $~lib/rt/tlsf/__alloc
-  local.set $7
-  local.get $7
+  local.set $17
+  local.get $17
   local.get $5
   i32.load
   call $~lib/rt/pure/__retain
   i32.store
-  local.get $7
+  local.get $17
   local.get $5
   i32.load offset=4
   local.get $4
@@ -3071,19 +3132,19 @@
   i32.shl
   i32.add
   i32.store offset=4
-  local.get $7
+  local.get $17
   local.get $3
   local.get $4
   i32.sub
   i32.const 3
   i32.shl
   i32.store offset=8
-  local.get $7
+  local.get $17
   call $~lib/rt/pure/__retain
-  local.set $8
+  local.set $18
   local.get $5
   call $~lib/rt/pure/__release
-  local.get $8
+  local.get $18
  )
  (func $~setArgumentsLength (param $0 i32)
   local.get $0
@@ -3258,10 +3319,18 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
-  (local $9 f64)
+  (local $9 i32)
   (local $10 f64)
-  (local $11 i32)
-  (local $12 f64)
+  (local $11 f64)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 f64)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 f64)
+  (local $20 f64)
   local.get $1
   i32.const 31
   i32.add
@@ -3325,23 +3394,23 @@
     local.get $7
     i32.const 1
     i32.shr_s
-    local.set $8
+    local.set $9
     local.get $0
-    local.get $8
+    local.get $9
     i32.const 3
     i32.shl
     i32.add
     f64.load
-    local.set $9
+    local.set $10
     local.get $0
     local.get $5
     i32.const 3
     i32.shl
     i32.add
     f64.load
-    local.set $10
-    local.get $9
+    local.set $11
     local.get $10
+    local.get $11
     i32.const 2
     global.set $~argumentsLength
     local.get $2
@@ -3376,14 +3445,14 @@
      i32.const 3
      i32.shl
      i32.add
-     local.get $9
+     local.get $10
      f64.store
      local.get $0
-     local.get $8
+     local.get $9
      i32.const 3
      i32.shl
      i32.add
-     local.get $10
+     local.get $11
      f64.store
     end
     local.get $5
@@ -3396,83 +3465,83 @@
   local.get $1
   i32.const 1
   i32.sub
-  local.set $5
+  local.set $12
   loop $for-loop|2
-   local.get $5
+   local.get $12
    i32.const 2
    i32.ge_s
-   local.set $6
-   local.get $6
+   local.set $13
+   local.get $13
    if
     local.get $0
     f64.load
-    local.set $10
+    local.set $14
     local.get $0
     local.get $0
-    local.get $5
+    local.get $12
     i32.const 3
     i32.shl
     i32.add
     f64.load
     f64.store
     local.get $0
-    local.get $5
+    local.get $12
     i32.const 3
     i32.shl
     i32.add
-    local.get $10
+    local.get $14
     f64.store
     i32.const 1
-    local.set $8
+    local.set $15
     loop $while-continue|3
-     local.get $8
+     local.get $15
      i32.const 1
      i32.shl
      local.get $4
-     local.get $8
+     local.get $15
      i32.const 5
      i32.shr_u
      i32.const 2
      i32.shl
      i32.add
      i32.load
-     local.get $8
+     local.get $15
      i32.const 31
      i32.and
      i32.shr_u
      i32.const 1
      i32.and
      i32.add
-     local.tee $7
-     local.get $5
+     local.tee $16
+     local.get $12
      i32.lt_s
-     local.set $11
-     local.get $11
+     local.set $17
+     local.get $17
      if
-      local.get $7
-      local.set $8
+      local.get $16
+      local.set $15
       br $while-continue|3
      end
     end
     loop $while-continue|4
-     local.get $8
+     local.get $15
      i32.const 0
      i32.gt_s
-     local.set $11
-     local.get $11
+     local.set $18
+     local.get $18
      if
       local.get $0
       f64.load
-      local.set $10
+      local.set $14
       local.get $0
-      local.get $8
+      local.get $15
       i32.const 3
       i32.shl
       i32.add
       f64.load
-      local.set $9
-      local.get $10
-      local.get $9
+      local.set $19
+      local.get $14
+      local.get $19
       i32.const 2
       global.set $~argumentsLength
       local.get $2
@@ -3481,14 +3550,14 @@
       i32.lt_s
       if
        local.get $4
-       local.get $8
+       local.get $15
        i32.const 5
        i32.shr_u
        i32.const 2
        i32.shl
        i32.add
        local.get $4
-       local.get $8
+       local.get $15
        i32.const 5
        i32.shr_u
        i32.const 2
@@ -3496,34 +3565,34 @@
        i32.add
        i32.load
        i32.const 1
-       local.get $8
+       local.get $15
        i32.const 31
        i32.and
        i32.shl
        i32.xor
        i32.store
        local.get $0
-       local.get $8
+       local.get $15
        i32.const 3
        i32.shl
        i32.add
-       local.get $10
+       local.get $14
        f64.store
        local.get $0
-       local.get $9
+       local.get $19
        f64.store
       end
-      local.get $8
+      local.get $15
       i32.const 1
       i32.shr_s
-      local.set $8
+      local.set $15
       br $while-continue|4
      end
     end
-    local.get $5
+    local.get $12
     i32.const 1
     i32.sub
-    local.set $5
+    local.set $12
     br $for-loop|2
    end
   end
@@ -3531,13 +3600,13 @@
   call $~lib/rt/tlsf/__free
   local.get $0
   f64.load offset=8
-  local.set $12
+  local.set $20
   local.get $0
   local.get $0
   f64.load
   f64.store offset=8
   local.get $0
-  local.get $12
+  local.get $20
   f64.store
  )
  (func $~lib/typedarray/Float64Array#sort (param $0 i32) (param $1 i32) (result i32)
@@ -3786,6 +3855,12 @@
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $7
@@ -3817,11 +3892,11 @@
    select
   else
    local.get $5
-   local.tee $10
+   local.tee $12
    local.get $9
-   local.tee $11
-   local.get $10
-   local.get $11
+   local.tee $13
+   local.get $12
+   local.get $13
    i32.lt_s
    select
   end
@@ -3833,20 +3908,20 @@
    local.get $9
    local.get $4
    i32.add
-   local.tee $10
+   local.tee $14
    i32.const 0
-   local.tee $11
-   local.get $10
-   local.get $11
+   local.tee $15
+   local.get $14
+   local.get $15
    i32.gt_s
    select
   else
    local.get $4
-   local.tee $10
+   local.tee $16
    local.get $9
-   local.tee $11
-   local.get $10
-   local.get $11
+   local.tee $17
+   local.get $16
+   local.get $17
    i32.lt_s
    select
   end
@@ -3875,6 +3950,88 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local $22 i32)
+  (local $23 i32)
+  (local $24 i32)
+  (local $25 i32)
+  (local $26 i32)
+  (local $27 i32)
+  (local $28 i32)
+  (local $29 i32)
+  (local $30 i32)
+  (local $31 i32)
+  (local $32 i32)
+  (local $33 i32)
+  (local $34 i32)
+  (local $35 i32)
+  (local $36 i32)
+  (local $37 i32)
+  (local $38 i32)
+  (local $39 i32)
+  (local $40 i32)
+  (local $41 i32)
+  (local $42 i32)
+  (local $43 i32)
+  (local $44 i32)
+  (local $45 i32)
+  (local $46 i32)
+  (local $47 i32)
+  (local $48 i32)
+  (local $49 i32)
+  (local $50 i32)
+  (local $51 i32)
+  (local $52 i32)
+  (local $53 i32)
+  (local $54 i32)
+  (local $55 i32)
+  (local $56 i32)
+  (local $57 i32)
+  (local $58 i32)
+  (local $59 i32)
+  (local $60 i32)
+  (local $61 i32)
+  (local $62 i32)
+  (local $63 i32)
+  (local $64 i32)
+  (local $65 i32)
+  (local $66 i32)
+  (local $67 i32)
+  (local $68 i32)
+  (local $69 i32)
+  (local $70 i32)
+  (local $71 i32)
+  (local $72 i32)
+  (local $73 i32)
+  (local $74 i32)
+  (local $75 i32)
+  (local $76 i32)
+  (local $77 i32)
+  (local $78 i32)
+  (local $79 i32)
+  (local $80 i32)
+  (local $81 i32)
+  (local $82 i32)
+  (local $83 i32)
+  (local $84 i32)
+  (local $85 i32)
+  (local $86 i32)
+  (local $87 i32)
+  (local $88 i32)
   loop $while-continue|0
    local.get $2
    if (result i32)
@@ -3894,11 +4051,11 @@
     local.set $0
     local.get $6
     local.get $1
-    local.tee $6
+    local.tee $7
     i32.const 1
     i32.add
     local.set $1
-    local.get $6
+    local.get $7
     i32.load8_u
     i32.store8
     local.get $2
@@ -3918,8 +4075,8 @@
     local.get $2
     i32.const 16
     i32.ge_u
-    local.set $5
-    local.get $5
+    local.set $8
+    local.get $8
     if
      local.get $0
      local.get $1
@@ -4028,17 +4185,17 @@
    i32.and
    if
     local.get $0
-    local.tee $5
+    local.tee $9
     i32.const 1
     i32.add
     local.set $0
-    local.get $5
+    local.get $9
     local.get $1
-    local.tee $5
+    local.tee $10
     i32.const 1
     i32.add
     local.set $1
-    local.get $5
+    local.get $10
     i32.load8_u
     i32.store8
    end
@@ -4055,16 +4212,16 @@
        local.get $0
        i32.const 3
        i32.and
-       local.set $5
-       local.get $5
+       local.set $11
+       local.get $11
        i32.const 1
        i32.eq
        br_if $case0|2
-       local.get $5
+       local.get $11
        i32.const 2
        i32.eq
        br_if $case1|2
-       local.get $5
+       local.get $11
        i32.const 3
        i32.eq
        br_if $case2|2
@@ -4074,45 +4231,45 @@
       i32.load
       local.set $3
       local.get $0
-      local.tee $5
+      local.tee $12
       i32.const 1
       i32.add
       local.set $0
-      local.get $5
+      local.get $12
       local.get $1
-      local.tee $5
+      local.tee $13
       i32.const 1
       i32.add
       local.set $1
-      local.get $5
+      local.get $13
       i32.load8_u
       i32.store8
       local.get $0
-      local.tee $5
+      local.tee $14
       i32.const 1
       i32.add
       local.set $0
-      local.get $5
+      local.get $14
       local.get $1
-      local.tee $5
+      local.tee $15
       i32.const 1
       i32.add
       local.set $1
-      local.get $5
+      local.get $15
       i32.load8_u
       i32.store8
       local.get $0
-      local.tee $5
+      local.tee $16
       i32.const 1
       i32.add
       local.set $0
-      local.get $5
+      local.get $16
       local.get $1
-      local.tee $5
+      local.tee $17
       i32.const 1
       i32.add
       local.set $1
-      local.get $5
+      local.get $17
       i32.load8_u
       i32.store8
       local.get $2
@@ -4123,8 +4280,8 @@
        local.get $2
        i32.const 17
        i32.ge_u
-       local.set $5
-       local.get $5
+       local.set $18
+       local.get $18
        if
         local.get $1
         i32.const 1
@@ -4209,31 +4366,31 @@
      i32.load
      local.set $3
      local.get $0
-     local.tee $5
+     local.tee $19
      i32.const 1
      i32.add
      local.set $0
-     local.get $5
+     local.get $19
      local.get $1
-     local.tee $5
+     local.tee $20
      i32.const 1
      i32.add
      local.set $1
-     local.get $5
+     local.get $20
      i32.load8_u
      i32.store8
      local.get $0
-     local.tee $5
+     local.tee $21
      i32.const 1
      i32.add
      local.set $0
-     local.get $5
+     local.get $21
      local.get $1
-     local.tee $5
+     local.tee $22
      i32.const 1
      i32.add
      local.set $1
-     local.get $5
+     local.get $22
      i32.load8_u
      i32.store8
      local.get $2
@@ -4244,8 +4401,8 @@
       local.get $2
       i32.const 18
       i32.ge_u
-      local.set $5
-      local.get $5
+      local.set $23
+      local.get $23
       if
        local.get $1
        i32.const 2
@@ -4330,17 +4487,17 @@
     i32.load
     local.set $3
     local.get $0
-    local.tee $5
+    local.tee $24
     i32.const 1
     i32.add
     local.set $0
-    local.get $5
+    local.get $24
     local.get $1
-    local.tee $5
+    local.tee $25
     i32.const 1
     i32.add
     local.set $1
-    local.get $5
+    local.get $25
     i32.load8_u
     i32.store8
     local.get $2
@@ -4351,8 +4508,8 @@
      local.get $2
      i32.const 19
      i32.ge_u
-     local.set $5
-     local.get $5
+     local.set $26
+     local.get $26
      if
       local.get $1
       i32.const 3
@@ -4439,227 +4596,227 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $27
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $27
    local.get $1
-   local.tee $5
+   local.tee $28
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $28
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $29
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $29
    local.get $1
-   local.tee $5
+   local.tee $30
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $30
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $31
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $31
    local.get $1
-   local.tee $5
+   local.tee $32
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $32
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $33
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $33
    local.get $1
-   local.tee $5
+   local.tee $34
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $34
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $35
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $35
    local.get $1
-   local.tee $5
+   local.tee $36
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $36
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $37
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $37
    local.get $1
-   local.tee $5
+   local.tee $38
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $38
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $39
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $39
    local.get $1
-   local.tee $5
+   local.tee $40
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $40
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $41
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $41
    local.get $1
-   local.tee $5
+   local.tee $42
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $42
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $43
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $43
    local.get $1
-   local.tee $5
+   local.tee $44
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $44
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $45
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $45
    local.get $1
-   local.tee $5
+   local.tee $46
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $46
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $47
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $47
    local.get $1
-   local.tee $5
+   local.tee $48
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $48
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $49
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $49
    local.get $1
-   local.tee $5
+   local.tee $50
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $50
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $51
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $51
    local.get $1
-   local.tee $5
+   local.tee $52
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $52
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $53
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $53
    local.get $1
-   local.tee $5
+   local.tee $54
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $54
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $55
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $55
    local.get $1
-   local.tee $5
+   local.tee $56
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $56
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $57
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $57
    local.get $1
-   local.tee $5
+   local.tee $58
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $58
    i32.load8_u
    i32.store8
   end
@@ -4668,115 +4825,115 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $59
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $59
    local.get $1
-   local.tee $5
+   local.tee $60
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $60
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $61
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $61
    local.get $1
-   local.tee $5
+   local.tee $62
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $62
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $63
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $63
    local.get $1
-   local.tee $5
+   local.tee $64
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $64
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $65
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $65
    local.get $1
-   local.tee $5
+   local.tee $66
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $66
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $67
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $67
    local.get $1
-   local.tee $5
+   local.tee $68
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $68
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $69
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $69
    local.get $1
-   local.tee $5
+   local.tee $70
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $70
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $71
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $71
    local.get $1
-   local.tee $5
+   local.tee $72
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $72
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $73
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $73
    local.get $1
-   local.tee $5
+   local.tee $74
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $74
    i32.load8_u
    i32.store8
   end
@@ -4785,59 +4942,59 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $75
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $75
    local.get $1
-   local.tee $5
+   local.tee $76
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $76
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $77
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $77
    local.get $1
-   local.tee $5
+   local.tee $78
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $78
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $79
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $79
    local.get $1
-   local.tee $5
+   local.tee $80
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $80
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $81
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $81
    local.get $1
-   local.tee $5
+   local.tee $82
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $82
    i32.load8_u
    i32.store8
   end
@@ -4846,31 +5003,31 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $83
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $83
    local.get $1
-   local.tee $5
+   local.tee $84
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $84
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $85
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $85
    local.get $1
-   local.tee $5
+   local.tee $86
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $86
    i32.load8_u
    i32.store8
   end
@@ -4879,17 +5036,17 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $87
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $87
    local.get $1
-   local.tee $5
+   local.tee $88
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $88
    i32.load8_u
    i32.store8
   end
@@ -4900,6 +5057,14 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
   block $~lib/util/memory/memmove|inlined.0
    local.get $0
    local.set $5
@@ -4977,11 +5142,11 @@
        local.set $5
        local.get $7
        local.get $4
-       local.tee $7
+       local.tee $8
        i32.const 1
        i32.add
        local.set $4
-       local.get $7
+       local.get $8
        i32.load8_u
        i32.store8
        br $while-continue|0
@@ -4991,8 +5156,8 @@
       local.get $3
       i32.const 8
       i32.ge_u
-      local.set $6
-      local.get $6
+      local.set $9
+      local.get $9
       if
        local.get $5
        local.get $4
@@ -5016,21 +5181,21 @@
     end
     loop $while-continue|2
      local.get $3
-     local.set $6
-     local.get $6
+     local.set $10
+     local.get $10
      if
       local.get $5
-      local.tee $7
+      local.tee $11
       i32.const 1
       i32.add
       local.set $5
-      local.get $7
+      local.get $11
       local.get $4
-      local.tee $7
+      local.tee $12
       i32.const 1
       i32.add
       local.set $4
-      local.get $7
+      local.get $12
       i32.load8_u
       i32.store8
       local.get $3
@@ -5059,8 +5224,8 @@
       i32.add
       i32.const 7
       i32.and
-      local.set $6
-      local.get $6
+      local.set $13
+      local.get $13
       if
        local.get $3
        i32.eqz
@@ -5085,8 +5250,8 @@
       local.get $3
       i32.const 8
       i32.ge_u
-      local.set $6
-      local.get $6
+      local.set $14
+      local.get $14
       if
        local.get $3
        i32.const 8
@@ -5106,8 +5271,8 @@
     end
     loop $while-continue|5
      local.get $3
-     local.set $6
-     local.get $6
+     local.set $15
+     local.get $15
      if
       local.get $5
       local.get $3
@@ -5232,6 +5397,8 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $0
@@ -5254,48 +5421,48 @@
    return
   end
   i32.const 0
-  local.set $2
+  local.set $3
   local.get $0
   call $~lib/typedarray/Int8Array#get:length
-  local.set $3
+  local.set $4
   loop $for-loop|0
-   local.get $2
    local.get $3
-   i32.lt_s
-   local.set $4
    local.get $4
+   i32.lt_s
+   local.set $5
+   local.get $5
    if
     local.get $0
-    local.get $2
+    local.get $3
     call $~lib/typedarray/Int8Array#__get
     local.get $1
-    local.get $2
+    local.get $3
     call $~lib/array/Array<i8>#__get
     i32.ne
     if
      i32.const 0
-     local.set $5
+     local.set $6
      local.get $0
      call $~lib/rt/pure/__release
      local.get $1
      call $~lib/rt/pure/__release
-     local.get $5
+     local.get $6
      return
     end
-    local.get $2
+    local.get $3
     i32.const 1
     i32.add
-    local.set $2
+    local.set $3
     br $for-loop|0
    end
   end
   i32.const 1
-  local.set $3
+  local.set $7
   local.get $0
   call $~lib/rt/pure/__release
   local.get $1
   call $~lib/rt/pure/__release
-  local.get $3
+  local.get $7
  )
  (func $~lib/typedarray/Int8Array#subarray (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
@@ -5304,6 +5471,16 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $5
@@ -5330,11 +5507,11 @@
    select
   else
    local.get $4
-   local.tee $7
+   local.tee $9
    local.get $6
-   local.tee $8
-   local.get $7
-   local.get $8
+   local.tee $10
+   local.get $9
+   local.get $10
    i32.lt_s
    select
   end
@@ -5346,43 +5523,43 @@
    local.get $6
    local.get $3
    i32.add
-   local.tee $7
+   local.tee $11
    i32.const 0
-   local.tee $8
-   local.get $7
-   local.get $8
+   local.tee $12
+   local.get $11
+   local.get $12
    i32.gt_s
    select
   else
    local.get $3
-   local.tee $7
+   local.tee $13
    local.get $6
-   local.tee $8
-   local.get $7
-   local.get $8
+   local.tee $14
+   local.get $13
+   local.get $14
    i32.lt_s
    select
   end
   local.set $3
   local.get $3
-  local.tee $7
+  local.tee $15
   local.get $4
-  local.tee $8
-  local.get $7
-  local.get $8
+  local.tee $16
+  local.get $15
+  local.get $16
   i32.gt_s
   select
   local.set $3
   i32.const 12
   i32.const 3
   call $~lib/rt/tlsf/__alloc
-  local.set $7
-  local.get $7
+  local.set $17
+  local.get $17
   local.get $5
   i32.load
   call $~lib/rt/pure/__retain
   i32.store
-  local.get $7
+  local.get $17
   local.get $5
   i32.load offset=4
   local.get $4
@@ -5390,19 +5567,19 @@
   i32.shl
   i32.add
   i32.store offset=4
-  local.get $7
+  local.get $17
   local.get $3
   local.get $4
   i32.sub
   i32.const 0
   i32.shl
   i32.store offset=8
-  local.get $7
+  local.get $17
   call $~lib/rt/pure/__retain
-  local.set $8
+  local.set $18
   local.get $5
   call $~lib/rt/pure/__release
-  local.get $8
+  local.get $18
  )
  (func $~lib/typedarray/Int32Array#fill (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
@@ -5413,6 +5590,13 @@
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $7
@@ -5444,11 +5628,11 @@
    select
   else
    local.get $5
-   local.tee $10
+   local.tee $12
    local.get $9
-   local.tee $11
-   local.get $10
-   local.get $11
+   local.tee $13
+   local.get $12
+   local.get $13
    i32.lt_s
    select
   end
@@ -5460,20 +5644,20 @@
    local.get $9
    local.get $4
    i32.add
-   local.tee $10
+   local.tee $14
    i32.const 0
-   local.tee $11
-   local.get $10
-   local.get $11
+   local.tee $15
+   local.get $14
+   local.get $15
    i32.gt_s
    select
   else
    local.get $4
-   local.tee $10
+   local.tee $16
    local.get $9
-   local.tee $11
-   local.get $10
-   local.get $11
+   local.tee $17
+   local.get $16
+   local.get $17
    i32.lt_s
    select
   end
@@ -5486,8 +5670,8 @@
    local.get $5
    local.get $4
    i32.lt_s
-   local.set $10
-   local.get $10
+   local.set $18
+   local.get $18
    if
     local.get $8
     local.get $5
@@ -5545,6 +5729,8 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $0
@@ -5567,48 +5753,48 @@
    return
   end
   i32.const 0
-  local.set $2
+  local.set $3
   local.get $0
   call $~lib/typedarray/Int32Array#get:length
-  local.set $3
+  local.set $4
   loop $for-loop|0
-   local.get $2
    local.get $3
-   i32.lt_s
-   local.set $4
    local.get $4
+   i32.lt_s
+   local.set $5
+   local.get $5
    if
     local.get $0
-    local.get $2
+    local.get $3
     call $~lib/typedarray/Int32Array#__get
     local.get $1
-    local.get $2
+    local.get $3
     call $~lib/array/Array<i32>#__get
     i32.ne
     if
      i32.const 0
-     local.set $5
+     local.set $6
      local.get $0
      call $~lib/rt/pure/__release
      local.get $1
      call $~lib/rt/pure/__release
-     local.get $5
+     local.get $6
      return
     end
-    local.get $2
+    local.get $3
     i32.const 1
     i32.add
-    local.set $2
+    local.set $3
     br $for-loop|0
    end
   end
   i32.const 1
-  local.set $3
+  local.set $7
   local.get $0
   call $~lib/rt/pure/__release
   local.get $1
   call $~lib/rt/pure/__release
-  local.get $3
+  local.get $7
  )
  (func $~lib/typedarray/Int32Array#slice (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
@@ -5618,6 +5804,16 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $5
@@ -5644,11 +5840,11 @@
    select
   else
    local.get $4
-   local.tee $7
+   local.tee $9
    local.get $6
-   local.tee $8
-   local.get $7
-   local.get $8
+   local.tee $10
+   local.get $9
+   local.get $10
    i32.lt_s
    select
   end
@@ -5660,20 +5856,20 @@
    local.get $3
    local.get $6
    i32.add
-   local.tee $7
+   local.tee $11
    i32.const 0
-   local.tee $8
-   local.get $7
-   local.get $8
+   local.tee $12
+   local.get $11
+   local.get $12
    i32.gt_s
    select
   else
    local.get $3
-   local.tee $7
+   local.tee $13
    local.get $6
-   local.tee $8
-   local.get $7
-   local.get $8
+   local.tee $14
+   local.get $13
+   local.get $14
    i32.lt_s
    select
   end
@@ -5681,21 +5877,21 @@
   local.get $3
   local.get $4
   i32.sub
-  local.tee $7
+  local.tee $15
   i32.const 0
-  local.tee $8
-  local.get $7
-  local.get $8
+  local.tee $16
+  local.get $15
+  local.get $16
   i32.gt_s
   select
   local.set $6
   i32.const 0
   local.get $6
   call $~lib/typedarray/Int32Array#constructor
-  local.tee $7
+  local.tee $17
   call $~lib/rt/pure/__retain
-  local.set $8
-  local.get $8
+  local.set $18
+  local.get $18
   i32.load offset=4
   local.get $5
   i32.load offset=4
@@ -5707,13 +5903,13 @@
   i32.const 2
   i32.shl
   call $~lib/memory/memory.copy
-  local.get $8
-  local.set $9
+  local.get $18
+  local.set $19
   local.get $5
   call $~lib/rt/pure/__release
-  local.get $7
+  local.get $17
   call $~lib/rt/pure/__release
-  local.get $9
+  local.get $19
  )
  (func $~lib/typedarray/Int32Array#copyWithin (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
@@ -5727,6 +5923,21 @@
   (local $12 i32)
   (local $13 i32)
   (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local $22 i32)
+  (local $23 i32)
+  (local $24 i32)
+  (local $25 i32)
+  (local $26 i32)
+  (local $27 i32)
+  (local $28 i32)
+  (local $29 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $7
@@ -5758,24 +5969,24 @@
    local.get $8
    local.get $6
    i32.add
-   local.tee $10
+   local.tee $12
    i32.const 0
-   local.tee $11
-   local.get $10
-   local.get $11
+   local.tee $13
+   local.get $12
+   local.get $13
    i32.gt_s
    select
   else
    local.get $6
-   local.tee $10
+   local.tee $14
    local.get $8
-   local.tee $11
-   local.get $10
-   local.get $11
+   local.tee $15
+   local.get $14
+   local.get $15
    i32.lt_s
    select
   end
-  local.set $10
+  local.set $16
   local.get $5
   i32.const 0
   i32.lt_s
@@ -5783,24 +5994,24 @@
    local.get $8
    local.get $5
    i32.add
-   local.tee $11
+   local.tee $17
    i32.const 0
-   local.tee $12
-   local.get $11
-   local.get $12
+   local.tee $18
+   local.get $17
+   local.get $18
    i32.gt_s
    select
   else
    local.get $5
-   local.tee $11
+   local.tee $19
    local.get $8
-   local.tee $12
-   local.get $11
-   local.get $12
+   local.tee $20
+   local.get $19
+   local.get $20
    i32.lt_s
    select
   end
-  local.set $11
+  local.set $21
   local.get $4
   i32.const 0
   i32.lt_s
@@ -5808,48 +6019,48 @@
    local.get $8
    local.get $4
    i32.add
-   local.tee $12
+   local.tee $22
    i32.const 0
-   local.tee $13
-   local.get $12
-   local.get $13
+   local.tee $23
+   local.get $22
+   local.get $23
    i32.gt_s
    select
   else
    local.get $4
-   local.tee $12
+   local.tee $24
    local.get $8
-   local.tee $13
-   local.get $12
-   local.get $13
+   local.tee $25
+   local.get $24
+   local.get $25
    i32.lt_s
    select
   end
-  local.set $12
-  local.get $12
-  local.get $11
+  local.set $26
+  local.get $26
+  local.get $21
   i32.sub
-  local.tee $13
+  local.tee $27
   local.get $8
-  local.get $10
+  local.get $16
   i32.sub
-  local.tee $14
-  local.get $13
-  local.get $14
+  local.tee $28
+  local.get $27
+  local.get $28
   i32.lt_s
   select
-  local.set $13
+  local.set $29
   local.get $9
-  local.get $10
+  local.get $16
   i32.const 2
   i32.shl
   i32.add
   local.get $9
-  local.get $11
+  local.get $21
   i32.const 2
   i32.shl
   i32.add
-  local.get $13
+  local.get $29
   i32.const 2
   i32.shl
   call $~lib/memory/memory.copy
@@ -5876,6 +6087,7 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $5
@@ -5920,10 +6132,10 @@
    end
   end
   local.get $3
-  local.set $8
+  local.set $10
   local.get $5
   call $~lib/rt/pure/__release
-  local.get $8
+  local.get $10
  )
  (func $std/typedarray/testReduce<~lib/typedarray/Int8Array,i8>
   (local $0 i32)
@@ -6014,6 +6226,7 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $5
@@ -6058,10 +6271,10 @@
    end
   end
   local.get $3
-  local.set $8
+  local.set $10
   local.get $5
   call $~lib/rt/pure/__release
-  local.get $8
+  local.get $10
  )
  (func $std/typedarray/testReduce<~lib/typedarray/Uint8Array,u8>
   (local $0 i32)
@@ -6130,6 +6343,7 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $5
@@ -6174,10 +6388,10 @@
    end
   end
   local.get $3
-  local.set $8
+  local.set $10
   local.get $5
   call $~lib/rt/pure/__release
-  local.get $8
+  local.get $10
  )
  (func $std/typedarray/testReduce<~lib/typedarray/Uint8ClampedArray,u8>
   (local $0 i32)
@@ -6270,6 +6484,7 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $5
@@ -6314,10 +6529,10 @@
    end
   end
   local.get $3
-  local.set $8
+  local.set $10
   local.get $5
   call $~lib/rt/pure/__release
-  local.get $8
+  local.get $10
  )
  (func $std/typedarray/testReduce<~lib/typedarray/Int16Array,i16>
   (local $0 i32)
@@ -6412,6 +6627,7 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $5
@@ -6456,10 +6672,10 @@
    end
   end
   local.get $3
-  local.set $8
+  local.set $10
   local.get $5
   call $~lib/rt/pure/__release
-  local.get $8
+  local.get $10
  )
  (func $std/typedarray/testReduce<~lib/typedarray/Uint16Array,u16>
   (local $0 i32)
@@ -6528,6 +6744,7 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $5
@@ -6572,10 +6789,10 @@
    end
   end
   local.get $3
-  local.set $8
+  local.set $10
   local.get $5
   call $~lib/rt/pure/__release
-  local.get $8
+  local.get $10
  )
  (func $std/typedarray/testReduce<~lib/typedarray/Int32Array,i32>
   (local $0 i32)
@@ -6666,6 +6883,7 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $5
@@ -6710,10 +6928,10 @@
    end
   end
   local.get $3
-  local.set $8
+  local.set $10
   local.get $5
   call $~lib/rt/pure/__release
-  local.get $8
+  local.get $10
  )
  (func $std/typedarray/testReduce<~lib/typedarray/Uint32Array,u32>
   (local $0 i32)
@@ -7311,6 +7529,7 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $5
@@ -7355,10 +7574,10 @@
    end
   end
   local.get $3
-  local.set $7
+  local.set $9
   local.get $5
   call $~lib/rt/pure/__release
-  local.get $7
+  local.get $9
  )
  (func $std/typedarray/testReduceRight<~lib/typedarray/Int8Array,i8>
   (local $0 i32)
@@ -7428,6 +7647,7 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $5
@@ -7472,10 +7692,10 @@
    end
   end
   local.get $3
-  local.set $7
+  local.set $9
   local.get $5
   call $~lib/rt/pure/__release
-  local.get $7
+  local.get $9
  )
  (func $std/typedarray/testReduceRight<~lib/typedarray/Uint8Array,u8>
   (local $0 i32)
@@ -7543,6 +7763,7 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $5
@@ -7587,10 +7808,10 @@
    end
   end
   local.get $3
-  local.set $7
+  local.set $9
   local.get $5
   call $~lib/rt/pure/__release
-  local.get $7
+  local.get $9
  )
  (func $std/typedarray/testReduceRight<~lib/typedarray/Uint8ClampedArray,u8>
   (local $0 i32)
@@ -7658,6 +7879,7 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $5
@@ -7702,10 +7924,10 @@
    end
   end
   local.get $3
-  local.set $7
+  local.set $9
   local.get $5
   call $~lib/rt/pure/__release
-  local.get $7
+  local.get $9
  )
  (func $std/typedarray/testReduceRight<~lib/typedarray/Int16Array,i16>
   (local $0 i32)
@@ -7775,6 +7997,7 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $5
@@ -7819,10 +8042,10 @@
    end
   end
   local.get $3
-  local.set $7
+  local.set $9
   local.get $5
   call $~lib/rt/pure/__release
-  local.get $7
+  local.get $9
  )
  (func $std/typedarray/testReduceRight<~lib/typedarray/Uint16Array,u16>
   (local $0 i32)
@@ -7890,6 +8113,7 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $5
@@ -7934,10 +8158,10 @@
    end
   end
   local.get $3
-  local.set $7
+  local.set $9
   local.get $5
   call $~lib/rt/pure/__release
-  local.get $7
+  local.get $9
  )
  (func $std/typedarray/testReduceRight<~lib/typedarray/Int32Array,i32>
   (local $0 i32)
@@ -8003,6 +8227,7 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $5
@@ -8047,10 +8272,10 @@
    end
   end
   local.get $3
-  local.set $7
+  local.set $9
   local.get $5
   call $~lib/rt/pure/__release
-  local.get $7
+  local.get $9
  )
  (func $std/typedarray/testReduceRight<~lib/typedarray/Uint32Array,u32>
   (local $0 i32)
@@ -8575,6 +8800,7 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
+  (local $11 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $3
@@ -8644,10 +8870,10 @@
   i32.store offset=8
   local.get $7
   call $~lib/rt/pure/__retain
-  local.set $9
+  local.set $11
   local.get $3
   call $~lib/rt/pure/__release
-  local.get $9
+  local.get $11
  )
  (func $std/typedarray/testArrayMap<~lib/typedarray/Int8Array,i8>
   (local $0 i32)
@@ -8747,6 +8973,7 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
+  (local $11 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $3
@@ -8816,10 +9043,10 @@
   i32.store offset=8
   local.get $7
   call $~lib/rt/pure/__retain
-  local.set $9
+  local.set $11
   local.get $3
   call $~lib/rt/pure/__release
-  local.get $9
+  local.get $11
  )
  (func $~lib/typedarray/Uint8Array#__get (param $0 i32) (param $1 i32) (result i32)
   local.get $1
@@ -8938,6 +9165,7 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
+  (local $11 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $3
@@ -9007,10 +9235,10 @@
   i32.store offset=8
   local.get $7
   call $~lib/rt/pure/__retain
-  local.set $9
+  local.set $11
   local.get $3
   call $~lib/rt/pure/__release
-  local.get $9
+  local.get $11
  )
  (func $std/typedarray/testArrayMap<~lib/typedarray/Uint8ClampedArray,u8>
   (local $0 i32)
@@ -9110,6 +9338,7 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
+  (local $11 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $3
@@ -9179,10 +9408,10 @@
   i32.store offset=8
   local.get $7
   call $~lib/rt/pure/__retain
-  local.set $9
+  local.set $11
   local.get $3
   call $~lib/rt/pure/__release
-  local.get $9
+  local.get $11
  )
  (func $~lib/typedarray/Int16Array#__get (param $0 i32) (param $1 i32) (result i32)
   local.get $1
@@ -9305,6 +9534,7 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
+  (local $11 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $3
@@ -9374,10 +9604,10 @@
   i32.store offset=8
   local.get $7
   call $~lib/rt/pure/__retain
-  local.set $9
+  local.set $11
   local.get $3
   call $~lib/rt/pure/__release
-  local.get $9
+  local.get $11
  )
  (func $~lib/typedarray/Uint16Array#__get (param $0 i32) (param $1 i32) (result i32)
   local.get $1
@@ -9500,6 +9730,7 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
+  (local $11 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $3
@@ -9569,10 +9800,10 @@
   i32.store offset=8
   local.get $7
   call $~lib/rt/pure/__retain
-  local.set $9
+  local.set $11
   local.get $3
   call $~lib/rt/pure/__release
-  local.get $9
+  local.get $11
  )
  (func $std/typedarray/testArrayMap<~lib/typedarray/Int32Array,i32>
   (local $0 i32)
@@ -9672,6 +9903,7 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
+  (local $11 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $3
@@ -9741,10 +9973,10 @@
   i32.store offset=8
   local.get $7
   call $~lib/rt/pure/__retain
-  local.set $9
+  local.set $11
   local.get $3
   call $~lib/rt/pure/__release
-  local.get $9
+  local.get $11
  )
  (func $~lib/typedarray/Uint32Array#__get (param $0 i32) (param $1 i32) (result i32)
   local.get $1
@@ -9867,6 +10099,7 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
+  (local $11 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $3
@@ -9936,10 +10169,10 @@
   i32.store offset=8
   local.get $7
   call $~lib/rt/pure/__retain
-  local.set $9
+  local.set $11
   local.get $3
   call $~lib/rt/pure/__release
-  local.get $9
+  local.get $11
  )
  (func $~lib/typedarray/Int64Array#__get (param $0 i32) (param $1 i32) (result i64)
   local.get $1
@@ -10062,6 +10295,7 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
+  (local $11 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $3
@@ -10131,10 +10365,10 @@
   i32.store offset=8
   local.get $7
   call $~lib/rt/pure/__retain
-  local.set $9
+  local.set $11
   local.get $3
   call $~lib/rt/pure/__release
-  local.get $9
+  local.get $11
  )
  (func $~lib/typedarray/Uint64Array#__get (param $0 i32) (param $1 i32) (result i64)
   local.get $1
@@ -10257,6 +10491,7 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
+  (local $11 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $3
@@ -10326,10 +10561,10 @@
   i32.store offset=8
   local.get $7
   call $~lib/rt/pure/__retain
-  local.set $9
+  local.set $11
   local.get $3
   call $~lib/rt/pure/__release
-  local.get $9
+  local.get $11
  )
  (func $~lib/typedarray/Float32Array#__get (param $0 i32) (param $1 i32) (result f32)
   local.get $1
@@ -10452,6 +10687,7 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
+  (local $11 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $3
@@ -10521,10 +10757,10 @@
   i32.store offset=8
   local.get $7
   call $~lib/rt/pure/__retain
-  local.set $9
+  local.set $11
   local.get $3
   call $~lib/rt/pure/__release
-  local.get $9
+  local.get $11
  )
  (func $std/typedarray/testArrayMap<~lib/typedarray/Float64Array,f64>
   (local $0 i32)
@@ -10625,6 +10861,7 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
   local.get $2
   call $~lib/rt/tlsf/prepareSize
   local.set $3
@@ -10682,8 +10919,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $5
-   local.get $5
+   local.set $8
+   local.get $8
    local.get $3
    i32.ge_u
    if
@@ -10694,7 +10931,7 @@
     local.get $4
     i32.const 3
     i32.and
-    local.get $5
+    local.get $8
     i32.or
     i32.store
     local.get $1
@@ -10713,12 +10950,12 @@
   local.get $1
   i32.load offset=8
   call $~lib/rt/tlsf/allocateBlock
-  local.set $8
-  local.get $8
+  local.set $9
+  local.get $9
   local.get $1
   i32.load offset=4
   i32.store offset=4
-  local.get $8
+  local.get $9
   i32.const 16
   i32.add
   local.get $1
@@ -10733,13 +10970,13 @@
    i32.const 1
    drop
    local.get $1
-   local.get $8
+   local.get $9
    call $~lib/rt/rtrace/onrealloc
    local.get $0
    local.get $1
    call $~lib/rt/tlsf/freeBlock
   end
-  local.get $8
+  local.get $9
  )
  (func $~lib/rt/tlsf/__realloc (param $0 i32) (param $1 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
@@ -10762,6 +10999,9 @@
   (local $10 i32)
   (local $11 i32)
   (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $3
@@ -10832,27 +11072,27 @@
   local.get $8
   i32.const 0
   i32.shl
-  local.set $9
+  local.set $13
   local.get $6
-  local.get $9
+  local.get $13
   call $~lib/rt/tlsf/__realloc
-  local.set $10
+  local.set $14
   local.get $5
-  local.get $10
+  local.get $14
   call $~lib/rt/pure/__retain
   i32.store
   local.get $5
-  local.get $9
+  local.get $13
   i32.store offset=8
   local.get $5
-  local.get $10
+  local.get $14
   i32.store offset=4
   local.get $5
   call $~lib/rt/pure/__retain
-  local.set $11
+  local.set $15
   local.get $3
   call $~lib/rt/pure/__release
-  local.get $11
+  local.get $15
  )
  (func $std/typedarray/testArrayFilter<~lib/typedarray/Int8Array,i8>
   (local $0 i32)
@@ -10990,6 +11230,9 @@
   (local $10 i32)
   (local $11 i32)
   (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $3
@@ -11060,27 +11303,27 @@
   local.get $8
   i32.const 0
   i32.shl
-  local.set $9
+  local.set $13
   local.get $6
-  local.get $9
+  local.get $13
   call $~lib/rt/tlsf/__realloc
-  local.set $10
+  local.set $14
   local.get $5
-  local.get $10
+  local.get $14
   call $~lib/rt/pure/__retain
   i32.store
   local.get $5
-  local.get $9
+  local.get $13
   i32.store offset=8
   local.get $5
-  local.get $10
+  local.get $14
   i32.store offset=4
   local.get $5
   call $~lib/rt/pure/__retain
-  local.set $11
+  local.set $15
   local.get $3
   call $~lib/rt/pure/__release
-  local.get $11
+  local.get $15
  )
  (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint8Array,u8>
   (local $0 i32)
@@ -11218,6 +11461,9 @@
   (local $10 i32)
   (local $11 i32)
   (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $3
@@ -11288,27 +11534,27 @@
   local.get $8
   i32.const 0
   i32.shl
-  local.set $9
+  local.set $13
   local.get $6
-  local.get $9
+  local.get $13
   call $~lib/rt/tlsf/__realloc
-  local.set $10
+  local.set $14
   local.get $5
-  local.get $10
+  local.get $14
   call $~lib/rt/pure/__retain
   i32.store
   local.get $5
-  local.get $9
+  local.get $13
   i32.store offset=8
   local.get $5
-  local.get $10
+  local.get $14
   i32.store offset=4
   local.get $5
   call $~lib/rt/pure/__retain
-  local.set $11
+  local.set $15
   local.get $3
   call $~lib/rt/pure/__release
-  local.get $11
+  local.get $15
  )
  (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint8ClampedArray,u8>
   (local $0 i32)
@@ -11448,6 +11694,9 @@
   (local $10 i32)
   (local $11 i32)
   (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $3
@@ -11518,27 +11767,27 @@
   local.get $8
   i32.const 1
   i32.shl
-  local.set $9
+  local.set $13
   local.get $6
-  local.get $9
+  local.get $13
   call $~lib/rt/tlsf/__realloc
-  local.set $10
+  local.set $14
   local.get $5
-  local.get $10
+  local.get $14
   call $~lib/rt/pure/__retain
   i32.store
   local.get $5
-  local.get $9
+  local.get $13
   i32.store offset=8
   local.get $5
-  local.get $10
+  local.get $14
   i32.store offset=4
   local.get $5
   call $~lib/rt/pure/__retain
-  local.set $11
+  local.set $15
   local.get $3
   call $~lib/rt/pure/__release
-  local.get $11
+  local.get $15
  )
  (func $std/typedarray/testArrayFilter<~lib/typedarray/Int16Array,i16>
   (local $0 i32)
@@ -11676,6 +11925,9 @@
   (local $10 i32)
   (local $11 i32)
   (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $3
@@ -11746,27 +11998,27 @@
   local.get $8
   i32.const 1
   i32.shl
-  local.set $9
+  local.set $13
   local.get $6
-  local.get $9
+  local.get $13
   call $~lib/rt/tlsf/__realloc
-  local.set $10
+  local.set $14
   local.get $5
-  local.get $10
+  local.get $14
   call $~lib/rt/pure/__retain
   i32.store
   local.get $5
-  local.get $9
+  local.get $13
   i32.store offset=8
   local.get $5
-  local.get $10
+  local.get $14
   i32.store offset=4
   local.get $5
   call $~lib/rt/pure/__retain
-  local.set $11
+  local.set $15
   local.get $3
   call $~lib/rt/pure/__release
-  local.get $11
+  local.get $15
  )
  (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint16Array,u16>
   (local $0 i32)
@@ -11902,6 +12154,9 @@
   (local $10 i32)
   (local $11 i32)
   (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $3
@@ -11972,27 +12227,27 @@
   local.get $8
   i32.const 2
   i32.shl
-  local.set $9
+  local.set $13
   local.get $6
-  local.get $9
+  local.get $13
   call $~lib/rt/tlsf/__realloc
-  local.set $10
+  local.set $14
   local.get $5
-  local.get $10
+  local.get $14
   call $~lib/rt/pure/__retain
   i32.store
   local.get $5
-  local.get $9
+  local.get $13
   i32.store offset=8
   local.get $5
-  local.get $10
+  local.get $14
   i32.store offset=4
   local.get $5
   call $~lib/rt/pure/__retain
-  local.set $11
+  local.set $15
   local.get $3
   call $~lib/rt/pure/__release
-  local.get $11
+  local.get $15
  )
  (func $std/typedarray/testArrayFilter<~lib/typedarray/Int32Array,i32>
   (local $0 i32)
@@ -12128,6 +12383,9 @@
   (local $10 i32)
   (local $11 i32)
   (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $3
@@ -12198,27 +12456,27 @@
   local.get $8
   i32.const 2
   i32.shl
-  local.set $9
+  local.set $13
   local.get $6
-  local.get $9
+  local.get $13
   call $~lib/rt/tlsf/__realloc
-  local.set $10
+  local.set $14
   local.get $5
-  local.get $10
+  local.get $14
   call $~lib/rt/pure/__retain
   i32.store
   local.get $5
-  local.get $9
+  local.get $13
   i32.store offset=8
   local.get $5
-  local.get $10
+  local.get $14
   i32.store offset=4
   local.get $5
   call $~lib/rt/pure/__retain
-  local.set $11
+  local.set $15
   local.get $3
   call $~lib/rt/pure/__release
-  local.get $11
+  local.get $15
  )
  (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint32Array,u32>
   (local $0 i32)
@@ -12354,6 +12612,9 @@
   (local $10 i32)
   (local $11 i64)
   (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $3
@@ -12424,27 +12685,27 @@
   local.get $8
   i32.const 3
   i32.shl
-  local.set $9
+  local.set $13
   local.get $6
-  local.get $9
+  local.get $13
   call $~lib/rt/tlsf/__realloc
-  local.set $10
+  local.set $14
   local.get $5
-  local.get $10
+  local.get $14
   call $~lib/rt/pure/__retain
   i32.store
   local.get $5
-  local.get $9
+  local.get $13
   i32.store offset=8
   local.get $5
-  local.get $10
+  local.get $14
   i32.store offset=4
   local.get $5
   call $~lib/rt/pure/__retain
-  local.set $12
+  local.set $15
   local.get $3
   call $~lib/rt/pure/__release
-  local.get $12
+  local.get $15
  )
  (func $std/typedarray/testArrayFilter<~lib/typedarray/Int64Array,i64>
   (local $0 i32)
@@ -12580,6 +12841,9 @@
   (local $10 i32)
   (local $11 i64)
   (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $3
@@ -12650,27 +12914,27 @@
   local.get $8
   i32.const 3
   i32.shl
-  local.set $9
+  local.set $13
   local.get $6
-  local.get $9
+  local.get $13
   call $~lib/rt/tlsf/__realloc
-  local.set $10
+  local.set $14
   local.get $5
-  local.get $10
+  local.get $14
   call $~lib/rt/pure/__retain
   i32.store
   local.get $5
-  local.get $9
+  local.get $13
   i32.store offset=8
   local.get $5
-  local.get $10
+  local.get $14
   i32.store offset=4
   local.get $5
   call $~lib/rt/pure/__retain
-  local.set $12
+  local.set $15
   local.get $3
   call $~lib/rt/pure/__release
-  local.get $12
+  local.get $15
  )
  (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint64Array,u64>
   (local $0 i32)
@@ -12806,6 +13070,9 @@
   (local $10 i32)
   (local $11 f32)
   (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $3
@@ -12876,27 +13143,27 @@
   local.get $8
   i32.const 2
   i32.shl
-  local.set $9
+  local.set $13
   local.get $6
-  local.get $9
+  local.get $13
   call $~lib/rt/tlsf/__realloc
-  local.set $10
+  local.set $14
   local.get $5
-  local.get $10
+  local.get $14
   call $~lib/rt/pure/__retain
   i32.store
   local.get $5
-  local.get $9
+  local.get $13
   i32.store offset=8
   local.get $5
-  local.get $10
+  local.get $14
   i32.store offset=4
   local.get $5
   call $~lib/rt/pure/__retain
-  local.set $12
+  local.set $15
   local.get $3
   call $~lib/rt/pure/__release
-  local.get $12
+  local.get $15
  )
  (func $std/typedarray/testArrayFilter<~lib/typedarray/Float32Array,f32>
   (local $0 i32)
@@ -13032,6 +13299,9 @@
   (local $10 i32)
   (local $11 f64)
   (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $3
@@ -13102,27 +13372,27 @@
   local.get $8
   i32.const 3
   i32.shl
-  local.set $9
+  local.set $13
   local.get $6
-  local.get $9
+  local.get $13
   call $~lib/rt/tlsf/__realloc
-  local.set $10
+  local.set $14
   local.get $5
-  local.get $10
+  local.get $14
   call $~lib/rt/pure/__retain
   i32.store
   local.get $5
-  local.get $9
+  local.get $13
   i32.store offset=8
   local.get $5
-  local.get $10
+  local.get $14
   i32.store offset=4
   local.get $5
   call $~lib/rt/pure/__retain
-  local.set $12
+  local.set $15
   local.get $3
   call $~lib/rt/pure/__release
-  local.get $12
+  local.get $15
  )
  (func $std/typedarray/testArrayFilter<~lib/typedarray/Float64Array,f64>
   (local $0 i32)
@@ -13258,6 +13528,7 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
   block $~lib/typedarray/SOME<~lib/typedarray/Int8Array,i8>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
@@ -13307,10 +13578,10 @@
     end
    end
    i32.const 0
-   local.set $6
+   local.set $9
    local.get $3
    call $~lib/rt/pure/__release
-   local.get $6
+   local.get $9
   end
  )
  (func $std/typedarray/testArraySome<~lib/typedarray/Int8Array,i8>~anonymous|1 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -13412,6 +13683,7 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
   block $~lib/typedarray/SOME<~lib/typedarray/Uint8Array,u8>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
@@ -13461,10 +13733,10 @@
     end
    end
    i32.const 0
-   local.set $6
+   local.set $9
    local.get $3
    call $~lib/rt/pure/__release
-   local.get $6
+   local.get $9
   end
  )
  (func $std/typedarray/testArraySome<~lib/typedarray/Uint8Array,u8>~anonymous|1 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -13564,6 +13836,7 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
   block $~lib/typedarray/SOME<~lib/typedarray/Uint8ClampedArray,u8>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
@@ -13613,10 +13886,10 @@
     end
    end
    i32.const 0
-   local.set $6
+   local.set $9
    local.get $3
    call $~lib/rt/pure/__release
-   local.get $6
+   local.get $9
   end
  )
  (func $std/typedarray/testArraySome<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|1 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -13718,6 +13991,7 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
   block $~lib/typedarray/SOME<~lib/typedarray/Int16Array,i16>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
@@ -13767,10 +14041,10 @@
     end
    end
    i32.const 0
-   local.set $6
+   local.set $9
    local.get $3
    call $~lib/rt/pure/__release
-   local.get $6
+   local.get $9
   end
  )
  (func $std/typedarray/testArraySome<~lib/typedarray/Int16Array,i16>~anonymous|1 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -13872,6 +14146,7 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
   block $~lib/typedarray/SOME<~lib/typedarray/Uint16Array,u16>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
@@ -13921,10 +14196,10 @@
     end
    end
    i32.const 0
-   local.set $6
+   local.set $9
    local.get $3
    call $~lib/rt/pure/__release
-   local.get $6
+   local.get $9
   end
  )
  (func $std/typedarray/testArraySome<~lib/typedarray/Uint16Array,u16>~anonymous|1 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -14022,6 +14297,7 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
   block $~lib/typedarray/SOME<~lib/typedarray/Int32Array,i32>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
@@ -14071,10 +14347,10 @@
     end
    end
    i32.const 0
-   local.set $6
+   local.set $9
    local.get $3
    call $~lib/rt/pure/__release
-   local.get $6
+   local.get $9
   end
  )
  (func $std/typedarray/testArraySome<~lib/typedarray/Int32Array,i32>~anonymous|1 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -14170,6 +14446,7 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
   block $~lib/typedarray/SOME<~lib/typedarray/Uint32Array,u32>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
@@ -14219,10 +14496,10 @@
     end
    end
    i32.const 0
-   local.set $6
+   local.set $9
    local.get $3
    call $~lib/rt/pure/__release
-   local.get $6
+   local.get $9
   end
  )
  (func $std/typedarray/testArraySome<~lib/typedarray/Uint32Array,u32>~anonymous|1 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -14318,6 +14595,7 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
   block $~lib/typedarray/SOME<~lib/typedarray/Int64Array,i64>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
@@ -14367,10 +14645,10 @@
     end
    end
    i32.const 0
-   local.set $6
+   local.set $9
    local.get $3
    call $~lib/rt/pure/__release
-   local.get $6
+   local.get $9
   end
  )
  (func $std/typedarray/testArraySome<~lib/typedarray/Int64Array,i64>~anonymous|1 (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
@@ -14466,6 +14744,7 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
   block $~lib/typedarray/SOME<~lib/typedarray/Uint64Array,u64>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
@@ -14515,10 +14794,10 @@
     end
    end
    i32.const 0
-   local.set $6
+   local.set $9
    local.get $3
    call $~lib/rt/pure/__release
-   local.get $6
+   local.get $9
   end
  )
  (func $std/typedarray/testArraySome<~lib/typedarray/Uint64Array,u64>~anonymous|1 (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
@@ -14614,6 +14893,7 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
   block $~lib/typedarray/SOME<~lib/typedarray/Float32Array,f32>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
@@ -14663,10 +14943,10 @@
     end
    end
    i32.const 0
-   local.set $6
+   local.set $9
    local.get $3
    call $~lib/rt/pure/__release
-   local.get $6
+   local.get $9
   end
  )
  (func $std/typedarray/testArraySome<~lib/typedarray/Float32Array,f32>~anonymous|1 (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
@@ -14762,6 +15042,7 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
   block $~lib/typedarray/SOME<~lib/typedarray/Float64Array,f64>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
@@ -14811,10 +15092,10 @@
     end
    end
    i32.const 0
-   local.set $6
+   local.set $9
    local.get $3
    call $~lib/rt/pure/__release
-   local.get $6
+   local.get $9
   end
  )
  (func $std/typedarray/testArraySome<~lib/typedarray/Float64Array,f64>~anonymous|1 (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
@@ -14914,6 +15195,7 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
   block $~lib/typedarray/FIND_INDEX<~lib/typedarray/Int8Array,i8>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
@@ -14963,10 +15245,10 @@
     end
    end
    i32.const -1
-   local.set $6
+   local.set $9
    local.get $3
    call $~lib/rt/pure/__release
-   local.get $6
+   local.get $9
   end
  )
  (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int8Array,i8>~anonymous|1 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -15069,6 +15351,7 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
   block $~lib/typedarray/FIND_INDEX<~lib/typedarray/Uint8Array,u8>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
@@ -15118,10 +15401,10 @@
     end
    end
    i32.const -1
-   local.set $6
+   local.set $9
    local.get $3
    call $~lib/rt/pure/__release
-   local.get $6
+   local.get $9
   end
  )
  (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint8Array,u8>~anonymous|1 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -15222,6 +15505,7 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
   block $~lib/typedarray/FIND_INDEX<~lib/typedarray/Uint8ClampedArray,u8>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
@@ -15271,10 +15555,10 @@
     end
    end
    i32.const -1
-   local.set $6
+   local.set $9
    local.get $3
    call $~lib/rt/pure/__release
-   local.get $6
+   local.get $9
   end
  )
  (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|1 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -15377,6 +15661,7 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
   block $~lib/typedarray/FIND_INDEX<~lib/typedarray/Int16Array,i16>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
@@ -15426,10 +15711,10 @@
     end
    end
    i32.const -1
-   local.set $6
+   local.set $9
    local.get $3
    call $~lib/rt/pure/__release
-   local.get $6
+   local.get $9
   end
  )
  (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int16Array,i16>~anonymous|1 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -15532,6 +15817,7 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
   block $~lib/typedarray/FIND_INDEX<~lib/typedarray/Uint16Array,u16>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
@@ -15581,10 +15867,10 @@
     end
    end
    i32.const -1
-   local.set $6
+   local.set $9
    local.get $3
    call $~lib/rt/pure/__release
-   local.get $6
+   local.get $9
   end
  )
  (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint16Array,u16>~anonymous|1 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -15683,6 +15969,7 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
   block $~lib/typedarray/FIND_INDEX<~lib/typedarray/Int32Array,i32>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
@@ -15732,10 +16019,10 @@
     end
    end
    i32.const -1
-   local.set $6
+   local.set $9
    local.get $3
    call $~lib/rt/pure/__release
-   local.get $6
+   local.get $9
   end
  )
  (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int32Array,i32>~anonymous|1 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -15832,6 +16119,7 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
   block $~lib/typedarray/FIND_INDEX<~lib/typedarray/Uint32Array,u32>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
@@ -15881,10 +16169,10 @@
     end
    end
    i32.const -1
-   local.set $6
+   local.set $9
    local.get $3
    call $~lib/rt/pure/__release
-   local.get $6
+   local.get $9
   end
  )
  (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint32Array,u32>~anonymous|1 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -15981,6 +16269,7 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
   block $~lib/typedarray/FIND_INDEX<~lib/typedarray/Int64Array,i64>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
@@ -16030,10 +16319,10 @@
     end
    end
    i32.const -1
-   local.set $6
+   local.set $9
    local.get $3
    call $~lib/rt/pure/__release
-   local.get $6
+   local.get $9
   end
  )
  (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int64Array,i64>~anonymous|1 (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
@@ -16130,6 +16419,7 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
   block $~lib/typedarray/FIND_INDEX<~lib/typedarray/Uint64Array,u64>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
@@ -16179,10 +16469,10 @@
     end
    end
    i32.const -1
-   local.set $6
+   local.set $9
    local.get $3
    call $~lib/rt/pure/__release
-   local.get $6
+   local.get $9
   end
  )
  (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint64Array,u64>~anonymous|1 (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
@@ -16279,6 +16569,7 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
   block $~lib/typedarray/FIND_INDEX<~lib/typedarray/Float32Array,f32>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
@@ -16328,10 +16619,10 @@
     end
    end
    i32.const -1
-   local.set $6
+   local.set $9
    local.get $3
    call $~lib/rt/pure/__release
-   local.get $6
+   local.get $9
   end
  )
  (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Float32Array,f32>~anonymous|1 (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
@@ -16428,6 +16719,7 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
   block $~lib/typedarray/FIND_INDEX<~lib/typedarray/Float64Array,f64>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
@@ -16477,10 +16769,10 @@
     end
    end
    i32.const -1
-   local.set $6
+   local.set $9
    local.get $3
    call $~lib/rt/pure/__release
-   local.get $6
+   local.get $9
   end
  )
  (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Float64Array,f64>~anonymous|1 (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
@@ -16583,6 +16875,7 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
   block $~lib/typedarray/EVERY<~lib/typedarray/Int8Array,i8>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
@@ -16635,10 +16928,10 @@
     end
    end
    i32.const 1
-   local.set $6
+   local.set $9
    local.get $3
    call $~lib/rt/pure/__release
-   local.get $6
+   local.get $9
   end
  )
  (func $std/typedarray/testArrayEvery<~lib/typedarray/Int8Array,i8>~anonymous|1 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -16742,6 +17035,7 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
   block $~lib/typedarray/EVERY<~lib/typedarray/Uint8Array,u8>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
@@ -16794,10 +17088,10 @@
     end
    end
    i32.const 1
-   local.set $6
+   local.set $9
    local.get $3
    call $~lib/rt/pure/__release
-   local.get $6
+   local.get $9
   end
  )
  (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint8Array,u8>~anonymous|1 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -16899,6 +17193,7 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
   block $~lib/typedarray/EVERY<~lib/typedarray/Uint8ClampedArray,u8>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
@@ -16951,10 +17246,10 @@
     end
    end
    i32.const 1
-   local.set $6
+   local.set $9
    local.get $3
    call $~lib/rt/pure/__release
-   local.get $6
+   local.get $9
   end
  )
  (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|1 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -17058,6 +17353,7 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
   block $~lib/typedarray/EVERY<~lib/typedarray/Int16Array,i16>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
@@ -17110,10 +17406,10 @@
     end
    end
    i32.const 1
-   local.set $6
+   local.set $9
    local.get $3
    call $~lib/rt/pure/__release
-   local.get $6
+   local.get $9
   end
  )
  (func $std/typedarray/testArrayEvery<~lib/typedarray/Int16Array,i16>~anonymous|1 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -17217,6 +17513,7 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
   block $~lib/typedarray/EVERY<~lib/typedarray/Uint16Array,u16>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
@@ -17269,10 +17566,10 @@
     end
    end
    i32.const 1
-   local.set $6
+   local.set $9
    local.get $3
    call $~lib/rt/pure/__release
-   local.get $6
+   local.get $9
   end
  )
  (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint16Array,u16>~anonymous|1 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -17372,6 +17669,7 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
   block $~lib/typedarray/EVERY<~lib/typedarray/Int32Array,i32>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
@@ -17424,10 +17722,10 @@
     end
    end
    i32.const 1
-   local.set $6
+   local.set $9
    local.get $3
    call $~lib/rt/pure/__release
-   local.get $6
+   local.get $9
   end
  )
  (func $std/typedarray/testArrayEvery<~lib/typedarray/Int32Array,i32>~anonymous|1 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -17525,6 +17823,7 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
   block $~lib/typedarray/EVERY<~lib/typedarray/Uint32Array,u32>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
@@ -17577,10 +17876,10 @@
     end
    end
    i32.const 1
-   local.set $6
+   local.set $9
    local.get $3
    call $~lib/rt/pure/__release
-   local.get $6
+   local.get $9
   end
  )
  (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint32Array,u32>~anonymous|1 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -17678,6 +17977,7 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
   block $~lib/typedarray/EVERY<~lib/typedarray/Int64Array,i64>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
@@ -17730,10 +18030,10 @@
     end
    end
    i32.const 1
-   local.set $6
+   local.set $9
    local.get $3
    call $~lib/rt/pure/__release
-   local.get $6
+   local.get $9
   end
  )
  (func $std/typedarray/testArrayEvery<~lib/typedarray/Int64Array,i64>~anonymous|1 (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
@@ -17831,6 +18131,7 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
   block $~lib/typedarray/EVERY<~lib/typedarray/Uint64Array,u64>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
@@ -17883,10 +18184,10 @@
     end
    end
    i32.const 1
-   local.set $6
+   local.set $9
    local.get $3
    call $~lib/rt/pure/__release
-   local.get $6
+   local.get $9
   end
  )
  (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint64Array,u64>~anonymous|1 (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
@@ -18232,6 +18533,7 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
   block $~lib/typedarray/EVERY<~lib/typedarray/Float32Array,f32>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
@@ -18284,10 +18586,10 @@
     end
    end
    i32.const 1
-   local.set $6
+   local.set $9
    local.get $3
    call $~lib/rt/pure/__release
-   local.get $6
+   local.get $9
   end
  )
  (func $std/typedarray/testArrayEvery<~lib/typedarray/Float32Array,f32>~anonymous|1 (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
@@ -18639,6 +18941,7 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
   block $~lib/typedarray/EVERY<~lib/typedarray/Float64Array,f64>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
@@ -18691,10 +18994,10 @@
     end
    end
    i32.const 1
-   local.set $6
+   local.set $9
    local.get $3
    call $~lib/rt/pure/__release
-   local.get $6
+   local.get $9
   end
  )
  (func $std/typedarray/testArrayEvery<~lib/typedarray/Float64Array,f64>~anonymous|1 (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
@@ -20601,6 +20904,9 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
   global.get $std/typedarray/testArrayReverseValues
   call $~lib/rt/pure/__retain
   local.set $0
@@ -20659,22 +20965,22 @@
   call $~lib/typedarray/Int8Array#reverse
   call $~lib/rt/pure/__release
   i32.const 0
-  local.set $6
+  local.set $8
   loop $for-loop|1
-   local.get $6
+   local.get $8
    local.get $1
    i32.lt_s
-   local.set $7
-   local.get $7
+   local.set $9
+   local.get $9
    if
     local.get $3
-    local.get $6
+    local.get $8
     call $~lib/typedarray/Int8Array#__get
     local.get $0
     local.get $1
     i32.const 1
     i32.sub
-    local.get $6
+    local.get $8
     i32.sub
     call $~lib/array/Array<i32>#__get
     i32.const 24
@@ -20691,10 +20997,10 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $6
+    local.get $8
     i32.const 1
     i32.add
-    local.set $6
+    local.set $8
     br $for-loop|1
    end
   end
@@ -20702,10 +21008,10 @@
   i32.const 4
   i32.const 8
   call $~lib/typedarray/Int8Array#subarray
-  local.tee $6
+  local.tee $10
   call $~lib/typedarray/Int8Array#reverse
-  local.set $8
-  local.get $8
+  local.set $11
+  local.get $11
   i32.const 0
   call $~lib/typedarray/Int8Array#__get
   i32.const 8
@@ -20719,7 +21025,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $8
+  local.get $11
   i32.const 1
   call $~lib/typedarray/Int8Array#__get
   i32.const 7
@@ -20733,7 +21039,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $8
+  local.get $11
   i32.const 2
   call $~lib/typedarray/Int8Array#__get
   i32.const 6
@@ -20747,7 +21053,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $8
+  local.get $11
   i32.const 3
   call $~lib/typedarray/Int8Array#__get
   i32.const 5
@@ -20765,7 +21071,7 @@
   call $~lib/rt/pure/__release
   local.get $4
   call $~lib/rt/pure/__release
-  local.get $6
+  local.get $10
   call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
@@ -20773,7 +21079,7 @@
   call $~lib/rt/pure/__release
   local.get $5
   call $~lib/rt/pure/__release
-  local.get $8
+  local.get $11
   call $~lib/rt/pure/__release
  )
  (func $~lib/typedarray/Uint8Array#reverse (param $0 i32) (result i32)
@@ -20847,6 +21153,16 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $5
@@ -20873,11 +21189,11 @@
    select
   else
    local.get $4
-   local.tee $7
+   local.tee $9
    local.get $6
-   local.tee $8
-   local.get $7
-   local.get $8
+   local.tee $10
+   local.get $9
+   local.get $10
    i32.lt_s
    select
   end
@@ -20889,43 +21205,43 @@
    local.get $6
    local.get $3
    i32.add
-   local.tee $7
+   local.tee $11
    i32.const 0
-   local.tee $8
-   local.get $7
-   local.get $8
+   local.tee $12
+   local.get $11
+   local.get $12
    i32.gt_s
    select
   else
    local.get $3
-   local.tee $7
+   local.tee $13
    local.get $6
-   local.tee $8
-   local.get $7
-   local.get $8
+   local.tee $14
+   local.get $13
+   local.get $14
    i32.lt_s
    select
   end
   local.set $3
   local.get $3
-  local.tee $7
+  local.tee $15
   local.get $4
-  local.tee $8
-  local.get $7
-  local.get $8
+  local.tee $16
+  local.get $15
+  local.get $16
   i32.gt_s
   select
   local.set $3
   i32.const 12
   i32.const 4
   call $~lib/rt/tlsf/__alloc
-  local.set $7
-  local.get $7
+  local.set $17
+  local.get $17
   local.get $5
   i32.load
   call $~lib/rt/pure/__retain
   i32.store
-  local.get $7
+  local.get $17
   local.get $5
   i32.load offset=4
   local.get $4
@@ -20933,19 +21249,19 @@
   i32.shl
   i32.add
   i32.store offset=4
-  local.get $7
+  local.get $17
   local.get $3
   local.get $4
   i32.sub
   i32.const 0
   i32.shl
   i32.store offset=8
-  local.get $7
+  local.get $17
   call $~lib/rt/pure/__retain
-  local.set $8
+  local.set $18
   local.get $5
   call $~lib/rt/pure/__release
-  local.get $8
+  local.get $18
  )
  (func $std/typedarray/testArrayReverse<~lib/typedarray/Uint8Array,u8>
   (local $0 i32)
@@ -20957,6 +21273,9 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
   global.get $std/typedarray/testArrayReverseValues
   call $~lib/rt/pure/__retain
   local.set $0
@@ -21011,22 +21330,22 @@
   call $~lib/typedarray/Uint8Array#reverse
   call $~lib/rt/pure/__release
   i32.const 0
-  local.set $6
+  local.set $8
   loop $for-loop|1
-   local.get $6
+   local.get $8
    local.get $1
    i32.lt_s
-   local.set $7
-   local.get $7
+   local.set $9
+   local.get $9
    if
     local.get $3
-    local.get $6
+    local.get $8
     call $~lib/typedarray/Uint8Array#__get
     local.get $0
     local.get $1
     i32.const 1
     i32.sub
-    local.get $6
+    local.get $8
     i32.sub
     call $~lib/array/Array<i32>#__get
     i32.const 255
@@ -21041,10 +21360,10 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $6
+    local.get $8
     i32.const 1
     i32.add
-    local.set $6
+    local.set $8
     br $for-loop|1
    end
   end
@@ -21052,10 +21371,10 @@
   i32.const 4
   i32.const 8
   call $~lib/typedarray/Uint8Array#subarray
-  local.tee $6
+  local.tee $10
   call $~lib/typedarray/Uint8Array#reverse
-  local.set $8
-  local.get $8
+  local.set $11
+  local.get $11
   i32.const 0
   call $~lib/typedarray/Uint8Array#__get
   i32.const 8
@@ -21069,7 +21388,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $8
+  local.get $11
   i32.const 1
   call $~lib/typedarray/Uint8Array#__get
   i32.const 7
@@ -21083,7 +21402,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $8
+  local.get $11
   i32.const 2
   call $~lib/typedarray/Uint8Array#__get
   i32.const 6
@@ -21097,7 +21416,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $8
+  local.get $11
   i32.const 3
   call $~lib/typedarray/Uint8Array#__get
   i32.const 5
@@ -21115,7 +21434,7 @@
   call $~lib/rt/pure/__release
   local.get $4
   call $~lib/rt/pure/__release
-  local.get $6
+  local.get $10
   call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
@@ -21123,7 +21442,7 @@
   call $~lib/rt/pure/__release
   local.get $5
   call $~lib/rt/pure/__release
-  local.get $8
+  local.get $11
   call $~lib/rt/pure/__release
  )
  (func $~lib/typedarray/Uint8ClampedArray#reverse (param $0 i32) (result i32)
@@ -21197,6 +21516,16 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $5
@@ -21223,11 +21552,11 @@
    select
   else
    local.get $4
-   local.tee $7
+   local.tee $9
    local.get $6
-   local.tee $8
-   local.get $7
-   local.get $8
+   local.tee $10
+   local.get $9
+   local.get $10
    i32.lt_s
    select
   end
@@ -21239,43 +21568,43 @@
    local.get $6
    local.get $3
    i32.add
-   local.tee $7
+   local.tee $11
    i32.const 0
-   local.tee $8
-   local.get $7
-   local.get $8
+   local.tee $12
+   local.get $11
+   local.get $12
    i32.gt_s
    select
   else
    local.get $3
-   local.tee $7
+   local.tee $13
    local.get $6
-   local.tee $8
-   local.get $7
-   local.get $8
+   local.tee $14
+   local.get $13
+   local.get $14
    i32.lt_s
    select
   end
   local.set $3
   local.get $3
-  local.tee $7
+  local.tee $15
   local.get $4
-  local.tee $8
-  local.get $7
-  local.get $8
+  local.tee $16
+  local.get $15
+  local.get $16
   i32.gt_s
   select
   local.set $3
   i32.const 12
   i32.const 5
   call $~lib/rt/tlsf/__alloc
-  local.set $7
-  local.get $7
+  local.set $17
+  local.get $17
   local.get $5
   i32.load
   call $~lib/rt/pure/__retain
   i32.store
-  local.get $7
+  local.get $17
   local.get $5
   i32.load offset=4
   local.get $4
@@ -21283,19 +21612,19 @@
   i32.shl
   i32.add
   i32.store offset=4
-  local.get $7
+  local.get $17
   local.get $3
   local.get $4
   i32.sub
   i32.const 0
   i32.shl
   i32.store offset=8
-  local.get $7
+  local.get $17
   call $~lib/rt/pure/__retain
-  local.set $8
+  local.set $18
   local.get $5
   call $~lib/rt/pure/__release
-  local.get $8
+  local.get $18
  )
  (func $std/typedarray/testArrayReverse<~lib/typedarray/Uint8ClampedArray,u8>
   (local $0 i32)
@@ -21307,6 +21636,9 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
   global.get $std/typedarray/testArrayReverseValues
   call $~lib/rt/pure/__retain
   local.set $0
@@ -21361,22 +21693,22 @@
   call $~lib/typedarray/Uint8ClampedArray#reverse
   call $~lib/rt/pure/__release
   i32.const 0
-  local.set $6
+  local.set $8
   loop $for-loop|1
-   local.get $6
+   local.get $8
    local.get $1
    i32.lt_s
-   local.set $7
-   local.get $7
+   local.set $9
+   local.get $9
    if
     local.get $3
-    local.get $6
+    local.get $8
     call $~lib/typedarray/Uint8ClampedArray#__get
     local.get $0
     local.get $1
     i32.const 1
     i32.sub
-    local.get $6
+    local.get $8
     i32.sub
     call $~lib/array/Array<i32>#__get
     i32.const 255
@@ -21391,10 +21723,10 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $6
+    local.get $8
     i32.const 1
     i32.add
-    local.set $6
+    local.set $8
     br $for-loop|1
    end
   end
@@ -21402,10 +21734,10 @@
   i32.const 4
   i32.const 8
   call $~lib/typedarray/Uint8ClampedArray#subarray
-  local.tee $6
+  local.tee $10
   call $~lib/typedarray/Uint8ClampedArray#reverse
-  local.set $8
-  local.get $8
+  local.set $11
+  local.get $11
   i32.const 0
   call $~lib/typedarray/Uint8ClampedArray#__get
   i32.const 8
@@ -21419,7 +21751,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $8
+  local.get $11
   i32.const 1
   call $~lib/typedarray/Uint8ClampedArray#__get
   i32.const 7
@@ -21433,7 +21765,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $8
+  local.get $11
   i32.const 2
   call $~lib/typedarray/Uint8ClampedArray#__get
   i32.const 6
@@ -21447,7 +21779,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $8
+  local.get $11
   i32.const 3
   call $~lib/typedarray/Uint8ClampedArray#__get
   i32.const 5
@@ -21465,7 +21797,7 @@
   call $~lib/rt/pure/__release
   local.get $4
   call $~lib/rt/pure/__release
-  local.get $6
+  local.get $10
   call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
@@ -21473,7 +21805,7 @@
   call $~lib/rt/pure/__release
   local.get $5
   call $~lib/rt/pure/__release
-  local.get $8
+  local.get $11
   call $~lib/rt/pure/__release
  )
  (func $~lib/typedarray/Int16Array#reverse (param $0 i32) (result i32)
@@ -21547,6 +21879,16 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $5
@@ -21573,11 +21915,11 @@
    select
   else
    local.get $4
-   local.tee $7
+   local.tee $9
    local.get $6
-   local.tee $8
-   local.get $7
-   local.get $8
+   local.tee $10
+   local.get $9
+   local.get $10
    i32.lt_s
    select
   end
@@ -21589,43 +21931,43 @@
    local.get $6
    local.get $3
    i32.add
-   local.tee $7
+   local.tee $11
    i32.const 0
-   local.tee $8
-   local.get $7
-   local.get $8
+   local.tee $12
+   local.get $11
+   local.get $12
    i32.gt_s
    select
   else
    local.get $3
-   local.tee $7
+   local.tee $13
    local.get $6
-   local.tee $8
-   local.get $7
-   local.get $8
+   local.tee $14
+   local.get $13
+   local.get $14
    i32.lt_s
    select
   end
   local.set $3
   local.get $3
-  local.tee $7
+  local.tee $15
   local.get $4
-  local.tee $8
-  local.get $7
-  local.get $8
+  local.tee $16
+  local.get $15
+  local.get $16
   i32.gt_s
   select
   local.set $3
   i32.const 12
   i32.const 6
   call $~lib/rt/tlsf/__alloc
-  local.set $7
-  local.get $7
+  local.set $17
+  local.get $17
   local.get $5
   i32.load
   call $~lib/rt/pure/__retain
   i32.store
-  local.get $7
+  local.get $17
   local.get $5
   i32.load offset=4
   local.get $4
@@ -21633,19 +21975,19 @@
   i32.shl
   i32.add
   i32.store offset=4
-  local.get $7
+  local.get $17
   local.get $3
   local.get $4
   i32.sub
   i32.const 1
   i32.shl
   i32.store offset=8
-  local.get $7
+  local.get $17
   call $~lib/rt/pure/__retain
-  local.set $8
+  local.set $18
   local.get $5
   call $~lib/rt/pure/__release
-  local.get $8
+  local.get $18
  )
  (func $std/typedarray/testArrayReverse<~lib/typedarray/Int16Array,i16>
   (local $0 i32)
@@ -21657,6 +21999,9 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
   global.get $std/typedarray/testArrayReverseValues
   call $~lib/rt/pure/__retain
   local.set $0
@@ -21715,22 +22060,22 @@
   call $~lib/typedarray/Int16Array#reverse
   call $~lib/rt/pure/__release
   i32.const 0
-  local.set $6
+  local.set $8
   loop $for-loop|1
-   local.get $6
+   local.get $8
    local.get $1
    i32.lt_s
-   local.set $7
-   local.get $7
+   local.set $9
+   local.get $9
    if
     local.get $3
-    local.get $6
+    local.get $8
     call $~lib/typedarray/Int16Array#__get
     local.get $0
     local.get $1
     i32.const 1
     i32.sub
-    local.get $6
+    local.get $8
     i32.sub
     call $~lib/array/Array<i32>#__get
     i32.const 16
@@ -21747,10 +22092,10 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $6
+    local.get $8
     i32.const 1
     i32.add
-    local.set $6
+    local.set $8
     br $for-loop|1
    end
   end
@@ -21758,10 +22103,10 @@
   i32.const 4
   i32.const 8
   call $~lib/typedarray/Int16Array#subarray
-  local.tee $6
+  local.tee $10
   call $~lib/typedarray/Int16Array#reverse
-  local.set $8
-  local.get $8
+  local.set $11
+  local.get $11
   i32.const 0
   call $~lib/typedarray/Int16Array#__get
   i32.const 8
@@ -21775,7 +22120,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $8
+  local.get $11
   i32.const 1
   call $~lib/typedarray/Int16Array#__get
   i32.const 7
@@ -21789,7 +22134,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $8
+  local.get $11
   i32.const 2
   call $~lib/typedarray/Int16Array#__get
   i32.const 6
@@ -21803,7 +22148,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $8
+  local.get $11
   i32.const 3
   call $~lib/typedarray/Int16Array#__get
   i32.const 5
@@ -21821,7 +22166,7 @@
   call $~lib/rt/pure/__release
   local.get $4
   call $~lib/rt/pure/__release
-  local.get $6
+  local.get $10
   call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
@@ -21829,7 +22174,7 @@
   call $~lib/rt/pure/__release
   local.get $5
   call $~lib/rt/pure/__release
-  local.get $8
+  local.get $11
   call $~lib/rt/pure/__release
  )
  (func $~lib/typedarray/Uint16Array#reverse (param $0 i32) (result i32)
@@ -21903,6 +22248,16 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $5
@@ -21929,11 +22284,11 @@
    select
   else
    local.get $4
-   local.tee $7
+   local.tee $9
    local.get $6
-   local.tee $8
-   local.get $7
-   local.get $8
+   local.tee $10
+   local.get $9
+   local.get $10
    i32.lt_s
    select
   end
@@ -21945,43 +22300,43 @@
    local.get $6
    local.get $3
    i32.add
-   local.tee $7
+   local.tee $11
    i32.const 0
-   local.tee $8
-   local.get $7
-   local.get $8
+   local.tee $12
+   local.get $11
+   local.get $12
    i32.gt_s
    select
   else
    local.get $3
-   local.tee $7
+   local.tee $13
    local.get $6
-   local.tee $8
-   local.get $7
-   local.get $8
+   local.tee $14
+   local.get $13
+   local.get $14
    i32.lt_s
    select
   end
   local.set $3
   local.get $3
-  local.tee $7
+  local.tee $15
   local.get $4
-  local.tee $8
-  local.get $7
-  local.get $8
+  local.tee $16
+  local.get $15
+  local.get $16
   i32.gt_s
   select
   local.set $3
   i32.const 12
   i32.const 7
   call $~lib/rt/tlsf/__alloc
-  local.set $7
-  local.get $7
+  local.set $17
+  local.get $17
   local.get $5
   i32.load
   call $~lib/rt/pure/__retain
   i32.store
-  local.get $7
+  local.get $17
   local.get $5
   i32.load offset=4
   local.get $4
@@ -21989,19 +22344,19 @@
   i32.shl
   i32.add
   i32.store offset=4
-  local.get $7
+  local.get $17
   local.get $3
   local.get $4
   i32.sub
   i32.const 1
   i32.shl
   i32.store offset=8
-  local.get $7
+  local.get $17
   call $~lib/rt/pure/__retain
-  local.set $8
+  local.set $18
   local.get $5
   call $~lib/rt/pure/__release
-  local.get $8
+  local.get $18
  )
  (func $std/typedarray/testArrayReverse<~lib/typedarray/Uint16Array,u16>
   (local $0 i32)
@@ -22013,6 +22368,9 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
   global.get $std/typedarray/testArrayReverseValues
   call $~lib/rt/pure/__retain
   local.set $0
@@ -22067,22 +22425,22 @@
   call $~lib/typedarray/Uint16Array#reverse
   call $~lib/rt/pure/__release
   i32.const 0
-  local.set $6
+  local.set $8
   loop $for-loop|1
-   local.get $6
+   local.get $8
    local.get $1
    i32.lt_s
-   local.set $7
-   local.get $7
+   local.set $9
+   local.get $9
    if
     local.get $3
-    local.get $6
+    local.get $8
     call $~lib/typedarray/Uint16Array#__get
     local.get $0
     local.get $1
     i32.const 1
     i32.sub
-    local.get $6
+    local.get $8
     i32.sub
     call $~lib/array/Array<i32>#__get
     i32.const 65535
@@ -22097,10 +22455,10 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $6
+    local.get $8
     i32.const 1
     i32.add
-    local.set $6
+    local.set $8
     br $for-loop|1
    end
   end
@@ -22108,10 +22466,10 @@
   i32.const 4
   i32.const 8
   call $~lib/typedarray/Uint16Array#subarray
-  local.tee $6
+  local.tee $10
   call $~lib/typedarray/Uint16Array#reverse
-  local.set $8
-  local.get $8
+  local.set $11
+  local.get $11
   i32.const 0
   call $~lib/typedarray/Uint16Array#__get
   i32.const 8
@@ -22125,7 +22483,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $8
+  local.get $11
   i32.const 1
   call $~lib/typedarray/Uint16Array#__get
   i32.const 7
@@ -22139,7 +22497,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $8
+  local.get $11
   i32.const 2
   call $~lib/typedarray/Uint16Array#__get
   i32.const 6
@@ -22153,7 +22511,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $8
+  local.get $11
   i32.const 3
   call $~lib/typedarray/Uint16Array#__get
   i32.const 5
@@ -22171,7 +22529,7 @@
   call $~lib/rt/pure/__release
   local.get $4
   call $~lib/rt/pure/__release
-  local.get $6
+  local.get $10
   call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
@@ -22179,7 +22537,7 @@
   call $~lib/rt/pure/__release
   local.get $5
   call $~lib/rt/pure/__release
-  local.get $8
+  local.get $11
   call $~lib/rt/pure/__release
  )
  (func $~lib/typedarray/Int32Array#reverse (param $0 i32) (result i32)
@@ -22256,6 +22614,9 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
   global.get $std/typedarray/testArrayReverseValues
   call $~lib/rt/pure/__retain
   local.set $0
@@ -22306,22 +22667,22 @@
   call $~lib/typedarray/Int32Array#reverse
   call $~lib/rt/pure/__release
   i32.const 0
-  local.set $6
+  local.set $8
   loop $for-loop|1
-   local.get $6
+   local.get $8
    local.get $1
    i32.lt_s
-   local.set $7
-   local.get $7
+   local.set $9
+   local.get $9
    if
     local.get $3
-    local.get $6
+    local.get $8
     call $~lib/typedarray/Int32Array#__get
     local.get $0
     local.get $1
     i32.const 1
     i32.sub
-    local.get $6
+    local.get $8
     i32.sub
     call $~lib/array/Array<i32>#__get
     i32.eq
@@ -22334,10 +22695,10 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $6
+    local.get $8
     i32.const 1
     i32.add
-    local.set $6
+    local.set $8
     br $for-loop|1
    end
   end
@@ -22345,10 +22706,10 @@
   i32.const 4
   i32.const 8
   call $~lib/typedarray/Int32Array#subarray
-  local.tee $6
+  local.tee $10
   call $~lib/typedarray/Int32Array#reverse
-  local.set $8
-  local.get $8
+  local.set $11
+  local.get $11
   i32.const 0
   call $~lib/typedarray/Int32Array#__get
   i32.const 8
@@ -22362,7 +22723,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $8
+  local.get $11
   i32.const 1
   call $~lib/typedarray/Int32Array#__get
   i32.const 7
@@ -22376,7 +22737,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $8
+  local.get $11
   i32.const 2
   call $~lib/typedarray/Int32Array#__get
   i32.const 6
@@ -22390,7 +22751,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $8
+  local.get $11
   i32.const 3
   call $~lib/typedarray/Int32Array#__get
   i32.const 5
@@ -22408,7 +22769,7 @@
   call $~lib/rt/pure/__release
   local.get $4
   call $~lib/rt/pure/__release
-  local.get $6
+  local.get $10
   call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
@@ -22416,7 +22777,7 @@
   call $~lib/rt/pure/__release
   local.get $5
   call $~lib/rt/pure/__release
-  local.get $8
+  local.get $11
   call $~lib/rt/pure/__release
  )
  (func $~lib/typedarray/Uint32Array#reverse (param $0 i32) (result i32)
@@ -22490,6 +22851,16 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $5
@@ -22516,11 +22887,11 @@
    select
   else
    local.get $4
-   local.tee $7
+   local.tee $9
    local.get $6
-   local.tee $8
-   local.get $7
-   local.get $8
+   local.tee $10
+   local.get $9
+   local.get $10
    i32.lt_s
    select
   end
@@ -22532,43 +22903,43 @@
    local.get $6
    local.get $3
    i32.add
-   local.tee $7
+   local.tee $11
    i32.const 0
-   local.tee $8
-   local.get $7
-   local.get $8
+   local.tee $12
+   local.get $11
+   local.get $12
    i32.gt_s
    select
   else
    local.get $3
-   local.tee $7
+   local.tee $13
    local.get $6
-   local.tee $8
-   local.get $7
-   local.get $8
+   local.tee $14
+   local.get $13
+   local.get $14
    i32.lt_s
    select
   end
   local.set $3
   local.get $3
-  local.tee $7
+  local.tee $15
   local.get $4
-  local.tee $8
-  local.get $7
-  local.get $8
+  local.tee $16
+  local.get $15
+  local.get $16
   i32.gt_s
   select
   local.set $3
   i32.const 12
   i32.const 9
   call $~lib/rt/tlsf/__alloc
-  local.set $7
-  local.get $7
+  local.set $17
+  local.get $17
   local.get $5
   i32.load
   call $~lib/rt/pure/__retain
   i32.store
-  local.get $7
+  local.get $17
   local.get $5
   i32.load offset=4
   local.get $4
@@ -22576,19 +22947,19 @@
   i32.shl
   i32.add
   i32.store offset=4
-  local.get $7
+  local.get $17
   local.get $3
   local.get $4
   i32.sub
   i32.const 2
   i32.shl
   i32.store offset=8
-  local.get $7
+  local.get $17
   call $~lib/rt/pure/__retain
-  local.set $8
+  local.set $18
   local.get $5
   call $~lib/rt/pure/__release
-  local.get $8
+  local.get $18
  )
  (func $std/typedarray/testArrayReverse<~lib/typedarray/Uint32Array,u32>
   (local $0 i32)
@@ -22600,6 +22971,9 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
   global.get $std/typedarray/testArrayReverseValues
   call $~lib/rt/pure/__retain
   local.set $0
@@ -22650,22 +23024,22 @@
   call $~lib/typedarray/Uint32Array#reverse
   call $~lib/rt/pure/__release
   i32.const 0
-  local.set $6
+  local.set $8
   loop $for-loop|1
-   local.get $6
+   local.get $8
    local.get $1
    i32.lt_s
-   local.set $7
-   local.get $7
+   local.set $9
+   local.get $9
    if
     local.get $3
-    local.get $6
+    local.get $8
     call $~lib/typedarray/Uint32Array#__get
     local.get $0
     local.get $1
     i32.const 1
     i32.sub
-    local.get $6
+    local.get $8
     i32.sub
     call $~lib/array/Array<i32>#__get
     i32.eq
@@ -22678,10 +23052,10 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $6
+    local.get $8
     i32.const 1
     i32.add
-    local.set $6
+    local.set $8
     br $for-loop|1
    end
   end
@@ -22689,10 +23063,10 @@
   i32.const 4
   i32.const 8
   call $~lib/typedarray/Uint32Array#subarray
-  local.tee $6
+  local.tee $10
   call $~lib/typedarray/Uint32Array#reverse
-  local.set $8
-  local.get $8
+  local.set $11
+  local.get $11
   i32.const 0
   call $~lib/typedarray/Uint32Array#__get
   i32.const 8
@@ -22706,7 +23080,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $8
+  local.get $11
   i32.const 1
   call $~lib/typedarray/Uint32Array#__get
   i32.const 7
@@ -22720,7 +23094,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $8
+  local.get $11
   i32.const 2
   call $~lib/typedarray/Uint32Array#__get
   i32.const 6
@@ -22734,7 +23108,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $8
+  local.get $11
   i32.const 3
   call $~lib/typedarray/Uint32Array#__get
   i32.const 5
@@ -22752,7 +23126,7 @@
   call $~lib/rt/pure/__release
   local.get $4
   call $~lib/rt/pure/__release
-  local.get $6
+  local.get $10
   call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
@@ -22760,7 +23134,7 @@
   call $~lib/rt/pure/__release
   local.get $5
   call $~lib/rt/pure/__release
-  local.get $8
+  local.get $11
   call $~lib/rt/pure/__release
  )
  (func $~lib/typedarray/Int64Array#reverse (param $0 i32) (result i32)
@@ -22834,6 +23208,16 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $5
@@ -22860,11 +23244,11 @@
    select
   else
    local.get $4
-   local.tee $7
+   local.tee $9
    local.get $6
-   local.tee $8
-   local.get $7
-   local.get $8
+   local.tee $10
+   local.get $9
+   local.get $10
    i32.lt_s
    select
   end
@@ -22876,43 +23260,43 @@
    local.get $6
    local.get $3
    i32.add
-   local.tee $7
+   local.tee $11
    i32.const 0
-   local.tee $8
-   local.get $7
-   local.get $8
+   local.tee $12
+   local.get $11
+   local.get $12
    i32.gt_s
    select
   else
    local.get $3
-   local.tee $7
+   local.tee $13
    local.get $6
-   local.tee $8
-   local.get $7
-   local.get $8
+   local.tee $14
+   local.get $13
+   local.get $14
    i32.lt_s
    select
   end
   local.set $3
   local.get $3
-  local.tee $7
+  local.tee $15
   local.get $4
-  local.tee $8
-  local.get $7
-  local.get $8
+  local.tee $16
+  local.get $15
+  local.get $16
   i32.gt_s
   select
   local.set $3
   i32.const 12
   i32.const 10
   call $~lib/rt/tlsf/__alloc
-  local.set $7
-  local.get $7
+  local.set $17
+  local.get $17
   local.get $5
   i32.load
   call $~lib/rt/pure/__retain
   i32.store
-  local.get $7
+  local.get $17
   local.get $5
   i32.load offset=4
   local.get $4
@@ -22920,19 +23304,19 @@
   i32.shl
   i32.add
   i32.store offset=4
-  local.get $7
+  local.get $17
   local.get $3
   local.get $4
   i32.sub
   i32.const 3
   i32.shl
   i32.store offset=8
-  local.get $7
+  local.get $17
   call $~lib/rt/pure/__retain
-  local.set $8
+  local.set $18
   local.get $5
   call $~lib/rt/pure/__release
-  local.get $8
+  local.get $18
  )
  (func $std/typedarray/testArrayReverse<~lib/typedarray/Int64Array,i64>
   (local $0 i32)
@@ -22944,6 +23328,9 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
   global.get $std/typedarray/testArrayReverseValues
   call $~lib/rt/pure/__retain
   local.set $0
@@ -22996,22 +23383,22 @@
   call $~lib/typedarray/Int64Array#reverse
   call $~lib/rt/pure/__release
   i32.const 0
-  local.set $6
+  local.set $8
   loop $for-loop|1
-   local.get $6
+   local.get $8
    local.get $1
    i32.lt_s
-   local.set $7
-   local.get $7
+   local.set $9
+   local.get $9
    if
     local.get $3
-    local.get $6
+    local.get $8
     call $~lib/typedarray/Int64Array#__get
     local.get $0
     local.get $1
     i32.const 1
     i32.sub
-    local.get $6
+    local.get $8
     i32.sub
     call $~lib/array/Array<i32>#__get
     i64.extend_i32_s
@@ -23025,10 +23412,10 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $6
+    local.get $8
     i32.const 1
     i32.add
-    local.set $6
+    local.set $8
     br $for-loop|1
    end
   end
@@ -23036,10 +23423,10 @@
   i32.const 4
   i32.const 8
   call $~lib/typedarray/Int64Array#subarray
-  local.tee $6
+  local.tee $10
   call $~lib/typedarray/Int64Array#reverse
-  local.set $8
-  local.get $8
+  local.set $11
+  local.get $11
   i32.const 0
   call $~lib/typedarray/Int64Array#__get
   i64.const 8
@@ -23053,7 +23440,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $8
+  local.get $11
   i32.const 1
   call $~lib/typedarray/Int64Array#__get
   i64.const 7
@@ -23067,7 +23454,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $8
+  local.get $11
   i32.const 2
   call $~lib/typedarray/Int64Array#__get
   i64.const 6
@@ -23081,7 +23468,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $8
+  local.get $11
   i32.const 3
   call $~lib/typedarray/Int64Array#__get
   i64.const 5
@@ -23099,7 +23486,7 @@
   call $~lib/rt/pure/__release
   local.get $4
   call $~lib/rt/pure/__release
-  local.get $6
+  local.get $10
   call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
@@ -23107,7 +23494,7 @@
   call $~lib/rt/pure/__release
   local.get $5
   call $~lib/rt/pure/__release
-  local.get $8
+  local.get $11
   call $~lib/rt/pure/__release
  )
  (func $~lib/typedarray/Uint64Array#reverse (param $0 i32) (result i32)
@@ -23181,6 +23568,16 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $5
@@ -23207,11 +23604,11 @@
    select
   else
    local.get $4
-   local.tee $7
+   local.tee $9
    local.get $6
-   local.tee $8
-   local.get $7
-   local.get $8
+   local.tee $10
+   local.get $9
+   local.get $10
    i32.lt_s
    select
   end
@@ -23223,43 +23620,43 @@
    local.get $6
    local.get $3
    i32.add
-   local.tee $7
+   local.tee $11
    i32.const 0
-   local.tee $8
-   local.get $7
-   local.get $8
+   local.tee $12
+   local.get $11
+   local.get $12
    i32.gt_s
    select
   else
    local.get $3
-   local.tee $7
+   local.tee $13
    local.get $6
-   local.tee $8
-   local.get $7
-   local.get $8
+   local.tee $14
+   local.get $13
+   local.get $14
    i32.lt_s
    select
   end
   local.set $3
   local.get $3
-  local.tee $7
+  local.tee $15
   local.get $4
-  local.tee $8
-  local.get $7
-  local.get $8
+  local.tee $16
+  local.get $15
+  local.get $16
   i32.gt_s
   select
   local.set $3
   i32.const 12
   i32.const 11
   call $~lib/rt/tlsf/__alloc
-  local.set $7
-  local.get $7
+  local.set $17
+  local.get $17
   local.get $5
   i32.load
   call $~lib/rt/pure/__retain
   i32.store
-  local.get $7
+  local.get $17
   local.get $5
   i32.load offset=4
   local.get $4
@@ -23267,19 +23664,19 @@
   i32.shl
   i32.add
   i32.store offset=4
-  local.get $7
+  local.get $17
   local.get $3
   local.get $4
   i32.sub
   i32.const 3
   i32.shl
   i32.store offset=8
-  local.get $7
+  local.get $17
   call $~lib/rt/pure/__retain
-  local.set $8
+  local.set $18
   local.get $5
   call $~lib/rt/pure/__release
-  local.get $8
+  local.get $18
  )
  (func $std/typedarray/testArrayReverse<~lib/typedarray/Uint64Array,u64>
   (local $0 i32)
@@ -23291,6 +23688,9 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
   global.get $std/typedarray/testArrayReverseValues
   call $~lib/rt/pure/__retain
   local.set $0
@@ -23343,22 +23743,22 @@
   call $~lib/typedarray/Uint64Array#reverse
   call $~lib/rt/pure/__release
   i32.const 0
-  local.set $6
+  local.set $8
   loop $for-loop|1
-   local.get $6
+   local.get $8
    local.get $1
    i32.lt_s
-   local.set $7
-   local.get $7
+   local.set $9
+   local.get $9
    if
     local.get $3
-    local.get $6
+    local.get $8
     call $~lib/typedarray/Uint64Array#__get
     local.get $0
     local.get $1
     i32.const 1
     i32.sub
-    local.get $6
+    local.get $8
     i32.sub
     call $~lib/array/Array<i32>#__get
     i64.extend_i32_s
@@ -23372,10 +23772,10 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $6
+    local.get $8
     i32.const 1
     i32.add
-    local.set $6
+    local.set $8
     br $for-loop|1
    end
   end
@@ -23383,10 +23783,10 @@
   i32.const 4
   i32.const 8
   call $~lib/typedarray/Uint64Array#subarray
-  local.tee $6
+  local.tee $10
   call $~lib/typedarray/Uint64Array#reverse
-  local.set $8
-  local.get $8
+  local.set $11
+  local.get $11
   i32.const 0
   call $~lib/typedarray/Uint64Array#__get
   i64.const 8
@@ -23400,7 +23800,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $8
+  local.get $11
   i32.const 1
   call $~lib/typedarray/Uint64Array#__get
   i64.const 7
@@ -23414,7 +23814,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $8
+  local.get $11
   i32.const 2
   call $~lib/typedarray/Uint64Array#__get
   i64.const 6
@@ -23428,7 +23828,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $8
+  local.get $11
   i32.const 3
   call $~lib/typedarray/Uint64Array#__get
   i64.const 5
@@ -23446,7 +23846,7 @@
   call $~lib/rt/pure/__release
   local.get $4
   call $~lib/rt/pure/__release
-  local.get $6
+  local.get $10
   call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
@@ -23454,7 +23854,7 @@
   call $~lib/rt/pure/__release
   local.get $5
   call $~lib/rt/pure/__release
-  local.get $8
+  local.get $11
   call $~lib/rt/pure/__release
  )
  (func $~lib/typedarray/Float32Array#reverse (param $0 i32) (result i32)
@@ -23528,6 +23928,16 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $5
@@ -23554,11 +23964,11 @@
    select
   else
    local.get $4
-   local.tee $7
+   local.tee $9
    local.get $6
-   local.tee $8
-   local.get $7
-   local.get $8
+   local.tee $10
+   local.get $9
+   local.get $10
    i32.lt_s
    select
   end
@@ -23570,43 +23980,43 @@
    local.get $6
    local.get $3
    i32.add
-   local.tee $7
+   local.tee $11
    i32.const 0
-   local.tee $8
-   local.get $7
-   local.get $8
+   local.tee $12
+   local.get $11
+   local.get $12
    i32.gt_s
    select
   else
    local.get $3
-   local.tee $7
+   local.tee $13
    local.get $6
-   local.tee $8
-   local.get $7
-   local.get $8
+   local.tee $14
+   local.get $13
+   local.get $14
    i32.lt_s
    select
   end
   local.set $3
   local.get $3
-  local.tee $7
+  local.tee $15
   local.get $4
-  local.tee $8
-  local.get $7
-  local.get $8
+  local.tee $16
+  local.get $15
+  local.get $16
   i32.gt_s
   select
   local.set $3
   i32.const 12
   i32.const 12
   call $~lib/rt/tlsf/__alloc
-  local.set $7
-  local.get $7
+  local.set $17
+  local.get $17
   local.get $5
   i32.load
   call $~lib/rt/pure/__retain
   i32.store
-  local.get $7
+  local.get $17
   local.get $5
   i32.load offset=4
   local.get $4
@@ -23614,19 +24024,19 @@
   i32.shl
   i32.add
   i32.store offset=4
-  local.get $7
+  local.get $17
   local.get $3
   local.get $4
   i32.sub
   i32.const 2
   i32.shl
   i32.store offset=8
-  local.get $7
+  local.get $17
   call $~lib/rt/pure/__retain
-  local.set $8
+  local.set $18
   local.get $5
   call $~lib/rt/pure/__release
-  local.get $8
+  local.get $18
  )
  (func $std/typedarray/testArrayReverse<~lib/typedarray/Float32Array,f32>
   (local $0 i32)
@@ -23638,6 +24048,9 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
   global.get $std/typedarray/testArrayReverseValues
   call $~lib/rt/pure/__retain
   local.set $0
@@ -23690,22 +24103,22 @@
   call $~lib/typedarray/Float32Array#reverse
   call $~lib/rt/pure/__release
   i32.const 0
-  local.set $6
+  local.set $8
   loop $for-loop|1
-   local.get $6
+   local.get $8
    local.get $1
    i32.lt_s
-   local.set $7
-   local.get $7
+   local.set $9
+   local.get $9
    if
     local.get $3
-    local.get $6
+    local.get $8
     call $~lib/typedarray/Float32Array#__get
     local.get $0
     local.get $1
     i32.const 1
     i32.sub
-    local.get $6
+    local.get $8
     i32.sub
     call $~lib/array/Array<i32>#__get
     f32.convert_i32_s
@@ -23719,10 +24132,10 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $6
+    local.get $8
     i32.const 1
     i32.add
-    local.set $6
+    local.set $8
     br $for-loop|1
    end
   end
@@ -23730,10 +24143,10 @@
   i32.const 4
   i32.const 8
   call $~lib/typedarray/Float32Array#subarray
-  local.tee $6
+  local.tee $10
   call $~lib/typedarray/Float32Array#reverse
-  local.set $8
-  local.get $8
+  local.set $11
+  local.get $11
   i32.const 0
   call $~lib/typedarray/Float32Array#__get
   f32.const 8
@@ -23747,7 +24160,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $8
+  local.get $11
   i32.const 1
   call $~lib/typedarray/Float32Array#__get
   f32.const 7
@@ -23761,7 +24174,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $8
+  local.get $11
   i32.const 2
   call $~lib/typedarray/Float32Array#__get
   f32.const 6
@@ -23775,7 +24188,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $8
+  local.get $11
   i32.const 3
   call $~lib/typedarray/Float32Array#__get
   f32.const 5
@@ -23793,7 +24206,7 @@
   call $~lib/rt/pure/__release
   local.get $4
   call $~lib/rt/pure/__release
-  local.get $6
+  local.get $10
   call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
@@ -23801,7 +24214,7 @@
   call $~lib/rt/pure/__release
   local.get $5
   call $~lib/rt/pure/__release
-  local.get $8
+  local.get $11
   call $~lib/rt/pure/__release
  )
  (func $~lib/typedarray/Float64Array#reverse (param $0 i32) (result i32)
@@ -23878,6 +24291,9 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
   global.get $std/typedarray/testArrayReverseValues
   call $~lib/rt/pure/__retain
   local.set $0
@@ -23930,22 +24346,22 @@
   call $~lib/typedarray/Float64Array#reverse
   call $~lib/rt/pure/__release
   i32.const 0
-  local.set $6
+  local.set $8
   loop $for-loop|1
-   local.get $6
+   local.get $8
    local.get $1
    i32.lt_s
-   local.set $7
-   local.get $7
+   local.set $9
+   local.get $9
    if
     local.get $3
-    local.get $6
+    local.get $8
     call $~lib/typedarray/Float64Array#__get
     local.get $0
     local.get $1
     i32.const 1
     i32.sub
-    local.get $6
+    local.get $8
     i32.sub
     call $~lib/array/Array<i32>#__get
     f64.convert_i32_s
@@ -23959,10 +24375,10 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $6
+    local.get $8
     i32.const 1
     i32.add
-    local.set $6
+    local.set $8
     br $for-loop|1
    end
   end
@@ -23970,10 +24386,10 @@
   i32.const 4
   i32.const 8
   call $~lib/typedarray/Float64Array#subarray
-  local.tee $6
+  local.tee $10
   call $~lib/typedarray/Float64Array#reverse
-  local.set $8
-  local.get $8
+  local.set $11
+  local.get $11
   i32.const 0
   call $~lib/typedarray/Float64Array#__get
   f64.const 8
@@ -23987,7 +24403,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $8
+  local.get $11
   i32.const 1
   call $~lib/typedarray/Float64Array#__get
   f64.const 7
@@ -24001,7 +24417,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $8
+  local.get $11
   i32.const 2
   call $~lib/typedarray/Float64Array#__get
   f64.const 6
@@ -24015,7 +24431,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $8
+  local.get $11
   i32.const 3
   call $~lib/typedarray/Float64Array#__get
   f64.const 5
@@ -24033,7 +24449,7 @@
   call $~lib/rt/pure/__release
   local.get $4
   call $~lib/rt/pure/__release
-  local.get $6
+  local.get $10
   call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
@@ -24041,7 +24457,7 @@
   call $~lib/rt/pure/__release
   local.get $5
   call $~lib/rt/pure/__release
-  local.get $8
+  local.get $11
   call $~lib/rt/pure/__release
  )
  (func $~lib/typedarray/Int8Array#indexOf (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -24053,6 +24469,10 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
   block $~lib/typedarray/INDEX_OF<~lib/typedarray/Int8Array,i8>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
@@ -24091,26 +24511,26 @@
     local.get $7
     local.get $6
     i32.add
-    local.tee $8
-    i32.const 0
     local.tee $9
-    local.get $8
+    i32.const 0
+    local.tee $10
     local.get $9
+    local.get $10
     i32.gt_s
     select
     local.set $6
    end
    local.get $5
    i32.load offset=4
-   local.set $8
+   local.set $11
    loop $while-continue|0
     local.get $6
     local.get $7
     i32.lt_s
-    local.set $9
-    local.get $9
+    local.set $12
+    local.get $12
     if
-     local.get $8
+     local.get $11
      local.get $6
      i32.const 0
      i32.shl
@@ -24124,10 +24544,10 @@
      i32.eq
      if
       local.get $6
-      local.set $10
+      local.set $13
       local.get $5
       call $~lib/rt/pure/__release
-      local.get $10
+      local.get $13
       br $~lib/typedarray/INDEX_OF<~lib/typedarray/Int8Array,i8>|inlined.0
      end
      local.get $6
@@ -24138,10 +24558,10 @@
     end
    end
    i32.const -1
-   local.set $9
+   local.set $14
    local.get $5
    call $~lib/rt/pure/__release
-   local.get $9
+   local.get $14
   end
  )
  (func $~lib/typedarray/Int8Array#lastIndexOf (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -24153,6 +24573,8 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
   block $~lib/typedarray/LAST_INDEX_OF<~lib/typedarray/Int8Array,i8>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
@@ -24198,15 +24620,15 @@
    end
    local.get $5
    i32.load offset=4
-   local.set $8
+   local.set $9
    loop $while-continue|0
     local.get $6
     i32.const 0
     i32.ge_s
-    local.set $9
-    local.get $9
+    local.set $10
+    local.get $10
     if
-     local.get $8
+     local.get $9
      local.get $6
      i32.const 0
      i32.shl
@@ -24220,10 +24642,10 @@
      i32.eq
      if
       local.get $6
-      local.set $10
+      local.set $11
       local.get $5
       call $~lib/rt/pure/__release
-      local.get $10
+      local.get $11
       br $~lib/typedarray/LAST_INDEX_OF<~lib/typedarray/Int8Array,i8>|inlined.0
      end
      local.get $6
@@ -24234,10 +24656,10 @@
     end
    end
    i32.const -1
-   local.set $9
+   local.set $12
    local.get $5
    call $~lib/rt/pure/__release
-   local.get $9
+   local.get $12
   end
  )
  (func $~lib/typedarray/Int8Array#lastIndexOf@varargs (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -24748,6 +25170,10 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
   block $~lib/typedarray/INDEX_OF<~lib/typedarray/Uint8Array,u8>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
@@ -24786,26 +25212,26 @@
     local.get $7
     local.get $6
     i32.add
-    local.tee $8
-    i32.const 0
     local.tee $9
-    local.get $8
+    i32.const 0
+    local.tee $10
     local.get $9
+    local.get $10
     i32.gt_s
     select
     local.set $6
    end
    local.get $5
    i32.load offset=4
-   local.set $8
+   local.set $11
    loop $while-continue|0
     local.get $6
     local.get $7
     i32.lt_s
-    local.set $9
-    local.get $9
+    local.set $12
+    local.get $12
     if
-     local.get $8
+     local.get $11
      local.get $6
      i32.const 0
      i32.shl
@@ -24817,10 +25243,10 @@
      i32.eq
      if
       local.get $6
-      local.set $10
+      local.set $13
       local.get $5
       call $~lib/rt/pure/__release
-      local.get $10
+      local.get $13
       br $~lib/typedarray/INDEX_OF<~lib/typedarray/Uint8Array,u8>|inlined.0
      end
      local.get $6
@@ -24831,10 +25257,10 @@
     end
    end
    i32.const -1
-   local.set $9
+   local.set $14
    local.get $5
    call $~lib/rt/pure/__release
-   local.get $9
+   local.get $14
   end
  )
  (func $~lib/typedarray/Uint8Array#lastIndexOf (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -24846,6 +25272,8 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
   block $~lib/typedarray/LAST_INDEX_OF<~lib/typedarray/Uint8Array,u8>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
@@ -24891,15 +25319,15 @@
    end
    local.get $5
    i32.load offset=4
-   local.set $8
+   local.set $9
    loop $while-continue|0
     local.get $6
     i32.const 0
     i32.ge_s
-    local.set $9
-    local.get $9
+    local.set $10
+    local.get $10
     if
-     local.get $8
+     local.get $9
      local.get $6
      i32.const 0
      i32.shl
@@ -24911,10 +25339,10 @@
      i32.eq
      if
       local.get $6
-      local.set $10
+      local.set $11
       local.get $5
       call $~lib/rt/pure/__release
-      local.get $10
+      local.get $11
       br $~lib/typedarray/LAST_INDEX_OF<~lib/typedarray/Uint8Array,u8>|inlined.0
      end
      local.get $6
@@ -24925,10 +25353,10 @@
     end
    end
    i32.const -1
-   local.set $9
+   local.set $12
    local.get $5
    call $~lib/rt/pure/__release
-   local.get $9
+   local.get $12
   end
  )
  (func $~lib/typedarray/Uint8Array#lastIndexOf@varargs (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -25437,6 +25865,10 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
   block $~lib/typedarray/INDEX_OF<~lib/typedarray/Uint8ClampedArray,u8>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
@@ -25475,26 +25907,26 @@
     local.get $7
     local.get $6
     i32.add
-    local.tee $8
-    i32.const 0
     local.tee $9
-    local.get $8
+    i32.const 0
+    local.tee $10
     local.get $9
+    local.get $10
     i32.gt_s
     select
     local.set $6
    end
    local.get $5
    i32.load offset=4
-   local.set $8
+   local.set $11
    loop $while-continue|0
     local.get $6
     local.get $7
     i32.lt_s
-    local.set $9
-    local.get $9
+    local.set $12
+    local.get $12
     if
-     local.get $8
+     local.get $11
      local.get $6
      i32.const 0
      i32.shl
@@ -25506,10 +25938,10 @@
      i32.eq
      if
       local.get $6
-      local.set $10
+      local.set $13
       local.get $5
       call $~lib/rt/pure/__release
-      local.get $10
+      local.get $13
       br $~lib/typedarray/INDEX_OF<~lib/typedarray/Uint8ClampedArray,u8>|inlined.0
      end
      local.get $6
@@ -25520,10 +25952,10 @@
     end
    end
    i32.const -1
-   local.set $9
+   local.set $14
    local.get $5
    call $~lib/rt/pure/__release
-   local.get $9
+   local.get $14
   end
  )
  (func $~lib/typedarray/Uint8ClampedArray#lastIndexOf (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -25535,6 +25967,8 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
   block $~lib/typedarray/LAST_INDEX_OF<~lib/typedarray/Uint8ClampedArray,u8>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
@@ -25580,15 +26014,15 @@
    end
    local.get $5
    i32.load offset=4
-   local.set $8
+   local.set $9
    loop $while-continue|0
     local.get $6
     i32.const 0
     i32.ge_s
-    local.set $9
-    local.get $9
+    local.set $10
+    local.get $10
     if
-     local.get $8
+     local.get $9
      local.get $6
      i32.const 0
      i32.shl
@@ -25600,10 +26034,10 @@
      i32.eq
      if
       local.get $6
-      local.set $10
+      local.set $11
       local.get $5
       call $~lib/rt/pure/__release
-      local.get $10
+      local.get $11
       br $~lib/typedarray/LAST_INDEX_OF<~lib/typedarray/Uint8ClampedArray,u8>|inlined.0
      end
      local.get $6
@@ -25614,10 +26048,10 @@
     end
    end
    i32.const -1
-   local.set $9
+   local.set $12
    local.get $5
    call $~lib/rt/pure/__release
-   local.get $9
+   local.get $12
   end
  )
  (func $~lib/typedarray/Uint8ClampedArray#lastIndexOf@varargs (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -26126,6 +26560,10 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
   block $~lib/typedarray/INDEX_OF<~lib/typedarray/Int16Array,i16>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
@@ -26164,26 +26602,26 @@
     local.get $7
     local.get $6
     i32.add
-    local.tee $8
-    i32.const 0
     local.tee $9
-    local.get $8
+    i32.const 0
+    local.tee $10
     local.get $9
+    local.get $10
     i32.gt_s
     select
     local.set $6
    end
    local.get $5
    i32.load offset=4
-   local.set $8
+   local.set $11
    loop $while-continue|0
     local.get $6
     local.get $7
     i32.lt_s
-    local.set $9
-    local.get $9
+    local.set $12
+    local.get $12
     if
-     local.get $8
+     local.get $11
      local.get $6
      i32.const 1
      i32.shl
@@ -26197,10 +26635,10 @@
      i32.eq
      if
       local.get $6
-      local.set $10
+      local.set $13
       local.get $5
       call $~lib/rt/pure/__release
-      local.get $10
+      local.get $13
       br $~lib/typedarray/INDEX_OF<~lib/typedarray/Int16Array,i16>|inlined.0
      end
      local.get $6
@@ -26211,10 +26649,10 @@
     end
    end
    i32.const -1
-   local.set $9
+   local.set $14
    local.get $5
    call $~lib/rt/pure/__release
-   local.get $9
+   local.get $14
   end
  )
  (func $~lib/typedarray/Int16Array#lastIndexOf (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -26226,6 +26664,8 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
   block $~lib/typedarray/LAST_INDEX_OF<~lib/typedarray/Int16Array,i16>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
@@ -26271,15 +26711,15 @@
    end
    local.get $5
    i32.load offset=4
-   local.set $8
+   local.set $9
    loop $while-continue|0
     local.get $6
     i32.const 0
     i32.ge_s
-    local.set $9
-    local.get $9
+    local.set $10
+    local.get $10
     if
-     local.get $8
+     local.get $9
      local.get $6
      i32.const 1
      i32.shl
@@ -26293,10 +26733,10 @@
      i32.eq
      if
       local.get $6
-      local.set $10
+      local.set $11
       local.get $5
       call $~lib/rt/pure/__release
-      local.get $10
+      local.get $11
       br $~lib/typedarray/LAST_INDEX_OF<~lib/typedarray/Int16Array,i16>|inlined.0
      end
      local.get $6
@@ -26307,10 +26747,10 @@
     end
    end
    i32.const -1
-   local.set $9
+   local.set $12
    local.get $5
    call $~lib/rt/pure/__release
-   local.get $9
+   local.get $12
   end
  )
  (func $~lib/typedarray/Int16Array#lastIndexOf@varargs (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -26821,6 +27261,10 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
   block $~lib/typedarray/INDEX_OF<~lib/typedarray/Uint16Array,u16>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
@@ -26859,26 +27303,26 @@
     local.get $7
     local.get $6
     i32.add
-    local.tee $8
-    i32.const 0
     local.tee $9
-    local.get $8
+    i32.const 0
+    local.tee $10
     local.get $9
+    local.get $10
     i32.gt_s
     select
     local.set $6
    end
    local.get $5
    i32.load offset=4
-   local.set $8
+   local.set $11
    loop $while-continue|0
     local.get $6
     local.get $7
     i32.lt_s
-    local.set $9
-    local.get $9
+    local.set $12
+    local.get $12
     if
-     local.get $8
+     local.get $11
      local.get $6
      i32.const 1
      i32.shl
@@ -26890,10 +27334,10 @@
      i32.eq
      if
       local.get $6
-      local.set $10
+      local.set $13
       local.get $5
       call $~lib/rt/pure/__release
-      local.get $10
+      local.get $13
       br $~lib/typedarray/INDEX_OF<~lib/typedarray/Uint16Array,u16>|inlined.0
      end
      local.get $6
@@ -26904,10 +27348,10 @@
     end
    end
    i32.const -1
-   local.set $9
+   local.set $14
    local.get $5
    call $~lib/rt/pure/__release
-   local.get $9
+   local.get $14
   end
  )
  (func $~lib/typedarray/Uint16Array#lastIndexOf (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -26919,6 +27363,8 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
   block $~lib/typedarray/LAST_INDEX_OF<~lib/typedarray/Uint16Array,u16>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
@@ -26964,15 +27410,15 @@
    end
    local.get $5
    i32.load offset=4
-   local.set $8
+   local.set $9
    loop $while-continue|0
     local.get $6
     i32.const 0
     i32.ge_s
-    local.set $9
-    local.get $9
+    local.set $10
+    local.get $10
     if
-     local.get $8
+     local.get $9
      local.get $6
      i32.const 1
      i32.shl
@@ -26984,10 +27430,10 @@
      i32.eq
      if
       local.get $6
-      local.set $10
+      local.set $11
       local.get $5
       call $~lib/rt/pure/__release
-      local.get $10
+      local.get $11
       br $~lib/typedarray/LAST_INDEX_OF<~lib/typedarray/Uint16Array,u16>|inlined.0
      end
      local.get $6
@@ -26998,10 +27444,10 @@
     end
    end
    i32.const -1
-   local.set $9
+   local.set $12
    local.get $5
    call $~lib/rt/pure/__release
-   local.get $9
+   local.get $12
   end
  )
  (func $~lib/typedarray/Uint16Array#lastIndexOf@varargs (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -27510,6 +27956,10 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
   block $~lib/typedarray/INDEX_OF<~lib/typedarray/Int32Array,i32>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
@@ -27548,26 +27998,26 @@
     local.get $7
     local.get $6
     i32.add
-    local.tee $8
-    i32.const 0
     local.tee $9
-    local.get $8
+    i32.const 0
+    local.tee $10
     local.get $9
+    local.get $10
     i32.gt_s
     select
     local.set $6
    end
    local.get $5
    i32.load offset=4
-   local.set $8
+   local.set $11
    loop $while-continue|0
     local.get $6
     local.get $7
     i32.lt_s
-    local.set $9
-    local.get $9
+    local.set $12
+    local.get $12
     if
-     local.get $8
+     local.get $11
      local.get $6
      i32.const 2
      i32.shl
@@ -27577,10 +28027,10 @@
      i32.eq
      if
       local.get $6
-      local.set $10
+      local.set $13
       local.get $5
       call $~lib/rt/pure/__release
-      local.get $10
+      local.get $13
       br $~lib/typedarray/INDEX_OF<~lib/typedarray/Int32Array,i32>|inlined.0
      end
      local.get $6
@@ -27591,10 +28041,10 @@
     end
    end
    i32.const -1
-   local.set $9
+   local.set $14
    local.get $5
    call $~lib/rt/pure/__release
-   local.get $9
+   local.get $14
   end
  )
  (func $~lib/typedarray/Int32Array#lastIndexOf (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -27606,6 +28056,8 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
   block $~lib/typedarray/LAST_INDEX_OF<~lib/typedarray/Int32Array,i32>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
@@ -27651,15 +28103,15 @@
    end
    local.get $5
    i32.load offset=4
-   local.set $8
+   local.set $9
    loop $while-continue|0
     local.get $6
     i32.const 0
     i32.ge_s
-    local.set $9
-    local.get $9
+    local.set $10
+    local.get $10
     if
-     local.get $8
+     local.get $9
      local.get $6
      i32.const 2
      i32.shl
@@ -27669,10 +28121,10 @@
      i32.eq
      if
       local.get $6
-      local.set $10
+      local.set $11
       local.get $5
       call $~lib/rt/pure/__release
-      local.get $10
+      local.get $11
       br $~lib/typedarray/LAST_INDEX_OF<~lib/typedarray/Int32Array,i32>|inlined.0
      end
      local.get $6
@@ -27683,10 +28135,10 @@
     end
    end
    i32.const -1
-   local.set $9
+   local.set $12
    local.get $5
    call $~lib/rt/pure/__release
-   local.get $9
+   local.get $12
   end
  )
  (func $~lib/typedarray/Int32Array#lastIndexOf@varargs (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -28193,6 +28645,10 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
   block $~lib/typedarray/INDEX_OF<~lib/typedarray/Uint32Array,u32>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
@@ -28231,26 +28687,26 @@
     local.get $7
     local.get $6
     i32.add
-    local.tee $8
-    i32.const 0
     local.tee $9
-    local.get $8
+    i32.const 0
+    local.tee $10
     local.get $9
+    local.get $10
     i32.gt_s
     select
     local.set $6
    end
    local.get $5
    i32.load offset=4
-   local.set $8
+   local.set $11
    loop $while-continue|0
     local.get $6
     local.get $7
     i32.lt_s
-    local.set $9
-    local.get $9
+    local.set $12
+    local.get $12
     if
-     local.get $8
+     local.get $11
      local.get $6
      i32.const 2
      i32.shl
@@ -28260,10 +28716,10 @@
      i32.eq
      if
       local.get $6
-      local.set $10
+      local.set $13
       local.get $5
       call $~lib/rt/pure/__release
-      local.get $10
+      local.get $13
       br $~lib/typedarray/INDEX_OF<~lib/typedarray/Uint32Array,u32>|inlined.0
      end
      local.get $6
@@ -28274,10 +28730,10 @@
     end
    end
    i32.const -1
-   local.set $9
+   local.set $14
    local.get $5
    call $~lib/rt/pure/__release
-   local.get $9
+   local.get $14
   end
  )
  (func $~lib/typedarray/Uint32Array#lastIndexOf (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -28289,6 +28745,8 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
   block $~lib/typedarray/LAST_INDEX_OF<~lib/typedarray/Uint32Array,u32>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
@@ -28334,15 +28792,15 @@
    end
    local.get $5
    i32.load offset=4
-   local.set $8
+   local.set $9
    loop $while-continue|0
     local.get $6
     i32.const 0
     i32.ge_s
-    local.set $9
-    local.get $9
+    local.set $10
+    local.get $10
     if
-     local.get $8
+     local.get $9
      local.get $6
      i32.const 2
      i32.shl
@@ -28352,10 +28810,10 @@
      i32.eq
      if
       local.get $6
-      local.set $10
+      local.set $11
       local.get $5
       call $~lib/rt/pure/__release
-      local.get $10
+      local.get $11
       br $~lib/typedarray/LAST_INDEX_OF<~lib/typedarray/Uint32Array,u32>|inlined.0
      end
      local.get $6
@@ -28366,10 +28824,10 @@
     end
    end
    i32.const -1
-   local.set $9
+   local.set $12
    local.get $5
    call $~lib/rt/pure/__release
-   local.get $9
+   local.get $12
   end
  )
  (func $~lib/typedarray/Uint32Array#lastIndexOf@varargs (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -28876,6 +29334,10 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
   block $~lib/typedarray/INDEX_OF<~lib/typedarray/Int64Array,i64>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
@@ -28914,26 +29376,26 @@
     local.get $7
     local.get $6
     i32.add
-    local.tee $8
-    i32.const 0
     local.tee $9
-    local.get $8
+    i32.const 0
+    local.tee $10
     local.get $9
+    local.get $10
     i32.gt_s
     select
     local.set $6
    end
    local.get $5
    i32.load offset=4
-   local.set $8
+   local.set $11
    loop $while-continue|0
     local.get $6
     local.get $7
     i32.lt_s
-    local.set $9
-    local.get $9
+    local.set $12
+    local.get $12
     if
-     local.get $8
+     local.get $11
      local.get $6
      i32.const 3
      i32.shl
@@ -28943,10 +29405,10 @@
      i64.eq
      if
       local.get $6
-      local.set $10
+      local.set $13
       local.get $5
       call $~lib/rt/pure/__release
-      local.get $10
+      local.get $13
       br $~lib/typedarray/INDEX_OF<~lib/typedarray/Int64Array,i64>|inlined.0
      end
      local.get $6
@@ -28957,10 +29419,10 @@
     end
    end
    i32.const -1
-   local.set $9
+   local.set $14
    local.get $5
    call $~lib/rt/pure/__release
-   local.get $9
+   local.get $14
   end
  )
  (func $~lib/typedarray/Int64Array#lastIndexOf (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
@@ -28972,6 +29434,8 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
   block $~lib/typedarray/LAST_INDEX_OF<~lib/typedarray/Int64Array,i64>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
@@ -29017,15 +29481,15 @@
    end
    local.get $5
    i32.load offset=4
-   local.set $8
+   local.set $9
    loop $while-continue|0
     local.get $6
     i32.const 0
     i32.ge_s
-    local.set $9
-    local.get $9
+    local.set $10
+    local.get $10
     if
-     local.get $8
+     local.get $9
      local.get $6
      i32.const 3
      i32.shl
@@ -29035,10 +29499,10 @@
      i64.eq
      if
       local.get $6
-      local.set $10
+      local.set $11
       local.get $5
       call $~lib/rt/pure/__release
-      local.get $10
+      local.get $11
       br $~lib/typedarray/LAST_INDEX_OF<~lib/typedarray/Int64Array,i64>|inlined.0
      end
      local.get $6
@@ -29049,10 +29513,10 @@
     end
    end
    i32.const -1
-   local.set $9
+   local.set $12
    local.get $5
    call $~lib/rt/pure/__release
-   local.get $9
+   local.get $12
   end
  )
  (func $~lib/typedarray/Int64Array#lastIndexOf@varargs (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
@@ -29560,6 +30024,10 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
   block $~lib/typedarray/INDEX_OF<~lib/typedarray/Uint64Array,u64>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
@@ -29598,26 +30066,26 @@
     local.get $7
     local.get $6
     i32.add
-    local.tee $8
-    i32.const 0
     local.tee $9
-    local.get $8
+    i32.const 0
+    local.tee $10
     local.get $9
+    local.get $10
     i32.gt_s
     select
     local.set $6
    end
    local.get $5
    i32.load offset=4
-   local.set $8
+   local.set $11
    loop $while-continue|0
     local.get $6
     local.get $7
     i32.lt_s
-    local.set $9
-    local.get $9
+    local.set $12
+    local.get $12
     if
-     local.get $8
+     local.get $11
      local.get $6
      i32.const 3
      i32.shl
@@ -29627,10 +30095,10 @@
      i64.eq
      if
       local.get $6
-      local.set $10
+      local.set $13
       local.get $5
       call $~lib/rt/pure/__release
-      local.get $10
+      local.get $13
       br $~lib/typedarray/INDEX_OF<~lib/typedarray/Uint64Array,u64>|inlined.0
      end
      local.get $6
@@ -29641,10 +30109,10 @@
     end
    end
    i32.const -1
-   local.set $9
+   local.set $14
    local.get $5
    call $~lib/rt/pure/__release
-   local.get $9
+   local.get $14
   end
  )
  (func $~lib/typedarray/Uint64Array#lastIndexOf (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
@@ -29656,6 +30124,8 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
   block $~lib/typedarray/LAST_INDEX_OF<~lib/typedarray/Uint64Array,u64>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
@@ -29701,15 +30171,15 @@
    end
    local.get $5
    i32.load offset=4
-   local.set $8
+   local.set $9
    loop $while-continue|0
     local.get $6
     i32.const 0
     i32.ge_s
-    local.set $9
-    local.get $9
+    local.set $10
+    local.get $10
     if
-     local.get $8
+     local.get $9
      local.get $6
      i32.const 3
      i32.shl
@@ -29719,10 +30189,10 @@
      i64.eq
      if
       local.get $6
-      local.set $10
+      local.set $11
       local.get $5
       call $~lib/rt/pure/__release
-      local.get $10
+      local.get $11
       br $~lib/typedarray/LAST_INDEX_OF<~lib/typedarray/Uint64Array,u64>|inlined.0
      end
      local.get $6
@@ -29733,10 +30203,10 @@
     end
    end
    i32.const -1
-   local.set $9
+   local.set $12
    local.get $5
    call $~lib/rt/pure/__release
-   local.get $9
+   local.get $12
   end
  )
  (func $~lib/typedarray/Uint64Array#lastIndexOf@varargs (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
@@ -30244,6 +30714,10 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
   block $~lib/typedarray/INDEX_OF<~lib/typedarray/Float32Array,f32>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
@@ -30282,26 +30756,26 @@
     local.get $7
     local.get $6
     i32.add
-    local.tee $8
-    i32.const 0
     local.tee $9
-    local.get $8
+    i32.const 0
+    local.tee $10
     local.get $9
+    local.get $10
     i32.gt_s
     select
     local.set $6
    end
    local.get $5
    i32.load offset=4
-   local.set $8
+   local.set $11
    loop $while-continue|0
     local.get $6
     local.get $7
     i32.lt_s
-    local.set $9
-    local.get $9
+    local.set $12
+    local.get $12
     if
-     local.get $8
+     local.get $11
      local.get $6
      i32.const 2
      i32.shl
@@ -30311,10 +30785,10 @@
      f32.eq
      if
       local.get $6
-      local.set $10
+      local.set $13
       local.get $5
       call $~lib/rt/pure/__release
-      local.get $10
+      local.get $13
       br $~lib/typedarray/INDEX_OF<~lib/typedarray/Float32Array,f32>|inlined.0
      end
      local.get $6
@@ -30325,10 +30799,10 @@
     end
    end
    i32.const -1
-   local.set $9
+   local.set $14
    local.get $5
    call $~lib/rt/pure/__release
-   local.get $9
+   local.get $14
   end
  )
  (func $~lib/typedarray/Float32Array#lastIndexOf (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
@@ -30340,6 +30814,8 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
   block $~lib/typedarray/LAST_INDEX_OF<~lib/typedarray/Float32Array,f32>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
@@ -30385,15 +30861,15 @@
    end
    local.get $5
    i32.load offset=4
-   local.set $8
+   local.set $9
    loop $while-continue|0
     local.get $6
     i32.const 0
     i32.ge_s
-    local.set $9
-    local.get $9
+    local.set $10
+    local.get $10
     if
-     local.get $8
+     local.get $9
      local.get $6
      i32.const 2
      i32.shl
@@ -30403,10 +30879,10 @@
      f32.eq
      if
       local.get $6
-      local.set $10
+      local.set $11
       local.get $5
       call $~lib/rt/pure/__release
-      local.get $10
+      local.get $11
       br $~lib/typedarray/LAST_INDEX_OF<~lib/typedarray/Float32Array,f32>|inlined.0
      end
      local.get $6
@@ -30417,10 +30893,10 @@
     end
    end
    i32.const -1
-   local.set $9
+   local.set $12
    local.get $5
    call $~lib/rt/pure/__release
-   local.get $9
+   local.get $12
   end
  )
  (func $~lib/typedarray/Float32Array#lastIndexOf@varargs (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
@@ -30928,6 +31404,10 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
   block $~lib/typedarray/INDEX_OF<~lib/typedarray/Float64Array,f64>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
@@ -30966,26 +31446,26 @@
     local.get $7
     local.get $6
     i32.add
-    local.tee $8
-    i32.const 0
     local.tee $9
-    local.get $8
+    i32.const 0
+    local.tee $10
     local.get $9
+    local.get $10
     i32.gt_s
     select
     local.set $6
    end
    local.get $5
    i32.load offset=4
-   local.set $8
+   local.set $11
    loop $while-continue|0
     local.get $6
     local.get $7
     i32.lt_s
-    local.set $9
-    local.get $9
+    local.set $12
+    local.get $12
     if
-     local.get $8
+     local.get $11
      local.get $6
      i32.const 3
      i32.shl
@@ -30995,10 +31475,10 @@
      f64.eq
      if
       local.get $6
-      local.set $10
+      local.set $13
       local.get $5
       call $~lib/rt/pure/__release
-      local.get $10
+      local.get $13
       br $~lib/typedarray/INDEX_OF<~lib/typedarray/Float64Array,f64>|inlined.0
      end
      local.get $6
@@ -31009,10 +31489,10 @@
     end
    end
    i32.const -1
-   local.set $9
+   local.set $14
    local.get $5
    call $~lib/rt/pure/__release
-   local.get $9
+   local.get $14
   end
  )
  (func $~lib/typedarray/Float64Array#lastIndexOf (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
@@ -31024,6 +31504,8 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
   block $~lib/typedarray/LAST_INDEX_OF<~lib/typedarray/Float64Array,f64>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
@@ -31069,15 +31551,15 @@
    end
    local.get $5
    i32.load offset=4
-   local.set $8
+   local.set $9
    loop $while-continue|0
     local.get $6
     i32.const 0
     i32.ge_s
-    local.set $9
-    local.get $9
+    local.set $10
+    local.get $10
     if
-     local.get $8
+     local.get $9
      local.get $6
      i32.const 3
      i32.shl
@@ -31087,10 +31569,10 @@
      f64.eq
      if
       local.get $6
-      local.set $10
+      local.set $11
       local.get $5
       call $~lib/rt/pure/__release
-      local.get $10
+      local.get $11
       br $~lib/typedarray/LAST_INDEX_OF<~lib/typedarray/Float64Array,f64>|inlined.0
      end
      local.get $6
@@ -31101,10 +31583,10 @@
     end
    end
    i32.const -1
-   local.set $9
+   local.set $12
    local.get $5
    call $~lib/rt/pure/__release
-   local.get $9
+   local.get $12
   end
  )
  (func $~lib/typedarray/Float64Array#lastIndexOf@varargs (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
@@ -31611,8 +32093,12 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
-  (local $10 f64)
+  (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 f64)
+  (local $14 i32)
+  (local $15 i32)
   block $~lib/typedarray/INCLUDES<~lib/typedarray/Float64Array,f64>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
@@ -31653,40 +32139,40 @@
     local.get $7
     local.get $6
     i32.add
-    local.tee $8
-    i32.const 0
     local.tee $9
-    local.get $8
+    i32.const 0
+    local.tee $10
     local.get $9
+    local.get $10
     i32.gt_s
     select
     local.set $6
    end
    local.get $5
    i32.load offset=4
-   local.set $8
+   local.set $11
    loop $while-continue|0
     local.get $6
     local.get $7
     i32.lt_s
-    local.set $9
-    local.get $9
+    local.set $12
+    local.get $12
     if
-     local.get $8
+     local.get $11
      local.get $6
      i32.const 3
      i32.shl
      i32.add
      f64.load
-     local.set $10
-     local.get $10
+     local.set $13
+     local.get $13
      local.get $4
      f64.eq
      if (result i32)
       i32.const 1
      else
-      local.get $10
-      local.get $10
+      local.get $13
+      local.get $13
       f64.ne
       local.get $4
       local.get $4
@@ -31695,10 +32181,10 @@
      end
      if
       i32.const 1
-      local.set $11
+      local.set $14
       local.get $5
       call $~lib/rt/pure/__release
-      local.get $11
+      local.get $14
       br $~lib/typedarray/INCLUDES<~lib/typedarray/Float64Array,f64>|inlined.0
      end
      local.get $6
@@ -31709,10 +32195,10 @@
     end
    end
    i32.const 0
-   local.set $9
+   local.set $15
    local.get $5
    call $~lib/rt/pure/__release
-   local.get $9
+   local.get $15
    br $~lib/typedarray/INCLUDES<~lib/typedarray/Float64Array,f64>|inlined.0
   end
  )
@@ -31724,8 +32210,12 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
-  (local $10 f32)
+  (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 f32)
+  (local $14 i32)
+  (local $15 i32)
   block $~lib/typedarray/INCLUDES<~lib/typedarray/Float32Array,f32>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
@@ -31766,40 +32256,40 @@
     local.get $7
     local.get $6
     i32.add
-    local.tee $8
-    i32.const 0
     local.tee $9
-    local.get $8
+    i32.const 0
+    local.tee $10
     local.get $9
+    local.get $10
     i32.gt_s
     select
     local.set $6
    end
    local.get $5
    i32.load offset=4
-   local.set $8
+   local.set $11
    loop $while-continue|0
     local.get $6
     local.get $7
     i32.lt_s
-    local.set $9
-    local.get $9
+    local.set $12
+    local.get $12
     if
-     local.get $8
+     local.get $11
      local.get $6
      i32.const 2
      i32.shl
      i32.add
      f32.load
-     local.set $10
-     local.get $10
+     local.set $13
+     local.get $13
      local.get $4
      f32.eq
      if (result i32)
       i32.const 1
      else
-      local.get $10
-      local.get $10
+      local.get $13
+      local.get $13
       f32.ne
       local.get $4
       local.get $4
@@ -31808,10 +32298,10 @@
      end
      if
       i32.const 1
-      local.set $11
+      local.set $14
       local.get $5
       call $~lib/rt/pure/__release
-      local.get $11
+      local.get $14
       br $~lib/typedarray/INCLUDES<~lib/typedarray/Float32Array,f32>|inlined.0
      end
      local.get $6
@@ -31822,10 +32312,10 @@
     end
    end
    i32.const 0
-   local.set $9
+   local.set $15
    local.get $5
    call $~lib/rt/pure/__release
-   local.get $9
+   local.get $15
    br $~lib/typedarray/INCLUDES<~lib/typedarray/Float32Array,f32>|inlined.0
   end
  )
@@ -31894,6 +32384,9 @@
   (local $9 i64)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
   loop $while-continue|0
    local.get $1
    i32.const 10000
@@ -31958,30 +32451,30 @@
    local.get $1
    i32.const 100
    i32.div_u
-   local.set $3
+   local.set $10
    local.get $1
    i32.const 100
    i32.rem_u
-   local.set $10
-   local.get $3
+   local.set $11
+   local.get $10
    local.set $1
    local.get $2
    i32.const 2
    i32.sub
    local.set $2
    i32.const 1940
-   local.get $10
+   local.get $11
    i32.const 2
    i32.shl
    i32.add
    i32.load
-   local.set $11
+   local.set $12
    local.get $0
    local.get $2
    i32.const 1
    i32.shl
    i32.add
-   local.get $11
+   local.get $12
    i32.store
   end
   local.get $1
@@ -31998,13 +32491,13 @@
    i32.shl
    i32.add
    i32.load
-   local.set $11
+   local.set $13
    local.get $0
    local.get $2
    i32.const 1
    i32.shl
    i32.add
-   local.get $11
+   local.get $13
    i32.store
   else
    local.get $2
@@ -32014,13 +32507,13 @@
    i32.const 48
    local.get $1
    i32.add
-   local.set $11
+   local.set $14
    local.get $0
    local.get $2
    i32.const 1
    i32.shl
    i32.add
-   local.get $11
+   local.get $14
    i32.store16
   end
  )
@@ -32223,6 +32716,16 @@
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
   local.get $0
   call $~lib/string/String#get:length
   local.set $3
@@ -32234,67 +32737,67 @@
   local.get $5
   i32.gt_s
   select
-  local.tee $4
+  local.tee $6
   local.get $3
-  local.tee $5
-  local.get $4
-  local.get $5
-  i32.lt_s
-  select
-  local.set $6
-  local.get $2
-  local.tee $4
-  i32.const 0
-  local.tee $5
-  local.get $4
-  local.get $5
-  i32.gt_s
-  select
-  local.tee $4
-  local.get $3
-  local.tee $5
-  local.get $4
-  local.get $5
-  i32.lt_s
-  select
-  local.set $7
+  local.tee $7
   local.get $6
-  local.tee $4
   local.get $7
-  local.tee $5
-  local.get $4
-  local.get $5
   i32.lt_s
   select
-  i32.const 1
-  i32.shl
   local.set $8
-  local.get $6
-  local.tee $4
-  local.get $7
-  local.tee $5
-  local.get $4
-  local.get $5
+  local.get $2
+  local.tee $9
+  i32.const 0
+  local.tee $10
+  local.get $9
+  local.get $10
+  i32.gt_s
+  select
+  local.tee $11
+  local.get $3
+  local.tee $12
+  local.get $11
+  local.get $12
+  i32.lt_s
+  select
+  local.set $13
+  local.get $8
+  local.tee $14
+  local.get $13
+  local.tee $15
+  local.get $14
+  local.get $15
+  i32.lt_s
+  select
+  i32.const 1
+  i32.shl
+  local.set $16
+  local.get $8
+  local.tee $17
+  local.get $13
+  local.tee $18
+  local.get $17
+  local.get $18
   i32.gt_s
   select
   i32.const 1
   i32.shl
-  local.set $9
-  local.get $9
-  local.get $8
+  local.set $19
+  local.get $19
+  local.get $16
   i32.sub
-  local.set $10
-  local.get $10
+  local.set $20
+  local.get $20
   i32.eqz
   if
    i32.const 1920
    call $~lib/rt/pure/__retain
    return
   end
-  local.get $8
+  local.get $16
   i32.eqz
   if (result i32)
-   local.get $9
+   local.get $19
    local.get $3
    i32.const 1
    i32.shl
@@ -32307,17 +32810,17 @@
    call $~lib/rt/pure/__retain
    return
   end
-  local.get $10
+  local.get $20
   i32.const 1
   call $~lib/rt/tlsf/__alloc
-  local.set $11
-  local.get $11
+  local.set $21
+  local.get $21
   local.get $0
-  local.get $8
+  local.get $16
   i32.add
-  local.get $10
+  local.get $20
   call $~lib/memory/memory.copy
-  local.get $11
+  local.get $21
   call $~lib/rt/pure/__retain
  )
  (func $~lib/util/string/joinIntegerArray<i8> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -32329,6 +32832,11 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
   local.get $2
   call $~lib/rt/pure/__retain
   local.set $2
@@ -32353,77 +32861,77 @@
    local.get $0
    i32.load8_s
    call $~lib/util/number/itoa<i8>
-   local.tee $4
-   local.set $5
+   local.tee $5
+   local.set $6
    local.get $2
    call $~lib/rt/pure/__release
-   local.get $5
+   local.get $6
    return
   end
   local.get $2
   call $~lib/string/String#get:length
-  local.set $6
+  local.set $7
   i32.const 11
-  local.get $6
+  local.get $7
   i32.add
   local.get $3
   i32.mul
   i32.const 11
   i32.add
-  local.set $7
-  local.get $7
+  local.set $8
+  local.get $8
   i32.const 1
   i32.shl
   i32.const 1
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
-  local.set $8
-  i32.const 0
   local.set $9
   i32.const 0
-  local.set $4
+  local.set $10
+  i32.const 0
+  local.set $12
   loop $for-loop|0
-   local.get $4
+   local.get $12
    local.get $3
    i32.lt_s
-   local.set $5
-   local.get $5
+   local.set $13
+   local.get $13
    if
     local.get $0
-    local.get $4
+    local.get $12
     i32.const 0
     i32.shl
     i32.add
     i32.load8_s
-    local.set $10
-    local.get $9
-    local.get $8
+    local.set $11
+    local.get $10
     local.get $9
     local.get $10
+    local.get $11
     call $~lib/util/number/itoa_stream<i8>
     i32.add
-    local.set $9
-    local.get $6
+    local.set $10
+    local.get $7
     if
-     local.get $8
      local.get $9
+     local.get $10
      i32.const 1
      i32.shl
      i32.add
      local.get $2
-     local.get $6
+     local.get $7
      i32.const 1
      i32.shl
      call $~lib/memory/memory.copy
-     local.get $9
-     local.get $6
+     local.get $10
+     local.get $7
      i32.add
-     local.set $9
+     local.set $10
     end
-    local.get $4
+    local.get $12
     i32.const 1
     i32.add
-    local.set $4
+    local.set $12
     br $for-loop|0
    end
   end
@@ -32433,35 +32941,35 @@
   i32.shl
   i32.add
   i32.load8_s
-  local.set $10
-  local.get $9
-  local.get $8
+  local.set $11
+  local.get $10
   local.get $9
   local.get $10
+  local.get $11
   call $~lib/util/number/itoa_stream<i8>
   i32.add
-  local.set $9
-  local.get $7
-  local.get $9
+  local.set $10
+  local.get $8
+  local.get $10
   i32.gt_s
   if
-   local.get $8
-   i32.const 0
    local.get $9
+   i32.const 0
+   local.get $10
    call $~lib/string/String#substring
-   local.set $4
+   local.set $14
    local.get $2
    call $~lib/rt/pure/__release
-   local.get $8
+   local.get $9
    call $~lib/rt/pure/__release
-   local.get $4
+   local.get $14
    return
   end
-  local.get $8
-  local.set $4
+  local.get $9
+  local.set $15
   local.get $2
   call $~lib/rt/pure/__release
-  local.get $4
+  local.get $15
  )
  (func $~lib/typedarray/Int8Array#join (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
@@ -32486,6 +32994,9 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $0
@@ -32557,33 +33068,33 @@
   end
   loop $while-continue|1
    local.get $4
-   local.tee $7
+   local.tee $8
    i32.const 1
    i32.sub
    local.set $4
-   local.get $7
-   local.set $7
-   local.get $7
+   local.get $8
+   local.set $9
+   local.get $9
    if
     local.get $5
     i32.load16_u
-    local.set $8
+    local.set $10
     local.get $6
     i32.load16_u
-    local.set $9
-    local.get $8
-    local.get $9
+    local.set $11
+    local.get $10
+    local.get $11
     i32.ne
     if
-     local.get $8
-     local.get $9
+     local.get $10
+     local.get $11
      i32.sub
-     local.set $10
+     local.set $12
      local.get $0
      call $~lib/rt/pure/__release
      local.get $2
      call $~lib/rt/pure/__release
-     local.get $10
+     local.get $12
      return
     end
     local.get $5
@@ -32598,16 +33109,19 @@
    end
   end
   i32.const 0
-  local.set $7
+  local.set $13
   local.get $0
   call $~lib/rt/pure/__release
   local.get $2
   call $~lib/rt/pure/__release
-  local.get $7
+  local.get $13
  )
  (func $~lib/string/String.__eq (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $0
@@ -32639,44 +33153,44 @@
   end
   if
    i32.const 0
-   local.set $2
+   local.set $3
    local.get $0
    call $~lib/rt/pure/__release
    local.get $1
    call $~lib/rt/pure/__release
-   local.get $2
+   local.get $3
    return
   end
   local.get $0
   call $~lib/string/String#get:length
-  local.set $3
-  local.get $3
+  local.set $4
+  local.get $4
   local.get $1
   call $~lib/string/String#get:length
   i32.ne
   if
    i32.const 0
-   local.set $2
+   local.set $5
    local.get $0
    call $~lib/rt/pure/__release
    local.get $1
    call $~lib/rt/pure/__release
-   local.get $2
+   local.get $5
    return
   end
   local.get $0
   i32.const 0
   local.get $1
   i32.const 0
-  local.get $3
+  local.get $4
   call $~lib/util/string/compareImpl
   i32.eqz
-  local.set $2
+  local.set $6
   local.get $0
   call $~lib/rt/pure/__release
   local.get $1
   call $~lib/rt/pure/__release
-  local.get $2
+  local.get $6
  )
  (func $~lib/typedarray/Int8Array#toString (param $0 i32) (result i32)
   local.get $0
@@ -32886,6 +33400,11 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
   local.get $2
   call $~lib/rt/pure/__retain
   local.set $2
@@ -32910,77 +33429,77 @@
    local.get $0
    i32.load8_u
    call $~lib/util/number/itoa<u8>
-   local.tee $4
-   local.set $5
+   local.tee $5
+   local.set $6
    local.get $2
    call $~lib/rt/pure/__release
-   local.get $5
+   local.get $6
    return
   end
   local.get $2
   call $~lib/string/String#get:length
-  local.set $6
+  local.set $7
   i32.const 10
-  local.get $6
+  local.get $7
   i32.add
   local.get $3
   i32.mul
   i32.const 10
   i32.add
-  local.set $7
-  local.get $7
+  local.set $8
+  local.get $8
   i32.const 1
   i32.shl
   i32.const 1
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
-  local.set $8
-  i32.const 0
   local.set $9
   i32.const 0
-  local.set $4
+  local.set $10
+  i32.const 0
+  local.set $12
   loop $for-loop|0
-   local.get $4
+   local.get $12
    local.get $3
    i32.lt_s
-   local.set $5
-   local.get $5
+   local.set $13
+   local.get $13
    if
     local.get $0
-    local.get $4
+    local.get $12
     i32.const 0
     i32.shl
     i32.add
     i32.load8_u
-    local.set $10
-    local.get $9
-    local.get $8
+    local.set $11
+    local.get $10
     local.get $9
     local.get $10
+    local.get $11
     call $~lib/util/number/itoa_stream<u8>
     i32.add
-    local.set $9
-    local.get $6
+    local.set $10
+    local.get $7
     if
-     local.get $8
      local.get $9
+     local.get $10
      i32.const 1
      i32.shl
      i32.add
      local.get $2
-     local.get $6
+     local.get $7
      i32.const 1
      i32.shl
      call $~lib/memory/memory.copy
-     local.get $9
-     local.get $6
+     local.get $10
+     local.get $7
      i32.add
-     local.set $9
+     local.set $10
     end
-    local.get $4
+    local.get $12
     i32.const 1
     i32.add
-    local.set $4
+    local.set $12
     br $for-loop|0
    end
   end
@@ -32990,35 +33509,35 @@
   i32.shl
   i32.add
   i32.load8_u
-  local.set $10
-  local.get $9
-  local.get $8
+  local.set $11
+  local.get $10
   local.get $9
   local.get $10
+  local.get $11
   call $~lib/util/number/itoa_stream<u8>
   i32.add
-  local.set $9
-  local.get $7
-  local.get $9
+  local.set $10
+  local.get $8
+  local.get $10
   i32.gt_s
   if
-   local.get $8
-   i32.const 0
    local.get $9
+   i32.const 0
+   local.get $10
    call $~lib/string/String#substring
-   local.set $4
+   local.set $14
    local.get $2
    call $~lib/rt/pure/__release
-   local.get $8
+   local.get $9
    call $~lib/rt/pure/__release
-   local.get $4
+   local.get $14
    return
   end
-  local.get $8
-  local.set $4
+  local.get $9
+  local.set $15
   local.get $2
   call $~lib/rt/pure/__release
-  local.get $4
+  local.get $15
  )
  (func $~lib/typedarray/Uint8Array#join (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
@@ -33336,6 +33855,11 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
   local.get $2
   call $~lib/rt/pure/__retain
   local.set $2
@@ -33360,77 +33884,77 @@
    local.get $0
    i32.load16_s
    call $~lib/util/number/itoa<i16>
-   local.tee $4
-   local.set $5
+   local.tee $5
+   local.set $6
    local.get $2
    call $~lib/rt/pure/__release
-   local.get $5
+   local.get $6
    return
   end
   local.get $2
   call $~lib/string/String#get:length
-  local.set $6
+  local.set $7
   i32.const 11
-  local.get $6
+  local.get $7
   i32.add
   local.get $3
   i32.mul
   i32.const 11
   i32.add
-  local.set $7
-  local.get $7
+  local.set $8
+  local.get $8
   i32.const 1
   i32.shl
   i32.const 1
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
-  local.set $8
-  i32.const 0
   local.set $9
   i32.const 0
-  local.set $4
+  local.set $10
+  i32.const 0
+  local.set $12
   loop $for-loop|0
-   local.get $4
+   local.get $12
    local.get $3
    i32.lt_s
-   local.set $5
-   local.get $5
+   local.set $13
+   local.get $13
    if
     local.get $0
-    local.get $4
+    local.get $12
     i32.const 1
     i32.shl
     i32.add
     i32.load16_s
-    local.set $10
-    local.get $9
-    local.get $8
+    local.set $11
+    local.get $10
     local.get $9
     local.get $10
+    local.get $11
     call $~lib/util/number/itoa_stream<i16>
     i32.add
-    local.set $9
-    local.get $6
+    local.set $10
+    local.get $7
     if
-     local.get $8
      local.get $9
+     local.get $10
      i32.const 1
      i32.shl
      i32.add
      local.get $2
-     local.get $6
+     local.get $7
      i32.const 1
      i32.shl
      call $~lib/memory/memory.copy
-     local.get $9
-     local.get $6
+     local.get $10
+     local.get $7
      i32.add
-     local.set $9
+     local.set $10
     end
-    local.get $4
+    local.get $12
     i32.const 1
     i32.add
-    local.set $4
+    local.set $12
     br $for-loop|0
    end
   end
@@ -33440,35 +33964,35 @@
   i32.shl
   i32.add
   i32.load16_s
-  local.set $10
-  local.get $9
-  local.get $8
+  local.set $11
+  local.get $10
   local.get $9
   local.get $10
+  local.get $11
   call $~lib/util/number/itoa_stream<i16>
   i32.add
-  local.set $9
-  local.get $7
-  local.get $9
+  local.set $10
+  local.get $8
+  local.get $10
   i32.gt_s
   if
-   local.get $8
-   i32.const 0
    local.get $9
+   i32.const 0
+   local.get $10
    call $~lib/string/String#substring
-   local.set $4
+   local.set $14
    local.get $2
    call $~lib/rt/pure/__release
-   local.get $8
+   local.get $9
    call $~lib/rt/pure/__release
-   local.get $4
+   local.get $14
    return
   end
-  local.get $8
-  local.set $4
+  local.get $9
+  local.set $15
   local.get $2
   call $~lib/rt/pure/__release
-  local.get $4
+  local.get $15
  )
  (func $~lib/typedarray/Int16Array#join (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
@@ -33656,6 +34180,11 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
   local.get $2
   call $~lib/rt/pure/__retain
   local.set $2
@@ -33680,77 +34209,77 @@
    local.get $0
    i32.load16_u
    call $~lib/util/number/itoa<u16>
-   local.tee $4
-   local.set $5
+   local.tee $5
+   local.set $6
    local.get $2
    call $~lib/rt/pure/__release
-   local.get $5
+   local.get $6
    return
   end
   local.get $2
   call $~lib/string/String#get:length
-  local.set $6
+  local.set $7
   i32.const 10
-  local.get $6
+  local.get $7
   i32.add
   local.get $3
   i32.mul
   i32.const 10
   i32.add
-  local.set $7
-  local.get $7
+  local.set $8
+  local.get $8
   i32.const 1
   i32.shl
   i32.const 1
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
-  local.set $8
-  i32.const 0
   local.set $9
   i32.const 0
-  local.set $4
+  local.set $10
+  i32.const 0
+  local.set $12
   loop $for-loop|0
-   local.get $4
+   local.get $12
    local.get $3
    i32.lt_s
-   local.set $5
-   local.get $5
+   local.set $13
+   local.get $13
    if
     local.get $0
-    local.get $4
+    local.get $12
     i32.const 1
     i32.shl
     i32.add
     i32.load16_u
-    local.set $10
-    local.get $9
-    local.get $8
+    local.set $11
+    local.get $10
     local.get $9
     local.get $10
+    local.get $11
     call $~lib/util/number/itoa_stream<u16>
     i32.add
-    local.set $9
-    local.get $6
+    local.set $10
+    local.get $7
     if
-     local.get $8
      local.get $9
+     local.get $10
      i32.const 1
      i32.shl
      i32.add
      local.get $2
-     local.get $6
+     local.get $7
      i32.const 1
      i32.shl
      call $~lib/memory/memory.copy
-     local.get $9
-     local.get $6
+     local.get $10
+     local.get $7
      i32.add
-     local.set $9
+     local.set $10
     end
-    local.get $4
+    local.get $12
     i32.const 1
     i32.add
-    local.set $4
+    local.set $12
     br $for-loop|0
    end
   end
@@ -33760,35 +34289,35 @@
   i32.shl
   i32.add
   i32.load16_u
-  local.set $10
-  local.get $9
-  local.get $8
+  local.set $11
+  local.get $10
   local.get $9
   local.get $10
+  local.get $11
   call $~lib/util/number/itoa_stream<u16>
   i32.add
-  local.set $9
-  local.get $7
-  local.get $9
+  local.set $10
+  local.get $8
+  local.get $10
   i32.gt_s
   if
-   local.get $8
-   i32.const 0
    local.get $9
+   i32.const 0
+   local.get $10
    call $~lib/string/String#substring
-   local.set $4
+   local.set $14
    local.get $2
    call $~lib/rt/pure/__release
-   local.get $8
+   local.get $9
    call $~lib/rt/pure/__release
-   local.get $4
+   local.get $14
    return
   end
-  local.get $8
-  local.set $4
+  local.get $9
+  local.set $15
   local.get $2
   call $~lib/rt/pure/__release
-  local.get $4
+  local.get $15
  )
  (func $~lib/typedarray/Uint16Array#join (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
@@ -33990,6 +34519,11 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
   local.get $2
   call $~lib/rt/pure/__retain
   local.set $2
@@ -34014,77 +34548,77 @@
    local.get $0
    i32.load
    call $~lib/util/number/itoa<i32>
-   local.tee $4
-   local.set $5
+   local.tee $5
+   local.set $6
    local.get $2
    call $~lib/rt/pure/__release
-   local.get $5
+   local.get $6
    return
   end
   local.get $2
   call $~lib/string/String#get:length
-  local.set $6
+  local.set $7
   i32.const 11
-  local.get $6
+  local.get $7
   i32.add
   local.get $3
   i32.mul
   i32.const 11
   i32.add
-  local.set $7
-  local.get $7
+  local.set $8
+  local.get $8
   i32.const 1
   i32.shl
   i32.const 1
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
-  local.set $8
-  i32.const 0
   local.set $9
   i32.const 0
-  local.set $4
+  local.set $10
+  i32.const 0
+  local.set $12
   loop $for-loop|0
-   local.get $4
+   local.get $12
    local.get $3
    i32.lt_s
-   local.set $5
-   local.get $5
+   local.set $13
+   local.get $13
    if
     local.get $0
-    local.get $4
+    local.get $12
     i32.const 2
     i32.shl
     i32.add
     i32.load
-    local.set $10
-    local.get $9
-    local.get $8
+    local.set $11
+    local.get $10
     local.get $9
     local.get $10
+    local.get $11
     call $~lib/util/number/itoa_stream<i32>
     i32.add
-    local.set $9
-    local.get $6
+    local.set $10
+    local.get $7
     if
-     local.get $8
      local.get $9
+     local.get $10
      i32.const 1
      i32.shl
      i32.add
      local.get $2
-     local.get $6
+     local.get $7
      i32.const 1
      i32.shl
      call $~lib/memory/memory.copy
-     local.get $9
-     local.get $6
+     local.get $10
+     local.get $7
      i32.add
-     local.set $9
+     local.set $10
     end
-    local.get $4
+    local.get $12
     i32.const 1
     i32.add
-    local.set $4
+    local.set $12
     br $for-loop|0
    end
   end
@@ -34094,35 +34628,35 @@
   i32.shl
   i32.add
   i32.load
-  local.set $10
-  local.get $9
-  local.get $8
+  local.set $11
+  local.get $10
   local.get $9
   local.get $10
+  local.get $11
   call $~lib/util/number/itoa_stream<i32>
   i32.add
-  local.set $9
-  local.get $7
-  local.get $9
+  local.set $10
+  local.get $8
+  local.get $10
   i32.gt_s
   if
-   local.get $8
-   i32.const 0
    local.get $9
+   i32.const 0
+   local.get $10
    call $~lib/string/String#substring
-   local.set $4
+   local.set $14
    local.get $2
    call $~lib/rt/pure/__release
-   local.get $8
+   local.get $9
    call $~lib/rt/pure/__release
-   local.get $4
+   local.get $14
    return
   end
-  local.get $8
-  local.set $4
+  local.get $9
+  local.set $15
   local.get $2
   call $~lib/rt/pure/__release
-  local.get $4
+  local.get $15
  )
  (func $~lib/typedarray/Int32Array#join (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
@@ -34300,6 +34834,11 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
   local.get $2
   call $~lib/rt/pure/__retain
   local.set $2
@@ -34324,77 +34863,77 @@
    local.get $0
    i32.load
    call $~lib/util/number/itoa<u32>
-   local.tee $4
-   local.set $5
+   local.tee $5
+   local.set $6
    local.get $2
    call $~lib/rt/pure/__release
-   local.get $5
+   local.get $6
    return
   end
   local.get $2
   call $~lib/string/String#get:length
-  local.set $6
+  local.set $7
   i32.const 10
-  local.get $6
+  local.get $7
   i32.add
   local.get $3
   i32.mul
   i32.const 10
   i32.add
-  local.set $7
-  local.get $7
+  local.set $8
+  local.get $8
   i32.const 1
   i32.shl
   i32.const 1
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
-  local.set $8
-  i32.const 0
   local.set $9
   i32.const 0
-  local.set $4
+  local.set $10
+  i32.const 0
+  local.set $12
   loop $for-loop|0
-   local.get $4
+   local.get $12
    local.get $3
    i32.lt_s
-   local.set $5
-   local.get $5
+   local.set $13
+   local.get $13
    if
     local.get $0
-    local.get $4
+    local.get $12
     i32.const 2
     i32.shl
     i32.add
     i32.load
-    local.set $10
-    local.get $9
-    local.get $8
+    local.set $11
+    local.get $10
     local.get $9
     local.get $10
+    local.get $11
     call $~lib/util/number/itoa_stream<u32>
     i32.add
-    local.set $9
-    local.get $6
+    local.set $10
+    local.get $7
     if
-     local.get $8
      local.get $9
+     local.get $10
      i32.const 1
      i32.shl
      i32.add
      local.get $2
-     local.get $6
+     local.get $7
      i32.const 1
      i32.shl
      call $~lib/memory/memory.copy
-     local.get $9
-     local.get $6
+     local.get $10
+     local.get $7
      i32.add
-     local.set $9
+     local.set $10
     end
-    local.get $4
+    local.get $12
     i32.const 1
     i32.add
-    local.set $4
+    local.set $12
     br $for-loop|0
    end
   end
@@ -34404,35 +34943,35 @@
   i32.shl
   i32.add
   i32.load
-  local.set $10
-  local.get $9
-  local.get $8
+  local.set $11
+  local.get $10
   local.get $9
   local.get $10
+  local.get $11
   call $~lib/util/number/itoa_stream<u32>
   i32.add
-  local.set $9
-  local.get $7
-  local.get $9
+  local.set $10
+  local.get $8
+  local.get $10
   i32.gt_s
   if
-   local.get $8
-   i32.const 0
    local.get $9
+   i32.const 0
+   local.get $10
    call $~lib/string/String#substring
-   local.set $4
+   local.set $14
    local.get $2
    call $~lib/rt/pure/__release
-   local.get $8
+   local.get $9
    call $~lib/rt/pure/__release
-   local.get $4
+   local.get $14
    return
   end
-  local.get $8
-  local.set $4
+  local.get $9
+  local.set $15
   local.get $2
   call $~lib/rt/pure/__release
-  local.get $4
+  local.get $15
  )
  (func $~lib/typedarray/Uint32Array#join (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
@@ -34716,7 +35255,10 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i64)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i64)
+  (local $11 i32)
   local.get $0
   i64.const 0
   i64.ne
@@ -34775,26 +35317,26 @@
    call $~lib/util/number/decimalCount64High
    local.get $1
    i32.add
-   local.set $4
-   local.get $4
+   local.set $8
+   local.get $8
    i32.const 1
    i32.shl
    i32.const 1
    call $~lib/rt/tlsf/__alloc
    local.set $2
    local.get $2
-   local.set $6
+   local.set $11
    local.get $0
-   local.set $8
-   local.get $4
-   local.set $5
+   local.set $10
+   local.get $8
+   local.set $9
    i32.const 0
    i32.const 1
    i32.ge_s
    drop
-   local.get $6
-   local.get $8
-   local.get $5
+   local.get $11
+   local.get $10
+   local.get $9
    call $~lib/util/number/utoa64_lut
   end
   local.get $1
@@ -34827,7 +35369,9 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
-  (local $9 i64)
+  (local $9 i32)
+  (local $10 i64)
+  (local $11 i32)
   local.get $0
   local.get $1
   i32.const 1
@@ -34920,18 +35464,18 @@
    i32.add
    local.set $4
    local.get $0
-   local.set $7
+   local.set $11
    local.get $2
-   local.set $9
+   local.set $10
    local.get $4
-   local.set $6
+   local.set $9
    i32.const 0
    i32.const 1
    i32.ge_s
    drop
-   local.get $7
+   local.get $11
+   local.get $10
    local.get $9
-   local.get $6
    call $~lib/util/number/utoa64_lut
   end
   local.get $4
@@ -34944,7 +35488,12 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
-  (local $10 i64)
+  (local $10 i32)
+  (local $11 i64)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
   local.get $2
   call $~lib/rt/pure/__retain
   local.set $2
@@ -34969,77 +35518,77 @@
    local.get $0
    i64.load
    call $~lib/util/number/itoa<i64>
-   local.tee $4
-   local.set $5
+   local.tee $5
+   local.set $6
    local.get $2
    call $~lib/rt/pure/__release
-   local.get $5
+   local.get $6
    return
   end
   local.get $2
   call $~lib/string/String#get:length
-  local.set $6
+  local.set $7
   i32.const 21
-  local.get $6
+  local.get $7
   i32.add
   local.get $3
   i32.mul
   i32.const 21
   i32.add
-  local.set $7
-  local.get $7
+  local.set $8
+  local.get $8
   i32.const 1
   i32.shl
   i32.const 1
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
-  local.set $8
-  i32.const 0
   local.set $9
   i32.const 0
-  local.set $4
+  local.set $10
+  i32.const 0
+  local.set $12
   loop $for-loop|0
-   local.get $4
+   local.get $12
    local.get $3
    i32.lt_s
-   local.set $5
-   local.get $5
+   local.set $13
+   local.get $13
    if
     local.get $0
-    local.get $4
+    local.get $12
     i32.const 3
     i32.shl
     i32.add
     i64.load
-    local.set $10
-    local.get $9
-    local.get $8
+    local.set $11
+    local.get $10
     local.get $9
     local.get $10
+    local.get $11
     call $~lib/util/number/itoa_stream<i64>
     i32.add
-    local.set $9
-    local.get $6
+    local.set $10
+    local.get $7
     if
-     local.get $8
      local.get $9
+     local.get $10
      i32.const 1
      i32.shl
      i32.add
      local.get $2
-     local.get $6
+     local.get $7
      i32.const 1
      i32.shl
      call $~lib/memory/memory.copy
-     local.get $9
-     local.get $6
+     local.get $10
+     local.get $7
      i32.add
-     local.set $9
+     local.set $10
     end
-    local.get $4
+    local.get $12
     i32.const 1
     i32.add
-    local.set $4
+    local.set $12
     br $for-loop|0
    end
   end
@@ -35049,35 +35598,35 @@
   i32.shl
   i32.add
   i64.load
-  local.set $10
-  local.get $9
-  local.get $8
+  local.set $11
+  local.get $10
   local.get $9
   local.get $10
+  local.get $11
   call $~lib/util/number/itoa_stream<i64>
   i32.add
-  local.set $9
-  local.get $7
-  local.get $9
+  local.set $10
+  local.get $8
+  local.get $10
   i32.gt_s
   if
-   local.get $8
-   i32.const 0
    local.get $9
+   i32.const 0
+   local.get $10
    call $~lib/string/String#substring
-   local.set $4
+   local.set $14
    local.get $2
    call $~lib/rt/pure/__release
-   local.get $8
+   local.get $9
    call $~lib/rt/pure/__release
-   local.get $4
+   local.get $14
    return
   end
-  local.get $8
-  local.set $4
+  local.get $9
+  local.set $15
   local.get $2
   call $~lib/rt/pure/__release
-  local.get $4
+  local.get $15
  )
  (func $~lib/typedarray/Int64Array#join (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
@@ -35178,7 +35727,10 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i64)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i64)
+  (local $10 i32)
   local.get $0
   i64.const 0
   i64.ne
@@ -35221,26 +35773,26 @@
   else
    local.get $0
    call $~lib/util/number/decimalCount64High
-   local.set $3
-   local.get $3
+   local.set $7
+   local.get $7
    i32.const 1
    i32.shl
    i32.const 1
    call $~lib/rt/tlsf/__alloc
    local.set $1
    local.get $1
-   local.set $5
+   local.set $10
    local.get $0
-   local.set $7
-   local.get $3
-   local.set $4
+   local.set $9
+   local.get $7
+   local.set $8
    i32.const 0
    i32.const 1
    i32.ge_s
    drop
-   local.get $5
-   local.get $7
-   local.get $4
+   local.get $10
+   local.get $9
+   local.get $8
    call $~lib/util/number/utoa64_lut
   end
   local.get $1
@@ -35267,7 +35819,9 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
-  (local $9 i64)
+  (local $9 i32)
+  (local $10 i64)
+  (local $11 i32)
   local.get $0
   local.get $1
   i32.const 1
@@ -35336,18 +35890,18 @@
    i32.add
    local.set $4
    local.get $0
-   local.set $7
+   local.set $11
    local.get $2
-   local.set $9
+   local.set $10
    local.get $4
-   local.set $6
+   local.set $9
    i32.const 0
    i32.const 1
    i32.ge_s
    drop
-   local.get $7
+   local.get $11
+   local.get $10
    local.get $9
-   local.get $6
    call $~lib/util/number/utoa64_lut
   end
   local.get $4
@@ -35360,7 +35914,12 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
-  (local $10 i64)
+  (local $10 i32)
+  (local $11 i64)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
   local.get $2
   call $~lib/rt/pure/__retain
   local.set $2
@@ -35385,77 +35944,77 @@
    local.get $0
    i64.load
    call $~lib/util/number/itoa<u64>
-   local.tee $4
-   local.set $5
+   local.tee $5
+   local.set $6
    local.get $2
    call $~lib/rt/pure/__release
-   local.get $5
+   local.get $6
    return
   end
   local.get $2
   call $~lib/string/String#get:length
-  local.set $6
+  local.set $7
   i32.const 20
-  local.get $6
+  local.get $7
   i32.add
   local.get $3
   i32.mul
   i32.const 20
   i32.add
-  local.set $7
-  local.get $7
+  local.set $8
+  local.get $8
   i32.const 1
   i32.shl
   i32.const 1
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
-  local.set $8
-  i32.const 0
   local.set $9
   i32.const 0
-  local.set $4
+  local.set $10
+  i32.const 0
+  local.set $12
   loop $for-loop|0
-   local.get $4
+   local.get $12
    local.get $3
    i32.lt_s
-   local.set $5
-   local.get $5
+   local.set $13
+   local.get $13
    if
     local.get $0
-    local.get $4
+    local.get $12
     i32.const 3
     i32.shl
     i32.add
     i64.load
-    local.set $10
-    local.get $9
-    local.get $8
+    local.set $11
+    local.get $10
     local.get $9
     local.get $10
+    local.get $11
     call $~lib/util/number/itoa_stream<u64>
     i32.add
-    local.set $9
-    local.get $6
+    local.set $10
+    local.get $7
     if
-     local.get $8
      local.get $9
+     local.get $10
      i32.const 1
      i32.shl
      i32.add
      local.get $2
-     local.get $6
+     local.get $7
      i32.const 1
      i32.shl
      call $~lib/memory/memory.copy
-     local.get $9
-     local.get $6
+     local.get $10
+     local.get $7
      i32.add
-     local.set $9
+     local.set $10
     end
-    local.get $4
+    local.get $12
     i32.const 1
     i32.add
-    local.set $4
+    local.set $12
     br $for-loop|0
    end
   end
@@ -35465,35 +36024,35 @@
   i32.shl
   i32.add
   i64.load
-  local.set $10
-  local.get $9
-  local.get $8
+  local.set $11
+  local.get $10
   local.get $9
   local.get $10
+  local.get $11
   call $~lib/util/number/itoa_stream<u64>
   i32.add
-  local.set $9
-  local.get $7
-  local.get $9
+  local.set $10
+  local.get $8
+  local.get $10
   i32.gt_s
   if
-   local.get $8
-   i32.const 0
    local.get $9
+   i32.const 0
+   local.get $10
    call $~lib/string/String#substring
-   local.set $4
+   local.set $14
    local.get $2
    call $~lib/rt/pure/__release
-   local.get $8
+   local.get $9
    call $~lib/rt/pure/__release
-   local.get $4
+   local.get $14
    return
   end
-  local.get $8
-  local.set $4
+  local.get $9
+  local.set $15
   local.get $2
   call $~lib/rt/pure/__release
-  local.get $4
+  local.get $15
  )
  (func $~lib/typedarray/Uint64Array#join (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
@@ -35600,16 +36159,31 @@
   (local $16 i32)
   (local $17 i32)
   (local $18 i32)
-  (local $19 i64)
+  (local $19 i32)
   (local $20 i64)
   (local $21 i64)
   (local $22 i64)
   (local $23 i64)
-  (local $24 i32)
+  (local $24 i64)
   (local $25 i32)
   (local $26 i32)
   (local $27 i32)
-  (local $28 i64)
+  (local $28 i32)
+  (local $29 i32)
+  (local $30 i32)
+  (local $31 i32)
+  (local $32 i64)
+  (local $33 i32)
+  (local $34 i64)
+  (local $35 i64)
+  (local $36 i64)
+  (local $37 i64)
+  (local $38 i32)
+  (local $39 i32)
+  (local $40 i32)
+  (local $41 i32)
+  (local $42 i32)
+  (local $43 i32)
   i32.const 0
   local.get $4
   i32.sub
@@ -35813,11 +36387,11 @@
     if
      local.get $0
      local.get $15
-     local.tee $18
+     local.tee $19
      i32.const 1
      i32.add
      local.set $15
-     local.get $18
+     local.get $19
      i32.const 1
      i32.shl
      i32.add
@@ -35839,8 +36413,8 @@
     i64.shl
     local.get $13
     i64.add
-    local.set $19
-    local.get $19
+    local.set $20
+    local.get $20
     local.get $5
     i64.le_u
     if
@@ -35849,13 +36423,13 @@
      i32.add
      global.set $~lib/util/number/_K
      local.get $0
-     local.set $24
+     local.set $26
      local.get $15
-     local.set $18
+     local.set $25
      local.get $5
+     local.set $24
+     local.get $20
      local.set $23
-     local.get $19
-     local.set $22
      i32.const 3448
      local.get $14
      i32.const 2
@@ -35865,71 +36439,71 @@
      local.get $7
      i64.extend_i32_s
      i64.shl
-     local.set $21
+     local.set $22
      local.get $10
-     local.set $20
-     local.get $24
-     local.get $18
+     local.set $21
+     local.get $26
+     local.get $25
      i32.const 1
      i32.sub
      i32.const 1
      i32.shl
      i32.add
-     local.set $25
-     local.get $25
+     local.set $27
+     local.get $27
      i32.load16_u
-     local.set $26
+     local.set $28
      loop $while-continue|3
-      local.get $22
-      local.get $20
+      local.get $23
+      local.get $21
       i64.lt_u
       if (result i32)
+       local.get $24
        local.get $23
-       local.get $22
        i64.sub
-       local.get $21
+       local.get $22
        i64.ge_u
       else
        i32.const 0
       end
       if (result i32)
+       local.get $23
        local.get $22
-       local.get $21
        i64.add
-       local.get $20
+       local.get $21
        i64.lt_u
        if (result i32)
         i32.const 1
        else
-        local.get $20
-        local.get $22
-        i64.sub
-        local.get $22
         local.get $21
+        local.get $23
+        i64.sub
+        local.get $23
+        local.get $22
         i64.add
-        local.get $20
+        local.get $21
         i64.sub
         i64.gt_u
        end
       else
        i32.const 0
       end
-      local.set $27
-      local.get $27
+      local.set $30
+      local.get $30
       if
-       local.get $26
+       local.get $28
        i32.const 1
        i32.sub
-       local.set $26
+       local.set $28
+       local.get $23
        local.get $22
-       local.get $21
        i64.add
-       local.set $22
+       local.set $23
        br $while-continue|3
       end
      end
-     local.get $25
-     local.get $26
+     local.get $27
+     local.get $28
      i32.store16
      local.get $15
      return
@@ -35939,8 +36513,8 @@
   end
   loop $while-continue|4
    i32.const 1
-   local.set $16
-   local.get $16
+   local.set $31
+   local.get $31
    if
     local.get $13
     i64.const 10
@@ -35954,8 +36528,8 @@
     local.get $7
     i64.extend_i32_s
     i64.shr_u
-    local.set $23
-    local.get $23
+    local.set $32
+    local.get $32
     local.get $15
     i64.extend_i32_s
     i64.or
@@ -35964,16 +36538,16 @@
     if
      local.get $0
      local.get $15
-     local.tee $26
+     local.tee $33
      i32.const 1
      i32.add
      local.set $15
-     local.get $26
+     local.get $33
      i32.const 1
      i32.shl
      i32.add
      i32.const 48
-     local.get $23
+     local.get $32
      i32.wrap_i64
      i32.const 65535
      i32.and
@@ -36008,79 +36582,79 @@
      i64.mul
      local.set $10
      local.get $0
-     local.set $18
+     local.set $39
      local.get $15
-     local.set $27
+     local.set $38
      local.get $5
-     local.set $28
+     local.set $37
      local.get $13
-     local.set $22
+     local.set $36
      local.get $8
-     local.set $21
+     local.set $35
      local.get $10
-     local.set $20
-     local.get $18
-     local.get $27
+     local.set $34
+     local.get $39
+     local.get $38
      i32.const 1
      i32.sub
      i32.const 1
      i32.shl
      i32.add
-     local.set $26
-     local.get $26
+     local.set $40
+     local.get $40
      i32.load16_u
-     local.set $25
+     local.set $41
      loop $while-continue|6
-      local.get $22
-      local.get $20
+      local.get $36
+      local.get $34
       i64.lt_u
       if (result i32)
-       local.get $28
-       local.get $22
+       local.get $37
+       local.get $36
        i64.sub
-       local.get $21
+       local.get $35
        i64.ge_u
       else
        i32.const 0
       end
       if (result i32)
-       local.get $22
-       local.get $21
+       local.get $36
+       local.get $35
        i64.add
-       local.get $20
+       local.get $34
        i64.lt_u
        if (result i32)
         i32.const 1
        else
-        local.get $20
-        local.get $22
+        local.get $34
+        local.get $36
         i64.sub
-        local.get $22
-        local.get $21
+        local.get $36
+        local.get $35
         i64.add
-        local.get $20
+        local.get $34
         i64.sub
         i64.gt_u
        end
       else
        i32.const 0
       end
-      local.set $24
-      local.get $24
+      local.set $43
+      local.get $43
       if
-       local.get $25
+       local.get $41
        i32.const 1
        i32.sub
-       local.set $25
-       local.get $22
-       local.get $21
+       local.set $41
+       local.get $36
+       local.get $35
        i64.add
-       local.set $22
+       local.set $36
        br $while-continue|6
       end
      end
-     local.get $26
-     local.get $25
+     local.get $40
+     local.get $41
      i32.store16
      local.get $15
      return
@@ -36100,6 +36674,19 @@
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local $22 i32)
+  (local $23 i32)
+  (local $24 i32)
   local.get $2
   i32.eqz
   if
@@ -36189,11 +36776,11 @@
     i32.const 1
     i32.shl
     i32.add
-    local.set $4
-    local.get $4
+    local.set $6
+    local.get $6
     i32.const 2
     i32.add
-    local.get $4
+    local.get $6
     i32.const 0
     local.get $2
     i32.sub
@@ -36226,9 +36813,9 @@
      i32.const 2
      local.get $3
      i32.sub
-     local.set $4
+     local.set $7
      local.get $0
-     local.get $4
+     local.get $7
      i32.const 1
      i32.shl
      i32.add
@@ -36245,30 +36832,30 @@
      i32.or
      i32.store
      i32.const 2
-     local.set $5
+     local.set $8
      loop $for-loop|1
-      local.get $5
-      local.get $4
+      local.get $8
+      local.get $7
       i32.lt_s
-      local.set $6
-      local.get $6
+      local.set $9
+      local.get $9
       if
        local.get $0
-       local.get $5
+       local.get $8
        i32.const 1
        i32.shl
        i32.add
        i32.const 48
        i32.store16
-       local.get $5
+       local.get $8
        i32.const 1
        i32.add
-       local.set $5
+       local.set $8
        br $for-loop|1
       end
      end
      local.get $1
-     local.get $4
+     local.get $7
      i32.add
      return
     else
@@ -36282,48 +36869,48 @@
       local.get $0
       i32.const 4
       i32.add
-      local.set $5
+      local.set $11
       local.get $3
       i32.const 1
       i32.sub
-      local.set $6
-      local.get $6
+      local.set $10
+      local.get $10
       i32.const 0
       i32.lt_s
-      local.set $4
-      local.get $4
+      local.set $12
+      local.get $12
       if
        i32.const 0
-       local.get $6
+       local.get $10
        i32.sub
-       local.set $6
+       local.set $10
       end
-      local.get $6
+      local.get $10
       call $~lib/util/number/decimalCount32
       i32.const 1
       i32.add
-      local.set $7
-      local.get $5
-      local.set $10
-      local.get $6
-      local.set $9
-      local.get $7
-      local.set $8
+      local.set $13
+      local.get $11
+      local.set $16
+      local.get $10
+      local.set $15
+      local.get $13
+      local.set $14
       i32.const 0
       i32.const 1
       i32.ge_s
       drop
-      local.get $10
-      local.get $9
-      local.get $8
+      local.get $16
+      local.get $15
+      local.get $14
       call $~lib/util/number/utoa32_lut
-      local.get $5
+      local.get $11
       i32.const 45
       i32.const 43
-      local.get $4
+      local.get $12
       select
       i32.store16
-      local.get $7
+      local.get $13
       local.set $1
       local.get $1
       i32.const 2
@@ -36333,14 +36920,14 @@
       local.get $1
       i32.const 1
       i32.shl
-      local.set $7
+      local.set $17
       local.get $0
       i32.const 4
       i32.add
       local.get $0
       i32.const 2
       i32.add
-      local.get $7
+      local.get $17
       i32.const 2
       i32.sub
       call $~lib/memory/memory.copy
@@ -36348,58 +36935,58 @@
       i32.const 46
       i32.store16 offset=2
       local.get $0
-      local.get $7
+      local.get $17
       i32.add
       i32.const 101
       i32.store16 offset=2
       local.get $1
       local.get $0
-      local.get $7
+      local.get $17
       i32.add
       i32.const 4
       i32.add
-      local.set $9
+      local.set $19
       local.get $3
       i32.const 1
       i32.sub
-      local.set $8
-      local.get $8
+      local.set $18
+      local.get $18
       i32.const 0
       i32.lt_s
-      local.set $4
-      local.get $4
+      local.set $20
+      local.get $20
       if
        i32.const 0
-       local.get $8
+       local.get $18
        i32.sub
-       local.set $8
+       local.set $18
       end
-      local.get $8
+      local.get $18
       call $~lib/util/number/decimalCount32
       i32.const 1
       i32.add
-      local.set $5
-      local.get $9
-      local.set $11
-      local.get $8
-      local.set $6
-      local.get $5
-      local.set $10
+      local.set $21
+      local.get $19
+      local.set $24
+      local.get $18
+      local.set $23
+      local.get $21
+      local.set $22
       i32.const 0
       i32.const 1
       i32.ge_s
       drop
-      local.get $11
-      local.get $6
-      local.get $10
+      local.get $24
+      local.get $23
+      local.get $22
       call $~lib/util/number/utoa32_lut
-      local.get $9
+      local.get $19
       i32.const 45
       i32.const 43
-      local.get $4
+      local.get $20
       select
       i32.store16
-      local.get $5
+      local.get $21
       i32.add
       local.set $1
       local.get $1
@@ -36430,19 +37017,51 @@
   (local $13 i32)
   (local $14 i32)
   (local $15 i32)
-  (local $16 f64)
-  (local $17 i64)
-  (local $18 i64)
-  (local $19 i64)
-  (local $20 i64)
+  (local $16 i32)
+  (local $17 f64)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
   (local $21 i64)
-  (local $22 i64)
+  (local $22 i32)
   (local $23 i64)
   (local $24 i64)
   (local $25 i64)
-  (local $26 i32)
+  (local $26 i64)
   (local $27 i64)
-  (local $28 i32)
+  (local $28 i64)
+  (local $29 i64)
+  (local $30 i64)
+  (local $31 i64)
+  (local $32 i64)
+  (local $33 i32)
+  (local $34 i32)
+  (local $35 i32)
+  (local $36 i64)
+  (local $37 i64)
+  (local $38 i64)
+  (local $39 i64)
+  (local $40 i64)
+  (local $41 i64)
+  (local $42 i64)
+  (local $43 i64)
+  (local $44 i64)
+  (local $45 i64)
+  (local $46 i32)
+  (local $47 i32)
+  (local $48 i32)
+  (local $49 i64)
+  (local $50 i64)
+  (local $51 i64)
+  (local $52 i64)
+  (local $53 i64)
+  (local $54 i64)
+  (local $55 i64)
+  (local $56 i64)
+  (local $57 i64)
+  (local $58 i64)
+  (local $59 i64)
+  (local $60 i32)
   local.get $1
   f64.const 0
   f64.lt
@@ -36546,47 +37165,47 @@
   local.get $13
   global.set $~lib/util/number/_exp
   global.get $~lib/util/number/_exp
-  local.set $10
+  local.set $16
   i32.const -61
-  local.get $10
+  local.get $16
   i32.sub
   f64.convert_i32_s
   f64.const 0.30102999566398114
   f64.mul
   f64.const 347
   f64.add
-  local.set $16
-  local.get $16
+  local.set $17
+  local.get $17
   i32.trunc_f64_s
-  local.set $15
-  local.get $15
-  local.get $15
+  local.set $18
+  local.get $18
+  local.get $18
   f64.convert_i32_s
-  local.get $16
+  local.get $17
   f64.ne
   i32.add
-  local.set $15
-  local.get $15
+  local.set $18
+  local.get $18
   i32.const 3
   i32.shr_s
   i32.const 1
   i32.add
-  local.set $14
+  local.set $19
   i32.const 348
-  local.get $14
+  local.get $19
   i32.const 3
   i32.shl
   i32.sub
   global.set $~lib/util/number/_K
   i32.const 2576
-  local.get $14
+  local.get $19
   i32.const 3
   i32.shl
   i32.add
   i64.load
   global.set $~lib/util/number/_frc_pow
   i32.const 3272
-  local.get $14
+  local.get $19
   i32.const 1
   i32.shl
   i32.add
@@ -36595,249 +37214,249 @@
   local.get $9
   i64.clz
   i32.wrap_i64
-  local.set $14
+  local.set $20
   local.get $9
-  local.get $14
+  local.get $20
   i64.extend_i32_s
   i64.shl
   local.set $9
   local.get $7
-  local.get $14
+  local.get $20
   i32.sub
   local.set $7
   global.get $~lib/util/number/_frc_pow
-  local.set $12
+  local.set $21
   global.get $~lib/util/number/_exp_pow
-  local.set $15
+  local.set $22
   local.get $9
-  local.set $17
-  local.get $12
-  local.set $11
-  local.get $17
-  i64.const 4294967295
-  i64.and
-  local.set $18
-  local.get $11
-  i64.const 4294967295
-  i64.and
-  local.set $19
-  local.get $17
-  i64.const 32
-  i64.shr_u
-  local.set $20
-  local.get $11
-  i64.const 32
-  i64.shr_u
-  local.set $21
-  local.get $18
-  local.get $19
-  i64.mul
-  local.set $22
-  local.get $20
-  local.get $19
-  i64.mul
-  local.get $22
-  i64.const 32
-  i64.shr_u
-  i64.add
-  local.set $23
-  local.get $18
+  local.set $24
   local.get $21
-  i64.mul
+  local.set $23
+  local.get $24
+  i64.const 4294967295
+  i64.and
+  local.set $25
   local.get $23
   i64.const 4294967295
   i64.and
-  i64.add
-  local.set $24
+  local.set $26
   local.get $24
+  i64.const 32
+  i64.shr_u
+  local.set $27
+  local.get $23
+  i64.const 32
+  i64.shr_u
+  local.set $28
+  local.get $25
+  local.get $26
+  i64.mul
+  local.set $29
+  local.get $27
+  local.get $26
+  i64.mul
+  local.get $29
+  i64.const 32
+  i64.shr_u
+  i64.add
+  local.set $30
+  local.get $25
+  local.get $28
+  i64.mul
+  local.get $30
+  i64.const 4294967295
+  i64.and
+  i64.add
+  local.set $31
+  local.get $31
   i64.const 2147483647
   i64.add
-  local.set $24
-  local.get $23
+  local.set $31
+  local.get $30
   i64.const 32
   i64.shr_u
-  local.set $23
-  local.get $24
+  local.set $30
+  local.get $31
   i64.const 32
   i64.shr_u
-  local.set $24
-  local.get $20
-  local.get $21
+  local.set $31
+  local.get $27
+  local.get $28
   i64.mul
-  local.get $23
+  local.get $30
   i64.add
-  local.get $24
+  local.get $31
   i64.add
-  local.set $24
+  local.set $32
   local.get $7
-  local.set $10
-  local.get $15
-  local.set $13
-  local.get $10
-  local.get $13
+  local.set $34
+  local.get $22
+  local.set $33
+  local.get $34
+  local.get $33
   i32.add
   i32.const 64
   i32.add
-  local.set $10
+  local.set $35
   global.get $~lib/util/number/_frc_plus
-  local.set $17
-  local.get $12
-  local.set $11
-  local.get $17
-  i64.const 4294967295
-  i64.and
-  local.set $23
-  local.get $11
-  i64.const 4294967295
-  i64.and
-  local.set $22
-  local.get $17
-  i64.const 32
-  i64.shr_u
-  local.set $21
-  local.get $11
-  i64.const 32
-  i64.shr_u
-  local.set $20
-  local.get $23
-  local.get $22
-  i64.mul
-  local.set $19
+  local.set $37
   local.get $21
-  local.get $22
+  local.set $36
+  local.get $37
+  i64.const 4294967295
+  i64.and
+  local.set $38
+  local.get $36
+  i64.const 4294967295
+  i64.and
+  local.set $39
+  local.get $37
+  i64.const 32
+  i64.shr_u
+  local.set $40
+  local.get $36
+  i64.const 32
+  i64.shr_u
+  local.set $41
+  local.get $38
+  local.get $39
   i64.mul
-  local.get $19
+  local.set $42
+  local.get $40
+  local.get $39
+  i64.mul
+  local.get $42
   i64.const 32
   i64.shr_u
   i64.add
-  local.set $18
-  local.get $23
-  local.get $20
+  local.set $43
+  local.get $38
+  local.get $41
   i64.mul
-  local.get $18
+  local.get $43
   i64.const 4294967295
   i64.and
   i64.add
-  local.set $25
-  local.get $25
+  local.set $44
+  local.get $44
   i64.const 2147483647
   i64.add
-  local.set $25
-  local.get $18
+  local.set $44
+  local.get $43
   i64.const 32
   i64.shr_u
-  local.set $18
-  local.get $25
+  local.set $43
+  local.get $44
   i64.const 32
   i64.shr_u
-  local.set $25
-  local.get $21
-  local.get $20
+  local.set $44
+  local.get $40
+  local.get $41
   i64.mul
-  local.get $18
+  local.get $43
   i64.add
-  local.get $25
+  local.get $44
   i64.add
   i64.const 1
   i64.sub
-  local.set $25
+  local.set $45
   global.get $~lib/util/number/_exp
-  local.set $26
-  local.get $15
-  local.set $13
-  local.get $26
-  local.get $13
+  local.set $47
+  local.get $22
+  local.set $46
+  local.get $47
+  local.get $46
   i32.add
   i32.const 64
   i32.add
-  local.set $26
+  local.set $48
   global.get $~lib/util/number/_frc_minus
-  local.set $17
-  local.get $12
-  local.set $11
-  local.get $17
-  i64.const 4294967295
-  i64.and
-  local.set $18
-  local.get $11
-  i64.const 4294967295
-  i64.and
-  local.set $19
-  local.get $17
-  i64.const 32
-  i64.shr_u
-  local.set $20
-  local.get $11
-  i64.const 32
-  i64.shr_u
-  local.set $21
-  local.get $18
-  local.get $19
-  i64.mul
-  local.set $22
-  local.get $20
-  local.get $19
-  i64.mul
-  local.get $22
-  i64.const 32
-  i64.shr_u
-  i64.add
-  local.set $23
-  local.get $18
+  local.set $50
   local.get $21
+  local.set $49
+  local.get $50
+  i64.const 4294967295
+  i64.and
+  local.set $51
+  local.get $49
+  i64.const 4294967295
+  i64.and
+  local.set $52
+  local.get $50
+  i64.const 32
+  i64.shr_u
+  local.set $53
+  local.get $49
+  i64.const 32
+  i64.shr_u
+  local.set $54
+  local.get $51
+  local.get $52
   i64.mul
-  local.get $23
+  local.set $55
+  local.get $53
+  local.get $52
+  i64.mul
+  local.get $55
+  i64.const 32
+  i64.shr_u
+  i64.add
+  local.set $56
+  local.get $51
+  local.get $54
+  i64.mul
+  local.get $56
   i64.const 4294967295
   i64.and
   i64.add
-  local.set $27
-  local.get $27
+  local.set $57
+  local.get $57
   i64.const 2147483647
   i64.add
-  local.set $27
-  local.get $23
+  local.set $57
+  local.get $56
   i64.const 32
   i64.shr_u
-  local.set $23
-  local.get $27
+  local.set $56
+  local.get $57
   i64.const 32
   i64.shr_u
-  local.set $27
-  local.get $20
-  local.get $21
+  local.set $57
+  local.get $53
+  local.get $54
   i64.mul
-  local.get $23
+  local.get $56
   i64.add
-  local.get $27
+  local.get $57
   i64.add
   i64.const 1
   i64.add
-  local.set $27
-  local.get $25
-  local.get $27
+  local.set $58
+  local.get $45
+  local.get $58
   i64.sub
-  local.set $23
+  local.set $59
   local.get $4
-  local.get $24
-  local.get $10
-  local.get $25
-  local.get $26
-  local.get $23
+  local.get $32
+  local.get $35
+  local.get $45
+  local.get $48
+  local.get $59
   local.get $3
   call $~lib/util/number/genDigits
-  local.set $28
+  local.set $60
   local.get $0
   local.get $2
   i32.const 1
   i32.shl
   i32.add
-  local.get $28
+  local.get $60
   local.get $2
   i32.sub
   global.get $~lib/util/number/_K
   call $~lib/util/number/prettify
-  local.set $28
-  local.get $28
+  local.set $60
+  local.get $60
   local.get $2
   i32.add
  )
@@ -36988,7 +37607,12 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
-  (local $10 f32)
+  (local $10 i32)
+  (local $11 f32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
   local.get $2
   call $~lib/rt/pure/__retain
   local.set $2
@@ -37014,78 +37638,78 @@
    f32.load
    f64.promote_f32
    call $~lib/util/number/dtoa
-   local.tee $4
-   local.set $5
+   local.tee $5
+   local.set $6
    local.get $2
    call $~lib/rt/pure/__release
-   local.get $5
+   local.get $6
    return
   end
   local.get $2
   call $~lib/string/String#get:length
-  local.set $6
+  local.set $7
   i32.const 28
-  local.get $6
+  local.get $7
   i32.add
   local.get $3
   i32.mul
   i32.const 28
   i32.add
-  local.set $7
-  local.get $7
+  local.set $8
+  local.get $8
   i32.const 1
   i32.shl
   i32.const 1
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
-  local.set $8
-  i32.const 0
   local.set $9
   i32.const 0
-  local.set $4
+  local.set $10
+  i32.const 0
+  local.set $12
   loop $for-loop|0
-   local.get $4
+   local.get $12
    local.get $3
    i32.lt_s
-   local.set $5
-   local.get $5
+   local.set $13
+   local.get $13
    if
     local.get $0
-    local.get $4
+    local.get $12
     i32.const 2
     i32.shl
     i32.add
     f32.load
-    local.set $10
-    local.get $9
-    local.get $8
+    local.set $11
+    local.get $10
     local.get $9
     local.get $10
+    local.get $11
     f64.promote_f32
     call $~lib/util/number/dtoa_stream
     i32.add
-    local.set $9
-    local.get $6
+    local.set $10
+    local.get $7
     if
-     local.get $8
      local.get $9
+     local.get $10
      i32.const 1
      i32.shl
      i32.add
      local.get $2
-     local.get $6
+     local.get $7
      i32.const 1
      i32.shl
      call $~lib/memory/memory.copy
-     local.get $9
-     local.get $6
+     local.get $10
+     local.get $7
      i32.add
-     local.set $9
+     local.set $10
     end
-    local.get $4
+    local.get $12
     i32.const 1
     i32.add
-    local.set $4
+    local.set $12
     br $for-loop|0
    end
   end
@@ -37095,36 +37719,36 @@
   i32.shl
   i32.add
   f32.load
-  local.set $10
-  local.get $9
-  local.get $8
+  local.set $11
+  local.get $10
   local.get $9
   local.get $10
+  local.get $11
   f64.promote_f32
   call $~lib/util/number/dtoa_stream
   i32.add
-  local.set $9
-  local.get $7
-  local.get $9
+  local.set $10
+  local.get $8
+  local.get $10
   i32.gt_s
   if
-   local.get $8
-   i32.const 0
    local.get $9
+   i32.const 0
+   local.get $10
    call $~lib/string/String#substring
-   local.set $4
+   local.set $14
    local.get $2
    call $~lib/rt/pure/__release
-   local.get $8
+   local.get $9
    call $~lib/rt/pure/__release
-   local.get $4
+   local.get $14
    return
   end
-  local.get $8
-  local.set $4
+  local.get $9
+  local.set $15
   local.get $2
   call $~lib/rt/pure/__release
-  local.get $4
+  local.get $15
  )
  (func $~lib/typedarray/Float32Array#join (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
@@ -37226,7 +37850,12 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
-  (local $10 f64)
+  (local $10 i32)
+  (local $11 f64)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
   local.get $2
   call $~lib/rt/pure/__retain
   local.set $2
@@ -37251,77 +37880,77 @@
    local.get $0
    f64.load
    call $~lib/util/number/dtoa
-   local.tee $4
-   local.set $5
+   local.tee $5
+   local.set $6
    local.get $2
    call $~lib/rt/pure/__release
-   local.get $5
+   local.get $6
    return
   end
   local.get $2
   call $~lib/string/String#get:length
-  local.set $6
+  local.set $7
   i32.const 28
-  local.get $6
+  local.get $7
   i32.add
   local.get $3
   i32.mul
   i32.const 28
   i32.add
-  local.set $7
-  local.get $7
+  local.set $8
+  local.get $8
   i32.const 1
   i32.shl
   i32.const 1
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
-  local.set $8
-  i32.const 0
   local.set $9
   i32.const 0
-  local.set $4
+  local.set $10
+  i32.const 0
+  local.set $12
   loop $for-loop|0
-   local.get $4
+   local.get $12
    local.get $3
    i32.lt_s
-   local.set $5
-   local.get $5
+   local.set $13
+   local.get $13
    if
     local.get $0
-    local.get $4
+    local.get $12
     i32.const 3
     i32.shl
     i32.add
     f64.load
-    local.set $10
-    local.get $9
-    local.get $8
+    local.set $11
+    local.get $10
     local.get $9
     local.get $10
+    local.get $11
     call $~lib/util/number/dtoa_stream
     i32.add
-    local.set $9
-    local.get $6
+    local.set $10
+    local.get $7
     if
-     local.get $8
      local.get $9
+     local.get $10
      i32.const 1
      i32.shl
      i32.add
      local.get $2
-     local.get $6
+     local.get $7
      i32.const 1
      i32.shl
      call $~lib/memory/memory.copy
-     local.get $9
-     local.get $6
+     local.get $10
+     local.get $7
      i32.add
-     local.set $9
+     local.set $10
     end
-    local.get $4
+    local.get $12
     i32.const 1
     i32.add
-    local.set $4
+    local.set $12
     br $for-loop|0
    end
   end
@@ -37331,35 +37960,35 @@
   i32.shl
   i32.add
   f64.load
-  local.set $10
-  local.get $9
-  local.get $8
+  local.set $11
+  local.get $10
   local.get $9
   local.get $10
+  local.get $11
   call $~lib/util/number/dtoa_stream
   i32.add
-  local.set $9
-  local.get $7
-  local.get $9
+  local.set $10
+  local.get $8
+  local.get $10
   i32.gt_s
   if
-   local.get $8
-   i32.const 0
    local.get $9
+   i32.const 0
+   local.get $10
    call $~lib/string/String#substring
-   local.set $4
+   local.set $14
    local.get $2
    call $~lib/rt/pure/__release
-   local.get $8
+   local.get $9
    call $~lib/rt/pure/__release
-   local.get $4
+   local.get $14
    return
   end
-  local.get $8
-  local.set $4
+  local.get $9
+  local.set $15
   local.get $2
   call $~lib/rt/pure/__release
-  local.get $4
+  local.get $15
  )
  (func $~lib/typedarray/Float64Array#join (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
@@ -37498,6 +38127,7 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $0
@@ -37606,10 +38236,10 @@
   local.get $5
   call $~lib/rt/pure/__release
   local.get $9
-  local.set $8
+  local.set $10
   local.get $0
   call $~lib/rt/pure/__release
-  local.get $8
+  local.get $10
  )
  (func $~lib/typedarray/Uint8Array.wrap@varargs (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $2of2
@@ -37640,6 +38270,14 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
   local.get $0
   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
   local.set $3
@@ -37659,11 +38297,11 @@
    select
   else
    local.get $1
-   local.tee $4
+   local.tee $6
    local.get $3
-   local.tee $5
-   local.get $4
-   local.get $5
+   local.tee $7
+   local.get $6
+   local.get $7
    i32.lt_s
    select
   end
@@ -37675,20 +38313,20 @@
    local.get $3
    local.get $2
    i32.add
-   local.tee $4
+   local.tee $8
    i32.const 0
-   local.tee $5
-   local.get $4
-   local.get $5
+   local.tee $9
+   local.get $8
+   local.get $9
    i32.gt_s
    select
   else
    local.get $2
-   local.tee $4
+   local.tee $10
    local.get $3
-   local.tee $5
-   local.get $4
-   local.get $5
+   local.tee $11
+   local.get $10
+   local.get $11
    i32.lt_s
    select
   end
@@ -37696,25 +38334,25 @@
   local.get $2
   local.get $1
   i32.sub
-  local.tee $4
+  local.tee $12
   i32.const 0
-  local.tee $5
-  local.get $4
-  local.get $5
+  local.tee $13
+  local.get $12
+  local.get $13
   i32.gt_s
   select
-  local.set $6
-  local.get $6
+  local.set $14
+  local.get $14
   i32.const 0
   call $~lib/rt/tlsf/__alloc
-  local.set $7
-  local.get $7
+  local.set $15
+  local.get $15
   local.get $0
   local.get $1
   i32.add
-  local.get $6
+  local.get $14
   call $~lib/memory/memory.copy
-  local.get $7
+  local.get $15
   call $~lib/rt/pure/__retain
  )
  (func $~lib/typedarray/Int8Array.wrap (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -37725,6 +38363,7 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $0
@@ -37833,10 +38472,10 @@
   local.get $5
   call $~lib/rt/pure/__release
   local.get $9
-  local.set $8
+  local.set $10
   local.get $0
   call $~lib/rt/pure/__release
-  local.get $8
+  local.get $10
  )
  (func $~lib/typedarray/Int8Array.wrap@varargs (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $2of2
@@ -37870,6 +38509,9 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
   global.get $std/typedarray/testArrayWrapValues
   call $~lib/rt/pure/__retain
   local.set $0
@@ -37929,25 +38571,25 @@
   global.set $~argumentsLength
   i32.const 0
   call $~lib/typedarray/Int8Array.wrap@varargs
-  local.set $5
+  local.set $8
   local.get $7
   call $~lib/rt/pure/__release
-  local.get $5
+  local.get $8
   local.set $7
   i32.const 0
-  local.set $5
+  local.set $9
   loop $for-loop|1
-   local.get $5
+   local.get $9
    local.get $1
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $10
+   local.get $10
    if
     local.get $3
-    local.get $5
+    local.get $9
     call $~lib/typedarray/Int8Array#__get
     local.get $7
-    local.get $5
+    local.get $9
     call $~lib/typedarray/Int8Array#__get
     i32.eq
     i32.eqz
@@ -37959,10 +38601,10 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $5
+    local.get $9
     i32.const 1
     i32.add
-    local.set $5
+    local.set $9
     br $for-loop|1
    end
   end
@@ -37986,6 +38628,9 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
   global.get $std/typedarray/testArrayWrapValues
   call $~lib/rt/pure/__retain
   local.set $0
@@ -38045,25 +38690,25 @@
   global.set $~argumentsLength
   i32.const 0
   call $~lib/typedarray/Uint8Array.wrap@varargs
-  local.set $5
+  local.set $8
   local.get $7
   call $~lib/rt/pure/__release
-  local.get $5
+  local.get $8
   local.set $7
   i32.const 0
-  local.set $5
+  local.set $9
   loop $for-loop|1
-   local.get $5
+   local.get $9
    local.get $1
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $10
+   local.get $10
    if
     local.get $3
-    local.get $5
+    local.get $9
     call $~lib/typedarray/Uint8Array#__get
     local.get $7
-    local.get $5
+    local.get $9
     call $~lib/typedarray/Uint8Array#__get
     i32.eq
     i32.eqz
@@ -38075,10 +38720,10 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $5
+    local.get $9
     i32.const 1
     i32.add
-    local.set $5
+    local.set $9
     br $for-loop|1
    end
   end
@@ -38101,6 +38746,7 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $0
@@ -38209,10 +38855,10 @@
   local.get $5
   call $~lib/rt/pure/__release
   local.get $9
-  local.set $8
+  local.set $10
   local.get $0
   call $~lib/rt/pure/__release
-  local.get $8
+  local.get $10
  )
  (func $~lib/typedarray/Uint8ClampedArray.wrap@varargs (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $2of2
@@ -38246,6 +38892,9 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
   global.get $std/typedarray/testArrayWrapValues
   call $~lib/rt/pure/__retain
   local.set $0
@@ -38307,25 +38956,25 @@
   global.set $~argumentsLength
   i32.const 0
   call $~lib/typedarray/Uint8ClampedArray.wrap@varargs
-  local.set $5
+  local.set $8
   local.get $7
   call $~lib/rt/pure/__release
-  local.get $5
+  local.get $8
   local.set $7
   i32.const 0
-  local.set $5
+  local.set $9
   loop $for-loop|1
-   local.get $5
+   local.get $9
    local.get $1
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $10
+   local.get $10
    if
     local.get $3
-    local.get $5
+    local.get $9
     call $~lib/typedarray/Uint8ClampedArray#__get
     local.get $7
-    local.get $5
+    local.get $9
     call $~lib/typedarray/Uint8ClampedArray#__get
     i32.eq
     i32.eqz
@@ -38337,10 +38986,10 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $5
+    local.get $9
     i32.const 1
     i32.add
-    local.set $5
+    local.set $9
     br $for-loop|1
    end
   end
@@ -38363,6 +39012,7 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $0
@@ -38471,10 +39121,10 @@
   local.get $5
   call $~lib/rt/pure/__release
   local.get $9
-  local.set $8
+  local.set $10
   local.get $0
   call $~lib/rt/pure/__release
-  local.get $8
+  local.get $10
  )
  (func $~lib/typedarray/Int16Array.wrap@varargs (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $2of2
@@ -38508,6 +39158,9 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
   global.get $std/typedarray/testArrayWrapValues
   call $~lib/rt/pure/__retain
   local.set $0
@@ -38573,25 +39226,25 @@
   global.set $~argumentsLength
   i32.const 0
   call $~lib/typedarray/Int16Array.wrap@varargs
-  local.set $5
+  local.set $8
   local.get $7
   call $~lib/rt/pure/__release
-  local.get $5
+  local.get $8
   local.set $7
   i32.const 0
-  local.set $5
+  local.set $9
   loop $for-loop|1
-   local.get $5
+   local.get $9
    local.get $1
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $10
+   local.get $10
    if
     local.get $3
-    local.get $5
+    local.get $9
     call $~lib/typedarray/Int16Array#__get
     local.get $7
-    local.get $5
+    local.get $9
     call $~lib/typedarray/Int16Array#__get
     i32.eq
     i32.eqz
@@ -38603,10 +39256,10 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $5
+    local.get $9
     i32.const 1
     i32.add
-    local.set $5
+    local.set $9
     br $for-loop|1
    end
   end
@@ -38629,6 +39282,7 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $0
@@ -38737,10 +39391,10 @@
   local.get $5
   call $~lib/rt/pure/__release
   local.get $9
-  local.set $8
+  local.set $10
   local.get $0
   call $~lib/rt/pure/__release
-  local.get $8
+  local.get $10
  )
  (func $~lib/typedarray/Uint16Array.wrap@varargs (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $2of2
@@ -38774,6 +39428,9 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
   global.get $std/typedarray/testArrayWrapValues
   call $~lib/rt/pure/__retain
   local.set $0
@@ -38839,25 +39496,25 @@
   global.set $~argumentsLength
   i32.const 0
   call $~lib/typedarray/Uint16Array.wrap@varargs
-  local.set $5
+  local.set $8
   local.get $7
   call $~lib/rt/pure/__release
-  local.get $5
+  local.get $8
   local.set $7
   i32.const 0
-  local.set $5
+  local.set $9
   loop $for-loop|1
-   local.get $5
+   local.get $9
    local.get $1
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $10
+   local.get $10
    if
     local.get $3
-    local.get $5
+    local.get $9
     call $~lib/typedarray/Uint16Array#__get
     local.get $7
-    local.get $5
+    local.get $9
     call $~lib/typedarray/Uint16Array#__get
     i32.eq
     i32.eqz
@@ -38869,10 +39526,10 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $5
+    local.get $9
     i32.const 1
     i32.add
-    local.set $5
+    local.set $9
     br $for-loop|1
    end
   end
@@ -38895,6 +39552,7 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $0
@@ -39003,10 +39661,10 @@
   local.get $5
   call $~lib/rt/pure/__release
   local.get $9
-  local.set $8
+  local.set $10
   local.get $0
   call $~lib/rt/pure/__release
-  local.get $8
+  local.get $10
  )
  (func $~lib/typedarray/Int32Array.wrap@varargs (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $2of2
@@ -39040,6 +39698,9 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
   global.get $std/typedarray/testArrayWrapValues
   call $~lib/rt/pure/__retain
   local.set $0
@@ -39105,25 +39766,25 @@
   global.set $~argumentsLength
   i32.const 0
   call $~lib/typedarray/Int32Array.wrap@varargs
-  local.set $5
+  local.set $8
   local.get $7
   call $~lib/rt/pure/__release
-  local.get $5
+  local.get $8
   local.set $7
   i32.const 0
-  local.set $5
+  local.set $9
   loop $for-loop|1
-   local.get $5
+   local.get $9
    local.get $1
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $10
+   local.get $10
    if
     local.get $3
-    local.get $5
+    local.get $9
     call $~lib/typedarray/Int32Array#__get
     local.get $7
-    local.get $5
+    local.get $9
     call $~lib/typedarray/Int32Array#__get
     i32.eq
     i32.eqz
@@ -39135,10 +39796,10 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $5
+    local.get $9
     i32.const 1
     i32.add
-    local.set $5
+    local.set $9
     br $for-loop|1
    end
   end
@@ -39161,6 +39822,7 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $0
@@ -39269,10 +39931,10 @@
   local.get $5
   call $~lib/rt/pure/__release
   local.get $9
-  local.set $8
+  local.set $10
   local.get $0
   call $~lib/rt/pure/__release
-  local.get $8
+  local.get $10
  )
  (func $~lib/typedarray/Uint32Array.wrap@varargs (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $2of2
@@ -39306,6 +39968,9 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
   global.get $std/typedarray/testArrayWrapValues
   call $~lib/rt/pure/__retain
   local.set $0
@@ -39373,25 +40038,25 @@
   global.set $~argumentsLength
   i32.const 0
   call $~lib/typedarray/Uint32Array.wrap@varargs
-  local.set $5
+  local.set $8
   local.get $7
   call $~lib/rt/pure/__release
-  local.get $5
+  local.get $8
   local.set $7
   i32.const 0
-  local.set $5
+  local.set $9
   loop $for-loop|1
-   local.get $5
+   local.get $9
    local.get $1
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $10
+   local.get $10
    if
     local.get $3
-    local.get $5
+    local.get $9
     call $~lib/typedarray/Uint32Array#__get
     local.get $7
-    local.get $5
+    local.get $9
     call $~lib/typedarray/Uint32Array#__get
     i32.eq
     i32.eqz
@@ -39403,10 +40068,10 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $5
+    local.get $9
     i32.const 1
     i32.add
-    local.set $5
+    local.set $9
     br $for-loop|1
    end
   end
@@ -39429,6 +40094,7 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $0
@@ -39537,10 +40203,10 @@
   local.get $5
   call $~lib/rt/pure/__release
   local.get $9
-  local.set $8
+  local.set $10
   local.get $0
   call $~lib/rt/pure/__release
-  local.get $8
+  local.get $10
  )
  (func $~lib/typedarray/Int64Array.wrap@varargs (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $2of2
@@ -39574,6 +40240,9 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
   global.get $std/typedarray/testArrayWrapValues
   call $~lib/rt/pure/__retain
   local.set $0
@@ -39644,25 +40313,25 @@
   global.set $~argumentsLength
   i32.const 0
   call $~lib/typedarray/Int64Array.wrap@varargs
-  local.set $5
+  local.set $8
   local.get $7
   call $~lib/rt/pure/__release
-  local.get $5
+  local.get $8
   local.set $7
   i32.const 0
-  local.set $5
+  local.set $9
   loop $for-loop|1
-   local.get $5
+   local.get $9
    local.get $1
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $10
+   local.get $10
    if
     local.get $3
-    local.get $5
+    local.get $9
     call $~lib/typedarray/Int64Array#__get
     local.get $7
-    local.get $5
+    local.get $9
     call $~lib/typedarray/Int64Array#__get
     i64.eq
     i32.eqz
@@ -39674,10 +40343,10 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $5
+    local.get $9
     i32.const 1
     i32.add
-    local.set $5
+    local.set $9
     br $for-loop|1
    end
   end
@@ -39700,6 +40369,7 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $0
@@ -39808,10 +40478,10 @@
   local.get $5
   call $~lib/rt/pure/__release
   local.get $9
-  local.set $8
+  local.set $10
   local.get $0
   call $~lib/rt/pure/__release
-  local.get $8
+  local.get $10
  )
  (func $~lib/typedarray/Uint64Array.wrap@varargs (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $2of2
@@ -39845,6 +40515,9 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
   global.get $std/typedarray/testArrayWrapValues
   call $~lib/rt/pure/__retain
   local.set $0
@@ -39917,25 +40590,25 @@
   global.set $~argumentsLength
   i32.const 0
   call $~lib/typedarray/Uint64Array.wrap@varargs
-  local.set $5
+  local.set $8
   local.get $7
   call $~lib/rt/pure/__release
-  local.get $5
+  local.get $8
   local.set $7
   i32.const 0
-  local.set $5
+  local.set $9
   loop $for-loop|1
-   local.get $5
+   local.get $9
    local.get $1
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $10
+   local.get $10
    if
     local.get $3
-    local.get $5
+    local.get $9
     call $~lib/typedarray/Uint64Array#__get
     local.get $7
-    local.get $5
+    local.get $9
     call $~lib/typedarray/Uint64Array#__get
     i64.eq
     i32.eqz
@@ -39947,10 +40620,10 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $5
+    local.get $9
     i32.const 1
     i32.add
-    local.set $5
+    local.set $9
     br $for-loop|1
    end
   end
@@ -39973,6 +40646,7 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $0
@@ -40081,10 +40755,10 @@
   local.get $5
   call $~lib/rt/pure/__release
   local.get $9
-  local.set $8
+  local.set $10
   local.get $0
   call $~lib/rt/pure/__release
-  local.get $8
+  local.get $10
  )
  (func $~lib/typedarray/Float32Array.wrap@varargs (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $2of2
@@ -40118,6 +40792,9 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
   global.get $std/typedarray/testArrayWrapValues
   call $~lib/rt/pure/__retain
   local.set $0
@@ -40192,25 +40869,25 @@
   global.set $~argumentsLength
   i32.const 0
   call $~lib/typedarray/Float32Array.wrap@varargs
-  local.set $5
+  local.set $8
   local.get $7
   call $~lib/rt/pure/__release
-  local.get $5
+  local.get $8
   local.set $7
   i32.const 0
-  local.set $5
+  local.set $9
   loop $for-loop|1
-   local.get $5
+   local.get $9
    local.get $1
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $10
+   local.get $10
    if
     local.get $3
-    local.get $5
+    local.get $9
     call $~lib/typedarray/Float32Array#__get
     local.get $7
-    local.get $5
+    local.get $9
     call $~lib/typedarray/Float32Array#__get
     f32.eq
     i32.eqz
@@ -40222,10 +40899,10 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $5
+    local.get $9
     i32.const 1
     i32.add
-    local.set $5
+    local.set $9
     br $for-loop|1
    end
   end
@@ -40248,6 +40925,7 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.set $0
@@ -40356,10 +41034,10 @@
   local.get $5
   call $~lib/rt/pure/__release
   local.get $9
-  local.set $8
+  local.set $10
   local.get $0
   call $~lib/rt/pure/__release
-  local.get $8
+  local.get $10
  )
  (func $~lib/typedarray/Float64Array.wrap@varargs (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $2of2
@@ -40393,6 +41071,9 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
   global.get $std/typedarray/testArrayWrapValues
   call $~lib/rt/pure/__retain
   local.set $0
@@ -40469,25 +41150,25 @@
   global.set $~argumentsLength
   i32.const 0
   call $~lib/typedarray/Float64Array.wrap@varargs
-  local.set $5
+  local.set $8
   local.get $7
   call $~lib/rt/pure/__release
-  local.get $5
+  local.get $8
   local.set $7
   i32.const 0
-  local.set $5
+  local.set $9
   loop $for-loop|1
-   local.get $5
+   local.get $9
    local.get $1
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $10
+   local.get $10
    if
     local.get $3
-    local.get $5
+    local.get $9
     call $~lib/typedarray/Float64Array#__get
     local.get $7
-    local.get $5
+    local.get $9
     call $~lib/typedarray/Float64Array#__get
     f64.eq
     i32.eqz
@@ -40499,10 +41180,10 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $5
+    local.get $9
     i32.const 1
     i32.add
-    local.set $5
+    local.set $9
     br $for-loop|1
    end
   end
@@ -41538,6 +42219,16 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
@@ -41607,7 +42298,7 @@
   i32.const 3936
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $6
+  local.tee $7
   call $std/typedarray/valuesEqual<~lib/typedarray/Int8Array>
   local.get $4
   global.get $std/typedarray/setSource2
@@ -41620,7 +42311,7 @@
   i32.const 4016
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $7
+  local.tee $10
   call $std/typedarray/valuesEqual<~lib/typedarray/Int8Array>
   local.get $4
   local.get $0
@@ -41633,7 +42324,7 @@
   i32.const 4048
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $8
+  local.tee $13
   call $std/typedarray/valuesEqual<~lib/typedarray/Int8Array>
   i32.const 1
   drop
@@ -41648,9 +42339,9 @@
   i32.const 4080
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $9
+  local.tee $16
   call $std/typedarray/valuesEqual<~lib/typedarray/Int8Array>
-  local.get $9
+  local.get $16
   call $~lib/rt/pure/__release
   local.get $4
   local.get $1
@@ -41673,9 +42364,9 @@
   i32.const 4112
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $5
+  local.tee $19
   call $std/typedarray/valuesEqual<~lib/typedarray/Int8Array>
-  local.get $5
+  local.get $19
   call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
@@ -41687,11 +42378,11 @@
   call $~lib/rt/pure/__release
   local.get $4
   call $~lib/rt/pure/__release
-  local.get $6
-  call $~lib/rt/pure/__release
   local.get $7
   call $~lib/rt/pure/__release
-  local.get $8
+  local.get $10
+  call $~lib/rt/pure/__release
+  local.get $13
   call $~lib/rt/pure/__release
  )
  (func $~lib/typedarray/Uint8Array#set<~lib/array/Array<i32>> (param $0 i32) (param $1 i32) (param $2 i32)
@@ -42720,6 +43411,16 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
@@ -42789,7 +43490,7 @@
   i32.const 4144
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $6
+  local.tee $7
   call $std/typedarray/valuesEqual<~lib/typedarray/Uint8Array>
   local.get $4
   global.get $std/typedarray/setSource2
@@ -42802,7 +43503,7 @@
   i32.const 4224
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $7
+  local.tee $10
   call $std/typedarray/valuesEqual<~lib/typedarray/Uint8Array>
   local.get $4
   local.get $0
@@ -42815,7 +43516,7 @@
   i32.const 4256
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $8
+  local.tee $13
   call $std/typedarray/valuesEqual<~lib/typedarray/Uint8Array>
   i32.const 1
   drop
@@ -42830,9 +43531,9 @@
   i32.const 4288
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $9
+  local.tee $16
   call $std/typedarray/valuesEqual<~lib/typedarray/Uint8Array>
-  local.get $9
+  local.get $16
   call $~lib/rt/pure/__release
   local.get $4
   local.get $1
@@ -42855,9 +43556,9 @@
   i32.const 4320
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $5
+  local.tee $19
   call $std/typedarray/valuesEqual<~lib/typedarray/Uint8Array>
-  local.get $5
+  local.get $19
   call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
@@ -42869,11 +43570,11 @@
   call $~lib/rt/pure/__release
   local.get $4
   call $~lib/rt/pure/__release
-  local.get $6
-  call $~lib/rt/pure/__release
   local.get $7
   call $~lib/rt/pure/__release
-  local.get $8
+  local.get $10
+  call $~lib/rt/pure/__release
+  local.get $13
   call $~lib/rt/pure/__release
  )
  (func $~lib/typedarray/Uint8ClampedArray#set<~lib/array/Array<i32>> (param $0 i32) (param $1 i32) (param $2 i32)
@@ -43974,6 +44675,16 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
@@ -44043,7 +44754,7 @@
   i32.const 4352
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $6
+  local.tee $7
   call $std/typedarray/valuesEqual<~lib/typedarray/Uint8ClampedArray>
   local.get $4
   global.get $std/typedarray/setSource2
@@ -44056,7 +44767,7 @@
   i32.const 4448
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $7
+  local.tee $10
   call $std/typedarray/valuesEqual<~lib/typedarray/Uint8ClampedArray>
   local.get $4
   local.get $0
@@ -44069,7 +44780,7 @@
   i32.const 4480
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $8
+  local.tee $13
   call $std/typedarray/valuesEqual<~lib/typedarray/Uint8ClampedArray>
   i32.const 1
   drop
@@ -44084,9 +44795,9 @@
   i32.const 4512
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $9
+  local.tee $16
   call $std/typedarray/valuesEqual<~lib/typedarray/Uint8ClampedArray>
-  local.get $9
+  local.get $16
   call $~lib/rt/pure/__release
   local.get $4
   local.get $1
@@ -44109,9 +44820,9 @@
   i32.const 4544
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $5
+  local.tee $19
   call $std/typedarray/valuesEqual<~lib/typedarray/Uint8ClampedArray>
-  local.get $5
+  local.get $19
   call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
@@ -44123,11 +44834,11 @@
   call $~lib/rt/pure/__release
   local.get $4
   call $~lib/rt/pure/__release
-  local.get $6
-  call $~lib/rt/pure/__release
   local.get $7
   call $~lib/rt/pure/__release
-  local.get $8
+  local.get $10
+  call $~lib/rt/pure/__release
+  local.get $13
   call $~lib/rt/pure/__release
  )
  (func $~lib/typedarray/Int16Array#set<~lib/array/Array<i32>> (param $0 i32) (param $1 i32) (param $2 i32)
@@ -45211,6 +45922,16 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
@@ -45280,7 +46001,7 @@
   i32.const 4576
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $6
+  local.tee $7
   call $std/typedarray/valuesEqual<~lib/typedarray/Int16Array>
   local.get $4
   global.get $std/typedarray/setSource2
@@ -45293,7 +46014,7 @@
   i32.const 4672
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $7
+  local.tee $10
   call $std/typedarray/valuesEqual<~lib/typedarray/Int16Array>
   local.get $4
   local.get $0
@@ -45306,7 +46027,7 @@
   i32.const 4720
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $8
+  local.tee $13
   call $std/typedarray/valuesEqual<~lib/typedarray/Int16Array>
   i32.const 1
   drop
@@ -45321,9 +46042,9 @@
   i32.const 4768
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $9
+  local.tee $16
   call $std/typedarray/valuesEqual<~lib/typedarray/Int16Array>
-  local.get $9
+  local.get $16
   call $~lib/rt/pure/__release
   local.get $4
   local.get $1
@@ -45346,9 +46067,9 @@
   i32.const 4816
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $5
+  local.tee $19
   call $std/typedarray/valuesEqual<~lib/typedarray/Int16Array>
-  local.get $5
+  local.get $19
   call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
@@ -45360,11 +46081,11 @@
   call $~lib/rt/pure/__release
   local.get $4
   call $~lib/rt/pure/__release
-  local.get $6
-  call $~lib/rt/pure/__release
   local.get $7
   call $~lib/rt/pure/__release
-  local.get $8
+  local.get $10
+  call $~lib/rt/pure/__release
+  local.get $13
   call $~lib/rt/pure/__release
  )
  (func $~lib/typedarray/Uint16Array#set<~lib/array/Array<i32>> (param $0 i32) (param $1 i32) (param $2 i32)
@@ -46448,6 +47169,16 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
@@ -46517,7 +47248,7 @@
   i32.const 4864
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $6
+  local.tee $7
   call $std/typedarray/valuesEqual<~lib/typedarray/Uint16Array>
   local.get $4
   global.get $std/typedarray/setSource2
@@ -46530,7 +47261,7 @@
   i32.const 4960
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $7
+  local.tee $10
   call $std/typedarray/valuesEqual<~lib/typedarray/Uint16Array>
   local.get $4
   local.get $0
@@ -46543,7 +47274,7 @@
   i32.const 5008
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $8
+  local.tee $13
   call $std/typedarray/valuesEqual<~lib/typedarray/Uint16Array>
   i32.const 1
   drop
@@ -46558,9 +47289,9 @@
   i32.const 5056
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $9
+  local.tee $16
   call $std/typedarray/valuesEqual<~lib/typedarray/Uint16Array>
-  local.get $9
+  local.get $16
   call $~lib/rt/pure/__release
   local.get $4
   local.get $1
@@ -46583,9 +47314,9 @@
   i32.const 5104
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $5
+  local.tee $19
   call $std/typedarray/valuesEqual<~lib/typedarray/Uint16Array>
-  local.get $5
+  local.get $19
   call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
@@ -46597,11 +47328,11 @@
   call $~lib/rt/pure/__release
   local.get $4
   call $~lib/rt/pure/__release
-  local.get $6
-  call $~lib/rt/pure/__release
   local.get $7
   call $~lib/rt/pure/__release
-  local.get $8
+  local.get $10
+  call $~lib/rt/pure/__release
+  local.get $13
   call $~lib/rt/pure/__release
  )
  (func $~lib/typedarray/Int32Array#set<~lib/array/Array<i32>> (param $0 i32) (param $1 i32) (param $2 i32)
@@ -47672,6 +48403,16 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
@@ -47741,7 +48482,7 @@
   i32.const 5152
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $6
+  local.tee $7
   call $std/typedarray/valuesEqual<~lib/typedarray/Int32Array>
   local.get $4
   global.get $std/typedarray/setSource2
@@ -47754,7 +48495,7 @@
   i32.const 5264
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $7
+  local.tee $10
   call $std/typedarray/valuesEqual<~lib/typedarray/Int32Array>
   local.get $4
   local.get $0
@@ -47767,7 +48508,7 @@
   i32.const 5328
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $8
+  local.tee $13
   call $std/typedarray/valuesEqual<~lib/typedarray/Int32Array>
   i32.const 1
   drop
@@ -47782,9 +48523,9 @@
   i32.const 5392
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $9
+  local.tee $16
   call $std/typedarray/valuesEqual<~lib/typedarray/Int32Array>
-  local.get $9
+  local.get $16
   call $~lib/rt/pure/__release
   local.get $4
   local.get $1
@@ -47807,9 +48548,9 @@
   i32.const 5456
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $5
+  local.tee $19
   call $std/typedarray/valuesEqual<~lib/typedarray/Int32Array>
-  local.get $5
+  local.get $19
   call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
@@ -47821,11 +48562,11 @@
   call $~lib/rt/pure/__release
   local.get $4
   call $~lib/rt/pure/__release
-  local.get $6
-  call $~lib/rt/pure/__release
   local.get $7
   call $~lib/rt/pure/__release
-  local.get $8
+  local.get $10
+  call $~lib/rt/pure/__release
+  local.get $13
   call $~lib/rt/pure/__release
  )
  (func $~lib/typedarray/Uint32Array#set<~lib/array/Array<i32>> (param $0 i32) (param $1 i32) (param $2 i32)
@@ -48909,6 +49650,16 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
@@ -48978,7 +49729,7 @@
   i32.const 5520
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $6
+  local.tee $7
   call $std/typedarray/valuesEqual<~lib/typedarray/Uint32Array>
   local.get $4
   global.get $std/typedarray/setSource2
@@ -48991,7 +49742,7 @@
   i32.const 5632
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $7
+  local.tee $10
   call $std/typedarray/valuesEqual<~lib/typedarray/Uint32Array>
   local.get $4
   local.get $0
@@ -49004,7 +49755,7 @@
   i32.const 5696
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $8
+  local.tee $13
   call $std/typedarray/valuesEqual<~lib/typedarray/Uint32Array>
   i32.const 1
   drop
@@ -49019,9 +49770,9 @@
   i32.const 5760
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $9
+  local.tee $16
   call $std/typedarray/valuesEqual<~lib/typedarray/Uint32Array>
-  local.get $9
+  local.get $16
   call $~lib/rt/pure/__release
   local.get $4
   local.get $1
@@ -49044,9 +49795,9 @@
   i32.const 5824
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $5
+  local.tee $19
   call $std/typedarray/valuesEqual<~lib/typedarray/Uint32Array>
-  local.get $5
+  local.get $19
   call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
@@ -49058,11 +49809,11 @@
   call $~lib/rt/pure/__release
   local.get $4
   call $~lib/rt/pure/__release
-  local.get $6
-  call $~lib/rt/pure/__release
   local.get $7
   call $~lib/rt/pure/__release
-  local.get $8
+  local.get $10
+  call $~lib/rt/pure/__release
+  local.get $13
   call $~lib/rt/pure/__release
  )
  (func $~lib/typedarray/Int64Array#set<~lib/array/Array<i32>> (param $0 i32) (param $1 i32) (param $2 i32)
@@ -50146,6 +50897,16 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
@@ -50215,7 +50976,7 @@
   i32.const 5888
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $6
+  local.tee $7
   call $std/typedarray/valuesEqual<~lib/typedarray/Int64Array>
   local.get $4
   global.get $std/typedarray/setSource2
@@ -50228,7 +50989,7 @@
   i32.const 6032
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $7
+  local.tee $10
   call $std/typedarray/valuesEqual<~lib/typedarray/Int64Array>
   local.get $4
   local.get $0
@@ -50241,7 +51002,7 @@
   i32.const 6128
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $8
+  local.tee $13
   call $std/typedarray/valuesEqual<~lib/typedarray/Int64Array>
   i32.const 1
   drop
@@ -50256,9 +51017,9 @@
   i32.const 6224
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $9
+  local.tee $16
   call $std/typedarray/valuesEqual<~lib/typedarray/Int64Array>
-  local.get $9
+  local.get $16
   call $~lib/rt/pure/__release
   local.get $4
   local.get $1
@@ -50281,9 +51042,9 @@
   i32.const 6320
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $5
+  local.tee $19
   call $std/typedarray/valuesEqual<~lib/typedarray/Int64Array>
-  local.get $5
+  local.get $19
   call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
@@ -50295,11 +51056,11 @@
   call $~lib/rt/pure/__release
   local.get $4
   call $~lib/rt/pure/__release
-  local.get $6
-  call $~lib/rt/pure/__release
   local.get $7
   call $~lib/rt/pure/__release
-  local.get $8
+  local.get $10
+  call $~lib/rt/pure/__release
+  local.get $13
   call $~lib/rt/pure/__release
  )
  (func $~lib/typedarray/Uint64Array#set<~lib/array/Array<i32>> (param $0 i32) (param $1 i32) (param $2 i32)
@@ -51383,6 +52144,16 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
@@ -51452,7 +52223,7 @@
   i32.const 6416
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $6
+  local.tee $7
   call $std/typedarray/valuesEqual<~lib/typedarray/Uint64Array>
   local.get $4
   global.get $std/typedarray/setSource2
@@ -51465,7 +52236,7 @@
   i32.const 6560
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $7
+  local.tee $10
   call $std/typedarray/valuesEqual<~lib/typedarray/Uint64Array>
   local.get $4
   local.get $0
@@ -51478,7 +52249,7 @@
   i32.const 6656
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $8
+  local.tee $13
   call $std/typedarray/valuesEqual<~lib/typedarray/Uint64Array>
   i32.const 1
   drop
@@ -51493,9 +52264,9 @@
   i32.const 6752
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $9
+  local.tee $16
   call $std/typedarray/valuesEqual<~lib/typedarray/Uint64Array>
-  local.get $9
+  local.get $16
   call $~lib/rt/pure/__release
   local.get $4
   local.get $1
@@ -51518,9 +52289,9 @@
   i32.const 6848
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $5
+  local.tee $19
   call $std/typedarray/valuesEqual<~lib/typedarray/Uint64Array>
-  local.get $5
+  local.get $19
   call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
@@ -51532,11 +52303,11 @@
   call $~lib/rt/pure/__release
   local.get $4
   call $~lib/rt/pure/__release
-  local.get $6
-  call $~lib/rt/pure/__release
   local.get $7
   call $~lib/rt/pure/__release
-  local.get $8
+  local.get $10
+  call $~lib/rt/pure/__release
+  local.get $13
   call $~lib/rt/pure/__release
  )
  (func $~lib/typedarray/Float32Array#set<~lib/array/Array<i32>> (param $0 i32) (param $1 i32) (param $2 i32)
@@ -52467,6 +53238,13 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
@@ -52536,7 +53314,7 @@
   i32.const 6944
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $6
+  local.tee $7
   call $std/typedarray/valuesEqual<~lib/typedarray/Float32Array>
   local.get $4
   global.get $std/typedarray/setSource2
@@ -52549,7 +53327,7 @@
   i32.const 7056
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $7
+  local.tee $10
   call $std/typedarray/valuesEqual<~lib/typedarray/Float32Array>
   local.get $4
   local.get $0
@@ -52562,7 +53340,7 @@
   i32.const 7120
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $8
+  local.tee $13
   call $std/typedarray/valuesEqual<~lib/typedarray/Float32Array>
   i32.const 0
   drop
@@ -52587,9 +53365,9 @@
   i32.const 7184
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $9
+  local.tee $16
   call $std/typedarray/valuesEqual<~lib/typedarray/Float32Array>
-  local.get $9
+  local.get $16
   call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
@@ -52601,11 +53379,11 @@
   call $~lib/rt/pure/__release
   local.get $4
   call $~lib/rt/pure/__release
-  local.get $6
-  call $~lib/rt/pure/__release
   local.get $7
   call $~lib/rt/pure/__release
-  local.get $8
+  local.get $10
+  call $~lib/rt/pure/__release
+  local.get $13
   call $~lib/rt/pure/__release
  )
  (func $~lib/typedarray/Float64Array#set<~lib/array/Array<i32>> (param $0 i32) (param $1 i32) (param $2 i32)
@@ -53588,6 +54366,13 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
@@ -53657,7 +54442,7 @@
   i32.const 7248
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $6
+  local.tee $7
   call $std/typedarray/valuesEqual<~lib/typedarray/Float64Array>
   local.get $4
   global.get $std/typedarray/setSource2
@@ -53670,7 +54455,7 @@
   i32.const 7392
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $7
+  local.tee $10
   call $std/typedarray/valuesEqual<~lib/typedarray/Float64Array>
   local.get $4
   local.get $0
@@ -53683,7 +54468,7 @@
   i32.const 7488
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $8
+  local.tee $13
   call $std/typedarray/valuesEqual<~lib/typedarray/Float64Array>
   i32.const 0
   drop
@@ -53708,9 +54493,9 @@
   i32.const 7584
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $9
+  local.tee $16
   call $std/typedarray/valuesEqual<~lib/typedarray/Float64Array>
-  local.get $9
+  local.get $16
   call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
@@ -53722,11 +54507,11 @@
   call $~lib/rt/pure/__release
   local.get $4
   call $~lib/rt/pure/__release
-  local.get $6
-  call $~lib/rt/pure/__release
   local.get $7
   call $~lib/rt/pure/__release
-  local.get $8
+  local.get $10
+  call $~lib/rt/pure/__release
+  local.get $13
   call $~lib/rt/pure/__release
  )
  (func $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Float32Array> (param $0 i32) (param $1 i32) (param $2 i32)
@@ -54201,6 +54986,134 @@
   (local $24 i32)
   (local $25 i32)
   (local $26 i32)
+  (local $27 i32)
+  (local $28 i32)
+  (local $29 i32)
+  (local $30 i32)
+  (local $31 i32)
+  (local $32 i32)
+  (local $33 i32)
+  (local $34 i32)
+  (local $35 i32)
+  (local $36 i32)
+  (local $37 i32)
+  (local $38 i32)
+  (local $39 i32)
+  (local $40 i32)
+  (local $41 i32)
+  (local $42 i32)
+  (local $43 i32)
+  (local $44 i32)
+  (local $45 i32)
+  (local $46 i32)
+  (local $47 i32)
+  (local $48 i32)
+  (local $49 i32)
+  (local $50 i32)
+  (local $51 i32)
+  (local $52 i32)
+  (local $53 i32)
+  (local $54 i32)
+  (local $55 i32)
+  (local $56 i32)
+  (local $57 i32)
+  (local $58 i32)
+  (local $59 i32)
+  (local $60 i32)
+  (local $61 i32)
+  (local $62 i32)
+  (local $63 i32)
+  (local $64 i32)
+  (local $65 i32)
+  (local $66 i32)
+  (local $67 i32)
+  (local $68 i32)
+  (local $69 i32)
+  (local $70 i32)
+  (local $71 i32)
+  (local $72 i32)
+  (local $73 i32)
+  (local $74 i32)
+  (local $75 i32)
+  (local $76 i32)
+  (local $77 i32)
+  (local $78 i32)
+  (local $79 i32)
+  (local $80 i32)
+  (local $81 i32)
+  (local $82 i32)
+  (local $83 i32)
+  (local $84 i32)
+  (local $85 i32)
+  (local $86 i32)
+  (local $87 i32)
+  (local $88 i32)
+  (local $89 i32)
+  (local $90 i32)
+  (local $91 i32)
+  (local $92 i32)
+  (local $93 i32)
+  (local $94 i32)
+  (local $95 i32)
+  (local $96 i32)
+  (local $97 i32)
+  (local $98 i32)
+  (local $99 i32)
+  (local $100 i32)
+  (local $101 i32)
+  (local $102 i32)
+  (local $103 i32)
+  (local $104 i32)
+  (local $105 i32)
+  (local $106 i32)
+  (local $107 i32)
+  (local $108 i32)
+  (local $109 i32)
+  (local $110 i32)
+  (local $111 i32)
+  (local $112 i32)
+  (local $113 i32)
+  (local $114 i32)
+  (local $115 i32)
+  (local $116 i32)
+  (local $117 i32)
+  (local $118 i32)
+  (local $119 i32)
+  (local $120 i32)
+  (local $121 i32)
+  (local $122 i32)
+  (local $123 i32)
+  (local $124 i32)
+  (local $125 i32)
+  (local $126 i32)
+  (local $127 i32)
+  (local $128 i32)
+  (local $129 i32)
+  (local $130 i32)
+  (local $131 i32)
+  (local $132 i32)
+  (local $133 i32)
+  (local $134 i32)
+  (local $135 i32)
+  (local $136 i32)
+  (local $137 i32)
+  (local $138 i32)
+  (local $139 i32)
+  (local $140 i32)
+  (local $141 i32)
+  (local $142 i32)
+  (local $143 i32)
+  (local $144 i32)
+  (local $145 i32)
+  (local $146 i32)
+  (local $147 i32)
+  (local $148 i32)
+  (local $149 i32)
+  (local $150 i32)
+  (local $151 i32)
+  (local $152 i32)
+  (local $153 i32)
+  (local $154 i32)
   global.get $~lib/typedarray/Int8Array.BYTES_PER_ELEMENT
   i32.const 1
   i32.eq
@@ -54419,49 +55332,49 @@
   i32.const 0
   i32.const 8
   call $~lib/typedarray/Float64Array#constructor
-  local.set $0
-  local.get $0
+  local.set $2
+  local.get $2
   i32.const 0
   f64.const 1
   call $~lib/typedarray/Float64Array#__set
-  local.get $0
+  local.get $2
   i32.const 1
   f64.const 2
   call $~lib/typedarray/Float64Array#__set
-  local.get $0
+  local.get $2
   i32.const 2
   f64.const 7
   call $~lib/typedarray/Float64Array#__set
-  local.get $0
+  local.get $2
   i32.const 3
   f64.const 6
   call $~lib/typedarray/Float64Array#__set
-  local.get $0
+  local.get $2
   i32.const 4
   f64.const 5
   call $~lib/typedarray/Float64Array#__set
-  local.get $0
+  local.get $2
   i32.const 5
   f64.const 4
   call $~lib/typedarray/Float64Array#__set
-  local.get $0
+  local.get $2
   i32.const 6
   f64.const 3
   call $~lib/typedarray/Float64Array#__set
-  local.get $0
+  local.get $2
   i32.const 7
   f64.const 8
   call $~lib/typedarray/Float64Array#__set
-  local.get $0
+  local.get $2
   i32.const 2
   i32.const 6
   call $~lib/typedarray/Float64Array#subarray
-  local.set $1
-  local.get $0
+  local.set $3
+  local.get $2
   call $~lib/rt/pure/__release
-  local.get $1
-  local.set $0
-  local.get $0
+  local.get $3
+  local.set $2
+  local.get $2
   call $~lib/typedarray/Float64Array#get:length
   i32.const 4
   i32.eq
@@ -54474,7 +55387,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $2
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
   i32.const 2
   i32.const 8
@@ -54489,7 +55402,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $2
   i32.load offset=8
   i32.const 4
   i32.const 8
@@ -54504,19 +55417,19 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $2
   i32.const 0
   global.set $~argumentsLength
   i32.const 0
   call $~lib/typedarray/Float64Array#sort@varargs
   call $~lib/rt/pure/__release
-  local.get $0
+  local.get $2
   i32.const 0
   call $~lib/typedarray/Float64Array#__get
   f64.const 4
   f64.eq
   if (result i32)
-   local.get $0
+   local.get $2
    i32.const 1
    call $~lib/typedarray/Float64Array#__get
    f64.const 5
@@ -54525,7 +55438,7 @@
    i32.const 0
   end
   if (result i32)
-   local.get $0
+   local.get $2
    i32.const 2
    call $~lib/typedarray/Float64Array#__get
    f64.const 6
@@ -54534,7 +55447,7 @@
    i32.const 0
   end
   if (result i32)
-   local.get $0
+   local.get $2
    i32.const 3
    call $~lib/typedarray/Float64Array#__get
    f64.const 7
@@ -54551,25 +55464,25 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $2
   call $~lib/rt/pure/__release
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Uint8ClampedArray#constructor
-  local.set $0
-  local.get $0
+  local.set $4
+  local.get $4
   i32.const 0
   i32.const -32
   call $~lib/typedarray/Uint8ClampedArray#__set
-  local.get $0
+  local.get $4
   i32.const 1
   i32.const 2
   call $~lib/typedarray/Uint8ClampedArray#__set
-  local.get $0
+  local.get $4
   i32.const 2
   i32.const 256
   call $~lib/typedarray/Uint8ClampedArray#__set
-  local.get $0
+  local.get $4
   i32.const 0
   call $~lib/typedarray/Uint8ClampedArray#__get
   i32.const 0
@@ -54583,7 +55496,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $4
   i32.const 1
   call $~lib/typedarray/Uint8ClampedArray#__get
   i32.const 2
@@ -54597,7 +55510,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $4
   i32.const 2
   call $~lib/typedarray/Uint8ClampedArray#__get
   i32.const 255
@@ -54611,46 +55524,46 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $4
   call $~lib/rt/pure/__release
   i32.const 0
   i32.const 5
   call $~lib/typedarray/Int8Array#constructor
-  local.set $0
-  local.get $0
+  local.set $5
+  local.get $5
   i32.const 0
   i32.const 1
   call $~lib/typedarray/Int8Array#__set
-  local.get $0
+  local.get $5
   i32.const 1
   i32.const 2
   call $~lib/typedarray/Int8Array#__set
-  local.get $0
+  local.get $5
   i32.const 2
   i32.const 3
   call $~lib/typedarray/Int8Array#__set
-  local.get $0
+  local.get $5
   i32.const 3
   i32.const 4
   call $~lib/typedarray/Int8Array#__set
-  local.get $0
+  local.get $5
   i32.const 4
   i32.const 5
   call $~lib/typedarray/Int8Array#__set
-  local.get $0
+  local.get $5
   i32.const 1
   i32.const 1
   i32.const 3
   call $~lib/typedarray/Int8Array#fill
   call $~lib/rt/pure/__release
-  local.get $0
+  local.get $5
   i32.const 5
   i32.const 0
   i32.const 14
   i32.const 496
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $2
+  local.tee $8
   call $std/typedarray/isInt8ArrayEqual
   i32.eqz
   if
@@ -54661,20 +55574,20 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $5
   i32.const 0
   i32.const 0
   global.get $~lib/builtins/i32.MAX_VALUE
   call $~lib/typedarray/Int8Array#fill
   call $~lib/rt/pure/__release
-  local.get $0
+  local.get $5
   i32.const 5
   i32.const 0
   i32.const 14
   i32.const 576
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $3
+  local.tee $11
   call $std/typedarray/isInt8ArrayEqual
   i32.eqz
   if
@@ -54685,20 +55598,20 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $5
   i32.const 1
   i32.const 0
   i32.const -3
   call $~lib/typedarray/Int8Array#fill
   call $~lib/rt/pure/__release
-  local.get $0
+  local.get $5
   i32.const 5
   i32.const 0
   i32.const 14
   i32.const 608
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $4
+  local.tee $14
   call $std/typedarray/isInt8ArrayEqual
   i32.eqz
   if
@@ -54709,20 +55622,20 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $5
   i32.const 2
   i32.const -2
   global.get $~lib/builtins/i32.MAX_VALUE
   call $~lib/typedarray/Int8Array#fill
   call $~lib/rt/pure/__release
-  local.get $0
+  local.get $5
   i32.const 5
   i32.const 0
   i32.const 14
   i32.const 640
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $5
+  local.tee $17
   call $std/typedarray/isInt8ArrayEqual
   i32.eqz
   if
@@ -54733,20 +55646,20 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $5
   i32.const 0
   i32.const 1
   i32.const 0
   call $~lib/typedarray/Int8Array#fill
   call $~lib/rt/pure/__release
-  local.get $0
+  local.get $5
   i32.const 5
   i32.const 0
   i32.const 14
   i32.const 672
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $6
+  local.tee $20
   call $std/typedarray/isInt8ArrayEqual
   i32.eqz
   if
@@ -54757,18 +55670,18 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $5
   i32.const 1
   i32.const 4
   call $~lib/typedarray/Int8Array#subarray
-  local.set $1
-  local.get $1
+  local.set $21
+  local.get $21
   i32.const 0
   i32.const 0
   global.get $~lib/builtins/i32.MAX_VALUE
   call $~lib/typedarray/Int8Array#fill
   call $~lib/rt/pure/__release
-  local.get $1
+  local.get $21
   call $~lib/typedarray/Int8Array#get:length
   i32.const 3
   i32.eq
@@ -54781,7 +55694,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $21
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
   i32.const 1
   i32.eq
@@ -54794,7 +55707,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $21
   i32.load offset=8
   i32.const 3
   i32.eq
@@ -54807,14 +55720,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $21
   i32.const 3
   i32.const 0
   i32.const 14
   i32.const 704
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $8
+  local.tee $24
   call $std/typedarray/isInt8ArrayEqual
   i32.eqz
   if
@@ -54825,14 +55738,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $5
   i32.const 5
   i32.const 0
   i32.const 14
   i32.const 736
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $9
+  local.tee $27
   call $std/typedarray/isInt8ArrayEqual
   i32.eqz
   if
@@ -54843,62 +55756,62 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
-  call $~lib/rt/pure/__release
-  local.get $2
-  call $~lib/rt/pure/__release
-  local.get $3
-  call $~lib/rt/pure/__release
-  local.get $4
-  call $~lib/rt/pure/__release
   local.get $5
-  call $~lib/rt/pure/__release
-  local.get $6
-  call $~lib/rt/pure/__release
-  local.get $1
   call $~lib/rt/pure/__release
   local.get $8
   call $~lib/rt/pure/__release
-  local.get $9
+  local.get $11
+  call $~lib/rt/pure/__release
+  local.get $14
+  call $~lib/rt/pure/__release
+  local.get $17
+  call $~lib/rt/pure/__release
+  local.get $20
+  call $~lib/rt/pure/__release
+  local.get $21
+  call $~lib/rt/pure/__release
+  local.get $24
+  call $~lib/rt/pure/__release
+  local.get $27
   call $~lib/rt/pure/__release
   i32.const 0
   i32.const 5
   call $~lib/typedarray/Int32Array#constructor
-  local.set $9
-  local.get $9
+  local.set $28
+  local.get $28
   i32.const 0
   i32.const 1
   call $~lib/typedarray/Int32Array#__set
-  local.get $9
+  local.get $28
   i32.const 1
   i32.const 2
   call $~lib/typedarray/Int32Array#__set
-  local.get $9
+  local.get $28
   i32.const 2
   i32.const 3
   call $~lib/typedarray/Int32Array#__set
-  local.get $9
+  local.get $28
   i32.const 3
   i32.const 4
   call $~lib/typedarray/Int32Array#__set
-  local.get $9
+  local.get $28
   i32.const 4
   i32.const 5
   call $~lib/typedarray/Int32Array#__set
-  local.get $9
+  local.get $28
   i32.const 1
   i32.const 1
   i32.const 3
   call $~lib/typedarray/Int32Array#fill
   call $~lib/rt/pure/__release
-  local.get $9
+  local.get $28
   i32.const 5
   i32.const 2
   i32.const 15
   i32.const 768
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $1
+  local.tee $31
   call $std/typedarray/isInt32ArrayEqual
   i32.eqz
   if
@@ -54909,20 +55822,20 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $9
+  local.get $28
   i32.const 0
   i32.const 0
   global.get $~lib/builtins/i32.MAX_VALUE
   call $~lib/typedarray/Int32Array#fill
   call $~lib/rt/pure/__release
-  local.get $9
+  local.get $28
   i32.const 5
   i32.const 2
   i32.const 15
   i32.const 816
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $6
+  local.tee $34
   call $std/typedarray/isInt32ArrayEqual
   i32.eqz
   if
@@ -54933,20 +55846,20 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $9
+  local.get $28
   i32.const 1
   i32.const 0
   i32.const -3
   call $~lib/typedarray/Int32Array#fill
   call $~lib/rt/pure/__release
-  local.get $9
+  local.get $28
   i32.const 5
   i32.const 2
   i32.const 15
   i32.const 864
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $5
+  local.tee $37
   call $std/typedarray/isInt32ArrayEqual
   i32.eqz
   if
@@ -54957,20 +55870,20 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $9
+  local.get $28
   i32.const 2
   i32.const -2
   global.get $~lib/builtins/i32.MAX_VALUE
   call $~lib/typedarray/Int32Array#fill
   call $~lib/rt/pure/__release
-  local.get $9
+  local.get $28
   i32.const 5
   i32.const 2
   i32.const 15
   i32.const 912
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $4
+  local.tee $40
   call $std/typedarray/isInt32ArrayEqual
   i32.eqz
   if
@@ -54981,20 +55894,20 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $9
+  local.get $28
   i32.const 0
   i32.const 1
   i32.const 0
   call $~lib/typedarray/Int32Array#fill
   call $~lib/rt/pure/__release
-  local.get $9
+  local.get $28
   i32.const 5
   i32.const 2
   i32.const 15
   i32.const 960
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $3
+  local.tee $43
   call $std/typedarray/isInt32ArrayEqual
   i32.eqz
   if
@@ -55005,18 +55918,18 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $9
+  local.get $28
   i32.const 1
   i32.const 4
   call $~lib/typedarray/Int32Array#subarray
-  local.set $8
-  local.get $8
+  local.set $44
+  local.get $44
   i32.const 0
   i32.const 0
   global.get $~lib/builtins/i32.MAX_VALUE
   call $~lib/typedarray/Int32Array#fill
   call $~lib/rt/pure/__release
-  local.get $8
+  local.get $44
   call $~lib/typedarray/Int32Array#get:length
   i32.const 3
   i32.eq
@@ -55029,7 +55942,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $8
+  local.get $44
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
   i32.const 1
   i32.const 4
@@ -55044,7 +55957,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $8
+  local.get $44
   i32.load offset=8
   i32.const 3
   i32.const 4
@@ -55059,14 +55972,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $8
+  local.get $44
   i32.const 3
   i32.const 2
   i32.const 15
   i32.const 1008
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $0
+  local.tee $47
   call $std/typedarray/isInt32ArrayEqual
   i32.eqz
   if
@@ -55077,14 +55990,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $9
+  local.get $28
   i32.const 5
   i32.const 2
   i32.const 15
   i32.const 1040
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $7
+  local.tee $50
   call $std/typedarray/isInt32ArrayEqual
   i32.eqz
   if
@@ -55095,58 +56008,58 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $9
+  local.get $28
   call $~lib/rt/pure/__release
-  local.get $1
+  local.get $31
   call $~lib/rt/pure/__release
-  local.get $6
+  local.get $34
   call $~lib/rt/pure/__release
-  local.get $5
+  local.get $37
   call $~lib/rt/pure/__release
-  local.get $4
+  local.get $40
   call $~lib/rt/pure/__release
-  local.get $3
+  local.get $43
   call $~lib/rt/pure/__release
-  local.get $8
+  local.get $44
   call $~lib/rt/pure/__release
-  local.get $0
+  local.get $47
   call $~lib/rt/pure/__release
-  local.get $7
+  local.get $50
   call $~lib/rt/pure/__release
   i32.const 0
   i32.const 6
   call $~lib/typedarray/Int8Array#constructor
-  local.set $7
-  local.get $7
+  local.set $51
+  local.get $51
   i32.const 0
   i32.const 1
   call $~lib/typedarray/Int8Array#__set
-  local.get $7
+  local.get $51
   i32.const 1
   i32.const 2
   call $~lib/typedarray/Int8Array#__set
-  local.get $7
+  local.get $51
   i32.const 2
   i32.const 3
   call $~lib/typedarray/Int8Array#__set
-  local.get $7
+  local.get $51
   i32.const 3
   i32.const 4
   call $~lib/typedarray/Int8Array#__set
-  local.get $7
+  local.get $51
   i32.const 4
   i32.const 5
   call $~lib/typedarray/Int8Array#__set
-  local.get $7
+  local.get $51
   i32.const 5
   i32.const 6
   call $~lib/typedarray/Int8Array#__set
-  local.get $7
+  local.get $51
   i32.const 1
   i32.const 6
   call $~lib/typedarray/Int8Array#subarray
-  local.set $0
-  local.get $0
+  local.set $52
+  local.get $52
   i32.const 0
   call $~lib/typedarray/Int8Array#__get
   i32.const 2
@@ -55160,7 +56073,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $52
   call $~lib/typedarray/Int8Array#get:length
   i32.const 5
   i32.eq
@@ -55173,7 +56086,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $52
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
   i32.const 1
   i32.eq
@@ -55186,7 +56099,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $52
   i32.load offset=8
   i32.const 5
   i32.eq
@@ -55199,12 +56112,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $52
   i32.const 1
   i32.const 5
   call $~lib/typedarray/Int8Array#subarray
-  local.set $8
-  local.get $8
+  local.set $53
+  local.get $53
   i32.const 0
   call $~lib/typedarray/Int8Array#__get
   i32.const 3
@@ -55218,7 +56131,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $8
+  local.get $53
   call $~lib/typedarray/Int8Array#get:length
   i32.const 4
   i32.eq
@@ -55231,7 +56144,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $8
+  local.get $53
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
   i32.const 2
   i32.eq
@@ -55244,7 +56157,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $8
+  local.get $53
   i32.load offset=8
   i32.const 4
   i32.eq
@@ -55257,12 +56170,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $8
+  local.get $53
   i32.const 1
   i32.const 4
   call $~lib/typedarray/Int8Array#subarray
-  local.set $3
-  local.get $3
+  local.set $54
+  local.get $54
   i32.const 0
   call $~lib/typedarray/Int8Array#__get
   i32.const 4
@@ -55276,7 +56189,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $54
   call $~lib/typedarray/Int8Array#get:length
   i32.const 3
   i32.eq
@@ -55289,7 +56202,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $54
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
   i32.const 3
   i32.eq
@@ -55302,7 +56215,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $54
   i32.load offset=8
   i32.const 3
   i32.eq
@@ -55315,56 +56228,56 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $7
+  local.get $51
   call $~lib/rt/pure/__release
-  local.get $0
+  local.get $52
   call $~lib/rt/pure/__release
-  local.get $8
+  local.get $53
   call $~lib/rt/pure/__release
-  local.get $3
+  local.get $54
   call $~lib/rt/pure/__release
   i32.const 0
   i32.const 5
   call $~lib/typedarray/Int32Array#constructor
-  local.set $3
-  local.get $3
+  local.set $55
+  local.get $55
   i32.const 0
   i32.const 1
   call $~lib/typedarray/Int32Array#__set
-  local.get $3
+  local.get $55
   i32.const 1
   i32.const 2
   call $~lib/typedarray/Int32Array#__set
-  local.get $3
+  local.get $55
   i32.const 2
   i32.const 3
   call $~lib/typedarray/Int32Array#__set
-  local.get $3
+  local.get $55
   i32.const 3
   i32.const 4
   call $~lib/typedarray/Int32Array#__set
-  local.get $3
+  local.get $55
   i32.const 4
   i32.const 5
   call $~lib/typedarray/Int32Array#__set
-  local.get $3
+  local.get $55
   i32.const 0
   global.get $~lib/builtins/i32.MAX_VALUE
   call $~lib/typedarray/Int32Array#slice
-  local.set $8
-  local.get $3
+  local.set $56
+  local.get $55
   i32.const 0
   i32.const 3
   global.get $~lib/builtins/i32.MAX_VALUE
   call $~lib/typedarray/Int32Array#copyWithin
-  local.tee $0
+  local.tee $57
   i32.const 5
   i32.const 2
   i32.const 15
   i32.const 1088
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $4
+  local.tee $60
   call $std/typedarray/isInt32ArrayEqual
   i32.eqz
   if
@@ -55375,28 +56288,28 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $8
+  local.get $56
   i32.const 0
   global.get $~lib/builtins/i32.MAX_VALUE
   call $~lib/typedarray/Int32Array#slice
-  local.set $2
-  local.get $3
+  local.set $61
+  local.get $55
   call $~lib/rt/pure/__release
-  local.get $2
-  local.set $3
-  local.get $3
+  local.get $61
+  local.set $55
+  local.get $55
   i32.const 1
   i32.const 3
   global.get $~lib/builtins/i32.MAX_VALUE
   call $~lib/typedarray/Int32Array#copyWithin
-  local.tee $2
+  local.tee $62
   i32.const 5
   i32.const 2
   i32.const 15
   i32.const 1136
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $5
+  local.tee $65
   call $std/typedarray/isInt32ArrayEqual
   i32.eqz
   if
@@ -55407,28 +56320,28 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $8
+  local.get $56
   i32.const 0
   global.get $~lib/builtins/i32.MAX_VALUE
   call $~lib/typedarray/Int32Array#slice
-  local.set $9
-  local.get $3
+  local.set $66
+  local.get $55
   call $~lib/rt/pure/__release
-  local.get $9
-  local.set $3
-  local.get $3
+  local.get $66
+  local.set $55
+  local.get $55
   i32.const 1
   i32.const 2
   global.get $~lib/builtins/i32.MAX_VALUE
   call $~lib/typedarray/Int32Array#copyWithin
-  local.tee $9
+  local.tee $67
   i32.const 5
   i32.const 2
   i32.const 15
   i32.const 1184
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $6
+  local.tee $70
   call $std/typedarray/isInt32ArrayEqual
   i32.eqz
   if
@@ -55439,28 +56352,28 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $8
+  local.get $56
   i32.const 0
   global.get $~lib/builtins/i32.MAX_VALUE
   call $~lib/typedarray/Int32Array#slice
-  local.set $1
-  local.get $3
+  local.set $71
+  local.get $55
   call $~lib/rt/pure/__release
-  local.get $1
-  local.set $3
-  local.get $3
+  local.get $71
+  local.set $55
+  local.get $55
   i32.const 2
   i32.const 2
   global.get $~lib/builtins/i32.MAX_VALUE
   call $~lib/typedarray/Int32Array#copyWithin
-  local.tee $1
+  local.tee $72
   i32.const 5
   i32.const 2
   i32.const 15
   i32.const 1232
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $10
+  local.tee $75
   call $std/typedarray/isInt32ArrayEqual
   i32.eqz
   if
@@ -55471,28 +56384,28 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $8
+  local.get $56
   i32.const 0
   global.get $~lib/builtins/i32.MAX_VALUE
   call $~lib/typedarray/Int32Array#slice
-  local.set $7
-  local.get $3
+  local.set $76
+  local.get $55
   call $~lib/rt/pure/__release
-  local.get $7
-  local.set $3
-  local.get $3
+  local.get $76
+  local.set $55
+  local.get $55
   i32.const 0
   i32.const 3
   i32.const 4
   call $~lib/typedarray/Int32Array#copyWithin
-  local.tee $7
+  local.tee $77
   i32.const 5
   i32.const 2
   i32.const 15
   i32.const 1280
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $12
+  local.tee $80
   call $std/typedarray/isInt32ArrayEqual
   i32.eqz
   if
@@ -55503,28 +56416,28 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $8
+  local.get $56
   i32.const 0
   global.get $~lib/builtins/i32.MAX_VALUE
   call $~lib/typedarray/Int32Array#slice
-  local.set $11
-  local.get $3
+  local.set $81
+  local.get $55
   call $~lib/rt/pure/__release
-  local.get $11
-  local.set $3
-  local.get $3
+  local.get $81
+  local.set $55
+  local.get $55
   i32.const 1
   i32.const 3
   i32.const 4
   call $~lib/typedarray/Int32Array#copyWithin
-  local.tee $11
+  local.tee $82
   i32.const 5
   i32.const 2
   i32.const 15
   i32.const 1328
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $14
+  local.tee $85
   call $std/typedarray/isInt32ArrayEqual
   i32.eqz
   if
@@ -55535,28 +56448,28 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $8
+  local.get $56
   i32.const 0
   global.get $~lib/builtins/i32.MAX_VALUE
   call $~lib/typedarray/Int32Array#slice
-  local.set $13
-  local.get $3
+  local.set $86
+  local.get $55
   call $~lib/rt/pure/__release
-  local.get $13
-  local.set $3
-  local.get $3
+  local.get $86
+  local.set $55
+  local.get $55
   i32.const 1
   i32.const 2
   i32.const 4
   call $~lib/typedarray/Int32Array#copyWithin
-  local.tee $13
+  local.tee $87
   i32.const 5
   i32.const 2
   i32.const 15
   i32.const 1376
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $16
+  local.tee $90
   call $std/typedarray/isInt32ArrayEqual
   i32.eqz
   if
@@ -55567,28 +56480,28 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $8
+  local.get $56
   i32.const 0
   global.get $~lib/builtins/i32.MAX_VALUE
   call $~lib/typedarray/Int32Array#slice
-  local.set $15
-  local.get $3
+  local.set $91
+  local.get $55
   call $~lib/rt/pure/__release
-  local.get $15
-  local.set $3
-  local.get $3
+  local.get $91
+  local.set $55
+  local.get $55
   i32.const 0
   i32.const -2
   global.get $~lib/builtins/i32.MAX_VALUE
   call $~lib/typedarray/Int32Array#copyWithin
-  local.tee $15
+  local.tee $92
   i32.const 5
   i32.const 2
   i32.const 15
   i32.const 1424
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $18
+  local.tee $95
   call $std/typedarray/isInt32ArrayEqual
   i32.eqz
   if
@@ -55599,28 +56512,28 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $8
+  local.get $56
   i32.const 0
   global.get $~lib/builtins/i32.MAX_VALUE
   call $~lib/typedarray/Int32Array#slice
-  local.set $17
-  local.get $3
+  local.set $96
+  local.get $55
   call $~lib/rt/pure/__release
-  local.get $17
-  local.set $3
-  local.get $3
+  local.get $96
+  local.set $55
+  local.get $55
   i32.const 0
   i32.const -2
   i32.const -1
   call $~lib/typedarray/Int32Array#copyWithin
-  local.tee $17
+  local.tee $97
   i32.const 5
   i32.const 2
   i32.const 15
   i32.const 1472
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $20
+  local.tee $100
   call $std/typedarray/isInt32ArrayEqual
   i32.eqz
   if
@@ -55631,28 +56544,28 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $8
+  local.get $56
   i32.const 0
   global.get $~lib/builtins/i32.MAX_VALUE
   call $~lib/typedarray/Int32Array#slice
-  local.set $19
-  local.get $3
+  local.set $101
+  local.get $55
   call $~lib/rt/pure/__release
-  local.get $19
-  local.set $3
-  local.get $3
+  local.get $101
+  local.set $55
+  local.get $55
   i32.const -4
   i32.const -3
   i32.const -2
   call $~lib/typedarray/Int32Array#copyWithin
-  local.tee $19
+  local.tee $102
   i32.const 5
   i32.const 2
   i32.const 15
   i32.const 1520
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $22
+  local.tee $105
   call $std/typedarray/isInt32ArrayEqual
   i32.eqz
   if
@@ -55663,28 +56576,28 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $8
+  local.get $56
   i32.const 0
   global.get $~lib/builtins/i32.MAX_VALUE
   call $~lib/typedarray/Int32Array#slice
-  local.set $21
-  local.get $3
+  local.set $106
+  local.get $55
   call $~lib/rt/pure/__release
-  local.get $21
-  local.set $3
-  local.get $3
+  local.get $106
+  local.set $55
+  local.get $55
   i32.const -4
   i32.const -3
   i32.const -1
   call $~lib/typedarray/Int32Array#copyWithin
-  local.tee $21
+  local.tee $107
   i32.const 5
   i32.const 2
   i32.const 15
   i32.const 1568
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $24
+  local.tee $110
   call $std/typedarray/isInt32ArrayEqual
   i32.eqz
   if
@@ -55695,28 +56608,28 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $8
+  local.get $56
   i32.const 0
   global.get $~lib/builtins/i32.MAX_VALUE
   call $~lib/typedarray/Int32Array#slice
-  local.set $23
-  local.get $3
+  local.set $111
+  local.get $55
   call $~lib/rt/pure/__release
-  local.get $23
-  local.set $3
-  local.get $3
+  local.get $111
+  local.set $55
+  local.get $55
   i32.const -4
   i32.const -3
   global.get $~lib/builtins/i32.MAX_VALUE
   call $~lib/typedarray/Int32Array#copyWithin
-  local.tee $23
+  local.tee $112
   i32.const 5
   i32.const 2
   i32.const 15
   i32.const 1616
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $26
+  local.tee $115
   call $std/typedarray/isInt32ArrayEqual
   i32.eqz
   if
@@ -55727,88 +56640,88 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $55
   call $~lib/rt/pure/__release
-  local.get $8
+  local.get $56
   call $~lib/rt/pure/__release
-  local.get $0
+  local.get $57
   call $~lib/rt/pure/__release
-  local.get $4
+  local.get $60
   call $~lib/rt/pure/__release
-  local.get $2
+  local.get $62
   call $~lib/rt/pure/__release
-  local.get $5
+  local.get $65
   call $~lib/rt/pure/__release
-  local.get $9
+  local.get $67
   call $~lib/rt/pure/__release
-  local.get $6
+  local.get $70
   call $~lib/rt/pure/__release
-  local.get $1
+  local.get $72
   call $~lib/rt/pure/__release
-  local.get $10
+  local.get $75
   call $~lib/rt/pure/__release
-  local.get $7
+  local.get $77
   call $~lib/rt/pure/__release
-  local.get $12
+  local.get $80
   call $~lib/rt/pure/__release
-  local.get $11
+  local.get $82
   call $~lib/rt/pure/__release
-  local.get $14
+  local.get $85
   call $~lib/rt/pure/__release
-  local.get $13
+  local.get $87
   call $~lib/rt/pure/__release
-  local.get $16
+  local.get $90
   call $~lib/rt/pure/__release
-  local.get $15
+  local.get $92
   call $~lib/rt/pure/__release
-  local.get $18
+  local.get $95
   call $~lib/rt/pure/__release
-  local.get $17
+  local.get $97
   call $~lib/rt/pure/__release
-  local.get $20
+  local.get $100
   call $~lib/rt/pure/__release
-  local.get $19
+  local.get $102
   call $~lib/rt/pure/__release
-  local.get $22
+  local.get $105
   call $~lib/rt/pure/__release
-  local.get $21
+  local.get $107
   call $~lib/rt/pure/__release
-  local.get $24
+  local.get $110
   call $~lib/rt/pure/__release
-  local.get $23
+  local.get $112
   call $~lib/rt/pure/__release
-  local.get $26
+  local.get $115
   call $~lib/rt/pure/__release
   i32.const 0
   i32.const 5
   call $~lib/typedarray/Int32Array#constructor
-  local.set $26
-  local.get $26
+  local.set $116
+  local.get $116
   i32.const 0
   i32.const 1
   call $~lib/typedarray/Int32Array#__set
-  local.get $26
+  local.get $116
   i32.const 1
   i32.const 2
   call $~lib/typedarray/Int32Array#__set
-  local.get $26
+  local.get $116
   i32.const 2
   i32.const 3
   call $~lib/typedarray/Int32Array#__set
-  local.get $26
+  local.get $116
   i32.const 3
   i32.const 4
   call $~lib/typedarray/Int32Array#__set
-  local.get $26
+  local.get $116
   i32.const 4
   i32.const 5
   call $~lib/typedarray/Int32Array#__set
-  local.get $26
+  local.get $116
   i32.const 1
   i32.const 4
   call $~lib/typedarray/Int32Array#subarray
-  local.set $23
-  local.get $23
+  local.set $117
+  local.get $117
   call $~lib/typedarray/Int32Array#get:length
   i32.const 3
   i32.eq
@@ -55821,7 +56734,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $23
+  local.get $117
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
   i32.const 4
   i32.eq
@@ -55834,7 +56747,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $23
+  local.get $117
   i32.load offset=8
   i32.const 12
   i32.eq
@@ -55847,12 +56760,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $26
+  local.get $116
   i32.const 1
   i32.const 3
   call $~lib/typedarray/Int32Array#slice
-  local.set $24
-  local.get $24
+  local.set $118
+  local.get $118
   i32.const 0
   call $~lib/typedarray/Int32Array#__get
   i32.const 2
@@ -55866,7 +56779,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $24
+  local.get $118
   i32.const 1
   call $~lib/typedarray/Int32Array#__get
   i32.const 3
@@ -55880,7 +56793,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $24
+  local.get $118
   call $~lib/typedarray/Int32Array#get:length
   i32.const 2
   i32.eq
@@ -55893,7 +56806,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $24
+  local.get $118
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
   i32.const 0
   i32.eq
@@ -55906,7 +56819,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $24
+  local.get $118
   i32.load offset=8
   i32.const 8
   i32.eq
@@ -55919,12 +56832,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $23
+  local.get $117
   i32.const 1
   i32.const 2
   call $~lib/typedarray/Int32Array#slice
-  local.set $21
-  local.get $21
+  local.set $119
+  local.get $119
   i32.const 0
   call $~lib/typedarray/Int32Array#__get
   i32.const 3
@@ -55938,7 +56851,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $21
+  local.get $119
   call $~lib/typedarray/Int32Array#get:length
   i32.const 1
   i32.eq
@@ -55951,7 +56864,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $21
+  local.get $119
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
   i32.const 0
   i32.eq
@@ -55964,7 +56877,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $21
+  local.get $119
   i32.load offset=8
   i32.const 4
   i32.eq
@@ -55977,13 +56890,13 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $26
+  local.get $116
   i32.const 0
   global.get $~lib/builtins/i32.MAX_VALUE
   call $~lib/typedarray/Int32Array#slice
-  local.set $22
-  local.get $22
-  local.get $26
+  local.set $120
+  local.get $120
+  local.get $116
   i32.ne
   i32.eqz
   if
@@ -55994,9 +56907,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $22
+  local.get $120
   call $~lib/typedarray/Int32Array#get:length
-  local.get $26
+  local.get $116
   call $~lib/typedarray/Int32Array#get:length
   i32.eq
   i32.eqz
@@ -56008,9 +56921,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $22
+  local.get $120
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
-  local.get $26
+  local.get $116
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
   i32.eq
   i32.eqz
@@ -56022,9 +56935,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $22
+  local.get $120
   i32.load offset=8
-  local.get $26
+  local.get $116
   i32.load offset=8
   i32.eq
   i32.eqz
@@ -56036,15 +56949,15 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $26
+  local.get $116
   call $~lib/rt/pure/__release
-  local.get $23
+  local.get $117
   call $~lib/rt/pure/__release
-  local.get $24
+  local.get $118
   call $~lib/rt/pure/__release
-  local.get $21
+  local.get $119
   call $~lib/rt/pure/__release
-  local.get $22
+  local.get $120
   call $~lib/rt/pure/__release
   call $std/typedarray/testReduce<~lib/typedarray/Int8Array,i8>
   call $std/typedarray/testReduce<~lib/typedarray/Uint8Array,u8>
@@ -56159,12 +57072,12 @@
   i32.const 0
   i32.const 1
   call $~lib/typedarray/Float64Array#constructor
-  local.set $21
-  local.get $21
+  local.set $127
+  local.get $127
   i32.const 0
   f64.const nan:0x8000000000000
   call $~lib/typedarray/Float64Array#__set
-  local.get $21
+  local.get $127
   f64.const nan:0x8000000000000
   i32.const 0
   call $~lib/typedarray/Float64Array#indexOf
@@ -56179,7 +57092,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $21
+  local.get $127
   f64.const nan:0x8000000000000
   i32.const 0
   call $~lib/typedarray/Float64Array#includes
@@ -56199,12 +57112,12 @@
   i32.const 0
   i32.const 1
   call $~lib/typedarray/Float32Array#constructor
-  local.set $22
-  local.get $22
+  local.set $128
+  local.get $128
   i32.const 0
   f32.const nan:0x400000
   call $~lib/typedarray/Float32Array#__set
-  local.get $22
+  local.get $128
   f32.const nan:0x400000
   i32.const 0
   call $~lib/typedarray/Float32Array#indexOf
@@ -56219,7 +57132,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $22
+  local.get $128
   f32.const nan:0x400000
   i32.const 0
   call $~lib/typedarray/Float32Array#includes
@@ -56236,9 +57149,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $21
+  local.get $127
   call $~lib/rt/pure/__release
-  local.get $22
+  local.get $128
   call $~lib/rt/pure/__release
   call $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Int8Array,i8>
   call $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Uint8Array,u8>
@@ -56254,15 +57167,15 @@
   i32.const 0
   i32.const 0
   call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $21
-  local.get $21
+  local.set $131
+  local.get $131
   i32.const 0
   i32.const 2
   global.set $~argumentsLength
   i32.const 0
   call $~lib/typedarray/Uint8Array.wrap@varargs
-  local.set $22
-  local.get $22
+  local.set $132
+  local.get $132
   call $~lib/typedarray/Uint8Array#get:length
   i32.const 0
   i32.eq
@@ -56278,23 +57191,23 @@
   i32.const 0
   i32.const 2
   call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $25
-  local.get $21
+  local.set $133
+  local.get $131
   call $~lib/rt/pure/__release
-  local.get $25
-  local.set $21
-  local.get $21
+  local.get $133
+  local.set $131
+  local.get $131
   i32.const 2
   i32.const 2
   global.set $~argumentsLength
   i32.const 0
   call $~lib/typedarray/Uint8Array.wrap@varargs
-  local.set $3
-  local.get $22
+  local.set $134
+  local.get $132
   call $~lib/rt/pure/__release
-  local.get $3
-  local.set $22
-  local.get $22
+  local.get $134
+  local.set $132
+  local.get $132
   call $~lib/typedarray/Uint8Array#get:length
   i32.const 0
   i32.eq
@@ -56307,9 +57220,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $21
+  local.get $131
   call $~lib/rt/pure/__release
-  local.get $22
+  local.get $132
   call $~lib/rt/pure/__release
   call $std/typedarray/testArrayWrap<~lib/typedarray/Int8Array,i8>
   call $std/typedarray/testArrayWrap<~lib/typedarray/Uint8Array,u8>
@@ -56336,148 +57249,148 @@
   i32.const 0
   i32.const 10
   call $~lib/typedarray/Uint8ClampedArray#constructor
-  local.set $22
+  local.set $143
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Float32Array#constructor
-  local.set $21
-  local.get $21
+  local.set $144
+  local.get $144
   i32.const 0
   f32.const 400
   call $~lib/typedarray/Float32Array#__set
-  local.get $21
+  local.get $144
   i32.const 1
   f32.const nan:0x400000
   call $~lib/typedarray/Float32Array#__set
-  local.get $21
+  local.get $144
   i32.const 2
   f32.const inf
   call $~lib/typedarray/Float32Array#__set
   i32.const 0
   i32.const 4
   call $~lib/typedarray/Int64Array#constructor
-  local.set $3
-  local.get $3
+  local.set $145
+  local.get $145
   i32.const 0
   i64.const -10
   call $~lib/typedarray/Int64Array#__set
-  local.get $3
+  local.get $145
   i32.const 1
   i64.const 100
   call $~lib/typedarray/Int64Array#__set
-  local.get $3
+  local.get $145
   i32.const 2
   i64.const 10
   call $~lib/typedarray/Int64Array#__set
-  local.get $3
+  local.get $145
   i32.const 3
   i64.const 300
   call $~lib/typedarray/Int64Array#__set
   i32.const 0
   i32.const 2
   call $~lib/typedarray/Int32Array#constructor
-  local.set $25
-  local.get $25
+  local.set $146
+  local.get $146
   i32.const 0
   i32.const 300
   call $~lib/typedarray/Int32Array#__set
-  local.get $25
+  local.get $146
   i32.const 1
   i32.const -1
   call $~lib/typedarray/Int32Array#__set
-  local.get $22
-  local.get $21
+  local.get $143
+  local.get $144
   i32.const 1
   call $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Float32Array>
-  local.get $22
-  local.get $3
+  local.get $143
+  local.get $145
   i32.const 4
   call $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Int64Array>
-  local.get $22
-  local.get $25
+  local.get $143
+  local.get $146
   i32.const 8
   call $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Int32Array>
-  local.get $22
+  local.get $143
   i32.const 10
   i32.const 0
   i32.const 18
   i32.const 7680
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $23
+  local.tee $149
   call $std/typedarray/valuesEqual<~lib/typedarray/Uint8ClampedArray>
   i32.const 0
   i32.const 4
   call $~lib/typedarray/Uint32Array#constructor
-  local.set $24
-  local.get $24
+  local.set $150
+  local.get $150
   i32.const 0
   i32.const 1
   call $~lib/typedarray/Uint32Array#__set
-  local.get $24
+  local.get $150
   i32.const 1
   i32.const 300
   call $~lib/typedarray/Uint32Array#__set
-  local.get $24
+  local.get $150
   i32.const 2
   i32.const 100
   call $~lib/typedarray/Uint32Array#__set
-  local.get $24
+  local.get $150
   i32.const 3
   i32.const -1
   call $~lib/typedarray/Uint32Array#__set
   i32.const 0
   i32.const 4
   call $~lib/typedarray/Int16Array#constructor
-  local.set $26
-  local.get $26
+  local.set $151
+  local.get $151
   i32.const 0
   i32.const -10
   call $~lib/typedarray/Int16Array#__set
-  local.get $26
+  local.get $151
   i32.const 1
   i32.const 100
   call $~lib/typedarray/Int16Array#__set
-  local.get $26
+  local.get $151
   i32.const 2
   i32.const 10
   call $~lib/typedarray/Int16Array#__set
-  local.get $26
+  local.get $151
   i32.const 3
   i32.const 300
   call $~lib/typedarray/Int16Array#__set
-  local.get $22
-  local.get $24
+  local.get $143
+  local.get $150
   i32.const 0
   call $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Uint32Array>
-  local.get $22
-  local.get $26
+  local.get $143
+  local.get $151
   i32.const 5
   call $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Int16Array>
-  local.get $22
+  local.get $143
   i32.const 10
   i32.const 0
   i32.const 18
   i32.const 7712
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $20
+  local.tee $154
   call $std/typedarray/valuesEqual<~lib/typedarray/Uint8ClampedArray>
-  local.get $22
+  local.get $143
   call $~lib/rt/pure/__release
-  local.get $21
+  local.get $144
   call $~lib/rt/pure/__release
-  local.get $3
+  local.get $145
   call $~lib/rt/pure/__release
-  local.get $25
+  local.get $146
   call $~lib/rt/pure/__release
-  local.get $23
+  local.get $149
   call $~lib/rt/pure/__release
-  local.get $24
+  local.get $150
   call $~lib/rt/pure/__release
-  local.get $26
+  local.get $151
   call $~lib/rt/pure/__release
-  local.get $20
+  local.get $154
   call $~lib/rt/pure/__release
  )
  (func $~start

--- a/tests/compiler/typeof.untouched.wat
+++ b/tests/compiler/typeof.untouched.wat
@@ -54,6 +54,9 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
   local.get $0
   call $~lib/rt/stub/__retain
   local.set $0
@@ -125,33 +128,33 @@
   end
   loop $while-continue|1
    local.get $4
-   local.tee $7
+   local.tee $8
    i32.const 1
    i32.sub
    local.set $4
-   local.get $7
-   local.set $7
-   local.get $7
+   local.get $8
+   local.set $9
+   local.get $9
    if
     local.get $5
     i32.load16_u
-    local.set $8
+    local.set $10
     local.get $6
     i32.load16_u
-    local.set $9
-    local.get $8
-    local.get $9
+    local.set $11
+    local.get $10
+    local.get $11
     i32.ne
     if
-     local.get $8
-     local.get $9
+     local.get $10
+     local.get $11
      i32.sub
-     local.set $10
+     local.set $12
      local.get $0
      call $~lib/rt/stub/__release
      local.get $2
      call $~lib/rt/stub/__release
-     local.get $10
+     local.get $12
      return
     end
     local.get $5
@@ -166,16 +169,19 @@
    end
   end
   i32.const 0
-  local.set $7
+  local.set $13
   local.get $0
   call $~lib/rt/stub/__release
   local.get $2
   call $~lib/rt/stub/__release
-  local.get $7
+  local.get $13
  )
  (func $~lib/string/String.__eq (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   local.get $0
   call $~lib/rt/stub/__retain
   local.set $0
@@ -207,44 +213,44 @@
   end
   if
    i32.const 0
-   local.set $2
+   local.set $3
    local.get $0
    call $~lib/rt/stub/__release
    local.get $1
    call $~lib/rt/stub/__release
-   local.get $2
+   local.get $3
    return
   end
   local.get $0
   call $~lib/string/String#get:length
-  local.set $3
-  local.get $3
+  local.set $4
+  local.get $4
   local.get $1
   call $~lib/string/String#get:length
   i32.ne
   if
    i32.const 0
-   local.set $2
+   local.set $5
    local.get $0
    call $~lib/rt/stub/__release
    local.get $1
    call $~lib/rt/stub/__release
-   local.get $2
+   local.get $5
    return
   end
   local.get $0
   i32.const 0
   local.get $1
   i32.const 0
-  local.get $3
+  local.get $4
   call $~lib/util/string/compareImpl
   i32.eqz
-  local.set $2
+  local.set $6
   local.get $0
   call $~lib/rt/stub/__release
   local.get $1
   call $~lib/rt/stub/__release
-  local.get $2
+  local.get $6
  )
  (func $start:typeof~anonymous|0
   nop
@@ -255,6 +261,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   memory.size
   local.set $1
   local.get $1
@@ -285,8 +292,8 @@
    local.get $5
    i32.gt_s
    select
-   local.set $4
-   local.get $4
+   local.set $6
+   local.get $6
    memory.grow
    i32.const 0
    i32.lt_s

--- a/tests/compiler/unary.untouched.wat
+++ b/tests/compiler/unary.untouched.wat
@@ -11,8 +11,19 @@
  (func $start:unary
   (local $0 f64)
   (local $1 i32)
-  (local $2 i64)
-  (local $3 f32)
+  (local $2 i32)
+  (local $3 i64)
+  (local $4 i64)
+  (local $5 f32)
+  (local $6 f64)
+  (local $7 f32)
+  (local $8 f32)
+  (local $9 f32)
+  (local $10 f64)
+  (local $11 f64)
+  (local $12 f64)
+  (local $13 f64)
+  (local $14 f64)
   i32.const 1
   drop
   i32.const -1
@@ -111,11 +122,11 @@
   local.get $1
   global.set $unary/i
   global.get $unary/i
-  local.tee $1
+  local.tee $2
   i32.const 1
   i32.sub
   global.set $unary/i
-  local.get $1
+  local.get $2
   global.set $unary/i
   global.get $unary/I
   drop
@@ -191,18 +202,18 @@
   global.get $unary/I
   global.set $unary/I
   global.get $unary/I
-  local.tee $2
+  local.tee $3
   i64.const 1
   i64.add
   global.set $unary/I
-  local.get $2
+  local.get $3
   global.set $unary/I
   global.get $unary/I
-  local.tee $2
+  local.tee $4
   i64.const 1
   i64.sub
   global.set $unary/I
-  local.get $2
+  local.get $4
   global.set $unary/I
   global.get $unary/f
   drop
@@ -210,11 +221,11 @@
   f32.neg
   drop
   global.get $unary/f
-  local.tee $3
+  local.tee $5
   f32.const 0
   f32.ne
-  local.get $3
-  local.get $3
+  local.get $5
+  local.get $5
   f32.eq
   i32.and
   i32.eqz
@@ -240,11 +251,11 @@
   f32.const -1.25
   global.set $unary/f
   f64.const 1.25
-  local.tee $0
+  local.tee $6
   f64.const 0
   f64.ne
-  local.get $0
-  local.get $0
+  local.get $6
+  local.get $6
   f64.eq
   i32.and
   i32.eqz
@@ -255,11 +266,11 @@
   f32.neg
   global.set $unary/f
   global.get $unary/f
-  local.tee $3
+  local.tee $7
   f32.const 0
   f32.ne
-  local.get $3
-  local.get $3
+  local.get $7
+  local.get $7
   f32.eq
   i32.and
   i32.eqz
@@ -277,18 +288,18 @@
   global.get $unary/f
   global.set $unary/f
   global.get $unary/f
-  local.tee $3
+  local.tee $8
   f32.const 1
   f32.add
   global.set $unary/f
-  local.get $3
+  local.get $8
   global.set $unary/f
   global.get $unary/f
-  local.tee $3
+  local.tee $9
   f32.const 1
   f32.sub
   global.set $unary/f
-  local.get $3
+  local.get $9
   global.set $unary/f
   global.get $unary/F
   drop
@@ -296,11 +307,11 @@
   f64.neg
   drop
   global.get $unary/F
-  local.tee $0
+  local.tee $10
   f64.const 0
   f64.ne
-  local.get $0
-  local.get $0
+  local.get $10
+  local.get $10
   f64.eq
   i32.and
   i32.eqz
@@ -326,11 +337,11 @@
   f64.const -1.25
   global.set $unary/F
   f64.const 1.25
-  local.tee $0
+  local.tee $11
   f64.const 0
   f64.ne
-  local.get $0
-  local.get $0
+  local.get $11
+  local.get $11
   f64.eq
   i32.and
   i32.eqz
@@ -342,11 +353,11 @@
   f64.neg
   global.set $unary/F
   global.get $unary/F
-  local.tee $0
+  local.tee $12
   f64.const 0
   f64.ne
-  local.get $0
-  local.get $0
+  local.get $12
+  local.get $12
   f64.eq
   i32.and
   i32.eqz
@@ -365,18 +376,18 @@
   global.get $unary/F
   global.set $unary/F
   global.get $unary/F
-  local.tee $0
+  local.tee $13
   f64.const 1
   f64.add
   global.set $unary/F
-  local.get $0
+  local.get $13
   global.set $unary/F
   global.get $unary/F
-  local.tee $0
+  local.tee $14
   f64.const 1
   f64.sub
   global.set $unary/F
-  local.get $0
+  local.get $14
   global.set $unary/F
  )
  (func $~start

--- a/tests/compiler/wasi/abort.untouched.wat
+++ b/tests/compiler/wasi/abort.untouched.wat
@@ -34,6 +34,12 @@
   (local $10 i32)
   (local $11 i32)
   (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
   local.get $0
   local.get $1
   i32.const 1
@@ -109,8 +115,8 @@
       if
        local.get $0
        i32.load16_u offset=2
-       local.set $9
-       local.get $9
+       local.set $10
+       local.get $10
        i32.const 64512
        i32.and
        i32.const 56320
@@ -123,7 +129,7 @@
         i32.const 10
         i32.shl
         i32.add
-        local.get $9
+        local.get $10
         i32.const 1023
         i32.and
         i32.or
@@ -133,7 +139,7 @@
         i32.shr_u
         i32.const 240
         i32.or
-        local.set $8
+        local.set $11
         local.get $7
         i32.const 12
         i32.shr_u
@@ -141,7 +147,7 @@
         i32.and
         i32.const 128
         i32.or
-        local.set $10
+        local.set $12
         local.get $7
         i32.const 6
         i32.shr_u
@@ -149,26 +155,26 @@
         i32.and
         i32.const 128
         i32.or
-        local.set $11
+        local.set $13
         local.get $7
         i32.const 63
         i32.and
         i32.const 128
         i32.or
-        local.set $12
+        local.set $14
         local.get $5
-        local.get $12
+        local.get $14
         i32.const 24
         i32.shl
-        local.get $11
+        local.get $13
         i32.const 16
         i32.shl
         i32.or
-        local.get $10
+        local.get $12
         i32.const 8
         i32.shl
         i32.or
-        local.get $8
+        local.get $11
         i32.or
         i32.store
         local.get $5
@@ -187,7 +193,7 @@
       i32.shr_u
       i32.const 224
       i32.or
-      local.set $9
+      local.set $15
       local.get $7
       i32.const 6
       i32.shr_u
@@ -195,22 +201,22 @@
       i32.and
       i32.const 128
       i32.or
-      local.set $12
+      local.set $16
       local.get $7
       i32.const 63
       i32.and
       i32.const 128
       i32.or
-      local.set $11
+      local.set $17
       local.get $5
-      local.get $12
+      local.get $16
       i32.const 8
       i32.shl
-      local.get $9
+      local.get $15
       i32.or
       i32.store16
       local.get $5
-      local.get $11
+      local.get $17
       i32.store8 offset=2
       local.get $5
       i32.const 3
@@ -228,11 +234,11 @@
   local.get $3
   if
    local.get $5
-   local.tee $6
+   local.tee $18
    i32.const 1
    i32.add
    local.set $5
-   local.get $6
+   local.get $18
    i32.const 0
    i32.store8
   end
@@ -304,6 +310,9 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
   local.get $0
   call $~lib/rt/stub/__retain
   local.set $0
@@ -376,7 +385,7 @@
    local.get $2
    i32.const 10
    i32.div_u
-   local.set $5
+   local.set $7
    local.get $4
    i32.const 1
    i32.sub
@@ -387,11 +396,11 @@
    i32.rem_u
    i32.add
    i32.store8
-   local.get $5
+   local.get $7
    local.set $2
    local.get $2
-   local.set $7
-   local.get $7
+   local.set $8
+   local.get $8
    br_if $do-continue|0
   end
   local.get $4
@@ -399,11 +408,11 @@
   i32.add
   local.set $4
   local.get $4
-  local.tee $7
+  local.tee $9
   i32.const 1
   i32.add
   local.set $4
-  local.get $7
+  local.get $9
   i32.const 58
   i32.store8
   local.get $3
@@ -417,7 +426,7 @@
    local.get $3
    i32.const 10
    i32.div_u
-   local.set $7
+   local.set $10
    local.get $4
    i32.const 1
    i32.sub
@@ -428,11 +437,11 @@
    i32.rem_u
    i32.add
    i32.store8
-   local.get $7
+   local.get $10
    local.set $3
    local.get $3
-   local.set $8
-   local.get $8
+   local.set $11
+   local.get $11
    br_if $do-continue|1
   end
   local.get $4

--- a/tests/compiler/wasi/seed.untouched.wat
+++ b/tests/compiler/wasi/seed.untouched.wat
@@ -136,6 +136,12 @@
   (local $10 i32)
   (local $11 i32)
   (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
   local.get $0
   local.get $1
   i32.const 1
@@ -211,8 +217,8 @@
       if
        local.get $0
        i32.load16_u offset=2
-       local.set $9
-       local.get $9
+       local.set $10
+       local.get $10
        i32.const 64512
        i32.and
        i32.const 56320
@@ -225,7 +231,7 @@
         i32.const 10
         i32.shl
         i32.add
-        local.get $9
+        local.get $10
         i32.const 1023
         i32.and
         i32.or
@@ -235,7 +241,7 @@
         i32.shr_u
         i32.const 240
         i32.or
-        local.set $8
+        local.set $11
         local.get $7
         i32.const 12
         i32.shr_u
@@ -243,7 +249,7 @@
         i32.and
         i32.const 128
         i32.or
-        local.set $10
+        local.set $12
         local.get $7
         i32.const 6
         i32.shr_u
@@ -251,26 +257,26 @@
         i32.and
         i32.const 128
         i32.or
-        local.set $11
+        local.set $13
         local.get $7
         i32.const 63
         i32.and
         i32.const 128
         i32.or
-        local.set $12
+        local.set $14
         local.get $5
-        local.get $12
+        local.get $14
         i32.const 24
         i32.shl
-        local.get $11
+        local.get $13
         i32.const 16
         i32.shl
         i32.or
-        local.get $10
+        local.get $12
         i32.const 8
         i32.shl
         i32.or
-        local.get $8
+        local.get $11
         i32.or
         i32.store
         local.get $5
@@ -289,7 +295,7 @@
       i32.shr_u
       i32.const 224
       i32.or
-      local.set $9
+      local.set $15
       local.get $7
       i32.const 6
       i32.shr_u
@@ -297,22 +303,22 @@
       i32.and
       i32.const 128
       i32.or
-      local.set $12
+      local.set $16
       local.get $7
       i32.const 63
       i32.and
       i32.const 128
       i32.or
-      local.set $11
+      local.set $17
       local.get $5
-      local.get $12
+      local.get $16
       i32.const 8
       i32.shl
-      local.get $9
+      local.get $15
       i32.or
       i32.store16
       local.get $5
-      local.get $11
+      local.get $17
       i32.store8 offset=2
       local.get $5
       i32.const 3
@@ -330,11 +336,11 @@
   local.get $3
   if
    local.get $5
-   local.tee $6
+   local.tee $18
    i32.const 1
    i32.add
    local.set $5
-   local.get $6
+   local.get $18
    i32.const 0
    i32.store8
   end
@@ -406,6 +412,9 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
   local.get $0
   call $~lib/rt/stub/__retain
   local.set $0
@@ -478,7 +487,7 @@
    local.get $2
    i32.const 10
    i32.div_u
-   local.set $5
+   local.set $7
    local.get $4
    i32.const 1
    i32.sub
@@ -489,11 +498,11 @@
    i32.rem_u
    i32.add
    i32.store8
-   local.get $5
+   local.get $7
    local.set $2
    local.get $2
-   local.set $7
-   local.get $7
+   local.set $8
+   local.get $8
    br_if $do-continue|0
   end
   local.get $4
@@ -501,11 +510,11 @@
   i32.add
   local.set $4
   local.get $4
-  local.tee $7
+  local.tee $9
   i32.const 1
   i32.add
   local.set $4
-  local.get $7
+  local.get $9
   i32.const 58
   i32.store8
   local.get $3
@@ -519,7 +528,7 @@
    local.get $3
    i32.const 10
    i32.div_u
-   local.set $7
+   local.set $10
    local.get $4
    i32.const 1
    i32.sub
@@ -530,11 +539,11 @@
    i32.rem_u
    i32.add
    i32.store8
-   local.get $7
+   local.get $10
    local.set $3
    local.get $3
-   local.set $8
-   local.get $8
+   local.set $11
+   local.get $11
    br_if $do-continue|1
   end
   local.get $4

--- a/tests/compiler/wasi/trace.optimized.wat
+++ b/tests/compiler/wasi/trace.optimized.wat
@@ -736,8 +736,6 @@
    global.get $~lib/util/number/_K
    i32.add
    global.set $~lib/util/number/_K
-   local.get $8
-   local.set $1
    local.get $9
    i32.const 0
    local.get $4
@@ -748,7 +746,7 @@
    i32.add
    i64.load32_u
    i64.mul
-   local.set $3
+   local.set $1
    local.get $0
    local.get $6
    i32.const 1
@@ -761,30 +759,30 @@
    local.set $4
    loop $while-continue|6
     i32.const 1
-    local.get $3
     local.get $1
+    local.get $8
     i64.sub
-    local.get $1
+    local.get $8
     local.get $11
     i64.add
-    local.get $3
+    local.get $1
     i64.sub
     i64.gt_u
-    local.get $1
+    local.get $8
     local.get $11
     i64.add
-    local.get $3
+    local.get $1
     i64.lt_u
     select
     i32.const 0
     local.get $5
-    local.get $1
+    local.get $8
     i64.sub
     local.get $11
     i64.ge_u
     i32.const 0
+    local.get $8
     local.get $1
-    local.get $3
     i64.lt_u
     select
     select
@@ -793,10 +791,10 @@
      i32.const 1
      i32.sub
      local.set $4
-     local.get $1
+     local.get $8
      local.get $11
      i64.add
-     local.set $1
+     local.set $8
      br $while-continue|6
     end
    end

--- a/tests/compiler/wasi/trace.untouched.wat
+++ b/tests/compiler/wasi/trace.untouched.wat
@@ -46,6 +46,7 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
   local.get $0
   call $~lib/rt/stub/__retain
   local.set $0
@@ -146,10 +147,10 @@
    end
   end
   local.get $4
-  local.set $5
+  local.set $7
   local.get $0
   call $~lib/rt/stub/__release
-  local.get $5
+  local.get $7
  )
  (func $~lib/rt/stub/maybeGrowMemory (param $0 i32)
   (local $1 i32)
@@ -157,6 +158,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   memory.size
   local.set $1
   local.get $1
@@ -187,8 +189,8 @@
    local.get $5
    i32.gt_s
    select
-   local.set $4
-   local.get $4
+   local.set $6
+   local.get $6
    memory.grow
    i32.const 0
    i32.lt_s
@@ -278,6 +280,12 @@
   (local $10 i32)
   (local $11 i32)
   (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
   local.get $0
   local.get $1
   i32.const 1
@@ -353,8 +361,8 @@
       if
        local.get $0
        i32.load16_u offset=2
-       local.set $9
-       local.get $9
+       local.set $10
+       local.get $10
        i32.const 64512
        i32.and
        i32.const 56320
@@ -367,7 +375,7 @@
         i32.const 10
         i32.shl
         i32.add
-        local.get $9
+        local.get $10
         i32.const 1023
         i32.and
         i32.or
@@ -377,7 +385,7 @@
         i32.shr_u
         i32.const 240
         i32.or
-        local.set $8
+        local.set $11
         local.get $7
         i32.const 12
         i32.shr_u
@@ -385,7 +393,7 @@
         i32.and
         i32.const 128
         i32.or
-        local.set $10
+        local.set $12
         local.get $7
         i32.const 6
         i32.shr_u
@@ -393,26 +401,26 @@
         i32.and
         i32.const 128
         i32.or
-        local.set $11
+        local.set $13
         local.get $7
         i32.const 63
         i32.and
         i32.const 128
         i32.or
-        local.set $12
+        local.set $14
         local.get $5
-        local.get $12
+        local.get $14
         i32.const 24
         i32.shl
-        local.get $11
+        local.get $13
         i32.const 16
         i32.shl
         i32.or
-        local.get $10
+        local.get $12
         i32.const 8
         i32.shl
         i32.or
-        local.get $8
+        local.get $11
         i32.or
         i32.store
         local.get $5
@@ -431,7 +439,7 @@
       i32.shr_u
       i32.const 224
       i32.or
-      local.set $9
+      local.set $15
       local.get $7
       i32.const 6
       i32.shr_u
@@ -439,22 +447,22 @@
       i32.and
       i32.const 128
       i32.or
-      local.set $12
+      local.set $16
       local.get $7
       i32.const 63
       i32.and
       i32.const 128
       i32.or
-      local.set $11
+      local.set $17
       local.get $5
-      local.get $12
+      local.get $16
       i32.const 8
       i32.shl
-      local.get $9
+      local.get $15
       i32.or
       i32.store16
       local.get $5
-      local.get $11
+      local.get $17
       i32.store8 offset=2
       local.get $5
       i32.const 3
@@ -472,11 +480,11 @@
   local.get $3
   if
    local.get $5
-   local.tee $6
+   local.tee $18
    i32.const 1
    i32.add
    local.set $5
-   local.get $6
+   local.get $18
    i32.const 0
    i32.store8
   end
@@ -552,16 +560,31 @@
   (local $16 i32)
   (local $17 i32)
   (local $18 i32)
-  (local $19 i64)
+  (local $19 i32)
   (local $20 i64)
   (local $21 i64)
   (local $22 i64)
   (local $23 i64)
-  (local $24 i32)
+  (local $24 i64)
   (local $25 i32)
   (local $26 i32)
   (local $27 i32)
-  (local $28 i64)
+  (local $28 i32)
+  (local $29 i32)
+  (local $30 i32)
+  (local $31 i32)
+  (local $32 i64)
+  (local $33 i32)
+  (local $34 i64)
+  (local $35 i64)
+  (local $36 i64)
+  (local $37 i64)
+  (local $38 i32)
+  (local $39 i32)
+  (local $40 i32)
+  (local $41 i32)
+  (local $42 i32)
+  (local $43 i32)
   i32.const 0
   local.get $4
   i32.sub
@@ -765,11 +788,11 @@
     if
      local.get $0
      local.get $15
-     local.tee $18
+     local.tee $19
      i32.const 1
      i32.add
      local.set $15
-     local.get $18
+     local.get $19
      i32.const 1
      i32.shl
      i32.add
@@ -791,8 +814,8 @@
     i64.shl
     local.get $13
     i64.add
-    local.set $19
-    local.get $19
+    local.set $20
+    local.get $20
     local.get $5
     i64.le_u
     if
@@ -801,13 +824,13 @@
      i32.add
      global.set $~lib/util/number/_K
      local.get $0
-     local.set $24
+     local.set $26
      local.get $15
-     local.set $18
+     local.set $25
      local.get $5
+     local.set $24
+     local.get $20
      local.set $23
-     local.get $19
-     local.set $22
      i32.const 928
      local.get $14
      i32.const 2
@@ -817,71 +840,71 @@
      local.get $7
      i64.extend_i32_s
      i64.shl
-     local.set $21
+     local.set $22
      local.get $10
-     local.set $20
-     local.get $24
-     local.get $18
+     local.set $21
+     local.get $26
+     local.get $25
      i32.const 1
      i32.sub
      i32.const 1
      i32.shl
      i32.add
-     local.set $25
-     local.get $25
+     local.set $27
+     local.get $27
      i32.load16_u
-     local.set $26
+     local.set $28
      loop $while-continue|3
-      local.get $22
-      local.get $20
+      local.get $23
+      local.get $21
       i64.lt_u
       if (result i32)
+       local.get $24
        local.get $23
-       local.get $22
        i64.sub
-       local.get $21
+       local.get $22
        i64.ge_u
       else
        i32.const 0
       end
       if (result i32)
+       local.get $23
        local.get $22
-       local.get $21
        i64.add
-       local.get $20
+       local.get $21
        i64.lt_u
        if (result i32)
         i32.const 1
        else
-        local.get $20
-        local.get $22
-        i64.sub
-        local.get $22
         local.get $21
+        local.get $23
+        i64.sub
+        local.get $23
+        local.get $22
         i64.add
-        local.get $20
+        local.get $21
         i64.sub
         i64.gt_u
        end
       else
        i32.const 0
       end
-      local.set $27
-      local.get $27
+      local.set $30
+      local.get $30
       if
-       local.get $26
+       local.get $28
        i32.const 1
        i32.sub
-       local.set $26
+       local.set $28
+       local.get $23
        local.get $22
-       local.get $21
        i64.add
-       local.set $22
+       local.set $23
        br $while-continue|3
       end
      end
-     local.get $25
-     local.get $26
+     local.get $27
+     local.get $28
      i32.store16
      local.get $15
      return
@@ -891,8 +914,8 @@
   end
   loop $while-continue|4
    i32.const 1
-   local.set $16
-   local.get $16
+   local.set $31
+   local.get $31
    if
     local.get $13
     i64.const 10
@@ -906,8 +929,8 @@
     local.get $7
     i64.extend_i32_s
     i64.shr_u
-    local.set $23
-    local.get $23
+    local.set $32
+    local.get $32
     local.get $15
     i64.extend_i32_s
     i64.or
@@ -916,16 +939,16 @@
     if
      local.get $0
      local.get $15
-     local.tee $26
+     local.tee $33
      i32.const 1
      i32.add
      local.set $15
-     local.get $26
+     local.get $33
      i32.const 1
      i32.shl
      i32.add
      i32.const 48
-     local.get $23
+     local.get $32
      i32.wrap_i64
      i32.const 65535
      i32.and
@@ -960,79 +983,79 @@
      i64.mul
      local.set $10
      local.get $0
-     local.set $18
+     local.set $39
      local.get $15
-     local.set $27
+     local.set $38
      local.get $5
-     local.set $28
+     local.set $37
      local.get $13
-     local.set $22
+     local.set $36
      local.get $8
-     local.set $21
+     local.set $35
      local.get $10
-     local.set $20
-     local.get $18
-     local.get $27
+     local.set $34
+     local.get $39
+     local.get $38
      i32.const 1
      i32.sub
      i32.const 1
      i32.shl
      i32.add
-     local.set $26
-     local.get $26
+     local.set $40
+     local.get $40
      i32.load16_u
-     local.set $25
+     local.set $41
      loop $while-continue|6
-      local.get $22
-      local.get $20
+      local.get $36
+      local.get $34
       i64.lt_u
       if (result i32)
-       local.get $28
-       local.get $22
+       local.get $37
+       local.get $36
        i64.sub
-       local.get $21
+       local.get $35
        i64.ge_u
       else
        i32.const 0
       end
       if (result i32)
-       local.get $22
-       local.get $21
+       local.get $36
+       local.get $35
        i64.add
-       local.get $20
+       local.get $34
        i64.lt_u
        if (result i32)
         i32.const 1
        else
-        local.get $20
-        local.get $22
+        local.get $34
+        local.get $36
         i64.sub
-        local.get $22
-        local.get $21
+        local.get $36
+        local.get $35
         i64.add
-        local.get $20
+        local.get $34
         i64.sub
         i64.gt_u
        end
       else
        i32.const 0
       end
-      local.set $24
-      local.get $24
+      local.set $43
+      local.get $43
       if
-       local.get $25
+       local.get $41
        i32.const 1
        i32.sub
-       local.set $25
-       local.get $22
-       local.get $21
+       local.set $41
+       local.get $36
+       local.get $35
        i64.add
-       local.set $22
+       local.set $36
        br $while-continue|6
       end
      end
-     local.get $26
-     local.get $25
+     local.get $40
+     local.get $41
      i32.store16
      local.get $15
      return
@@ -1047,6 +1070,88 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local $22 i32)
+  (local $23 i32)
+  (local $24 i32)
+  (local $25 i32)
+  (local $26 i32)
+  (local $27 i32)
+  (local $28 i32)
+  (local $29 i32)
+  (local $30 i32)
+  (local $31 i32)
+  (local $32 i32)
+  (local $33 i32)
+  (local $34 i32)
+  (local $35 i32)
+  (local $36 i32)
+  (local $37 i32)
+  (local $38 i32)
+  (local $39 i32)
+  (local $40 i32)
+  (local $41 i32)
+  (local $42 i32)
+  (local $43 i32)
+  (local $44 i32)
+  (local $45 i32)
+  (local $46 i32)
+  (local $47 i32)
+  (local $48 i32)
+  (local $49 i32)
+  (local $50 i32)
+  (local $51 i32)
+  (local $52 i32)
+  (local $53 i32)
+  (local $54 i32)
+  (local $55 i32)
+  (local $56 i32)
+  (local $57 i32)
+  (local $58 i32)
+  (local $59 i32)
+  (local $60 i32)
+  (local $61 i32)
+  (local $62 i32)
+  (local $63 i32)
+  (local $64 i32)
+  (local $65 i32)
+  (local $66 i32)
+  (local $67 i32)
+  (local $68 i32)
+  (local $69 i32)
+  (local $70 i32)
+  (local $71 i32)
+  (local $72 i32)
+  (local $73 i32)
+  (local $74 i32)
+  (local $75 i32)
+  (local $76 i32)
+  (local $77 i32)
+  (local $78 i32)
+  (local $79 i32)
+  (local $80 i32)
+  (local $81 i32)
+  (local $82 i32)
+  (local $83 i32)
+  (local $84 i32)
+  (local $85 i32)
+  (local $86 i32)
+  (local $87 i32)
+  (local $88 i32)
   loop $while-continue|0
    local.get $2
    if (result i32)
@@ -1066,11 +1171,11 @@
     local.set $0
     local.get $6
     local.get $1
-    local.tee $6
+    local.tee $7
     i32.const 1
     i32.add
     local.set $1
-    local.get $6
+    local.get $7
     i32.load8_u
     i32.store8
     local.get $2
@@ -1090,8 +1195,8 @@
     local.get $2
     i32.const 16
     i32.ge_u
-    local.set $5
-    local.get $5
+    local.set $8
+    local.get $8
     if
      local.get $0
      local.get $1
@@ -1200,17 +1305,17 @@
    i32.and
    if
     local.get $0
-    local.tee $5
+    local.tee $9
     i32.const 1
     i32.add
     local.set $0
-    local.get $5
+    local.get $9
     local.get $1
-    local.tee $5
+    local.tee $10
     i32.const 1
     i32.add
     local.set $1
-    local.get $5
+    local.get $10
     i32.load8_u
     i32.store8
    end
@@ -1227,16 +1332,16 @@
        local.get $0
        i32.const 3
        i32.and
-       local.set $5
-       local.get $5
+       local.set $11
+       local.get $11
        i32.const 1
        i32.eq
        br_if $case0|2
-       local.get $5
+       local.get $11
        i32.const 2
        i32.eq
        br_if $case1|2
-       local.get $5
+       local.get $11
        i32.const 3
        i32.eq
        br_if $case2|2
@@ -1246,45 +1351,45 @@
       i32.load
       local.set $3
       local.get $0
-      local.tee $5
+      local.tee $12
       i32.const 1
       i32.add
       local.set $0
-      local.get $5
+      local.get $12
       local.get $1
-      local.tee $5
+      local.tee $13
       i32.const 1
       i32.add
       local.set $1
-      local.get $5
+      local.get $13
       i32.load8_u
       i32.store8
       local.get $0
-      local.tee $5
+      local.tee $14
       i32.const 1
       i32.add
       local.set $0
-      local.get $5
+      local.get $14
       local.get $1
-      local.tee $5
+      local.tee $15
       i32.const 1
       i32.add
       local.set $1
-      local.get $5
+      local.get $15
       i32.load8_u
       i32.store8
       local.get $0
-      local.tee $5
+      local.tee $16
       i32.const 1
       i32.add
       local.set $0
-      local.get $5
+      local.get $16
       local.get $1
-      local.tee $5
+      local.tee $17
       i32.const 1
       i32.add
       local.set $1
-      local.get $5
+      local.get $17
       i32.load8_u
       i32.store8
       local.get $2
@@ -1295,8 +1400,8 @@
        local.get $2
        i32.const 17
        i32.ge_u
-       local.set $5
-       local.get $5
+       local.set $18
+       local.get $18
        if
         local.get $1
         i32.const 1
@@ -1381,31 +1486,31 @@
      i32.load
      local.set $3
      local.get $0
-     local.tee $5
+     local.tee $19
      i32.const 1
      i32.add
      local.set $0
-     local.get $5
+     local.get $19
      local.get $1
-     local.tee $5
+     local.tee $20
      i32.const 1
      i32.add
      local.set $1
-     local.get $5
+     local.get $20
      i32.load8_u
      i32.store8
      local.get $0
-     local.tee $5
+     local.tee $21
      i32.const 1
      i32.add
      local.set $0
-     local.get $5
+     local.get $21
      local.get $1
-     local.tee $5
+     local.tee $22
      i32.const 1
      i32.add
      local.set $1
-     local.get $5
+     local.get $22
      i32.load8_u
      i32.store8
      local.get $2
@@ -1416,8 +1521,8 @@
       local.get $2
       i32.const 18
       i32.ge_u
-      local.set $5
-      local.get $5
+      local.set $23
+      local.get $23
       if
        local.get $1
        i32.const 2
@@ -1502,17 +1607,17 @@
     i32.load
     local.set $3
     local.get $0
-    local.tee $5
+    local.tee $24
     i32.const 1
     i32.add
     local.set $0
-    local.get $5
+    local.get $24
     local.get $1
-    local.tee $5
+    local.tee $25
     i32.const 1
     i32.add
     local.set $1
-    local.get $5
+    local.get $25
     i32.load8_u
     i32.store8
     local.get $2
@@ -1523,8 +1628,8 @@
      local.get $2
      i32.const 19
      i32.ge_u
-     local.set $5
-     local.get $5
+     local.set $26
+     local.get $26
      if
       local.get $1
       i32.const 3
@@ -1611,227 +1716,227 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $27
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $27
    local.get $1
-   local.tee $5
+   local.tee $28
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $28
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $29
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $29
    local.get $1
-   local.tee $5
+   local.tee $30
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $30
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $31
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $31
    local.get $1
-   local.tee $5
+   local.tee $32
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $32
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $33
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $33
    local.get $1
-   local.tee $5
+   local.tee $34
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $34
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $35
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $35
    local.get $1
-   local.tee $5
+   local.tee $36
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $36
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $37
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $37
    local.get $1
-   local.tee $5
+   local.tee $38
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $38
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $39
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $39
    local.get $1
-   local.tee $5
+   local.tee $40
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $40
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $41
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $41
    local.get $1
-   local.tee $5
+   local.tee $42
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $42
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $43
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $43
    local.get $1
-   local.tee $5
+   local.tee $44
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $44
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $45
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $45
    local.get $1
-   local.tee $5
+   local.tee $46
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $46
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $47
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $47
    local.get $1
-   local.tee $5
+   local.tee $48
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $48
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $49
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $49
    local.get $1
-   local.tee $5
+   local.tee $50
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $50
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $51
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $51
    local.get $1
-   local.tee $5
+   local.tee $52
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $52
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $53
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $53
    local.get $1
-   local.tee $5
+   local.tee $54
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $54
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $55
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $55
    local.get $1
-   local.tee $5
+   local.tee $56
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $56
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $57
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $57
    local.get $1
-   local.tee $5
+   local.tee $58
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $58
    i32.load8_u
    i32.store8
   end
@@ -1840,115 +1945,115 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $59
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $59
    local.get $1
-   local.tee $5
+   local.tee $60
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $60
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $61
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $61
    local.get $1
-   local.tee $5
+   local.tee $62
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $62
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $63
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $63
    local.get $1
-   local.tee $5
+   local.tee $64
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $64
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $65
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $65
    local.get $1
-   local.tee $5
+   local.tee $66
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $66
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $67
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $67
    local.get $1
-   local.tee $5
+   local.tee $68
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $68
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $69
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $69
    local.get $1
-   local.tee $5
+   local.tee $70
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $70
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $71
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $71
    local.get $1
-   local.tee $5
+   local.tee $72
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $72
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $73
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $73
    local.get $1
-   local.tee $5
+   local.tee $74
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $74
    i32.load8_u
    i32.store8
   end
@@ -1957,59 +2062,59 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $75
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $75
    local.get $1
-   local.tee $5
+   local.tee $76
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $76
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $77
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $77
    local.get $1
-   local.tee $5
+   local.tee $78
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $78
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $79
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $79
    local.get $1
-   local.tee $5
+   local.tee $80
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $80
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $81
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $81
    local.get $1
-   local.tee $5
+   local.tee $82
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $82
    i32.load8_u
    i32.store8
   end
@@ -2018,31 +2123,31 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $83
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $83
    local.get $1
-   local.tee $5
+   local.tee $84
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $84
    i32.load8_u
    i32.store8
    local.get $0
-   local.tee $5
+   local.tee $85
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $85
    local.get $1
-   local.tee $5
+   local.tee $86
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $86
    i32.load8_u
    i32.store8
   end
@@ -2051,17 +2156,17 @@
   i32.and
   if
    local.get $0
-   local.tee $5
+   local.tee $87
    i32.const 1
    i32.add
    local.set $0
-   local.get $5
+   local.get $87
    local.get $1
-   local.tee $5
+   local.tee $88
    i32.const 1
    i32.add
    local.set $1
-   local.get $5
+   local.get $88
    i32.load8_u
    i32.store8
   end
@@ -2072,6 +2177,14 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
   block $~lib/util/memory/memmove|inlined.0
    local.get $0
    local.set $5
@@ -2149,11 +2262,11 @@
        local.set $5
        local.get $7
        local.get $4
-       local.tee $7
+       local.tee $8
        i32.const 1
        i32.add
        local.set $4
-       local.get $7
+       local.get $8
        i32.load8_u
        i32.store8
        br $while-continue|0
@@ -2163,8 +2276,8 @@
       local.get $3
       i32.const 8
       i32.ge_u
-      local.set $6
-      local.get $6
+      local.set $9
+      local.get $9
       if
        local.get $5
        local.get $4
@@ -2188,21 +2301,21 @@
     end
     loop $while-continue|2
      local.get $3
-     local.set $6
-     local.get $6
+     local.set $10
+     local.get $10
      if
       local.get $5
-      local.tee $7
+      local.tee $11
       i32.const 1
       i32.add
       local.set $5
-      local.get $7
+      local.get $11
       local.get $4
-      local.tee $7
+      local.tee $12
       i32.const 1
       i32.add
       local.set $4
-      local.get $7
+      local.get $12
       i32.load8_u
       i32.store8
       local.get $3
@@ -2231,8 +2344,8 @@
       i32.add
       i32.const 7
       i32.and
-      local.set $6
-      local.get $6
+      local.set $13
+      local.get $13
       if
        local.get $3
        i32.eqz
@@ -2257,8 +2370,8 @@
       local.get $3
       i32.const 8
       i32.ge_u
-      local.set $6
-      local.get $6
+      local.set $14
+      local.get $14
       if
        local.get $3
        i32.const 8
@@ -2278,8 +2391,8 @@
     end
     loop $while-continue|5
      local.get $3
-     local.set $6
-     local.get $6
+     local.set $15
+     local.get $15
      if
       local.get $5
       local.get $3
@@ -2308,6 +2421,9 @@
   (local $9 i64)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
   loop $while-continue|0
    local.get $1
    i32.const 10000
@@ -2372,30 +2488,30 @@
    local.get $1
    i32.const 100
    i32.div_u
-   local.set $3
+   local.set $10
    local.get $1
    i32.const 100
    i32.rem_u
-   local.set $10
-   local.get $3
+   local.set $11
+   local.get $10
    local.set $1
    local.get $2
    i32.const 2
    i32.sub
    local.set $2
    i32.const 968
-   local.get $10
+   local.get $11
    i32.const 2
    i32.shl
    i32.add
    i32.load
-   local.set $11
+   local.set $12
    local.get $0
    local.get $2
    i32.const 1
    i32.shl
    i32.add
-   local.get $11
+   local.get $12
    i32.store
   end
   local.get $1
@@ -2412,13 +2528,13 @@
    i32.shl
    i32.add
    i32.load
-   local.set $11
+   local.set $13
    local.get $0
    local.get $2
    i32.const 1
    i32.shl
    i32.add
-   local.get $11
+   local.get $13
    i32.store
   else
    local.get $2
@@ -2428,13 +2544,13 @@
    i32.const 48
    local.get $1
    i32.add
-   local.set $11
+   local.set $14
    local.get $0
    local.get $2
    i32.const 1
    i32.shl
    i32.add
-   local.get $11
+   local.get $14
    i32.store16
   end
  )
@@ -2448,6 +2564,19 @@
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local $22 i32)
+  (local $23 i32)
+  (local $24 i32)
   local.get $2
   i32.eqz
   if
@@ -2537,11 +2666,11 @@
     i32.const 1
     i32.shl
     i32.add
-    local.set $4
-    local.get $4
+    local.set $6
+    local.get $6
     i32.const 2
     i32.add
-    local.get $4
+    local.get $6
     i32.const 0
     local.get $2
     i32.sub
@@ -2574,9 +2703,9 @@
      i32.const 2
      local.get $3
      i32.sub
-     local.set $4
+     local.set $7
      local.get $0
-     local.get $4
+     local.get $7
      i32.const 1
      i32.shl
      i32.add
@@ -2593,30 +2722,30 @@
      i32.or
      i32.store
      i32.const 2
-     local.set $5
+     local.set $8
      loop $for-loop|1
-      local.get $5
-      local.get $4
+      local.get $8
+      local.get $7
       i32.lt_s
-      local.set $6
-      local.get $6
+      local.set $9
+      local.get $9
       if
        local.get $0
-       local.get $5
+       local.get $8
        i32.const 1
        i32.shl
        i32.add
        i32.const 48
        i32.store16
-       local.get $5
+       local.get $8
        i32.const 1
        i32.add
-       local.set $5
+       local.set $8
        br $for-loop|1
       end
      end
      local.get $1
-     local.get $4
+     local.get $7
      i32.add
      return
     else
@@ -2630,48 +2759,48 @@
       local.get $0
       i32.const 4
       i32.add
-      local.set $5
+      local.set $11
       local.get $3
       i32.const 1
       i32.sub
-      local.set $6
-      local.get $6
+      local.set $10
+      local.get $10
       i32.const 0
       i32.lt_s
-      local.set $4
-      local.get $4
+      local.set $12
+      local.get $12
       if
        i32.const 0
-       local.get $6
+       local.get $10
        i32.sub
-       local.set $6
+       local.set $10
       end
-      local.get $6
+      local.get $10
       call $~lib/util/number/decimalCount32
       i32.const 1
       i32.add
-      local.set $7
-      local.get $5
-      local.set $10
-      local.get $6
-      local.set $9
-      local.get $7
-      local.set $8
+      local.set $13
+      local.get $11
+      local.set $16
+      local.get $10
+      local.set $15
+      local.get $13
+      local.set $14
       i32.const 0
       i32.const 1
       i32.ge_s
       drop
-      local.get $10
-      local.get $9
-      local.get $8
+      local.get $16
+      local.get $15
+      local.get $14
       call $~lib/util/number/utoa32_lut
-      local.get $5
+      local.get $11
       i32.const 45
       i32.const 43
-      local.get $4
+      local.get $12
       select
       i32.store16
-      local.get $7
+      local.get $13
       local.set $1
       local.get $1
       i32.const 2
@@ -2681,14 +2810,14 @@
       local.get $1
       i32.const 1
       i32.shl
-      local.set $7
+      local.set $17
       local.get $0
       i32.const 4
       i32.add
       local.get $0
       i32.const 2
       i32.add
-      local.get $7
+      local.get $17
       i32.const 2
       i32.sub
       call $~lib/memory/memory.copy
@@ -2696,58 +2825,58 @@
       i32.const 46
       i32.store16 offset=2
       local.get $0
-      local.get $7
+      local.get $17
       i32.add
       i32.const 101
       i32.store16 offset=2
       local.get $1
       local.get $0
-      local.get $7
+      local.get $17
       i32.add
       i32.const 4
       i32.add
-      local.set $9
+      local.set $19
       local.get $3
       i32.const 1
       i32.sub
-      local.set $8
-      local.get $8
+      local.set $18
+      local.get $18
       i32.const 0
       i32.lt_s
-      local.set $4
-      local.get $4
+      local.set $20
+      local.get $20
       if
        i32.const 0
-       local.get $8
+       local.get $18
        i32.sub
-       local.set $8
+       local.set $18
       end
-      local.get $8
+      local.get $18
       call $~lib/util/number/decimalCount32
       i32.const 1
       i32.add
-      local.set $5
-      local.get $9
-      local.set $11
-      local.get $8
-      local.set $6
-      local.get $5
-      local.set $10
+      local.set $21
+      local.get $19
+      local.set $24
+      local.get $18
+      local.set $23
+      local.get $21
+      local.set $22
       i32.const 0
       i32.const 1
       i32.ge_s
       drop
-      local.get $11
-      local.get $6
-      local.get $10
+      local.get $24
+      local.get $23
+      local.get $22
       call $~lib/util/number/utoa32_lut
-      local.get $9
+      local.get $19
       i32.const 45
       i32.const 43
-      local.get $4
+      local.get $20
       select
       i32.store16
-      local.get $5
+      local.get $21
       i32.add
       local.set $1
       local.get $1
@@ -2778,19 +2907,51 @@
   (local $13 i32)
   (local $14 i32)
   (local $15 i32)
-  (local $16 f64)
-  (local $17 i64)
-  (local $18 i64)
-  (local $19 i64)
-  (local $20 i64)
+  (local $16 i32)
+  (local $17 f64)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
   (local $21 i64)
-  (local $22 i64)
+  (local $22 i32)
   (local $23 i64)
   (local $24 i64)
   (local $25 i64)
-  (local $26 i32)
+  (local $26 i64)
   (local $27 i64)
-  (local $28 i32)
+  (local $28 i64)
+  (local $29 i64)
+  (local $30 i64)
+  (local $31 i64)
+  (local $32 i64)
+  (local $33 i32)
+  (local $34 i32)
+  (local $35 i32)
+  (local $36 i64)
+  (local $37 i64)
+  (local $38 i64)
+  (local $39 i64)
+  (local $40 i64)
+  (local $41 i64)
+  (local $42 i64)
+  (local $43 i64)
+  (local $44 i64)
+  (local $45 i64)
+  (local $46 i32)
+  (local $47 i32)
+  (local $48 i32)
+  (local $49 i64)
+  (local $50 i64)
+  (local $51 i64)
+  (local $52 i64)
+  (local $53 i64)
+  (local $54 i64)
+  (local $55 i64)
+  (local $56 i64)
+  (local $57 i64)
+  (local $58 i64)
+  (local $59 i64)
+  (local $60 i32)
   local.get $1
   f64.const 0
   f64.lt
@@ -2894,47 +3055,47 @@
   local.get $13
   global.set $~lib/util/number/_exp
   global.get $~lib/util/number/_exp
-  local.set $10
+  local.set $16
   i32.const -61
-  local.get $10
+  local.get $16
   i32.sub
   f64.convert_i32_s
   f64.const 0.30102999566398114
   f64.mul
   f64.const 347
   f64.add
-  local.set $16
-  local.get $16
+  local.set $17
+  local.get $17
   i32.trunc_f64_s
-  local.set $15
-  local.get $15
-  local.get $15
+  local.set $18
+  local.get $18
+  local.get $18
   f64.convert_i32_s
-  local.get $16
+  local.get $17
   f64.ne
   i32.add
-  local.set $15
-  local.get $15
+  local.set $18
+  local.get $18
   i32.const 3
   i32.shr_s
   i32.const 1
   i32.add
-  local.set $14
+  local.set $19
   i32.const 348
-  local.get $14
+  local.get $19
   i32.const 3
   i32.shl
   i32.sub
   global.set $~lib/util/number/_K
   i32.const 56
-  local.get $14
+  local.get $19
   i32.const 3
   i32.shl
   i32.add
   i64.load
   global.set $~lib/util/number/_frc_pow
   i32.const 752
-  local.get $14
+  local.get $19
   i32.const 1
   i32.shl
   i32.add
@@ -2943,249 +3104,249 @@
   local.get $9
   i64.clz
   i32.wrap_i64
-  local.set $14
+  local.set $20
   local.get $9
-  local.get $14
+  local.get $20
   i64.extend_i32_s
   i64.shl
   local.set $9
   local.get $7
-  local.get $14
+  local.get $20
   i32.sub
   local.set $7
   global.get $~lib/util/number/_frc_pow
-  local.set $12
+  local.set $21
   global.get $~lib/util/number/_exp_pow
-  local.set $15
+  local.set $22
   local.get $9
-  local.set $17
-  local.get $12
-  local.set $11
-  local.get $17
-  i64.const 4294967295
-  i64.and
-  local.set $18
-  local.get $11
-  i64.const 4294967295
-  i64.and
-  local.set $19
-  local.get $17
-  i64.const 32
-  i64.shr_u
-  local.set $20
-  local.get $11
-  i64.const 32
-  i64.shr_u
-  local.set $21
-  local.get $18
-  local.get $19
-  i64.mul
-  local.set $22
-  local.get $20
-  local.get $19
-  i64.mul
-  local.get $22
-  i64.const 32
-  i64.shr_u
-  i64.add
-  local.set $23
-  local.get $18
+  local.set $24
   local.get $21
-  i64.mul
+  local.set $23
+  local.get $24
+  i64.const 4294967295
+  i64.and
+  local.set $25
   local.get $23
   i64.const 4294967295
   i64.and
-  i64.add
-  local.set $24
+  local.set $26
   local.get $24
+  i64.const 32
+  i64.shr_u
+  local.set $27
+  local.get $23
+  i64.const 32
+  i64.shr_u
+  local.set $28
+  local.get $25
+  local.get $26
+  i64.mul
+  local.set $29
+  local.get $27
+  local.get $26
+  i64.mul
+  local.get $29
+  i64.const 32
+  i64.shr_u
+  i64.add
+  local.set $30
+  local.get $25
+  local.get $28
+  i64.mul
+  local.get $30
+  i64.const 4294967295
+  i64.and
+  i64.add
+  local.set $31
+  local.get $31
   i64.const 2147483647
   i64.add
-  local.set $24
-  local.get $23
+  local.set $31
+  local.get $30
   i64.const 32
   i64.shr_u
-  local.set $23
-  local.get $24
+  local.set $30
+  local.get $31
   i64.const 32
   i64.shr_u
-  local.set $24
-  local.get $20
-  local.get $21
+  local.set $31
+  local.get $27
+  local.get $28
   i64.mul
-  local.get $23
+  local.get $30
   i64.add
-  local.get $24
+  local.get $31
   i64.add
-  local.set $24
+  local.set $32
   local.get $7
-  local.set $10
-  local.get $15
-  local.set $13
-  local.get $10
-  local.get $13
+  local.set $34
+  local.get $22
+  local.set $33
+  local.get $34
+  local.get $33
   i32.add
   i32.const 64
   i32.add
-  local.set $10
+  local.set $35
   global.get $~lib/util/number/_frc_plus
-  local.set $17
-  local.get $12
-  local.set $11
-  local.get $17
-  i64.const 4294967295
-  i64.and
-  local.set $23
-  local.get $11
-  i64.const 4294967295
-  i64.and
-  local.set $22
-  local.get $17
-  i64.const 32
-  i64.shr_u
-  local.set $21
-  local.get $11
-  i64.const 32
-  i64.shr_u
-  local.set $20
-  local.get $23
-  local.get $22
-  i64.mul
-  local.set $19
+  local.set $37
   local.get $21
-  local.get $22
+  local.set $36
+  local.get $37
+  i64.const 4294967295
+  i64.and
+  local.set $38
+  local.get $36
+  i64.const 4294967295
+  i64.and
+  local.set $39
+  local.get $37
+  i64.const 32
+  i64.shr_u
+  local.set $40
+  local.get $36
+  i64.const 32
+  i64.shr_u
+  local.set $41
+  local.get $38
+  local.get $39
   i64.mul
-  local.get $19
+  local.set $42
+  local.get $40
+  local.get $39
+  i64.mul
+  local.get $42
   i64.const 32
   i64.shr_u
   i64.add
-  local.set $18
-  local.get $23
-  local.get $20
+  local.set $43
+  local.get $38
+  local.get $41
   i64.mul
-  local.get $18
+  local.get $43
   i64.const 4294967295
   i64.and
   i64.add
-  local.set $25
-  local.get $25
+  local.set $44
+  local.get $44
   i64.const 2147483647
   i64.add
-  local.set $25
-  local.get $18
+  local.set $44
+  local.get $43
   i64.const 32
   i64.shr_u
-  local.set $18
-  local.get $25
+  local.set $43
+  local.get $44
   i64.const 32
   i64.shr_u
-  local.set $25
-  local.get $21
-  local.get $20
+  local.set $44
+  local.get $40
+  local.get $41
   i64.mul
-  local.get $18
+  local.get $43
   i64.add
-  local.get $25
+  local.get $44
   i64.add
   i64.const 1
   i64.sub
-  local.set $25
+  local.set $45
   global.get $~lib/util/number/_exp
-  local.set $26
-  local.get $15
-  local.set $13
-  local.get $26
-  local.get $13
+  local.set $47
+  local.get $22
+  local.set $46
+  local.get $47
+  local.get $46
   i32.add
   i32.const 64
   i32.add
-  local.set $26
+  local.set $48
   global.get $~lib/util/number/_frc_minus
-  local.set $17
-  local.get $12
-  local.set $11
-  local.get $17
-  i64.const 4294967295
-  i64.and
-  local.set $18
-  local.get $11
-  i64.const 4294967295
-  i64.and
-  local.set $19
-  local.get $17
-  i64.const 32
-  i64.shr_u
-  local.set $20
-  local.get $11
-  i64.const 32
-  i64.shr_u
-  local.set $21
-  local.get $18
-  local.get $19
-  i64.mul
-  local.set $22
-  local.get $20
-  local.get $19
-  i64.mul
-  local.get $22
-  i64.const 32
-  i64.shr_u
-  i64.add
-  local.set $23
-  local.get $18
+  local.set $50
   local.get $21
+  local.set $49
+  local.get $50
+  i64.const 4294967295
+  i64.and
+  local.set $51
+  local.get $49
+  i64.const 4294967295
+  i64.and
+  local.set $52
+  local.get $50
+  i64.const 32
+  i64.shr_u
+  local.set $53
+  local.get $49
+  i64.const 32
+  i64.shr_u
+  local.set $54
+  local.get $51
+  local.get $52
   i64.mul
-  local.get $23
+  local.set $55
+  local.get $53
+  local.get $52
+  i64.mul
+  local.get $55
+  i64.const 32
+  i64.shr_u
+  i64.add
+  local.set $56
+  local.get $51
+  local.get $54
+  i64.mul
+  local.get $56
   i64.const 4294967295
   i64.and
   i64.add
-  local.set $27
-  local.get $27
+  local.set $57
+  local.get $57
   i64.const 2147483647
   i64.add
-  local.set $27
-  local.get $23
+  local.set $57
+  local.get $56
   i64.const 32
   i64.shr_u
-  local.set $23
-  local.get $27
+  local.set $56
+  local.get $57
   i64.const 32
   i64.shr_u
-  local.set $27
-  local.get $20
-  local.get $21
+  local.set $57
+  local.get $53
+  local.get $54
   i64.mul
-  local.get $23
+  local.get $56
   i64.add
-  local.get $27
+  local.get $57
   i64.add
   i64.const 1
   i64.add
-  local.set $27
-  local.get $25
-  local.get $27
+  local.set $58
+  local.get $45
+  local.get $58
   i64.sub
-  local.set $23
+  local.set $59
   local.get $4
-  local.get $24
-  local.get $10
-  local.get $25
-  local.get $26
-  local.get $23
+  local.get $32
+  local.get $35
+  local.get $45
+  local.get $48
+  local.get $59
   local.get $3
   call $~lib/util/number/genDigits
-  local.set $28
+  local.set $60
   local.get $0
   local.get $2
   i32.const 1
   i32.shl
   i32.add
-  local.get $28
+  local.get $60
   local.get $2
   i32.sub
   global.get $~lib/util/number/_K
   call $~lib/util/number/prettify
-  local.set $28
-  local.get $28
+  local.set $60
+  local.get $60
   local.get $2
   i32.add
  )
@@ -3273,6 +3434,9 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
   local.get $0
   call $~lib/rt/stub/__retain
   local.set $0
@@ -3345,7 +3509,7 @@
    local.get $2
    i32.const 10
    i32.div_u
-   local.set $5
+   local.set $7
    local.get $4
    i32.const 1
    i32.sub
@@ -3356,11 +3520,11 @@
    i32.rem_u
    i32.add
    i32.store8
-   local.get $5
+   local.get $7
    local.set $2
    local.get $2
-   local.set $7
-   local.get $7
+   local.set $8
+   local.get $8
    br_if $do-continue|0
   end
   local.get $4
@@ -3368,11 +3532,11 @@
   i32.add
   local.set $4
   local.get $4
-  local.tee $7
+  local.tee $9
   i32.const 1
   i32.add
   local.set $4
-  local.get $7
+  local.get $9
   i32.const 58
   i32.store8
   local.get $3
@@ -3386,7 +3550,7 @@
    local.get $3
    i32.const 10
    i32.div_u
-   local.set $7
+   local.set $10
    local.get $4
    i32.const 1
    i32.sub
@@ -3397,11 +3561,11 @@
    i32.rem_u
    i32.add
    i32.store8
-   local.get $7
+   local.get $10
    local.set $3
    local.get $3
-   local.set $8
-   local.get $8
+   local.set $11
+   local.get $11
    br_if $do-continue|1
   end
   local.get $4
@@ -3491,6 +3655,7 @@
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
   local.get $0
   call $~lib/rt/stub/__retain
   local.set $0
@@ -3555,11 +3720,11 @@
   local.get $1
   if
    local.get $11
-   local.tee $7
+   local.tee $12
    i32.const 1
    i32.add
    local.set $11
-   local.get $7
+   local.get $12
    i32.const 32
    i32.store8
    local.get $9

--- a/tests/compiler/while.untouched.wat
+++ b/tests/compiler/while.untouched.wat
@@ -190,6 +190,7 @@
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
+  (local $3 i32)
   i32.const 1
   local.set $0
   i32.const 0
@@ -209,8 +210,8 @@
    else
     i32.const 0
    end
-   local.set $2
-   local.get $2
+   local.set $3
+   local.get $3
    if
     nop
     br $while-continue|0
@@ -493,6 +494,15 @@
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
   local.get $1
   i32.load
   local.set $2
@@ -629,59 +639,59 @@
   i32.eq
   if
    local.get $0
-   local.set $11
+   local.set $14
    local.get $4
-   local.set $10
+   local.set $13
    local.get $5
-   local.set $9
+   local.set $12
    local.get $7
-   local.set $8
-   local.get $11
-   local.get $10
+   local.set $11
+   local.get $14
+   local.get $13
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $12
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
+   local.get $11
    i32.store offset=96
    local.get $7
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $16
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $15
+    local.get $16
+    local.get $15
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $17
     local.get $0
-    local.set $8
+    local.set $20
     local.get $4
-    local.set $11
-    local.get $9
+    local.set $19
+    local.get $17
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
-    local.set $10
-    local.get $8
-    local.get $11
+    local.tee $17
+    local.set $18
+    local.get $20
+    local.get $19
     i32.const 2
     i32.shl
     i32.add
-    local.get $10
+    local.get $18
     i32.store offset=4
-    local.get $9
+    local.get $17
     i32.eqz
     if
      local.get $0
@@ -711,6 +721,20 @@
   (local $11 i32)
   (local $12 i32)
   (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local $22 i32)
+  (local $23 i32)
+  (local $24 i32)
+  (local $25 i32)
+  (local $26 i32)
+  (local $27 i32)
   i32.const 1
   drop
   local.get $1
@@ -773,8 +797,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $3
+   local.set $6
+   local.get $6
    i32.const 1073741808
    i32.lt_u
    if
@@ -785,16 +809,16 @@
     local.get $2
     i32.const 3
     i32.and
-    local.get $3
+    local.get $6
     i32.or
     local.tee $2
     i32.store
     local.get $1
-    local.set $6
-    local.get $6
+    local.set $7
+    local.get $7
     i32.const 16
     i32.add
-    local.get $6
+    local.get $7
     i32.load
     i32.const 3
     i32.const -1
@@ -812,18 +836,18 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $8
+   local.get $8
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
+   local.set $9
+   local.get $9
    i32.load
-   local.set $3
+   local.set $10
    i32.const 1
    drop
-   local.get $3
+   local.get $10
    i32.const 1
    i32.and
    i32.eqz
@@ -835,7 +859,7 @@
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $3
+   local.get $10
    i32.const 3
    i32.const -1
    i32.xor
@@ -848,23 +872,23 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $7
+   local.set $11
+   local.get $11
    i32.const 1073741808
    i32.lt_u
    if
     local.get $0
-    local.get $6
+    local.get $9
     call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
+    local.get $9
+    local.get $10
     i32.const 3
     i32.and
-    local.get $7
+    local.get $11
     i32.or
     local.tee $2
     i32.store
-    local.get $6
+    local.get $9
     local.set $1
    end
   end
@@ -878,14 +902,14 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $12
   i32.const 1
   drop
-  local.get $8
+  local.get $12
   i32.const 16
   i32.ge_u
   if (result i32)
-   local.get $8
+   local.get $12
    i32.const 1073741808
    i32.lt_u
   else
@@ -905,7 +929,7 @@
   local.get $1
   i32.const 16
   i32.add
-  local.get $8
+  local.get $12
   i32.add
   local.get $4
   i32.eq
@@ -923,24 +947,24 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $12
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $13
+   local.get $12
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $14
   else
    i32.const 31
-   local.get $8
+   local.get $12
    i32.clz
    i32.sub
-   local.set $9
-   local.get $8
-   local.get $9
+   local.set $13
+   local.get $12
+   local.get $13
    i32.const 4
    i32.sub
    i32.shr_u
@@ -948,21 +972,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $14
+   local.get $13
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $13
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $13
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $14
    i32.const 16
    i32.lt_u
   else
@@ -978,86 +1002,86 @@
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
-  local.set $6
-  local.get $7
-  local.get $3
+  local.set $17
+  local.get $13
+  local.set $16
+  local.get $14
+  local.set $15
+  local.get $17
+  local.get $16
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $15
   i32.add
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=96
-  local.set $11
+  local.set $18
   local.get $1
   i32.const 0
   i32.store offset=16
   local.get $1
-  local.get $11
+  local.get $18
   i32.store offset=20
-  local.get $11
+  local.get $18
   if
-   local.get $11
+   local.get $18
    local.get $1
    i32.store offset=16
   end
   local.get $0
-  local.set $12
-  local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
+  local.set $22
+  local.get $13
+  local.set $21
+  local.get $14
+  local.set $20
   local.get $1
-  local.set $6
-  local.get $12
-  local.get $7
+  local.set $19
+  local.get $22
+  local.get $21
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $20
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $19
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $13
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.set $13
-  local.get $9
-  local.set $12
+  local.set $27
+  local.get $13
+  local.set $26
   local.get $0
-  local.set $3
-  local.get $9
-  local.set $6
-  local.get $3
-  local.get $6
+  local.set $24
+  local.get $13
+  local.set $23
+  local.get $24
+  local.get $23
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $14
   i32.shl
   i32.or
-  local.set $7
-  local.get $13
-  local.get $12
+  local.set $25
+  local.get $27
+  local.get $26
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $25
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -1068,6 +1092,7 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
   i32.const 1
   drop
   local.get $1
@@ -1207,11 +1232,11 @@
   i32.or
   i32.store
   local.get $0
-  local.set $9
+  local.set $10
   local.get $4
-  local.set $3
+  local.set $9
+  local.get $10
   local.get $9
-  local.get $3
   i32.store offset=1568
   local.get $0
   local.get $8
@@ -1231,6 +1256,12 @@
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
   global.get $~lib/rt/tlsf/ROOT
   local.set $0
   local.get $0
@@ -1287,66 +1318,66 @@
    local.get $4
    i32.store offset=1568
    i32.const 0
-   local.set $5
+   local.set $6
    loop $for-loop|0
-    local.get $5
+    local.get $6
     i32.const 23
     i32.lt_u
-    local.set $4
-    local.get $4
+    local.set $7
+    local.get $7
     if
      local.get $0
-     local.set $8
-     local.get $5
-     local.set $7
+     local.set $10
+     local.get $6
+     local.set $9
      i32.const 0
-     local.set $6
-     local.get $8
-     local.get $7
+     local.set $8
+     local.get $10
+     local.get $9
      i32.const 2
      i32.shl
      i32.add
-     local.get $6
+     local.get $8
      i32.store offset=4
      i32.const 0
-     local.set $8
+     local.set $11
      loop $for-loop|1
-      local.get $8
+      local.get $11
       i32.const 16
       i32.lt_u
-      local.set $7
-      local.get $7
+      local.set $12
+      local.get $12
       if
        local.get $0
-       local.set $11
-       local.get $5
-       local.set $10
-       local.get $8
-       local.set $9
-       i32.const 0
-       local.set $6
+       local.set $16
+       local.get $6
+       local.set $15
        local.get $11
-       local.get $10
+       local.set $14
+       i32.const 0
+       local.set $13
+       local.get $16
+       local.get $15
        i32.const 4
        i32.shl
-       local.get $9
+       local.get $14
        i32.add
        i32.const 2
        i32.shl
        i32.add
-       local.get $6
+       local.get $13
        i32.store offset=96
-       local.get $8
+       local.get $11
        i32.const 1
        i32.add
-       local.set $8
+       local.set $11
        br $for-loop|1
       end
      end
-     local.get $5
+     local.get $6
      i32.const 1
      i32.add
-     local.set $5
+     local.set $6
      br $for-loop|0
     end
    end
@@ -1359,11 +1390,11 @@
    i32.const -1
    i32.xor
    i32.and
-   local.set $5
+   local.set $17
    i32.const 0
    drop
    local.get $0
-   local.get $5
+   local.get $17
    memory.size
    i32.const 16
    i32.shl
@@ -1412,6 +1443,14 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
   local.get $1
   i32.const 256
   i32.lt_u
@@ -1485,11 +1524,11 @@
    unreachable
   end
   local.get $0
-  local.set $5
+  local.set $6
   local.get $2
-  local.set $4
+  local.set $5
+  local.get $6
   local.get $5
-  local.get $4
   i32.const 2
   i32.shl
   i32.add
@@ -1500,10 +1539,10 @@
   local.get $3
   i32.shl
   i32.and
-  local.set $6
-  i32.const 0
   local.set $7
-  local.get $6
+  i32.const 0
+  local.set $8
+  local.get $7
   i32.eqz
   if
    local.get $0
@@ -1516,30 +1555,30 @@
    i32.add
    i32.shl
    i32.and
-   local.set $5
-   local.get $5
+   local.set $9
+   local.get $9
    i32.eqz
    if
     i32.const 0
-    local.set $7
+    local.set $8
    else
-    local.get $5
+    local.get $9
     i32.ctz
     local.set $2
     local.get $0
-    local.set $8
+    local.set $11
     local.get $2
-    local.set $4
-    local.get $8
-    local.get $4
+    local.set $10
+    local.get $11
+    local.get $10
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $6
+    local.set $7
     i32.const 1
     drop
-    local.get $6
+    local.get $7
     i32.eqz
     if
      i32.const 0
@@ -1550,45 +1589,45 @@
      unreachable
     end
     local.get $0
-    local.set $9
+    local.set $14
     local.get $2
-    local.set $8
-    local.get $6
+    local.set $13
+    local.get $7
     i32.ctz
-    local.set $4
-    local.get $9
-    local.get $8
+    local.set $12
+    local.get $14
+    local.get $13
     i32.const 4
     i32.shl
-    local.get $4
+    local.get $12
     i32.add
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=96
-    local.set $7
+    local.set $8
    end
   else
    local.get $0
-   local.set $9
+   local.set $17
    local.get $2
-   local.set $8
-   local.get $6
+   local.set $16
+   local.get $7
    i32.ctz
-   local.set $4
-   local.get $9
-   local.get $8
+   local.set $15
+   local.get $17
+   local.get $16
    i32.const 4
    i32.shl
-   local.get $4
+   local.get $15
    i32.add
    i32.const 2
    i32.shl
    i32.add
    i32.load offset=96
-   local.set $7
+   local.set $8
   end
-  local.get $7
+  local.get $8
  )
  (func $~lib/rt/tlsf/growMemory (param $0 i32) (param $1 i32)
   (local $2 i32)
@@ -1597,6 +1636,7 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
   i32.const 0
   drop
   local.get $1
@@ -1643,15 +1683,15 @@
   i32.shr_u
   local.set $4
   local.get $2
-  local.tee $3
-  local.get $4
   local.tee $5
-  local.get $3
+  local.get $4
+  local.tee $6
   local.get $5
+  local.get $6
   i32.gt_s
   select
-  local.set $6
-  local.get $6
+  local.set $7
+  local.get $7
   memory.grow
   i32.const 0
   i32.lt_s
@@ -1665,12 +1705,12 @@
    end
   end
   memory.size
-  local.set $7
+  local.set $8
   local.get $0
   local.get $2
   i32.const 16
   i32.shl
-  local.get $7
+  local.get $8
   i32.const 16
   i32.shl
   call $~lib/rt/tlsf/addMemory
@@ -1680,6 +1720,8 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
   local.get $1
   i32.load
   local.set $3
@@ -1744,11 +1786,11 @@
    i32.and
    i32.store
    local.get $1
-   local.set $5
-   local.get $5
+   local.set $7
+   local.get $7
    i32.const 16
    i32.add
-   local.get $5
+   local.get $7
    i32.load
    i32.const 3
    i32.const -1
@@ -1756,11 +1798,11 @@
    i32.and
    i32.add
    local.get $1
-   local.set $5
-   local.get $5
+   local.set $6
+   local.get $6
    i32.const 16
    i32.add
-   local.get $5
+   local.get $6
    i32.load
    i32.const 3
    i32.const -1
@@ -2004,6 +2046,7 @@
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
   i32.const 0
   local.set $0
   i32.const 0
@@ -2038,10 +2081,10 @@
     else
      i32.const 0
      call $while/Ref#constructor
-     local.set $4
+     local.set $5
      local.get $1
      call $~lib/rt/pure/__release
-     local.get $4
+     local.get $5
      local.set $1
     end
     br $while-continue|0
@@ -2085,6 +2128,7 @@
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
   i32.const 0
   local.set $0
   i32.const 0
@@ -2107,18 +2151,18 @@
      i32.eq
      if
       i32.const 0
-      local.tee $2
-      local.get $1
       local.tee $4
+      local.get $1
+      local.tee $5
       i32.ne
       if
-       local.get $2
-       call $~lib/rt/pure/__retain
-       local.set $2
        local.get $4
+       call $~lib/rt/pure/__retain
+       local.set $4
+       local.get $5
        call $~lib/rt/pure/__release
       end
-      local.get $2
+      local.get $4
       local.set $1
       br $while-break|0
      end


### PR DESCRIPTION
In https://github.com/AssemblyScript/assemblyscript/pull/1240 it came up that the way we free temporary locals for reuse during compilation is both unexpected for developers new to the codebase as well as hard to get right when passing compiled expressions that might or might not (re)use a temporary local down to other code paths.

As such, this is an experiment what'd happen if every top-level, scoped and temporary local would be unique, making this process more convenient and less error-prone at the cost of emitting larger untouched functions. Note that the `std/set` and `std/map` tests don't compile this way currently due to unification of local states in loops, needing a new mechanism if we decide to go this route.