### PR TITLE
Slice version 0.10.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "assemblyscript",
-  "version": "0.9.4",
+  "version": "0.10.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "assemblyscript",
     "wasm"
   ],
-  "version": "0.9.4",
+  "version": "0.10.0",
   "author": "Daniel Wirtz <dcode+assemblyscript@dcode.io>",
   "contributors": [],
   "license": "Apache-2.0",


### PR DESCRIPTION
## Breaking changes
* Added a `seed` import (along `abort` and `trace`) for seeding the random number generator
* Arrays no longer inherit from ArrayBufferView, but are now distinct
* The loader API now more closely aligns with the WebAssembly API
* Various compiler API changes (i.e. decoupled the parser from the program)
* Classes initialized from object literals can no longer define a constructor
* Moved examples from the main repo to their [own repo](https://github.com/AssemblyScript/examples)
* Modules now become validated by default (disable with `--noValidate`, `--validate` is gone)
* Reworked memory options (added `--noExportMemory`, `--initialMemory`, `--maximumMemory`, with `--sharedMemory` now being a boolean flag)
* Renamed the `--asmjsFile` command line option to `--jsFile` (alias: `-j`)

## Improvements
* **Simplified WASI integration via `import "wasi"` (implements abort, trace, seed)**
* **Implemented virtual overloading and interfaces (consider this minimal viable)**
* Reworked optimization pass pipeline / more aggressive inlining
* Added support for Binaryen's `lowMemoryUnused` feature
* Added `--lowMemoryLimit` option for embedded scenarios with less than one page of memory
* Added support for `StaticArray` to the loader
* Non-MVP types are now always present to aid conditional compilation (i.e. same source, with and without SIMD)
* Added `Array<T>#flat`
* Updated stdlib to Unicode 13.0.0
* Added a `--yes` option to asinit to accept all prompts
* Added `memory.data` to explicitly create static memory segments
* Expose `setArgumentsLength` (for varargs calls) only when required
* Added `v128.pmin<T>`, `v128.pmax<T>`, `v128.abs<T>`, `v128.bitmask<T>` incl. their respective inline-assembler variants

## Relevant fixes
* Fixed column numbers in diagnostics being off by one
* Made `asc` respect absolute output paths
* Fixed various issues with object literal compilation
* Fixed WASI struct sizes to match the specification
* Fixed default export issues