### PR TITLE
Update Binaryen and other dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,9 +25,9 @@
       }
     },
     "@types/node": {
-      "version": "13.13.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.2.tgz",
-      "integrity": "sha512-LB2R1Oyhpg8gu4SON/mfforE525+Hi/M1ineICEDftqNVTyFg1aRIeGuTvXAoWHc4nbrFncWtJgMmoyRvuGh7A==",
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.1.tgz",
+      "integrity": "sha512-FAYBGwC+W6F9+huFIDtn43cpy7+SzG+atzRiTfdp3inUKL2hXnd4rG8hylJLIh4+hqrQy1P17kvJByE/z825hA==",
       "dev": true
     },
     "@webassemblyjs/ast": {
@@ -566,9 +566,9 @@
       "dev": true
     },
     "binaryen": {
-      "version": "92.0.0-nightly.20200426",
-      "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-92.0.0-nightly.20200426.tgz",
-      "integrity": "sha512-e9aKrfV8MBFjLBITaY89/ulGhZ0AQ9RDb0B4ZGg7Qe3fM445JNiQh6Dc2k0+wTAU95oUAY0uGnNEIGUtEnirag=="
+      "version": "93.0.0-nightly.20200514",
+      "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-93.0.0-nightly.20200514.tgz",
+      "integrity": "sha512-SRRItmNvhRVfoWWbRloO4i8IqkKH8rZ7/0QWRgLpM3umupK8gBpo9MY7Zp3pDysRSp+rVoqxvM5x4tFyCSa9zw=="
     },
     "bindings": {
       "version": "1.5.0",
@@ -4150,9 +4150,9 @@
       }
     },
     "ts-loader": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-6.2.2.tgz",
-      "integrity": "sha512-HDo5kXZCBml3EUPcc7RlZOV/JGlLHwppTLEHb3SHnr5V7NXD4klMEkrhJe5wgRbaWsSXi+Y1SIBN/K9B6zWGWQ==",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-7.0.4.tgz",
+      "integrity": "sha512-5du6OQHl+4ZjO4crEyoYUyWSrmmo7bAO+inkaILZ68mvahqrfoa4nn0DRmpQ4ruT4l+cuJCgF0xD7SBIyLeeow==",
       "dev": true,
       "requires": {
         "chalk": "^2.3.0",
@@ -4241,9 +4241,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
-      "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.2.tgz",
+      "integrity": "sha512-q2ktq4n/uLuNNShyayit+DTobV2ApPEo/6so68JaD5ojvc/6GClBipedB9zNWYxRSAlZXAe405Rlijzl6qDiSw==",
       "dev": true
     },
     "union-value": {

--- a/package.json
+++ b/package.json
@@ -21,22 +21,22 @@
     "url": "https://github.com/AssemblyScript/assemblyscript/issues"
   },
   "dependencies": {
-    "binaryen": "92.0.0-nightly.20200426",
+    "binaryen": "93.0.0-nightly.20200514",
     "long": "^4.0.0",
     "source-map-support": "^0.5.19",
     "ts-node": "^6.2.0"
   },
   "devDependencies": {
-    "@types/node": "^13.13.2",
+    "@types/node": "^14.0.1",
     "browser-process-hrtime": "^1.0.0",
     "diff": "^4.0.2",
     "glob": "^7.1.6",
     "physical-cpu-count": "^2.0.0",
     "source-map-support": "^0.5.19",
-    "ts-loader": "^6.2.2",
+    "ts-loader": "^7.0.4",
     "ts-node": "^6.2.0",
     "tslint": "^5.20.1",
-    "typescript": "^3.8.3",
+    "typescript": "^3.9.2",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.11"
   },

--- a/src/glue/binaryen.d.ts
+++ b/src/glue/binaryen.d.ts
@@ -532,6 +532,7 @@ export declare function _BinaryenPop(module: BinaryenModuleRef, type: BinaryenTy
 export declare function _BinaryenExpressionGetId(expr: BinaryenExpressionRef): BinaryenExpressionId;
 export declare function _BinaryenExpressionGetType(expr: BinaryenExpressionRef): BinaryenType;
 export declare function _BinaryenExpressionPrint(expr: BinaryenExpressionRef): void;
+export declare function _BinaryenExpressionCopy(expr: BinaryenExpressionRef, module: BinaryenModuleRef): BinaryenExpressionRef;
 
 export declare function _BinaryenBlockGetName(expr: BinaryenExpressionRef): usize;
 export declare function _BinaryenBlockGetNumChildren(expr: BinaryenExpressionRef): BinaryenIndex;
@@ -837,5 +838,3 @@ export declare function _BinaryenGetFlexibleInlineMaxSize(): BinaryenIndex;
 export declare function _BinaryenSetFlexibleInlineMaxSize(size: BinaryenIndex): void;
 export declare function _BinaryenGetOneCallerInlineMaxSize(): BinaryenIndex;
 export declare function _BinaryenSetOneCallerInlineMaxSize(size: BinaryenIndex): void;
-
-export declare function _BinaryenSetAPITracing(on: bool): void;

--- a/src/module.ts
+++ b/src/module.ts
@@ -392,17 +392,21 @@ export enum BinaryOp {
   DivF32x4 = 159 /* _BinaryenDivVecF32x4 */,
   MinF32x4 = 160 /* _BinaryenMinVecF32x4 */,
   MaxF32x4 = 161 /* _BinaryenMaxVecF32x4 */,
-  AddF64x2 = 162 /* _BinaryenAddVecF64x2 */,
-  SubF64x2 = 163 /* _BinaryenSubVecF64x2 */,
-  MulF64x2 = 164 /* _BinaryenMulVecF64x2 */,
-  DivF64x2 = 165 /* _BinaryenDivVecF64x2 */,
-  MinF64x2 = 166 /* _BinaryenMinVecF64x2 */,
-  MaxF64x2 = 167 /* _BinaryenMaxVecF64x2 */,
-  NarrowI16x8ToI8x16 = 168 /* _BinaryenNarrowSVecI16x8ToVecI8x16 */,
-  NarrowU16x8ToU8x16 = 169 /* _BinaryenNarrowUVecI16x8ToVecI8x16 */,
-  NarrowI32x4ToI16x8 = 170 /* _BinaryenNarrowSVecI32x4ToVecI16x8 */,
-  NarrowU32x4ToU16x8 = 171 /* _BinaryenNarrowUVecI32x4ToVecI16x8 */,
-  SwizzleV8x16 = 172 /* _BinaryenSwizzleVec8x16 */
+  PminF32x4 = 162 /* _BinaryenPMinVecF32x4 */,
+  PmaxF32x4 = 163 /* _BinaryenPMaxVecF32x4 */,
+  AddF64x2 = 164 /* _BinaryenAddVecF64x2 */,
+  SubF64x2 = 165 /* _BinaryenSubVecF64x2 */,
+  MulF64x2 = 166 /* _BinaryenMulVecF64x2 */,
+  DivF64x2 = 167 /* _BinaryenDivVecF64x2 */,
+  MinF64x2 = 168 /* _BinaryenMinVecF64x2 */,
+  MaxF64x2 = 169 /* _BinaryenMaxVecF64x2 */,
+  PminF64x2 = 170 /* _BinaryenPMinVecF64x2 */,
+  PmaxF64x2 = 171 /* _BinaryenPMaxVecF64x2 */,
+  NarrowI16x8ToI8x16 = 172 /* _BinaryenNarrowSVecI16x8ToVecI8x16 */,
+  NarrowU16x8ToU8x16 = 173 /* _BinaryenNarrowUVecI16x8ToVecI8x16 */,
+  NarrowI32x4ToI16x8 = 174 /* _BinaryenNarrowSVecI32x4ToVecI16x8 */,
+  NarrowU32x4ToU16x8 = 175 /* _BinaryenNarrowUVecI32x4ToVecI16x8 */,
+  SwizzleV8x16 = 176 /* _BinaryenSwizzleVec8x16 */
 }
 
 export enum HostOp {
@@ -1776,6 +1780,10 @@ export class Module {
       }
     }
     return 0;
+  }
+
+  copyExpression(expr: ExpressionRef): ExpressionRef {
+    return binaryen._BinaryenExpressionCopy(expr, this.ref);
   }
 
   runExpression(expr: ExpressionRef, flags: ExpressionRunnerFlags, maxDepth: i32 = 50, maxLoopIterations: i32 = 1): ExpressionRef {

--- a/std/assembly/builtins.ts
+++ b/std/assembly/builtins.ts
@@ -1095,6 +1095,14 @@ export namespace v128 {
 
   // @ts-ignore: decorator
   @builtin
+  export declare function pmin<T>(a: v128, b: v128): v128;
+
+  // @ts-ignore: decorator
+  @builtin
+  export declare function pmax<T>(a: v128, b: v128): v128;
+
+  // @ts-ignore: decorator
+  @builtin
   export declare function dot<T>(a: v128, b: v128): v128; // i16 only
 
   // @ts-ignore: decorator
@@ -1765,6 +1773,14 @@ export namespace f32x4 {
 
   // @ts-ignore: decorator
   @builtin
+  export declare function pmin(a: v128, b: v128): v128;
+
+  // @ts-ignore: decorator
+  @builtin
+  export declare function pmax(a: v128, b: v128): v128;
+
+  // @ts-ignore: decorator
+  @builtin
   export declare function abs(a: v128): v128;
 
   // @ts-ignore: decorator
@@ -1857,6 +1873,14 @@ export namespace f64x2 {
   // @ts-ignore: decorator
   @builtin
   export declare function max(a: v128, b: v128): v128;
+
+  // @ts-ignore: decorator
+  @builtin
+  export declare function pmin(a: v128, b: v128): v128;
+
+  // @ts-ignore: decorator
+  @builtin
+  export declare function pmax(a: v128, b: v128): v128;
 
   // @ts-ignore: decorator
   @builtin

--- a/std/assembly/index.d.ts
+++ b/std/assembly/index.d.ts
@@ -597,6 +597,10 @@ declare namespace v128 {
   export function min<T>(a: v128, b: v128): v128;
   /** Computes the maximum of each lane. */
   export function max<T>(a: v128, b: v128): v128;
+  /** Computes the pseudo-minimum of each lane. */
+  export function pmin<T>(a: v128, b: v128): v128;
+  /** Computes the pseudo-maximum of each lane. */
+  export function pmax<T>(a: v128, b: v128): v128;
   /** Computes the dot product of two lanes each, yielding lanes one size wider than the input. */
   export function dot<T = i16>(a: v128, b: v128): v128;
   /** Computes the average of each lane. */
@@ -933,6 +937,10 @@ declare namespace f32x4 {
   export function min(a: v128, b: v128): v128;
   /** Computes the maximum of each 32-bit float lane. */
   export function max(a: v128, b: v128): v128;
+  /** Computes the pseudo-minimum of each 32-bit float lane. */
+  export function pmin(a: v128, b: v128): v128;
+  /** Computes the pseudo-maximum of each 32-bit float lane. */
+  export function pmax(a: v128, b: v128): v128;
   /** Computes the absolute value of each 32-bit float lane. */
   export function abs(a: v128): v128;
   /** Computes the square root of each 32-bit float lane. */
@@ -981,6 +989,10 @@ declare namespace f64x2 {
   export function min(a: v128, b: v128): v128;
   /** Computes the maximum of each 64-bit float lane. */
   export function max(a: v128, b: v128): v128;
+  /** Computes the pseudo-minimum of each 64-bit float lane. */
+  export function pmin(a: v128, b: v128): v128;
+  /** Computes the pseudo-maximum of each 64-bit float lane. */
+  export function pmax(a: v128, b: v128): v128;
   /** Computes the absolute value of each 64-bit float lane. */
   export function abs(a: v128): v128;
   /** Computes the square root of each 64-bit float lane. */


### PR DESCRIPTION
Removes API tracing definitions, adds `copyExpression` and `f32x4/f64x2.pmin/pmax`.