### PR TITLE
Changed the Array.flat() definition to work with Typescript Compiler

### DIFF
--- a/std/assembly/index.d.ts
+++ b/std/assembly/index.d.ts
@@ -1430,7 +1430,7 @@ declare class Array<T> {
   join(separator?: string): string;
   reverse(): T[];
   /** Flattens an array of arrays. If any null entries exist in the array, they are ignored, unlike JavaScript's version of Array#flat(). */
-  flat(): valueof<T>[];
+  flat(): T[];
   toString(): string;
 }
 

--- a/std/assembly/index.d.ts
+++ b/std/assembly/index.d.ts
@@ -1430,7 +1430,7 @@ declare class Array<T> {
   join(separator?: string): string;
   reverse(): T[];
   /** Flattens an array of arrays. If any null entries exist in the array, they are ignored, unlike JavaScript's version of Array#flat(). */
-  flat(): T[];
+  flat<U>(this: Array<Array<U>>): U[];
   toString(): string;
 }
 

--- a/std/assembly/index.d.ts
+++ b/std/assembly/index.d.ts
@@ -1430,7 +1430,7 @@ declare class Array<T> {
   join(separator?: string): string;
   reverse(): T[];
   /** Flattens an array of arrays. If any null entries exist in the array, they are ignored, unlike JavaScript's version of Array#flat(). */
-  flat<U>(this: Array<Array<U>>): U[];
+  flat(): T extends unknown[] ? T : never;
   toString(): string;
 }
 


### PR DESCRIPTION
Hello!

So when I was [upgrading as-bind](https://github.com/torch2424/as-bind/pull/34), I noticed that AssemblyScript wasn't working with the Typescript compiler, due to a bad definition the Typescript compiler didn't like:

![Screenshot from 2020-05-15 12-26-51](https://user-images.githubusercontent.com/1448289/82091000-7b464c00-96ab-11ea-8556-21c929b083f4.png)

So I went ahead and just modified my `node_modules` directly. I tried the type: `valueof<T extends unknown[]>[]`, but that didn't work. I *think* this new type in this PR correctly represents what we want, and it works (ignore the red test, was just trying to test things really quick):

![Screenshot from 2020-05-15 12-52-11](https://user-images.githubusercontent.com/1448289/82091066-9618c080-96ab-11ea-8d3c-081f7707d15a.png)
![Screenshot from 2020-05-15 12-51-57](https://user-images.githubusercontent.com/1448289/82091075-9a44de00-96ab-11ea-8560-12c65ba1a5b4.png)
![Screenshot from 2020-05-15 12-51-51](https://user-images.githubusercontent.com/1448289/82091083-9d3fce80-96ab-11ea-8467-14dbcbe71202.png)

cc @dcodeIO @MaxGraey 

We may want to push a minor out to npm for this? Since this will require people to modify their node modules for the `tsc` compatibility.