### PR TITLE
modernize loader

### DIFF
--- a/lib/loader/index.js
+++ b/lib/loader/index.js
@@ -72,10 +72,9 @@ function preInstantiate(imports) {
     const memory = extendedExports.memory || env.memory; // prefer exported, otherwise try imported
     throw Error(`abort: ${getString(memory, msg)} at ${getString(memory, file)}:${line}:${colm}`);
   };
-  env.trace = env.trace || function trace(msg, n) {
+  env.trace = env.trace || function trace(msg, n, ...args) {
     const memory = extendedExports.memory || env.memory;
-    const params = Array.prototype.slice.call(arguments, 2, 2 + n);
-    console.log(`trace: ${getString(memory, msg) + (n ? " " : "") + params.join(", ")}`);
+    console.log(`trace: ${getString(memory, msg) + (n ? " " : "") + args.slice(0, n).join(", ")}`);
   };
   env.seed = env.seed || Date.now;
   imports.Math = imports.Math || Math;

--- a/lib/loader/index.js
+++ b/lib/loader/index.js
@@ -101,7 +101,7 @@ function postInstantiate(extendedExports, instance) {
   }
 
   /** Gets and validate runtime type info for the given id for array like objects */
-  function validateArrayInfo(id) {
+  function getArrayInfo(id) {
     const info = getInfo(id);
     if (!(info & (ARRAYBUFFERVIEW | ARRAY | STATICARRAY))) throw Error(`not an array: ${id}, flags=${info}`);
     return info;
@@ -167,7 +167,7 @@ function postInstantiate(extendedExports, instance) {
 
   /** Allocates a new array in the module's memory and returns its retained pointer. */
   function __allocArray(id, values) {
-    const info = validateArrayInfo(id);
+    const info = getArrayInfo(id);
     const align = getValueAlign(info);
     const length = values.length;
     const buf = alloc(length << align, info & STATICARRAY ? id : ARRAYBUFFER_ID);
@@ -198,7 +198,7 @@ function postInstantiate(extendedExports, instance) {
   function __getArrayView(arr) {
     const U32 = new Uint32Array(memory.buffer);
     const id = U32[arr + ID_OFFSET >>> 2];
-    const info = validateArrayInfo(id);
+    const info = getArrayInfo(id);
     const align = getValueAlign(info);
     let buf = info & STATICARRAY
       ? arr

--- a/lib/loader/index.js
+++ b/lib/loader/index.js
@@ -74,11 +74,10 @@ function preInstantiate(imports) {
   };
   env.trace = env.trace || function trace(msg, n) {
     const memory = extendedExports.memory || env.memory;
-    console.log(`trace: ${getString(memory, msg) + (n ? " " : "") + Array.prototype.slice.call(arguments, 2, 2 + n).join(", ")}`);
+    const params = Array.prototype.slice.call(arguments, 2, 2 + n);
+    console.log(`trace: ${getString(memory, msg) + (n ? " " : "") + params.join(", ")}`);
   };
-  env.seed = env.seed || function seed() {
-    return Date.now();
-  };
+  env.seed = env.seed || Date.now;
   imports.Math = imports.Math || Math;
   imports.Date = imports.Date || Date;
 

--- a/lib/loader/index.js
+++ b/lib/loader/index.js
@@ -44,7 +44,7 @@ const CHUNKSIZE = 1024;
 function getStringImpl(buffer, ptr) {
   const U32 = new Uint32Array(buffer);
   const U16 = new Uint16Array(buffer);
-  let length = U32[(ptr + SIZE_OFFSET) >>> 2] >>> 1;
+  let length = U32[ptr + SIZE_OFFSET >>> 2] >>> 1;
   let offset = ptr >>> 1;
   if (length <= CHUNKSIZE) return String.fromCharCode.apply(String, U16.subarray(offset, offset + length));
   let parts = '';
@@ -269,7 +269,7 @@ function postInstantiate(extendedExports, instance) {
   /** Tests whether an object is an instance of the class represented by the specified base id. */
   function __instanceof(ptr, baseId) {
     const U32 = new Uint32Array(memory.buffer);
-    let id = U32[(ptr + ID_OFFSET) >>> 2];
+    let id = U32[ptr + ID_OFFSET >>> 2];
     if (id <= U32[rttiBase >>> 2]) {
       do if (id == baseId) return true;
       while (id = getBase(id));

--- a/lib/loader/index.js
+++ b/lib/loader/index.js
@@ -47,14 +47,14 @@ function getStringImpl(buffer, ptr) {
   let length = U32[(ptr + SIZE_OFFSET) >>> 2] >>> 1;
   let offset = ptr >>> 1;
   if (length <= CHUNKSIZE) return String.fromCharCode.apply(String, U16.subarray(offset, offset + length));
-  const parts = [];
+  let parts = '';
   do {
     const last = U16[offset + CHUNKSIZE - 1];
     const size = last >= 0xD800 && last < 0xDC00 ? CHUNKSIZE - 1 : CHUNKSIZE;
-    parts.push(String.fromCharCode.apply(String, U16.subarray(offset, offset += size)));
+    parts += String.fromCharCode.apply(String, U16.subarray(offset, offset += size));
     length -= size;
   } while (length > CHUNKSIZE);
-  return parts.join("") + String.fromCharCode.apply(String, U16.subarray(offset, offset + length));
+  return parts + String.fromCharCode.apply(String, U16.subarray(offset, offset + length));
 }
 
 /** Prepares the base module prior to instantiation. */
@@ -70,11 +70,11 @@ function preInstantiate(imports) {
   const env = (imports.env = imports.env || {});
   env.abort = env.abort || function abort(msg, file, line, colm) {
     const memory = extendedExports.memory || env.memory; // prefer exported, otherwise try imported
-    throw Error("abort: " + getString(memory, msg) + " at " + getString(memory, file) + ":" + line + ":" + colm);
+    throw Error(`abort: ${getString(memory, msg)} at ${getString(memory, file)}:${line}:${colm}`);
   };
   env.trace = env.trace || function trace(msg, n) {
     const memory = extendedExports.memory || env.memory;
-    console.log("trace: " + getString(memory, msg) + (n ? " " : "") + Array.prototype.slice.call(arguments, 2, 2 + n).join(", "));
+    console.log(`trace: ${getString(memory, msg) + (n ? " " : "") + Array.prototype.slice.call(arguments, 2, 2 + n).join(", ")}`);
   };
   env.seed = env.seed || function seed() {
     return Date.now();
@@ -98,7 +98,7 @@ function postInstantiate(extendedExports, instance) {
   function getInfo(id) {
     const U32 = new Uint32Array(memory.buffer);
     const count = U32[rttiBase >>> 2];
-    if ((id >>>= 0) >= count) throw Error("invalid id: " + id);
+    if ((id >>>= 0) >= count) throw Error(`invalid id: ${id}`);
     return U32[(rttiBase + 4 >>> 2) + id * 2];
   }
 
@@ -106,7 +106,7 @@ function postInstantiate(extendedExports, instance) {
   function getBase(id) {
     const U32 = new Uint32Array(memory.buffer);
     const count = U32[rttiBase >>> 2];
-    if ((id >>>= 0) >= count) throw Error("invalid id: " + id);
+    if ((id >>>= 0) >= count) throw Error(`invalid id: ${id}`);
     return U32[(rttiBase + 4 >>> 2) + id * 2 + 1];
   }
 
@@ -135,7 +135,7 @@ function postInstantiate(extendedExports, instance) {
   function __getString(ptr) {
     const buffer = memory.buffer;
     const id = new Uint32Array(buffer)[ptr + ID_OFFSET >>> 2];
-    if (id !== STRING_ID) throw Error("not a string: " + ptr);
+    if (id !== STRING_ID) throw Error(`not a string: ${ptr}`);
     return getStringImpl(buffer, ptr);
   }
 
@@ -157,13 +157,13 @@ function postInstantiate(extendedExports, instance) {
         case 3: return new (signed ? BigInt64Array : BigUint64Array)(buffer);
       }
     }
-    throw Error("unsupported align: " + alignLog2);
+    throw Error(`unsupported align: ${alignLog2}`);
   }
 
   /** Allocates a new array in the module's memory and returns its retained pointer. */
   function __allocArray(id, values) {
     const info = getInfo(id);
-    if (!(info & (ARRAYBUFFERVIEW | ARRAY | STATICARRAY))) throw Error("not an array: " + id + ", flags= " + info);
+    if (!(info & (ARRAYBUFFERVIEW | ARRAY | STATICARRAY))) throw Error(`not an array: ${id}, flags=${info}`);
     const align = getValueAlign(info);
     const length = values.length;
     const buf = alloc(length << align, info & STATICARRAY ? id : ARRAYBUFFER_ID);
@@ -195,7 +195,7 @@ function postInstantiate(extendedExports, instance) {
     const U32 = new Uint32Array(memory.buffer);
     const id = U32[arr + ID_OFFSET >>> 2];
     const info = getInfo(id);
-    if (!(info & (ARRAYBUFFERVIEW | ARRAY | STATICARRAY))) throw Error("not an array: " + id + ", flags=" + info);
+    if (!(info & (ARRAYBUFFERVIEW | ARRAY | STATICARRAY))) throw Error(`not an array: ${id}, flags=${info}`);
     const align = getValueAlign(info);
     let buf = info & STATICARRAY
       ? arr
@@ -244,8 +244,8 @@ function postInstantiate(extendedExports, instance) {
 
   /** Attach a set of get TypedArray and View functions to the exports. */
   function attachTypedArrayFunctions(ctor, name, align) {
-    extendedExports["__get" + name] = getTypedArray.bind(null, ctor, align);
-    extendedExports["__get" + name + "View"] = getTypedArrayView.bind(null, ctor, align);
+    extendedExports[`__get${name}`] = getTypedArray.bind(null, ctor, align);
+    extendedExports[`__get${name}View`] = getTypedArrayView.bind(null, ctor, align);
   }
 
   [
@@ -273,7 +273,7 @@ function postInstantiate(extendedExports, instance) {
     const U32 = new Uint32Array(memory.buffer);
     let id = U32[(ptr + ID_OFFSET) >>> 2];
     if (id <= U32[rttiBase >>> 2]) {
-      do if (id == baseId) return true;
+      do if (id === baseId) return true;
       while (id = getBase(id));
     }
     return false;
@@ -364,9 +364,7 @@ function demangle(exports, extendedExports = {}) {
           return ctor.wrap(ctor.prototype.constructor(0, ...args));
         };
         ctor.prototype = {
-          valueOf: function valueOf() {
-            return this[THIS];
-          }
+          valueOf() { return this[THIS]; }
         };
         ctor.wrap = function(thisValue) {
           return Object.create(ctor.prototype, { [THIS]: { value: thisValue, writable: false } });
@@ -383,8 +381,8 @@ function demangle(exports, extendedExports = {}) {
           let getter = exports[internalName.replace("set:", "get:")];
           let setter = exports[internalName.replace("get:", "set:")];
           Object.defineProperty(curr, name, {
-            get: function() { return getter(this[THIS]); },
-            set: function(value) { setter(this[THIS], value); },
+            get() { return getter(this[THIS]); },
+            set(value) { setter(this[THIS], value); },
             enumerable: true
           });
         }

--- a/lib/loader/index.js
+++ b/lib/loader/index.js
@@ -364,7 +364,7 @@ function demangle(exports, extendedExports = {}) {
           return ctor.wrap(ctor.prototype.constructor(0, ...args));
         };
         ctor.prototype = {
-          valueOf() { return this[THIS]; }
+          valueOf: function valueOf() { return this[THIS]; }
         };
         ctor.wrap = function(thisValue) {
           return Object.create(ctor.prototype, { [THIS]: { value: thisValue, writable: false } });
@@ -381,8 +381,8 @@ function demangle(exports, extendedExports = {}) {
           let getter = exports[internalName.replace("set:", "get:")];
           let setter = exports[internalName.replace("get:", "set:")];
           Object.defineProperty(curr, name, {
-            get() { return getter(this[THIS]); },
-            set(value) { setter(this[THIS], value); },
+            get: function() { return getter(this[THIS]); },
+            set: function(value) { setter(this[THIS], value); },
             enumerable: true
           });
         }

--- a/lib/loader/index.js
+++ b/lib/loader/index.js
@@ -273,7 +273,7 @@ function postInstantiate(extendedExports, instance) {
     const U32 = new Uint32Array(memory.buffer);
     let id = U32[(ptr + ID_OFFSET) >>> 2];
     if (id <= U32[rttiBase >>> 2]) {
-      do if (id === baseId) return true;
+      do if (id == baseId) return true;
       while (id = getBase(id));
     }
     return false;
@@ -364,7 +364,7 @@ function demangle(exports, extendedExports = {}) {
           return ctor.wrap(ctor.prototype.constructor(0, ...args));
         };
         ctor.prototype = {
-          valueOf: function valueOf() { return this[THIS]; }
+          valueOf() { return this[THIS]; }
         };
         ctor.wrap = function(thisValue) {
           return Object.create(ctor.prototype, { [THIS]: { value: thisValue, writable: false } });
@@ -381,8 +381,8 @@ function demangle(exports, extendedExports = {}) {
           let getter = exports[internalName.replace("set:", "get:")];
           let setter = exports[internalName.replace("get:", "set:")];
           Object.defineProperty(curr, name, {
-            get: function() { return getter(this[THIS]); },
-            set: function(value) { setter(this[THIS], value); },
+            get() { return getter(this[THIS]); },
+            set(value) { setter(this[THIS], value); },
             enumerable: true
           });
         }

--- a/lib/loader/index.js
+++ b/lib/loader/index.js
@@ -74,7 +74,7 @@ function preInstantiate(imports) {
   };
   env.trace = env.trace || function trace(msg, n, ...args) {
     const memory = extendedExports.memory || env.memory;
-    console.log(`trace: ${getString(memory, msg) + (n ? " " : "") + args.slice(0, n).join(", ")}`);
+    console.log(`trace: ${getString(memory, msg)}${n ? " " : ""}${args.slice(0, n).join(", ")}`);
   };
   env.seed = env.seed || Date.now;
   imports.Math = imports.Math || Math;

--- a/lib/loader/index.js
+++ b/lib/loader/index.js
@@ -100,6 +100,13 @@ function postInstantiate(extendedExports, instance) {
     return U32[(rttiBase + 4 >>> 2) + id * 2];
   }
 
+  /** Gets and validate runtime type info for the given id for array like objects */
+  function validateArrayInfo(id) {
+    const info = getInfo(id);
+    if (!(info & (ARRAYBUFFERVIEW | ARRAY | STATICARRAY))) throw Error(`not an array: ${id}, flags=${info}`);
+    return info;
+  }
+
   /** Gets the runtime base id for the given id. */
   function getBase(id) {
     const U32 = new Uint32Array(memory.buffer);
@@ -160,8 +167,7 @@ function postInstantiate(extendedExports, instance) {
 
   /** Allocates a new array in the module's memory and returns its retained pointer. */
   function __allocArray(id, values) {
-    const info = getInfo(id);
-    if (!(info & (ARRAYBUFFERVIEW | ARRAY | STATICARRAY))) throw Error(`not an array: ${id}, flags=${info}`);
+    const info = validateArrayInfo(id);
     const align = getValueAlign(info);
     const length = values.length;
     const buf = alloc(length << align, info & STATICARRAY ? id : ARRAYBUFFER_ID);
@@ -192,8 +198,7 @@ function postInstantiate(extendedExports, instance) {
   function __getArrayView(arr) {
     const U32 = new Uint32Array(memory.buffer);
     const id = U32[arr + ID_OFFSET >>> 2];
-    const info = getInfo(id);
-    if (!(info & (ARRAYBUFFERVIEW | ARRAY | STATICARRAY))) throw Error(`not an array: ${id}, flags=${info}`);
+    const info = validateArrayInfo(id);
     const align = getValueAlign(info);
     let buf = info & STATICARRAY
       ? arr


### PR DESCRIPTION
- use string templates
- speedup `getStringImpl` by switching from collecting array parts to direct string concatenations