### PR TITLE
Add provided set to cli parser

### DIFF
--- a/cli/util/options.d.ts
+++ b/cli/util/options.d.ts
@@ -31,7 +31,9 @@ interface Result {
   /** Normal arguments. */
   arguments: string[],
   /** Trailing arguments. */
-  trailing: string[]
+  trailing: string[],
+  /** Provided arguments from the cli. */
+  provided: Set<string>
 }
 
 /** Parses the specified command line arguments according to the given configuration. */

--- a/cli/util/options.js
+++ b/cli/util/options.js
@@ -21,6 +21,7 @@ function parse(argv, config) {
   var unknown = [];
   var arguments = [];
   var trailing = [];
+  var provided = new Set();
 
   // make an alias map and initialize defaults
   var aliases = {};
@@ -53,6 +54,7 @@ function parse(argv, config) {
       else { arguments.push(arg); continue; } // argument
     }
     if (option) {
+      provided.add(key);
       if (option.type == null || option.type === "b") options[key] = true; // flag
       else {
         if (i + 1 < argv.length && argv[i + 1].charCodeAt(0) != 45) { // present
@@ -82,7 +84,7 @@ function parse(argv, config) {
   }
   while (i < k) trailing.push(argv[i++]); // trailing
 
-  return { options, unknown, arguments, trailing };
+  return { options, unknown, arguments, trailing, provided };
 }
 
 exports.parse = parse;

--- a/cli/util/options.js
+++ b/cli/util/options.js
@@ -54,10 +54,13 @@ function parse(argv, config) {
       else { arguments.push(arg); continue; } // argument
     }
     if (option) {
-      provided.add(key);
-      if (option.type == null || option.type === "b") options[key] = true; // flag
-      else {
+      if (option.type == null || option.type === "b") {
+        options[key] = true; // flag
+        provided.add(key);
+      } else {
+        // the argument was provided
         if (i + 1 < argv.length && argv[i + 1].charCodeAt(0) != 45) { // present
+          provided.add(key);
           switch (option.type) {
             case "i": options[key] = parseInt(argv[++i], 10); break;
             case "I": options[key] = (options[key] || []).concat(parseInt(argv[++i], 10)); break;


### PR DESCRIPTION
This will be useful in the following ways:

1. Aspect and other projects that bootstrap the compiler can reuse the cli parser and reduce code size
2. We can reuse this for when I get back around to asconfig
3. Maybe other uses

This is a very small change too. Should `provided` be a `Set<string>`, or `string[]`?