### PR TITLE
Add argument to not implemented error message

### DIFF
--- a/src/builtins.ts
+++ b/src/builtins.ts
@@ -2838,7 +2838,7 @@ function builtin_assert(ctx: BuiltinContext): ExpressionRef {
     }
   }
   compiler.error(
-    DiagnosticCode.Not_implemented,
+    DiagnosticCode.Not_implemented_0,
     ctx.reportNode.typeArgumentsRange
   );
   return abort;

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -2917,7 +2917,7 @@ export class Compiler extends DiagnosticEmitter {
     this.error(
       DiagnosticCode.Not_implemented_0,
       statement.range,
-      ""
+      "Try Statements"
     );
     return this.module.unreachable();
   }

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -2107,7 +2107,7 @@ export class Compiler extends DiagnosticEmitter {
       case NodeKind.TYPEDECLARATION: {
         // TODO: integrate inner type declaration into flow
         this.error(
-          DiagnosticCode.Not_implemented,
+          DiagnosticCode.Not_implemented_0,
           statement.range
         );
         stmt = module.unreachable();
@@ -2182,7 +2182,7 @@ export class Compiler extends DiagnosticEmitter {
     var labelNode = statement.label;
     if (labelNode) {
       this.error(
-        DiagnosticCode.Not_implemented,
+        DiagnosticCode.Not_implemented_0,
         labelNode.range
       );
       return module.unreachable();
@@ -2216,7 +2216,7 @@ export class Compiler extends DiagnosticEmitter {
     var label = statement.label;
     if (label) {
       this.error(
-        DiagnosticCode.Not_implemented,
+        DiagnosticCode.Not_implemented_0,
         label.range
       );
       return module.unreachable();
@@ -2581,7 +2581,7 @@ export class Compiler extends DiagnosticEmitter {
     statement: ForOfStatement
   ): ExpressionRef {
     this.error(
-      DiagnosticCode.Not_implemented,
+      DiagnosticCode.Not_implemented_0,
       statement.range
     );
     return this.module.unreachable();
@@ -2915,8 +2915,9 @@ export class Compiler extends DiagnosticEmitter {
     // TODO: can't yet support something like: try { return ... } finally { ... }
     // worthwhile to investigate lowering returns to block results (here)?
     this.error(
-      DiagnosticCode.Not_implemented,
-      statement.range
+      DiagnosticCode.Not_implemented_0,
+      statement.range,
+      ""
     );
     return this.module.unreachable();
   }
@@ -3454,7 +3455,7 @@ export class Compiler extends DiagnosticEmitter {
       }
       default: {
         this.error(
-          DiagnosticCode.Not_implemented,
+          DiagnosticCode.Not_implemented_0,
           expression.range
         );
         expr = this.module.unreachable();
@@ -3782,7 +3783,7 @@ export class Compiler extends DiagnosticEmitter {
         //   }
         // }
         this.error(
-          DiagnosticCode.Not_implemented,
+          DiagnosticCode.Not_implemented_0,
           expression.range
         );
         return this.module.unreachable();
@@ -4312,7 +4313,7 @@ export class Compiler extends DiagnosticEmitter {
           case TypeKind.ANYREF: {
             // TODO: ref.eq
             this.error(
-              DiagnosticCode.Not_implemented,
+              DiagnosticCode.Not_implemented_0,
               expression.range
             );
             expr = module.unreachable();
@@ -4412,7 +4413,7 @@ export class Compiler extends DiagnosticEmitter {
           case TypeKind.ANYREF: {
             // TODO: !ref.eq
             this.error(
-              DiagnosticCode.Not_implemented,
+              DiagnosticCode.Not_implemented_0,
               expression.range
             );
             expr = module.unreachable();
@@ -5951,7 +5952,7 @@ export class Compiler extends DiagnosticEmitter {
       }
       default: {
         this.error(
-          DiagnosticCode.Not_implemented,
+          DiagnosticCode.Not_implemented_0,
           expression.range
         );
         return this.module.unreachable();
@@ -6155,7 +6156,7 @@ export class Compiler extends DiagnosticEmitter {
       }
     }
     this.error(
-      DiagnosticCode.Not_implemented,
+      DiagnosticCode.Not_implemented_0,
       valueExpression.range
     );
     return module.unreachable();
@@ -6628,7 +6629,7 @@ export class Compiler extends DiagnosticEmitter {
       ));
     }
     this.error(
-      DiagnosticCode.Not_implemented,
+      DiagnosticCode.Not_implemented_0,
       expression.expression.range
     );
     return this.module.unreachable();
@@ -6659,7 +6660,7 @@ export class Compiler extends DiagnosticEmitter {
     var hasRest = signature.hasRest;
     if (hasRest) {
       this.error(
-        DiagnosticCode.Not_implemented,
+        DiagnosticCode.Not_implemented_0,
         reportNode.range
       );
       return false;
@@ -8148,7 +8149,7 @@ export class Compiler extends DiagnosticEmitter {
         if (target.parent != flow.parentFunction) {
           // TODO: closures
           this.error(
-            DiagnosticCode.Not_implemented,
+            DiagnosticCode.Not_implemented_0,
             expression.range
           );
           return module.unreachable();
@@ -8213,7 +8214,7 @@ export class Compiler extends DiagnosticEmitter {
       }
     }
     this.error(
-      DiagnosticCode.Not_implemented,
+      DiagnosticCode.Not_implemented_0,
       expression.range
     );
     return this.module.unreachable();
@@ -8468,7 +8469,7 @@ export class Compiler extends DiagnosticEmitter {
       // case LiteralKind.REGEXP:
     }
     this.error(
-      DiagnosticCode.Not_implemented,
+      DiagnosticCode.Not_implemented_0,
       expression.range
     );
     this.currentType = contextualType;
@@ -9319,7 +9320,7 @@ export class Compiler extends DiagnosticEmitter {
       }
     }
     this.error(
-      DiagnosticCode.Not_implemented,
+      DiagnosticCode.Not_implemented_0,
       expression.range
     );
     return module.unreachable();

--- a/src/diagnosticMessages.generated.ts
+++ b/src/diagnosticMessages.generated.ts
@@ -7,7 +7,7 @@
 
 /** Enum of available diagnostic codes. */
 export enum DiagnosticCode {
-  Not_implemented = 100,
+  Not_implemented_0 = 100,
   Operation_is_unsafe = 101,
   User_defined_0 = 102,
   Feature_0_is_not_enabled = 103,
@@ -180,7 +180,7 @@ export enum DiagnosticCode {
 /** Translates a diagnostic code to its respective string. */
 export function diagnosticCodeToString(code: DiagnosticCode): string {
   switch (code) {
-    case 100: return "Not implemented.";
+    case 100: return "Not implemented: {0}";
     case 101: return "Operation is unsafe.";
     case 102: return "User-defined: {0}";
     case 103: return "Feature '{0}' is not enabled.";

--- a/src/diagnosticMessages.json
+++ b/src/diagnosticMessages.json
@@ -1,5 +1,5 @@
 {
-  "Not implemented.": 100,
+  "Not implemented: {0}": 100,
   "Operation is unsafe.": 101,
   "User-defined: {0}": 102,
   "Feature '{0}' is not enabled.": 103,

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -2606,7 +2606,7 @@ export class Parser extends DiagnosticEmitter {
       if (tn.skip(Token.COMMA)) {
         // TODO: default + star, default + members
         this.error(
-          DiagnosticCode.Not_implemented,
+          DiagnosticCode.Not_implemented_0,
           tn.range()
         );
         return null;

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -1036,7 +1036,7 @@ export class Resolver extends DiagnosticEmitter {
     }
     if (reportMode == ReportMode.REPORT) {
       this.error(
-        DiagnosticCode.Not_implemented,
+        DiagnosticCode.Not_implemented_0,
         node.range
       );
     }
@@ -1160,7 +1160,7 @@ export class Resolver extends DiagnosticEmitter {
     }
     if (reportMode == ReportMode.REPORT) {
       this.error(
-        DiagnosticCode.Not_implemented,
+        DiagnosticCode.Not_implemented_0,
         node.range
       );
     }
@@ -1658,7 +1658,7 @@ export class Resolver extends DiagnosticEmitter {
         //   return this.resolveClass(this.program.readonlyArrayPrototype, [ elementType ]);
         // }
         this.error(
-          DiagnosticCode.Not_implemented,
+          DiagnosticCode.Not_implemented_0,
           node.range
         );
         return null;
@@ -1884,7 +1884,7 @@ export class Resolver extends DiagnosticEmitter {
     }
     if (reportMode == ReportMode.REPORT) {
       this.error(
-        DiagnosticCode.Not_implemented,
+        DiagnosticCode.Not_implemented_0,
         node.range
       );
     }
@@ -2108,7 +2108,7 @@ export class Resolver extends DiagnosticEmitter {
     }
     if (reportMode == ReportMode.REPORT) {
       this.error(
-        DiagnosticCode.Not_implemented,
+        DiagnosticCode.Not_implemented_0,
         node.range
       );
     }
@@ -2318,7 +2318,7 @@ export class Resolver extends DiagnosticEmitter {
     }
     if (reportMode == ReportMode.REPORT) {
       this.error(
-        DiagnosticCode.Not_implemented,
+        DiagnosticCode.Not_implemented_0,
         node.range
       );
     }


### PR DESCRIPTION
Issue: https://github.com/AssemblyScript/assemblyscript/issues/1286

Right now `Not Implemented` accepts no arguments, but it'd be nice if it also included a string which stated what exactly isn't implemented for cases when the range alone doesn't suffice.

Here I've just added the argument for the preexisting message, however I could also make an additional diagnostic message which has the argument so that we don't have to go fix every use of not implemented. The only issue with that is that we'd need a different diagnostic code, and based on the fact that they've been manually specified I'm assuming there's some special meaning behind the selected codes.

Without passing the argument: `ERROR AS100: Not implemented: {0}`
When passing the argument: `ERROR AS100: Not implemented: Try Statements`

So we'd likely need to go update all the current Not implemented error calls for this to go in.

Would love to have this for the closures PR so that I can make the Not implemented errors more clear

Thoughts?