### PR TITLE
Remove printrtti and buildrtti

### DIFF
--- a/cli/asc.d.ts
+++ b/cli/asc.d.ts
@@ -133,8 +133,6 @@ interface CompilerOptions {
   listFiles?: boolean;
   /** Prints measuring information on I/O and compile times. */
   measure?: boolean;
-  /** Prints the module's runtime type information to stderr. */
-  printrtti?: boolean;
   /** Disables terminal colors. */
   noColors?: boolean;
   /** Specifies an alternative file extension. */

--- a/cli/asc.js
+++ b/cli/asc.js
@@ -846,9 +846,7 @@ exports.main = function main(argv, options, callback) {
   if (args.measure) {
     printStats(stats, stderr);
   }
-  if (args.printrtti) {
-    printRTTI(program, stderr);
-  }
+
   return callback(null);
 
   function readFileNode(filename, baseDir) {
@@ -1000,15 +998,6 @@ function printStats(stats, output) {
 }
 
 exports.printStats = printStats;
-
-/** Prints runtime type information. */
-function printRTTI(program, output) {
-  if (!output) output = process.stderr;
-  output.write("# Runtime type information (RTTI)\n");
-  output.write(assemblyscript.buildRTTI(program));
-}
-
-exports.printRTTI = printRTTI;
 
 var allocBuffer = typeof global !== "undefined" && global.Buffer
   ? global.Buffer.allocUnsafe || function(len) { return new global.Buffer(len); }

--- a/cli/asc.json
+++ b/cli/asc.json
@@ -303,11 +303,6 @@
     "type": "b",
     "default": false
   },
-  "printrtti": {
-    "description": "Prints the module's runtime type information to stderr.",
-    "type": "b",
-    "default": false
-  },
   " ...": {
     "description": "Specifies node.js options (CLI only). See: node --help"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -242,38 +242,6 @@ export function buildTSD(program: Program): string {
   return TSDBuilder.build(program);
 }
 
-/** Builds a JSON file of a program's runtime type information. */
-export function buildRTTI(program: Program): string {
-  var sb = new Array<string>();
-  sb.push("{\n  \"names\": [\n");
-  // TODO: for (let cls of program.managedClasses.values()) {
-  for (let _values = Map_values(program.managedClasses), i = 0, k = _values.length; i < k; ++i) {
-    let cls = unchecked(_values[i]);
-    sb.push("    \"");
-    sb.push(cls.internalName);
-    sb.push("\",\n");
-  }
-  sb.push("  ],\n  \"base\": [\n");
-  // TODO: for (let cls of program.managedClasses.values()) {
-  for (let _values = Map_values(program.managedClasses), i = 0, k = _values.length; i < k; ++i) {
-    let cls = unchecked(_values[i]);
-    let base = cls.base;
-    sb.push("    ");
-    sb.push(base ? base.id.toString() : "0");
-    sb.push(",\n");
-  }
-  sb.push("  ],\n  \"flags\": [\n");
-  // TODO: for (let cls of program.managedClasses.values()) {
-  for (let _values = Map_values(program.managedClasses), i = 0, k = _values.length; i < k; ++i) {
-    let cls = unchecked(_values[i]);
-    sb.push("    ");
-    sb.push(cls.rttiFlags.toString());
-    sb.push(",\n");
-  }
-  sb.push("  ]\n}\n");
-  return sb.join("");
-}
-
 // Full API
 export * from "./ast";
 export * from "./common";


### PR DESCRIPTION
These functions were helpful for debugging, but it appears that set of problems are stable. From a previous conversation with @dcodeIO, he was thinking about removing these functions, and I figure it would be a good idea to get the ball rolling on this breaking change.

Questions:

1. Is anyone actually using this feature?
2. Am I forgetting something that should also be removed?
3. Should we leave buildrtti in so that downstream developers can still use it anyway?
