### PR TITLE
Rename asmjsFile to jsFile

### DIFF
--- a/cli/asc.d.ts
+++ b/cli/asc.d.ts
@@ -77,8 +77,8 @@ interface CompilerOptions {
   binaryFile?: string;
   /** Specifies the text output file (.wat). */
   textFile?: string;
-  /** Specifies the asm.js output file (.js). */
-  asmjsFile?: string;
+  /** Specifies the JavaScript (via wasm2js) output file (.js). */
+  jsFile?: string;
   /** Specifies the WebIDL output file (.webidl). */
   idlFile?: string;
   /** Specifies the TypeScript definition output file (.d.ts). */

--- a/cli/asc.js
+++ b/cli/asc.js
@@ -714,8 +714,8 @@ exports.main = function main(argv, options, callback) {
     if (args.outFile != null) {
       if (/\.was?t$/.test(args.outFile) && args.textFile == null) {
         args.textFile = args.outFile;
-      } else if (/\.js$/.test(args.outFile) && args.asmjsFile == null) {
-        args.asmjsFile = args.outFile;
+      } else if (/\.js$/.test(args.outFile) && args.jsFile == null) {
+        args.jsFile = args.outFile;
       } else if (args.binaryFile == null) {
         args.binaryFile = args.outFile;
       }
@@ -766,21 +766,21 @@ exports.main = function main(argv, options, callback) {
       }
     }
 
-    // Write asm.js
-    if (args.asmjsFile != null) {
-      let asm;
-      if (args.asmjsFile.length) {
+    // Write JS
+    if (args.jsFile != null) {
+      let js;
+      if (args.jsFile.length) {
         stats.emitCount++;
         stats.emitTime += measure(() => {
-          asm = module.toAsmjs();
+          js = module.toAsmjs();
         });
-        writeFile(args.asmjsFile, asm, baseDir);
+        writeFile(args.jsFile, js, baseDir);
       } else if (!hasStdout) {
         stats.emitCount++;
         stats.emitTime += measure(() => {
-          asm = module.toAsmjs();
+          js = module.toAsmjs();
         });
-        writeStdout(asm);
+        writeStdout(js);
         hasStdout = true;
       }
       hasOutput = true;

--- a/cli/asc.json
+++ b/cli/asc.json
@@ -88,11 +88,11 @@
     "type": "s",
     "alias": "t"
   },
-  "asmjsFile": {
+  "jsFile": {
     "category": "Output",
-    "description": "Specifies the asm.js output file (.js).",
+    "description": "Specifies the JavaScript (via wasm2js) output file (.js).",
     "type": "s",
-    "alias": "a"
+    "alias": "j"
   },
   "idlFile": {
     "category": "Output",


### PR DESCRIPTION
Renames the `--asmjsFile` (alias `-a`) command line option to `--jsFile` (alias `-j`), matching what has been done on the Binaryen side, i.e. the respective tool is now also named `wasm2js` and the generated file isn't actually valid asm.js anymore.