### PR TITLE
Fix incorrect flow state after throwing

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -2837,8 +2837,9 @@ export class Compiler extends DiagnosticEmitter {
       this.makeAbort(message, statement)
     );
     // generates dead code (after unreachable) but still updates state
-    this.performAutoreleases(flow, stmts);
-    this.finishAutoreleases(flow, stmts);
+    var dropped = new Array<ExpressionRef>();
+    this.performAutoreleases(flow, dropped);
+    this.finishAutoreleases(flow, dropped);
     flow.freeScopedLocals();
 
     return this.module.flatten(stmts);

--- a/tests/compiler/assert-nonnull.untouched.wat
+++ b/tests/compiler/assert-nonnull.untouched.wat
@@ -139,8 +139,6 @@
   local.get $2
   i32.eqz
   if
-   local.get $2
-   call $~lib/rt/stub/__release
    i32.const 208
    i32.const 160
    i32.const 108

--- a/tests/compiler/class.untouched.wat
+++ b/tests/compiler/class.untouched.wat
@@ -483,8 +483,6 @@
   i32.shr_u
   i32.gt_u
   if
-   local.get $0
-   call $~lib/rt/stub/__release
    i32.const 32
    i32.const 80
    i32.const 57

--- a/tests/compiler/infer-array.untouched.wat
+++ b/tests/compiler/infer-array.untouched.wat
@@ -1726,8 +1726,6 @@
   local.get $2
   i32.eqz
   if
-   local.get $2
-   call $~lib/rt/stub/__release
    i32.const 640
    i32.const 128
    i32.const 108

--- a/tests/compiler/resolve-elementaccess.untouched.wat
+++ b/tests/compiler/resolve-elementaccess.untouched.wat
@@ -409,8 +409,6 @@
   i32.shr_u
   i32.gt_u
   if
-   local.get $0
-   call $~lib/rt/stub/__release
    i32.const 32
    i32.const 80
    i32.const 18

--- a/tests/compiler/retain-release-sanity.untouched.wat
+++ b/tests/compiler/retain-release-sanity.untouched.wat
@@ -1792,8 +1792,6 @@
   i32.shr_u
   i32.gt_u
   if
-   local.get $0
-   call $~lib/rt/pure/__release
    i32.const 32
    i32.const 80
    i32.const 57
@@ -3452,8 +3450,6 @@
   i32.shr_u
   i32.gt_u
   if
-   local.get $0
-   call $~lib/rt/pure/__release
    i32.const 32
    i32.const 80
    i32.const 57
@@ -3534,8 +3530,6 @@
   i32.shr_u
   i32.gt_u
   if
-   local.get $0
-   call $~lib/rt/pure/__release
    i32.const 32
    i32.const 80
    i32.const 57

--- a/tests/compiler/retain-release.untouched.wat
+++ b/tests/compiler/retain-release.untouched.wat
@@ -718,8 +718,6 @@
     global.get $retain-release/REF
     call $~lib/rt/stub/__retain
     local.set $2
-    local.get $2
-    call $~lib/rt/stub/__release
     i32.const 32
     i32.const 64
     i32.const 367

--- a/tests/compiler/std/array-access.untouched.wat
+++ b/tests/compiler/std/array-access.untouched.wat
@@ -62,8 +62,6 @@
   local.get $2
   i32.eqz
   if
-   local.get $2
-   call $~lib/rt/stub/__release
    i32.const 144
    i32.const 96
    i32.const 108
@@ -159,8 +157,6 @@
   local.get $2
   i32.eqz
   if
-   local.get $2
-   call $~lib/rt/stub/__release
    i32.const 144
    i32.const 96
    i32.const 108
@@ -453,8 +449,6 @@
   local.get $2
   i32.eqz
   if
-   local.get $2
-   call $~lib/rt/stub/__release
    i32.const 144
    i32.const 96
    i32.const 108

--- a/tests/compiler/std/array.optimized.wat
+++ b/tests/compiler/std/array.optimized.wat
@@ -1532,8 +1532,6 @@
   i32.const 268435452
   i32.gt_u
   if
-   local.get $3
-   call $~lib/rt/pure/__release
    i32.const 1040
    i32.const 1088
    i32.const 57
@@ -2816,8 +2814,6 @@
   local.tee $0
   i32.eqz
   if
-   local.get $0
-   call $~lib/rt/pure/__release
    i32.const 4928
    i32.const 1088
    i32.const 108

--- a/tests/compiler/std/array.untouched.wat
+++ b/tests/compiler/std/array.untouched.wat
@@ -2011,8 +2011,6 @@
   i32.shr_u
   i32.gt_u
   if
-   local.get $0
-   call $~lib/rt/pure/__release
    i32.const 32
    i32.const 80
    i32.const 57
@@ -2140,8 +2138,6 @@
   i32.shr_u
   i32.gt_u
   if
-   local.get $0
-   call $~lib/rt/pure/__release
    i32.const 32
    i32.const 336
    i32.const 18
@@ -4454,8 +4450,6 @@
   i32.shr_u
   i32.gt_u
   if
-   local.get $1
-   call $~lib/rt/pure/__release
    i32.const 32
    i32.const 80
    i32.const 229
@@ -5496,8 +5490,6 @@
   local.get $2
   i32.eqz
   if
-   local.get $2
-   call $~lib/rt/pure/__release
    i32.const 3920
    i32.const 80
    i32.const 108
@@ -9744,8 +9736,6 @@
   i32.shr_u
   i32.gt_u
   if
-   local.get $0
-   call $~lib/rt/pure/__release
    i32.const 32
    i32.const 80
    i32.const 57
@@ -9838,8 +9828,6 @@
    i32.const 0
    i32.lt_s
    if
-    local.get $2
-    call $~lib/rt/pure/__release
     i32.const 496
     i32.const 80
     i32.const 120
@@ -10144,8 +10132,6 @@
   local.get $2
   i32.eqz
   if
-   local.get $2
-   call $~lib/rt/pure/__release
    i32.const 3920
    i32.const 80
    i32.const 108
@@ -10280,8 +10266,6 @@
   i32.shr_u
   i32.gt_u
   if
-   local.get $0
-   call $~lib/rt/pure/__release
    i32.const 32
    i32.const 80
    i32.const 57
@@ -10389,8 +10373,6 @@
    i32.const 0
    i32.lt_s
    if
-    local.get $2
-    call $~lib/rt/pure/__release
     i32.const 496
     i32.const 80
     i32.const 120
@@ -10688,8 +10670,6 @@
   local.get $2
   i32.eqz
   if
-   local.get $2
-   call $~lib/rt/pure/__release
    i32.const 3920
    i32.const 80
    i32.const 108
@@ -11584,8 +11564,6 @@
   i32.shr_u
   i32.gt_u
   if
-   local.get $0
-   call $~lib/rt/pure/__release
    i32.const 32
    i32.const 80
    i32.const 57
@@ -11864,8 +11842,6 @@
    i32.const 0
    i32.lt_s
    if
-    local.get $2
-    call $~lib/rt/pure/__release
     i32.const 496
     i32.const 80
     i32.const 120
@@ -12141,8 +12117,6 @@
   local.get $2
   i32.eqz
   if
-   local.get $2
-   call $~lib/rt/pure/__release
    i32.const 3920
    i32.const 80
    i32.const 108

--- a/tests/compiler/std/arraybuffer.optimized.wat
+++ b/tests/compiler/std/arraybuffer.optimized.wat
@@ -1532,8 +1532,6 @@
   i32.shr_u
   i32.gt_u
   if
-   local.get $0
-   call $~lib/rt/pure/__release
    i32.const 1040
    i32.const 1088
    i32.const 18
@@ -1862,8 +1860,6 @@
   i32.gt_u
   i32.or
   if
-   local.get $8
-   call $~lib/rt/pure/__release
    i32.const 1040
    i32.const 1408
    i32.const 25

--- a/tests/compiler/std/arraybuffer.untouched.wat
+++ b/tests/compiler/std/arraybuffer.untouched.wat
@@ -1758,8 +1758,6 @@
   i32.const 1073741808
   i32.gt_u
   if
-   local.get $0
-   call $~lib/rt/pure/__release
    i32.const 32
    i32.const 80
    i32.const 49
@@ -3348,8 +3346,6 @@
   i32.shr_u
   i32.gt_u
   if
-   local.get $0
-   call $~lib/rt/pure/__release
    i32.const 32
    i32.const 80
    i32.const 18
@@ -3592,10 +3588,6 @@
   i32.gt_u
   i32.or
   if
-   local.get $0
-   call $~lib/rt/pure/__release
-   local.get $1
-   call $~lib/rt/pure/__release
    i32.const 32
    i32.const 400
    i32.const 25

--- a/tests/compiler/std/dataview.optimized.wat
+++ b/tests/compiler/std/dataview.optimized.wat
@@ -1236,8 +1236,6 @@
   i32.gt_u
   i32.or
   if
-   local.get $4
-   call $~lib/rt/pure/__release
    i32.const 1040
    i32.const 1440
    i32.const 25

--- a/tests/compiler/std/dataview.untouched.wat
+++ b/tests/compiler/std/dataview.untouched.wat
@@ -1788,8 +1788,6 @@
   i32.shr_u
   i32.gt_u
   if
-   local.get $0
-   call $~lib/rt/pure/__release
    i32.const 32
    i32.const 80
    i32.const 18
@@ -1913,10 +1911,6 @@
   i32.gt_u
   i32.or
   if
-   local.get $0
-   call $~lib/rt/pure/__release
-   local.get $1
-   call $~lib/rt/pure/__release
    i32.const 32
    i32.const 432
    i32.const 25

--- a/tests/compiler/std/map.optimized.wat
+++ b/tests/compiler/std/map.optimized.wat
@@ -2125,8 +2125,6 @@
   i32.const 1073741808
   i32.gt_u
   if
-   local.get $0
-   call $~lib/rt/pure/__release
    i32.const 1040
    i32.const 1472
    i32.const 57
@@ -2230,8 +2228,6 @@
   i32.const 268435452
   i32.gt_u
   if
-   local.get $3
-   call $~lib/rt/pure/__release
    i32.const 1040
    i32.const 1472
    i32.const 57
@@ -3906,8 +3902,6 @@
   i32.const 1073741808
   i32.gt_u
   if
-   local.get $0
-   call $~lib/rt/pure/__release
    i32.const 1040
    i32.const 1472
    i32.const 57
@@ -5136,78 +5130,6 @@
   local.get $0
   i32.load offset=4
  )
- (func $~lib/array/Array<i16>#constructor (param $0 i32) (result i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  i32.const 16
-  i32.const 12
-  call $~lib/rt/tlsf/__alloc
-  call $~lib/rt/pure/__retain
-  local.tee $3
-  i32.const 0
-  i32.store
-  local.get $3
-  i32.const 0
-  i32.store offset=4
-  local.get $3
-  i32.const 0
-  i32.store offset=8
-  local.get $3
-  i32.const 0
-  i32.store offset=12
-  local.get $0
-  i32.const 536870904
-  i32.gt_u
-  if
-   local.get $3
-   call $~lib/rt/pure/__release
-   i32.const 1040
-   i32.const 1472
-   i32.const 57
-   i32.const 60
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $0
-  i32.const 1
-  i32.shl
-  local.tee $4
-  i32.const 0
-  call $~lib/rt/tlsf/__alloc
-  local.tee $1
-  local.get $4
-  call $~lib/memory/memory.fill
-  local.get $1
-  local.set $2
-  local.get $1
-  local.get $3
-  i32.load
-  local.tee $5
-  i32.ne
-  if
-   local.get $2
-   call $~lib/rt/pure/__retain
-   local.set $2
-   local.get $5
-   call $~lib/rt/pure/__release
-  end
-  local.get $3
-  local.get $2
-  i32.store
-  local.get $3
-  local.get $1
-  i32.store offset=4
-  local.get $3
-  local.get $4
-  i32.store offset=8
-  local.get $3
-  local.get $0
-  i32.store offset=12
-  local.get $3
- )
  (func $~lib/array/Array<i16>#__set (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $1
@@ -5257,6 +5179,123 @@
   local.get $0
   local.get $1
   i32.store offset=12
+ )
+ (func $~lib/map/Map<i16,i32>#keys (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  local.get $0
+  i32.load offset=8
+  local.set $4
+  local.get $0
+  i32.load offset=16
+  local.tee $7
+  local.set $6
+  i32.const 16
+  i32.const 12
+  call $~lib/rt/tlsf/__alloc
+  call $~lib/rt/pure/__retain
+  local.tee $0
+  i32.const 0
+  i32.store
+  local.get $0
+  i32.const 0
+  i32.store offset=4
+  local.get $0
+  i32.const 0
+  i32.store offset=8
+  local.get $0
+  i32.const 0
+  i32.store offset=12
+  local.get $7
+  i32.const 536870904
+  i32.gt_u
+  if
+   i32.const 1040
+   i32.const 1472
+   i32.const 57
+   i32.const 60
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $6
+  i32.const 1
+  i32.shl
+  local.tee $5
+  i32.const 0
+  call $~lib/rt/tlsf/__alloc
+  local.tee $2
+  local.get $5
+  call $~lib/memory/memory.fill
+  local.get $2
+  local.set $1
+  local.get $2
+  local.get $0
+  i32.load
+  local.tee $3
+  i32.ne
+  if
+   local.get $1
+   call $~lib/rt/pure/__retain
+   local.set $1
+   local.get $3
+   call $~lib/rt/pure/__release
+  end
+  local.get $0
+  local.get $1
+  i32.store
+  local.get $0
+  local.get $2
+  i32.store offset=4
+  local.get $0
+  local.get $5
+  i32.store offset=8
+  local.get $0
+  local.get $6
+  i32.store offset=12
+  loop $for-loop|0
+   local.get $8
+   local.get $7
+   i32.lt_s
+   if
+    local.get $4
+    local.get $8
+    i32.const 12
+    i32.mul
+    i32.add
+    local.tee $2
+    i32.load offset=8
+    i32.const 1
+    i32.and
+    i32.eqz
+    if
+     local.get $0
+     local.get $9
+     local.get $2
+     i32.load16_s
+     call $~lib/array/Array<i16>#__set
+     local.get $9
+     i32.const 1
+     i32.add
+     local.set $9
+    end
+    local.get $8
+    i32.const 1
+    i32.add
+    local.set $8
+    br $for-loop|0
+   end
+  end
+  local.get $0
+  local.get $9
+  call $~lib/array/Array<i16>#set:length
+  local.get $0
  )
  (func $~lib/map/Map<i16,i16>#rehash (param $0 i32) (param $1 i32)
   (local $2 i32)
@@ -5807,49 +5846,8 @@
    unreachable
   end
   local.get $0
-  i32.load offset=8
-  local.set $6
-  local.get $0
-  i32.load offset=16
-  local.tee $7
-  call $~lib/array/Array<i16>#constructor
-  local.set $1
-  loop $for-loop|0
-   local.get $4
-   local.get $7
-   i32.lt_s
-   if
-    local.get $6
-    local.get $4
-    i32.const 12
-    i32.mul
-    i32.add
-    local.tee $5
-    i32.load offset=8
-    i32.const 1
-    i32.and
-    i32.eqz
-    if
-     local.get $1
-     local.get $3
-     local.get $5
-     i32.load16_s
-     call $~lib/array/Array<i16>#__set
-     local.get $3
-     i32.const 1
-     i32.add
-     local.set $3
-    end
-    local.get $4
-    i32.const 1
-    i32.add
-    local.set $4
-    br $for-loop|0
-   end
-  end
-  local.get $1
-  local.get $3
-  call $~lib/array/Array<i16>#set:length
+  call $~lib/map/Map<i16,i32>#keys
+  local.set $4
   local.get $0
   call $~lib/map/Map<i8,i32>#values
   local.set $6
@@ -5878,15 +5876,15 @@
   local.get $3
   call $~lib/map/Map<i8,i8>#clear
   call $~lib/map/Map<i32,i32>#constructor
-  local.set $4
+  local.set $5
   loop $for-loop|4
    local.get $2
-   local.get $1
+   local.get $4
    i32.load offset=12
    i32.lt_s
    if
     local.get $2
-    local.get $1
+    local.get $4
     i32.load offset=12
     i32.ge_u
     if
@@ -5897,20 +5895,20 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $1
+    local.get $4
     i32.load offset=4
     local.get $2
     i32.const 1
     i32.shl
     i32.add
     i32.load16_s
-    local.set $5
+    local.set $1
     local.get $6
     local.get $2
     call $~lib/array/Array<i32>#__get
     local.set $7
     local.get $0
-    local.get $5
+    local.get $1
     call $~lib/map/Map<i16,i32>#has
     i32.eqz
     if
@@ -5936,16 +5934,16 @@
      unreachable
     end
     local.get $3
-    local.get $5
-    local.get $5
+    local.get $1
+    local.get $1
     call $~lib/map/Map<i16,i16>#set
     call $~lib/rt/pure/__release
-    local.get $4
+    local.get $5
     local.get $7
     i32.const 20
     i32.sub
-    local.tee $5
-    local.get $5
+    local.tee $1
+    local.get $1
     call $~lib/map/Map<i32,i32>#set
     call $~lib/rt/pure/__release
     local.get $2
@@ -5967,7 +5965,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $5
   i32.load offset=20
   i32.const 100
   i32.ne
@@ -6144,13 +6142,13 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $4
   call $~lib/rt/pure/__release
   local.get $6
   call $~lib/rt/pure/__release
   local.get $3
   call $~lib/rt/pure/__release
-  local.get $4
+  local.get $5
   call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
@@ -6414,34 +6412,43 @@
   local.get $0
   i32.load offset=4
  )
- (func $~lib/array/Array<u16>#constructor (param $0 i32) (result i32)
+ (func $~lib/map/Map<u16,i32>#keys (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  local.get $0
+  i32.load offset=8
+  local.set $4
+  local.get $0
+  i32.load offset=16
+  local.tee $7
+  local.set $6
   i32.const 16
   i32.const 15
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
-  local.tee $3
+  local.tee $0
   i32.const 0
   i32.store
-  local.get $3
+  local.get $0
   i32.const 0
   i32.store offset=4
-  local.get $3
+  local.get $0
   i32.const 0
   i32.store offset=8
-  local.get $3
+  local.get $0
   i32.const 0
   i32.store offset=12
-  local.get $0
+  local.get $7
   i32.const 536870904
   i32.gt_u
   if
-   local.get $3
-   call $~lib/rt/pure/__release
    i32.const 1040
    i32.const 1472
    i32.const 57
@@ -6449,42 +6456,78 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $6
   i32.const 1
   i32.shl
-  local.tee $4
+  local.tee $5
   i32.const 0
   call $~lib/rt/tlsf/__alloc
-  local.tee $1
-  local.get $4
+  local.tee $2
+  local.get $5
   call $~lib/memory/memory.fill
-  local.get $1
-  local.set $2
-  local.get $1
-  local.get $3
+  local.get $2
+  local.set $1
+  local.get $2
+  local.get $0
   i32.load
-  local.tee $5
+  local.tee $3
   i32.ne
   if
-   local.get $2
+   local.get $1
    call $~lib/rt/pure/__retain
-   local.set $2
-   local.get $5
+   local.set $1
+   local.get $3
    call $~lib/rt/pure/__release
   end
-  local.get $3
-  local.get $2
-  i32.store
-  local.get $3
-  local.get $1
-  i32.store offset=4
-  local.get $3
-  local.get $4
-  i32.store offset=8
-  local.get $3
   local.get $0
+  local.get $1
+  i32.store
+  local.get $0
+  local.get $2
+  i32.store offset=4
+  local.get $0
+  local.get $5
+  i32.store offset=8
+  local.get $0
+  local.get $6
   i32.store offset=12
-  local.get $3
+  loop $for-loop|0
+   local.get $8
+   local.get $7
+   i32.lt_s
+   if
+    local.get $4
+    local.get $8
+    i32.const 12
+    i32.mul
+    i32.add
+    local.tee $2
+    i32.load offset=8
+    i32.const 1
+    i32.and
+    i32.eqz
+    if
+     local.get $0
+     local.get $9
+     local.get $2
+     i32.load16_u
+     call $~lib/array/Array<i16>#__set
+     local.get $9
+     i32.const 1
+     i32.add
+     local.set $9
+    end
+    local.get $8
+    i32.const 1
+    i32.add
+    local.set $8
+    br $for-loop|0
+   end
+  end
+  local.get $0
+  local.get $9
+  call $~lib/array/Array<i16>#set:length
+  local.get $0
  )
  (func $~lib/map/Map<u16,u16>#rehash (param $0 i32) (param $1 i32)
   (local $2 i32)
@@ -7017,49 +7060,8 @@
    unreachable
   end
   local.get $0
-  i32.load offset=8
-  local.set $6
-  local.get $0
-  i32.load offset=16
-  local.tee $7
-  call $~lib/array/Array<u16>#constructor
-  local.set $1
-  loop $for-loop|0
-   local.get $4
-   local.get $7
-   i32.lt_s
-   if
-    local.get $6
-    local.get $4
-    i32.const 12
-    i32.mul
-    i32.add
-    local.tee $5
-    i32.load offset=8
-    i32.const 1
-    i32.and
-    i32.eqz
-    if
-     local.get $1
-     local.get $3
-     local.get $5
-     i32.load16_u
-     call $~lib/array/Array<i16>#__set
-     local.get $3
-     i32.const 1
-     i32.add
-     local.set $3
-    end
-    local.get $4
-    i32.const 1
-    i32.add
-    local.set $4
-    br $for-loop|0
-   end
-  end
-  local.get $1
-  local.get $3
-  call $~lib/array/Array<i16>#set:length
+  call $~lib/map/Map<u16,i32>#keys
+  local.set $4
   local.get $0
   call $~lib/map/Map<i8,i32>#values
   local.set $6
@@ -7088,15 +7090,15 @@
   local.get $3
   call $~lib/map/Map<i8,i8>#clear
   call $~lib/map/Map<i32,i32>#constructor
-  local.set $4
+  local.set $5
   loop $for-loop|4
    local.get $2
-   local.get $1
+   local.get $4
    i32.load offset=12
    i32.lt_s
    if
     local.get $2
-    local.get $1
+    local.get $4
     i32.load offset=12
     i32.ge_u
     if
@@ -7107,20 +7109,20 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $1
+    local.get $4
     i32.load offset=4
     local.get $2
     i32.const 1
     i32.shl
     i32.add
     i32.load16_u
-    local.set $5
+    local.set $1
     local.get $6
     local.get $2
     call $~lib/array/Array<i32>#__get
     local.set $7
     local.get $0
-    local.get $5
+    local.get $1
     call $~lib/map/Map<u16,i32>#has
     i32.eqz
     if
@@ -7146,16 +7148,16 @@
      unreachable
     end
     local.get $3
-    local.get $5
-    local.get $5
+    local.get $1
+    local.get $1
     call $~lib/map/Map<u16,u16>#set
     call $~lib/rt/pure/__release
-    local.get $4
+    local.get $5
     local.get $7
     i32.const 20
     i32.sub
-    local.tee $5
-    local.get $5
+    local.tee $1
+    local.get $1
     call $~lib/map/Map<i32,i32>#set
     call $~lib/rt/pure/__release
     local.get $2
@@ -7177,7 +7179,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $5
   i32.load offset=20
   i32.const 100
   i32.ne
@@ -7346,13 +7348,13 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $4
   call $~lib/rt/pure/__release
   local.get $6
   call $~lib/rt/pure/__release
   local.get $3
   call $~lib/rt/pure/__release
-  local.get $4
+  local.get $5
   call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
@@ -7906,34 +7908,43 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/array/Array<u32>#constructor (param $0 i32) (result i32)
+ (func $~lib/map/Map<u32,i32>#keys (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  local.get $0
+  i32.load offset=8
+  local.set $4
+  local.get $0
+  i32.load offset=16
+  local.tee $7
+  local.set $6
   i32.const 16
   i32.const 18
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
-  local.tee $3
+  local.tee $0
   i32.const 0
   i32.store
-  local.get $3
+  local.get $0
   i32.const 0
   i32.store offset=4
-  local.get $3
+  local.get $0
   i32.const 0
   i32.store offset=8
-  local.get $3
+  local.get $0
   i32.const 0
   i32.store offset=12
-  local.get $0
+  local.get $7
   i32.const 268435452
   i32.gt_u
   if
-   local.get $3
-   call $~lib/rt/pure/__release
    i32.const 1040
    i32.const 1472
    i32.const 57
@@ -7941,42 +7952,78 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $6
   i32.const 2
   i32.shl
-  local.tee $4
+  local.tee $5
   i32.const 0
   call $~lib/rt/tlsf/__alloc
-  local.tee $1
-  local.get $4
+  local.tee $2
+  local.get $5
   call $~lib/memory/memory.fill
-  local.get $1
-  local.set $2
-  local.get $1
-  local.get $3
+  local.get $2
+  local.set $1
+  local.get $2
+  local.get $0
   i32.load
-  local.tee $5
+  local.tee $3
   i32.ne
   if
-   local.get $2
+   local.get $1
    call $~lib/rt/pure/__retain
-   local.set $2
-   local.get $5
+   local.set $1
+   local.get $3
    call $~lib/rt/pure/__release
   end
-  local.get $3
-  local.get $2
-  i32.store
-  local.get $3
-  local.get $1
-  i32.store offset=4
-  local.get $3
-  local.get $4
-  i32.store offset=8
-  local.get $3
   local.get $0
+  local.get $1
+  i32.store
+  local.get $0
+  local.get $2
+  i32.store offset=4
+  local.get $0
+  local.get $5
+  i32.store offset=8
+  local.get $0
+  local.get $6
   i32.store offset=12
-  local.get $3
+  loop $for-loop|0
+   local.get $8
+   local.get $7
+   i32.lt_s
+   if
+    local.get $4
+    local.get $8
+    i32.const 12
+    i32.mul
+    i32.add
+    local.tee $2
+    i32.load offset=8
+    i32.const 1
+    i32.and
+    i32.eqz
+    if
+     local.get $0
+     local.get $9
+     local.get $2
+     i32.load
+     call $~lib/array/Array<i32>#__set
+     local.get $9
+     i32.const 1
+     i32.add
+     local.set $9
+    end
+    local.get $8
+    i32.const 1
+    i32.add
+    local.set $8
+    br $for-loop|0
+   end
+  end
+  local.get $0
+  local.get $9
+  call $~lib/array/Array<i32>#set:length
+  local.get $0
  )
  (func $std/map/testNumeric<u32,i32>
   (local $0 i32)
@@ -8168,49 +8215,8 @@
    unreachable
   end
   local.get $0
-  i32.load offset=8
-  local.set $5
-  local.get $0
-  i32.load offset=16
-  local.tee $6
-  call $~lib/array/Array<u32>#constructor
-  local.set $1
-  loop $for-loop|01
-   local.get $4
-   local.get $6
-   i32.lt_s
-   if
-    local.get $5
-    local.get $4
-    i32.const 12
-    i32.mul
-    i32.add
-    local.tee $7
-    i32.load offset=8
-    i32.const 1
-    i32.and
-    i32.eqz
-    if
-     local.get $1
-     local.get $3
-     local.get $7
-     i32.load
-     call $~lib/array/Array<i32>#__set
-     local.get $3
-     i32.const 1
-     i32.add
-     local.set $3
-    end
-    local.get $4
-    i32.const 1
-    i32.add
-    local.set $4
-    br $for-loop|01
-   end
-  end
-  local.get $1
-  local.get $3
-  call $~lib/array/Array<i32>#set:length
+  call $~lib/map/Map<u32,i32>#keys
+  local.set $4
   local.get $0
   call $~lib/map/Map<i8,i32>#values
   local.set $6
@@ -8218,44 +8224,44 @@
   i32.const 19
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
-  local.tee $3
+  local.tee $1
   i32.const 0
   i32.store
-  local.get $3
+  local.get $1
   i32.const 0
   i32.store offset=4
-  local.get $3
+  local.get $1
   i32.const 0
   i32.store offset=8
-  local.get $3
+  local.get $1
   i32.const 0
   i32.store offset=12
-  local.get $3
+  local.get $1
   i32.const 0
   i32.store offset=16
-  local.get $3
+  local.get $1
   i32.const 0
   i32.store offset=20
-  local.get $3
+  local.get $1
   call $~lib/map/Map<i8,i32>#clear
   call $~lib/map/Map<i32,i32>#constructor
-  local.set $4
+  local.set $5
   loop $for-loop|2
    local.get $2
-   local.get $1
+   local.get $4
    i32.load offset=12
    i32.lt_s
    if
-    local.get $1
+    local.get $4
     local.get $2
     call $~lib/array/Array<i32>#__get
-    local.set $5
+    local.set $3
     local.get $6
     local.get $2
     call $~lib/array/Array<i32>#__get
     local.set $7
     local.get $0
-    local.get $5
+    local.get $3
     call $~lib/map/Map<i32,i32>#has
     i32.eqz
     if
@@ -8280,17 +8286,17 @@
      call $~lib/builtins/abort
      unreachable
     end
+    local.get $1
     local.get $3
-    local.get $5
-    local.get $5
+    local.get $3
     call $~lib/map/Map<i32,i32>#set
     call $~lib/rt/pure/__release
-    local.get $4
+    local.get $5
     local.get $7
     i32.const 20
     i32.sub
-    local.tee $5
-    local.get $5
+    local.tee $3
+    local.get $3
     call $~lib/map/Map<i32,i32>#set
     call $~lib/rt/pure/__release
     local.get $2
@@ -8300,7 +8306,7 @@
     br $for-loop|2
    end
   end
-  local.get $3
+  local.get $1
   i32.load offset=20
   i32.const 100
   i32.ne
@@ -8312,7 +8318,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $5
   i32.load offset=20
   i32.const 100
   i32.ne
@@ -8473,13 +8479,13 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $4
   call $~lib/rt/pure/__release
   local.get $6
   call $~lib/rt/pure/__release
-  local.get $3
+  local.get $1
   call $~lib/rt/pure/__release
-  local.get $4
+  local.get $5
   call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
@@ -8877,78 +8883,6 @@
   local.get $0
   i32.load offset=8
  )
- (func $~lib/array/Array<i64>#constructor (param $0 i32) (result i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  i32.const 16
-  i32.const 21
-  call $~lib/rt/tlsf/__alloc
-  call $~lib/rt/pure/__retain
-  local.tee $3
-  i32.const 0
-  i32.store
-  local.get $3
-  i32.const 0
-  i32.store offset=4
-  local.get $3
-  i32.const 0
-  i32.store offset=8
-  local.get $3
-  i32.const 0
-  i32.store offset=12
-  local.get $0
-  i32.const 134217726
-  i32.gt_u
-  if
-   local.get $3
-   call $~lib/rt/pure/__release
-   i32.const 1040
-   i32.const 1472
-   i32.const 57
-   i32.const 60
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $0
-  i32.const 3
-  i32.shl
-  local.tee $4
-  i32.const 0
-  call $~lib/rt/tlsf/__alloc
-  local.tee $1
-  local.get $4
-  call $~lib/memory/memory.fill
-  local.get $1
-  local.set $2
-  local.get $1
-  local.get $3
-  i32.load
-  local.tee $5
-  i32.ne
-  if
-   local.get $2
-   call $~lib/rt/pure/__retain
-   local.set $2
-   local.get $5
-   call $~lib/rt/pure/__release
-  end
-  local.get $3
-  local.get $2
-  i32.store
-  local.get $3
-  local.get $1
-  i32.store offset=4
-  local.get $3
-  local.get $4
-  i32.store offset=8
-  local.get $3
-  local.get $0
-  i32.store offset=12
-  local.get $3
- )
  (func $~lib/array/Array<i64>#__set (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   local.get $1
@@ -8998,6 +8932,123 @@
   local.get $0
   local.get $1
   i32.store offset=12
+ )
+ (func $~lib/map/Map<i64,i32>#keys (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  local.get $0
+  i32.load offset=8
+  local.set $4
+  local.get $0
+  i32.load offset=16
+  local.tee $7
+  local.set $6
+  i32.const 16
+  i32.const 21
+  call $~lib/rt/tlsf/__alloc
+  call $~lib/rt/pure/__retain
+  local.tee $0
+  i32.const 0
+  i32.store
+  local.get $0
+  i32.const 0
+  i32.store offset=4
+  local.get $0
+  i32.const 0
+  i32.store offset=8
+  local.get $0
+  i32.const 0
+  i32.store offset=12
+  local.get $7
+  i32.const 134217726
+  i32.gt_u
+  if
+   i32.const 1040
+   i32.const 1472
+   i32.const 57
+   i32.const 60
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $6
+  i32.const 3
+  i32.shl
+  local.tee $5
+  i32.const 0
+  call $~lib/rt/tlsf/__alloc
+  local.tee $2
+  local.get $5
+  call $~lib/memory/memory.fill
+  local.get $2
+  local.set $1
+  local.get $2
+  local.get $0
+  i32.load
+  local.tee $3
+  i32.ne
+  if
+   local.get $1
+   call $~lib/rt/pure/__retain
+   local.set $1
+   local.get $3
+   call $~lib/rt/pure/__release
+  end
+  local.get $0
+  local.get $1
+  i32.store
+  local.get $0
+  local.get $2
+  i32.store offset=4
+  local.get $0
+  local.get $5
+  i32.store offset=8
+  local.get $0
+  local.get $6
+  i32.store offset=12
+  loop $for-loop|0
+   local.get $8
+   local.get $7
+   i32.lt_s
+   if
+    local.get $4
+    local.get $8
+    i32.const 4
+    i32.shl
+    i32.add
+    local.tee $2
+    i32.load offset=12
+    i32.const 1
+    i32.and
+    i32.eqz
+    if
+     local.get $0
+     local.get $9
+     local.get $2
+     i64.load
+     call $~lib/array/Array<i64>#__set
+     local.get $9
+     i32.const 1
+     i32.add
+     local.set $9
+    end
+    local.get $8
+    i32.const 1
+    i32.add
+    local.set $8
+    br $for-loop|0
+   end
+  end
+  local.get $0
+  local.get $9
+  call $~lib/array/Array<i64>#set:length
+  local.get $0
  )
  (func $~lib/map/Map<i64,i32>#values (param $0 i32) (result i32)
   (local $1 i32)
@@ -9435,7 +9486,6 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
   i32.const 24
   i32.const 20
   call $~lib/rt/tlsf/__alloc
@@ -9622,52 +9672,11 @@
    unreachable
   end
   local.get $1
-  i32.load offset=8
-  local.set $6
-  local.get $1
-  i32.load offset=16
-  local.tee $4
-  call $~lib/array/Array<i64>#constructor
+  call $~lib/map/Map<i64,i32>#keys
   local.set $5
-  loop $for-loop|01
-   local.get $3
-   local.get $4
-   i32.lt_s
-   if
-    local.get $6
-    local.get $3
-    i32.const 4
-    i32.shl
-    i32.add
-    local.tee $8
-    i32.load offset=12
-    i32.const 1
-    i32.and
-    i32.eqz
-    if
-     local.get $5
-     local.get $2
-     local.get $8
-     i64.load
-     call $~lib/array/Array<i64>#__set
-     local.get $2
-     i32.const 1
-     i32.add
-     local.set $2
-    end
-    local.get $3
-    i32.const 1
-    i32.add
-    local.set $3
-    br $for-loop|01
-   end
-  end
-  local.get $5
-  local.get $2
-  call $~lib/array/Array<i64>#set:length
   local.get $1
   call $~lib/map/Map<i64,i32>#values
-  local.set $6
+  local.set $7
   i32.const 24
   i32.const 22
   call $~lib/rt/tlsf/__alloc
@@ -9693,19 +9702,19 @@
   local.get $2
   call $~lib/map/Map<i64,i64>#clear
   call $~lib/map/Map<i32,i32>#constructor
-  local.set $3
+  local.set $6
   loop $for-loop|2
-   local.get $7
+   local.get $3
    local.get $5
    i32.load offset=12
    i32.lt_s
    if
     local.get $5
-    local.get $7
+    local.get $3
     call $~lib/array/Array<i64>#__get
     local.set $0
-    local.get $6
     local.get $7
+    local.get $3
     call $~lib/array/Array<i32>#__get
     local.set $4
     local.get $1
@@ -9740,7 +9749,7 @@
     local.get $0
     call $~lib/map/Map<i64,i64>#set
     call $~lib/rt/pure/__release
-    local.get $3
+    local.get $6
     local.get $4
     i32.const 20
     i32.sub
@@ -9748,10 +9757,10 @@
     local.get $4
     call $~lib/map/Map<i32,i32>#set
     call $~lib/rt/pure/__release
-    local.get $7
+    local.get $3
     i32.const 1
     i32.add
-    local.set $7
+    local.set $3
     br $for-loop|2
    end
   end
@@ -9767,7 +9776,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $6
   i32.load offset=20
   i32.const 100
   i32.ne
@@ -9932,43 +9941,52 @@
   end
   local.get $5
   call $~lib/rt/pure/__release
-  local.get $6
+  local.get $7
   call $~lib/rt/pure/__release
   local.get $2
   call $~lib/rt/pure/__release
-  local.get $3
+  local.get $6
   call $~lib/rt/pure/__release
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/array/Array<u64>#constructor (param $0 i32) (result i32)
+ (func $~lib/map/Map<u64,i32>#keys (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  local.get $0
+  i32.load offset=8
+  local.set $4
+  local.get $0
+  i32.load offset=16
+  local.tee $7
+  local.set $6
   i32.const 16
   i32.const 24
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
-  local.tee $3
+  local.tee $0
   i32.const 0
   i32.store
-  local.get $3
+  local.get $0
   i32.const 0
   i32.store offset=4
-  local.get $3
+  local.get $0
   i32.const 0
   i32.store offset=8
-  local.get $3
+  local.get $0
   i32.const 0
   i32.store offset=12
-  local.get $0
+  local.get $7
   i32.const 134217726
   i32.gt_u
   if
-   local.get $3
-   call $~lib/rt/pure/__release
    i32.const 1040
    i32.const 1472
    i32.const 57
@@ -9976,42 +9994,78 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $6
   i32.const 3
   i32.shl
-  local.tee $4
+  local.tee $5
   i32.const 0
   call $~lib/rt/tlsf/__alloc
-  local.tee $1
-  local.get $4
+  local.tee $2
+  local.get $5
   call $~lib/memory/memory.fill
-  local.get $1
-  local.set $2
-  local.get $1
-  local.get $3
+  local.get $2
+  local.set $1
+  local.get $2
+  local.get $0
   i32.load
-  local.tee $5
+  local.tee $3
   i32.ne
   if
-   local.get $2
+   local.get $1
    call $~lib/rt/pure/__retain
-   local.set $2
-   local.get $5
+   local.set $1
+   local.get $3
    call $~lib/rt/pure/__release
   end
-  local.get $3
-  local.get $2
-  i32.store
-  local.get $3
-  local.get $1
-  i32.store offset=4
-  local.get $3
-  local.get $4
-  i32.store offset=8
-  local.get $3
   local.get $0
+  local.get $1
+  i32.store
+  local.get $0
+  local.get $2
+  i32.store offset=4
+  local.get $0
+  local.get $5
+  i32.store offset=8
+  local.get $0
+  local.get $6
   i32.store offset=12
-  local.get $3
+  loop $for-loop|0
+   local.get $8
+   local.get $7
+   i32.lt_s
+   if
+    local.get $4
+    local.get $8
+    i32.const 4
+    i32.shl
+    i32.add
+    local.tee $2
+    i32.load offset=12
+    i32.const 1
+    i32.and
+    i32.eqz
+    if
+     local.get $0
+     local.get $9
+     local.get $2
+     i64.load
+     call $~lib/array/Array<i64>#__set
+     local.get $9
+     i32.const 1
+     i32.add
+     local.set $9
+    end
+    local.get $8
+    i32.const 1
+    i32.add
+    local.set $8
+    br $for-loop|0
+   end
+  end
+  local.get $0
+  local.get $9
+  call $~lib/array/Array<i64>#set:length
+  local.get $0
  )
  (func $std/map/testNumeric<u64,i32>
   (local $0 i64)
@@ -10022,7 +10076,6 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
   i32.const 24
   i32.const 23
   call $~lib/rt/tlsf/__alloc
@@ -10209,52 +10262,11 @@
    unreachable
   end
   local.get $1
-  i32.load offset=8
-  local.set $6
-  local.get $1
-  i32.load offset=16
-  local.tee $4
-  call $~lib/array/Array<u64>#constructor
+  call $~lib/map/Map<u64,i32>#keys
   local.set $5
-  loop $for-loop|01
-   local.get $3
-   local.get $4
-   i32.lt_s
-   if
-    local.get $6
-    local.get $3
-    i32.const 4
-    i32.shl
-    i32.add
-    local.tee $8
-    i32.load offset=12
-    i32.const 1
-    i32.and
-    i32.eqz
-    if
-     local.get $5
-     local.get $2
-     local.get $8
-     i64.load
-     call $~lib/array/Array<i64>#__set
-     local.get $2
-     i32.const 1
-     i32.add
-     local.set $2
-    end
-    local.get $3
-    i32.const 1
-    i32.add
-    local.set $3
-    br $for-loop|01
-   end
-  end
-  local.get $5
-  local.get $2
-  call $~lib/array/Array<i64>#set:length
   local.get $1
   call $~lib/map/Map<i64,i32>#values
-  local.set $6
+  local.set $7
   i32.const 24
   i32.const 25
   call $~lib/rt/tlsf/__alloc
@@ -10280,19 +10292,19 @@
   local.get $2
   call $~lib/map/Map<i64,i64>#clear
   call $~lib/map/Map<i32,i32>#constructor
-  local.set $3
+  local.set $6
   loop $for-loop|2
-   local.get $7
+   local.get $3
    local.get $5
    i32.load offset=12
    i32.lt_s
    if
     local.get $5
-    local.get $7
+    local.get $3
     call $~lib/array/Array<i64>#__get
     local.set $0
-    local.get $6
     local.get $7
+    local.get $3
     call $~lib/array/Array<i32>#__get
     local.set $4
     local.get $1
@@ -10327,7 +10339,7 @@
     local.get $0
     call $~lib/map/Map<i64,i64>#set
     call $~lib/rt/pure/__release
-    local.get $3
+    local.get $6
     local.get $4
     i32.const 20
     i32.sub
@@ -10335,10 +10347,10 @@
     local.get $4
     call $~lib/map/Map<i32,i32>#set
     call $~lib/rt/pure/__release
-    local.get $7
+    local.get $3
     i32.const 1
     i32.add
-    local.set $7
+    local.set $3
     br $for-loop|2
    end
   end
@@ -10354,7 +10366,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $6
   i32.load offset=20
   i32.const 100
   i32.ne
@@ -10519,11 +10531,11 @@
   end
   local.get $5
   call $~lib/rt/pure/__release
-  local.get $6
+  local.get $7
   call $~lib/rt/pure/__release
   local.get $2
   call $~lib/rt/pure/__release
-  local.get $3
+  local.get $6
   call $~lib/rt/pure/__release
   local.get $1
   call $~lib/rt/pure/__release
@@ -10826,34 +10838,44 @@
   local.get $0
   i32.load offset=4
  )
- (func $~lib/array/Array<f32>#constructor (param $0 i32) (result i32)
+ (func $~lib/map/Map<f32,i32>#keys (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
-  (local $3 i32)
+  (local $3 f32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  local.get $0
+  i32.load offset=8
+  local.set $5
+  local.get $0
+  i32.load offset=16
+  local.tee $8
+  local.set $7
   i32.const 16
   i32.const 27
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
-  local.tee $3
+  local.tee $0
   i32.const 0
   i32.store
-  local.get $3
+  local.get $0
   i32.const 0
   i32.store offset=4
-  local.get $3
+  local.get $0
   i32.const 0
   i32.store offset=8
-  local.get $3
+  local.get $0
   i32.const 0
   i32.store offset=12
-  local.get $0
+  local.get $8
   i32.const 268435452
   i32.gt_u
   if
-   local.get $3
-   call $~lib/rt/pure/__release
    i32.const 1040
    i32.const 1472
    i32.const 57
@@ -10861,83 +10883,66 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $7
   i32.const 2
   i32.shl
-  local.tee $4
+  local.tee $6
   i32.const 0
   call $~lib/rt/tlsf/__alloc
-  local.tee $1
-  local.get $4
+  local.tee $2
+  local.get $6
   call $~lib/memory/memory.fill
-  local.get $1
-  local.set $2
-  local.get $1
-  local.get $3
+  local.get $2
+  local.set $1
+  local.get $2
+  local.get $0
   i32.load
-  local.tee $5
+  local.tee $4
   i32.ne
   if
-   local.get $2
+   local.get $1
    call $~lib/rt/pure/__retain
-   local.set $2
-   local.get $5
+   local.set $1
+   local.get $4
    call $~lib/rt/pure/__release
   end
-  local.get $3
-  local.get $2
-  i32.store
-  local.get $3
+  local.get $0
   local.get $1
+  i32.store
+  local.get $0
+  local.get $2
   i32.store offset=4
-  local.get $3
-  local.get $4
+  local.get $0
+  local.get $6
   i32.store offset=8
-  local.get $3
   local.get $0
+  local.get $7
   i32.store offset=12
-  local.get $3
- )
- (func $~lib/map/Map<f32,i32>#keys (param $0 i32) (result i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 f32)
-  local.get $0
-  i32.load offset=8
-  local.set $4
-  local.get $0
-  i32.load offset=16
-  local.tee $5
-  call $~lib/array/Array<f32>#constructor
-  local.set $0
   loop $for-loop|0
-   local.get $2
-   local.get $5
+   local.get $9
+   local.get $8
    i32.lt_s
    if
-    local.get $4
-    local.get $2
+    local.get $5
+    local.get $9
     i32.const 12
     i32.mul
     i32.add
-    local.tee $3
+    local.tee $2
     i32.load offset=8
     i32.const 1
     i32.and
     i32.eqz
     if
-     local.get $3
+     local.get $2
      f32.load
-     local.set $6
-     local.get $1
+     local.set $3
+     local.get $10
      local.get $0
      i32.load offset=12
      i32.ge_u
      if
-      local.get $1
+      local.get $10
       i32.const 0
       i32.lt_s
       if
@@ -10949,38 +10954,38 @@
        unreachable
       end
       local.get $0
-      local.get $1
+      local.get $10
       i32.const 1
       i32.add
-      local.tee $3
+      local.tee $2
       i32.const 2
       call $~lib/array/ensureSize
       local.get $0
-      local.get $3
+      local.get $2
       i32.store offset=12
      end
      local.get $0
      i32.load offset=4
-     local.get $1
+     local.get $10
      i32.const 2
      i32.shl
      i32.add
-     local.get $6
+     local.get $3
      f32.store
-     local.get $1
+     local.get $10
      i32.const 1
      i32.add
-     local.set $1
+     local.set $10
     end
-    local.get $2
+    local.get $9
     i32.const 1
     i32.add
-    local.set $2
+    local.set $9
     br $for-loop|0
    end
   end
   local.get $0
-  local.get $1
+  local.get $10
   call $~lib/array/Array<i32>#set:length
   local.get $0
  )
@@ -12059,34 +12064,44 @@
   local.get $0
   i32.load offset=8
  )
- (func $~lib/array/Array<f64>#constructor (param $0 i32) (result i32)
+ (func $~lib/map/Map<f64,i32>#keys (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
-  (local $3 i32)
+  (local $3 f64)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  local.get $0
+  i32.load offset=8
+  local.set $5
+  local.get $0
+  i32.load offset=16
+  local.tee $8
+  local.set $7
   i32.const 16
   i32.const 30
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
-  local.tee $3
+  local.tee $0
   i32.const 0
   i32.store
-  local.get $3
+  local.get $0
   i32.const 0
   i32.store offset=4
-  local.get $3
+  local.get $0
   i32.const 0
   i32.store offset=8
-  local.get $3
+  local.get $0
   i32.const 0
   i32.store offset=12
-  local.get $0
+  local.get $8
   i32.const 134217726
   i32.gt_u
   if
-   local.get $3
-   call $~lib/rt/pure/__release
    i32.const 1040
    i32.const 1472
    i32.const 57
@@ -12094,83 +12109,66 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $7
   i32.const 3
   i32.shl
-  local.tee $4
+  local.tee $6
   i32.const 0
   call $~lib/rt/tlsf/__alloc
-  local.tee $1
-  local.get $4
+  local.tee $2
+  local.get $6
   call $~lib/memory/memory.fill
-  local.get $1
-  local.set $2
-  local.get $1
-  local.get $3
+  local.get $2
+  local.set $1
+  local.get $2
+  local.get $0
   i32.load
-  local.tee $5
+  local.tee $4
   i32.ne
   if
-   local.get $2
+   local.get $1
    call $~lib/rt/pure/__retain
-   local.set $2
-   local.get $5
+   local.set $1
+   local.get $4
    call $~lib/rt/pure/__release
   end
-  local.get $3
-  local.get $2
-  i32.store
-  local.get $3
+  local.get $0
   local.get $1
+  i32.store
+  local.get $0
+  local.get $2
   i32.store offset=4
-  local.get $3
-  local.get $4
+  local.get $0
+  local.get $6
   i32.store offset=8
-  local.get $3
   local.get $0
+  local.get $7
   i32.store offset=12
-  local.get $3
- )
- (func $~lib/map/Map<f64,i32>#keys (param $0 i32) (result i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 f64)
-  local.get $0
-  i32.load offset=8
-  local.set $4
-  local.get $0
-  i32.load offset=16
-  local.tee $5
-  call $~lib/array/Array<f64>#constructor
-  local.set $0
   loop $for-loop|0
-   local.get $2
-   local.get $5
+   local.get $9
+   local.get $8
    i32.lt_s
    if
-    local.get $4
-    local.get $2
+    local.get $5
+    local.get $9
     i32.const 4
     i32.shl
     i32.add
-    local.tee $3
+    local.tee $2
     i32.load offset=12
     i32.const 1
     i32.and
     i32.eqz
     if
-     local.get $3
+     local.get $2
      f64.load
-     local.set $6
-     local.get $1
+     local.set $3
+     local.get $10
      local.get $0
      i32.load offset=12
      i32.ge_u
      if
-      local.get $1
+      local.get $10
       i32.const 0
       i32.lt_s
       if
@@ -12182,38 +12180,38 @@
        unreachable
       end
       local.get $0
-      local.get $1
+      local.get $10
       i32.const 1
       i32.add
-      local.tee $3
+      local.tee $2
       i32.const 3
       call $~lib/array/ensureSize
       local.get $0
-      local.get $3
+      local.get $2
       i32.store offset=12
      end
      local.get $0
      i32.load offset=4
-     local.get $1
+     local.get $10
      i32.const 3
      i32.shl
      i32.add
-     local.get $6
+     local.get $3
      f64.store
-     local.get $1
+     local.get $10
      i32.const 1
      i32.add
-     local.set $1
+     local.set $10
     end
-    local.get $2
+    local.get $9
     i32.const 1
     i32.add
-    local.set $2
+    local.set $9
     br $for-loop|0
    end
   end
   local.get $0
-  local.get $1
+  local.get $10
   call $~lib/array/Array<i64>#set:length
   local.get $0
  )

--- a/tests/compiler/std/map.untouched.wat
+++ b/tests/compiler/std/map.untouched.wat
@@ -1774,8 +1774,6 @@
   i32.const 1073741808
   i32.gt_u
   if
-   local.get $0
-   call $~lib/rt/pure/__release
    i32.const 32
    i32.const 80
    i32.const 49
@@ -2324,8 +2322,6 @@
   i32.shr_u
   i32.gt_u
   if
-   local.get $0
-   call $~lib/rt/pure/__release
    i32.const 32
    i32.const 464
    i32.const 57
@@ -4048,8 +4044,6 @@
   i32.shr_u
   i32.gt_u
   if
-   local.get $0
-   call $~lib/rt/pure/__release
    i32.const 32
    i32.const 464
    i32.const 57
@@ -6281,8 +6275,6 @@
   i32.shr_u
   i32.gt_u
   if
-   local.get $0
-   call $~lib/rt/pure/__release
    i32.const 32
    i32.const 464
    i32.const 57
@@ -8100,8 +8092,6 @@
   i32.shr_u
   i32.gt_u
   if
-   local.get $0
-   call $~lib/rt/pure/__release
    i32.const 32
    i32.const 464
    i32.const 57
@@ -9929,8 +9919,6 @@
   i32.shr_u
   i32.gt_u
   if
-   local.get $0
-   call $~lib/rt/pure/__release
    i32.const 32
    i32.const 464
    i32.const 57
@@ -12507,8 +12495,6 @@
   i32.shr_u
   i32.gt_u
   if
-   local.get $0
-   call $~lib/rt/pure/__release
    i32.const 32
    i32.const 464
    i32.const 57
@@ -14404,8 +14390,6 @@
   i32.shr_u
   i32.gt_u
   if
-   local.get $0
-   call $~lib/rt/pure/__release
    i32.const 32
    i32.const 464
    i32.const 57
@@ -16236,8 +16220,6 @@
   i32.shr_u
   i32.gt_u
   if
-   local.get $0
-   call $~lib/rt/pure/__release
    i32.const 32
    i32.const 464
    i32.const 57
@@ -18024,8 +18006,6 @@
   i32.shr_u
   i32.gt_u
   if
-   local.get $0
-   call $~lib/rt/pure/__release
    i32.const 32
    i32.const 464
    i32.const 57
@@ -19795,8 +19775,6 @@
   i32.shr_u
   i32.gt_u
   if
-   local.get $0
-   call $~lib/rt/pure/__release
    i32.const 32
    i32.const 464
    i32.const 57

--- a/tests/compiler/std/set.optimized.wat
+++ b/tests/compiler/std/set.optimized.wat
@@ -1,7 +1,7 @@
 (module
  (type $i32_i32_=>_none (func (param i32 i32)))
- (type $i32_=>_i32 (func (param i32) (result i32)))
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
+ (type $i32_=>_i32 (func (param i32) (result i32)))
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
  (type $i32_=>_none (func (param i32)))
@@ -2116,8 +2116,6 @@
   i32.const 1073741808
   i32.gt_u
   if
-   local.get $0
-   call $~lib/rt/pure/__release
    i32.const 1040
    i32.const 1360
    i32.const 57
@@ -2885,8 +2883,6 @@
   i32.const 1073741808
   i32.gt_u
   if
-   local.get $0
-   call $~lib/rt/pure/__release
    i32.const 1040
    i32.const 1360
    i32.const 57
@@ -3670,78 +3666,6 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/array/Array<i16>#constructor (param $0 i32) (result i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  i32.const 16
-  i32.const 8
-  call $~lib/rt/tlsf/__alloc
-  call $~lib/rt/pure/__retain
-  local.tee $3
-  i32.const 0
-  i32.store
-  local.get $3
-  i32.const 0
-  i32.store offset=4
-  local.get $3
-  i32.const 0
-  i32.store offset=8
-  local.get $3
-  i32.const 0
-  i32.store offset=12
-  local.get $0
-  i32.const 536870904
-  i32.gt_u
-  if
-   local.get $3
-   call $~lib/rt/pure/__release
-   i32.const 1040
-   i32.const 1360
-   i32.const 57
-   i32.const 60
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $0
-  i32.const 1
-  i32.shl
-  local.tee $4
-  i32.const 0
-  call $~lib/rt/tlsf/__alloc
-  local.tee $1
-  local.get $4
-  call $~lib/memory/memory.fill
-  local.get $1
-  local.set $2
-  local.get $1
-  local.get $3
-  i32.load
-  local.tee $5
-  i32.ne
-  if
-   local.get $2
-   call $~lib/rt/pure/__retain
-   local.set $2
-   local.get $5
-   call $~lib/rt/pure/__release
-  end
-  local.get $3
-  local.get $2
-  i32.store
-  local.get $3
-  local.get $1
-  i32.store offset=4
-  local.get $3
-  local.get $4
-  i32.store offset=8
-  local.get $3
-  local.get $0
-  i32.store offset=12
-  local.get $3
- )
  (func $~lib/array/Array<i16>#__set (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $1
@@ -3791,6 +3715,123 @@
   local.get $0
   local.get $1
   i32.store offset=12
+ )
+ (func $~lib/set/Set<i16>#values (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  local.get $0
+  i32.load offset=8
+  local.set $4
+  local.get $0
+  i32.load offset=16
+  local.tee $7
+  local.set $6
+  i32.const 16
+  i32.const 8
+  call $~lib/rt/tlsf/__alloc
+  call $~lib/rt/pure/__retain
+  local.tee $0
+  i32.const 0
+  i32.store
+  local.get $0
+  i32.const 0
+  i32.store offset=4
+  local.get $0
+  i32.const 0
+  i32.store offset=8
+  local.get $0
+  i32.const 0
+  i32.store offset=12
+  local.get $7
+  i32.const 536870904
+  i32.gt_u
+  if
+   i32.const 1040
+   i32.const 1360
+   i32.const 57
+   i32.const 60
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $6
+  i32.const 1
+  i32.shl
+  local.tee $5
+  i32.const 0
+  call $~lib/rt/tlsf/__alloc
+  local.tee $2
+  local.get $5
+  call $~lib/memory/memory.fill
+  local.get $2
+  local.set $1
+  local.get $2
+  local.get $0
+  i32.load
+  local.tee $3
+  i32.ne
+  if
+   local.get $1
+   call $~lib/rt/pure/__retain
+   local.set $1
+   local.get $3
+   call $~lib/rt/pure/__release
+  end
+  local.get $0
+  local.get $1
+  i32.store
+  local.get $0
+  local.get $2
+  i32.store offset=4
+  local.get $0
+  local.get $5
+  i32.store offset=8
+  local.get $0
+  local.get $6
+  i32.store offset=12
+  loop $for-loop|0
+   local.get $8
+   local.get $7
+   i32.lt_s
+   if
+    local.get $4
+    local.get $8
+    i32.const 3
+    i32.shl
+    i32.add
+    local.tee $2
+    i32.load offset=4
+    i32.const 1
+    i32.and
+    i32.eqz
+    if
+     local.get $0
+     local.get $9
+     local.get $2
+     i32.load16_s
+     call $~lib/array/Array<i16>#__set
+     local.get $9
+     i32.const 1
+     i32.add
+     local.set $9
+    end
+    local.get $8
+    i32.const 1
+    i32.add
+    local.set $8
+    br $for-loop|0
+   end
+  end
+  local.get $0
+  local.get $9
+  call $~lib/array/Array<i16>#set:length
+  local.get $0
  )
  (func $~lib/array/Array<i16>#__get (param $0 i32) (param $1 i32) (result i32)
   local.get $1
@@ -3881,10 +3922,6 @@
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
   call $~lib/set/Set<i16>#constructor
   local.set $0
   loop $for-loop|1
@@ -4001,49 +4038,8 @@
    unreachable
   end
   local.get $0
-  i32.load offset=8
-  local.set $5
-  local.get $0
-  i32.load offset=16
-  local.tee $6
-  call $~lib/array/Array<i16>#constructor
+  call $~lib/set/Set<i16>#values
   local.set $2
-  loop $for-loop|0
-   local.get $4
-   local.get $6
-   i32.lt_s
-   if
-    local.get $5
-    local.get $4
-    i32.const 3
-    i32.shl
-    i32.add
-    local.tee $7
-    i32.load offset=4
-    i32.const 1
-    i32.and
-    i32.eqz
-    if
-     local.get $2
-     local.get $3
-     local.get $7
-     i32.load16_s
-     call $~lib/array/Array<i16>#__set
-     local.get $3
-     i32.const 1
-     i32.add
-     local.set $3
-    end
-    local.get $4
-    i32.const 1
-    i32.add
-    local.set $4
-    br $for-loop|0
-   end
-  end
-  local.get $2
-  local.get $3
-  call $~lib/array/Array<i16>#set:length
   call $~lib/set/Set<i16>#constructor
   local.set $3
   loop $for-loop|4
@@ -4493,34 +4489,43 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/array/Array<u16>#constructor (param $0 i32) (result i32)
+ (func $~lib/set/Set<u16>#values (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  local.get $0
+  i32.load offset=8
+  local.set $4
+  local.get $0
+  i32.load offset=16
+  local.tee $7
+  local.set $6
   i32.const 16
   i32.const 10
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
-  local.tee $3
+  local.tee $0
   i32.const 0
   i32.store
-  local.get $3
+  local.get $0
   i32.const 0
   i32.store offset=4
-  local.get $3
+  local.get $0
   i32.const 0
   i32.store offset=8
-  local.get $3
+  local.get $0
   i32.const 0
   i32.store offset=12
-  local.get $0
+  local.get $7
   i32.const 536870904
   i32.gt_u
   if
-   local.get $3
-   call $~lib/rt/pure/__release
    i32.const 1040
    i32.const 1360
    i32.const 57
@@ -4528,42 +4533,78 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $6
   i32.const 1
   i32.shl
-  local.tee $4
+  local.tee $5
   i32.const 0
   call $~lib/rt/tlsf/__alloc
-  local.tee $1
-  local.get $4
+  local.tee $2
+  local.get $5
   call $~lib/memory/memory.fill
-  local.get $1
-  local.set $2
-  local.get $1
-  local.get $3
+  local.get $2
+  local.set $1
+  local.get $2
+  local.get $0
   i32.load
-  local.tee $5
+  local.tee $3
   i32.ne
   if
-   local.get $2
+   local.get $1
    call $~lib/rt/pure/__retain
-   local.set $2
-   local.get $5
+   local.set $1
+   local.get $3
    call $~lib/rt/pure/__release
   end
-  local.get $3
-  local.get $2
-  i32.store
-  local.get $3
-  local.get $1
-  i32.store offset=4
-  local.get $3
-  local.get $4
-  i32.store offset=8
-  local.get $3
   local.get $0
+  local.get $1
+  i32.store
+  local.get $0
+  local.get $2
+  i32.store offset=4
+  local.get $0
+  local.get $5
+  i32.store offset=8
+  local.get $0
+  local.get $6
   i32.store offset=12
-  local.get $3
+  loop $for-loop|0
+   local.get $8
+   local.get $7
+   i32.lt_s
+   if
+    local.get $4
+    local.get $8
+    i32.const 3
+    i32.shl
+    i32.add
+    local.tee $2
+    i32.load offset=4
+    i32.const 1
+    i32.and
+    i32.eqz
+    if
+     local.get $0
+     local.get $9
+     local.get $2
+     i32.load16_u
+     call $~lib/array/Array<i16>#__set
+     local.get $9
+     i32.const 1
+     i32.add
+     local.set $9
+    end
+    local.get $8
+    i32.const 1
+    i32.add
+    local.set $8
+    br $for-loop|0
+   end
+  end
+  local.get $0
+  local.get $9
+  call $~lib/array/Array<i16>#set:length
+  local.get $0
  )
  (func $~lib/array/Array<u16>#__get (param $0 i32) (param $1 i32) (result i32)
   local.get $1
@@ -4652,10 +4693,6 @@
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
   call $~lib/set/Set<u16>#constructor
   local.set $0
   loop $for-loop|1
@@ -4768,49 +4805,8 @@
    unreachable
   end
   local.get $0
-  i32.load offset=8
-  local.set $5
-  local.get $0
-  i32.load offset=16
-  local.tee $6
-  call $~lib/array/Array<u16>#constructor
+  call $~lib/set/Set<u16>#values
   local.set $2
-  loop $for-loop|0
-   local.get $4
-   local.get $6
-   i32.lt_s
-   if
-    local.get $5
-    local.get $4
-    i32.const 3
-    i32.shl
-    i32.add
-    local.tee $7
-    i32.load offset=4
-    i32.const 1
-    i32.and
-    i32.eqz
-    if
-     local.get $2
-     local.get $3
-     local.get $7
-     i32.load16_u
-     call $~lib/array/Array<i16>#__set
-     local.get $3
-     i32.const 1
-     i32.add
-     local.set $3
-    end
-    local.get $4
-    i32.const 1
-    i32.add
-    local.set $4
-    br $for-loop|0
-   end
-  end
-  local.get $2
-  local.get $3
-  call $~lib/array/Array<i16>#set:length
   call $~lib/set/Set<u16>#constructor
   local.set $3
   loop $for-loop|4
@@ -5324,78 +5320,6 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/array/Array<i32>#constructor (param $0 i32) (result i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  i32.const 16
-  i32.const 12
-  call $~lib/rt/tlsf/__alloc
-  call $~lib/rt/pure/__retain
-  local.tee $3
-  i32.const 0
-  i32.store
-  local.get $3
-  i32.const 0
-  i32.store offset=4
-  local.get $3
-  i32.const 0
-  i32.store offset=8
-  local.get $3
-  i32.const 0
-  i32.store offset=12
-  local.get $0
-  i32.const 268435452
-  i32.gt_u
-  if
-   local.get $3
-   call $~lib/rt/pure/__release
-   i32.const 1040
-   i32.const 1360
-   i32.const 57
-   i32.const 60
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $0
-  i32.const 2
-  i32.shl
-  local.tee $4
-  i32.const 0
-  call $~lib/rt/tlsf/__alloc
-  local.tee $1
-  local.get $4
-  call $~lib/memory/memory.fill
-  local.get $1
-  local.set $2
-  local.get $1
-  local.get $3
-  i32.load
-  local.tee $5
-  i32.ne
-  if
-   local.get $2
-   call $~lib/rt/pure/__retain
-   local.set $2
-   local.get $5
-   call $~lib/rt/pure/__release
-  end
-  local.get $3
-  local.get $2
-  i32.store
-  local.get $3
-  local.get $1
-  i32.store offset=4
-  local.get $3
-  local.get $4
-  i32.store offset=8
-  local.get $3
-  local.get $0
-  i32.store offset=12
-  local.get $3
- )
  (func $~lib/array/Array<i32>#__set (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $1
@@ -5445,6 +5369,123 @@
   local.get $0
   local.get $1
   i32.store offset=12
+ )
+ (func $~lib/set/Set<i32>#values (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  local.get $0
+  i32.load offset=8
+  local.set $4
+  local.get $0
+  i32.load offset=16
+  local.tee $7
+  local.set $6
+  i32.const 16
+  i32.const 12
+  call $~lib/rt/tlsf/__alloc
+  call $~lib/rt/pure/__retain
+  local.tee $0
+  i32.const 0
+  i32.store
+  local.get $0
+  i32.const 0
+  i32.store offset=4
+  local.get $0
+  i32.const 0
+  i32.store offset=8
+  local.get $0
+  i32.const 0
+  i32.store offset=12
+  local.get $7
+  i32.const 268435452
+  i32.gt_u
+  if
+   i32.const 1040
+   i32.const 1360
+   i32.const 57
+   i32.const 60
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $6
+  i32.const 2
+  i32.shl
+  local.tee $5
+  i32.const 0
+  call $~lib/rt/tlsf/__alloc
+  local.tee $2
+  local.get $5
+  call $~lib/memory/memory.fill
+  local.get $2
+  local.set $1
+  local.get $2
+  local.get $0
+  i32.load
+  local.tee $3
+  i32.ne
+  if
+   local.get $1
+   call $~lib/rt/pure/__retain
+   local.set $1
+   local.get $3
+   call $~lib/rt/pure/__release
+  end
+  local.get $0
+  local.get $1
+  i32.store
+  local.get $0
+  local.get $2
+  i32.store offset=4
+  local.get $0
+  local.get $5
+  i32.store offset=8
+  local.get $0
+  local.get $6
+  i32.store offset=12
+  loop $for-loop|0
+   local.get $8
+   local.get $7
+   i32.lt_s
+   if
+    local.get $4
+    local.get $8
+    i32.const 3
+    i32.shl
+    i32.add
+    local.tee $2
+    i32.load offset=4
+    i32.const 1
+    i32.and
+    i32.eqz
+    if
+     local.get $0
+     local.get $9
+     local.get $2
+     i32.load
+     call $~lib/array/Array<i32>#__set
+     local.get $9
+     i32.const 1
+     i32.add
+     local.set $9
+    end
+    local.get $8
+    i32.const 1
+    i32.add
+    local.set $8
+    br $for-loop|0
+   end
+  end
+  local.get $0
+  local.get $9
+  call $~lib/array/Array<i32>#set:length
+  local.get $0
  )
  (func $~lib/array/Array<i32>#__get (param $0 i32) (param $1 i32) (result i32)
   local.get $1
@@ -5531,10 +5572,6 @@
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
   call $~lib/set/Set<i32>#constructor
   local.set $0
   loop $for-loop|0
@@ -5643,49 +5680,8 @@
    unreachable
   end
   local.get $0
-  i32.load offset=8
-  local.set $5
-  local.get $0
-  i32.load offset=16
-  local.tee $6
-  call $~lib/array/Array<i32>#constructor
+  call $~lib/set/Set<i32>#values
   local.set $2
-  loop $for-loop|01
-   local.get $4
-   local.get $6
-   i32.lt_s
-   if
-    local.get $5
-    local.get $4
-    i32.const 3
-    i32.shl
-    i32.add
-    local.tee $7
-    i32.load offset=4
-    i32.const 1
-    i32.and
-    i32.eqz
-    if
-     local.get $2
-     local.get $3
-     local.get $7
-     i32.load
-     call $~lib/array/Array<i32>#__set
-     local.get $3
-     i32.const 1
-     i32.add
-     local.set $3
-    end
-    local.get $4
-    i32.const 1
-    i32.add
-    local.set $4
-    br $for-loop|01
-   end
-  end
-  local.get $2
-  local.get $3
-  call $~lib/array/Array<i32>#set:length
   call $~lib/set/Set<i32>#constructor
   local.set $3
   loop $for-loop|2
@@ -5900,80 +5896,7 @@
   call $~lib/set/Set<i8>#clear
   local.get $0
  )
- (func $~lib/array/Array<u32>#constructor (param $0 i32) (result i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  i32.const 16
-  i32.const 14
-  call $~lib/rt/tlsf/__alloc
-  call $~lib/rt/pure/__retain
-  local.tee $3
-  i32.const 0
-  i32.store
-  local.get $3
-  i32.const 0
-  i32.store offset=4
-  local.get $3
-  i32.const 0
-  i32.store offset=8
-  local.get $3
-  i32.const 0
-  i32.store offset=12
-  local.get $0
-  i32.const 268435452
-  i32.gt_u
-  if
-   local.get $3
-   call $~lib/rt/pure/__release
-   i32.const 1040
-   i32.const 1360
-   i32.const 57
-   i32.const 60
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $0
-  i32.const 2
-  i32.shl
-  local.tee $4
-  i32.const 0
-  call $~lib/rt/tlsf/__alloc
-  local.tee $1
-  local.get $4
-  call $~lib/memory/memory.fill
-  local.get $1
-  local.set $2
-  local.get $1
-  local.get $3
-  i32.load
-  local.tee $5
-  i32.ne
-  if
-   local.get $2
-   call $~lib/rt/pure/__retain
-   local.set $2
-   local.get $5
-   call $~lib/rt/pure/__release
-  end
-  local.get $3
-  local.get $2
-  i32.store
-  local.get $3
-  local.get $1
-  i32.store offset=4
-  local.get $3
-  local.get $4
-  i32.store offset=8
-  local.get $3
-  local.get $0
-  i32.store offset=12
-  local.get $3
- )
- (func $std/set/testNumeric<u32>
-  (local $0 i32)
+ (func $~lib/set/Set<u32>#values (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -5981,6 +5904,120 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  local.get $0
+  i32.load offset=8
+  local.set $4
+  local.get $0
+  i32.load offset=16
+  local.tee $7
+  local.set $6
+  i32.const 16
+  i32.const 14
+  call $~lib/rt/tlsf/__alloc
+  call $~lib/rt/pure/__retain
+  local.tee $0
+  i32.const 0
+  i32.store
+  local.get $0
+  i32.const 0
+  i32.store offset=4
+  local.get $0
+  i32.const 0
+  i32.store offset=8
+  local.get $0
+  i32.const 0
+  i32.store offset=12
+  local.get $7
+  i32.const 268435452
+  i32.gt_u
+  if
+   i32.const 1040
+   i32.const 1360
+   i32.const 57
+   i32.const 60
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $6
+  i32.const 2
+  i32.shl
+  local.tee $5
+  i32.const 0
+  call $~lib/rt/tlsf/__alloc
+  local.tee $2
+  local.get $5
+  call $~lib/memory/memory.fill
+  local.get $2
+  local.set $1
+  local.get $2
+  local.get $0
+  i32.load
+  local.tee $3
+  i32.ne
+  if
+   local.get $1
+   call $~lib/rt/pure/__retain
+   local.set $1
+   local.get $3
+   call $~lib/rt/pure/__release
+  end
+  local.get $0
+  local.get $1
+  i32.store
+  local.get $0
+  local.get $2
+  i32.store offset=4
+  local.get $0
+  local.get $5
+  i32.store offset=8
+  local.get $0
+  local.get $6
+  i32.store offset=12
+  loop $for-loop|0
+   local.get $8
+   local.get $7
+   i32.lt_s
+   if
+    local.get $4
+    local.get $8
+    i32.const 3
+    i32.shl
+    i32.add
+    local.tee $2
+    i32.load offset=4
+    i32.const 1
+    i32.and
+    i32.eqz
+    if
+     local.get $0
+     local.get $9
+     local.get $2
+     i32.load
+     call $~lib/array/Array<i32>#__set
+     local.get $9
+     i32.const 1
+     i32.add
+     local.set $9
+    end
+    local.get $8
+    i32.const 1
+    i32.add
+    local.set $8
+    br $for-loop|0
+   end
+  end
+  local.get $0
+  local.get $9
+  call $~lib/array/Array<i32>#set:length
+  local.get $0
+ )
+ (func $std/set/testNumeric<u32>
+  (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
   call $~lib/set/Set<u32>#constructor
   local.set $0
   loop $for-loop|0
@@ -6089,49 +6126,8 @@
    unreachable
   end
   local.get $0
-  i32.load offset=8
-  local.set $5
-  local.get $0
-  i32.load offset=16
-  local.tee $6
-  call $~lib/array/Array<u32>#constructor
+  call $~lib/set/Set<u32>#values
   local.set $2
-  loop $for-loop|01
-   local.get $4
-   local.get $6
-   i32.lt_s
-   if
-    local.get $5
-    local.get $4
-    i32.const 3
-    i32.shl
-    i32.add
-    local.tee $7
-    i32.load offset=4
-    i32.const 1
-    i32.and
-    i32.eqz
-    if
-     local.get $2
-     local.get $3
-     local.get $7
-     i32.load
-     call $~lib/array/Array<i32>#__set
-     local.get $3
-     i32.const 1
-     i32.add
-     local.set $3
-    end
-    local.get $4
-    i32.const 1
-    i32.add
-    local.set $4
-    br $for-loop|01
-   end
-  end
-  local.get $2
-  local.get $3
-  call $~lib/array/Array<i32>#set:length
   call $~lib/set/Set<u32>#constructor
   local.set $3
   loop $for-loop|2
@@ -6709,78 +6705,6 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/array/Array<i64>#constructor (param $0 i32) (result i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  i32.const 16
-  i32.const 16
-  call $~lib/rt/tlsf/__alloc
-  call $~lib/rt/pure/__retain
-  local.tee $3
-  i32.const 0
-  i32.store
-  local.get $3
-  i32.const 0
-  i32.store offset=4
-  local.get $3
-  i32.const 0
-  i32.store offset=8
-  local.get $3
-  i32.const 0
-  i32.store offset=12
-  local.get $0
-  i32.const 134217726
-  i32.gt_u
-  if
-   local.get $3
-   call $~lib/rt/pure/__release
-   i32.const 1040
-   i32.const 1360
-   i32.const 57
-   i32.const 60
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $0
-  i32.const 3
-  i32.shl
-  local.tee $4
-  i32.const 0
-  call $~lib/rt/tlsf/__alloc
-  local.tee $1
-  local.get $4
-  call $~lib/memory/memory.fill
-  local.get $1
-  local.set $2
-  local.get $1
-  local.get $3
-  i32.load
-  local.tee $5
-  i32.ne
-  if
-   local.get $2
-   call $~lib/rt/pure/__retain
-   local.set $2
-   local.get $5
-   call $~lib/rt/pure/__release
-  end
-  local.get $3
-  local.get $2
-  i32.store
-  local.get $3
-  local.get $1
-  i32.store offset=4
-  local.get $3
-  local.get $4
-  i32.store offset=8
-  local.get $3
-  local.get $0
-  i32.store offset=12
-  local.get $3
- )
  (func $~lib/array/Array<i64>#__set (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   local.get $1
@@ -6830,6 +6754,123 @@
   local.get $0
   local.get $1
   i32.store offset=12
+ )
+ (func $~lib/set/Set<i64>#values (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  local.get $0
+  i32.load offset=8
+  local.set $4
+  local.get $0
+  i32.load offset=16
+  local.tee $7
+  local.set $6
+  i32.const 16
+  i32.const 16
+  call $~lib/rt/tlsf/__alloc
+  call $~lib/rt/pure/__retain
+  local.tee $0
+  i32.const 0
+  i32.store
+  local.get $0
+  i32.const 0
+  i32.store offset=4
+  local.get $0
+  i32.const 0
+  i32.store offset=8
+  local.get $0
+  i32.const 0
+  i32.store offset=12
+  local.get $7
+  i32.const 134217726
+  i32.gt_u
+  if
+   i32.const 1040
+   i32.const 1360
+   i32.const 57
+   i32.const 60
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $6
+  i32.const 3
+  i32.shl
+  local.tee $5
+  i32.const 0
+  call $~lib/rt/tlsf/__alloc
+  local.tee $2
+  local.get $5
+  call $~lib/memory/memory.fill
+  local.get $2
+  local.set $1
+  local.get $2
+  local.get $0
+  i32.load
+  local.tee $3
+  i32.ne
+  if
+   local.get $1
+   call $~lib/rt/pure/__retain
+   local.set $1
+   local.get $3
+   call $~lib/rt/pure/__release
+  end
+  local.get $0
+  local.get $1
+  i32.store
+  local.get $0
+  local.get $2
+  i32.store offset=4
+  local.get $0
+  local.get $5
+  i32.store offset=8
+  local.get $0
+  local.get $6
+  i32.store offset=12
+  loop $for-loop|0
+   local.get $8
+   local.get $7
+   i32.lt_s
+   if
+    local.get $4
+    local.get $8
+    i32.const 4
+    i32.shl
+    i32.add
+    local.tee $2
+    i32.load offset=8
+    i32.const 1
+    i32.and
+    i32.eqz
+    if
+     local.get $0
+     local.get $9
+     local.get $2
+     i64.load
+     call $~lib/array/Array<i64>#__set
+     local.get $9
+     i32.const 1
+     i32.add
+     local.set $9
+    end
+    local.get $8
+    i32.const 1
+    i32.add
+    local.set $8
+    br $for-loop|0
+   end
+  end
+  local.get $0
+  local.get $9
+  call $~lib/array/Array<i64>#set:length
+  local.get $0
  )
  (func $~lib/array/Array<i64>#__get (param $0 i32) (param $1 i32) (result i64)
   local.get $1
@@ -6918,10 +6959,6 @@
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
   call $~lib/set/Set<i64>#constructor
   local.set $1
   loop $for-loop|0
@@ -7030,60 +7067,19 @@
    unreachable
   end
   local.get $1
-  i32.load offset=8
-  local.set $6
-  local.get $1
-  i32.load offset=16
-  local.tee $7
-  call $~lib/array/Array<i64>#constructor
-  local.set $3
-  loop $for-loop|01
-   local.get $4
-   local.get $7
-   i32.lt_s
-   if
-    local.get $6
-    local.get $4
-    i32.const 4
-    i32.shl
-    i32.add
-    local.tee $8
-    i32.load offset=8
-    i32.const 1
-    i32.and
-    i32.eqz
-    if
-     local.get $3
-     local.get $2
-     local.get $8
-     i64.load
-     call $~lib/array/Array<i64>#__set
-     local.get $2
-     i32.const 1
-     i32.add
-     local.set $2
-    end
-    local.get $4
-    i32.const 1
-    i32.add
-    local.set $4
-    br $for-loop|01
-   end
-  end
-  local.get $3
-  local.get $2
-  call $~lib/array/Array<i64>#set:length
-  call $~lib/set/Set<i64>#constructor
+  call $~lib/set/Set<i64>#values
   local.set $2
+  call $~lib/set/Set<i64>#constructor
+  local.set $4
   loop $for-loop|2
-   local.get $5
    local.get $3
+   local.get $2
    i32.load offset=12
    i32.lt_s
    if
     local.get $1
+    local.get $2
     local.get $3
-    local.get $5
     call $~lib/array/Array<i64>#__get
     call $~lib/set/Set<i64>#has
     i32.eqz
@@ -7095,20 +7091,20 @@
      call $~lib/builtins/abort
      unreachable
     end
+    local.get $4
     local.get $2
     local.get $3
-    local.get $5
     call $~lib/array/Array<i64>#__get
     call $~lib/set/Set<i64>#add
     call $~lib/rt/pure/__release
-    local.get $5
+    local.get $3
     i32.const 1
     i32.add
-    local.set $5
+    local.set $3
     br $for-loop|2
    end
   end
-  local.get $2
+  local.get $4
   i32.load offset=20
   local.get $1
   i32.load offset=20
@@ -7252,9 +7248,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
-  call $~lib/rt/pure/__release
   local.get $2
+  call $~lib/rt/pure/__release
+  local.get $4
   call $~lib/rt/pure/__release
   local.get $1
   call $~lib/rt/pure/__release
@@ -7287,80 +7283,7 @@
   call $~lib/set/Set<i64>#clear
   local.get $0
  )
- (func $~lib/array/Array<u64>#constructor (param $0 i32) (result i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  i32.const 16
-  i32.const 18
-  call $~lib/rt/tlsf/__alloc
-  call $~lib/rt/pure/__retain
-  local.tee $3
-  i32.const 0
-  i32.store
-  local.get $3
-  i32.const 0
-  i32.store offset=4
-  local.get $3
-  i32.const 0
-  i32.store offset=8
-  local.get $3
-  i32.const 0
-  i32.store offset=12
-  local.get $0
-  i32.const 134217726
-  i32.gt_u
-  if
-   local.get $3
-   call $~lib/rt/pure/__release
-   i32.const 1040
-   i32.const 1360
-   i32.const 57
-   i32.const 60
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $0
-  i32.const 3
-  i32.shl
-  local.tee $4
-  i32.const 0
-  call $~lib/rt/tlsf/__alloc
-  local.tee $1
-  local.get $4
-  call $~lib/memory/memory.fill
-  local.get $1
-  local.set $2
-  local.get $1
-  local.get $3
-  i32.load
-  local.tee $5
-  i32.ne
-  if
-   local.get $2
-   call $~lib/rt/pure/__retain
-   local.set $2
-   local.get $5
-   call $~lib/rt/pure/__release
-  end
-  local.get $3
-  local.get $2
-  i32.store
-  local.get $3
-  local.get $1
-  i32.store offset=4
-  local.get $3
-  local.get $4
-  i32.store offset=8
-  local.get $3
-  local.get $0
-  i32.store offset=12
-  local.get $3
- )
- (func $std/set/testNumeric<u64>
-  (local $0 i64)
+ (func $~lib/set/Set<u64>#values (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -7369,6 +7292,120 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
+  local.get $0
+  i32.load offset=8
+  local.set $4
+  local.get $0
+  i32.load offset=16
+  local.tee $7
+  local.set $6
+  i32.const 16
+  i32.const 18
+  call $~lib/rt/tlsf/__alloc
+  call $~lib/rt/pure/__retain
+  local.tee $0
+  i32.const 0
+  i32.store
+  local.get $0
+  i32.const 0
+  i32.store offset=4
+  local.get $0
+  i32.const 0
+  i32.store offset=8
+  local.get $0
+  i32.const 0
+  i32.store offset=12
+  local.get $7
+  i32.const 134217726
+  i32.gt_u
+  if
+   i32.const 1040
+   i32.const 1360
+   i32.const 57
+   i32.const 60
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $6
+  i32.const 3
+  i32.shl
+  local.tee $5
+  i32.const 0
+  call $~lib/rt/tlsf/__alloc
+  local.tee $2
+  local.get $5
+  call $~lib/memory/memory.fill
+  local.get $2
+  local.set $1
+  local.get $2
+  local.get $0
+  i32.load
+  local.tee $3
+  i32.ne
+  if
+   local.get $1
+   call $~lib/rt/pure/__retain
+   local.set $1
+   local.get $3
+   call $~lib/rt/pure/__release
+  end
+  local.get $0
+  local.get $1
+  i32.store
+  local.get $0
+  local.get $2
+  i32.store offset=4
+  local.get $0
+  local.get $5
+  i32.store offset=8
+  local.get $0
+  local.get $6
+  i32.store offset=12
+  loop $for-loop|0
+   local.get $8
+   local.get $7
+   i32.lt_s
+   if
+    local.get $4
+    local.get $8
+    i32.const 4
+    i32.shl
+    i32.add
+    local.tee $2
+    i32.load offset=8
+    i32.const 1
+    i32.and
+    i32.eqz
+    if
+     local.get $0
+     local.get $9
+     local.get $2
+     i64.load
+     call $~lib/array/Array<i64>#__set
+     local.get $9
+     i32.const 1
+     i32.add
+     local.set $9
+    end
+    local.get $8
+    i32.const 1
+    i32.add
+    local.set $8
+    br $for-loop|0
+   end
+  end
+  local.get $0
+  local.get $9
+  call $~lib/array/Array<i64>#set:length
+  local.get $0
+ )
+ (func $std/set/testNumeric<u64>
+  (local $0 i64)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
   call $~lib/set/Set<u64>#constructor
   local.set $1
   loop $for-loop|0
@@ -7477,60 +7514,19 @@
    unreachable
   end
   local.get $1
-  i32.load offset=8
-  local.set $6
-  local.get $1
-  i32.load offset=16
-  local.tee $7
-  call $~lib/array/Array<u64>#constructor
-  local.set $3
-  loop $for-loop|01
-   local.get $4
-   local.get $7
-   i32.lt_s
-   if
-    local.get $6
-    local.get $4
-    i32.const 4
-    i32.shl
-    i32.add
-    local.tee $8
-    i32.load offset=8
-    i32.const 1
-    i32.and
-    i32.eqz
-    if
-     local.get $3
-     local.get $2
-     local.get $8
-     i64.load
-     call $~lib/array/Array<i64>#__set
-     local.get $2
-     i32.const 1
-     i32.add
-     local.set $2
-    end
-    local.get $4
-    i32.const 1
-    i32.add
-    local.set $4
-    br $for-loop|01
-   end
-  end
-  local.get $3
-  local.get $2
-  call $~lib/array/Array<i64>#set:length
-  call $~lib/set/Set<u64>#constructor
+  call $~lib/set/Set<u64>#values
   local.set $2
+  call $~lib/set/Set<u64>#constructor
+  local.set $4
   loop $for-loop|2
-   local.get $5
    local.get $3
+   local.get $2
    i32.load offset=12
    i32.lt_s
    if
     local.get $1
+    local.get $2
     local.get $3
-    local.get $5
     call $~lib/array/Array<i64>#__get
     call $~lib/set/Set<i64>#has
     i32.eqz
@@ -7542,20 +7538,20 @@
      call $~lib/builtins/abort
      unreachable
     end
+    local.get $4
     local.get $2
     local.get $3
-    local.get $5
     call $~lib/array/Array<i64>#__get
     call $~lib/set/Set<i64>#add
     call $~lib/rt/pure/__release
-    local.get $5
+    local.get $3
     i32.const 1
     i32.add
-    local.set $5
+    local.set $3
     br $for-loop|2
    end
   end
-  local.get $2
+  local.get $4
   i32.load offset=20
   local.get $1
   i32.load offset=20
@@ -7699,9 +7695,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
-  call $~lib/rt/pure/__release
   local.get $2
+  call $~lib/rt/pure/__release
+  local.get $4
   call $~lib/rt/pure/__release
   local.get $1
   call $~lib/rt/pure/__release
@@ -8001,34 +7997,44 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/array/Array<f32>#constructor (param $0 i32) (result i32)
+ (func $~lib/set/Set<f32>#values (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
-  (local $3 i32)
+  (local $3 f32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  local.get $0
+  i32.load offset=8
+  local.set $5
+  local.get $0
+  i32.load offset=16
+  local.tee $8
+  local.set $7
   i32.const 16
   i32.const 20
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
-  local.tee $3
+  local.tee $0
   i32.const 0
   i32.store
-  local.get $3
+  local.get $0
   i32.const 0
   i32.store offset=4
-  local.get $3
+  local.get $0
   i32.const 0
   i32.store offset=8
-  local.get $3
+  local.get $0
   i32.const 0
   i32.store offset=12
-  local.get $0
+  local.get $8
   i32.const 268435452
   i32.gt_u
   if
-   local.get $3
-   call $~lib/rt/pure/__release
    i32.const 1040
    i32.const 1360
    i32.const 57
@@ -8036,83 +8042,66 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $7
   i32.const 2
   i32.shl
-  local.tee $4
+  local.tee $6
   i32.const 0
   call $~lib/rt/tlsf/__alloc
-  local.tee $1
-  local.get $4
+  local.tee $2
+  local.get $6
   call $~lib/memory/memory.fill
-  local.get $1
-  local.set $2
-  local.get $1
-  local.get $3
+  local.get $2
+  local.set $1
+  local.get $2
+  local.get $0
   i32.load
-  local.tee $5
+  local.tee $4
   i32.ne
   if
-   local.get $2
+   local.get $1
    call $~lib/rt/pure/__retain
-   local.set $2
-   local.get $5
+   local.set $1
+   local.get $4
    call $~lib/rt/pure/__release
   end
-  local.get $3
-  local.get $2
-  i32.store
-  local.get $3
+  local.get $0
   local.get $1
+  i32.store
+  local.get $0
+  local.get $2
   i32.store offset=4
-  local.get $3
-  local.get $4
+  local.get $0
+  local.get $6
   i32.store offset=8
-  local.get $3
   local.get $0
+  local.get $7
   i32.store offset=12
-  local.get $3
- )
- (func $~lib/set/Set<f32>#values (param $0 i32) (result i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 f32)
-  local.get $0
-  i32.load offset=8
-  local.set $4
-  local.get $0
-  i32.load offset=16
-  local.tee $5
-  call $~lib/array/Array<f32>#constructor
-  local.set $0
   loop $for-loop|0
-   local.get $2
-   local.get $5
+   local.get $9
+   local.get $8
    i32.lt_s
    if
-    local.get $4
-    local.get $2
+    local.get $5
+    local.get $9
     i32.const 3
     i32.shl
     i32.add
-    local.tee $3
+    local.tee $2
     i32.load offset=4
     i32.const 1
     i32.and
     i32.eqz
     if
-     local.get $3
+     local.get $2
      f32.load
-     local.set $6
-     local.get $1
+     local.set $3
+     local.get $10
      local.get $0
      i32.load offset=12
      i32.ge_u
      if
-      local.get $1
+      local.get $10
       i32.const 0
       i32.lt_s
       if
@@ -8124,38 +8113,38 @@
        unreachable
       end
       local.get $0
-      local.get $1
+      local.get $10
       i32.const 1
       i32.add
-      local.tee $3
+      local.tee $2
       i32.const 2
       call $~lib/array/ensureSize
       local.get $0
-      local.get $3
+      local.get $2
       i32.store offset=12
      end
      local.get $0
      i32.load offset=4
-     local.get $1
+     local.get $10
      i32.const 2
      i32.shl
      i32.add
-     local.get $6
+     local.get $3
      f32.store
-     local.get $1
+     local.get $10
      i32.const 1
      i32.add
-     local.set $1
+     local.set $10
     end
-    local.get $2
+    local.get $9
     i32.const 1
     i32.add
-    local.set $2
+    local.set $9
     br $for-loop|0
    end
   end
   local.get $0
-  local.get $1
+  local.get $10
   call $~lib/array/Array<i32>#set:length
   local.get $0
  )
@@ -8838,34 +8827,44 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/array/Array<f64>#constructor (param $0 i32) (result i32)
+ (func $~lib/set/Set<f64>#values (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
-  (local $3 i32)
+  (local $3 f64)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  local.get $0
+  i32.load offset=8
+  local.set $5
+  local.get $0
+  i32.load offset=16
+  local.tee $8
+  local.set $7
   i32.const 16
   i32.const 22
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
-  local.tee $3
+  local.tee $0
   i32.const 0
   i32.store
-  local.get $3
+  local.get $0
   i32.const 0
   i32.store offset=4
-  local.get $3
+  local.get $0
   i32.const 0
   i32.store offset=8
-  local.get $3
+  local.get $0
   i32.const 0
   i32.store offset=12
-  local.get $0
+  local.get $8
   i32.const 134217726
   i32.gt_u
   if
-   local.get $3
-   call $~lib/rt/pure/__release
    i32.const 1040
    i32.const 1360
    i32.const 57
@@ -8873,83 +8872,66 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $7
   i32.const 3
   i32.shl
-  local.tee $4
+  local.tee $6
   i32.const 0
   call $~lib/rt/tlsf/__alloc
-  local.tee $1
-  local.get $4
+  local.tee $2
+  local.get $6
   call $~lib/memory/memory.fill
-  local.get $1
-  local.set $2
-  local.get $1
-  local.get $3
+  local.get $2
+  local.set $1
+  local.get $2
+  local.get $0
   i32.load
-  local.tee $5
+  local.tee $4
   i32.ne
   if
-   local.get $2
+   local.get $1
    call $~lib/rt/pure/__retain
-   local.set $2
-   local.get $5
+   local.set $1
+   local.get $4
    call $~lib/rt/pure/__release
   end
-  local.get $3
-  local.get $2
-  i32.store
-  local.get $3
+  local.get $0
   local.get $1
+  i32.store
+  local.get $0
+  local.get $2
   i32.store offset=4
-  local.get $3
-  local.get $4
+  local.get $0
+  local.get $6
   i32.store offset=8
-  local.get $3
   local.get $0
+  local.get $7
   i32.store offset=12
-  local.get $3
- )
- (func $~lib/set/Set<f64>#values (param $0 i32) (result i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 f64)
-  local.get $0
-  i32.load offset=8
-  local.set $4
-  local.get $0
-  i32.load offset=16
-  local.tee $5
-  call $~lib/array/Array<f64>#constructor
-  local.set $0
   loop $for-loop|0
-   local.get $2
-   local.get $5
+   local.get $9
+   local.get $8
    i32.lt_s
    if
-    local.get $4
-    local.get $2
+    local.get $5
+    local.get $9
     i32.const 4
     i32.shl
     i32.add
-    local.tee $3
+    local.tee $2
     i32.load offset=8
     i32.const 1
     i32.and
     i32.eqz
     if
-     local.get $3
+     local.get $2
      f64.load
-     local.set $6
-     local.get $1
+     local.set $3
+     local.get $10
      local.get $0
      i32.load offset=12
      i32.ge_u
      if
-      local.get $1
+      local.get $10
       i32.const 0
       i32.lt_s
       if
@@ -8961,38 +8943,38 @@
        unreachable
       end
       local.get $0
-      local.get $1
+      local.get $10
       i32.const 1
       i32.add
-      local.tee $3
+      local.tee $2
       i32.const 3
       call $~lib/array/ensureSize
       local.get $0
-      local.get $3
+      local.get $2
       i32.store offset=12
      end
      local.get $0
      i32.load offset=4
-     local.get $1
+     local.get $10
      i32.const 3
      i32.shl
      i32.add
-     local.get $6
+     local.get $3
      f64.store
-     local.get $1
+     local.get $10
      i32.const 1
      i32.add
-     local.set $1
+     local.set $10
     end
-    local.get $2
+    local.get $9
     i32.const 1
     i32.add
-    local.set $2
+    local.set $9
     br $for-loop|0
    end
   end
   local.get $0
-  local.get $1
+  local.get $10
   call $~lib/array/Array<i64>#set:length
   local.get $0
  )

--- a/tests/compiler/std/set.untouched.wat
+++ b/tests/compiler/std/set.untouched.wat
@@ -1769,8 +1769,6 @@
   i32.const 1073741808
   i32.gt_u
   if
-   local.get $0
-   call $~lib/rt/pure/__release
    i32.const 32
    i32.const 80
    i32.const 49
@@ -2260,8 +2258,6 @@
   i32.shr_u
   i32.gt_u
   if
-   local.get $0
-   call $~lib/rt/pure/__release
    i32.const 32
    i32.const 352
    i32.const 57
@@ -4884,8 +4880,6 @@
   i32.shr_u
   i32.gt_u
   if
-   local.get $0
-   call $~lib/rt/pure/__release
    i32.const 32
    i32.const 352
    i32.const 57
@@ -6022,8 +6016,6 @@
   i32.shr_u
   i32.gt_u
   if
-   local.get $0
-   call $~lib/rt/pure/__release
    i32.const 32
    i32.const 352
    i32.const 57
@@ -7146,8 +7138,6 @@
   i32.shr_u
   i32.gt_u
   if
-   local.get $0
-   call $~lib/rt/pure/__release
    i32.const 32
    i32.const 352
    i32.const 57
@@ -8308,8 +8298,6 @@
   i32.shr_u
   i32.gt_u
   if
-   local.get $0
-   call $~lib/rt/pure/__release
    i32.const 32
    i32.const 352
    i32.const 57
@@ -9418,8 +9406,6 @@
   i32.shr_u
   i32.gt_u
   if
-   local.get $0
-   call $~lib/rt/pure/__release
    i32.const 32
    i32.const 352
    i32.const 57
@@ -10630,8 +10616,6 @@
   i32.shr_u
   i32.gt_u
   if
-   local.get $0
-   call $~lib/rt/pure/__release
    i32.const 32
    i32.const 352
    i32.const 57
@@ -11760,8 +11744,6 @@
   i32.shr_u
   i32.gt_u
   if
-   local.get $0
-   call $~lib/rt/pure/__release
    i32.const 32
    i32.const 352
    i32.const 57
@@ -12857,8 +12839,6 @@
   i32.shr_u
   i32.gt_u
   if
-   local.get $0
-   call $~lib/rt/pure/__release
    i32.const 32
    i32.const 352
    i32.const 57
@@ -13955,8 +13935,6 @@
   i32.shr_u
   i32.gt_u
   if
-   local.get $0
-   call $~lib/rt/pure/__release
    i32.const 32
    i32.const 352
    i32.const 57

--- a/tests/compiler/std/string.optimized.wat
+++ b/tests/compiler/std/string.optimized.wat
@@ -5434,8 +5434,6 @@
   local.tee $0
   i32.eqz
   if
-   local.get $0
-   call $~lib/rt/pure/__release
    i32.const 13248
    i32.const 13136
    i32.const 108

--- a/tests/compiler/std/string.untouched.wat
+++ b/tests/compiler/std/string.untouched.wat
@@ -8758,8 +8758,6 @@
   local.get $2
   i32.eqz
   if
-   local.get $2
-   call $~lib/rt/pure/__release
    i32.const 12240
    i32.const 12128
    i32.const 108

--- a/tests/compiler/std/symbol.untouched.wat
+++ b/tests/compiler/std/symbol.untouched.wat
@@ -416,8 +416,6 @@
   i32.const 1073741808
   i32.gt_u
   if
-   local.get $0
-   call $~lib/rt/stub/__release
    i32.const 112
    i32.const 160
    i32.const 49
@@ -960,8 +958,6 @@
   local.get $4
   i32.eqz
   if
-   local.get $1
-   call $~lib/rt/stub/__release
    i32.const 224
    i32.const 288
    i32.const 111

--- a/tests/compiler/std/typedarray.optimized.wat
+++ b/tests/compiler/std/typedarray.optimized.wat
@@ -1487,8 +1487,6 @@
   i32.shr_u
   i32.gt_u
   if
-   local.get $0
-   call $~lib/rt/pure/__release
    i32.const 1040
    i32.const 1088
    i32.const 18

--- a/tests/compiler/std/typedarray.untouched.wat
+++ b/tests/compiler/std/typedarray.untouched.wat
@@ -1971,8 +1971,6 @@
   i32.shr_u
   i32.gt_u
   if
-   local.get $0
-   call $~lib/rt/pure/__release
    i32.const 32
    i32.const 80
    i32.const 18
@@ -37460,8 +37458,6 @@
   i32.const 1073741808
   i32.gt_u
   if
-   local.get $0
-   call $~lib/rt/pure/__release
    i32.const 32
    i32.const 80
    i32.const 49
@@ -37519,8 +37515,6 @@
   i32.and
   i32.or
   if
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1741
@@ -37540,8 +37534,6 @@
     i32.const 0
     i32.and
     if
-     local.get $5
-     call $~lib/rt/pure/__release
      i32.const 32
      i32.const 432
      i32.const 1746
@@ -37554,8 +37546,6 @@
     i32.sub
     local.set $6
    else
-    local.get $5
-    call $~lib/rt/pure/__release
     i32.const 32
     i32.const 432
     i32.const 1750
@@ -37574,8 +37564,6 @@
    local.get $7
    i32.gt_s
    if
-    local.get $5
-    call $~lib/rt/pure/__release
     i32.const 32
     i32.const 432
     i32.const 1755
@@ -37746,8 +37734,6 @@
   i32.and
   i32.or
   if
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1741
@@ -37767,8 +37753,6 @@
     i32.const 0
     i32.and
     if
-     local.get $5
-     call $~lib/rt/pure/__release
      i32.const 32
      i32.const 432
      i32.const 1746
@@ -37781,8 +37765,6 @@
     i32.sub
     local.set $6
    else
-    local.get $5
-    call $~lib/rt/pure/__release
     i32.const 32
     i32.const 432
     i32.const 1750
@@ -37801,8 +37783,6 @@
    local.get $7
    i32.gt_s
    if
-    local.get $5
-    call $~lib/rt/pure/__release
     i32.const 32
     i32.const 432
     i32.const 1755
@@ -38122,8 +38102,6 @@
   i32.and
   i32.or
   if
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1741
@@ -38143,8 +38121,6 @@
     i32.const 0
     i32.and
     if
-     local.get $5
-     call $~lib/rt/pure/__release
      i32.const 32
      i32.const 432
      i32.const 1746
@@ -38157,8 +38133,6 @@
     i32.sub
     local.set $6
    else
-    local.get $5
-    call $~lib/rt/pure/__release
     i32.const 32
     i32.const 432
     i32.const 1750
@@ -38177,8 +38151,6 @@
    local.get $7
    i32.gt_s
    if
-    local.get $5
-    call $~lib/rt/pure/__release
     i32.const 32
     i32.const 432
     i32.const 1755
@@ -38384,8 +38356,6 @@
   i32.and
   i32.or
   if
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1741
@@ -38405,8 +38375,6 @@
     i32.const 1
     i32.and
     if
-     local.get $5
-     call $~lib/rt/pure/__release
      i32.const 32
      i32.const 432
      i32.const 1746
@@ -38419,8 +38387,6 @@
     i32.sub
     local.set $6
    else
-    local.get $5
-    call $~lib/rt/pure/__release
     i32.const 32
     i32.const 432
     i32.const 1750
@@ -38439,8 +38405,6 @@
    local.get $7
    i32.gt_s
    if
-    local.get $5
-    call $~lib/rt/pure/__release
     i32.const 32
     i32.const 432
     i32.const 1755
@@ -38650,8 +38614,6 @@
   i32.and
   i32.or
   if
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1741
@@ -38671,8 +38633,6 @@
     i32.const 1
     i32.and
     if
-     local.get $5
-     call $~lib/rt/pure/__release
      i32.const 32
      i32.const 432
      i32.const 1746
@@ -38685,8 +38645,6 @@
     i32.sub
     local.set $6
    else
-    local.get $5
-    call $~lib/rt/pure/__release
     i32.const 32
     i32.const 432
     i32.const 1750
@@ -38705,8 +38663,6 @@
    local.get $7
    i32.gt_s
    if
-    local.get $5
-    call $~lib/rt/pure/__release
     i32.const 32
     i32.const 432
     i32.const 1755
@@ -38916,8 +38872,6 @@
   i32.and
   i32.or
   if
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1741
@@ -38937,8 +38891,6 @@
     i32.const 3
     i32.and
     if
-     local.get $5
-     call $~lib/rt/pure/__release
      i32.const 32
      i32.const 432
      i32.const 1746
@@ -38951,8 +38903,6 @@
     i32.sub
     local.set $6
    else
-    local.get $5
-    call $~lib/rt/pure/__release
     i32.const 32
     i32.const 432
     i32.const 1750
@@ -38971,8 +38921,6 @@
    local.get $7
    i32.gt_s
    if
-    local.get $5
-    call $~lib/rt/pure/__release
     i32.const 32
     i32.const 432
     i32.const 1755
@@ -39182,8 +39130,6 @@
   i32.and
   i32.or
   if
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1741
@@ -39203,8 +39149,6 @@
     i32.const 3
     i32.and
     if
-     local.get $5
-     call $~lib/rt/pure/__release
      i32.const 32
      i32.const 432
      i32.const 1746
@@ -39217,8 +39161,6 @@
     i32.sub
     local.set $6
    else
-    local.get $5
-    call $~lib/rt/pure/__release
     i32.const 32
     i32.const 432
     i32.const 1750
@@ -39237,8 +39179,6 @@
    local.get $7
    i32.gt_s
    if
-    local.get $5
-    call $~lib/rt/pure/__release
     i32.const 32
     i32.const 432
     i32.const 1755
@@ -39450,8 +39390,6 @@
   i32.and
   i32.or
   if
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1741
@@ -39471,8 +39409,6 @@
     i32.const 7
     i32.and
     if
-     local.get $5
-     call $~lib/rt/pure/__release
      i32.const 32
      i32.const 432
      i32.const 1746
@@ -39485,8 +39421,6 @@
     i32.sub
     local.set $6
    else
-    local.get $5
-    call $~lib/rt/pure/__release
     i32.const 32
     i32.const 432
     i32.const 1750
@@ -39505,8 +39439,6 @@
    local.get $7
    i32.gt_s
    if
-    local.get $5
-    call $~lib/rt/pure/__release
     i32.const 32
     i32.const 432
     i32.const 1755
@@ -39721,8 +39653,6 @@
   i32.and
   i32.or
   if
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1741
@@ -39742,8 +39672,6 @@
     i32.const 7
     i32.and
     if
-     local.get $5
-     call $~lib/rt/pure/__release
      i32.const 32
      i32.const 432
      i32.const 1746
@@ -39756,8 +39684,6 @@
     i32.sub
     local.set $6
    else
-    local.get $5
-    call $~lib/rt/pure/__release
     i32.const 32
     i32.const 432
     i32.const 1750
@@ -39776,8 +39702,6 @@
    local.get $7
    i32.gt_s
    if
-    local.get $5
-    call $~lib/rt/pure/__release
     i32.const 32
     i32.const 432
     i32.const 1755
@@ -39994,8 +39918,6 @@
   i32.and
   i32.or
   if
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1741
@@ -40015,8 +39937,6 @@
     i32.const 3
     i32.and
     if
-     local.get $5
-     call $~lib/rt/pure/__release
      i32.const 32
      i32.const 432
      i32.const 1746
@@ -40029,8 +39949,6 @@
     i32.sub
     local.set $6
    else
-    local.get $5
-    call $~lib/rt/pure/__release
     i32.const 32
     i32.const 432
     i32.const 1750
@@ -40049,8 +39967,6 @@
    local.get $7
    i32.gt_s
    if
-    local.get $5
-    call $~lib/rt/pure/__release
     i32.const 32
     i32.const 432
     i32.const 1755
@@ -40269,8 +40185,6 @@
   i32.and
   i32.or
   if
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1741
@@ -40290,8 +40204,6 @@
     i32.const 7
     i32.and
     if
-     local.get $5
-     call $~lib/rt/pure/__release
      i32.const 32
      i32.const 432
      i32.const 1746
@@ -40304,8 +40216,6 @@
     i32.sub
     local.set $6
    else
-    local.get $5
-    call $~lib/rt/pure/__release
     i32.const 32
     i32.const 432
     i32.const 1750
@@ -40324,8 +40234,6 @@
    local.get $7
    i32.gt_s
    if
-    local.get $5
-    call $~lib/rt/pure/__release
     i32.const 32
     i32.const 432
     i32.const 1755
@@ -40543,10 +40451,6 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1774
@@ -40562,10 +40466,6 @@
   call $~lib/typedarray/Int8Array#get:length
   i32.gt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1775
@@ -40782,10 +40682,6 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1774
@@ -40801,10 +40697,6 @@
   call $~lib/typedarray/Int8Array#get:length
   i32.gt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1775
@@ -40930,10 +40822,6 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1774
@@ -40949,10 +40837,6 @@
   call $~lib/typedarray/Int8Array#get:length
   i32.gt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1775
@@ -41079,10 +40963,6 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1774
@@ -41098,10 +40978,6 @@
   call $~lib/typedarray/Int8Array#get:length
   i32.gt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1775
@@ -41222,10 +41098,6 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1774
@@ -41241,10 +41113,6 @@
   call $~lib/typedarray/Int8Array#get:length
   i32.gt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1775
@@ -41318,10 +41186,6 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1774
@@ -41337,10 +41201,6 @@
   call $~lib/typedarray/Int8Array#get:length
   i32.gt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1775
@@ -41457,10 +41317,6 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1774
@@ -41476,10 +41332,6 @@
   call $~lib/typedarray/Int8Array#get:length
   i32.gt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1775
@@ -41720,10 +41572,6 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1774
@@ -41739,10 +41587,6 @@
   call $~lib/typedarray/Uint8Array#get:length
   i32.gt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1775
@@ -41968,10 +41812,6 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1774
@@ -41987,10 +41827,6 @@
   call $~lib/typedarray/Uint8Array#get:length
   i32.gt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1775
@@ -42116,10 +41952,6 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1774
@@ -42135,10 +41967,6 @@
   call $~lib/typedarray/Uint8Array#get:length
   i32.gt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1775
@@ -42261,10 +42089,6 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1774
@@ -42280,10 +42104,6 @@
   call $~lib/typedarray/Uint8Array#get:length
   i32.gt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1775
@@ -42404,10 +42224,6 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1774
@@ -42423,10 +42239,6 @@
   call $~lib/typedarray/Uint8Array#get:length
   i32.gt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1775
@@ -42500,10 +42312,6 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1774
@@ -42519,10 +42327,6 @@
   call $~lib/typedarray/Uint8Array#get:length
   i32.gt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1775
@@ -42639,10 +42443,6 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1774
@@ -42658,10 +42458,6 @@
   call $~lib/typedarray/Uint8Array#get:length
   i32.gt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1775
@@ -42903,10 +42699,6 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1774
@@ -42922,10 +42714,6 @@
   call $~lib/typedarray/Uint8ClampedArray#get:length
   i32.gt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1775
@@ -43145,10 +42933,6 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1774
@@ -43164,10 +42948,6 @@
   call $~lib/typedarray/Uint8ClampedArray#get:length
   i32.gt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1775
@@ -43292,10 +43072,6 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1774
@@ -43311,10 +43087,6 @@
   call $~lib/typedarray/Uint8ClampedArray#get:length
   i32.gt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1775
@@ -43448,10 +43220,6 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1774
@@ -43467,10 +43235,6 @@
   call $~lib/typedarray/Uint8ClampedArray#get:length
   i32.gt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1775
@@ -43589,10 +43353,6 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1774
@@ -43608,10 +43368,6 @@
   call $~lib/typedarray/Uint8ClampedArray#get:length
   i32.gt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1775
@@ -43686,10 +43442,6 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1774
@@ -43705,10 +43457,6 @@
   call $~lib/typedarray/Uint8ClampedArray#get:length
   i32.gt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1775
@@ -43838,10 +43586,6 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1774
@@ -43857,10 +43601,6 @@
   call $~lib/typedarray/Uint8ClampedArray#get:length
   i32.gt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1775
@@ -44156,10 +43896,6 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1774
@@ -44175,10 +43911,6 @@
   call $~lib/typedarray/Int16Array#get:length
   i32.gt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1775
@@ -44406,10 +44138,6 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1774
@@ -44425,10 +44153,6 @@
   call $~lib/typedarray/Int16Array#get:length
   i32.gt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1775
@@ -44554,10 +44278,6 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1774
@@ -44573,10 +44293,6 @@
   call $~lib/typedarray/Int16Array#get:length
   i32.gt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1775
@@ -44699,10 +44415,6 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1774
@@ -44718,10 +44430,6 @@
   call $~lib/typedarray/Int16Array#get:length
   i32.gt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1775
@@ -44847,10 +44555,6 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1774
@@ -44866,10 +44570,6 @@
   call $~lib/typedarray/Int16Array#get:length
   i32.gt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1775
@@ -44986,10 +44686,6 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1774
@@ -45005,10 +44701,6 @@
   call $~lib/typedarray/Int16Array#get:length
   i32.gt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1775
@@ -45082,10 +44774,6 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1774
@@ -45101,10 +44789,6 @@
   call $~lib/typedarray/Int16Array#get:length
   i32.gt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1775
@@ -45393,10 +45077,6 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1774
@@ -45412,10 +45092,6 @@
   call $~lib/typedarray/Uint16Array#get:length
   i32.gt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1775
@@ -45643,10 +45319,6 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1774
@@ -45662,10 +45334,6 @@
   call $~lib/typedarray/Uint16Array#get:length
   i32.gt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1775
@@ -45791,10 +45459,6 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1774
@@ -45810,10 +45474,6 @@
   call $~lib/typedarray/Uint16Array#get:length
   i32.gt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1775
@@ -45936,10 +45596,6 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1774
@@ -45955,10 +45611,6 @@
   call $~lib/typedarray/Uint16Array#get:length
   i32.gt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1775
@@ -46084,10 +45736,6 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1774
@@ -46103,10 +45751,6 @@
   call $~lib/typedarray/Uint16Array#get:length
   i32.gt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1775
@@ -46223,10 +45867,6 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1774
@@ -46242,10 +45882,6 @@
   call $~lib/typedarray/Uint16Array#get:length
   i32.gt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1775
@@ -46319,10 +45955,6 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1774
@@ -46338,10 +45970,6 @@
   call $~lib/typedarray/Uint16Array#get:length
   i32.gt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1775
@@ -46625,10 +46253,6 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1774
@@ -46644,10 +46268,6 @@
   call $~lib/typedarray/Int32Array#get:length
   i32.gt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1775
@@ -46814,10 +46434,6 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1774
@@ -46833,10 +46449,6 @@
   call $~lib/typedarray/Int32Array#get:length
   i32.gt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1775
@@ -46962,10 +46574,6 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1774
@@ -46981,10 +46589,6 @@
   call $~lib/typedarray/Int32Array#get:length
   i32.gt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1775
@@ -47107,10 +46711,6 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1774
@@ -47126,10 +46726,6 @@
   call $~lib/typedarray/Int32Array#get:length
   i32.gt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1775
@@ -47255,10 +46851,6 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1774
@@ -47274,10 +46866,6 @@
   call $~lib/typedarray/Int32Array#get:length
   i32.gt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1775
@@ -47399,10 +46987,6 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1774
@@ -47418,10 +47002,6 @@
   call $~lib/typedarray/Int32Array#get:length
   i32.gt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1775
@@ -47543,10 +47123,6 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1774
@@ -47562,10 +47138,6 @@
   call $~lib/typedarray/Int32Array#get:length
   i32.gt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1775
@@ -47849,10 +47421,6 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1774
@@ -47868,10 +47436,6 @@
   call $~lib/typedarray/Uint32Array#get:length
   i32.gt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1775
@@ -48051,10 +47615,6 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1774
@@ -48070,10 +47630,6 @@
   call $~lib/typedarray/Uint32Array#get:length
   i32.gt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1775
@@ -48199,10 +47755,6 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1774
@@ -48218,10 +47770,6 @@
   call $~lib/typedarray/Uint32Array#get:length
   i32.gt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1775
@@ -48344,10 +47892,6 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1774
@@ -48363,10 +47907,6 @@
   call $~lib/typedarray/Uint32Array#get:length
   i32.gt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1775
@@ -48492,10 +48032,6 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1774
@@ -48511,10 +48047,6 @@
   call $~lib/typedarray/Uint32Array#get:length
   i32.gt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1775
@@ -48636,10 +48168,6 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1774
@@ -48655,10 +48183,6 @@
   call $~lib/typedarray/Uint32Array#get:length
   i32.gt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1775
@@ -48780,10 +48304,6 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1774
@@ -48799,10 +48319,6 @@
   call $~lib/typedarray/Uint32Array#get:length
   i32.gt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1775
@@ -49091,10 +48607,6 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1774
@@ -49110,10 +48622,6 @@
   call $~lib/typedarray/Int64Array#get:length
   i32.gt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1775
@@ -49341,10 +48849,6 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1774
@@ -49360,10 +48864,6 @@
   call $~lib/typedarray/Int64Array#get:length
   i32.gt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1775
@@ -49484,10 +48984,6 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1774
@@ -49503,10 +48999,6 @@
   call $~lib/typedarray/Int64Array#get:length
   i32.gt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1775
@@ -49581,10 +49073,6 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1774
@@ -49600,10 +49088,6 @@
   call $~lib/typedarray/Int64Array#get:length
   i32.gt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1775
@@ -49729,10 +49213,6 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1774
@@ -49748,10 +49228,6 @@
   call $~lib/typedarray/Int64Array#get:length
   i32.gt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1775
@@ -49873,10 +49349,6 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1774
@@ -49892,10 +49364,6 @@
   call $~lib/typedarray/Int64Array#get:length
   i32.gt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1775
@@ -50017,10 +49485,6 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1774
@@ -50036,10 +49500,6 @@
   call $~lib/typedarray/Int64Array#get:length
   i32.gt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1775
@@ -50328,10 +49788,6 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1774
@@ -50347,10 +49803,6 @@
   call $~lib/typedarray/Uint64Array#get:length
   i32.gt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1775
@@ -50578,10 +50030,6 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1774
@@ -50597,10 +50045,6 @@
   call $~lib/typedarray/Uint64Array#get:length
   i32.gt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1775
@@ -50721,10 +50165,6 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1774
@@ -50740,10 +50180,6 @@
   call $~lib/typedarray/Uint64Array#get:length
   i32.gt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1775
@@ -50818,10 +50254,6 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1774
@@ -50837,10 +50269,6 @@
   call $~lib/typedarray/Uint64Array#get:length
   i32.gt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1775
@@ -50966,10 +50394,6 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1774
@@ -50985,10 +50409,6 @@
   call $~lib/typedarray/Uint64Array#get:length
   i32.gt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1775
@@ -51110,10 +50530,6 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1774
@@ -51129,10 +50545,6 @@
   call $~lib/typedarray/Uint64Array#get:length
   i32.gt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1775
@@ -51254,10 +50666,6 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1774
@@ -51273,10 +50681,6 @@
   call $~lib/typedarray/Uint64Array#get:length
   i32.gt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1775
@@ -51565,10 +50969,6 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1774
@@ -51584,10 +50984,6 @@
   call $~lib/typedarray/Float32Array#get:length
   i32.gt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1775
@@ -51806,10 +51202,6 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1774
@@ -51825,10 +51217,6 @@
   call $~lib/typedarray/Float32Array#get:length
   i32.gt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1775
@@ -51902,10 +51290,6 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1774
@@ -51921,10 +51305,6 @@
   call $~lib/typedarray/Float32Array#get:length
   i32.gt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1775
@@ -52047,10 +51427,6 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1774
@@ -52066,10 +51442,6 @@
   call $~lib/typedarray/Float32Array#get:length
   i32.gt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1775
@@ -52192,10 +51564,6 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1774
@@ -52211,10 +51579,6 @@
   call $~lib/typedarray/Float32Array#get:length
   i32.gt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1775
@@ -52337,10 +51701,6 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1774
@@ -52356,10 +51716,6 @@
   call $~lib/typedarray/Float32Array#get:length
   i32.gt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1775
@@ -52634,10 +51990,6 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1774
@@ -52653,10 +52005,6 @@
   call $~lib/typedarray/Float64Array#get:length
   i32.gt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1775
@@ -52878,10 +52226,6 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1774
@@ -52897,10 +52241,6 @@
   call $~lib/typedarray/Float64Array#get:length
   i32.gt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1775
@@ -53023,10 +52363,6 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1774
@@ -53042,10 +52378,6 @@
   call $~lib/typedarray/Float64Array#get:length
   i32.gt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1775
@@ -53168,10 +52500,6 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1774
@@ -53187,10 +52515,6 @@
   call $~lib/typedarray/Float64Array#get:length
   i32.gt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1775
@@ -53313,10 +52637,6 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1774
@@ -53332,10 +52652,6 @@
   call $~lib/typedarray/Float64Array#get:length
   i32.gt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1775
@@ -53458,10 +52774,6 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1774
@@ -53477,10 +52789,6 @@
   call $~lib/typedarray/Float64Array#get:length
   i32.gt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1775
@@ -53756,10 +53064,6 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1774
@@ -53775,10 +53079,6 @@
   call $~lib/typedarray/Uint8ClampedArray#get:length
   i32.gt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1775
@@ -53903,10 +53203,6 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1774
@@ -53922,10 +53218,6 @@
   call $~lib/typedarray/Uint8ClampedArray#get:length
   i32.gt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1775
@@ -54057,10 +53349,6 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1774
@@ -54076,10 +53364,6 @@
   call $~lib/typedarray/Uint8ClampedArray#get:length
   i32.gt_s
   if
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    i32.const 368
    i32.const 432
    i32.const 1775

--- a/tests/compiler/throw.json
+++ b/tests/compiler/throw.json
@@ -1,0 +1,6 @@
+{
+  "asc_flags": [
+    "--runtime half",
+    "--use ASC_RTRACE=1"
+  ]
+}

--- a/tests/compiler/throw.optimized.wat
+++ b/tests/compiler/throw.optimized.wat
@@ -1,0 +1,53 @@
+(module
+ (type $none_=>_none (func))
+ (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
+ (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
+ (memory $0 1)
+ (data (i32.const 1024) "\06\00\00\00\01\00\00\00\01\00\00\00\06\00\00\001\002\003")
+ (data (i32.const 1056) "\06\00\00\00\01\00\00\00\01\00\00\00\06\00\00\002\003\004")
+ (data (i32.const 1088) "\12\00\00\00\01\00\00\00\01\00\00\00\12\00\00\00d\00o\00T\00h\00r\00o\00w\00I\00f")
+ (data (i32.const 1136) "\10\00\00\00\01\00\00\00\01\00\00\00\10\00\00\00t\00h\00r\00o\00w\00.\00t\00s")
+ (data (i32.const 1168) "\06\00\00\00\01\00\00\00\01\00\00\00\06\00\00\003\004\005")
+ (data (i32.const 1200) "\1a\00\00\00\01\00\00\00\01\00\00\00\1a\00\00\00d\00o\00T\00h\00r\00o\00w\00I\00f\00L\00o\00o\00p")
+ (data (i32.const 1248) "\06\00\00\00\01\00\00\00\01\00\00\00\06\00\00\004\005\006")
+ (data (i32.const 1280) "\06\00\00\00\01\00\00\00\01\00\00\00\06\00\00\005\006\007")
+ (data (i32.const 1312) "\0e\00\00\00\01\00\00\00\01\00\00\00\0e\00\00\00d\00o\00T\00h\00r\00o\00w")
+ (data (i32.const 1344) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00p\00u\00r\00e\00.\00t\00s")
+ (data (i32.const 1392) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s")
+ (export "memory" (memory $0))
+ (export "doThrow" (func $throw/doThrow))
+ (start $~start)
+ (func $throw/doThrow
+  i32.const 1328
+  i32.const 1152
+  i32.const 3
+  i32.const 3
+  call $~lib/builtins/abort
+  unreachable
+ )
+ (func $~start
+  (local $0 i32)
+  loop $while-continue|0
+   local.get $0
+   i32.const 1
+   i32.add
+   local.tee $0
+   i32.const 10
+   i32.lt_s
+   if
+    local.get $0
+    i32.const 10
+    i32.gt_s
+    if
+     i32.const 1216
+     i32.const 1152
+     i32.const 26
+     i32.const 7
+     call $~lib/builtins/abort
+     unreachable
+    end
+    br $while-continue|0
+   end
+  end
+ )
+)

--- a/tests/compiler/throw.ts
+++ b/tests/compiler/throw.ts
@@ -1,0 +1,35 @@
+export function doThrow(): void {
+  var a = "123";
+  throw new Error("doThrow");
+  // __release(a) - DCE'd
+}
+
+function doThrowIf(cond: bool): void {
+  var a = "123";
+  if (cond) {
+    let b = "234";
+    throw new Error("doThrowIf");
+    // __release(a+b) - DCE'd
+  }
+  var c = "345";
+  // __release(a+c)
+}
+doThrowIf(false);
+
+function doThrowIfLoop(max: i32): void {
+  var a = "123";
+  var i = 0;
+  while (++i < max) {
+    let b = "234";
+    if (i > max) { // never
+      let c = "345";
+      throw new Error("doThrowIfLoop");
+      // __release(a+b+c) - DCE'd
+    }
+    let d = "456";
+    // __release(b+d)
+  }
+  var e = "567";
+  // __release(a+e)
+}
+doThrowIfLoop(10);

--- a/tests/compiler/throw.untouched.wat
+++ b/tests/compiler/throw.untouched.wat
@@ -1,0 +1,872 @@
+(module
+ (type $i32_=>_none (func (param i32)))
+ (type $i32_i32_=>_none (func (param i32 i32)))
+ (type $none_=>_none (func))
+ (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
+ (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
+ (import "rtrace" "ondecrement" (func $~lib/rt/rtrace/ondecrement (param i32)))
+ (import "rtrace" "onfree" (func $~lib/rt/rtrace/onfree (param i32)))
+ (memory $0 1)
+ (data (i32.const 16) "\06\00\00\00\01\00\00\00\01\00\00\00\06\00\00\001\002\003\00")
+ (data (i32.const 48) "\06\00\00\00\01\00\00\00\01\00\00\00\06\00\00\002\003\004\00")
+ (data (i32.const 80) "\12\00\00\00\01\00\00\00\01\00\00\00\12\00\00\00d\00o\00T\00h\00r\00o\00w\00I\00f\00")
+ (data (i32.const 128) "\10\00\00\00\01\00\00\00\01\00\00\00\10\00\00\00t\00h\00r\00o\00w\00.\00t\00s\00")
+ (data (i32.const 160) "\06\00\00\00\01\00\00\00\01\00\00\00\06\00\00\003\004\005\00")
+ (data (i32.const 192) "\1a\00\00\00\01\00\00\00\01\00\00\00\1a\00\00\00d\00o\00T\00h\00r\00o\00w\00I\00f\00L\00o\00o\00p\00")
+ (data (i32.const 240) "\06\00\00\00\01\00\00\00\01\00\00\00\06\00\00\004\005\006\00")
+ (data (i32.const 272) "\06\00\00\00\01\00\00\00\01\00\00\00\06\00\00\005\006\007\00")
+ (data (i32.const 304) "\0e\00\00\00\01\00\00\00\01\00\00\00\0e\00\00\00d\00o\00T\00h\00r\00o\00w\00")
+ (data (i32.const 336) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00p\00u\00r\00e\00.\00t\00s\00")
+ (data (i32.const 384) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s\00")
+ (table $0 1 funcref)
+ (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
+ (global $~lib/heap/__heap_base i32 (i32.const 432))
+ (export "memory" (memory $0))
+ (export "doThrow" (func $throw/doThrow))
+ (start $~start)
+ (func $~lib/rt/pure/__release (param $0 i32)
+  local.get $0
+  global.get $~lib/heap/__heap_base
+  i32.gt_u
+  if
+   local.get $0
+   i32.const 16
+   i32.sub
+   call $~lib/rt/pure/decrement
+  end
+ )
+ (func $throw/doThrowIf (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  i32.const 32
+  local.set $1
+  local.get $0
+  if
+   i32.const 64
+   local.set $2
+   i32.const 96
+   i32.const 144
+   i32.const 11
+   i32.const 5
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 176
+  local.set $3
+  local.get $1
+  call $~lib/rt/pure/__release
+  local.get $3
+  call $~lib/rt/pure/__release
+ )
+ (func $throw/doThrowIfLoop (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  i32.const 32
+  local.set $1
+  i32.const 0
+  local.set $2
+  loop $while-continue|0
+   local.get $2
+   i32.const 1
+   i32.add
+   local.tee $2
+   local.get $0
+   i32.lt_s
+   local.set $3
+   local.get $3
+   if
+    i32.const 64
+    local.set $4
+    local.get $2
+    local.get $0
+    i32.gt_s
+    if
+     i32.const 176
+     local.set $5
+     i32.const 208
+     i32.const 144
+     i32.const 26
+     i32.const 7
+     call $~lib/builtins/abort
+     unreachable
+    end
+    i32.const 256
+    local.set $5
+    local.get $4
+    call $~lib/rt/pure/__release
+    local.get $5
+    call $~lib/rt/pure/__release
+    br $while-continue|0
+   end
+  end
+  i32.const 288
+  local.set $6
+  local.get $1
+  call $~lib/rt/pure/__release
+  local.get $6
+  call $~lib/rt/pure/__release
+ )
+ (func $start:throw
+  i32.const 0
+  call $throw/doThrowIf
+  i32.const 10
+  call $throw/doThrowIfLoop
+ )
+ (func $throw/doThrow
+  (local $0 i32)
+  i32.const 32
+  local.set $0
+  i32.const 320
+  i32.const 144
+  i32.const 3
+  i32.const 3
+  call $~lib/builtins/abort
+  unreachable
+ )
+ (func $~start
+  call $start:throw
+ )
+ (func $~lib/rt/tlsf/removeBlock (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  local.get $1
+  i32.load
+  local.set $2
+  i32.const 1
+  drop
+  local.get $2
+  i32.const 1
+  i32.and
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 400
+   i32.const 277
+   i32.const 14
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $2
+  i32.const 3
+  i32.const -1
+  i32.xor
+  i32.and
+  local.set $3
+  i32.const 1
+  drop
+  local.get $3
+  i32.const 16
+  i32.ge_u
+  if (result i32)
+   local.get $3
+   i32.const 1073741808
+   i32.lt_u
+  else
+   i32.const 0
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 400
+   i32.const 279
+   i32.const 14
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $3
+  i32.const 256
+  i32.lt_u
+  if
+   i32.const 0
+   local.set $4
+   local.get $3
+   i32.const 4
+   i32.shr_u
+   local.set $5
+  else
+   i32.const 31
+   local.get $3
+   i32.clz
+   i32.sub
+   local.set $4
+   local.get $3
+   local.get $4
+   i32.const 4
+   i32.sub
+   i32.shr_u
+   i32.const 1
+   i32.const 4
+   i32.shl
+   i32.xor
+   local.set $5
+   local.get $4
+   i32.const 8
+   i32.const 1
+   i32.sub
+   i32.sub
+   local.set $4
+  end
+  i32.const 1
+  drop
+  local.get $4
+  i32.const 23
+  i32.lt_u
+  if (result i32)
+   local.get $5
+   i32.const 16
+   i32.lt_u
+  else
+   i32.const 0
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 400
+   i32.const 292
+   i32.const 14
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $1
+  i32.load offset=16
+  local.set $6
+  local.get $1
+  i32.load offset=20
+  local.set $7
+  local.get $6
+  if
+   local.get $6
+   local.get $7
+   i32.store offset=20
+  end
+  local.get $7
+  if
+   local.get $7
+   local.get $6
+   i32.store offset=16
+  end
+  local.get $1
+  local.get $0
+  local.set $10
+  local.get $4
+  local.set $9
+  local.get $5
+  local.set $8
+  local.get $10
+  local.get $9
+  i32.const 4
+  i32.shl
+  local.get $8
+  i32.add
+  i32.const 2
+  i32.shl
+  i32.add
+  i32.load offset=96
+  i32.eq
+  if
+   local.get $0
+   local.set $11
+   local.get $4
+   local.set $10
+   local.get $5
+   local.set $9
+   local.get $7
+   local.set $8
+   local.get $11
+   local.get $10
+   i32.const 4
+   i32.shl
+   local.get $9
+   i32.add
+   i32.const 2
+   i32.shl
+   i32.add
+   local.get $8
+   i32.store offset=96
+   local.get $7
+   i32.eqz
+   if
+    local.get $0
+    local.set $9
+    local.get $4
+    local.set $8
+    local.get $9
+    local.get $8
+    i32.const 2
+    i32.shl
+    i32.add
+    i32.load offset=4
+    local.set $9
+    local.get $0
+    local.set $8
+    local.get $4
+    local.set $11
+    local.get $9
+    i32.const 1
+    local.get $5
+    i32.shl
+    i32.const -1
+    i32.xor
+    i32.and
+    local.tee $9
+    local.set $10
+    local.get $8
+    local.get $11
+    i32.const 2
+    i32.shl
+    i32.add
+    local.get $10
+    i32.store offset=4
+    local.get $9
+    i32.eqz
+    if
+     local.get $0
+     local.get $0
+     i32.load
+     i32.const 1
+     local.get $4
+     i32.shl
+     i32.const -1
+     i32.xor
+     i32.and
+     i32.store
+    end
+   end
+  end
+ )
+ (func $~lib/rt/tlsf/insertBlock (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  i32.const 1
+  drop
+  local.get $1
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 400
+   i32.const 205
+   i32.const 14
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $1
+  i32.load
+  local.set $2
+  i32.const 1
+  drop
+  local.get $2
+  i32.const 1
+  i32.and
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 400
+   i32.const 207
+   i32.const 14
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $1
+  local.set $3
+  local.get $3
+  i32.const 16
+  i32.add
+  local.get $3
+  i32.load
+  i32.const 3
+  i32.const -1
+  i32.xor
+  i32.and
+  i32.add
+  local.set $4
+  local.get $4
+  i32.load
+  local.set $5
+  local.get $5
+  i32.const 1
+  i32.and
+  if
+   local.get $2
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.const 16
+   i32.add
+   local.get $5
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.add
+   local.set $3
+   local.get $3
+   i32.const 1073741808
+   i32.lt_u
+   if
+    local.get $0
+    local.get $4
+    call $~lib/rt/tlsf/removeBlock
+    local.get $1
+    local.get $2
+    i32.const 3
+    i32.and
+    local.get $3
+    i32.or
+    local.tee $2
+    i32.store
+    local.get $1
+    local.set $6
+    local.get $6
+    i32.const 16
+    i32.add
+    local.get $6
+    i32.load
+    i32.const 3
+    i32.const -1
+    i32.xor
+    i32.and
+    i32.add
+    local.set $4
+    local.get $4
+    i32.load
+    local.set $5
+   end
+  end
+  local.get $2
+  i32.const 2
+  i32.and
+  if
+   local.get $1
+   local.set $6
+   local.get $6
+   i32.const 4
+   i32.sub
+   i32.load
+   local.set $6
+   local.get $6
+   i32.load
+   local.set $3
+   i32.const 1
+   drop
+   local.get $3
+   i32.const 1
+   i32.and
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 400
+    i32.const 228
+    i32.const 16
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $3
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.const 16
+   i32.add
+   local.get $2
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.add
+   local.set $7
+   local.get $7
+   i32.const 1073741808
+   i32.lt_u
+   if
+    local.get $0
+    local.get $6
+    call $~lib/rt/tlsf/removeBlock
+    local.get $6
+    local.get $3
+    i32.const 3
+    i32.and
+    local.get $7
+    i32.or
+    local.tee $2
+    i32.store
+    local.get $6
+    local.set $1
+   end
+  end
+  local.get $4
+  local.get $5
+  i32.const 2
+  i32.or
+  i32.store
+  local.get $2
+  i32.const 3
+  i32.const -1
+  i32.xor
+  i32.and
+  local.set $8
+  i32.const 1
+  drop
+  local.get $8
+  i32.const 16
+  i32.ge_u
+  if (result i32)
+   local.get $8
+   i32.const 1073741808
+   i32.lt_u
+  else
+   i32.const 0
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 400
+   i32.const 243
+   i32.const 14
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 1
+  drop
+  local.get $1
+  i32.const 16
+  i32.add
+  local.get $8
+  i32.add
+  local.get $4
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 400
+   i32.const 244
+   i32.const 14
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $4
+  i32.const 4
+  i32.sub
+  local.get $1
+  i32.store
+  local.get $8
+  i32.const 256
+  i32.lt_u
+  if
+   i32.const 0
+   local.set $9
+   local.get $8
+   i32.const 4
+   i32.shr_u
+   local.set $10
+  else
+   i32.const 31
+   local.get $8
+   i32.clz
+   i32.sub
+   local.set $9
+   local.get $8
+   local.get $9
+   i32.const 4
+   i32.sub
+   i32.shr_u
+   i32.const 1
+   i32.const 4
+   i32.shl
+   i32.xor
+   local.set $10
+   local.get $9
+   i32.const 8
+   i32.const 1
+   i32.sub
+   i32.sub
+   local.set $9
+  end
+  i32.const 1
+  drop
+  local.get $9
+  i32.const 23
+  i32.lt_u
+  if (result i32)
+   local.get $10
+   i32.const 16
+   i32.lt_u
+  else
+   i32.const 0
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 400
+   i32.const 260
+   i32.const 14
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  local.set $7
+  local.get $9
+  local.set $3
+  local.get $10
+  local.set $6
+  local.get $7
+  local.get $3
+  i32.const 4
+  i32.shl
+  local.get $6
+  i32.add
+  i32.const 2
+  i32.shl
+  i32.add
+  i32.load offset=96
+  local.set $11
+  local.get $1
+  i32.const 0
+  i32.store offset=16
+  local.get $1
+  local.get $11
+  i32.store offset=20
+  local.get $11
+  if
+   local.get $11
+   local.get $1
+   i32.store offset=16
+  end
+  local.get $0
+  local.set $12
+  local.get $9
+  local.set $7
+  local.get $10
+  local.set $3
+  local.get $1
+  local.set $6
+  local.get $12
+  local.get $7
+  i32.const 4
+  i32.shl
+  local.get $3
+  i32.add
+  i32.const 2
+  i32.shl
+  i32.add
+  local.get $6
+  i32.store offset=96
+  local.get $0
+  local.get $0
+  i32.load
+  i32.const 1
+  local.get $9
+  i32.shl
+  i32.or
+  i32.store
+  local.get $0
+  local.set $13
+  local.get $9
+  local.set $12
+  local.get $0
+  local.set $3
+  local.get $9
+  local.set $6
+  local.get $3
+  local.get $6
+  i32.const 2
+  i32.shl
+  i32.add
+  i32.load offset=4
+  i32.const 1
+  local.get $10
+  i32.shl
+  i32.or
+  local.set $7
+  local.get $13
+  local.get $12
+  i32.const 2
+  i32.shl
+  i32.add
+  local.get $7
+  i32.store offset=4
+ )
+ (func $~lib/rt/tlsf/freeBlock (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  local.get $1
+  i32.load
+  local.set $2
+  local.get $1
+  local.get $2
+  i32.const 1
+  i32.or
+  i32.store
+  local.get $0
+  local.get $1
+  call $~lib/rt/tlsf/insertBlock
+  i32.const 1
+  drop
+  local.get $1
+  call $~lib/rt/rtrace/onfree
+ )
+ (func $~lib/rt/pure/decrement (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  local.get $0
+  i32.load offset=4
+  local.set $1
+  local.get $1
+  i32.const 268435455
+  i32.and
+  local.set $2
+  i32.const 1
+  drop
+  local.get $0
+  call $~lib/rt/rtrace/ondecrement
+  i32.const 1
+  drop
+  local.get $0
+  i32.load
+  i32.const 1
+  i32.and
+  i32.eqz
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 352
+   i32.const 122
+   i32.const 14
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $2
+  i32.const 1
+  i32.eq
+  if
+   local.get $0
+   i32.const 16
+   i32.add
+   i32.const 1
+   call $~lib/rt/__visit_members
+   i32.const 1
+   drop
+   i32.const 1
+   drop
+   local.get $1
+   i32.const -2147483648
+   i32.and
+   i32.eqz
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 352
+    i32.const 126
+    i32.const 18
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/rt/tlsf/ROOT
+   local.get $0
+   call $~lib/rt/tlsf/freeBlock
+  else
+   i32.const 1
+   drop
+   local.get $2
+   i32.const 0
+   i32.gt_u
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 352
+    i32.const 136
+    i32.const 16
+    call $~lib/builtins/abort
+    unreachable
+   end
+   i32.const 1
+   drop
+   local.get $0
+   local.get $1
+   i32.const 268435455
+   i32.const -1
+   i32.xor
+   i32.and
+   local.get $2
+   i32.const 1
+   i32.sub
+   i32.or
+   i32.store offset=4
+  end
+ )
+ (func $~lib/rt/pure/__visit (param $0 i32) (param $1 i32)
+  local.get $0
+  global.get $~lib/heap/__heap_base
+  i32.lt_u
+  if
+   return
+  end
+  i32.const 1
+  drop
+  i32.const 1
+  drop
+  local.get $1
+  i32.const 1
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 352
+   i32.const 69
+   i32.const 16
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.const 16
+  i32.sub
+  call $~lib/rt/pure/decrement
+ )
+ (func $~lib/rt/__visit_members (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  block $switch$1$default
+   block $switch$1$case$4
+    block $switch$1$case$2
+     local.get $0
+     i32.const 8
+     i32.sub
+     i32.load
+     br_table $switch$1$case$2 $switch$1$case$2 $switch$1$case$4 $switch$1$default
+    end
+    return
+   end
+   local.get $0
+   i32.load
+   local.tee $2
+   if
+    local.get $2
+    local.get $1
+    call $~lib/rt/pure/__visit
+   end
+   return
+  end
+  unreachable
+ )
+)


### PR DESCRIPTION
Fixes flows not becoming properly terminated after `throw`ing, leading to invalid `__release`s down the road. Related: https://github.com/AssemblyScript/assemblyscript/issues/1261