### PR TITLE
Add unused type parameter to retain and release to prepare for closures

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -6196,9 +6196,9 @@ export class Compiler extends DiagnosticEmitter {
       if (flow.isAnyLocalFlag(localIndex, LocalFlags.ANY_RETAINED)) {
         valueExpr = this.makeReplace(
           valueExpr,
-          type,
-          module.local_get(localIndex, type.toNativeType()),
           valueType,
+          module.local_get(localIndex, type.toNativeType()),
+          type,
           alreadyRetained
         );
         if (tee) { // local = REPLACE(local, value)
@@ -6256,9 +6256,9 @@ export class Compiler extends DiagnosticEmitter {
       valueExpr = module.global_set(global.internalName,
         this.makeReplace(
           valueExpr,
-          type,
-          module.global_get(global.internalName, nativeType),
           valueType,
+          module.global_get(global.internalName, nativeType),
+          type,
           alreadyRetained
         )
       );

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -6027,7 +6027,7 @@ export class Compiler extends DiagnosticEmitter {
           this.currentType = tee ? global.type : Type.void;
           return module.unreachable();
         }
-        return this.makeGlobalAssignment(global, valueExpr, global.type, tee);
+        return this.makeGlobalAssignment(global, valueExpr, valueType, tee);
       }
       case ElementKind.FIELD: {
         let fieldInstance = <Field>target;
@@ -9164,7 +9164,8 @@ export class Compiler extends DiagnosticEmitter {
     //   return this
     // }
     var allocExpr = this.makeAllocation(classInstance);
-    if (classInstance.type.isManaged) allocExpr = this.makeRetain(allocExpr, classInstance.type);
+    let classType = classInstance.type;
+    if (classType.isManaged) allocExpr = this.makeRetain(allocExpr, classType);
     stmts.push(
       module.if(
         module.unary(nativeSizeType == NativeType.I64 ? UnaryOp.EqzI64 : UnaryOp.EqzI32,

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -9164,7 +9164,7 @@ export class Compiler extends DiagnosticEmitter {
     //   return this
     // }
     var allocExpr = this.makeAllocation(classInstance);
-    let classType = classInstance.type;
+    var classType = classInstance.type;
     if (classType.isManaged) allocExpr = this.makeRetain(allocExpr, classType);
     stmts.push(
       module.if(

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -5759,7 +5759,7 @@ export class Compiler extends DiagnosticEmitter {
               rightStmts.unshift(
                 this.makeRelease(
                   module.local_get(temp.index, leftType.toNativeType()),
-                  rightType
+                  leftType
                 )
               );
             }
@@ -8589,7 +8589,7 @@ export class Compiler extends DiagnosticEmitter {
             : module.i32(i64_low(bufferAddress))
         ], expression);
         this.currentType = arrayType;
-        expr = this.makeRetain(expr, elementType);
+        expr = this.makeRetain(expr, arrayType);
         if (arrayType.isManaged) {
           if (!(constraints & Constraints.WILL_RETAIN)) {
             expr = this.makeAutorelease(expr, arrayType);

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -6335,7 +6335,7 @@ export class Compiler extends DiagnosticEmitter {
                 module.local_get(tempThis.index, nativeThisType),
                 nativeFieldType, field.memoryOffset
               ),
-              valueType, // TODOFIX
+              valueType,
               alreadyRetained
             ),
             nativeFieldType, field.memoryOffset

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -7267,7 +7267,7 @@ export class Compiler extends DiagnosticEmitter {
     /** Old value being replaced. */
     oldExpr: ExpressionRef,
     /** The type shared between expressions. */
-    type: Type
+    type: Type,
     /** Whether the new value is already retained. */
     alreadyRetained: bool = false,
   ): ExpressionRef {

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -6196,8 +6196,8 @@ export class Compiler extends DiagnosticEmitter {
       if (flow.isAnyLocalFlag(localIndex, LocalFlags.ANY_RETAINED)) {
         valueExpr = this.makeReplace(
           valueExpr,
-          module.local_get(localIndex, type.toNativeType()),
           type,
+          module.local_get(localIndex, type.toNativeType()),
           valueType,
           alreadyRetained
         );
@@ -6256,8 +6256,8 @@ export class Compiler extends DiagnosticEmitter {
       valueExpr = module.global_set(global.internalName,
         this.makeReplace(
           valueExpr,
-          module.global_get(global.internalName, nativeType),
           type,
+          module.global_get(global.internalName, nativeType),
           valueType,
           alreadyRetained
         )
@@ -6330,11 +6330,11 @@ export class Compiler extends DiagnosticEmitter {
             module.local_tee(tempThis.index, thisExpr),
             this.makeReplace(
               module.local_tee(tempValue.index, valueExpr),
+              fieldType,
               module.load(fieldType.byteSize, fieldType.is(TypeFlags.SIGNED),
                 module.local_get(tempThis.index, nativeThisType),
                 nativeFieldType, field.memoryOffset
               ),
-              fieldType,
               valueType, // TODOFIX
               alreadyRetained
             ),
@@ -6349,12 +6349,12 @@ export class Compiler extends DiagnosticEmitter {
           module.local_tee(tempThis.index, thisExpr),
           this.makeReplace(
             valueExpr,
+            fieldType,
             module.load(fieldType.byteSize, fieldType.is(TypeFlags.SIGNED),
               module.local_get(tempThis.index, nativeThisType),
               nativeFieldType, field.memoryOffset
             ),
-            fieldType,
-            fieldType, // TODOFIX
+            valueType,
             alreadyRetained
           ),
           nativeFieldType, field.memoryOffset
@@ -7274,10 +7274,10 @@ export class Compiler extends DiagnosticEmitter {
   makeReplace(
     /** New value being assigned. */
     newExpr: ExpressionRef,
-    /** Old value being replaced. */
-    oldExpr: ExpressionRef,
     /** The type of the new expression. */
     newType: Type,
+    /** Old value being replaced. */
+    oldExpr: ExpressionRef,
     /** The type of the old expression. */
     oldType: Type,
     /** Whether the new value is already retained. */
@@ -8642,7 +8642,7 @@ export class Compiler extends DiagnosticEmitter {
               ? module.i64(0)
               : module.i32(0)
           ], expression),
-          program.options.isWasm64 ? Type.i64 : Type.i32
+          arrayType
         )
       )
     );
@@ -8775,7 +8775,7 @@ export class Compiler extends DiagnosticEmitter {
               ? module.i64(i64_low(bufferAddress), i64_high(bufferAddress))
               : module.i32(i64_low(bufferAddress))
           ], expression),
-          isWasm64 ? Type.i64 : Type.i32
+          program.arrayBufferInstance.type
         );
         if (arrayType.isManaged) {
           if (constraints & Constraints.WILL_RETAIN) {
@@ -8813,7 +8813,7 @@ export class Compiler extends DiagnosticEmitter {
               : module.i32(bufferSize),
             module.i32(arrayInstance.id)
           ], expression),
-          isWasm64 ? Type.i64 : Type.i32
+          program.arrayBufferInstance.type
         )
       )
     );

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -6195,8 +6195,8 @@ export class Compiler extends DiagnosticEmitter {
         valueExpr = this.makeReplace(
           valueExpr,
           module.local_get(localIndex, type.toNativeType()),
-          alreadyRetained,
-          type
+          type,
+          alreadyRetained
         );
         if (tee) { // local = REPLACE(local, value)
           this.currentType = type;
@@ -6252,8 +6252,8 @@ export class Compiler extends DiagnosticEmitter {
         this.makeReplace(
           valueExpr,
           module.global_get(global.internalName, nativeType),
-          alreadyRetained,
-          type
+          type,
+          alreadyRetained
         )
       );
       if (tee) { // (global = REPLACE(global, value))), global
@@ -6326,8 +6326,8 @@ export class Compiler extends DiagnosticEmitter {
                 module.local_get(tempThis.index, nativeThisType),
                 nativeFieldType, field.memoryOffset
               ),
-              alreadyRetained,
-              fieldType
+              fieldType,
+              alreadyRetained
             ),
             nativeFieldType, field.memoryOffset
           ),
@@ -6344,8 +6344,8 @@ export class Compiler extends DiagnosticEmitter {
               module.local_get(tempThis.index, nativeThisType),
               nativeFieldType, field.memoryOffset
             ),
-            alreadyRetained,
-            fieldType
+            fieldType,
+            alreadyRetained
           ),
           nativeFieldType, field.memoryOffset
         );
@@ -7266,10 +7266,10 @@ export class Compiler extends DiagnosticEmitter {
     newExpr: ExpressionRef,
     /** Old value being replaced. */
     oldExpr: ExpressionRef,
-    /** Whether the new value is already retained. */
-    alreadyRetained: bool = false,
     /** The type shared between expressions. */
     type: Type
+    /** Whether the new value is already retained. */
+    alreadyRetained: bool = false,
   ): ExpressionRef {
     var module = this.module;
     var flow = this.currentFlow;

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -6330,12 +6330,12 @@ export class Compiler extends DiagnosticEmitter {
             module.local_tee(tempThis.index, thisExpr),
             this.makeReplace(
               module.local_tee(tempValue.index, valueExpr),
-              fieldType,
+              valueType,
               module.load(fieldType.byteSize, fieldType.is(TypeFlags.SIGNED),
                 module.local_get(tempThis.index, nativeThisType),
                 nativeFieldType, field.memoryOffset
               ),
-              valueType,
+              fieldType,
               alreadyRetained
             ),
             nativeFieldType, field.memoryOffset
@@ -6349,12 +6349,12 @@ export class Compiler extends DiagnosticEmitter {
           module.local_tee(tempThis.index, thisExpr),
           this.makeReplace(
             valueExpr,
-            fieldType,
+            valueType,
             module.load(fieldType.byteSize, fieldType.is(TypeFlags.SIGNED),
               module.local_get(tempThis.index, nativeThisType),
               nativeFieldType, field.memoryOffset
             ),
-            valueType,
+            fieldType,
             alreadyRetained
           ),
           nativeFieldType, field.memoryOffset


### PR DESCRIPTION
Extracting some no-op changes from my [Closures PR](https://github.com/AssemblyScript/assemblyscript/pull/1240/files) to make it easier to parse.

What's been extracted is just the change to have type information passed into retain/release in any scenario where the expression could refer to a function pointer.

### Context behind this change:
While none of the below is actually present in this change, which does nothing, it explains what this change will be used for in the closures implementation.

With our current scheme of altering function references so that they can hold closures or normal function references, we need to know the type of a block in order to know how to retain or release it. 
- When the type is a function type, we check the MSB, and if it's set we retain/release a shifted value. If it isn't, we retain/release 0, which is a no-op.
- When the type isn't a function, retain/release as normal