### PR TITLE
Refactor compiler sources to adhere to TS strict mode

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,6 +50,8 @@ jobs:
       run: npm ci --no-audit
     - name: Clean distribution files
       run: npm run clean
+    - name: Check sources
+      run: npm run check
     - name: Test sources
       run: |
         if [[ `node bin/asc --version` != *"-dev" ]]; then

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,22 +5,28 @@
   "requires": true,
   "dependencies": {
     "@babel/code-frame": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
-      "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+      "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "^7.0.0"
+        "@babel/highlight": "^7.8.3"
       }
     },
+    "@babel/helper-validator-identifier": {
+      "version": "7.9.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.5.tgz",
+      "integrity": "sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g==",
+      "dev": true
+    },
     "@babel/highlight": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.5.0.tgz",
-      "integrity": "sha512-7dV4eu9gBxoM0dAnj/BCFDW9LFU0zvTrkq0ugM7pnHEgguOEeOz1so2ZghEdzviYzQEED0r4EAgpsBChKy1TRQ==",
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.9.0.tgz",
+      "integrity": "sha512-lJZPilxX7Op3Nv/2cvFdnlepPXDxi29wxteT57Q965oc5R9v86ztx0jfxVrTcBk8C2kcPkkDa2Z4T3ZsPPVWsQ==",
       "dev": true,
       "requires": {
+        "@babel/helper-validator-identifier": "^7.9.0",
         "chalk": "^2.0.0",
-        "esutils": "^2.0.2",
         "js-tokens": "^4.0.0"
       }
     },
@@ -1311,12 +1317,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
       "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-      "dev": true
-    },
-    "esutils": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
     "events": {
@@ -3579,9 +3579,9 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
-      "integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+      "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
       "dev": true,
       "requires": {
         "path-parse": "^1.0.6"

--- a/src/builtins.ts
+++ b/src/builtins.ts
@@ -613,20 +613,22 @@ export namespace BuiltinNames {
 
 /** Builtin compilation context. */
 export class BuiltinContext {
-  /** Compiler reference. */
-  compiler: Compiler;
-  /** Prototype being called. */
-  prototype: FunctionPrototype;
-  /** Provided type arguments. */
-  typeArguments: Type[] | null;
-  /** Provided operands. */
-  operands: Expression[];
-  /** Contextual type. */
-  contextualType: Type;
-  /** Respective call expression. */
-  reportNode: CallExpression;
-  /** Whether originating from inline assembly. */
-  contextIsExact: bool;
+  constructor(
+    /** Compiler reference. */
+    public compiler: Compiler,
+    /** Prototype being called. */
+    public prototype: FunctionPrototype,
+    /** Provided type arguments. */
+    public typeArguments: Type[] | null,
+    /** Provided operands. */
+    public operands: Expression[],
+    /** Contextual type. */
+    public contextualType: Type,
+    /** Respective call expression. */
+    public reportNode: CallExpression,
+    /** Whether originating from inline assembly. */
+    public contextIsExact: bool
+  ) {}
 }
 
 /** Global builtins map. */

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -57,7 +57,7 @@ export abstract class ExportsWalker {
   /** Constructs a new Element walker. */
   constructor(program: Program, includePrivate: bool = false) {
     this.program = program;
-    this.includePrivate;
+    this.includePrivate = includePrivate;
   }
 
   /** Walks all elements and calls the respective handlers. */

--- a/src/extra/ast.ts
+++ b/src/extra/ast.ts
@@ -932,14 +932,15 @@ export class ASTBuilder {
       }
     }
     var indexSignature = node.indexSignature;
-    if (indexSignature) {
-      this.visitIndexSignature(indexSignature);
-    }
     var members = node.members;
     var numMembers = members.length;
-    if (numMembers) {
+    if (indexSignature !== null || numMembers) {
       sb.push(" {\n");
       let indentLevel = ++this.indentLevel;
+      if (indexSignature) {
+        indent(sb, indentLevel);
+        this.visitNodeAndTerminate(indexSignature);
+      }
       for (let i = 0, k = members.length; i < k; ++i) {
         let member = members[i];
         if (member.kind != NodeKind.FIELDDECLARATION || (<FieldDeclaration>member).parameterIndex < 0) {

--- a/src/extra/ast.ts
+++ b/src/extra/ast.ts
@@ -66,13 +66,13 @@ import {
   VariableStatement,
   WhileStatement,
 
+  DeclarationStatement,
   ClassDeclaration,
   EnumDeclaration,
   EnumValueDeclaration,
   FieldDeclaration,
   FunctionDeclaration,
   ImportDeclaration,
-  IndexSignatureDeclaration,
   InterfaceDeclaration,
   MethodDeclaration,
   NamespaceDeclaration,
@@ -84,7 +84,7 @@ import {
   ParameterKind,
   ExportMember,
   SwitchCase,
-  DeclarationStatement,
+  IndexSignatureNode,
 
   isTypeOmitted
 } from "../ast";
@@ -315,10 +315,6 @@ export class ASTBuilder {
         this.visitImportDeclaration(<ImportDeclaration>node);
         break;
       }
-      case NodeKind.INDEXSIGNATUREDECLARATION: {
-        this.visitIndexSignatureDeclaration(<IndexSignatureDeclaration>node);
-        break;
-      }
       case NodeKind.INTERFACEDECLARATION: {
         this.visitInterfaceDeclaration(<InterfaceDeclaration>node);
         break;
@@ -356,6 +352,10 @@ export class ASTBuilder {
       }
       case NodeKind.SWITCHCASE: {
         this.visitSwitchCase(<SwitchCase>node);
+        break;
+      }
+      case NodeKind.INDEXSIGNATURE: {
+        this.visitIndexSignature(<IndexSignatureNode>node);
         break;
       }
       default: assert(false);
@@ -556,7 +556,7 @@ export class ASTBuilder {
 
   visitCallExpression(node: CallExpression): void {
     this.visitNode(node.expression);
-    this.visitArguments(node.typeArguments, node.arguments);
+    this.visitArguments(node.typeArguments, node.args);
   }
 
   private visitArguments(typeArguments: TypeNode[] | null, args: Expression[]): void {
@@ -772,7 +772,7 @@ export class ASTBuilder {
   visitNewExpression(node: NewExpression): void {
     this.sb.push("new ");
     this.visitTypeName(node.typeName);
-    this.visitArguments(node.typeArguments, node.arguments);
+    this.visitArguments(node.typeArguments, node.args);
   }
 
   visitParenthesizedExpression(node: ParenthesizedExpression): void {
@@ -930,6 +930,10 @@ export class ASTBuilder {
           this.visitTypeNode(implementsTypes[i]);
         }
       }
+    }
+    var indexSignature = node.indexSignature;
+    if (indexSignature) {
+      this.visitIndexSignature(indexSignature);
     }
     var members = node.members;
     var numMembers = members.length;
@@ -1305,7 +1309,7 @@ export class ASTBuilder {
     this.visitStringLiteralExpression(node.path);
   }
 
-  visitIndexSignatureDeclaration(node: IndexSignatureDeclaration): void {
+  visitIndexSignature(node: IndexSignatureNode): void {
     var sb = this.sb;
     sb.push("[key: ");
     this.visitTypeNode(node.keyType);
@@ -1576,7 +1580,7 @@ export class ASTBuilder {
     var sb = this.sb;
     sb.push("@");
     this.visitNode(node.name);
-    var args = node.arguments;
+    var args = node.args;
     if (args) {
       sb.push("(");
       let numArgs = args.length;

--- a/src/extra/ast.ts
+++ b/src/extra/ast.ts
@@ -823,13 +823,13 @@ export class ASTBuilder {
 
   // statements
 
-  visitNodeAndTerminate(statement: Statement): void {
-    this.visitNode(statement);
+  visitNodeAndTerminate(node: Node): void {
+    this.visitNode(node);
     var sb = this.sb;
     if (
-      !sb.length ||                          // leading EmptyStatement
-      statement.kind == NodeKind.VARIABLE || // potentially assigns a FunctionExpression
-      statement.kind == NodeKind.EXPRESSION  // potentially assigns a FunctionExpression
+      !sb.length ||                     // leading EmptyStatement
+      node.kind == NodeKind.VARIABLE || // potentially assigns a FunctionExpression
+      node.kind == NodeKind.EXPRESSION  // potentially assigns a FunctionExpression
     ) {
       sb.push(";\n");
     } else {

--- a/src/flow.ts
+++ b/src/flow.ts
@@ -184,56 +184,40 @@ export const enum ConditionKind {
 /** A control flow evaluator. */
 export class Flow {
 
-  /** Parent flow. */
-  parent: Flow | null;
-  /** Flow flags indicating specific conditions. */
-  flags: FlowFlags;
-  /** Function this flow belongs to. */
-  parentFunction: Function;
-  /** The label we break to when encountering a continue statement. */
-  continueLabel: string | null;
-  /** The label we break to when encountering a break statement. */
-  breakLabel: string | null;
-  /** The current return type. */
-  returnType: Type;
-  /** The current contextual type arguments. */
-  contextualTypeArguments: Map<string,Type> | null;
-  /** Scoped local variables. */
-  scopedLocals: Map<string,Local> | null = null;
-  /** Local flags. */
-  localFlags: LocalFlags[];
-  /** Function being inlined, when inlining. */
-  inlineFunction: Function | null;
-  /** The label we break to when encountering a return statement, when inlining. */
-  inlineReturnLabel: string | null;
-
   /** Creates the parent flow of the specified function. */
-  static create(parentFunction: Function): Flow {
-    var flow = new Flow();
-    flow.parent = null;
-    flow.flags = FlowFlags.NONE;
-    flow.parentFunction = parentFunction;
-    flow.continueLabel = null;
-    flow.breakLabel = null;
-    flow.returnType = parentFunction.signature.returnType;
-    flow.contextualTypeArguments = parentFunction.contextualTypeArguments;
-    flow.localFlags = [];
-    flow.inlineFunction = null;
-    flow.inlineReturnLabel = null;
-    return flow;
+  static createParent(parentFunction: Function): Flow {
+    return new Flow(parentFunction);
   }
 
   /** Creates an inline flow within `parentFunction`. */
   static createInline(parentFunction: Function, inlineFunction: Function): Flow {
-    var flow = Flow.create(parentFunction);
+    var flow = new Flow(parentFunction);
     flow.inlineFunction = inlineFunction;
     flow.inlineReturnLabel = inlineFunction.internalName + "|inlined." + (inlineFunction.nextInlineId++).toString();
-    flow.returnType = inlineFunction.signature.returnType;
-    flow.contextualTypeArguments = inlineFunction.contextualTypeArguments;
     return flow;
   }
 
-  private constructor() { }
+  private constructor(
+    /** Function this flow belongs to. */
+    public parentFunction: Function
+  ) {}
+
+  /** Parent flow. */
+  parent: Flow | null = null;
+  /** Flow flags indicating specific conditions. */
+  flags: FlowFlags = FlowFlags.NONE;
+  /** The label we break to when encountering a continue statement. */
+  continueLabel: string | null = null;
+  /** The label we break to when encountering a break statement. */
+  breakLabel: string | null = null;
+  /** Scoped local variables. */
+  scopedLocals: Map<string,Local> | null = null;
+  /** Local flags. */
+  localFlags: LocalFlags[] = [];
+  /** Function being inlined, when inlining. */
+  inlineFunction: Function | null = null;
+  /** The label we break to when encountering a return statement, when inlining. */
+  inlineReturnLabel: string | null = null;
 
   /** Tests if this is an inline flow. */
   get isInline(): bool {
@@ -247,6 +231,16 @@ export class Flow {
     return this.parentFunction;
   }
 
+  /** Gets the current return type. */
+  get returnType(): Type {
+    return this.actualFunction.signature.returnType;
+  }
+
+  /** Gets the current contextual type arguments. */
+  get contextualTypeArguments(): Map<string,Type> | null {
+    return this.actualFunction.contextualTypeArguments;
+  }
+
   /** Tests if this flow has the specified flag or flags. */
   is(flag: FlowFlags): bool { return (this.flags & flag) == flag; }
   /** Tests if this flow has one of the specified flags. */
@@ -258,9 +252,8 @@ export class Flow {
 
   /** Forks this flow to a child flow. */
   fork(resetBreakContext: bool = false): Flow {
-    var branch = new Flow();
+    var branch = new Flow(this.parentFunction);
     branch.parent = this;
-    branch.parentFunction = this.parentFunction;
     if (resetBreakContext) {
       branch.flags = this.flags & ~(
         FlowFlags.BREAKS |
@@ -273,8 +266,6 @@ export class Flow {
       branch.continueLabel = this.continueLabel;
       branch.breakLabel = this.breakLabel;
     }
-    branch.returnType = this.returnType;
-    branch.contextualTypeArguments = this.contextualTypeArguments;
     branch.localFlags = this.localFlags.slice();
     branch.inlineFunction = this.inlineFunction;
     branch.inlineReturnLabel = this.inlineReturnLabel;

--- a/src/module.ts
+++ b/src/module.ts
@@ -486,41 +486,34 @@ export enum ExpressionRunnerFlags {
 }
 
 export class MemorySegment {
-
-  buffer: Uint8Array;
-  offset: i64;
-
-  static create(buffer: Uint8Array, offset: i64): MemorySegment {
-    var segment = new MemorySegment();
-    segment.buffer = buffer;
-    segment.offset = offset;
-    return segment;
-  }
+  constructor(
+    /** Segment data. */
+    public buffer: Uint8Array,
+    /** Segment offset. */
+    public offset: i64
+  ) {}
 }
 
 export class Module {
-
-  ref: ModuleRef;
+  constructor(
+    /** Binaryen module reference. */
+    public ref: ModuleRef
+  ) {
+    this.lit = binaryen._malloc(binaryen._BinaryenSizeofLiteral());
+  }
 
   private lit: usize;
 
   static create(): Module {
-    var module = new Module();
-    module.ref = binaryen._BinaryenModuleCreate();
-    module.lit = binaryen._malloc(binaryen._BinaryenSizeofLiteral());
-    return module;
+    return new Module(binaryen._BinaryenModuleCreate());
   }
 
   static createFrom(buffer: Uint8Array): Module {
-    var module = new Module();
     var cArr = allocU8Array(buffer);
-    module.ref = binaryen._BinaryenModuleRead(cArr, buffer.length);
+    var module = new Module(binaryen._BinaryenModuleRead(cArr, buffer.length));
     binaryen._free(changetype<usize>(cArr));
-    module.lit = binaryen._malloc(binaryen._BinaryenSizeofLiteral());
     return module;
   }
-
-  private constructor() { }
 
   // constants
 
@@ -1643,13 +1636,11 @@ export class Module {
     binaryPtr = assert(binaryen.__i32_load(out));
     var binaryLen = binaryen.__i32_load(out + 4);
     sourceMapPtr = binaryen.__i32_load(out + 8); // may be NULL
-    var ret = new BinaryModule();
-    ret.output = readBuffer(binaryPtr, binaryLen);
-    ret.sourceMap = readString(sourceMapPtr);
+    var binary = new BinaryModule(readBuffer(binaryPtr, binaryLen), readString(sourceMapPtr));
     if (cStr) binaryen._free(cStr);
     binaryen._free(binaryPtr);
     if (sourceMapPtr) binaryen._free(sourceMapPtr);
-    return ret;
+    return binary;
   }
 
   toText(): string {
@@ -2100,18 +2091,16 @@ export function getEventResults(event: EventRef): NativeType {
 }
 
 export class Relooper {
-
-  module: Module;
-  ref: RelooperRef;
+  constructor(
+    /** Module this relooper belongs to. */
+    public module: Module,
+    /** Binaryen relooper reference. */
+    public ref: RelooperRef
+  ) {}
 
   static create(module: Module): Relooper {
-    var relooper = new Relooper();
-    relooper.module = module;
-    relooper.ref = binaryen._RelooperCreate(module.ref);
-    return relooper;
+    return new Relooper(module, binaryen._RelooperCreate(module.ref));
   }
-
-  private constructor() {}
 
   addBlock(code: ExpressionRef): RelooperBlockRef {
     return binaryen._RelooperAddBlock(this.ref, code);
@@ -2435,10 +2424,12 @@ export function readString(ptr: usize): string | null {
 
 /** Result structure of {@link Module#toBinary}. */
 export class BinaryModule {
-  /** WebAssembly binary. */
-  output: Uint8Array;
-  /** Source map, if generated. */
-  sourceMap: string | null;
+  constructor(
+    /** WebAssembly binary. */
+    public output: Uint8Array,
+    /** Source map, if generated. */
+    public sourceMap: string | null
+  ) {}
 }
 
 /** Tests if an expression needs an explicit 'unreachable' when it is the terminating statement. */

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -70,7 +70,7 @@ import {
   IfStatement,
   ImportDeclaration,
   ImportStatement,
-  IndexSignatureDeclaration,
+  IndexSignatureNode,
   NamespaceDeclaration,
   ParameterNode,
   ParameterKind,
@@ -101,7 +101,7 @@ export class Parser extends DiagnosticEmitter {
   /** Optional handler to intercept comments while tokenizing. */
   onComment: CommentHandler | null = null;
   /** Current file being parsed. */
-  currentSource: Source;
+  currentSource: Source | null = null;
   /** Dependency map **/
   dependees: Map<string, Source> = new Map();
   /** An array of parsed sources. */
@@ -135,15 +135,15 @@ export class Parser extends DiagnosticEmitter {
 
     // create the source element
     var source = new Source(
-      normalizedPath,
-      text,
       isEntry
         ? SourceKind.USER_ENTRY
         : path.startsWith(LIBRARY_PREFIX)
           ? path.indexOf(PATH_DELIMITER, LIBRARY_PREFIX.length) < 0
             ? SourceKind.LIBRARY_ENTRY
             : SourceKind.LIBRARY
-          : SourceKind.USER
+          : SourceKind.USER,
+      normalizedPath,
+      text
     );
 
     this.sources.push(source);
@@ -663,13 +663,16 @@ export class Parser extends DiagnosticEmitter {
     } else {
       isSignature = false; // not yet known
       do {
+        let paramStart: i32 = -1;
         let kind = ParameterKind.DEFAULT;
         if (tn.skip(Token.DOT_DOT_DOT)) {
+          paramStart = tn.tokenPos;
           isSignature = true;
           tn.discard(state);
           kind = ParameterKind.REST;
         }
         if (tn.skip(Token.THIS)) {
+          if (paramStart < 0) paramStart = tn.tokenPos;
           if (tn.skip(Token.COLON)) {
             isSignature = true;
             tn.discard(state);
@@ -690,6 +693,7 @@ export class Parser extends DiagnosticEmitter {
             return null;
           }
         } else if (tn.skipIdentifier()) {
+          if (paramStart < 0) paramStart = tn.tokenPos;
           let name = Node.createIdentifierExpression(tn.readIdentifier(), tn.range(tn.tokenPos, tn.pos));
           if (tn.skip(Token.QUESTION)) {
             isSignature = true;
@@ -711,10 +715,7 @@ export class Parser extends DiagnosticEmitter {
               this.tryParseSignatureIsSignature = isSignature;
               return null;
             }
-            let param = new ParameterNode();
-            param.parameterKind = kind;
-            param.name = name;
-            param.type = type;
+            let param = Node.createParameter(kind, name, type, null, tn.range(paramStart, tn.pos));
             if (!parameters) parameters = [ param ];
             else parameters.push(param);
           } else {
@@ -725,10 +726,7 @@ export class Parser extends DiagnosticEmitter {
               }
             }
             if (isSignature) {
-              let param = new ParameterNode();
-              param.parameterKind = kind;
-              param.name = name;
-              param.type = Node.createOmittedType(tn.range().atEnd);
+              let param = Node.createParameter(kind, name, Node.createOmittedType(tn.range(tn.pos)), null, tn.range(paramStart, tn.pos));
               if (!parameters) parameters = [ param ];
               else parameters.push(param);
               this.error(
@@ -776,10 +774,13 @@ export class Parser extends DiagnosticEmitter {
         isSignature = true;
         tn.discard(state);
         if (firstParamNameNoType) { // now we know
-          let param = new ParameterNode();
-          param.parameterKind = firstParamKind;
-          param.name = firstParamNameNoType;
-          param.type = Node.createOmittedType(firstParamNameNoType.range.atEnd);
+          let param = Node.createParameter(
+            firstParamKind,
+            firstParamNameNoType,
+            Node.createOmittedType(firstParamNameNoType.range.atEnd),
+            null,
+            firstParamNameNoType.range
+          );
           if (!parameters) parameters = [ param ];
           else parameters.push(param);
           this.error(
@@ -872,14 +873,14 @@ export class Parser extends DiagnosticEmitter {
 
     // at ('const' | 'let' | 'var'): VariableDeclaration (',' VariableDeclaration)* ';'?
 
-    var members = new Array<VariableDeclaration>();
+    var declarations = new Array<VariableDeclaration>();
     do {
-      let member = this.parseVariableDeclaration(tn, flags, decorators, isFor);
-      if (!member) return null;
-      members.push(member);
+      let declaration = this.parseVariableDeclaration(tn, flags, decorators, isFor);
+      if (!declaration) return null;
+      declarations.push(declaration);
     } while (tn.skip(Token.COMMA));
 
-    var ret = Node.createVariableStatement(members, decorators, tn.range(startPos, tn.pos));
+    var ret = Node.createVariableStatement(decorators, declarations, tn.range(startPos, tn.pos));
     tn.skip(Token.SEMICOLON);
     return ret;
   }
@@ -951,10 +952,10 @@ export class Parser extends DiagnosticEmitter {
     }
     return Node.createVariableDeclaration(
       identifier,
-      type,
-      initializer,
       parentDecorators,
       flags,
+      type,
+      initializer,
       range
     );
   }
@@ -1002,9 +1003,9 @@ export class Parser extends DiagnosticEmitter {
     }
     var ret = Node.createEnumDeclaration(
       identifier,
-      members,
       decorators,
       flags,
+      members,
       tn.range(startPos, tn.pos)
     );
     tn.skip(Token.SEMICOLON);
@@ -1033,8 +1034,8 @@ export class Parser extends DiagnosticEmitter {
     }
     return Node.createEnumValueDeclaration(
       identifier,
-      value,
       parentFlags,
+      value,
       Range.join(identifier.range, tn.range())
     );
   }
@@ -1332,14 +1333,14 @@ export class Parser extends DiagnosticEmitter {
         if (!initializer) return null;
       }
       let param = Node.createParameter(
-        identifier,
-        type,
-        initializer,
         isRest
           ? ParameterKind.REST
           : isOptional
             ? ParameterKind.OPTIONAL
             : ParameterKind.DEFAULT,
+        identifier,
+        type,
+        initializer,
         Range.join(assert(startRange), tn.range())
       );
       param.flags |= accessFlags;
@@ -1473,11 +1474,11 @@ export class Parser extends DiagnosticEmitter {
 
     var ret = Node.createFunctionDeclaration(
       name,
+      decorators,
+      flags,
       typeParameters,
       signature,
       body,
-      decorators,
-      flags,
       ArrowKind.NONE,
       tn.range(startPos, tn.pos)
     );
@@ -1588,10 +1589,10 @@ export class Parser extends DiagnosticEmitter {
     var declaration = Node.createFunctionDeclaration(
       name,
       null,
+      CommonFlags.NONE,
+      null,
       signature,
       body,
-      null,
-      CommonFlags.NONE,
       arrowKind,
       tn.range(startPos, tn.pos)
     );
@@ -1687,30 +1688,37 @@ export class Parser extends DiagnosticEmitter {
       assert(!implementsTypes);
       declaration = Node.createInterfaceDeclaration(
         identifier,
-        typeParameters,
-        extendsType,
-        members,
         decorators,
         flags,
+        typeParameters,
+        extendsType,
+        null,
+        members,
         tn.range(startPos, tn.pos)
       );
     } else {
       declaration = Node.createClassDeclaration(
         identifier,
+        decorators,
+        flags,
         typeParameters,
         extendsType,
         implementsTypes,
         members,
-        decorators,
-        flags,
         tn.range(startPos, tn.pos)
       );
     }
     if (!tn.skip(Token.CLOSEBRACE)) {
       do {
         let member = this.parseClassMember(tn, declaration);
-        if (member) members.push(member);
-        else {
+        if (member) {
+          if (member.kind == NodeKind.INDEXSIGNATURE) {
+            declaration.indexSignature = <IndexSignatureNode>member;
+          } else {
+            assert(member instanceof DeclarationStatement);
+            members.push(<DeclarationStatement>member);
+          }
+        } else {
           this.skipStatement(tn);
           if (tn.skip(Token.ENDOFFILE)) {
             this.error(
@@ -1750,19 +1758,25 @@ export class Parser extends DiagnosticEmitter {
     var members = new Array<DeclarationStatement>();
     var declaration = Node.createClassDeclaration(
       name,
-      [],
+      null,
+      CommonFlags.NONE,
+      null,
       null,
       null,
       members,
-      null,
-      CommonFlags.NONE,
       tn.range(startPos, tn.pos)
     );
     if (!tn.skip(Token.CLOSEBRACE)) {
       do {
         let member = this.parseClassMember(tn, declaration);
-        if (member) members.push(member);
-        else {
+        if (member) {
+          if (member.kind == NodeKind.INDEXSIGNATURE) {
+            declaration.indexSignature = <IndexSignatureNode>member;
+          } else {
+            assert(declaration instanceof DeclarationStatement);
+            members.push(<DeclarationStatement>member);
+          }
+        } else {
           this.skipStatement(tn);
           if (tn.skip(Token.ENDOFFILE)) {
             this.error(
@@ -1781,7 +1795,7 @@ export class Parser extends DiagnosticEmitter {
   parseClassMember(
     tn: Tokenizer,
     parent: ClassDeclaration
-  ): DeclarationStatement | null {
+  ): Node | null {
 
     // before:
     //   ('public' | 'private' | 'protected')?
@@ -2007,7 +2021,7 @@ export class Parser extends DiagnosticEmitter {
             tn.range(abstractStart, abstractEnd), "abstract"
           ); // recoverable
         }
-        let retIndex = this.parseIndexSignatureDeclaration(tn, flags, decorators);
+        let retIndex = this.parseIndexSignature(tn, flags, decorators);
         if (!retIndex) {
           if (flags & CommonFlags.READONLY) {
             this.error(
@@ -2067,10 +2081,10 @@ export class Parser extends DiagnosticEmitter {
           )) {
             let implicitFieldDeclaration = Node.createFieldDeclaration(
               parameter.name,
-              parameter.type,
-              null, // initialized via parameter
               null,
               parameter.flags | CommonFlags.INSTANCE,
+              parameter.type,
+              null, // initialized via parameter
               parameter.range
             );
             implicitFieldDeclaration.parameterIndex = i;
@@ -2167,11 +2181,11 @@ export class Parser extends DiagnosticEmitter {
 
       let retMethod = Node.createMethodDeclaration(
         name,
+        decorators,
+        flags,
         typeParameters,
         signature,
         body,
-        decorators,
-        flags,
         tn.range(startPos, tn.pos)
       );
       tn.skip(Token.SEMICOLON);
@@ -2245,10 +2259,10 @@ export class Parser extends DiagnosticEmitter {
       }
       let retField = Node.createFieldDeclaration(
         name,
-        type,
-        initializer,
         decorators,
         flags,
+        type,
+        initializer,
         range
       );
       tn.skip(Token.SEMICOLON);
@@ -2257,11 +2271,11 @@ export class Parser extends DiagnosticEmitter {
     return null;
   }
 
-  parseIndexSignatureDeclaration(
+  parseIndexSignature(
     tn: Tokenizer,
     flags: CommonFlags,
     decorators: DecoratorNode[] | null,
-  ): IndexSignatureDeclaration | null {
+  ): IndexSignatureNode | null {
 
     // at: '[': 'key' ':' Type ']' ':' Type
 
@@ -2297,7 +2311,7 @@ export class Parser extends DiagnosticEmitter {
                 );
                 return null;
               }
-              return Node.createIndexSignatureDeclaration(<NamedTypeNode>keyType, valueType, flags, tn.range(start, tn.pos));
+              return Node.createIndexSignature(<NamedTypeNode>keyType, valueType, flags, tn.range(start, tn.pos));
             } else {
               this.error(
                 DiagnosticCode._0_expected,
@@ -2346,9 +2360,9 @@ export class Parser extends DiagnosticEmitter {
         let members = new Array<Statement>();
         let declaration = Node.createNamespaceDeclaration(
           identifier,
-          members,
           decorators,
           flags,
+          members,
           tn.range(startPos, tn.pos)
         );
         while (!tn.skip(Token.CLOSEBRACE)) {
@@ -2392,6 +2406,7 @@ export class Parser extends DiagnosticEmitter {
     // at 'export': '{' ExportMember (',' ExportMember)* }' ('from' StringLiteral)? ';'?
 
     var path: StringLiteralExpression | null = null;
+    var currentSource = assert(this.currentSource);
     if (tn.skip(Token.OPENBRACE)) {
       let members = new Array<ExportMember>();
       while (!tn.skip(Token.CLOSEBRACE)) {
@@ -2424,7 +2439,7 @@ export class Parser extends DiagnosticEmitter {
       let ret = Node.createExportStatement(members, path, isDeclare, tn.range(startPos, tn.pos));
       let internalPath = ret.internalPath;
       if (internalPath !== null && !this.seenlog.has(internalPath)) {
-        this.dependees.set(internalPath, this.currentSource);
+        this.dependees.set(internalPath, currentSource);
         this.backlog.push(internalPath);
         this.seenlog.add(internalPath);
       }
@@ -2441,7 +2456,7 @@ export class Parser extends DiagnosticEmitter {
           if (!exportPaths) source.exportPaths = [ internalPath ];
           else if (!exportPaths.includes(internalPath)) exportPaths.push(internalPath);
           if (!this.seenlog.has(internalPath)) {
-            this.dependees.set(internalPath, this.currentSource);
+            this.dependees.set(internalPath, currentSource);
             this.backlog.push(internalPath);
           }
           tn.skip(Token.SEMICOLON);
@@ -2606,13 +2621,13 @@ export class Parser extends DiagnosticEmitter {
         let ret: ImportStatement;
         if (namespaceName) {
           assert(!members);
-          ret = Node.createImportStatementWithWildcard(namespaceName, path, tn.range(startPos, tn.pos));
+          ret = Node.createWildcardImportStatement(namespaceName, path, tn.range(startPos, tn.pos));
         } else {
           ret = Node.createImportStatement(members, path, tn.range(startPos, tn.pos));
         }
         let internalPath = ret.internalPath;
         if (!this.seenlog.has(internalPath)) {
-          this.dependees.set(internalPath, this.currentSource);
+          this.dependees.set(internalPath, assert(this.currentSource));
           this.backlog.push(internalPath);
         }
         tn.skip(Token.SEMICOLON);
@@ -3357,10 +3372,10 @@ export class Parser extends DiagnosticEmitter {
         if (!type) return null;
         let ret = Node.createTypeDeclaration(
           name,
-          typeParameters,
-          type,
           decorators,
           flags,
+          typeParameters,
+          type,
           tn.range(startPos, tn.pos)
         );
         tn.skip(Token.SEMICOLON);
@@ -3700,10 +3715,10 @@ export class Parser extends DiagnosticEmitter {
             Node.createEmptyIdentifierExpression(tn.range(startPos)),
             [
               Node.createParameter(
+                ParameterKind.DEFAULT,
                 identifier,
                 Node.createOmittedType(identifier.range.atEnd),
                 null,
-                ParameterKind.DEFAULT,
                 identifier.range
               )
             ],

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -764,7 +764,7 @@ export class Resolver extends DiagnosticEmitter {
 
       let parameterNodes = prototype.functionTypeNode.parameters;
       let numParameters = parameterNodes.length;
-      let argumentNodes = node.arguments;
+      let argumentNodes = node.args;
       let numArguments = argumentNodes.length;
 
       // infer types with generic components while updating contextual types
@@ -2400,9 +2400,9 @@ export class Resolver extends DiagnosticEmitter {
         // `unchecked` behaves like parenthesized
         if (
           functionPrototype.internalName == BuiltinNames.unchecked &&
-          node.arguments.length > 0
+          node.args.length > 0
         ) {
-          return this.resolveExpression(node.arguments[0], ctxFlow, ctxType, reportMode);
+          return this.resolveExpression(node.args[0], ctxFlow, ctxType, reportMode);
         }
         let instance = this.maybeInferCall(node, functionPrototype, ctxFlow, reportMode);
         if (!instance) return null;

--- a/src/tokenizer.ts
+++ b/src/tokenizer.ts
@@ -988,11 +988,14 @@ export class Tokenizer extends DiagnosticEmitter {
 
   mark(): State {
     var state = reusableState;
-    if (state) reusableState = null;
-    else state = new State();
-    state.pos = this.pos;
-    state.token = this.token;
-    state.tokenPos = this.tokenPos;
+    if (state) {
+      reusableState = null;
+      state.pos = this.pos;
+      state.token = this.token;
+      state.tokenPos = this.tokenPos;
+    } else {
+      state = new State(this.pos, this.token, this.tokenPos);
+    }
     return state;
   }
 
@@ -1570,12 +1573,14 @@ export class Tokenizer extends DiagnosticEmitter {
 
 /** Tokenizer state as returned by {@link Tokenizer#mark} and consumed by {@link Tokenizer#reset}. */
 export class State {
-  /** Current position. */
-  pos: i32;
-  /** Current token. */
-  token: Token;
-  /** Current token's position. */
-  tokenPos: i32;
+  constructor(
+    /** Current position. */
+    public pos: i32,
+    /** Current token. */
+    public token: Token,
+    /** Current token's position. */
+    public tokenPos: i32
+  ) {}
 }
 
 // Reusable state object to reduce allocations

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -4,7 +4,8 @@
     "outDir": "../out",
     "allowJs": false,
     "sourceMap": true,
-    "target": "ES2016"
+    "target": "ES2016",
+    "strict": true
   },
   "include": [
     "./**/*.ts"

--- a/std/assembly/map.ts
+++ b/std/assembly/map.ts
@@ -64,19 +64,21 @@ function ENTRY_SIZE<K,V>(): usize {
 export class Map<K,V> {
 
   // buckets holding references to the respective first entry within
-  private buckets: ArrayBuffer; // usize[bucketsMask + 1]
+  private buckets: ArrayBuffer | null; // usize[bucketsMask + 1], never null
   private bucketsMask: u32;
 
   // entries in insertion order
-  private entries: ArrayBuffer; // MapEntry<K,V>[entriesCapacity]
+  private entries: ArrayBuffer | null; // MapEntry<K,V>[entriesCapacity], never null
   private entriesCapacity: i32;
   private entriesOffset: i32;
   private entriesCount: i32;
 
-  get size(): i32 { return this.entriesCount; }
-
   constructor() {
     this.clear();
+  }
+
+  get size(): i32 {
+    return this.entriesCount;
   }
 
   clear(): void {

--- a/std/assembly/map.ts
+++ b/std/assembly/map.ts
@@ -63,18 +63,17 @@ function ENTRY_SIZE<K,V>(): usize {
 
 export class Map<K,V> {
 
-  // buckets holding references to the respective first entry within
-  private buckets: ArrayBuffer | null; // usize[bucketsMask + 1], never null
-  private bucketsMask: u32;
+  // buckets referencing their respective first entry, usize[bucketsMask + 1]
+  private buckets: ArrayBuffer = new ArrayBuffer(INITIAL_CAPACITY * <i32>BUCKET_SIZE);
+  private bucketsMask: u32 = INITIAL_CAPACITY - 1;
 
-  // entries in insertion order
-  private entries: ArrayBuffer | null; // MapEntry<K,V>[entriesCapacity], never null
-  private entriesCapacity: i32;
-  private entriesOffset: i32;
-  private entriesCount: i32;
+  // entries in insertion order, MapEntry<K,V>[entriesCapacity]
+  private entries: ArrayBuffer = new ArrayBuffer(INITIAL_CAPACITY * <i32>ENTRY_SIZE<K,V>());
+  private entriesCapacity: i32 = INITIAL_CAPACITY;
+  private entriesOffset: i32 = 0;
+  private entriesCount: i32 = 0;
 
   constructor() {
-    this.clear();
   }
 
   get size(): i32 {
@@ -82,11 +81,9 @@ export class Map<K,V> {
   }
 
   clear(): void {
-    const bucketsSize = INITIAL_CAPACITY * <i32>BUCKET_SIZE;
-    this.buckets = new ArrayBuffer(bucketsSize);
+    this.buckets = new ArrayBuffer(INITIAL_CAPACITY * <i32>BUCKET_SIZE);
     this.bucketsMask = INITIAL_CAPACITY - 1;
-    const entriesSize = INITIAL_CAPACITY * <i32>ENTRY_SIZE<K,V>();
-    this.entries = new ArrayBuffer(entriesSize);
+    this.entries = new ArrayBuffer(INITIAL_CAPACITY * <i32>ENTRY_SIZE<K,V>());
     this.entriesCapacity = INITIAL_CAPACITY;
     this.entriesOffset = 0;
     this.entriesCount = 0;

--- a/std/assembly/set.ts
+++ b/std/assembly/set.ts
@@ -60,18 +60,17 @@ function ENTRY_SIZE<T>(): usize {
 
 export class Set<T> {
 
-  // buckets holding references to the respective first entry within
-  private buckets: ArrayBuffer | null; // usize[bucketsMask + 1], never null
-  private bucketsMask: u32;
+  // buckets referencing their respective first entry, usize[bucketsMask + 1]
+  private buckets: ArrayBuffer = new ArrayBuffer(INITIAL_CAPACITY * <i32>BUCKET_SIZE);
+  private bucketsMask: u32 = INITIAL_CAPACITY - 1;
 
-  // entries in insertion order
-  private entries: ArrayBuffer | null; // SetEntry<K>[entriesCapacity], never null
-  private entriesCapacity: i32;
-  private entriesOffset: i32;
-  private entriesCount: i32;
+  // entries in insertion order, SetEntry<K>[entriesCapacity]
+  private entries: ArrayBuffer = new ArrayBuffer(INITIAL_CAPACITY * <i32>ENTRY_SIZE<T>());
+  private entriesCapacity: i32 = INITIAL_CAPACITY;
+  private entriesOffset: i32 = 0;
+  private entriesCount: i32 = 0;
 
   constructor() {
-    this.clear();
   }
 
   get size(): i32 {
@@ -79,11 +78,9 @@ export class Set<T> {
   }
 
   clear(): void {
-    const bucketsSize = INITIAL_CAPACITY * <i32>BUCKET_SIZE;
-    this.buckets = new ArrayBuffer(bucketsSize);
+    this.buckets = new ArrayBuffer(INITIAL_CAPACITY * <i32>BUCKET_SIZE);
     this.bucketsMask = INITIAL_CAPACITY - 1;
-    const entriesSize = INITIAL_CAPACITY * <i32>ENTRY_SIZE<T>();
-    this.entries = new ArrayBuffer(entriesSize);
+    this.entries = new ArrayBuffer(INITIAL_CAPACITY * <i32>ENTRY_SIZE<T>());
     this.entriesCapacity = INITIAL_CAPACITY;
     this.entriesOffset = 0;
     this.entriesCount = 0;

--- a/std/assembly/set.ts
+++ b/std/assembly/set.ts
@@ -61,18 +61,22 @@ function ENTRY_SIZE<T>(): usize {
 export class Set<T> {
 
   // buckets holding references to the respective first entry within
-  private buckets: ArrayBuffer; // usize[bucketsMask + 1]
+  private buckets: ArrayBuffer | null; // usize[bucketsMask + 1], never null
   private bucketsMask: u32;
 
   // entries in insertion order
-  private entries: ArrayBuffer; // SetEntry<K>[entriesCapacity]
+  private entries: ArrayBuffer | null; // SetEntry<K>[entriesCapacity], never null
   private entriesCapacity: i32;
   private entriesOffset: i32;
   private entriesCount: i32;
 
-  get size(): i32 { return this.entriesCount; }
+  constructor() {
+    this.clear();
+  }
 
-  constructor() { this.clear(); }
+  get size(): i32 {
+    return this.entriesCount;
+  }
 
   clear(): void {
     const bucketsSize = INITIAL_CAPACITY * <i32>BUCKET_SIZE;

--- a/std/assembly/shared/typeinfo.ts
+++ b/std/assembly/shared/typeinfo.ts
@@ -16,9 +16,9 @@
 @unmanaged
 export class Typeinfo {
   /** Flags describing the shape of this class type. */
-  flags: TypeinfoFlags;
+  flags: TypeinfoFlags = TypeinfoFlags.NONE;
   /** Base class id or `0` if none. */
-  base: u32;
+  base: u32 = 0;
 }
 
 /** Runtime type information flags. */

--- a/tests/compiler/builtins.optimized.wat
+++ b/tests/compiler/builtins.optimized.wat
@@ -592,9 +592,9 @@
   i32.const 5
   f64.const 0
   f64.const 0
-  f64.const 23
-  f64.const 24
-  f64.const 24
+  f64.const 15
+  f64.const 16
+  f64.const 16
   call $~lib/builtins/trace
   i32.const 1216
   i32.const 1216

--- a/tests/compiler/builtins.untouched.wat
+++ b/tests/compiler/builtins.untouched.wat
@@ -1727,11 +1727,11 @@
   local.set $0
   i32.const 0
   local.set $1
-  i32.const 23
+  i32.const 15
   local.set $6
-  i32.const 24
+  i32.const 16
   local.set $7
-  i32.const 24
+  i32.const 16
   local.set $8
   i32.const 128
   i32.const 5
@@ -1771,7 +1771,7 @@
    unreachable
   end
   local.get $6
-  i32.const 23
+  i32.const 15
   i32.eq
   i32.eqz
   if

--- a/tests/compiler/std/map.optimized.wat
+++ b/tests/compiler/std/map.optimized.wat
@@ -1645,7 +1645,7 @@
   if
    i32.const 1360
    i32.const 1424
-   i32.const 111
+   i32.const 113
    i32.const 17
    call $~lib/builtins/abort
    unreachable
@@ -3858,7 +3858,7 @@
   if
    i32.const 1360
    i32.const 1424
-   i32.const 111
+   i32.const 113
    i32.const 17
    call $~lib/builtins/abort
    unreachable
@@ -5122,7 +5122,7 @@
   if
    i32.const 1360
    i32.const 1424
-   i32.const 111
+   i32.const 113
    i32.const 17
    call $~lib/builtins/abort
    unreachable
@@ -6404,7 +6404,7 @@
   if
    i32.const 1360
    i32.const 1424
-   i32.const 111
+   i32.const 113
    i32.const 17
    call $~lib/builtins/abort
    unreachable
@@ -7379,7 +7379,7 @@
   if
    i32.const 1360
    i32.const 1424
-   i32.const 111
+   i32.const 113
    i32.const 17
    call $~lib/builtins/abort
    unreachable
@@ -8875,7 +8875,7 @@
   if
    i32.const 1360
    i32.const 1424
-   i32.const 111
+   i32.const 113
    i32.const 17
    call $~lib/builtins/abort
    unreachable
@@ -10830,7 +10830,7 @@
   if
    i32.const 1360
    i32.const 1424
-   i32.const 111
+   i32.const 113
    i32.const 17
    call $~lib/builtins/abort
    unreachable
@@ -12056,7 +12056,7 @@
   if
    i32.const 1360
    i32.const 1424
-   i32.const 111
+   i32.const 113
    i32.const 17
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/map.optimized.wat
+++ b/tests/compiler/std/map.optimized.wat
@@ -30,11 +30,11 @@
  (import "rtrace" "onfree" (func $~lib/rt/rtrace/onfree (param i32)))
  (import "rtrace" "ondecrement" (func $~lib/rt/rtrace/ondecrement (param i32)))
  (memory $0 1)
- (data (i32.const 1024) "\1c\00\00\00\01\00\00\00\01\00\00\00\1c\00\00\00I\00n\00v\00a\00l\00i\00d\00 \00l\00e\00n\00g\00t\00h")
- (data (i32.const 1072) "&\00\00\00\01\00\00\00\01\00\00\00&\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00b\00u\00f\00f\00e\00r\00.\00t\00s")
- (data (i32.const 1136) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s")
- (data (i32.const 1184) "(\00\00\00\01\00\00\00\01\00\00\00(\00\00\00a\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e")
- (data (i32.const 1248) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00p\00u\00r\00e\00.\00t\00s")
+ (data (i32.const 1024) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s")
+ (data (i32.const 1072) "(\00\00\00\01\00\00\00\01\00\00\00(\00\00\00a\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e")
+ (data (i32.const 1136) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00p\00u\00r\00e\00.\00t\00s")
+ (data (i32.const 1184) "\1c\00\00\00\01\00\00\00\01\00\00\00\1c\00\00\00I\00n\00v\00a\00l\00i\00d\00 \00l\00e\00n\00g\00t\00h")
+ (data (i32.const 1232) "&\00\00\00\01\00\00\00\01\00\00\00&\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00b\00u\00f\00f\00e\00r\00.\00t\00s")
  (data (i32.const 1296) "\14\00\00\00\01\00\00\00\01\00\00\00\14\00\00\00s\00t\00d\00/\00m\00a\00p\00.\00t\00s")
  (data (i32.const 1344) "$\00\00\00\01\00\00\00\01\00\00\00$\00\00\00K\00e\00y\00 \00d\00o\00e\00s\00 \00n\00o\00t\00 \00e\00x\00i\00s\00t")
  (data (i32.const 1408) "\16\00\00\00\01\00\00\00\01\00\00\00\16\00\00\00~\00l\00i\00b\00/\00m\00a\00p\00.\00t\00s")
@@ -44,17 +44,6 @@
  (global $~lib/rt/tlsf/collectLock (mut i32) (i32.const 0))
  (export "memory" (memory $0))
  (start $~start)
- (func $~lib/rt/pure/__release (param $0 i32)
-  local.get $0
-  i32.const 1556
-  i32.gt_u
-  if
-   local.get $0
-   i32.const 16
-   i32.sub
-   call $~lib/rt/pure/decrement
-  end
- )
  (func $~lib/rt/tlsf/removeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -68,7 +57,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 1152
+   i32.const 1040
    i32.const 277
    i32.const 14
    call $~lib/builtins/abort
@@ -90,7 +79,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 1152
+   i32.const 1040
    i32.const 279
    i32.const 14
    call $~lib/builtins/abort
@@ -133,7 +122,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 1152
+   i32.const 1040
    i32.const 292
    i32.const 14
    call $~lib/builtins/abort
@@ -229,7 +218,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 1152
+   i32.const 1040
    i32.const 205
    i32.const 14
    call $~lib/builtins/abort
@@ -243,7 +232,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 1152
+   i32.const 1040
    i32.const 207
    i32.const 14
    call $~lib/builtins/abort
@@ -316,7 +305,7 @@
    i32.eqz
    if
     i32.const 0
-    i32.const 1152
+    i32.const 1040
     i32.const 228
     i32.const 16
     call $~lib/builtins/abort
@@ -371,7 +360,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 1152
+   i32.const 1040
    i32.const 243
    i32.const 14
    call $~lib/builtins/abort
@@ -386,7 +375,7 @@
   i32.ne
   if
    i32.const 0
-   i32.const 1152
+   i32.const 1040
    i32.const 244
    i32.const 14
    call $~lib/builtins/abort
@@ -434,7 +423,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 1152
+   i32.const 1040
    i32.const 260
    i32.const 14
    call $~lib/builtins/abort
@@ -517,7 +506,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 1152
+   i32.const 1040
    i32.const 386
    i32.const 5
    call $~lib/builtins/abort
@@ -534,7 +523,7 @@
    i32.lt_u
    if
     i32.const 0
-    i32.const 1152
+    i32.const 1040
     i32.const 396
     i32.const 16
     call $~lib/builtins/abort
@@ -562,7 +551,7 @@
    i32.lt_u
    if
     i32.const 0
-    i32.const 1152
+    i32.const 1040
     i32.const 408
     i32.const 5
     call $~lib/builtins/abort
@@ -702,8 +691,8 @@
   i32.const 1073741808
   i32.ge_u
   if
-   i32.const 1200
-   i32.const 1152
+   i32.const 1088
+   i32.const 1040
    i32.const 461
    i32.const 30
    call $~lib/builtins/abort
@@ -776,7 +765,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 1152
+   i32.const 1040
    i32.const 338
    i32.const 14
    call $~lib/builtins/abort
@@ -828,7 +817,7 @@
     i32.eqz
     if
      i32.const 0
-     i32.const 1152
+     i32.const 1040
      i32.const 351
      i32.const 18
      call $~lib/builtins/abort
@@ -861,7 +850,7 @@
   i32.and
   if
    i32.const 0
-   i32.const 1152
+   i32.const 1040
    i32.const 365
    i32.const 14
    call $~lib/builtins/abort
@@ -932,7 +921,7 @@
   global.get $~lib/rt/tlsf/collectLock
   if
    i32.const 0
-   i32.const 1152
+   i32.const 1040
    i32.const 501
    i32.const 14
    call $~lib/builtins/abort
@@ -1023,7 +1012,7 @@
     i32.eqz
     if
      i32.const 0
-     i32.const 1152
+     i32.const 1040
      i32.const 513
      i32.const 20
      call $~lib/builtins/abort
@@ -1039,7 +1028,7 @@
   i32.lt_u
   if
    i32.const 0
-   i32.const 1152
+   i32.const 1040
    i32.const 521
    i32.const 14
    call $~lib/builtins/abort
@@ -1072,6 +1061,68 @@
   call $~lib/rt/tlsf/allocateBlock
   i32.const 16
   i32.add
+ )
+ (func $~lib/rt/pure/__retain (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  local.get $0
+  i32.const 1556
+  i32.gt_u
+  if
+   local.get $0
+   i32.const 16
+   i32.sub
+   local.tee $1
+   i32.load offset=4
+   local.tee $2
+   i32.const -268435456
+   i32.and
+   local.get $2
+   i32.const 1
+   i32.add
+   i32.const -268435456
+   i32.and
+   i32.ne
+   if
+    i32.const 0
+    i32.const 1152
+    i32.const 109
+    i32.const 3
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $1
+   local.get $2
+   i32.const 1
+   i32.add
+   i32.store offset=4
+   local.get $1
+   call $~lib/rt/rtrace/onincrement
+   local.get $1
+   i32.load
+   i32.const 1
+   i32.and
+   if
+    i32.const 0
+    i32.const 1152
+    i32.const 112
+    i32.const 14
+    call $~lib/builtins/abort
+    unreachable
+   end
+  end
+  local.get $0
+ )
+ (func $~lib/rt/pure/__release (param $0 i32)
+  local.get $0
+  i32.const 1556
+  i32.gt_u
+  if
+   local.get $0
+   i32.const 16
+   i32.sub
+   call $~lib/rt/pure/decrement
+  end
  )
  (func $~lib/memory/memory.fill (param $0 i32) (param $1 i32)
   (local $2 i32)
@@ -1231,65 +1282,14 @@
    end
   end
  )
- (func $~lib/rt/pure/__retain (param $0 i32) (result i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  i32.const 1556
-  i32.gt_u
-  if
-   local.get $0
-   i32.const 16
-   i32.sub
-   local.tee $1
-   i32.load offset=4
-   local.tee $2
-   i32.const -268435456
-   i32.and
-   local.get $2
-   i32.const 1
-   i32.add
-   i32.const -268435456
-   i32.and
-   i32.ne
-   if
-    i32.const 0
-    i32.const 1264
-    i32.const 109
-    i32.const 3
-    call $~lib/builtins/abort
-    unreachable
-   end
-   local.get $1
-   local.get $2
-   i32.const 1
-   i32.add
-   i32.store offset=4
-   local.get $1
-   call $~lib/rt/rtrace/onincrement
-   local.get $1
-   i32.load
-   i32.const 1
-   i32.and
-   if
-    i32.const 0
-    i32.const 1264
-    i32.const 112
-    i32.const 14
-    call $~lib/builtins/abort
-    unreachable
-   end
-  end
-  local.get $0
- )
  (func $~lib/arraybuffer/ArrayBuffer#constructor (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   i32.const 1073741808
   i32.gt_u
   if
-   i32.const 1040
-   i32.const 1088
+   i32.const 1200
+   i32.const 1248
    i32.const 49
    i32.const 43
    call $~lib/builtins/abort
@@ -1304,39 +1304,6 @@
   local.get $1
   call $~lib/rt/pure/__retain
   local.tee $0
- )
- (func $~lib/map/Map<i8,i32>#clear (param $0 i32)
-  (local $1 i32)
-  i32.const 16
-  call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $1
-  local.get $0
-  i32.load
-  call $~lib/rt/pure/__release
-  local.get $0
-  local.get $1
-  i32.store
-  local.get $0
-  i32.const 3
-  i32.store offset=4
-  i32.const 48
-  call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $1
-  local.get $0
-  i32.load offset=8
-  call $~lib/rt/pure/__release
-  local.get $0
-  local.get $1
-  i32.store offset=8
-  local.get $0
-  i32.const 4
-  i32.store offset=12
-  local.get $0
-  i32.const 0
-  i32.store offset=16
-  local.get $0
-  i32.const 0
-  i32.store offset=20
  )
  (func $~lib/util/hash/hash8 (param $0 i32) (result i32)
   local.get $0
@@ -1645,7 +1612,7 @@
   if
    i32.const 1360
    i32.const 1424
-   i32.const 113
+   i32.const 110
    i32.const 17
    call $~lib/builtins/abort
    unreachable
@@ -1961,7 +1928,7 @@
    i32.shr_u
    i32.gt_u
    if
-    i32.const 1040
+    i32.const 1200
     i32.const 1472
     i32.const 14
     i32.const 48
@@ -2004,7 +1971,7 @@
    i32.eqz
    if
     i32.const 0
-    i32.const 1152
+    i32.const 1040
     i32.const 581
     i32.const 3
     call $~lib/builtins/abort
@@ -2125,7 +2092,7 @@
   i32.const 1073741808
   i32.gt_u
   if
-   i32.const 1040
+   i32.const 1200
    i32.const 1472
    i32.const 57
    i32.const 60
@@ -2228,7 +2195,7 @@
   i32.const 268435452
   i32.gt_u
   if
-   i32.const 1040
+   i32.const 1200
    i32.const 1472
    i32.const 57
    i32.const 60
@@ -2374,28 +2341,22 @@
   call $~lib/array/Array<i32>#set:length
   local.get $0
  )
- (func $~lib/map/Map<i8,i8>#clear (param $0 i32)
-  (local $1 i32)
+ (func $~lib/map/Map<i32,i32>#constructor (result i32)
+  (local $0 i32)
+  i32.const 24
+  i32.const 7
+  call $~lib/rt/tlsf/__alloc
+  call $~lib/rt/pure/__retain
+  local.tee $0
   i32.const 16
   call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $1
-  local.get $0
-  i32.load
-  call $~lib/rt/pure/__release
-  local.get $0
-  local.get $1
   i32.store
   local.get $0
   i32.const 3
   i32.store offset=4
-  i32.const 32
+  local.get $0
+  i32.const 48
   call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $1
-  local.get $0
-  i32.load offset=8
-  call $~lib/rt/pure/__release
-  local.get $0
-  local.get $1
   i32.store offset=8
   local.get $0
   i32.const 4
@@ -2406,33 +2367,6 @@
   local.get $0
   i32.const 0
   i32.store offset=20
- )
- (func $~lib/map/Map<i32,i32>#constructor (result i32)
-  (local $0 i32)
-  i32.const 24
-  i32.const 7
-  call $~lib/rt/tlsf/__alloc
-  call $~lib/rt/pure/__retain
-  local.tee $0
-  i32.const 0
-  i32.store
-  local.get $0
-  i32.const 0
-  i32.store offset=4
-  local.get $0
-  i32.const 0
-  i32.store offset=8
-  local.get $0
-  i32.const 0
-  i32.store offset=12
-  local.get $0
-  i32.const 0
-  i32.store offset=16
-  local.get $0
-  i32.const 0
-  i32.store offset=20
-  local.get $0
-  call $~lib/map/Map<i8,i32>#clear
   local.get $0
  )
  (func $~lib/array/Array<i32>#__get (param $0 i32) (param $1 i32) (result i32)
@@ -3084,6 +3018,39 @@
    call $~lib/map/Map<i8,i32>#rehash
   end
  )
+ (func $~lib/map/Map<i8,i32>#clear (param $0 i32)
+  (local $1 i32)
+  i32.const 16
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $1
+  local.get $0
+  i32.load
+  call $~lib/rt/pure/__release
+  local.get $0
+  local.get $1
+  i32.store
+  local.get $0
+  i32.const 3
+  i32.store offset=4
+  i32.const 48
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $1
+  local.get $0
+  i32.load offset=8
+  call $~lib/rt/pure/__release
+  local.get $0
+  local.get $1
+  i32.store offset=8
+  local.get $0
+  i32.const 4
+  i32.store offset=12
+  local.get $0
+  i32.const 0
+  i32.store offset=16
+  local.get $0
+  i32.const 0
+  i32.store offset=20
+ )
  (func $std/map/testNumeric<i8,i32>
   (local $0 i32)
   (local $1 i32)
@@ -3098,16 +3065,18 @@
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
   local.tee $0
-  i32.const 0
+  i32.const 16
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store
   local.get $0
-  i32.const 0
+  i32.const 3
   i32.store offset=4
   local.get $0
-  i32.const 0
+  i32.const 48
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store offset=8
   local.get $0
-  i32.const 0
+  i32.const 4
   i32.store offset=12
   local.get $0
   i32.const 0
@@ -3115,8 +3084,6 @@
   local.get $0
   i32.const 0
   i32.store offset=20
-  local.get $0
-  call $~lib/map/Map<i8,i32>#clear
   loop $for-loop|1
    local.get $1
    i32.const 24
@@ -3312,16 +3279,18 @@
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
   local.tee $1
-  i32.const 0
+  i32.const 16
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store
   local.get $1
-  i32.const 0
+  i32.const 3
   i32.store offset=4
   local.get $1
-  i32.const 0
+  i32.const 32
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store offset=8
   local.get $1
-  i32.const 0
+  i32.const 4
   i32.store offset=12
   local.get $1
   i32.const 0
@@ -3329,8 +3298,6 @@
   local.get $1
   i32.const 0
   i32.store offset=20
-  local.get $1
-  call $~lib/map/Map<i8,i8>#clear
   call $~lib/map/Map<i32,i32>#constructor
   local.set $5
   loop $for-loop|4
@@ -3858,7 +3825,7 @@
   if
    i32.const 1360
    i32.const 1424
-   i32.const 113
+   i32.const 110
    i32.const 17
    call $~lib/builtins/abort
    unreachable
@@ -3902,7 +3869,7 @@
   i32.const 1073741808
   i32.gt_u
   if
-   i32.const 1040
+   i32.const 1200
    i32.const 1472
    i32.const 57
    i32.const 60
@@ -4320,16 +4287,18 @@
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
   local.tee $0
-  i32.const 0
+  i32.const 16
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store
   local.get $0
-  i32.const 0
+  i32.const 3
   i32.store offset=4
   local.get $0
-  i32.const 0
+  i32.const 48
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store offset=8
   local.get $0
-  i32.const 0
+  i32.const 4
   i32.store offset=12
   local.get $0
   i32.const 0
@@ -4337,8 +4306,6 @@
   local.get $0
   i32.const 0
   i32.store offset=20
-  local.get $0
-  call $~lib/map/Map<i8,i32>#clear
   loop $for-loop|1
    local.get $1
    i32.const 255
@@ -4520,16 +4487,18 @@
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
   local.tee $1
-  i32.const 0
+  i32.const 16
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store
   local.get $1
-  i32.const 0
+  i32.const 3
   i32.store offset=4
   local.get $1
-  i32.const 0
+  i32.const 32
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store offset=8
   local.get $1
-  i32.const 0
+  i32.const 4
   i32.store offset=12
   local.get $1
   i32.const 0
@@ -4537,8 +4506,6 @@
   local.get $1
   i32.const 0
   i32.store offset=20
-  local.get $1
-  call $~lib/map/Map<i8,i8>#clear
   call $~lib/map/Map<i32,i32>#constructor
   local.set $5
   loop $for-loop|4
@@ -5122,7 +5089,7 @@
   if
    i32.const 1360
    i32.const 1424
-   i32.const 113
+   i32.const 110
    i32.const 17
    call $~lib/builtins/abort
    unreachable
@@ -5217,7 +5184,7 @@
   i32.const 536870904
   i32.gt_u
   if
-   i32.const 1040
+   i32.const 1200
    i32.const 1472
    i32.const 57
    i32.const 60
@@ -5641,28 +5608,28 @@
   i32.const 11
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
-  local.tee $0
-  i32.const 0
+  local.tee $2
+  i32.const 16
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store
-  local.get $0
-  i32.const 0
+  local.get $2
+  i32.const 3
   i32.store offset=4
-  local.get $0
-  i32.const 0
+  local.get $2
+  i32.const 48
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store offset=8
-  local.get $0
-  i32.const 0
+  local.get $2
+  i32.const 4
   i32.store offset=12
-  local.get $0
+  local.get $2
   i32.const 0
   i32.store offset=16
-  local.get $0
+  local.get $2
   i32.const 0
   i32.store offset=20
-  local.get $0
-  call $~lib/map/Map<i8,i32>#clear
   loop $for-loop|1
-   local.get $1
+   local.get $3
    i32.const 16
    i32.shl
    i32.const 16
@@ -5670,8 +5637,8 @@
    i32.const 100
    i32.lt_s
    if
-    local.get $0
-    local.get $1
+    local.get $2
+    local.get $3
     call $~lib/map/Map<i16,i32>#has
     if
      i32.const 0
@@ -5681,9 +5648,9 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $0
-    local.get $1
-    local.get $1
+    local.get $2
+    local.get $3
+    local.get $3
     i32.const 16
     i32.shl
     i32.const 16
@@ -5692,8 +5659,8 @@
     i32.add
     call $~lib/map/Map<i16,i32>#set
     call $~lib/rt/pure/__release
-    local.get $0
-    local.get $1
+    local.get $2
+    local.get $3
     call $~lib/map/Map<i16,i32>#has
     i32.eqz
     if
@@ -5704,10 +5671,10 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $0
-    local.get $1
+    local.get $2
+    local.get $3
     call $~lib/map/Map<i16,i32>#get
-    local.get $1
+    local.get $3
     i32.const 16
     i32.shl
     i32.const 16
@@ -5723,14 +5690,14 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $1
+    local.get $3
     i32.const 1
     i32.add
-    local.set $1
+    local.set $3
     br $for-loop|1
    end
   end
-  local.get $0
+  local.get $2
   i32.load offset=20
   i32.const 100
   i32.ne
@@ -5743,9 +5710,9 @@
    unreachable
   end
   i32.const 0
-  local.set $1
+  local.set $3
   loop $for-loop|3
-   local.get $1
+   local.get $3
    i32.const 16
    i32.shl
    i32.const 16
@@ -5753,8 +5720,8 @@
    i32.const 100
    i32.lt_s
    if
-    local.get $0
-    local.get $1
+    local.get $2
+    local.get $3
     call $~lib/map/Map<i16,i32>#has
     i32.eqz
     if
@@ -5765,10 +5732,10 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $0
-    local.get $1
+    local.get $2
+    local.get $3
     call $~lib/map/Map<i16,i32>#get
-    local.get $1
+    local.get $3
     i32.const 16
     i32.shl
     i32.const 16
@@ -5784,9 +5751,9 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $0
-    local.get $1
-    local.get $1
+    local.get $2
+    local.get $3
+    local.get $3
     i32.const 16
     i32.shl
     i32.const 16
@@ -5795,8 +5762,8 @@
     i32.add
     call $~lib/map/Map<i16,i32>#set
     call $~lib/rt/pure/__release
-    local.get $0
-    local.get $1
+    local.get $2
+    local.get $3
     call $~lib/map/Map<i16,i32>#has
     i32.eqz
     if
@@ -5807,10 +5774,10 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $0
-    local.get $1
+    local.get $2
+    local.get $3
     call $~lib/map/Map<i16,i32>#get
-    local.get $1
+    local.get $3
     i32.const 16
     i32.shl
     i32.const 16
@@ -5826,14 +5793,14 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $1
+    local.get $3
     i32.const 1
     i32.add
-    local.set $1
+    local.set $3
     br $for-loop|3
    end
   end
-  local.get $0
+  local.get $2
   i32.load offset=20
   i32.const 100
   i32.ne
@@ -5845,10 +5812,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $2
   call $~lib/map/Map<i16,i32>#keys
   local.set $4
-  local.get $0
+  local.get $2
   call $~lib/map/Map<i8,i32>#values
   local.set $6
   i32.const 24
@@ -5856,16 +5823,18 @@
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
   local.tee $3
-  i32.const 0
+  i32.const 16
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store
   local.get $3
-  i32.const 0
+  i32.const 3
   i32.store offset=4
   local.get $3
-  i32.const 0
+  i32.const 32
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store offset=8
   local.get $3
-  i32.const 0
+  i32.const 4
   i32.store offset=12
   local.get $3
   i32.const 0
@@ -5873,17 +5842,16 @@
   local.get $3
   i32.const 0
   i32.store offset=20
-  local.get $3
-  call $~lib/map/Map<i8,i8>#clear
   call $~lib/map/Map<i32,i32>#constructor
   local.set $5
   loop $for-loop|4
-   local.get $2
+   local.get $0
    local.get $4
    i32.load offset=12
    i32.lt_s
    if
-    local.get $2
+    local.get $0
+    local.tee $1
     local.get $4
     i32.load offset=12
     i32.ge_u
@@ -5897,18 +5865,18 @@
     end
     local.get $4
     i32.load offset=4
-    local.get $2
+    local.get $1
     i32.const 1
     i32.shl
     i32.add
     i32.load16_s
-    local.set $1
+    local.set $0
     local.get $6
-    local.get $2
+    local.get $1
     call $~lib/array/Array<i32>#__get
     local.set $7
+    local.get $2
     local.get $0
-    local.get $1
     call $~lib/map/Map<i16,i32>#has
     i32.eqz
     if
@@ -5919,7 +5887,7 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $0
+    local.get $2
     local.get $7
     i32.const 20
     i32.sub
@@ -5934,22 +5902,22 @@
      unreachable
     end
     local.get $3
-    local.get $1
-    local.get $1
+    local.get $0
+    local.get $0
     call $~lib/map/Map<i16,i16>#set
     call $~lib/rt/pure/__release
     local.get $5
     local.get $7
     i32.const 20
     i32.sub
-    local.tee $1
-    local.get $1
+    local.tee $0
+    local.get $0
     call $~lib/map/Map<i32,i32>#set
     call $~lib/rt/pure/__release
-    local.get $2
+    local.get $1
     i32.const 1
     i32.add
-    local.set $2
+    local.set $0
     br $for-loop|4
    end
   end
@@ -5978,9 +5946,9 @@
    unreachable
   end
   i32.const 0
-  local.set $2
+  local.set $0
   loop $for-loop|6
-   local.get $2
+   local.get $0
    i32.const 16
    i32.shl
    i32.const 16
@@ -5988,8 +5956,8 @@
    i32.const 50
    i32.lt_s
    if
-    local.get $0
     local.get $2
+    local.get $0
     call $~lib/map/Map<i16,i32>#has
     i32.eqz
     if
@@ -6000,10 +5968,10 @@
      call $~lib/builtins/abort
      unreachable
     end
+    local.get $2
     local.get $0
-    local.get $2
     call $~lib/map/Map<i16,i32>#get
-    local.get $2
+    local.get $0
     i32.const 16
     i32.shl
     i32.const 16
@@ -6019,11 +5987,11 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $0
     local.get $2
+    local.get $0
     call $~lib/map/Map<i16,i32>#delete
-    local.get $0
     local.get $2
+    local.get $0
     call $~lib/map/Map<i16,i32>#has
     if
      i32.const 0
@@ -6033,14 +6001,14 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $2
+    local.get $0
     i32.const 1
     i32.add
-    local.set $2
+    local.set $0
     br $for-loop|6
    end
   end
-  local.get $0
+  local.get $2
   i32.load offset=20
   i32.const 50
   i32.ne
@@ -6053,9 +6021,9 @@
    unreachable
   end
   i32.const 0
-  local.set $2
+  local.set $0
   loop $for-loop|8
-   local.get $2
+   local.get $0
    i32.const 16
    i32.shl
    i32.const 16
@@ -6063,8 +6031,8 @@
    i32.const 50
    i32.lt_s
    if
-    local.get $0
     local.get $2
+    local.get $0
     call $~lib/map/Map<i16,i32>#has
     if
      i32.const 0
@@ -6074,9 +6042,9 @@
      call $~lib/builtins/abort
      unreachable
     end
+    local.get $2
     local.get $0
-    local.get $2
-    local.get $2
+    local.get $0
     i32.const 16
     i32.shl
     i32.const 16
@@ -6085,8 +6053,8 @@
     i32.add
     call $~lib/map/Map<i16,i32>#set
     call $~lib/rt/pure/__release
-    local.get $0
     local.get $2
+    local.get $0
     call $~lib/map/Map<i16,i32>#has
     i32.eqz
     if
@@ -6097,11 +6065,11 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $0
     local.get $2
+    local.get $0
     call $~lib/map/Map<i16,i32>#delete
-    local.get $0
     local.get $2
+    local.get $0
     call $~lib/map/Map<i16,i32>#has
     if
      i32.const 0
@@ -6111,14 +6079,14 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $2
+    local.get $0
     i32.const 1
     i32.add
-    local.set $2
+    local.set $0
     br $for-loop|8
    end
   end
-  local.get $0
+  local.get $2
   i32.load offset=20
   i32.const 50
   i32.ne
@@ -6130,9 +6098,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $2
   call $~lib/map/Map<i8,i32>#clear
-  local.get $0
+  local.get $2
   i32.load offset=20
   if
    i32.const 0
@@ -6150,7 +6118,7 @@
   call $~lib/rt/pure/__release
   local.get $5
   call $~lib/rt/pure/__release
-  local.get $0
+  local.get $2
   call $~lib/rt/pure/__release
  )
  (func $~lib/map/Map<u16,i32>#has (param $0 i32) (param $1 i32) (result i32)
@@ -6404,7 +6372,7 @@
   if
    i32.const 1360
    i32.const 1424
-   i32.const 113
+   i32.const 110
    i32.const 17
    call $~lib/builtins/abort
    unreachable
@@ -6449,7 +6417,7 @@
   i32.const 536870904
   i32.gt_u
   if
-   i32.const 1040
+   i32.const 1200
    i32.const 1472
    i32.const 57
    i32.const 60
@@ -6869,35 +6837,35 @@
   i32.const 14
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
-  local.tee $0
-  i32.const 0
+  local.tee $2
+  i32.const 16
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store
-  local.get $0
-  i32.const 0
+  local.get $2
+  i32.const 3
   i32.store offset=4
-  local.get $0
-  i32.const 0
+  local.get $2
+  i32.const 48
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store offset=8
-  local.get $0
-  i32.const 0
+  local.get $2
+  i32.const 4
   i32.store offset=12
-  local.get $0
+  local.get $2
   i32.const 0
   i32.store offset=16
-  local.get $0
+  local.get $2
   i32.const 0
   i32.store offset=20
-  local.get $0
-  call $~lib/map/Map<i8,i32>#clear
   loop $for-loop|1
-   local.get $1
+   local.get $3
    i32.const 65535
    i32.and
    i32.const 100
    i32.lt_u
    if
-    local.get $0
-    local.get $1
+    local.get $2
+    local.get $3
     call $~lib/map/Map<u16,i32>#has
     if
      i32.const 0
@@ -6907,17 +6875,17 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $0
-    local.get $1
-    local.get $1
+    local.get $2
+    local.get $3
+    local.get $3
     i32.const 65535
     i32.and
     i32.const 10
     i32.add
     call $~lib/map/Map<u16,i32>#set
     call $~lib/rt/pure/__release
-    local.get $0
-    local.get $1
+    local.get $2
+    local.get $3
     call $~lib/map/Map<u16,i32>#has
     i32.eqz
     if
@@ -6928,10 +6896,10 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $0
-    local.get $1
+    local.get $2
+    local.get $3
     call $~lib/map/Map<u16,i32>#get
-    local.get $1
+    local.get $3
     i32.const 65535
     i32.and
     i32.const 10
@@ -6945,14 +6913,14 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $1
+    local.get $3
     i32.const 1
     i32.add
-    local.set $1
+    local.set $3
     br $for-loop|1
    end
   end
-  local.get $0
+  local.get $2
   i32.load offset=20
   i32.const 100
   i32.ne
@@ -6965,16 +6933,16 @@
    unreachable
   end
   i32.const 0
-  local.set $1
+  local.set $3
   loop $for-loop|3
-   local.get $1
+   local.get $3
    i32.const 65535
    i32.and
    i32.const 100
    i32.lt_u
    if
-    local.get $0
-    local.get $1
+    local.get $2
+    local.get $3
     call $~lib/map/Map<u16,i32>#has
     i32.eqz
     if
@@ -6985,10 +6953,10 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $0
-    local.get $1
+    local.get $2
+    local.get $3
     call $~lib/map/Map<u16,i32>#get
-    local.get $1
+    local.get $3
     i32.const 65535
     i32.and
     i32.const 10
@@ -7002,17 +6970,17 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $0
-    local.get $1
-    local.get $1
+    local.get $2
+    local.get $3
+    local.get $3
     i32.const 65535
     i32.and
     i32.const 20
     i32.add
     call $~lib/map/Map<u16,i32>#set
     call $~lib/rt/pure/__release
-    local.get $0
-    local.get $1
+    local.get $2
+    local.get $3
     call $~lib/map/Map<u16,i32>#has
     i32.eqz
     if
@@ -7023,10 +6991,10 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $0
-    local.get $1
+    local.get $2
+    local.get $3
     call $~lib/map/Map<u16,i32>#get
-    local.get $1
+    local.get $3
     i32.const 65535
     i32.and
     i32.const 20
@@ -7040,14 +7008,14 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $1
+    local.get $3
     i32.const 1
     i32.add
-    local.set $1
+    local.set $3
     br $for-loop|3
    end
   end
-  local.get $0
+  local.get $2
   i32.load offset=20
   i32.const 100
   i32.ne
@@ -7059,10 +7027,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $2
   call $~lib/map/Map<u16,i32>#keys
   local.set $4
-  local.get $0
+  local.get $2
   call $~lib/map/Map<i8,i32>#values
   local.set $6
   i32.const 24
@@ -7070,16 +7038,18 @@
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
   local.tee $3
-  i32.const 0
+  i32.const 16
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store
   local.get $3
-  i32.const 0
+  i32.const 3
   i32.store offset=4
   local.get $3
-  i32.const 0
+  i32.const 32
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store offset=8
   local.get $3
-  i32.const 0
+  i32.const 4
   i32.store offset=12
   local.get $3
   i32.const 0
@@ -7087,17 +7057,16 @@
   local.get $3
   i32.const 0
   i32.store offset=20
-  local.get $3
-  call $~lib/map/Map<i8,i8>#clear
   call $~lib/map/Map<i32,i32>#constructor
   local.set $5
   loop $for-loop|4
-   local.get $2
+   local.get $0
    local.get $4
    i32.load offset=12
    i32.lt_s
    if
-    local.get $2
+    local.get $0
+    local.tee $1
     local.get $4
     i32.load offset=12
     i32.ge_u
@@ -7111,18 +7080,18 @@
     end
     local.get $4
     i32.load offset=4
-    local.get $2
+    local.get $1
     i32.const 1
     i32.shl
     i32.add
     i32.load16_u
-    local.set $1
+    local.set $0
     local.get $6
-    local.get $2
+    local.get $1
     call $~lib/array/Array<i32>#__get
     local.set $7
+    local.get $2
     local.get $0
-    local.get $1
     call $~lib/map/Map<u16,i32>#has
     i32.eqz
     if
@@ -7133,7 +7102,7 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $0
+    local.get $2
     local.get $7
     i32.const 20
     i32.sub
@@ -7148,22 +7117,22 @@
      unreachable
     end
     local.get $3
-    local.get $1
-    local.get $1
+    local.get $0
+    local.get $0
     call $~lib/map/Map<u16,u16>#set
     call $~lib/rt/pure/__release
     local.get $5
     local.get $7
     i32.const 20
     i32.sub
-    local.tee $1
-    local.get $1
+    local.tee $0
+    local.get $0
     call $~lib/map/Map<i32,i32>#set
     call $~lib/rt/pure/__release
-    local.get $2
+    local.get $1
     i32.const 1
     i32.add
-    local.set $2
+    local.set $0
     br $for-loop|4
    end
   end
@@ -7192,16 +7161,16 @@
    unreachable
   end
   i32.const 0
-  local.set $2
+  local.set $0
   loop $for-loop|6
-   local.get $2
+   local.get $0
    i32.const 65535
    i32.and
    i32.const 50
    i32.lt_u
    if
-    local.get $0
     local.get $2
+    local.get $0
     call $~lib/map/Map<u16,i32>#has
     i32.eqz
     if
@@ -7212,10 +7181,10 @@
      call $~lib/builtins/abort
      unreachable
     end
+    local.get $2
     local.get $0
-    local.get $2
     call $~lib/map/Map<u16,i32>#get
-    local.get $2
+    local.get $0
     i32.const 65535
     i32.and
     i32.const 20
@@ -7229,11 +7198,11 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $0
     local.get $2
+    local.get $0
     call $~lib/map/Map<u16,i32>#delete
-    local.get $0
     local.get $2
+    local.get $0
     call $~lib/map/Map<u16,i32>#has
     if
      i32.const 0
@@ -7243,14 +7212,14 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $2
+    local.get $0
     i32.const 1
     i32.add
-    local.set $2
+    local.set $0
     br $for-loop|6
    end
   end
-  local.get $0
+  local.get $2
   i32.load offset=20
   i32.const 50
   i32.ne
@@ -7263,16 +7232,16 @@
    unreachable
   end
   i32.const 0
-  local.set $2
+  local.set $0
   loop $for-loop|8
-   local.get $2
+   local.get $0
    i32.const 65535
    i32.and
    i32.const 50
    i32.lt_u
    if
-    local.get $0
     local.get $2
+    local.get $0
     call $~lib/map/Map<u16,i32>#has
     if
      i32.const 0
@@ -7282,17 +7251,17 @@
      call $~lib/builtins/abort
      unreachable
     end
+    local.get $2
     local.get $0
-    local.get $2
-    local.get $2
+    local.get $0
     i32.const 65535
     i32.and
     i32.const 10
     i32.add
     call $~lib/map/Map<u16,i32>#set
     call $~lib/rt/pure/__release
-    local.get $0
     local.get $2
+    local.get $0
     call $~lib/map/Map<u16,i32>#has
     i32.eqz
     if
@@ -7303,11 +7272,11 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $0
     local.get $2
+    local.get $0
     call $~lib/map/Map<u16,i32>#delete
-    local.get $0
     local.get $2
+    local.get $0
     call $~lib/map/Map<u16,i32>#has
     if
      i32.const 0
@@ -7317,14 +7286,14 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $2
+    local.get $0
     i32.const 1
     i32.add
-    local.set $2
+    local.set $0
     br $for-loop|8
    end
   end
-  local.get $0
+  local.get $2
   i32.load offset=20
   i32.const 50
   i32.ne
@@ -7336,9 +7305,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $2
   call $~lib/map/Map<i8,i32>#clear
-  local.get $0
+  local.get $2
   i32.load offset=20
   if
    i32.const 0
@@ -7356,7 +7325,7 @@
   call $~lib/rt/pure/__release
   local.get $5
   call $~lib/rt/pure/__release
-  local.get $0
+  local.get $2
   call $~lib/rt/pure/__release
  )
  (func $~lib/map/Map<i32,i32>#has (param $0 i32) (param $1 i32) (result i32)
@@ -7379,7 +7348,7 @@
   if
    i32.const 1360
    i32.const 1424
-   i32.const 113
+   i32.const 110
    i32.const 17
    call $~lib/builtins/abort
    unreachable
@@ -7945,7 +7914,7 @@
   i32.const 268435452
   i32.gt_u
   if
-   i32.const 1040
+   i32.const 1200
    i32.const 1472
    i32.const 57
    i32.const 60
@@ -8039,16 +8008,18 @@
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
   local.tee $0
-  i32.const 0
+  i32.const 16
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store
   local.get $0
-  i32.const 0
+  i32.const 3
   i32.store offset=4
   local.get $0
-  i32.const 0
+  i32.const 48
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store offset=8
   local.get $0
-  i32.const 0
+  i32.const 4
   i32.store offset=12
   local.get $0
   i32.const 0
@@ -8056,8 +8027,6 @@
   local.get $0
   i32.const 0
   i32.store offset=20
-  local.get $0
-  call $~lib/map/Map<i8,i32>#clear
   loop $for-loop|0
    local.get $1
    i32.const 100
@@ -8225,16 +8194,18 @@
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
   local.tee $1
-  i32.const 0
+  i32.const 16
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store
   local.get $1
-  i32.const 0
+  i32.const 3
   i32.store offset=4
   local.get $1
-  i32.const 0
+  i32.const 48
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store offset=8
   local.get $1
-  i32.const 0
+  i32.const 4
   i32.store offset=12
   local.get $1
   i32.const 0
@@ -8242,8 +8213,6 @@
   local.get $1
   i32.const 0
   i32.store offset=20
-  local.get $1
-  call $~lib/map/Map<i8,i32>#clear
   call $~lib/map/Map<i32,i32>#constructor
   local.set $5
   loop $for-loop|2
@@ -8489,39 +8458,6 @@
   call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
- )
- (func $~lib/map/Map<i64,i32>#clear (param $0 i32)
-  (local $1 i32)
-  i32.const 16
-  call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $1
-  local.get $0
-  i32.load
-  call $~lib/rt/pure/__release
-  local.get $0
-  local.get $1
-  i32.store
-  local.get $0
-  i32.const 3
-  i32.store offset=4
-  i32.const 64
-  call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $1
-  local.get $0
-  i32.load offset=8
-  call $~lib/rt/pure/__release
-  local.get $0
-  local.get $1
-  i32.store offset=8
-  local.get $0
-  i32.const 4
-  i32.store offset=12
-  local.get $0
-  i32.const 0
-  i32.store offset=16
-  local.get $0
-  i32.const 0
-  i32.store offset=20
  )
  (func $~lib/util/hash/hash64 (param $0 i64) (result i32)
   (local $1 i32)
@@ -8875,7 +8811,7 @@
   if
    i32.const 1360
    i32.const 1424
-   i32.const 113
+   i32.const 110
    i32.const 17
    call $~lib/builtins/abort
    unreachable
@@ -8970,7 +8906,7 @@
   i32.const 134217726
   i32.gt_u
   if
-   i32.const 1040
+   i32.const 1200
    i32.const 1472
    i32.const 57
    i32.const 60
@@ -9101,39 +9037,6 @@
   local.get $1
   call $~lib/array/Array<i32>#set:length
   local.get $0
- )
- (func $~lib/map/Map<i64,i64>#clear (param $0 i32)
-  (local $1 i32)
-  i32.const 16
-  call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $1
-  local.get $0
-  i32.load
-  call $~lib/rt/pure/__release
-  local.get $0
-  local.get $1
-  i32.store
-  local.get $0
-  i32.const 3
-  i32.store offset=4
-  i32.const 96
-  call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $1
-  local.get $0
-  i32.load offset=8
-  call $~lib/rt/pure/__release
-  local.get $0
-  local.get $1
-  i32.store offset=8
-  local.get $0
-  i32.const 4
-  i32.store offset=12
-  local.get $0
-  i32.const 0
-  i32.store offset=16
-  local.get $0
-  i32.const 0
-  i32.store offset=20
  )
  (func $~lib/array/Array<i64>#__get (param $0 i32) (param $1 i32) (result i64)
   local.get $1
@@ -9477,6 +9380,39 @@
    call $~lib/map/Map<i64,i32>#rehash
   end
  )
+ (func $~lib/map/Map<i64,i32>#clear (param $0 i32)
+  (local $1 i32)
+  i32.const 16
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $1
+  local.get $0
+  i32.load
+  call $~lib/rt/pure/__release
+  local.get $0
+  local.get $1
+  i32.store
+  local.get $0
+  i32.const 3
+  i32.store offset=4
+  i32.const 64
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $1
+  local.get $0
+  i32.load offset=8
+  call $~lib/rt/pure/__release
+  local.get $0
+  local.get $1
+  i32.store offset=8
+  local.get $0
+  i32.const 4
+  i32.store offset=12
+  local.get $0
+  i32.const 0
+  i32.store offset=16
+  local.get $0
+  i32.const 0
+  i32.store offset=20
+ )
  (func $std/map/testNumeric<i64,i32>
   (local $0 i64)
   (local $1 i32)
@@ -9491,16 +9427,18 @@
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
   local.tee $1
-  i32.const 0
+  i32.const 16
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store
   local.get $1
-  i32.const 0
+  i32.const 3
   i32.store offset=4
   local.get $1
-  i32.const 0
+  i32.const 64
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store offset=8
   local.get $1
-  i32.const 0
+  i32.const 4
   i32.store offset=12
   local.get $1
   i32.const 0
@@ -9508,8 +9446,6 @@
   local.get $1
   i32.const 0
   i32.store offset=20
-  local.get $1
-  call $~lib/map/Map<i64,i32>#clear
   loop $for-loop|0
    local.get $0
    i64.const 100
@@ -9682,16 +9618,18 @@
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
   local.tee $2
-  i32.const 0
+  i32.const 16
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store
   local.get $2
-  i32.const 0
+  i32.const 3
   i32.store offset=4
   local.get $2
-  i32.const 0
+  i32.const 96
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store offset=8
   local.get $2
-  i32.const 0
+  i32.const 4
   i32.store offset=12
   local.get $2
   i32.const 0
@@ -9699,8 +9637,6 @@
   local.get $2
   i32.const 0
   i32.store offset=20
-  local.get $2
-  call $~lib/map/Map<i64,i64>#clear
   call $~lib/map/Map<i32,i32>#constructor
   local.set $6
   loop $for-loop|2
@@ -9987,7 +9923,7 @@
   i32.const 134217726
   i32.gt_u
   if
-   i32.const 1040
+   i32.const 1200
    i32.const 1472
    i32.const 57
    i32.const 60
@@ -10081,16 +10017,18 @@
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
   local.tee $1
-  i32.const 0
+  i32.const 16
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store
   local.get $1
-  i32.const 0
+  i32.const 3
   i32.store offset=4
   local.get $1
-  i32.const 0
+  i32.const 64
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store offset=8
   local.get $1
-  i32.const 0
+  i32.const 4
   i32.store offset=12
   local.get $1
   i32.const 0
@@ -10098,8 +10036,6 @@
   local.get $1
   i32.const 0
   i32.store offset=20
-  local.get $1
-  call $~lib/map/Map<i64,i32>#clear
   loop $for-loop|0
    local.get $0
    i64.const 100
@@ -10272,16 +10208,18 @@
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
   local.tee $2
-  i32.const 0
+  i32.const 16
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store
   local.get $2
-  i32.const 0
+  i32.const 3
   i32.store offset=4
   local.get $2
-  i32.const 0
+  i32.const 96
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store offset=8
   local.get $2
-  i32.const 0
+  i32.const 4
   i32.store offset=12
   local.get $2
   i32.const 0
@@ -10289,8 +10227,6 @@
   local.get $2
   i32.const 0
   i32.store offset=20
-  local.get $2
-  call $~lib/map/Map<i64,i64>#clear
   call $~lib/map/Map<i32,i32>#constructor
   local.set $6
   loop $for-loop|2
@@ -10830,7 +10766,7 @@
   if
    i32.const 1360
    i32.const 1424
-   i32.const 113
+   i32.const 110
    i32.const 17
    call $~lib/builtins/abort
    unreachable
@@ -10876,7 +10812,7 @@
   i32.const 268435452
   i32.gt_u
   if
-   i32.const 1040
+   i32.const 1200
    i32.const 1472
    i32.const 57
    i32.const 60
@@ -11291,16 +11227,18 @@
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
   local.tee $1
-  i32.const 0
+  i32.const 16
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store
   local.get $1
-  i32.const 0
+  i32.const 3
   i32.store offset=4
   local.get $1
-  i32.const 0
+  i32.const 48
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store offset=8
   local.get $1
-  i32.const 0
+  i32.const 4
   i32.store offset=12
   local.get $1
   i32.const 0
@@ -11308,8 +11246,6 @@
   local.get $1
   i32.const 0
   i32.store offset=20
-  local.get $1
-  call $~lib/map/Map<i8,i32>#clear
   loop $for-loop|0
    local.get $0
    f32.const 100
@@ -11482,16 +11418,18 @@
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
   local.tee $2
-  i32.const 0
+  i32.const 16
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store
   local.get $2
-  i32.const 0
+  i32.const 3
   i32.store offset=4
   local.get $2
-  i32.const 0
+  i32.const 48
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store offset=8
   local.get $2
-  i32.const 0
+  i32.const 4
   i32.store offset=12
   local.get $2
   i32.const 0
@@ -11499,8 +11437,6 @@
   local.get $2
   i32.const 0
   i32.store offset=20
-  local.get $2
-  call $~lib/map/Map<i8,i32>#clear
   call $~lib/map/Map<i32,i32>#constructor
   local.set $6
   loop $for-loop|2
@@ -12056,7 +11992,7 @@
   if
    i32.const 1360
    i32.const 1424
-   i32.const 113
+   i32.const 110
    i32.const 17
    call $~lib/builtins/abort
    unreachable
@@ -12102,7 +12038,7 @@
   i32.const 134217726
   i32.gt_u
   if
-   i32.const 1040
+   i32.const 1200
    i32.const 1472
    i32.const 57
    i32.const 60
@@ -12553,16 +12489,18 @@
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
   local.tee $1
-  i32.const 0
+  i32.const 16
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store
   local.get $1
-  i32.const 0
+  i32.const 3
   i32.store offset=4
   local.get $1
-  i32.const 0
+  i32.const 64
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store offset=8
   local.get $1
-  i32.const 0
+  i32.const 4
   i32.store offset=12
   local.get $1
   i32.const 0
@@ -12570,8 +12508,6 @@
   local.get $1
   i32.const 0
   i32.store offset=20
-  local.get $1
-  call $~lib/map/Map<i64,i32>#clear
   loop $for-loop|0
    local.get $0
    f64.const 100
@@ -12744,16 +12680,18 @@
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
   local.tee $2
-  i32.const 0
+  i32.const 16
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store
   local.get $2
-  i32.const 0
+  i32.const 3
   i32.store offset=4
   local.get $2
-  i32.const 0
+  i32.const 96
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store offset=8
   local.get $2
-  i32.const 0
+  i32.const 4
   i32.store offset=12
   local.get $2
   i32.const 0
@@ -12761,8 +12699,6 @@
   local.get $2
   i32.const 0
   i32.store offset=20
-  local.get $2
-  call $~lib/map/Map<i64,i64>#clear
   call $~lib/map/Map<i32,i32>#constructor
   local.set $6
   loop $for-loop|2
@@ -13057,7 +12993,7 @@
   i32.and
   if
    i32.const 0
-   i32.const 1264
+   i32.const 1152
    i32.const 122
    i32.const 14
    call $~lib/builtins/abort
@@ -13106,7 +13042,7 @@
    i32.and
    if
     i32.const 0
-    i32.const 1264
+    i32.const 1152
     i32.const 126
     i32.const 18
     call $~lib/builtins/abort
@@ -13121,7 +13057,7 @@
    i32.le_u
    if
     i32.const 0
-    i32.const 1264
+    i32.const 1152
     i32.const 136
     i32.const 16
     call $~lib/builtins/abort

--- a/tests/compiler/std/map.untouched.wat
+++ b/tests/compiler/std/map.untouched.wat
@@ -2,8 +2,8 @@
  (type $i32_=>_i32 (func (param i32) (result i32)))
  (type $i32_i32_=>_none (func (param i32 i32)))
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
- (type $i32_=>_none (func (param i32)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
+ (type $i32_=>_none (func (param i32)))
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
  (type $none_=>_none (func))
  (type $i32_i64_=>_i32 (func (param i32 i64) (result i32)))
@@ -31,11 +31,11 @@
  (import "rtrace" "onfree" (func $~lib/rt/rtrace/onfree (param i32)))
  (import "rtrace" "ondecrement" (func $~lib/rt/rtrace/ondecrement (param i32)))
  (memory $0 1)
- (data (i32.const 16) "\1c\00\00\00\01\00\00\00\01\00\00\00\1c\00\00\00I\00n\00v\00a\00l\00i\00d\00 \00l\00e\00n\00g\00t\00h\00")
- (data (i32.const 64) "&\00\00\00\01\00\00\00\01\00\00\00&\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00b\00u\00f\00f\00e\00r\00.\00t\00s\00")
- (data (i32.const 128) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s\00")
- (data (i32.const 176) "(\00\00\00\01\00\00\00\01\00\00\00(\00\00\00a\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e\00")
- (data (i32.const 240) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00p\00u\00r\00e\00.\00t\00s\00")
+ (data (i32.const 16) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s\00")
+ (data (i32.const 64) "(\00\00\00\01\00\00\00\01\00\00\00(\00\00\00a\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e\00")
+ (data (i32.const 128) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00p\00u\00r\00e\00.\00t\00s\00")
+ (data (i32.const 176) "\1c\00\00\00\01\00\00\00\01\00\00\00\1c\00\00\00I\00n\00v\00a\00l\00i\00d\00 \00l\00e\00n\00g\00t\00h\00")
+ (data (i32.const 224) "&\00\00\00\01\00\00\00\01\00\00\00&\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00b\00u\00f\00f\00e\00r\00.\00t\00s\00")
  (data (i32.const 288) "\14\00\00\00\01\00\00\00\01\00\00\00\14\00\00\00s\00t\00d\00/\00m\00a\00p\00.\00t\00s\00")
  (data (i32.const 336) "$\00\00\00\01\00\00\00\01\00\00\00$\00\00\00K\00e\00y\00 \00d\00o\00e\00s\00 \00n\00o\00t\00 \00e\00x\00i\00s\00t\00")
  (data (i32.const 400) "\16\00\00\00\01\00\00\00\01\00\00\00\16\00\00\00~\00l\00i\00b\00/\00m\00a\00p\00.\00t\00s\00")
@@ -50,17 +50,6 @@
  (global $~lib/heap/__heap_base i32 (i32.const 548))
  (export "memory" (memory $0))
  (start $~start)
- (func $~lib/rt/pure/__release (param $0 i32)
-  local.get $0
-  global.get $~lib/heap/__heap_base
-  i32.gt_u
-  if
-   local.get $0
-   i32.const 16
-   i32.sub
-   call $~lib/rt/pure/decrement
-  end
- )
  (func $~lib/rt/tlsf/removeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -83,7 +72,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 277
    i32.const 14
    call $~lib/builtins/abort
@@ -110,7 +99,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 279
    i32.const 14
    call $~lib/builtins/abort
@@ -164,7 +153,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 292
    i32.const 14
    call $~lib/builtins/abort
@@ -296,7 +285,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 205
    i32.const 14
    call $~lib/builtins/abort
@@ -313,7 +302,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 207
    i32.const 14
    call $~lib/builtins/abort
@@ -408,7 +397,7 @@
    i32.eqz
    if
     i32.const 0
-    i32.const 144
+    i32.const 32
     i32.const 228
     i32.const 16
     call $~lib/builtins/abort
@@ -473,7 +462,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 243
    i32.const 14
    call $~lib/builtins/abort
@@ -491,7 +480,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 244
    i32.const 14
    call $~lib/builtins/abort
@@ -550,7 +539,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 260
    i32.const 14
    call $~lib/builtins/abort
@@ -671,7 +660,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 386
    i32.const 5
    call $~lib/builtins/abort
@@ -696,7 +685,7 @@
    i32.eqz
    if
     i32.const 0
-    i32.const 144
+    i32.const 32
     i32.const 396
     i32.const 16
     call $~lib/builtins/abort
@@ -729,7 +718,7 @@
    i32.eqz
    if
     i32.const 0
-    i32.const 144
+    i32.const 32
     i32.const 408
     i32.const 5
     call $~lib/builtins/abort
@@ -960,8 +949,8 @@
   i32.const 1073741808
   i32.ge_u
   if
-   i32.const 192
-   i32.const 144
+   i32.const 80
+   i32.const 32
    i32.const 461
    i32.const 30
    call $~lib/builtins/abort
@@ -1057,7 +1046,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 338
    i32.const 14
    call $~lib/builtins/abort
@@ -1122,7 +1111,7 @@
     i32.eqz
     if
      i32.const 0
-     i32.const 144
+     i32.const 32
      i32.const 351
      i32.const 18
      call $~lib/builtins/abort
@@ -1271,7 +1260,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 365
    i32.const 14
    call $~lib/builtins/abort
@@ -1364,7 +1353,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 501
    i32.const 14
    call $~lib/builtins/abort
@@ -1411,7 +1400,7 @@
      i32.eqz
      if
       i32.const 0
-      i32.const 144
+      i32.const 32
       i32.const 513
       i32.const 20
       call $~lib/builtins/abort
@@ -1432,7 +1421,7 @@
     i32.eqz
     if
      i32.const 0
-     i32.const 144
+     i32.const 32
      i32.const 518
      i32.const 18
      call $~lib/builtins/abort
@@ -1453,7 +1442,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 521
    i32.const 14
    call $~lib/builtins/abort
@@ -1488,6 +1477,82 @@
   call $~lib/rt/tlsf/allocateBlock
   i32.const 16
   i32.add
+ )
+ (func $~lib/rt/pure/increment (param $0 i32)
+  (local $1 i32)
+  local.get $0
+  i32.load offset=4
+  local.set $1
+  local.get $1
+  i32.const 268435455
+  i32.const -1
+  i32.xor
+  i32.and
+  local.get $1
+  i32.const 1
+  i32.add
+  i32.const 268435455
+  i32.const -1
+  i32.xor
+  i32.and
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 144
+   i32.const 109
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  local.get $1
+  i32.const 1
+  i32.add
+  i32.store offset=4
+  i32.const 1
+  drop
+  local.get $0
+  call $~lib/rt/rtrace/onincrement
+  i32.const 1
+  drop
+  local.get $0
+  i32.load
+  i32.const 1
+  i32.and
+  i32.eqz
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 144
+   i32.const 112
+   i32.const 14
+   call $~lib/builtins/abort
+   unreachable
+  end
+ )
+ (func $~lib/rt/pure/__retain (param $0 i32) (result i32)
+  local.get $0
+  global.get $~lib/heap/__heap_base
+  i32.gt_u
+  if
+   local.get $0
+   i32.const 16
+   i32.sub
+   call $~lib/rt/pure/increment
+  end
+  local.get $0
+ )
+ (func $~lib/rt/pure/__release (param $0 i32)
+  local.get $0
+  global.get $~lib/heap/__heap_base
+  i32.gt_u
+  if
+   local.get $0
+   i32.const 16
+   i32.sub
+   call $~lib/rt/pure/decrement
+  end
  )
  (func $~lib/memory/memory.fill (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
@@ -1702,71 +1767,6 @@
    end
   end
  )
- (func $~lib/rt/pure/increment (param $0 i32)
-  (local $1 i32)
-  local.get $0
-  i32.load offset=4
-  local.set $1
-  local.get $1
-  i32.const 268435455
-  i32.const -1
-  i32.xor
-  i32.and
-  local.get $1
-  i32.const 1
-  i32.add
-  i32.const 268435455
-  i32.const -1
-  i32.xor
-  i32.and
-  i32.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 256
-   i32.const 109
-   i32.const 3
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $0
-  local.get $1
-  i32.const 1
-  i32.add
-  i32.store offset=4
-  i32.const 1
-  drop
-  local.get $0
-  call $~lib/rt/rtrace/onincrement
-  i32.const 1
-  drop
-  local.get $0
-  i32.load
-  i32.const 1
-  i32.and
-  i32.eqz
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 256
-   i32.const 112
-   i32.const 14
-   call $~lib/builtins/abort
-   unreachable
-  end
- )
- (func $~lib/rt/pure/__retain (param $0 i32) (result i32)
-  local.get $0
-  global.get $~lib/heap/__heap_base
-  i32.gt_u
-  if
-   local.get $0
-   i32.const 16
-   i32.sub
-   call $~lib/rt/pure/increment
-  end
-  local.get $0
- )
  (func $~lib/arraybuffer/ArrayBuffer#constructor (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
@@ -1774,8 +1774,8 @@
   i32.const 1073741808
   i32.gt_u
   if
-   i32.const 32
-   i32.const 80
+   i32.const 192
+   i32.const 240
    i32.const 49
    i32.const 43
    call $~lib/builtins/abort
@@ -1796,46 +1796,6 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/map/Map<i8,i32>#clear (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  local.tee $1
-  i32.const 0
-  i32.const 16
-  call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $2
-  local.get $1
-  i32.load
-  call $~lib/rt/pure/__release
-  local.get $2
-  i32.store
-  local.get $0
-  i32.const 4
-  i32.const 1
-  i32.sub
-  i32.store offset=4
-  local.get $0
-  local.tee $2
-  i32.const 0
-  i32.const 48
-  call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $1
-  local.get $2
-  i32.load offset=8
-  call $~lib/rt/pure/__release
-  local.get $1
-  i32.store offset=8
-  local.get $0
-  i32.const 4
-  i32.store offset=12
-  local.get $0
-  i32.const 0
-  i32.store offset=16
-  local.get $0
-  i32.const 0
-  i32.store offset=20
- )
  (func $~lib/map/Map<i8,i32>#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
@@ -1848,15 +1808,25 @@
   end
   local.get $0
   i32.const 0
+  i32.const 4
+  i32.const 4
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store
   local.get $0
-  i32.const 0
+  i32.const 4
+  i32.const 1
+  i32.sub
   i32.store offset=4
   local.get $0
   i32.const 0
+  i32.const 4
+  i32.const 12
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store offset=8
   local.get $0
-  i32.const 0
+  i32.const 4
   i32.store offset=12
   local.get $0
   i32.const 0
@@ -1864,8 +1834,6 @@
   local.get $0
   i32.const 0
   i32.store offset=20
-  local.get $0
-  call $~lib/map/Map<i8,i32>#clear
   local.get $0
  )
  (func $~lib/util/hash/hash8 (param $0 i32) (result i32)
@@ -2277,7 +2245,7 @@
   if
    i32.const 352
    i32.const 416
-   i32.const 113
+   i32.const 110
    i32.const 17
    call $~lib/builtins/abort
    unreachable
@@ -2322,7 +2290,7 @@
   i32.shr_u
   i32.gt_u
   if
-   i32.const 32
+   i32.const 192
    i32.const 464
    i32.const 57
    i32.const 60
@@ -2409,7 +2377,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 581
    i32.const 3
    call $~lib/builtins/abort
@@ -3843,7 +3811,7 @@
    i32.shr_u
    i32.gt_u
    if
-    i32.const 32
+    i32.const 192
     i32.const 464
     i32.const 14
     i32.const 48
@@ -4044,7 +4012,7 @@
   i32.shr_u
   i32.gt_u
   if
-   i32.const 32
+   i32.const 192
    i32.const 464
    i32.const 57
    i32.const 60
@@ -4217,46 +4185,6 @@
   call $~lib/array/Array<i32>#set:length
   local.get $3
  )
- (func $~lib/map/Map<i8,i8>#clear (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  local.tee $1
-  i32.const 0
-  i32.const 16
-  call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $2
-  local.get $1
-  i32.load
-  call $~lib/rt/pure/__release
-  local.get $2
-  i32.store
-  local.get $0
-  i32.const 4
-  i32.const 1
-  i32.sub
-  i32.store offset=4
-  local.get $0
-  local.tee $2
-  i32.const 0
-  i32.const 32
-  call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $1
-  local.get $2
-  i32.load offset=8
-  call $~lib/rt/pure/__release
-  local.get $1
-  i32.store offset=8
-  local.get $0
-  i32.const 4
-  i32.store offset=12
-  local.get $0
-  i32.const 0
-  i32.store offset=16
-  local.get $0
-  i32.const 0
-  i32.store offset=20
- )
  (func $~lib/map/Map<i8,i8>#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
@@ -4269,39 +4197,10 @@
   end
   local.get $0
   i32.const 0
-  i32.store
-  local.get $0
-  i32.const 0
-  i32.store offset=4
-  local.get $0
-  i32.const 0
-  i32.store offset=8
-  local.get $0
-  i32.const 0
-  i32.store offset=12
-  local.get $0
-  i32.const 0
-  i32.store offset=16
-  local.get $0
-  i32.const 0
-  i32.store offset=20
-  local.get $0
-  call $~lib/map/Map<i8,i8>#clear
-  local.get $0
- )
- (func $~lib/map/Map<i32,i32>#clear (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  local.tee $1
-  i32.const 0
-  i32.const 16
+  i32.const 4
+  i32.const 4
+  i32.mul
   call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $2
-  local.get $1
-  i32.load
-  call $~lib/rt/pure/__release
-  local.get $2
   i32.store
   local.get $0
   i32.const 4
@@ -4309,15 +4208,11 @@
   i32.sub
   i32.store offset=4
   local.get $0
-  local.tee $2
   i32.const 0
-  i32.const 48
+  i32.const 4
+  i32.const 8
+  i32.mul
   call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $1
-  local.get $2
-  i32.load offset=8
-  call $~lib/rt/pure/__release
-  local.get $1
   i32.store offset=8
   local.get $0
   i32.const 4
@@ -4328,6 +4223,7 @@
   local.get $0
   i32.const 0
   i32.store offset=20
+  local.get $0
  )
  (func $~lib/map/Map<i32,i32>#constructor (param $0 i32) (result i32)
   local.get $0
@@ -4341,15 +4237,25 @@
   end
   local.get $0
   i32.const 0
+  i32.const 4
+  i32.const 4
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store
   local.get $0
-  i32.const 0
+  i32.const 4
+  i32.const 1
+  i32.sub
   i32.store offset=4
   local.get $0
   i32.const 0
+  i32.const 4
+  i32.const 12
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store offset=8
   local.get $0
-  i32.const 0
+  i32.const 4
   i32.store offset=12
   local.get $0
   i32.const 0
@@ -4357,8 +4263,6 @@
   local.get $0
   i32.const 0
   i32.store offset=20
-  local.get $0
-  call $~lib/map/Map<i32,i32>#clear
   local.get $0
  )
  (func $~lib/array/Array<i8>#get:length (param $0 i32) (result i32)
@@ -5255,6 +5159,50 @@
   end
   i32.const 1
  )
+ (func $~lib/map/Map<i8,i32>#clear (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  local.get $0
+  local.tee $1
+  i32.const 0
+  i32.const 4
+  i32.const 4
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $2
+  local.get $1
+  i32.load
+  call $~lib/rt/pure/__release
+  local.get $2
+  i32.store
+  local.get $0
+  i32.const 4
+  i32.const 1
+  i32.sub
+  i32.store offset=4
+  local.get $0
+  local.tee $2
+  i32.const 0
+  i32.const 4
+  i32.const 12
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $1
+  local.get $2
+  i32.load offset=8
+  call $~lib/rt/pure/__release
+  local.get $1
+  i32.store offset=8
+  local.get $0
+  i32.const 4
+  i32.store offset=12
+  local.get $0
+  i32.const 0
+  i32.store offset=16
+  local.get $0
+  i32.const 0
+  i32.store offset=20
+ )
  (func $std/map/testNumeric<i8,i32>
   (local $0 i32)
   (local $1 i32)
@@ -5764,46 +5712,6 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<u8,i32>#clear (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  local.tee $1
-  i32.const 0
-  i32.const 16
-  call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $2
-  local.get $1
-  i32.load
-  call $~lib/rt/pure/__release
-  local.get $2
-  i32.store
-  local.get $0
-  i32.const 4
-  i32.const 1
-  i32.sub
-  i32.store offset=4
-  local.get $0
-  local.tee $2
-  i32.const 0
-  i32.const 48
-  call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $1
-  local.get $2
-  i32.load offset=8
-  call $~lib/rt/pure/__release
-  local.get $1
-  i32.store offset=8
-  local.get $0
-  i32.const 4
-  i32.store offset=12
-  local.get $0
-  i32.const 0
-  i32.store offset=16
-  local.get $0
-  i32.const 0
-  i32.store offset=20
- )
  (func $~lib/map/Map<u8,i32>#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
@@ -5816,15 +5724,25 @@
   end
   local.get $0
   i32.const 0
+  i32.const 4
+  i32.const 4
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store
   local.get $0
-  i32.const 0
+  i32.const 4
+  i32.const 1
+  i32.sub
   i32.store offset=4
   local.get $0
   i32.const 0
+  i32.const 4
+  i32.const 12
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store offset=8
   local.get $0
-  i32.const 0
+  i32.const 4
   i32.store offset=12
   local.get $0
   i32.const 0
@@ -5832,8 +5750,6 @@
   local.get $0
   i32.const 0
   i32.store offset=20
-  local.get $0
-  call $~lib/map/Map<u8,i32>#clear
   local.get $0
  )
  (func $~lib/map/Map<u8,i32>#find (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -6230,7 +6146,7 @@
   if
    i32.const 352
    i32.const 416
-   i32.const 113
+   i32.const 110
    i32.const 17
    call $~lib/builtins/abort
    unreachable
@@ -6275,7 +6191,7 @@
   i32.shr_u
   i32.gt_u
   if
-   i32.const 32
+   i32.const 192
    i32.const 464
    i32.const 57
    i32.const 60
@@ -6513,46 +6429,6 @@
   call $~lib/array/Array<i32>#set:length
   local.get $3
  )
- (func $~lib/map/Map<u8,u8>#clear (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  local.tee $1
-  i32.const 0
-  i32.const 16
-  call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $2
-  local.get $1
-  i32.load
-  call $~lib/rt/pure/__release
-  local.get $2
-  i32.store
-  local.get $0
-  i32.const 4
-  i32.const 1
-  i32.sub
-  i32.store offset=4
-  local.get $0
-  local.tee $2
-  i32.const 0
-  i32.const 32
-  call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $1
-  local.get $2
-  i32.load offset=8
-  call $~lib/rt/pure/__release
-  local.get $1
-  i32.store offset=8
-  local.get $0
-  i32.const 4
-  i32.store offset=12
-  local.get $0
-  i32.const 0
-  i32.store offset=16
-  local.get $0
-  i32.const 0
-  i32.store offset=20
- )
  (func $~lib/map/Map<u8,u8>#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
@@ -6565,15 +6441,25 @@
   end
   local.get $0
   i32.const 0
+  i32.const 4
+  i32.const 4
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store
   local.get $0
-  i32.const 0
+  i32.const 4
+  i32.const 1
+  i32.sub
   i32.store offset=4
   local.get $0
   i32.const 0
+  i32.const 4
+  i32.const 8
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store offset=8
   local.get $0
-  i32.const 0
+  i32.const 4
   i32.store offset=12
   local.get $0
   i32.const 0
@@ -6581,8 +6467,6 @@
   local.get $0
   i32.const 0
   i32.store offset=20
-  local.get $0
-  call $~lib/map/Map<u8,u8>#clear
   local.get $0
  )
  (func $~lib/array/Array<u8>#get:length (param $0 i32) (result i32)
@@ -7047,6 +6931,50 @@
    call $~lib/map/Map<u8,i32>#rehash
   end
   i32.const 1
+ )
+ (func $~lib/map/Map<u8,i32>#clear (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  local.get $0
+  local.tee $1
+  i32.const 0
+  i32.const 4
+  i32.const 4
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $2
+  local.get $1
+  i32.load
+  call $~lib/rt/pure/__release
+  local.get $2
+  i32.store
+  local.get $0
+  i32.const 4
+  i32.const 1
+  i32.sub
+  i32.store offset=4
+  local.get $0
+  local.tee $2
+  i32.const 0
+  i32.const 4
+  i32.const 12
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $1
+  local.get $2
+  i32.load offset=8
+  call $~lib/rt/pure/__release
+  local.get $1
+  i32.store offset=8
+  local.get $0
+  i32.const 4
+  i32.store offset=12
+  local.get $0
+  i32.const 0
+  i32.store offset=16
+  local.get $0
+  i32.const 0
+  i32.store offset=20
  )
  (func $std/map/testNumeric<u8,i32>
   (local $0 i32)
@@ -7535,46 +7463,6 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<i16,i32>#clear (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  local.tee $1
-  i32.const 0
-  i32.const 16
-  call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $2
-  local.get $1
-  i32.load
-  call $~lib/rt/pure/__release
-  local.get $2
-  i32.store
-  local.get $0
-  i32.const 4
-  i32.const 1
-  i32.sub
-  i32.store offset=4
-  local.get $0
-  local.tee $2
-  i32.const 0
-  i32.const 48
-  call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $1
-  local.get $2
-  i32.load offset=8
-  call $~lib/rt/pure/__release
-  local.get $1
-  i32.store offset=8
-  local.get $0
-  i32.const 4
-  i32.store offset=12
-  local.get $0
-  i32.const 0
-  i32.store offset=16
-  local.get $0
-  i32.const 0
-  i32.store offset=20
- )
  (func $~lib/map/Map<i16,i32>#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
@@ -7587,15 +7475,25 @@
   end
   local.get $0
   i32.const 0
+  i32.const 4
+  i32.const 4
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store
   local.get $0
-  i32.const 0
+  i32.const 4
+  i32.const 1
+  i32.sub
   i32.store offset=4
   local.get $0
   i32.const 0
+  i32.const 4
+  i32.const 12
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store offset=8
   local.get $0
-  i32.const 0
+  i32.const 4
   i32.store offset=12
   local.get $0
   i32.const 0
@@ -7603,8 +7501,6 @@
   local.get $0
   i32.const 0
   i32.store offset=20
-  local.get $0
-  call $~lib/map/Map<i16,i32>#clear
   local.get $0
  )
  (func $~lib/util/hash/hash16 (param $0 i32) (result i32)
@@ -8047,7 +7943,7 @@
   if
    i32.const 352
    i32.const 416
-   i32.const 113
+   i32.const 110
    i32.const 17
    call $~lib/builtins/abort
    unreachable
@@ -8092,7 +7988,7 @@
   i32.shr_u
   i32.gt_u
   if
-   i32.const 32
+   i32.const 192
    i32.const 464
    i32.const 57
    i32.const 60
@@ -8330,46 +8226,6 @@
   call $~lib/array/Array<i32>#set:length
   local.get $3
  )
- (func $~lib/map/Map<i16,i16>#clear (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  local.tee $1
-  i32.const 0
-  i32.const 16
-  call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $2
-  local.get $1
-  i32.load
-  call $~lib/rt/pure/__release
-  local.get $2
-  i32.store
-  local.get $0
-  i32.const 4
-  i32.const 1
-  i32.sub
-  i32.store offset=4
-  local.get $0
-  local.tee $2
-  i32.const 0
-  i32.const 32
-  call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $1
-  local.get $2
-  i32.load offset=8
-  call $~lib/rt/pure/__release
-  local.get $1
-  i32.store offset=8
-  local.get $0
-  i32.const 4
-  i32.store offset=12
-  local.get $0
-  i32.const 0
-  i32.store offset=16
-  local.get $0
-  i32.const 0
-  i32.store offset=20
- )
  (func $~lib/map/Map<i16,i16>#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
@@ -8382,15 +8238,25 @@
   end
   local.get $0
   i32.const 0
+  i32.const 4
+  i32.const 4
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store
   local.get $0
-  i32.const 0
+  i32.const 4
+  i32.const 1
+  i32.sub
   i32.store offset=4
   local.get $0
   i32.const 0
+  i32.const 4
+  i32.const 8
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store offset=8
   local.get $0
-  i32.const 0
+  i32.const 4
   i32.store offset=12
   local.get $0
   i32.const 0
@@ -8398,8 +8264,6 @@
   local.get $0
   i32.const 0
   i32.store offset=20
-  local.get $0
-  call $~lib/map/Map<i16,i16>#clear
   local.get $0
  )
  (func $~lib/array/Array<i16>#get:length (param $0 i32) (result i32)
@@ -8882,6 +8746,50 @@
    call $~lib/map/Map<i16,i32>#rehash
   end
   i32.const 1
+ )
+ (func $~lib/map/Map<i16,i32>#clear (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  local.get $0
+  local.tee $1
+  i32.const 0
+  i32.const 4
+  i32.const 4
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $2
+  local.get $1
+  i32.load
+  call $~lib/rt/pure/__release
+  local.get $2
+  i32.store
+  local.get $0
+  i32.const 4
+  i32.const 1
+  i32.sub
+  i32.store offset=4
+  local.get $0
+  local.tee $2
+  i32.const 0
+  i32.const 4
+  i32.const 12
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $1
+  local.get $2
+  i32.load offset=8
+  call $~lib/rt/pure/__release
+  local.get $1
+  i32.store offset=8
+  local.get $0
+  i32.const 4
+  i32.store offset=12
+  local.get $0
+  i32.const 0
+  i32.store offset=16
+  local.get $0
+  i32.const 0
+  i32.store offset=20
  )
  (func $std/map/testNumeric<i16,i32>
   (local $0 i32)
@@ -9392,46 +9300,6 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<u16,i32>#clear (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  local.tee $1
-  i32.const 0
-  i32.const 16
-  call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $2
-  local.get $1
-  i32.load
-  call $~lib/rt/pure/__release
-  local.get $2
-  i32.store
-  local.get $0
-  i32.const 4
-  i32.const 1
-  i32.sub
-  i32.store offset=4
-  local.get $0
-  local.tee $2
-  i32.const 0
-  i32.const 48
-  call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $1
-  local.get $2
-  i32.load offset=8
-  call $~lib/rt/pure/__release
-  local.get $1
-  i32.store offset=8
-  local.get $0
-  i32.const 4
-  i32.store offset=12
-  local.get $0
-  i32.const 0
-  i32.store offset=16
-  local.get $0
-  i32.const 0
-  i32.store offset=20
- )
  (func $~lib/map/Map<u16,i32>#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
@@ -9444,15 +9312,25 @@
   end
   local.get $0
   i32.const 0
+  i32.const 4
+  i32.const 4
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store
   local.get $0
-  i32.const 0
+  i32.const 4
+  i32.const 1
+  i32.sub
   i32.store offset=4
   local.get $0
   i32.const 0
+  i32.const 4
+  i32.const 12
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store offset=8
   local.get $0
-  i32.const 0
+  i32.const 4
   i32.store offset=12
   local.get $0
   i32.const 0
@@ -9460,8 +9338,6 @@
   local.get $0
   i32.const 0
   i32.store offset=20
-  local.get $0
-  call $~lib/map/Map<u16,i32>#clear
   local.get $0
  )
  (func $~lib/map/Map<u16,i32>#find (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -9874,7 +9750,7 @@
   if
    i32.const 352
    i32.const 416
-   i32.const 113
+   i32.const 110
    i32.const 17
    call $~lib/builtins/abort
    unreachable
@@ -9919,7 +9795,7 @@
   i32.shr_u
   i32.gt_u
   if
-   i32.const 32
+   i32.const 192
    i32.const 464
    i32.const 57
    i32.const 60
@@ -10157,46 +10033,6 @@
   call $~lib/array/Array<i32>#set:length
   local.get $3
  )
- (func $~lib/map/Map<u16,u16>#clear (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  local.tee $1
-  i32.const 0
-  i32.const 16
-  call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $2
-  local.get $1
-  i32.load
-  call $~lib/rt/pure/__release
-  local.get $2
-  i32.store
-  local.get $0
-  i32.const 4
-  i32.const 1
-  i32.sub
-  i32.store offset=4
-  local.get $0
-  local.tee $2
-  i32.const 0
-  i32.const 32
-  call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $1
-  local.get $2
-  i32.load offset=8
-  call $~lib/rt/pure/__release
-  local.get $1
-  i32.store offset=8
-  local.get $0
-  i32.const 4
-  i32.store offset=12
-  local.get $0
-  i32.const 0
-  i32.store offset=16
-  local.get $0
-  i32.const 0
-  i32.store offset=20
- )
  (func $~lib/map/Map<u16,u16>#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
@@ -10209,15 +10045,25 @@
   end
   local.get $0
   i32.const 0
+  i32.const 4
+  i32.const 4
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store
   local.get $0
-  i32.const 0
+  i32.const 4
+  i32.const 1
+  i32.sub
   i32.store offset=4
   local.get $0
   i32.const 0
+  i32.const 4
+  i32.const 8
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store offset=8
   local.get $0
-  i32.const 0
+  i32.const 4
   i32.store offset=12
   local.get $0
   i32.const 0
@@ -10225,8 +10071,6 @@
   local.get $0
   i32.const 0
   i32.store offset=20
-  local.get $0
-  call $~lib/map/Map<u16,u16>#clear
   local.get $0
  )
  (func $~lib/array/Array<u16>#get:length (param $0 i32) (result i32)
@@ -10703,6 +10547,50 @@
    call $~lib/map/Map<u16,i32>#rehash
   end
   i32.const 1
+ )
+ (func $~lib/map/Map<u16,i32>#clear (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  local.get $0
+  local.tee $1
+  i32.const 0
+  i32.const 4
+  i32.const 4
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $2
+  local.get $1
+  i32.load
+  call $~lib/rt/pure/__release
+  local.get $2
+  i32.store
+  local.get $0
+  i32.const 4
+  i32.const 1
+  i32.sub
+  i32.store offset=4
+  local.get $0
+  local.tee $2
+  i32.const 0
+  i32.const 4
+  i32.const 12
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $1
+  local.get $2
+  i32.load offset=8
+  call $~lib/rt/pure/__release
+  local.get $1
+  i32.store offset=8
+  local.get $0
+  i32.const 4
+  i32.store offset=12
+  local.get $0
+  i32.const 0
+  i32.store offset=16
+  local.get $0
+  i32.const 0
+  i32.store offset=20
  )
  (func $std/map/testNumeric<u16,i32>
   (local $0 i32)
@@ -11261,7 +11149,7 @@
   if
    i32.const 352
    i32.const 416
-   i32.const 113
+   i32.const 110
    i32.const 17
    call $~lib/builtins/abort
    unreachable
@@ -11496,6 +11384,50 @@
    call $~lib/map/Map<i32,i32>#rehash
   end
   i32.const 1
+ )
+ (func $~lib/map/Map<i32,i32>#clear (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  local.get $0
+  local.tee $1
+  i32.const 0
+  i32.const 4
+  i32.const 4
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $2
+  local.get $1
+  i32.load
+  call $~lib/rt/pure/__release
+  local.get $2
+  i32.store
+  local.get $0
+  i32.const 4
+  i32.const 1
+  i32.sub
+  i32.store offset=4
+  local.get $0
+  local.tee $2
+  i32.const 0
+  i32.const 4
+  i32.const 12
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $1
+  local.get $2
+  i32.load offset=8
+  call $~lib/rt/pure/__release
+  local.get $1
+  i32.store offset=8
+  local.get $0
+  i32.const 4
+  i32.store offset=12
+  local.get $0
+  i32.const 0
+  i32.store offset=16
+  local.get $0
+  i32.const 0
+  i32.store offset=20
  )
  (func $std/map/testNumeric<i32,i32>
   (local $0 i32)
@@ -11960,46 +11892,6 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<u32,i32>#clear (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  local.tee $1
-  i32.const 0
-  i32.const 16
-  call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $2
-  local.get $1
-  i32.load
-  call $~lib/rt/pure/__release
-  local.get $2
-  i32.store
-  local.get $0
-  i32.const 4
-  i32.const 1
-  i32.sub
-  i32.store offset=4
-  local.get $0
-  local.tee $2
-  i32.const 0
-  i32.const 48
-  call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $1
-  local.get $2
-  i32.load offset=8
-  call $~lib/rt/pure/__release
-  local.get $1
-  i32.store offset=8
-  local.get $0
-  i32.const 4
-  i32.store offset=12
-  local.get $0
-  i32.const 0
-  i32.store offset=16
-  local.get $0
-  i32.const 0
-  i32.store offset=20
- )
  (func $~lib/map/Map<u32,i32>#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
@@ -12012,15 +11904,25 @@
   end
   local.get $0
   i32.const 0
+  i32.const 4
+  i32.const 4
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store
   local.get $0
-  i32.const 0
+  i32.const 4
+  i32.const 1
+  i32.sub
   i32.store offset=4
   local.get $0
   i32.const 0
+  i32.const 4
+  i32.const 12
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store offset=8
   local.get $0
-  i32.const 0
+  i32.const 4
   i32.store offset=12
   local.get $0
   i32.const 0
@@ -12028,8 +11930,6 @@
   local.get $0
   i32.const 0
   i32.store offset=20
-  local.get $0
-  call $~lib/map/Map<u32,i32>#clear
   local.get $0
  )
  (func $~lib/map/Map<u32,i32>#find (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -12450,7 +12350,7 @@
   if
    i32.const 352
    i32.const 416
-   i32.const 113
+   i32.const 110
    i32.const 17
    call $~lib/builtins/abort
    unreachable
@@ -12495,7 +12395,7 @@
   i32.shr_u
   i32.gt_u
   if
-   i32.const 32
+   i32.const 192
    i32.const 464
    i32.const 57
    i32.const 60
@@ -12733,46 +12633,6 @@
   call $~lib/array/Array<i32>#set:length
   local.get $3
  )
- (func $~lib/map/Map<u32,u32>#clear (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  local.tee $1
-  i32.const 0
-  i32.const 16
-  call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $2
-  local.get $1
-  i32.load
-  call $~lib/rt/pure/__release
-  local.get $2
-  i32.store
-  local.get $0
-  i32.const 4
-  i32.const 1
-  i32.sub
-  i32.store offset=4
-  local.get $0
-  local.tee $2
-  i32.const 0
-  i32.const 48
-  call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $1
-  local.get $2
-  i32.load offset=8
-  call $~lib/rt/pure/__release
-  local.get $1
-  i32.store offset=8
-  local.get $0
-  i32.const 4
-  i32.store offset=12
-  local.get $0
-  i32.const 0
-  i32.store offset=16
-  local.get $0
-  i32.const 0
-  i32.store offset=20
- )
  (func $~lib/map/Map<u32,u32>#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
@@ -12785,15 +12645,25 @@
   end
   local.get $0
   i32.const 0
+  i32.const 4
+  i32.const 4
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store
   local.get $0
-  i32.const 0
+  i32.const 4
+  i32.const 1
+  i32.sub
   i32.store offset=4
   local.get $0
   i32.const 0
+  i32.const 4
+  i32.const 12
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store offset=8
   local.get $0
-  i32.const 0
+  i32.const 4
   i32.store offset=12
   local.get $0
   i32.const 0
@@ -12801,8 +12671,6 @@
   local.get $0
   i32.const 0
   i32.store offset=20
-  local.get $0
-  call $~lib/map/Map<u32,u32>#clear
   local.get $0
  )
  (func $~lib/array/Array<u32>#get:length (param $0 i32) (result i32)
@@ -13286,6 +13154,50 @@
   end
   i32.const 1
  )
+ (func $~lib/map/Map<u32,i32>#clear (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  local.get $0
+  local.tee $1
+  i32.const 0
+  i32.const 4
+  i32.const 4
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $2
+  local.get $1
+  i32.load
+  call $~lib/rt/pure/__release
+  local.get $2
+  i32.store
+  local.get $0
+  i32.const 4
+  i32.const 1
+  i32.sub
+  i32.store offset=4
+  local.get $0
+  local.tee $2
+  i32.const 0
+  i32.const 4
+  i32.const 12
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $1
+  local.get $2
+  i32.load offset=8
+  call $~lib/rt/pure/__release
+  local.get $1
+  i32.store offset=8
+  local.get $0
+  i32.const 4
+  i32.store offset=12
+  local.get $0
+  i32.const 0
+  i32.store offset=16
+  local.get $0
+  i32.const 0
+  i32.store offset=20
+ )
  (func $std/map/testNumeric<u32,i32>
   (local $0 i32)
   (local $1 i32)
@@ -13749,46 +13661,6 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<i64,i32>#clear (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  local.tee $1
-  i32.const 0
-  i32.const 16
-  call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $2
-  local.get $1
-  i32.load
-  call $~lib/rt/pure/__release
-  local.get $2
-  i32.store
-  local.get $0
-  i32.const 4
-  i32.const 1
-  i32.sub
-  i32.store offset=4
-  local.get $0
-  local.tee $2
-  i32.const 0
-  i32.const 64
-  call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $1
-  local.get $2
-  i32.load offset=8
-  call $~lib/rt/pure/__release
-  local.get $1
-  i32.store offset=8
-  local.get $0
-  i32.const 4
-  i32.store offset=12
-  local.get $0
-  i32.const 0
-  i32.store offset=16
-  local.get $0
-  i32.const 0
-  i32.store offset=20
- )
  (func $~lib/map/Map<i64,i32>#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
@@ -13801,15 +13673,25 @@
   end
   local.get $0
   i32.const 0
+  i32.const 4
+  i32.const 4
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store
   local.get $0
-  i32.const 0
+  i32.const 4
+  i32.const 1
+  i32.sub
   i32.store offset=4
   local.get $0
   i32.const 0
+  i32.const 4
+  i32.const 16
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store offset=8
   local.get $0
-  i32.const 0
+  i32.const 4
   i32.store offset=12
   local.get $0
   i32.const 0
@@ -13817,8 +13699,6 @@
   local.get $0
   i32.const 0
   i32.store offset=20
-  local.get $0
-  call $~lib/map/Map<i64,i32>#clear
   local.get $0
  )
  (func $~lib/util/hash/hash64 (param $0 i64) (result i32)
@@ -14345,7 +14225,7 @@
   if
    i32.const 352
    i32.const 416
-   i32.const 113
+   i32.const 110
    i32.const 17
    call $~lib/builtins/abort
    unreachable
@@ -14390,7 +14270,7 @@
   i32.shr_u
   i32.gt_u
   if
-   i32.const 32
+   i32.const 192
    i32.const 464
    i32.const 57
    i32.const 60
@@ -14628,46 +14508,6 @@
   call $~lib/array/Array<i32>#set:length
   local.get $3
  )
- (func $~lib/map/Map<i64,i64>#clear (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  local.tee $1
-  i32.const 0
-  i32.const 16
-  call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $2
-  local.get $1
-  i32.load
-  call $~lib/rt/pure/__release
-  local.get $2
-  i32.store
-  local.get $0
-  i32.const 4
-  i32.const 1
-  i32.sub
-  i32.store offset=4
-  local.get $0
-  local.tee $2
-  i32.const 0
-  i32.const 96
-  call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $1
-  local.get $2
-  i32.load offset=8
-  call $~lib/rt/pure/__release
-  local.get $1
-  i32.store offset=8
-  local.get $0
-  i32.const 4
-  i32.store offset=12
-  local.get $0
-  i32.const 0
-  i32.store offset=16
-  local.get $0
-  i32.const 0
-  i32.store offset=20
- )
  (func $~lib/map/Map<i64,i64>#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
@@ -14680,15 +14520,25 @@
   end
   local.get $0
   i32.const 0
+  i32.const 4
+  i32.const 4
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store
   local.get $0
-  i32.const 0
+  i32.const 4
+  i32.const 1
+  i32.sub
   i32.store offset=4
   local.get $0
   i32.const 0
+  i32.const 4
+  i32.const 24
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store offset=8
   local.get $0
-  i32.const 0
+  i32.const 4
   i32.store offset=12
   local.get $0
   i32.const 0
@@ -14696,8 +14546,6 @@
   local.get $0
   i32.const 0
   i32.store offset=20
-  local.get $0
-  call $~lib/map/Map<i64,i64>#clear
   local.get $0
  )
  (func $~lib/array/Array<i64>#get:length (param $0 i32) (result i32)
@@ -15196,6 +15044,50 @@
   end
   i32.const 1
  )
+ (func $~lib/map/Map<i64,i32>#clear (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  local.get $0
+  local.tee $1
+  i32.const 0
+  i32.const 4
+  i32.const 4
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $2
+  local.get $1
+  i32.load
+  call $~lib/rt/pure/__release
+  local.get $2
+  i32.store
+  local.get $0
+  i32.const 4
+  i32.const 1
+  i32.sub
+  i32.store offset=4
+  local.get $0
+  local.tee $2
+  i32.const 0
+  i32.const 4
+  i32.const 16
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $1
+  local.get $2
+  i32.load offset=8
+  call $~lib/rt/pure/__release
+  local.get $1
+  i32.store offset=8
+  local.get $0
+  i32.const 4
+  i32.store offset=12
+  local.get $0
+  i32.const 0
+  i32.store offset=16
+  local.get $0
+  i32.const 0
+  i32.store offset=20
+ )
  (func $std/map/testNumeric<i64,i32>
   (local $0 i32)
   (local $1 i64)
@@ -15667,46 +15559,6 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<u64,i32>#clear (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  local.tee $1
-  i32.const 0
-  i32.const 16
-  call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $2
-  local.get $1
-  i32.load
-  call $~lib/rt/pure/__release
-  local.get $2
-  i32.store
-  local.get $0
-  i32.const 4
-  i32.const 1
-  i32.sub
-  i32.store offset=4
-  local.get $0
-  local.tee $2
-  i32.const 0
-  i32.const 64
-  call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $1
-  local.get $2
-  i32.load offset=8
-  call $~lib/rt/pure/__release
-  local.get $1
-  i32.store offset=8
-  local.get $0
-  i32.const 4
-  i32.store offset=12
-  local.get $0
-  i32.const 0
-  i32.store offset=16
-  local.get $0
-  i32.const 0
-  i32.store offset=20
- )
  (func $~lib/map/Map<u64,i32>#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
@@ -15719,15 +15571,25 @@
   end
   local.get $0
   i32.const 0
+  i32.const 4
+  i32.const 4
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store
   local.get $0
-  i32.const 0
+  i32.const 4
+  i32.const 1
+  i32.sub
   i32.store offset=4
   local.get $0
   i32.const 0
+  i32.const 4
+  i32.const 16
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store offset=8
   local.get $0
-  i32.const 0
+  i32.const 4
   i32.store offset=12
   local.get $0
   i32.const 0
@@ -15735,8 +15597,6 @@
   local.get $0
   i32.const 0
   i32.store offset=20
-  local.get $0
-  call $~lib/map/Map<u64,i32>#clear
   local.get $0
  )
  (func $~lib/map/Map<u64,i32>#find (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
@@ -16175,7 +16035,7 @@
   if
    i32.const 352
    i32.const 416
-   i32.const 113
+   i32.const 110
    i32.const 17
    call $~lib/builtins/abort
    unreachable
@@ -16220,7 +16080,7 @@
   i32.shr_u
   i32.gt_u
   if
-   i32.const 32
+   i32.const 192
    i32.const 464
    i32.const 57
    i32.const 60
@@ -16458,46 +16318,6 @@
   call $~lib/array/Array<i32>#set:length
   local.get $3
  )
- (func $~lib/map/Map<u64,u64>#clear (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  local.tee $1
-  i32.const 0
-  i32.const 16
-  call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $2
-  local.get $1
-  i32.load
-  call $~lib/rt/pure/__release
-  local.get $2
-  i32.store
-  local.get $0
-  i32.const 4
-  i32.const 1
-  i32.sub
-  i32.store offset=4
-  local.get $0
-  local.tee $2
-  i32.const 0
-  i32.const 96
-  call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $1
-  local.get $2
-  i32.load offset=8
-  call $~lib/rt/pure/__release
-  local.get $1
-  i32.store offset=8
-  local.get $0
-  i32.const 4
-  i32.store offset=12
-  local.get $0
-  i32.const 0
-  i32.store offset=16
-  local.get $0
-  i32.const 0
-  i32.store offset=20
- )
  (func $~lib/map/Map<u64,u64>#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
@@ -16510,15 +16330,25 @@
   end
   local.get $0
   i32.const 0
+  i32.const 4
+  i32.const 4
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store
   local.get $0
-  i32.const 0
+  i32.const 4
+  i32.const 1
+  i32.sub
   i32.store offset=4
   local.get $0
   i32.const 0
+  i32.const 4
+  i32.const 24
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store offset=8
   local.get $0
-  i32.const 0
+  i32.const 4
   i32.store offset=12
   local.get $0
   i32.const 0
@@ -16526,8 +16356,6 @@
   local.get $0
   i32.const 0
   i32.store offset=20
-  local.get $0
-  call $~lib/map/Map<u64,u64>#clear
   local.get $0
  )
  (func $~lib/array/Array<u64>#get:length (param $0 i32) (result i32)
@@ -17026,6 +16854,50 @@
   end
   i32.const 1
  )
+ (func $~lib/map/Map<u64,i32>#clear (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  local.get $0
+  local.tee $1
+  i32.const 0
+  i32.const 4
+  i32.const 4
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $2
+  local.get $1
+  i32.load
+  call $~lib/rt/pure/__release
+  local.get $2
+  i32.store
+  local.get $0
+  i32.const 4
+  i32.const 1
+  i32.sub
+  i32.store offset=4
+  local.get $0
+  local.tee $2
+  i32.const 0
+  i32.const 4
+  i32.const 16
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $1
+  local.get $2
+  i32.load offset=8
+  call $~lib/rt/pure/__release
+  local.get $1
+  i32.store offset=8
+  local.get $0
+  i32.const 4
+  i32.store offset=12
+  local.get $0
+  i32.const 0
+  i32.store offset=16
+  local.get $0
+  i32.const 0
+  i32.store offset=20
+ )
  (func $std/map/testNumeric<u64,i32>
   (local $0 i32)
   (local $1 i64)
@@ -17497,46 +17369,6 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<f32,i32>#clear (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  local.tee $1
-  i32.const 0
-  i32.const 16
-  call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $2
-  local.get $1
-  i32.load
-  call $~lib/rt/pure/__release
-  local.get $2
-  i32.store
-  local.get $0
-  i32.const 4
-  i32.const 1
-  i32.sub
-  i32.store offset=4
-  local.get $0
-  local.tee $2
-  i32.const 0
-  i32.const 48
-  call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $1
-  local.get $2
-  i32.load offset=8
-  call $~lib/rt/pure/__release
-  local.get $1
-  i32.store offset=8
-  local.get $0
-  i32.const 4
-  i32.store offset=12
-  local.get $0
-  i32.const 0
-  i32.store offset=16
-  local.get $0
-  i32.const 0
-  i32.store offset=20
- )
  (func $~lib/map/Map<f32,i32>#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
@@ -17549,15 +17381,25 @@
   end
   local.get $0
   i32.const 0
+  i32.const 4
+  i32.const 4
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store
   local.get $0
-  i32.const 0
+  i32.const 4
+  i32.const 1
+  i32.sub
   i32.store offset=4
   local.get $0
   i32.const 0
+  i32.const 4
+  i32.const 12
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store offset=8
   local.get $0
-  i32.const 0
+  i32.const 4
   i32.store offset=12
   local.get $0
   i32.const 0
@@ -17565,8 +17407,6 @@
   local.get $0
   i32.const 0
   i32.store offset=20
-  local.get $0
-  call $~lib/map/Map<f32,i32>#clear
   local.get $0
  )
  (func $~lib/map/Map<f32,i32>#find (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
@@ -17961,7 +17801,7 @@
   if
    i32.const 352
    i32.const 416
-   i32.const 113
+   i32.const 110
    i32.const 17
    call $~lib/builtins/abort
    unreachable
@@ -18006,7 +17846,7 @@
   i32.shr_u
   i32.gt_u
   if
-   i32.const 32
+   i32.const 192
    i32.const 464
    i32.const 57
    i32.const 60
@@ -18244,46 +18084,6 @@
   call $~lib/array/Array<i32>#set:length
   local.get $3
  )
- (func $~lib/map/Map<f32,f32>#clear (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  local.tee $1
-  i32.const 0
-  i32.const 16
-  call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $2
-  local.get $1
-  i32.load
-  call $~lib/rt/pure/__release
-  local.get $2
-  i32.store
-  local.get $0
-  i32.const 4
-  i32.const 1
-  i32.sub
-  i32.store offset=4
-  local.get $0
-  local.tee $2
-  i32.const 0
-  i32.const 48
-  call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $1
-  local.get $2
-  i32.load offset=8
-  call $~lib/rt/pure/__release
-  local.get $1
-  i32.store offset=8
-  local.get $0
-  i32.const 4
-  i32.store offset=12
-  local.get $0
-  i32.const 0
-  i32.store offset=16
-  local.get $0
-  i32.const 0
-  i32.store offset=20
- )
  (func $~lib/map/Map<f32,f32>#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
@@ -18296,15 +18096,25 @@
   end
   local.get $0
   i32.const 0
+  i32.const 4
+  i32.const 4
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store
   local.get $0
-  i32.const 0
+  i32.const 4
+  i32.const 1
+  i32.sub
   i32.store offset=4
   local.get $0
   i32.const 0
+  i32.const 4
+  i32.const 12
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store offset=8
   local.get $0
-  i32.const 0
+  i32.const 4
   i32.store offset=12
   local.get $0
   i32.const 0
@@ -18312,8 +18122,6 @@
   local.get $0
   i32.const 0
   i32.store offset=20
-  local.get $0
-  call $~lib/map/Map<f32,f32>#clear
   local.get $0
  )
  (func $~lib/array/Array<f32>#get:length (param $0 i32) (result i32)
@@ -18778,6 +18586,50 @@
    call $~lib/map/Map<f32,i32>#rehash
   end
   i32.const 1
+ )
+ (func $~lib/map/Map<f32,i32>#clear (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  local.get $0
+  local.tee $1
+  i32.const 0
+  i32.const 4
+  i32.const 4
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $2
+  local.get $1
+  i32.load
+  call $~lib/rt/pure/__release
+  local.get $2
+  i32.store
+  local.get $0
+  i32.const 4
+  i32.const 1
+  i32.sub
+  i32.store offset=4
+  local.get $0
+  local.tee $2
+  i32.const 0
+  i32.const 4
+  i32.const 12
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $1
+  local.get $2
+  i32.load offset=8
+  call $~lib/rt/pure/__release
+  local.get $1
+  i32.store offset=8
+  local.get $0
+  i32.const 4
+  i32.store offset=12
+  local.get $0
+  i32.const 0
+  i32.store offset=16
+  local.get $0
+  i32.const 0
+  i32.store offset=20
  )
  (func $std/map/testNumeric<f32,i32>
   (local $0 i32)
@@ -19250,46 +19102,6 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<f64,i32>#clear (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  local.tee $1
-  i32.const 0
-  i32.const 16
-  call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $2
-  local.get $1
-  i32.load
-  call $~lib/rt/pure/__release
-  local.get $2
-  i32.store
-  local.get $0
-  i32.const 4
-  i32.const 1
-  i32.sub
-  i32.store offset=4
-  local.get $0
-  local.tee $2
-  i32.const 0
-  i32.const 64
-  call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $1
-  local.get $2
-  i32.load offset=8
-  call $~lib/rt/pure/__release
-  local.get $1
-  i32.store offset=8
-  local.get $0
-  i32.const 4
-  i32.store offset=12
-  local.get $0
-  i32.const 0
-  i32.store offset=16
-  local.get $0
-  i32.const 0
-  i32.store offset=20
- )
  (func $~lib/map/Map<f64,i32>#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
@@ -19302,15 +19114,25 @@
   end
   local.get $0
   i32.const 0
+  i32.const 4
+  i32.const 4
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store
   local.get $0
-  i32.const 0
+  i32.const 4
+  i32.const 1
+  i32.sub
   i32.store offset=4
   local.get $0
   i32.const 0
+  i32.const 4
+  i32.const 16
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store offset=8
   local.get $0
-  i32.const 0
+  i32.const 4
   i32.store offset=12
   local.get $0
   i32.const 0
@@ -19318,8 +19140,6 @@
   local.get $0
   i32.const 0
   i32.store offset=20
-  local.get $0
-  call $~lib/map/Map<f64,i32>#clear
   local.get $0
  )
  (func $~lib/map/Map<f64,i32>#find (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
@@ -19730,7 +19550,7 @@
   if
    i32.const 352
    i32.const 416
-   i32.const 113
+   i32.const 110
    i32.const 17
    call $~lib/builtins/abort
    unreachable
@@ -19775,7 +19595,7 @@
   i32.shr_u
   i32.gt_u
   if
-   i32.const 32
+   i32.const 192
    i32.const 464
    i32.const 57
    i32.const 60
@@ -20013,46 +19833,6 @@
   call $~lib/array/Array<i32>#set:length
   local.get $3
  )
- (func $~lib/map/Map<f64,f64>#clear (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  local.tee $1
-  i32.const 0
-  i32.const 16
-  call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $2
-  local.get $1
-  i32.load
-  call $~lib/rt/pure/__release
-  local.get $2
-  i32.store
-  local.get $0
-  i32.const 4
-  i32.const 1
-  i32.sub
-  i32.store offset=4
-  local.get $0
-  local.tee $2
-  i32.const 0
-  i32.const 96
-  call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $1
-  local.get $2
-  i32.load offset=8
-  call $~lib/rt/pure/__release
-  local.get $1
-  i32.store offset=8
-  local.get $0
-  i32.const 4
-  i32.store offset=12
-  local.get $0
-  i32.const 0
-  i32.store offset=16
-  local.get $0
-  i32.const 0
-  i32.store offset=20
- )
  (func $~lib/map/Map<f64,f64>#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
@@ -20065,15 +19845,25 @@
   end
   local.get $0
   i32.const 0
+  i32.const 4
+  i32.const 4
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store
   local.get $0
-  i32.const 0
+  i32.const 4
+  i32.const 1
+  i32.sub
   i32.store offset=4
   local.get $0
   i32.const 0
+  i32.const 4
+  i32.const 24
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store offset=8
   local.get $0
-  i32.const 0
+  i32.const 4
   i32.store offset=12
   local.get $0
   i32.const 0
@@ -20081,8 +19871,6 @@
   local.get $0
   i32.const 0
   i32.store offset=20
-  local.get $0
-  call $~lib/map/Map<f64,f64>#clear
   local.get $0
  )
  (func $~lib/array/Array<f64>#get:length (param $0 i32) (result i32)
@@ -20559,6 +20347,50 @@
    call $~lib/map/Map<f64,i32>#rehash
   end
   i32.const 1
+ )
+ (func $~lib/map/Map<f64,i32>#clear (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  local.get $0
+  local.tee $1
+  i32.const 0
+  i32.const 4
+  i32.const 4
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $2
+  local.get $1
+  i32.load
+  call $~lib/rt/pure/__release
+  local.get $2
+  i32.store
+  local.get $0
+  i32.const 4
+  i32.const 1
+  i32.sub
+  i32.store offset=4
+  local.get $0
+  local.tee $2
+  i32.const 0
+  i32.const 4
+  i32.const 16
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $1
+  local.get $2
+  i32.load offset=8
+  call $~lib/rt/pure/__release
+  local.get $1
+  i32.store offset=8
+  local.get $0
+  i32.const 4
+  i32.store offset=12
+  local.get $0
+  i32.const 0
+  i32.store offset=16
+  local.get $0
+  i32.const 0
+  i32.store offset=20
  )
  (func $std/map/testNumeric<f64,i32>
   (local $0 i32)
@@ -21046,6 +20878,11 @@
  (func $~start
   call $start:std/map
  )
+ (func $~lib/rt/pure/__collect
+  i32.const 1
+  drop
+  return
+ )
  (func $~lib/rt/pure/finalize (param $0 i32)
   i32.const 0
   drop
@@ -21077,7 +20914,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 256
+   i32.const 144
    i32.const 122
    i32.const 14
    call $~lib/builtins/abort
@@ -21103,7 +20940,7 @@
    i32.eqz
    if
     i32.const 0
-    i32.const 256
+    i32.const 144
     i32.const 126
     i32.const 18
     call $~lib/builtins/abort
@@ -21120,7 +20957,7 @@
    i32.eqz
    if
     i32.const 0
-    i32.const 256
+    i32.const 144
     i32.const 136
     i32.const 16
     call $~lib/builtins/abort
@@ -21141,11 +20978,6 @@
    i32.store offset=4
   end
  )
- (func $~lib/rt/pure/__collect
-  i32.const 1
-  drop
-  return
- )
  (func $~lib/rt/pure/__visit (param $0 i32) (param $1 i32)
   local.get $0
   global.get $~lib/heap/__heap_base
@@ -21163,7 +20995,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 256
+   i32.const 144
    i32.const 69
    i32.const 16
    call $~lib/builtins/abort

--- a/tests/compiler/std/map.untouched.wat
+++ b/tests/compiler/std/map.untouched.wat
@@ -2277,7 +2277,7 @@
   if
    i32.const 352
    i32.const 416
-   i32.const 111
+   i32.const 113
    i32.const 17
    call $~lib/builtins/abort
    unreachable
@@ -6230,7 +6230,7 @@
   if
    i32.const 352
    i32.const 416
-   i32.const 111
+   i32.const 113
    i32.const 17
    call $~lib/builtins/abort
    unreachable
@@ -8047,7 +8047,7 @@
   if
    i32.const 352
    i32.const 416
-   i32.const 111
+   i32.const 113
    i32.const 17
    call $~lib/builtins/abort
    unreachable
@@ -9874,7 +9874,7 @@
   if
    i32.const 352
    i32.const 416
-   i32.const 111
+   i32.const 113
    i32.const 17
    call $~lib/builtins/abort
    unreachable
@@ -11261,7 +11261,7 @@
   if
    i32.const 352
    i32.const 416
-   i32.const 111
+   i32.const 113
    i32.const 17
    call $~lib/builtins/abort
    unreachable
@@ -12450,7 +12450,7 @@
   if
    i32.const 352
    i32.const 416
-   i32.const 111
+   i32.const 113
    i32.const 17
    call $~lib/builtins/abort
    unreachable
@@ -14345,7 +14345,7 @@
   if
    i32.const 352
    i32.const 416
-   i32.const 111
+   i32.const 113
    i32.const 17
    call $~lib/builtins/abort
    unreachable
@@ -16175,7 +16175,7 @@
   if
    i32.const 352
    i32.const 416
-   i32.const 111
+   i32.const 113
    i32.const 17
    call $~lib/builtins/abort
    unreachable
@@ -17961,7 +17961,7 @@
   if
    i32.const 352
    i32.const 416
-   i32.const 111
+   i32.const 113
    i32.const 17
    call $~lib/builtins/abort
    unreachable
@@ -19730,7 +19730,7 @@
   if
    i32.const 352
    i32.const 416
-   i32.const 111
+   i32.const 113
    i32.const 17
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/set.optimized.wat
+++ b/tests/compiler/std/set.optimized.wat
@@ -29,11 +29,11 @@
  (import "rtrace" "onfree" (func $~lib/rt/rtrace/onfree (param i32)))
  (import "rtrace" "ondecrement" (func $~lib/rt/rtrace/ondecrement (param i32)))
  (memory $0 1)
- (data (i32.const 1024) "\1c\00\00\00\01\00\00\00\01\00\00\00\1c\00\00\00I\00n\00v\00a\00l\00i\00d\00 \00l\00e\00n\00g\00t\00h")
- (data (i32.const 1072) "&\00\00\00\01\00\00\00\01\00\00\00&\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00b\00u\00f\00f\00e\00r\00.\00t\00s")
- (data (i32.const 1136) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s")
- (data (i32.const 1184) "(\00\00\00\01\00\00\00\01\00\00\00(\00\00\00a\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e")
- (data (i32.const 1248) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00p\00u\00r\00e\00.\00t\00s")
+ (data (i32.const 1024) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s")
+ (data (i32.const 1072) "(\00\00\00\01\00\00\00\01\00\00\00(\00\00\00a\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e")
+ (data (i32.const 1136) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00p\00u\00r\00e\00.\00t\00s")
+ (data (i32.const 1184) "\1c\00\00\00\01\00\00\00\01\00\00\00\1c\00\00\00I\00n\00v\00a\00l\00i\00d\00 \00l\00e\00n\00g\00t\00h")
+ (data (i32.const 1232) "&\00\00\00\01\00\00\00\01\00\00\00&\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00b\00u\00f\00f\00e\00r\00.\00t\00s")
  (data (i32.const 1296) "\14\00\00\00\01\00\00\00\01\00\00\00\14\00\00\00s\00t\00d\00/\00s\00e\00t\00.\00t\00s")
  (data (i32.const 1344) "\1a\00\00\00\01\00\00\00\01\00\00\00\1a\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00.\00t\00s")
  (data (i32.const 1392) "$\00\00\00\01\00\00\00\01\00\00\00$\00\00\00I\00n\00d\00e\00x\00 \00o\00u\00t\00 \00o\00f\00 \00r\00a\00n\00g\00e")
@@ -41,17 +41,6 @@
  (global $~lib/rt/tlsf/collectLock (mut i32) (i32.const 0))
  (export "memory" (memory $0))
  (start $~start)
- (func $~lib/rt/pure/__release (param $0 i32)
-  local.get $0
-  i32.const 1444
-  i32.gt_u
-  if
-   local.get $0
-   i32.const 16
-   i32.sub
-   call $~lib/rt/pure/decrement
-  end
- )
  (func $~lib/rt/tlsf/removeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -65,7 +54,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 1152
+   i32.const 1040
    i32.const 277
    i32.const 14
    call $~lib/builtins/abort
@@ -87,7 +76,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 1152
+   i32.const 1040
    i32.const 279
    i32.const 14
    call $~lib/builtins/abort
@@ -130,7 +119,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 1152
+   i32.const 1040
    i32.const 292
    i32.const 14
    call $~lib/builtins/abort
@@ -226,7 +215,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 1152
+   i32.const 1040
    i32.const 205
    i32.const 14
    call $~lib/builtins/abort
@@ -240,7 +229,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 1152
+   i32.const 1040
    i32.const 207
    i32.const 14
    call $~lib/builtins/abort
@@ -313,7 +302,7 @@
    i32.eqz
    if
     i32.const 0
-    i32.const 1152
+    i32.const 1040
     i32.const 228
     i32.const 16
     call $~lib/builtins/abort
@@ -368,7 +357,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 1152
+   i32.const 1040
    i32.const 243
    i32.const 14
    call $~lib/builtins/abort
@@ -383,7 +372,7 @@
   i32.ne
   if
    i32.const 0
-   i32.const 1152
+   i32.const 1040
    i32.const 244
    i32.const 14
    call $~lib/builtins/abort
@@ -431,7 +420,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 1152
+   i32.const 1040
    i32.const 260
    i32.const 14
    call $~lib/builtins/abort
@@ -514,7 +503,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 1152
+   i32.const 1040
    i32.const 386
    i32.const 5
    call $~lib/builtins/abort
@@ -531,7 +520,7 @@
    i32.lt_u
    if
     i32.const 0
-    i32.const 1152
+    i32.const 1040
     i32.const 396
     i32.const 16
     call $~lib/builtins/abort
@@ -559,7 +548,7 @@
    i32.lt_u
    if
     i32.const 0
-    i32.const 1152
+    i32.const 1040
     i32.const 408
     i32.const 5
     call $~lib/builtins/abort
@@ -699,8 +688,8 @@
   i32.const 1073741808
   i32.ge_u
   if
-   i32.const 1200
-   i32.const 1152
+   i32.const 1088
+   i32.const 1040
    i32.const 461
    i32.const 30
    call $~lib/builtins/abort
@@ -773,7 +762,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 1152
+   i32.const 1040
    i32.const 338
    i32.const 14
    call $~lib/builtins/abort
@@ -825,7 +814,7 @@
     i32.eqz
     if
      i32.const 0
-     i32.const 1152
+     i32.const 1040
      i32.const 351
      i32.const 18
      call $~lib/builtins/abort
@@ -858,7 +847,7 @@
   i32.and
   if
    i32.const 0
-   i32.const 1152
+   i32.const 1040
    i32.const 365
    i32.const 14
    call $~lib/builtins/abort
@@ -929,7 +918,7 @@
   global.get $~lib/rt/tlsf/collectLock
   if
    i32.const 0
-   i32.const 1152
+   i32.const 1040
    i32.const 501
    i32.const 14
    call $~lib/builtins/abort
@@ -1020,7 +1009,7 @@
     i32.eqz
     if
      i32.const 0
-     i32.const 1152
+     i32.const 1040
      i32.const 513
      i32.const 20
      call $~lib/builtins/abort
@@ -1036,7 +1025,7 @@
   i32.lt_u
   if
    i32.const 0
-   i32.const 1152
+   i32.const 1040
    i32.const 521
    i32.const 14
    call $~lib/builtins/abort
@@ -1069,6 +1058,68 @@
   call $~lib/rt/tlsf/allocateBlock
   i32.const 16
   i32.add
+ )
+ (func $~lib/rt/pure/__retain (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  local.get $0
+  i32.const 1444
+  i32.gt_u
+  if
+   local.get $0
+   i32.const 16
+   i32.sub
+   local.tee $1
+   i32.load offset=4
+   local.tee $2
+   i32.const -268435456
+   i32.and
+   local.get $2
+   i32.const 1
+   i32.add
+   i32.const -268435456
+   i32.and
+   i32.ne
+   if
+    i32.const 0
+    i32.const 1152
+    i32.const 109
+    i32.const 3
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $1
+   local.get $2
+   i32.const 1
+   i32.add
+   i32.store offset=4
+   local.get $1
+   call $~lib/rt/rtrace/onincrement
+   local.get $1
+   i32.load
+   i32.const 1
+   i32.and
+   if
+    i32.const 0
+    i32.const 1152
+    i32.const 112
+    i32.const 14
+    call $~lib/builtins/abort
+    unreachable
+   end
+  end
+  local.get $0
+ )
+ (func $~lib/rt/pure/__release (param $0 i32)
+  local.get $0
+  i32.const 1444
+  i32.gt_u
+  if
+   local.get $0
+   i32.const 16
+   i32.sub
+   call $~lib/rt/pure/decrement
+  end
  )
  (func $~lib/memory/memory.fill (param $0 i32) (param $1 i32)
   (local $2 i32)
@@ -1228,65 +1279,14 @@
    end
   end
  )
- (func $~lib/rt/pure/__retain (param $0 i32) (result i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  i32.const 1444
-  i32.gt_u
-  if
-   local.get $0
-   i32.const 16
-   i32.sub
-   local.tee $1
-   i32.load offset=4
-   local.tee $2
-   i32.const -268435456
-   i32.and
-   local.get $2
-   i32.const 1
-   i32.add
-   i32.const -268435456
-   i32.and
-   i32.ne
-   if
-    i32.const 0
-    i32.const 1264
-    i32.const 109
-    i32.const 3
-    call $~lib/builtins/abort
-    unreachable
-   end
-   local.get $1
-   local.get $2
-   i32.const 1
-   i32.add
-   i32.store offset=4
-   local.get $1
-   call $~lib/rt/rtrace/onincrement
-   local.get $1
-   i32.load
-   i32.const 1
-   i32.and
-   if
-    i32.const 0
-    i32.const 1264
-    i32.const 112
-    i32.const 14
-    call $~lib/builtins/abort
-    unreachable
-   end
-  end
-  local.get $0
- )
  (func $~lib/arraybuffer/ArrayBuffer#constructor (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   i32.const 1073741808
   i32.gt_u
   if
-   i32.const 1040
-   i32.const 1088
+   i32.const 1200
+   i32.const 1248
    i32.const 49
    i32.const 43
    call $~lib/builtins/abort
@@ -1302,28 +1302,22 @@
   call $~lib/rt/pure/__retain
   local.tee $0
  )
- (func $~lib/set/Set<i8>#clear (param $0 i32)
-  (local $1 i32)
+ (func $~lib/set/Set<i8>#constructor (result i32)
+  (local $0 i32)
+  i32.const 24
+  i32.const 3
+  call $~lib/rt/tlsf/__alloc
+  call $~lib/rt/pure/__retain
+  local.tee $0
   i32.const 16
   call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $1
-  local.get $0
-  i32.load
-  call $~lib/rt/pure/__release
-  local.get $0
-  local.get $1
   i32.store
   local.get $0
   i32.const 3
   i32.store offset=4
+  local.get $0
   i32.const 32
   call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $1
-  local.get $0
-  i32.load offset=8
-  call $~lib/rt/pure/__release
-  local.get $0
-  local.get $1
   i32.store offset=8
   local.get $0
   i32.const 4
@@ -1334,33 +1328,6 @@
   local.get $0
   i32.const 0
   i32.store offset=20
- )
- (func $~lib/set/Set<i8>#constructor (result i32)
-  (local $0 i32)
-  i32.const 24
-  i32.const 3
-  call $~lib/rt/tlsf/__alloc
-  call $~lib/rt/pure/__retain
-  local.tee $0
-  i32.const 0
-  i32.store
-  local.get $0
-  i32.const 0
-  i32.store offset=4
-  local.get $0
-  i32.const 0
-  i32.store offset=8
-  local.get $0
-  i32.const 0
-  i32.store offset=12
-  local.get $0
-  i32.const 0
-  i32.store offset=16
-  local.get $0
-  i32.const 0
-  i32.store offset=20
-  local.get $0
-  call $~lib/set/Set<i8>#clear
   local.get $0
  )
  (func $~lib/util/hash/hash8 (param $0 i32) (result i32)
@@ -1952,7 +1919,7 @@
    i32.shr_u
    i32.gt_u
    if
-    i32.const 1040
+    i32.const 1200
     i32.const 1360
     i32.const 14
     i32.const 48
@@ -1995,7 +1962,7 @@
    i32.eqz
    if
     i32.const 0
-    i32.const 1152
+    i32.const 1040
     i32.const 581
     i32.const 3
     call $~lib/builtins/abort
@@ -2116,7 +2083,7 @@
   i32.const 1073741808
   i32.gt_u
   if
-   i32.const 1040
+   i32.const 1200
    i32.const 1360
    i32.const 57
    i32.const 60
@@ -2274,6 +2241,39 @@
    local.get $2
    call $~lib/set/Set<i8>#rehash
   end
+ )
+ (func $~lib/set/Set<i8>#clear (param $0 i32)
+  (local $1 i32)
+  i32.const 16
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $1
+  local.get $0
+  i32.load
+  call $~lib/rt/pure/__release
+  local.get $0
+  local.get $1
+  i32.store
+  local.get $0
+  i32.const 3
+  i32.store offset=4
+  i32.const 32
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $1
+  local.get $0
+  i32.load offset=8
+  call $~lib/rt/pure/__release
+  local.get $0
+  local.get $1
+  i32.store offset=8
+  local.get $0
+  i32.const 4
+  i32.store offset=12
+  local.get $0
+  i32.const 0
+  i32.store offset=16
+  local.get $0
+  i32.const 0
+  i32.store offset=20
  )
  (func $std/set/testNumeric<i8>
   (local $0 i32)
@@ -2599,16 +2599,18 @@
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
   local.tee $0
-  i32.const 0
+  i32.const 16
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store
   local.get $0
-  i32.const 0
+  i32.const 3
   i32.store offset=4
   local.get $0
-  i32.const 0
+  i32.const 32
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store offset=8
   local.get $0
-  i32.const 0
+  i32.const 4
   i32.store offset=12
   local.get $0
   i32.const 0
@@ -2616,8 +2618,6 @@
   local.get $0
   i32.const 0
   i32.store offset=20
-  local.get $0
-  call $~lib/set/Set<i8>#clear
   local.get $0
  )
  (func $~lib/set/Set<u8>#has (param $0 i32) (param $1 i32) (result i32)
@@ -2883,7 +2883,7 @@
   i32.const 1073741808
   i32.gt_u
   if
-   i32.const 1040
+   i32.const 1200
    i32.const 1360
    i32.const 57
    i32.const 60
@@ -3356,16 +3356,18 @@
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
   local.tee $0
-  i32.const 0
+  i32.const 16
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store
   local.get $0
-  i32.const 0
+  i32.const 3
   i32.store offset=4
   local.get $0
-  i32.const 0
+  i32.const 32
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store offset=8
   local.get $0
-  i32.const 0
+  i32.const 4
   i32.store offset=12
   local.get $0
   i32.const 0
@@ -3373,8 +3375,6 @@
   local.get $0
   i32.const 0
   i32.store offset=20
-  local.get $0
-  call $~lib/set/Set<i8>#clear
   local.get $0
  )
  (func $~lib/util/hash/hash16 (param $0 i32) (result i32)
@@ -3753,7 +3753,7 @@
   i32.const 536870904
   i32.gt_u
   if
-   i32.const 1040
+   i32.const 1200
    i32.const 1360
    i32.const 57
    i32.const 60
@@ -4241,16 +4241,18 @@
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
   local.tee $0
-  i32.const 0
+  i32.const 16
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store
   local.get $0
-  i32.const 0
+  i32.const 3
   i32.store offset=4
   local.get $0
-  i32.const 0
+  i32.const 32
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store offset=8
   local.get $0
-  i32.const 0
+  i32.const 4
   i32.store offset=12
   local.get $0
   i32.const 0
@@ -4258,8 +4260,6 @@
   local.get $0
   i32.const 0
   i32.store offset=20
-  local.get $0
-  call $~lib/set/Set<i8>#clear
   local.get $0
  )
  (func $~lib/set/Set<u16>#has (param $0 i32) (param $1 i32) (result i32)
@@ -4526,7 +4526,7 @@
   i32.const 536870904
   i32.gt_u
   if
-   i32.const 1040
+   i32.const 1200
    i32.const 1360
    i32.const 57
    i32.const 60
@@ -5004,16 +5004,18 @@
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
   local.tee $0
-  i32.const 0
+  i32.const 16
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store
   local.get $0
-  i32.const 0
+  i32.const 3
   i32.store offset=4
   local.get $0
-  i32.const 0
+  i32.const 32
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store offset=8
   local.get $0
-  i32.const 0
+  i32.const 4
   i32.store offset=12
   local.get $0
   i32.const 0
@@ -5021,8 +5023,6 @@
   local.get $0
   i32.const 0
   i32.store offset=20
-  local.get $0
-  call $~lib/set/Set<i8>#clear
   local.get $0
  )
  (func $~lib/util/hash/hash32 (param $0 i32) (result i32)
@@ -5407,7 +5407,7 @@
   i32.const 268435452
   i32.gt_u
   if
-   i32.const 1040
+   i32.const 1200
    i32.const 1360
    i32.const 57
    i32.const 60
@@ -5875,16 +5875,18 @@
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
   local.tee $0
-  i32.const 0
+  i32.const 16
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store
   local.get $0
-  i32.const 0
+  i32.const 3
   i32.store offset=4
   local.get $0
-  i32.const 0
+  i32.const 32
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store offset=8
   local.get $0
-  i32.const 0
+  i32.const 4
   i32.store offset=12
   local.get $0
   i32.const 0
@@ -5892,8 +5894,6 @@
   local.get $0
   i32.const 0
   i32.store offset=20
-  local.get $0
-  call $~lib/set/Set<i8>#clear
   local.get $0
  )
  (func $~lib/set/Set<u32>#values (param $0 i32) (result i32)
@@ -5933,7 +5933,7 @@
   i32.const 268435452
   i32.gt_u
   if
-   i32.const 1040
+   i32.const 1200
    i32.const 1360
    i32.const 57
    i32.const 60
@@ -6314,28 +6314,22 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<i64>#clear (param $0 i32)
-  (local $1 i32)
+ (func $~lib/set/Set<i64>#constructor (result i32)
+  (local $0 i32)
+  i32.const 24
+  i32.const 15
+  call $~lib/rt/tlsf/__alloc
+  call $~lib/rt/pure/__retain
+  local.tee $0
   i32.const 16
   call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $1
-  local.get $0
-  i32.load
-  call $~lib/rt/pure/__release
-  local.get $0
-  local.get $1
   i32.store
   local.get $0
   i32.const 3
   i32.store offset=4
+  local.get $0
   i32.const 64
   call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $1
-  local.get $0
-  i32.load offset=8
-  call $~lib/rt/pure/__release
-  local.get $0
-  local.get $1
   i32.store offset=8
   local.get $0
   i32.const 4
@@ -6346,33 +6340,6 @@
   local.get $0
   i32.const 0
   i32.store offset=20
- )
- (func $~lib/set/Set<i64>#constructor (result i32)
-  (local $0 i32)
-  i32.const 24
-  i32.const 15
-  call $~lib/rt/tlsf/__alloc
-  call $~lib/rt/pure/__retain
-  local.tee $0
-  i32.const 0
-  i32.store
-  local.get $0
-  i32.const 0
-  i32.store offset=4
-  local.get $0
-  i32.const 0
-  i32.store offset=8
-  local.get $0
-  i32.const 0
-  i32.store offset=12
-  local.get $0
-  i32.const 0
-  i32.store offset=16
-  local.get $0
-  i32.const 0
-  i32.store offset=20
-  local.get $0
-  call $~lib/set/Set<i64>#clear
   local.get $0
  )
  (func $~lib/util/hash/hash64 (param $0 i64) (result i32)
@@ -6792,7 +6759,7 @@
   i32.const 134217726
   i32.gt_u
   if
-   i32.const 1040
+   i32.const 1200
    i32.const 1360
    i32.const 57
    i32.const 60
@@ -6952,6 +6919,39 @@
    local.get $3
    call $~lib/set/Set<i64>#rehash
   end
+ )
+ (func $~lib/set/Set<i64>#clear (param $0 i32)
+  (local $1 i32)
+  i32.const 16
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $1
+  local.get $0
+  i32.load
+  call $~lib/rt/pure/__release
+  local.get $0
+  local.get $1
+  i32.store
+  local.get $0
+  i32.const 3
+  i32.store offset=4
+  i32.const 64
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $1
+  local.get $0
+  i32.load offset=8
+  call $~lib/rt/pure/__release
+  local.get $0
+  local.get $1
+  i32.store offset=8
+  local.get $0
+  i32.const 4
+  i32.store offset=12
+  local.get $0
+  i32.const 0
+  i32.store offset=16
+  local.get $0
+  i32.const 0
+  i32.store offset=20
  )
  (func $std/set/testNumeric<i64>
   (local $0 i64)
@@ -7262,16 +7262,18 @@
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
   local.tee $0
-  i32.const 0
+  i32.const 16
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store
   local.get $0
-  i32.const 0
+  i32.const 3
   i32.store offset=4
   local.get $0
-  i32.const 0
+  i32.const 64
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store offset=8
   local.get $0
-  i32.const 0
+  i32.const 4
   i32.store offset=12
   local.get $0
   i32.const 0
@@ -7279,8 +7281,6 @@
   local.get $0
   i32.const 0
   i32.store offset=20
-  local.get $0
-  call $~lib/set/Set<i64>#clear
   local.get $0
  )
  (func $~lib/set/Set<u64>#values (param $0 i32) (result i32)
@@ -7320,7 +7320,7 @@
   i32.const 134217726
   i32.gt_u
   if
-   i32.const 1040
+   i32.const 1200
    i32.const 1360
    i32.const 57
    i32.const 60
@@ -7709,16 +7709,18 @@
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
   local.tee $0
-  i32.const 0
+  i32.const 16
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store
   local.get $0
-  i32.const 0
+  i32.const 3
   i32.store offset=4
   local.get $0
-  i32.const 0
+  i32.const 32
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store offset=8
   local.get $0
-  i32.const 0
+  i32.const 4
   i32.store offset=12
   local.get $0
   i32.const 0
@@ -7726,8 +7728,6 @@
   local.get $0
   i32.const 0
   i32.store offset=20
-  local.get $0
-  call $~lib/set/Set<i8>#clear
   local.get $0
  )
  (func $~lib/set/Set<f32>#find (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
@@ -8035,7 +8035,7 @@
   i32.const 268435452
   i32.gt_u
   if
-   i32.const 1040
+   i32.const 1200
    i32.const 1360
    i32.const 57
    i32.const 60
@@ -8539,16 +8539,18 @@
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
   local.tee $0
-  i32.const 0
+  i32.const 16
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store
   local.get $0
-  i32.const 0
+  i32.const 3
   i32.store offset=4
   local.get $0
-  i32.const 0
+  i32.const 64
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store offset=8
   local.get $0
-  i32.const 0
+  i32.const 4
   i32.store offset=12
   local.get $0
   i32.const 0
@@ -8556,8 +8558,6 @@
   local.get $0
   i32.const 0
   i32.store offset=20
-  local.get $0
-  call $~lib/set/Set<i64>#clear
   local.get $0
  )
  (func $~lib/set/Set<f64>#find (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
@@ -8865,7 +8865,7 @@
   i32.const 134217726
   i32.gt_u
   if
-   i32.const 1040
+   i32.const 1200
    i32.const 1360
    i32.const 57
    i32.const 60
@@ -9391,7 +9391,7 @@
   i32.and
   if
    i32.const 0
-   i32.const 1264
+   i32.const 1152
    i32.const 122
    i32.const 14
    call $~lib/builtins/abort
@@ -9440,7 +9440,7 @@
    i32.and
    if
     i32.const 0
-    i32.const 1264
+    i32.const 1152
     i32.const 126
     i32.const 18
     call $~lib/builtins/abort
@@ -9455,7 +9455,7 @@
    i32.le_u
    if
     i32.const 0
-    i32.const 1264
+    i32.const 1152
     i32.const 136
     i32.const 16
     call $~lib/builtins/abort

--- a/tests/compiler/std/set.untouched.wat
+++ b/tests/compiler/std/set.untouched.wat
@@ -28,11 +28,11 @@
  (import "rtrace" "onfree" (func $~lib/rt/rtrace/onfree (param i32)))
  (import "rtrace" "ondecrement" (func $~lib/rt/rtrace/ondecrement (param i32)))
  (memory $0 1)
- (data (i32.const 16) "\1c\00\00\00\01\00\00\00\01\00\00\00\1c\00\00\00I\00n\00v\00a\00l\00i\00d\00 \00l\00e\00n\00g\00t\00h\00")
- (data (i32.const 64) "&\00\00\00\01\00\00\00\01\00\00\00&\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00b\00u\00f\00f\00e\00r\00.\00t\00s\00")
- (data (i32.const 128) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s\00")
- (data (i32.const 176) "(\00\00\00\01\00\00\00\01\00\00\00(\00\00\00a\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e\00")
- (data (i32.const 240) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00p\00u\00r\00e\00.\00t\00s\00")
+ (data (i32.const 16) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s\00")
+ (data (i32.const 64) "(\00\00\00\01\00\00\00\01\00\00\00(\00\00\00a\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e\00")
+ (data (i32.const 128) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00p\00u\00r\00e\00.\00t\00s\00")
+ (data (i32.const 176) "\1c\00\00\00\01\00\00\00\01\00\00\00\1c\00\00\00I\00n\00v\00a\00l\00i\00d\00 \00l\00e\00n\00g\00t\00h\00")
+ (data (i32.const 224) "&\00\00\00\01\00\00\00\01\00\00\00&\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00b\00u\00f\00f\00e\00r\00.\00t\00s\00")
  (data (i32.const 288) "\14\00\00\00\01\00\00\00\01\00\00\00\14\00\00\00s\00t\00d\00/\00s\00e\00t\00.\00t\00s\00")
  (data (i32.const 336) "\1a\00\00\00\01\00\00\00\01\00\00\00\1a\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00.\00t\00s\00")
  (data (i32.const 384) "$\00\00\00\01\00\00\00\01\00\00\00$\00\00\00I\00n\00d\00e\00x\00 \00o\00u\00t\00 \00o\00f\00 \00r\00a\00n\00g\00e\00")
@@ -45,17 +45,6 @@
  (global $~lib/heap/__heap_base i32 (i32.const 436))
  (export "memory" (memory $0))
  (start $~start)
- (func $~lib/rt/pure/__release (param $0 i32)
-  local.get $0
-  global.get $~lib/heap/__heap_base
-  i32.gt_u
-  if
-   local.get $0
-   i32.const 16
-   i32.sub
-   call $~lib/rt/pure/decrement
-  end
- )
  (func $~lib/rt/tlsf/removeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -78,7 +67,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 277
    i32.const 14
    call $~lib/builtins/abort
@@ -105,7 +94,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 279
    i32.const 14
    call $~lib/builtins/abort
@@ -159,7 +148,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 292
    i32.const 14
    call $~lib/builtins/abort
@@ -291,7 +280,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 205
    i32.const 14
    call $~lib/builtins/abort
@@ -308,7 +297,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 207
    i32.const 14
    call $~lib/builtins/abort
@@ -403,7 +392,7 @@
    i32.eqz
    if
     i32.const 0
-    i32.const 144
+    i32.const 32
     i32.const 228
     i32.const 16
     call $~lib/builtins/abort
@@ -468,7 +457,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 243
    i32.const 14
    call $~lib/builtins/abort
@@ -486,7 +475,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 244
    i32.const 14
    call $~lib/builtins/abort
@@ -545,7 +534,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 260
    i32.const 14
    call $~lib/builtins/abort
@@ -666,7 +655,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 386
    i32.const 5
    call $~lib/builtins/abort
@@ -691,7 +680,7 @@
    i32.eqz
    if
     i32.const 0
-    i32.const 144
+    i32.const 32
     i32.const 396
     i32.const 16
     call $~lib/builtins/abort
@@ -724,7 +713,7 @@
    i32.eqz
    if
     i32.const 0
-    i32.const 144
+    i32.const 32
     i32.const 408
     i32.const 5
     call $~lib/builtins/abort
@@ -955,8 +944,8 @@
   i32.const 1073741808
   i32.ge_u
   if
-   i32.const 192
-   i32.const 144
+   i32.const 80
+   i32.const 32
    i32.const 461
    i32.const 30
    call $~lib/builtins/abort
@@ -1052,7 +1041,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 338
    i32.const 14
    call $~lib/builtins/abort
@@ -1117,7 +1106,7 @@
     i32.eqz
     if
      i32.const 0
-     i32.const 144
+     i32.const 32
      i32.const 351
      i32.const 18
      call $~lib/builtins/abort
@@ -1266,7 +1255,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 365
    i32.const 14
    call $~lib/builtins/abort
@@ -1359,7 +1348,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 501
    i32.const 14
    call $~lib/builtins/abort
@@ -1406,7 +1395,7 @@
      i32.eqz
      if
       i32.const 0
-      i32.const 144
+      i32.const 32
       i32.const 513
       i32.const 20
       call $~lib/builtins/abort
@@ -1427,7 +1416,7 @@
     i32.eqz
     if
      i32.const 0
-     i32.const 144
+     i32.const 32
      i32.const 518
      i32.const 18
      call $~lib/builtins/abort
@@ -1448,7 +1437,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 521
    i32.const 14
    call $~lib/builtins/abort
@@ -1483,6 +1472,82 @@
   call $~lib/rt/tlsf/allocateBlock
   i32.const 16
   i32.add
+ )
+ (func $~lib/rt/pure/increment (param $0 i32)
+  (local $1 i32)
+  local.get $0
+  i32.load offset=4
+  local.set $1
+  local.get $1
+  i32.const 268435455
+  i32.const -1
+  i32.xor
+  i32.and
+  local.get $1
+  i32.const 1
+  i32.add
+  i32.const 268435455
+  i32.const -1
+  i32.xor
+  i32.and
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 144
+   i32.const 109
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  local.get $1
+  i32.const 1
+  i32.add
+  i32.store offset=4
+  i32.const 1
+  drop
+  local.get $0
+  call $~lib/rt/rtrace/onincrement
+  i32.const 1
+  drop
+  local.get $0
+  i32.load
+  i32.const 1
+  i32.and
+  i32.eqz
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 144
+   i32.const 112
+   i32.const 14
+   call $~lib/builtins/abort
+   unreachable
+  end
+ )
+ (func $~lib/rt/pure/__retain (param $0 i32) (result i32)
+  local.get $0
+  global.get $~lib/heap/__heap_base
+  i32.gt_u
+  if
+   local.get $0
+   i32.const 16
+   i32.sub
+   call $~lib/rt/pure/increment
+  end
+  local.get $0
+ )
+ (func $~lib/rt/pure/__release (param $0 i32)
+  local.get $0
+  global.get $~lib/heap/__heap_base
+  i32.gt_u
+  if
+   local.get $0
+   i32.const 16
+   i32.sub
+   call $~lib/rt/pure/decrement
+  end
  )
  (func $~lib/memory/memory.fill (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
@@ -1697,71 +1762,6 @@
    end
   end
  )
- (func $~lib/rt/pure/increment (param $0 i32)
-  (local $1 i32)
-  local.get $0
-  i32.load offset=4
-  local.set $1
-  local.get $1
-  i32.const 268435455
-  i32.const -1
-  i32.xor
-  i32.and
-  local.get $1
-  i32.const 1
-  i32.add
-  i32.const 268435455
-  i32.const -1
-  i32.xor
-  i32.and
-  i32.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 256
-   i32.const 109
-   i32.const 3
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $0
-  local.get $1
-  i32.const 1
-  i32.add
-  i32.store offset=4
-  i32.const 1
-  drop
-  local.get $0
-  call $~lib/rt/rtrace/onincrement
-  i32.const 1
-  drop
-  local.get $0
-  i32.load
-  i32.const 1
-  i32.and
-  i32.eqz
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 256
-   i32.const 112
-   i32.const 14
-   call $~lib/builtins/abort
-   unreachable
-  end
- )
- (func $~lib/rt/pure/__retain (param $0 i32) (result i32)
-  local.get $0
-  global.get $~lib/heap/__heap_base
-  i32.gt_u
-  if
-   local.get $0
-   i32.const 16
-   i32.sub
-   call $~lib/rt/pure/increment
-  end
-  local.get $0
- )
  (func $~lib/arraybuffer/ArrayBuffer#constructor (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
@@ -1769,8 +1769,8 @@
   i32.const 1073741808
   i32.gt_u
   if
-   i32.const 32
-   i32.const 80
+   i32.const 192
+   i32.const 240
    i32.const 49
    i32.const 43
    call $~lib/builtins/abort
@@ -1791,46 +1791,6 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/set/Set<i8>#clear (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  local.tee $1
-  i32.const 0
-  i32.const 16
-  call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $2
-  local.get $1
-  i32.load
-  call $~lib/rt/pure/__release
-  local.get $2
-  i32.store
-  local.get $0
-  i32.const 4
-  i32.const 1
-  i32.sub
-  i32.store offset=4
-  local.get $0
-  local.tee $2
-  i32.const 0
-  i32.const 32
-  call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $1
-  local.get $2
-  i32.load offset=8
-  call $~lib/rt/pure/__release
-  local.get $1
-  i32.store offset=8
-  local.get $0
-  i32.const 4
-  i32.store offset=12
-  local.get $0
-  i32.const 0
-  i32.store offset=16
-  local.get $0
-  i32.const 0
-  i32.store offset=20
- )
  (func $~lib/set/Set<i8>#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
@@ -1843,15 +1803,25 @@
   end
   local.get $0
   i32.const 0
+  i32.const 4
+  i32.const 4
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store
   local.get $0
-  i32.const 0
+  i32.const 4
+  i32.const 1
+  i32.sub
   i32.store offset=4
   local.get $0
   i32.const 0
+  i32.const 4
+  i32.const 8
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store offset=8
   local.get $0
-  i32.const 0
+  i32.const 4
   i32.store offset=12
   local.get $0
   i32.const 0
@@ -1859,8 +1829,6 @@
   local.get $0
   i32.const 0
   i32.store offset=20
-  local.get $0
-  call $~lib/set/Set<i8>#clear
   local.get $0
  )
  (func $~lib/util/hash/hash8 (param $0 i32) (result i32)
@@ -2258,7 +2226,7 @@
   i32.shr_u
   i32.gt_u
   if
-   i32.const 32
+   i32.const 192
    i32.const 352
    i32.const 57
    i32.const 60
@@ -2345,7 +2313,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 32
    i32.const 581
    i32.const 3
    call $~lib/builtins/abort
@@ -3779,7 +3747,7 @@
    i32.shr_u
    i32.gt_u
    if
-    i32.const 32
+    i32.const 192
     i32.const 352
     i32.const 14
     i32.const 48
@@ -4069,6 +4037,50 @@
    call $~lib/set/Set<i8>#rehash
   end
   i32.const 1
+ )
+ (func $~lib/set/Set<i8>#clear (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  local.get $0
+  local.tee $1
+  i32.const 0
+  i32.const 4
+  i32.const 4
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $2
+  local.get $1
+  i32.load
+  call $~lib/rt/pure/__release
+  local.get $2
+  i32.store
+  local.get $0
+  i32.const 4
+  i32.const 1
+  i32.sub
+  i32.store offset=4
+  local.get $0
+  local.tee $2
+  i32.const 0
+  i32.const 4
+  i32.const 8
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $1
+  local.get $2
+  i32.load offset=8
+  call $~lib/rt/pure/__release
+  local.get $1
+  i32.store offset=8
+  local.get $0
+  i32.const 4
+  i32.store offset=12
+  local.get $0
+  i32.const 0
+  i32.store offset=16
+  local.get $0
+  i32.const 0
+  i32.store offset=20
  )
  (func $std/set/testNumeric<i8>
   (local $0 i32)
@@ -4426,46 +4438,6 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<u8>#clear (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  local.tee $1
-  i32.const 0
-  i32.const 16
-  call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $2
-  local.get $1
-  i32.load
-  call $~lib/rt/pure/__release
-  local.get $2
-  i32.store
-  local.get $0
-  i32.const 4
-  i32.const 1
-  i32.sub
-  i32.store offset=4
-  local.get $0
-  local.tee $2
-  i32.const 0
-  i32.const 32
-  call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $1
-  local.get $2
-  i32.load offset=8
-  call $~lib/rt/pure/__release
-  local.get $1
-  i32.store offset=8
-  local.get $0
-  i32.const 4
-  i32.store offset=12
-  local.get $0
-  i32.const 0
-  i32.store offset=16
-  local.get $0
-  i32.const 0
-  i32.store offset=20
- )
  (func $~lib/set/Set<u8>#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
@@ -4478,15 +4450,25 @@
   end
   local.get $0
   i32.const 0
+  i32.const 4
+  i32.const 4
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store
   local.get $0
-  i32.const 0
+  i32.const 4
+  i32.const 1
+  i32.sub
   i32.store offset=4
   local.get $0
   i32.const 0
+  i32.const 4
+  i32.const 8
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store offset=8
   local.get $0
-  i32.const 0
+  i32.const 4
   i32.store offset=12
   local.get $0
   i32.const 0
@@ -4494,8 +4476,6 @@
   local.get $0
   i32.const 0
   i32.store offset=20
-  local.get $0
-  call $~lib/set/Set<u8>#clear
   local.get $0
  )
  (func $~lib/set/Set<u8>#find (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -4880,7 +4860,7 @@
   i32.shr_u
   i32.gt_u
   if
-   i32.const 32
+   i32.const 192
    i32.const 352
    i32.const 57
    i32.const 60
@@ -5173,6 +5153,50 @@
    call $~lib/set/Set<u8>#rehash
   end
   i32.const 1
+ )
+ (func $~lib/set/Set<u8>#clear (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  local.get $0
+  local.tee $1
+  i32.const 0
+  i32.const 4
+  i32.const 4
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $2
+  local.get $1
+  i32.load
+  call $~lib/rt/pure/__release
+  local.get $2
+  i32.store
+  local.get $0
+  i32.const 4
+  i32.const 1
+  i32.sub
+  i32.store offset=4
+  local.get $0
+  local.tee $2
+  i32.const 0
+  i32.const 4
+  i32.const 8
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $1
+  local.get $2
+  i32.load offset=8
+  call $~lib/rt/pure/__release
+  local.get $1
+  i32.store offset=8
+  local.get $0
+  i32.const 4
+  i32.store offset=12
+  local.get $0
+  i32.const 0
+  i32.store offset=16
+  local.get $0
+  i32.const 0
+  i32.store offset=20
  )
  (func $std/set/testNumeric<u8>
   (local $0 i32)
@@ -5522,46 +5546,6 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<i16>#clear (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  local.tee $1
-  i32.const 0
-  i32.const 16
-  call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $2
-  local.get $1
-  i32.load
-  call $~lib/rt/pure/__release
-  local.get $2
-  i32.store
-  local.get $0
-  i32.const 4
-  i32.const 1
-  i32.sub
-  i32.store offset=4
-  local.get $0
-  local.tee $2
-  i32.const 0
-  i32.const 32
-  call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $1
-  local.get $2
-  i32.load offset=8
-  call $~lib/rt/pure/__release
-  local.get $1
-  i32.store offset=8
-  local.get $0
-  i32.const 4
-  i32.store offset=12
-  local.get $0
-  i32.const 0
-  i32.store offset=16
-  local.get $0
-  i32.const 0
-  i32.store offset=20
- )
  (func $~lib/set/Set<i16>#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
@@ -5574,15 +5558,25 @@
   end
   local.get $0
   i32.const 0
+  i32.const 4
+  i32.const 4
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store
   local.get $0
-  i32.const 0
+  i32.const 4
+  i32.const 1
+  i32.sub
   i32.store offset=4
   local.get $0
   i32.const 0
+  i32.const 4
+  i32.const 8
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store offset=8
   local.get $0
-  i32.const 0
+  i32.const 4
   i32.store offset=12
   local.get $0
   i32.const 0
@@ -5590,8 +5584,6 @@
   local.get $0
   i32.const 0
   i32.store offset=20
-  local.get $0
-  call $~lib/set/Set<i16>#clear
   local.get $0
  )
  (func $~lib/util/hash/hash16 (param $0 i32) (result i32)
@@ -6016,7 +6008,7 @@
   i32.shr_u
   i32.gt_u
   if
-   i32.const 32
+   i32.const 192
    i32.const 352
    i32.const 57
    i32.const 60
@@ -6315,6 +6307,50 @@
    call $~lib/set/Set<i16>#rehash
   end
   i32.const 1
+ )
+ (func $~lib/set/Set<i16>#clear (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  local.get $0
+  local.tee $1
+  i32.const 0
+  i32.const 4
+  i32.const 4
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $2
+  local.get $1
+  i32.load
+  call $~lib/rt/pure/__release
+  local.get $2
+  i32.store
+  local.get $0
+  i32.const 4
+  i32.const 1
+  i32.sub
+  i32.store offset=4
+  local.get $0
+  local.tee $2
+  i32.const 0
+  i32.const 4
+  i32.const 8
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $1
+  local.get $2
+  i32.load offset=8
+  call $~lib/rt/pure/__release
+  local.get $1
+  i32.store offset=8
+  local.get $0
+  i32.const 4
+  i32.store offset=12
+  local.get $0
+  i32.const 0
+  i32.store offset=16
+  local.get $0
+  i32.const 0
+  i32.store offset=20
  )
  (func $std/set/testNumeric<i16>
   (local $0 i32)
@@ -6672,46 +6708,6 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<u16>#clear (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  local.tee $1
-  i32.const 0
-  i32.const 16
-  call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $2
-  local.get $1
-  i32.load
-  call $~lib/rt/pure/__release
-  local.get $2
-  i32.store
-  local.get $0
-  i32.const 4
-  i32.const 1
-  i32.sub
-  i32.store offset=4
-  local.get $0
-  local.tee $2
-  i32.const 0
-  i32.const 32
-  call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $1
-  local.get $2
-  i32.load offset=8
-  call $~lib/rt/pure/__release
-  local.get $1
-  i32.store offset=8
-  local.get $0
-  i32.const 4
-  i32.store offset=12
-  local.get $0
-  i32.const 0
-  i32.store offset=16
-  local.get $0
-  i32.const 0
-  i32.store offset=20
- )
  (func $~lib/set/Set<u16>#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
@@ -6724,15 +6720,25 @@
   end
   local.get $0
   i32.const 0
+  i32.const 4
+  i32.const 4
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store
   local.get $0
-  i32.const 0
+  i32.const 4
+  i32.const 1
+  i32.sub
   i32.store offset=4
   local.get $0
   i32.const 0
+  i32.const 4
+  i32.const 8
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store offset=8
   local.get $0
-  i32.const 0
+  i32.const 4
   i32.store offset=12
   local.get $0
   i32.const 0
@@ -6740,8 +6746,6 @@
   local.get $0
   i32.const 0
   i32.store offset=20
-  local.get $0
-  call $~lib/set/Set<u16>#clear
   local.get $0
  )
  (func $~lib/set/Set<u16>#find (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -7138,7 +7142,7 @@
   i32.shr_u
   i32.gt_u
   if
-   i32.const 32
+   i32.const 192
    i32.const 352
    i32.const 57
    i32.const 60
@@ -7435,6 +7439,50 @@
    call $~lib/set/Set<u16>#rehash
   end
   i32.const 1
+ )
+ (func $~lib/set/Set<u16>#clear (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  local.get $0
+  local.tee $1
+  i32.const 0
+  i32.const 4
+  i32.const 4
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $2
+  local.get $1
+  i32.load
+  call $~lib/rt/pure/__release
+  local.get $2
+  i32.store
+  local.get $0
+  i32.const 4
+  i32.const 1
+  i32.sub
+  i32.store offset=4
+  local.get $0
+  local.tee $2
+  i32.const 0
+  i32.const 4
+  i32.const 8
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $1
+  local.get $2
+  i32.load offset=8
+  call $~lib/rt/pure/__release
+  local.get $1
+  i32.store offset=8
+  local.get $0
+  i32.const 4
+  i32.store offset=12
+  local.get $0
+  i32.const 0
+  i32.store offset=16
+  local.get $0
+  i32.const 0
+  i32.store offset=20
  )
  (func $std/set/testNumeric<u16>
   (local $0 i32)
@@ -7784,46 +7832,6 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<i32>#clear (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  local.tee $1
-  i32.const 0
-  i32.const 16
-  call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $2
-  local.get $1
-  i32.load
-  call $~lib/rt/pure/__release
-  local.get $2
-  i32.store
-  local.get $0
-  i32.const 4
-  i32.const 1
-  i32.sub
-  i32.store offset=4
-  local.get $0
-  local.tee $2
-  i32.const 0
-  i32.const 32
-  call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $1
-  local.get $2
-  i32.load offset=8
-  call $~lib/rt/pure/__release
-  local.get $1
-  i32.store offset=8
-  local.get $0
-  i32.const 4
-  i32.store offset=12
-  local.get $0
-  i32.const 0
-  i32.store offset=16
-  local.get $0
-  i32.const 0
-  i32.store offset=20
- )
  (func $~lib/set/Set<i32>#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
@@ -7836,15 +7844,25 @@
   end
   local.get $0
   i32.const 0
+  i32.const 4
+  i32.const 4
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store
   local.get $0
-  i32.const 0
+  i32.const 4
+  i32.const 1
+  i32.sub
   i32.store offset=4
   local.get $0
   i32.const 0
+  i32.const 4
+  i32.const 8
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store offset=8
   local.get $0
-  i32.const 0
+  i32.const 4
   i32.store offset=12
   local.get $0
   i32.const 0
@@ -7852,8 +7870,6 @@
   local.get $0
   i32.const 0
   i32.store offset=20
-  local.get $0
-  call $~lib/set/Set<i32>#clear
   local.get $0
  )
  (func $~lib/util/hash/hash32 (param $0 i32) (result i32)
@@ -8298,7 +8314,7 @@
   i32.shr_u
   i32.gt_u
   if
-   i32.const 32
+   i32.const 192
    i32.const 352
    i32.const 57
    i32.const 60
@@ -8597,6 +8613,50 @@
    call $~lib/set/Set<i32>#rehash
   end
   i32.const 1
+ )
+ (func $~lib/set/Set<i32>#clear (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  local.get $0
+  local.tee $1
+  i32.const 0
+  i32.const 4
+  i32.const 4
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $2
+  local.get $1
+  i32.load
+  call $~lib/rt/pure/__release
+  local.get $2
+  i32.store
+  local.get $0
+  i32.const 4
+  i32.const 1
+  i32.sub
+  i32.store offset=4
+  local.get $0
+  local.tee $2
+  i32.const 0
+  i32.const 4
+  i32.const 8
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $1
+  local.get $2
+  i32.load offset=8
+  call $~lib/rt/pure/__release
+  local.get $1
+  i32.store offset=8
+  local.get $0
+  i32.const 4
+  i32.store offset=12
+  local.get $0
+  i32.const 0
+  i32.store offset=16
+  local.get $0
+  i32.const 0
+  i32.store offset=20
  )
  (func $std/set/testNumeric<i32>
   (local $0 i32)
@@ -8934,46 +8994,6 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<u32>#clear (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  local.tee $1
-  i32.const 0
-  i32.const 16
-  call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $2
-  local.get $1
-  i32.load
-  call $~lib/rt/pure/__release
-  local.get $2
-  i32.store
-  local.get $0
-  i32.const 4
-  i32.const 1
-  i32.sub
-  i32.store offset=4
-  local.get $0
-  local.tee $2
-  i32.const 0
-  i32.const 32
-  call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $1
-  local.get $2
-  i32.load offset=8
-  call $~lib/rt/pure/__release
-  local.get $1
-  i32.store offset=8
-  local.get $0
-  i32.const 4
-  i32.store offset=12
-  local.get $0
-  i32.const 0
-  i32.store offset=16
-  local.get $0
-  i32.const 0
-  i32.store offset=20
- )
  (func $~lib/set/Set<u32>#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
@@ -8986,15 +9006,25 @@
   end
   local.get $0
   i32.const 0
+  i32.const 4
+  i32.const 4
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store
   local.get $0
-  i32.const 0
+  i32.const 4
+  i32.const 1
+  i32.sub
   i32.store offset=4
   local.get $0
   i32.const 0
+  i32.const 4
+  i32.const 8
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store offset=8
   local.get $0
-  i32.const 0
+  i32.const 4
   i32.store offset=12
   local.get $0
   i32.const 0
@@ -9002,8 +9032,6 @@
   local.get $0
   i32.const 0
   i32.store offset=20
-  local.get $0
-  call $~lib/set/Set<u32>#clear
   local.get $0
  )
  (func $~lib/set/Set<u32>#find (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -9406,7 +9434,7 @@
   i32.shr_u
   i32.gt_u
   if
-   i32.const 32
+   i32.const 192
    i32.const 352
    i32.const 57
    i32.const 60
@@ -9705,6 +9733,50 @@
    call $~lib/set/Set<u32>#rehash
   end
   i32.const 1
+ )
+ (func $~lib/set/Set<u32>#clear (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  local.get $0
+  local.tee $1
+  i32.const 0
+  i32.const 4
+  i32.const 4
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $2
+  local.get $1
+  i32.load
+  call $~lib/rt/pure/__release
+  local.get $2
+  i32.store
+  local.get $0
+  i32.const 4
+  i32.const 1
+  i32.sub
+  i32.store offset=4
+  local.get $0
+  local.tee $2
+  i32.const 0
+  i32.const 4
+  i32.const 8
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $1
+  local.get $2
+  i32.load offset=8
+  call $~lib/rt/pure/__release
+  local.get $1
+  i32.store offset=8
+  local.get $0
+  i32.const 4
+  i32.store offset=12
+  local.get $0
+  i32.const 0
+  i32.store offset=16
+  local.get $0
+  i32.const 0
+  i32.store offset=20
  )
  (func $std/set/testNumeric<u32>
   (local $0 i32)
@@ -10042,46 +10114,6 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<i64>#clear (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  local.tee $1
-  i32.const 0
-  i32.const 16
-  call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $2
-  local.get $1
-  i32.load
-  call $~lib/rt/pure/__release
-  local.get $2
-  i32.store
-  local.get $0
-  i32.const 4
-  i32.const 1
-  i32.sub
-  i32.store offset=4
-  local.get $0
-  local.tee $2
-  i32.const 0
-  i32.const 64
-  call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $1
-  local.get $2
-  i32.load offset=8
-  call $~lib/rt/pure/__release
-  local.get $1
-  i32.store offset=8
-  local.get $0
-  i32.const 4
-  i32.store offset=12
-  local.get $0
-  i32.const 0
-  i32.store offset=16
-  local.get $0
-  i32.const 0
-  i32.store offset=20
- )
  (func $~lib/set/Set<i64>#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
@@ -10094,15 +10126,25 @@
   end
   local.get $0
   i32.const 0
+  i32.const 4
+  i32.const 4
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store
   local.get $0
-  i32.const 0
+  i32.const 4
+  i32.const 1
+  i32.sub
   i32.store offset=4
   local.get $0
   i32.const 0
+  i32.const 4
+  i32.const 16
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store offset=8
   local.get $0
-  i32.const 0
+  i32.const 4
   i32.store offset=12
   local.get $0
   i32.const 0
@@ -10110,8 +10152,6 @@
   local.get $0
   i32.const 0
   i32.store offset=20
-  local.get $0
-  call $~lib/set/Set<i64>#clear
   local.get $0
  )
  (func $~lib/util/hash/hash64 (param $0 i64) (result i32)
@@ -10616,7 +10656,7 @@
   i32.shr_u
   i32.gt_u
   if
-   i32.const 32
+   i32.const 192
    i32.const 352
    i32.const 57
    i32.const 60
@@ -10920,6 +10960,50 @@
    call $~lib/set/Set<i64>#rehash
   end
   i32.const 1
+ )
+ (func $~lib/set/Set<i64>#clear (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  local.get $0
+  local.tee $1
+  i32.const 0
+  i32.const 4
+  i32.const 4
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $2
+  local.get $1
+  i32.load
+  call $~lib/rt/pure/__release
+  local.get $2
+  i32.store
+  local.get $0
+  i32.const 4
+  i32.const 1
+  i32.sub
+  i32.store offset=4
+  local.get $0
+  local.tee $2
+  i32.const 0
+  i32.const 4
+  i32.const 16
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $1
+  local.get $2
+  i32.load offset=8
+  call $~lib/rt/pure/__release
+  local.get $1
+  i32.store offset=8
+  local.get $0
+  i32.const 4
+  i32.store offset=12
+  local.get $0
+  i32.const 0
+  i32.store offset=16
+  local.get $0
+  i32.const 0
+  i32.store offset=20
  )
  (func $std/set/testNumeric<i64>
   (local $0 i32)
@@ -11258,46 +11342,6 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<u64>#clear (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  local.tee $1
-  i32.const 0
-  i32.const 16
-  call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $2
-  local.get $1
-  i32.load
-  call $~lib/rt/pure/__release
-  local.get $2
-  i32.store
-  local.get $0
-  i32.const 4
-  i32.const 1
-  i32.sub
-  i32.store offset=4
-  local.get $0
-  local.tee $2
-  i32.const 0
-  i32.const 64
-  call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $1
-  local.get $2
-  i32.load offset=8
-  call $~lib/rt/pure/__release
-  local.get $1
-  i32.store offset=8
-  local.get $0
-  i32.const 4
-  i32.store offset=12
-  local.get $0
-  i32.const 0
-  i32.store offset=16
-  local.get $0
-  i32.const 0
-  i32.store offset=20
- )
  (func $~lib/set/Set<u64>#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
@@ -11310,15 +11354,25 @@
   end
   local.get $0
   i32.const 0
+  i32.const 4
+  i32.const 4
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store
   local.get $0
-  i32.const 0
+  i32.const 4
+  i32.const 1
+  i32.sub
   i32.store offset=4
   local.get $0
   i32.const 0
+  i32.const 4
+  i32.const 16
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store offset=8
   local.get $0
-  i32.const 0
+  i32.const 4
   i32.store offset=12
   local.get $0
   i32.const 0
@@ -11326,8 +11380,6 @@
   local.get $0
   i32.const 0
   i32.store offset=20
-  local.get $0
-  call $~lib/set/Set<u64>#clear
   local.get $0
  )
  (func $~lib/set/Set<u64>#find (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
@@ -11744,7 +11796,7 @@
   i32.shr_u
   i32.gt_u
   if
-   i32.const 32
+   i32.const 192
    i32.const 352
    i32.const 57
    i32.const 60
@@ -12048,6 +12100,50 @@
    call $~lib/set/Set<u64>#rehash
   end
   i32.const 1
+ )
+ (func $~lib/set/Set<u64>#clear (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  local.get $0
+  local.tee $1
+  i32.const 0
+  i32.const 4
+  i32.const 4
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $2
+  local.get $1
+  i32.load
+  call $~lib/rt/pure/__release
+  local.get $2
+  i32.store
+  local.get $0
+  i32.const 4
+  i32.const 1
+  i32.sub
+  i32.store offset=4
+  local.get $0
+  local.tee $2
+  i32.const 0
+  i32.const 4
+  i32.const 16
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $1
+  local.get $2
+  i32.load offset=8
+  call $~lib/rt/pure/__release
+  local.get $1
+  i32.store offset=8
+  local.get $0
+  i32.const 4
+  i32.store offset=12
+  local.get $0
+  i32.const 0
+  i32.store offset=16
+  local.get $0
+  i32.const 0
+  i32.store offset=20
  )
  (func $std/set/testNumeric<u64>
   (local $0 i32)
@@ -12386,46 +12482,6 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<f32>#clear (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  local.tee $1
-  i32.const 0
-  i32.const 16
-  call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $2
-  local.get $1
-  i32.load
-  call $~lib/rt/pure/__release
-  local.get $2
-  i32.store
-  local.get $0
-  i32.const 4
-  i32.const 1
-  i32.sub
-  i32.store offset=4
-  local.get $0
-  local.tee $2
-  i32.const 0
-  i32.const 32
-  call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $1
-  local.get $2
-  i32.load offset=8
-  call $~lib/rt/pure/__release
-  local.get $1
-  i32.store offset=8
-  local.get $0
-  i32.const 4
-  i32.store offset=12
-  local.get $0
-  i32.const 0
-  i32.store offset=16
-  local.get $0
-  i32.const 0
-  i32.store offset=20
- )
  (func $~lib/set/Set<f32>#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
@@ -12438,15 +12494,25 @@
   end
   local.get $0
   i32.const 0
+  i32.const 4
+  i32.const 4
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store
   local.get $0
-  i32.const 0
+  i32.const 4
+  i32.const 1
+  i32.sub
   i32.store offset=4
   local.get $0
   i32.const 0
+  i32.const 4
+  i32.const 8
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store offset=8
   local.get $0
-  i32.const 0
+  i32.const 4
   i32.store offset=12
   local.get $0
   i32.const 0
@@ -12454,8 +12520,6 @@
   local.get $0
   i32.const 0
   i32.store offset=20
-  local.get $0
-  call $~lib/set/Set<f32>#clear
   local.get $0
  )
  (func $~lib/set/Set<f32>#find (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
@@ -12839,7 +12903,7 @@
   i32.shr_u
   i32.gt_u
   if
-   i32.const 32
+   i32.const 192
    i32.const 352
    i32.const 57
    i32.const 60
@@ -13132,6 +13196,50 @@
    call $~lib/set/Set<f32>#rehash
   end
   i32.const 1
+ )
+ (func $~lib/set/Set<f32>#clear (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  local.get $0
+  local.tee $1
+  i32.const 0
+  i32.const 4
+  i32.const 4
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $2
+  local.get $1
+  i32.load
+  call $~lib/rt/pure/__release
+  local.get $2
+  i32.store
+  local.get $0
+  i32.const 4
+  i32.const 1
+  i32.sub
+  i32.store offset=4
+  local.get $0
+  local.tee $2
+  i32.const 0
+  i32.const 4
+  i32.const 8
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $1
+  local.get $2
+  i32.load offset=8
+  call $~lib/rt/pure/__release
+  local.get $1
+  i32.store offset=8
+  local.get $0
+  i32.const 4
+  i32.store offset=12
+  local.get $0
+  i32.const 0
+  i32.store offset=16
+  local.get $0
+  i32.const 0
+  i32.store offset=20
  )
  (func $std/set/testNumeric<f32>
   (local $0 i32)
@@ -13470,46 +13578,6 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<f64>#clear (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  local.tee $1
-  i32.const 0
-  i32.const 16
-  call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $2
-  local.get $1
-  i32.load
-  call $~lib/rt/pure/__release
-  local.get $2
-  i32.store
-  local.get $0
-  i32.const 4
-  i32.const 1
-  i32.sub
-  i32.store offset=4
-  local.get $0
-  local.tee $2
-  i32.const 0
-  i32.const 64
-  call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $1
-  local.get $2
-  i32.load offset=8
-  call $~lib/rt/pure/__release
-  local.get $1
-  i32.store offset=8
-  local.get $0
-  i32.const 4
-  i32.store offset=12
-  local.get $0
-  i32.const 0
-  i32.store offset=16
-  local.get $0
-  i32.const 0
-  i32.store offset=20
- )
  (func $~lib/set/Set<f64>#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
@@ -13522,15 +13590,25 @@
   end
   local.get $0
   i32.const 0
+  i32.const 4
+  i32.const 4
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store
   local.get $0
-  i32.const 0
+  i32.const 4
+  i32.const 1
+  i32.sub
   i32.store offset=4
   local.get $0
   i32.const 0
+  i32.const 4
+  i32.const 16
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store offset=8
   local.get $0
-  i32.const 0
+  i32.const 4
   i32.store offset=12
   local.get $0
   i32.const 0
@@ -13538,8 +13616,6 @@
   local.get $0
   i32.const 0
   i32.store offset=20
-  local.get $0
-  call $~lib/set/Set<f64>#clear
   local.get $0
  )
  (func $~lib/set/Set<f64>#find (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
@@ -13935,7 +14011,7 @@
   i32.shr_u
   i32.gt_u
   if
-   i32.const 32
+   i32.const 192
    i32.const 352
    i32.const 57
    i32.const 60
@@ -14232,6 +14308,50 @@
    call $~lib/set/Set<f64>#rehash
   end
   i32.const 1
+ )
+ (func $~lib/set/Set<f64>#clear (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  local.get $0
+  local.tee $1
+  i32.const 0
+  i32.const 4
+  i32.const 4
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $2
+  local.get $1
+  i32.load
+  call $~lib/rt/pure/__release
+  local.get $2
+  i32.store
+  local.get $0
+  i32.const 4
+  i32.const 1
+  i32.sub
+  i32.store offset=4
+  local.get $0
+  local.tee $2
+  i32.const 0
+  i32.const 4
+  i32.const 16
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $1
+  local.get $2
+  i32.load offset=8
+  call $~lib/rt/pure/__release
+  local.get $1
+  i32.store offset=8
+  local.get $0
+  i32.const 4
+  i32.store offset=12
+  local.get $0
+  i32.const 0
+  i32.store offset=16
+  local.get $0
+  i32.const 0
+  i32.store offset=20
  )
  (func $std/set/testNumeric<f64>
   (local $0 i32)
@@ -14585,6 +14705,11 @@
  (func $~start
   call $start:std/set
  )
+ (func $~lib/rt/pure/__collect
+  i32.const 1
+  drop
+  return
+ )
  (func $~lib/rt/pure/finalize (param $0 i32)
   i32.const 0
   drop
@@ -14616,7 +14741,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 256
+   i32.const 144
    i32.const 122
    i32.const 14
    call $~lib/builtins/abort
@@ -14642,7 +14767,7 @@
    i32.eqz
    if
     i32.const 0
-    i32.const 256
+    i32.const 144
     i32.const 126
     i32.const 18
     call $~lib/builtins/abort
@@ -14659,7 +14784,7 @@
    i32.eqz
    if
     i32.const 0
-    i32.const 256
+    i32.const 144
     i32.const 136
     i32.const 16
     call $~lib/builtins/abort
@@ -14680,11 +14805,6 @@
    i32.store offset=4
   end
  )
- (func $~lib/rt/pure/__collect
-  i32.const 1
-  drop
-  return
- )
  (func $~lib/rt/pure/__visit (param $0 i32) (param $1 i32)
   local.get $0
   global.get $~lib/heap/__heap_base
@@ -14702,7 +14822,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 256
+   i32.const 144
    i32.const 69
    i32.const 16
    call $~lib/builtins/abort

--- a/tests/compiler/std/symbol.optimized.wat
+++ b/tests/compiler/std/symbol.optimized.wat
@@ -1039,7 +1039,7 @@
     if
      i32.const 1232
      i32.const 1296
-     i32.const 111
+     i32.const 113
      i32.const 17
      call $~lib/builtins/abort
      unreachable
@@ -1138,7 +1138,7 @@
   if
    i32.const 1232
    i32.const 1296
-   i32.const 111
+   i32.const 113
    i32.const 17
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/symbol.optimized.wat
+++ b/tests/compiler/std/symbol.optimized.wat
@@ -5,7 +5,6 @@
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
- (type $i32_=>_none (func (param i32)))
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
@@ -326,39 +325,6 @@
   local.get $0
   call $~lib/memory/memory.fill
   local.get $1
- )
- (func $~lib/map/Map<~lib/string/String,usize>#clear (param $0 i32)
-  (local $1 i32)
-  i32.const 16
-  call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $1
-  local.get $0
-  i32.load
-  drop
-  local.get $0
-  local.get $1
-  i32.store
-  local.get $0
-  i32.const 3
-  i32.store offset=4
-  i32.const 48
-  call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $1
-  local.get $0
-  i32.load offset=8
-  drop
-  local.get $0
-  local.get $1
-  i32.store offset=8
-  local.get $0
-  i32.const 4
-  i32.store offset=12
-  local.get $0
-  i32.const 0
-  i32.store offset=16
-  local.get $0
-  i32.const 0
-  i32.store offset=20
  )
  (func $~lib/string/String#get:length (param $0 i32) (result i32)
   local.get $0
@@ -1039,7 +1005,7 @@
     if
      i32.const 1232
      i32.const 1296
-     i32.const 113
+     i32.const 110
      i32.const 17
      call $~lib/builtins/abort
      unreachable
@@ -1053,16 +1019,18 @@
    i32.const 3
    call $~lib/rt/stub/__alloc
    local.tee $0
-   i32.const 0
+   i32.const 16
+   call $~lib/arraybuffer/ArrayBuffer#constructor
    i32.store
    local.get $0
-   i32.const 0
+   i32.const 3
    i32.store offset=4
    local.get $0
-   i32.const 0
+   i32.const 48
+   call $~lib/arraybuffer/ArrayBuffer#constructor
    i32.store offset=8
    local.get $0
-   i32.const 0
+   i32.const 4
    i32.store offset=12
    local.get $0
    i32.const 0
@@ -1070,24 +1038,24 @@
    local.get $0
    i32.const 0
    i32.store offset=20
-   local.get $0
-   call $~lib/map/Map<~lib/string/String,usize>#clear
    local.get $0
    global.set $~lib/symbol/stringToId
    i32.const 24
    i32.const 4
    call $~lib/rt/stub/__alloc
    local.tee $0
-   i32.const 0
+   i32.const 16
+   call $~lib/arraybuffer/ArrayBuffer#constructor
    i32.store
    local.get $0
-   i32.const 0
+   i32.const 3
    i32.store offset=4
    local.get $0
-   i32.const 0
+   i32.const 48
+   call $~lib/arraybuffer/ArrayBuffer#constructor
    i32.store offset=8
    local.get $0
-   i32.const 0
+   i32.const 4
    i32.store offset=12
    local.get $0
    i32.const 0
@@ -1095,8 +1063,6 @@
    local.get $0
    i32.const 0
    i32.store offset=20
-   local.get $0
-   call $~lib/map/Map<~lib/string/String,usize>#clear
    local.get $0
    global.set $~lib/symbol/idToString
   end
@@ -1138,7 +1104,7 @@
   if
    i32.const 1232
    i32.const 1296
-   i32.const 113
+   i32.const 110
    i32.const 17
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/symbol.untouched.wat
+++ b/tests/compiler/std/symbol.untouched.wat
@@ -960,7 +960,7 @@
   if
    i32.const 224
    i32.const 288
-   i32.const 111
+   i32.const 113
    i32.const 17
    call $~lib/builtins/abort
    unreachable
@@ -1803,7 +1803,7 @@
   if
    i32.const 224
    i32.const 288
-   i32.const 111
+   i32.const 113
    i32.const 17
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/symbol.untouched.wat
+++ b/tests/compiler/std/symbol.untouched.wat
@@ -1,10 +1,10 @@
 (module
  (type $i32_=>_i32 (func (param i32) (result i32)))
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
- (type $i32_=>_none (func (param i32)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
  (type $none_=>_none (func))
+ (type $i32_=>_none (func (param i32)))
  (type $i32_i32_=>_none (func (param i32 i32)))
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $i32_i32_i32_i32_i32_=>_i32 (func (param i32 i32 i32 i32 i32) (result i32)))
@@ -438,46 +438,6 @@
   call $~lib/rt/stub/__release
   local.get $3
  )
- (func $~lib/map/Map<~lib/string/String,usize>#clear (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  local.tee $1
-  i32.const 0
-  i32.const 16
-  call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $2
-  local.get $1
-  i32.load
-  call $~lib/rt/stub/__release
-  local.get $2
-  i32.store
-  local.get $0
-  i32.const 4
-  i32.const 1
-  i32.sub
-  i32.store offset=4
-  local.get $0
-  local.tee $2
-  i32.const 0
-  i32.const 48
-  call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $1
-  local.get $2
-  i32.load offset=8
-  call $~lib/rt/stub/__release
-  local.get $1
-  i32.store offset=8
-  local.get $0
-  i32.const 4
-  i32.store offset=12
-  local.get $0
-  i32.const 0
-  i32.store offset=16
-  local.get $0
-  i32.const 0
-  i32.store offset=20
- )
  (func $~lib/map/Map<~lib/string/String,usize>#constructor (param $0 i32) (result i32)
   local.get $0
   i32.eqz
@@ -490,39 +450,10 @@
   end
   local.get $0
   i32.const 0
-  i32.store
-  local.get $0
-  i32.const 0
-  i32.store offset=4
-  local.get $0
-  i32.const 0
-  i32.store offset=8
-  local.get $0
-  i32.const 0
-  i32.store offset=12
-  local.get $0
-  i32.const 0
-  i32.store offset=16
-  local.get $0
-  i32.const 0
-  i32.store offset=20
-  local.get $0
-  call $~lib/map/Map<~lib/string/String,usize>#clear
-  local.get $0
- )
- (func $~lib/map/Map<usize,~lib/string/String>#clear (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  local.tee $1
-  i32.const 0
-  i32.const 16
+  i32.const 4
+  i32.const 4
+  i32.mul
   call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $2
-  local.get $1
-  i32.load
-  call $~lib/rt/stub/__release
-  local.get $2
   i32.store
   local.get $0
   i32.const 4
@@ -530,15 +461,11 @@
   i32.sub
   i32.store offset=4
   local.get $0
-  local.tee $2
   i32.const 0
-  i32.const 48
+  i32.const 4
+  i32.const 12
+  i32.mul
   call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $1
-  local.get $2
-  i32.load offset=8
-  call $~lib/rt/stub/__release
-  local.get $1
   i32.store offset=8
   local.get $0
   i32.const 4
@@ -549,6 +476,7 @@
   local.get $0
   i32.const 0
   i32.store offset=20
+  local.get $0
  )
  (func $~lib/map/Map<usize,~lib/string/String>#constructor (param $0 i32) (result i32)
   local.get $0
@@ -562,15 +490,25 @@
   end
   local.get $0
   i32.const 0
+  i32.const 4
+  i32.const 4
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store
   local.get $0
-  i32.const 0
+  i32.const 4
+  i32.const 1
+  i32.sub
   i32.store offset=4
   local.get $0
   i32.const 0
+  i32.const 4
+  i32.const 12
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store offset=8
   local.get $0
-  i32.const 0
+  i32.const 4
   i32.store offset=12
   local.get $0
   i32.const 0
@@ -578,8 +516,6 @@
   local.get $0
   i32.const 0
   i32.store offset=20
-  local.get $0
-  call $~lib/map/Map<usize,~lib/string/String>#clear
   local.get $0
  )
  (func $~lib/string/String#get:length (param $0 i32) (result i32)
@@ -960,7 +896,7 @@
   if
    i32.const 224
    i32.const 288
-   i32.const 113
+   i32.const 110
    i32.const 17
    call $~lib/builtins/abort
    unreachable
@@ -1803,7 +1739,7 @@
   if
    i32.const 224
    i32.const 288
-   i32.const 113
+   i32.const 110
    i32.const 17
    call $~lib/builtins/abort
    unreachable

--- a/tslint.json
+++ b/tslint.json
@@ -1,6 +1,6 @@
 {
   "extends": "./lib/lint",
-  "defaultSeverity": "warning",
+  "defaultSeverity": "error",
   "rules": {
     "as-internal-case": {},
     "as-internal-diagnostics": {},


### PR DESCRIPTION
As the title says, this PR enables TypeScript's `--strict` mode (strict null checks, strict checking of function types, strict checking of property initialization in classes) in compiler sources by means of refactoring quite a bit of code. Also found a few potentially problematic places where `range`s were missing.

Helps https://github.com/AssemblyScript/assemblyscript/pull/1155 in particular in that the compiler sources don't need a heap of definitive assignment assertions anymore, where my expectation is that these will yield runtime checks ultimately, which we now avoid.

Technically this is a breaking change for internal compiler API users due to changed parameter orders and similar, but not for compiler users, so I'm not sure if we should make this a new major release just for that, or if it's ok to assume that internal API compatibility is something we can't guarantee between minor versions just yet?