### PR TITLE
Reference feature in not implemented diagnostic

### DIFF
--- a/src/builtins.ts
+++ b/src/builtins.ts
@@ -2838,8 +2838,9 @@ function builtin_assert(ctx: BuiltinContext): ExpressionRef {
     }
   }
   compiler.error(
-    DiagnosticCode.Not_implemented,
-    ctx.reportNode.typeArgumentsRange
+    DiagnosticCode.Operation_0_cannot_be_applied_to_type_1,
+    ctx.reportNode.typeArgumentsRange,
+    "assert", compiler.currentType.toString()
   );
   return abort;
 }

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -2107,8 +2107,9 @@ export class Compiler extends DiagnosticEmitter {
       case NodeKind.TYPEDECLARATION: {
         // TODO: integrate inner type declaration into flow
         this.error(
-          DiagnosticCode.Not_implemented,
-          statement.range
+          DiagnosticCode.Not_implemented_0,
+          statement.range,
+          "Inner type alias"
         );
         stmt = module.unreachable();
         break;
@@ -2182,8 +2183,9 @@ export class Compiler extends DiagnosticEmitter {
     var labelNode = statement.label;
     if (labelNode) {
       this.error(
-        DiagnosticCode.Not_implemented,
-        labelNode.range
+        DiagnosticCode.Not_implemented_0,
+        labelNode.range,
+        "Break label"
       );
       return module.unreachable();
     }
@@ -2216,8 +2218,9 @@ export class Compiler extends DiagnosticEmitter {
     var label = statement.label;
     if (label) {
       this.error(
-        DiagnosticCode.Not_implemented,
-        label.range
+        DiagnosticCode.Not_implemented_0,
+        label.range,
+        "Continue label"
       );
       return module.unreachable();
     }
@@ -2581,8 +2584,9 @@ export class Compiler extends DiagnosticEmitter {
     statement: ForOfStatement
   ): ExpressionRef {
     this.error(
-      DiagnosticCode.Not_implemented,
-      statement.range
+      DiagnosticCode.Not_implemented_0,
+      statement.range,
+      "Iterators"
     );
     return this.module.unreachable();
   }
@@ -2915,8 +2919,9 @@ export class Compiler extends DiagnosticEmitter {
     // TODO: can't yet support something like: try { return ... } finally { ... }
     // worthwhile to investigate lowering returns to block results (here)?
     this.error(
-      DiagnosticCode.Not_implemented,
-      statement.range
+      DiagnosticCode.Not_implemented_0,
+      statement.range,
+      "Exceptions"
     );
     return this.module.unreachable();
   }
@@ -3453,10 +3458,7 @@ export class Compiler extends DiagnosticEmitter {
         break;
       }
       default: {
-        this.error(
-          DiagnosticCode.Not_implemented,
-          expression.range
-        );
+        assert(false);
         expr = this.module.unreachable();
       }
     }
@@ -3782,8 +3784,9 @@ export class Compiler extends DiagnosticEmitter {
         //   }
         // }
         this.error(
-          DiagnosticCode.Not_implemented,
-          expression.range
+          DiagnosticCode.Not_implemented_0,
+          expression.range,
+          "Const assertion"
         );
         return this.module.unreachable();
       }
@@ -4312,8 +4315,9 @@ export class Compiler extends DiagnosticEmitter {
           case TypeKind.ANYREF: {
             // TODO: ref.eq
             this.error(
-              DiagnosticCode.Not_implemented,
-              expression.range
+              DiagnosticCode.Not_implemented_0,
+              expression.range,
+              "ref.eq instruction"
             );
             expr = module.unreachable();
             break;
@@ -4412,8 +4416,9 @@ export class Compiler extends DiagnosticEmitter {
           case TypeKind.ANYREF: {
             // TODO: !ref.eq
             this.error(
-              DiagnosticCode.Not_implemented,
-              expression.range
+              DiagnosticCode.Not_implemented_0,
+              expression.range,
+              "ref.eq instruction"
             );
             expr = module.unreachable();
             break;
@@ -5950,10 +5955,7 @@ export class Compiler extends DiagnosticEmitter {
         break;
       }
       default: {
-        this.error(
-          DiagnosticCode.Not_implemented,
-          expression.range
-        );
+        assert(false);
         return this.module.unreachable();
       }
     }
@@ -6154,10 +6156,7 @@ export class Compiler extends DiagnosticEmitter {
         }
       }
     }
-    this.error(
-      DiagnosticCode.Not_implemented,
-      valueExpression.range
-    );
+    assert(false);
     return module.unreachable();
   }
 
@@ -6627,10 +6626,7 @@ export class Compiler extends DiagnosticEmitter {
         false
       ));
     }
-    this.error(
-      DiagnosticCode.Not_implemented,
-      expression.expression.range
-    );
+    assert(false);
     return this.module.unreachable();
   }
 
@@ -6659,8 +6655,9 @@ export class Compiler extends DiagnosticEmitter {
     var hasRest = signature.hasRest;
     if (hasRest) {
       this.error(
-        DiagnosticCode.Not_implemented,
-        reportNode.range
+        DiagnosticCode.Not_implemented_0,
+        reportNode.range,
+        "Rest parameters"
       );
       return false;
     }
@@ -8148,8 +8145,9 @@ export class Compiler extends DiagnosticEmitter {
         if (target.parent != flow.parentFunction) {
           // TODO: closures
           this.error(
-            DiagnosticCode.Not_implemented,
-            expression.range
+            DiagnosticCode.Not_implemented_0,
+            expression.range,
+            "Closures"
           );
           return module.unreachable();
         }
@@ -8212,10 +8210,7 @@ export class Compiler extends DiagnosticEmitter {
         return module.i32(index);
       }
     }
-    this.error(
-      DiagnosticCode.Not_implemented,
-      expression.range
-    );
+    assert(false);
     return this.module.unreachable();
   }
 
@@ -8465,13 +8460,17 @@ export class Compiler extends DiagnosticEmitter {
         assert(!implicitlyNegate);
         return this.compileObjectLiteral(<ObjectLiteralExpression>expression, contextualType);
       }
-      // case LiteralKind.REGEXP:
+      case LiteralKind.REGEXP: {
+        this.error(
+          DiagnosticCode.Not_implemented_0,
+          expression.range,
+          "Regular expressions"
+        );
+        this.currentType = contextualType;
+        return module.unreachable();
+      }
     }
-    this.error(
-      DiagnosticCode.Not_implemented,
-      expression.range
-    );
-    this.currentType = contextualType;
+    assert(false);
     return module.unreachable();
   }
 
@@ -9318,10 +9317,7 @@ export class Compiler extends DiagnosticEmitter {
         return module.unreachable();
       }
     }
-    this.error(
-      DiagnosticCode.Not_implemented,
-      expression.range
-    );
+    assert(false);
     return module.unreachable();
   }
 

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -1531,10 +1531,12 @@ export class Compiler extends DiagnosticEmitter {
 
         // Just prepended allocation is dropped when returning non-'this'
         if (flow.is(FlowFlags.MAY_RETURN_NONTHIS)) {
-          this.pedantic(
-            DiagnosticCode.Explicitly_returning_constructor_drops_this_allocation,
-            instance.identifierNode.range
-          );
+          if (this.options.pedantic) {
+            this.pedantic(
+              DiagnosticCode.Explicitly_returning_constructor_drops_this_allocation,
+              instance.identifierNode.range
+            );
+          }
         }
       }
 

--- a/src/diagnosticMessages.generated.ts
+++ b/src/diagnosticMessages.generated.ts
@@ -7,7 +7,7 @@
 
 /** Enum of available diagnostic codes. */
 export enum DiagnosticCode {
-  Not_implemented = 100,
+  Not_implemented_0 = 100,
   Operation_is_unsafe = 101,
   User_defined_0 = 102,
   Feature_0_is_not_enabled = 103,
@@ -180,7 +180,7 @@ export enum DiagnosticCode {
 /** Translates a diagnostic code to its respective string. */
 export function diagnosticCodeToString(code: DiagnosticCode): string {
   switch (code) {
-    case 100: return "Not implemented.";
+    case 100: return "Not implemented: {0}";
     case 101: return "Operation is unsafe.";
     case 102: return "User-defined: {0}";
     case 103: return "Feature '{0}' is not enabled.";

--- a/src/diagnosticMessages.json
+++ b/src/diagnosticMessages.json
@@ -1,5 +1,5 @@
 {
-  "Not implemented.": 100,
+  "Not implemented: {0}": 100,
   "Operation is unsafe.": 101,
   "User-defined: {0}": 102,
   "Feature '{0}' is not enabled.": 103,

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -2606,8 +2606,9 @@ export class Parser extends DiagnosticEmitter {
       if (tn.skip(Token.COMMA)) {
         // TODO: default + star, default + members
         this.error(
-          DiagnosticCode.Not_implemented,
-          tn.range()
+          DiagnosticCode.Not_implemented_0,
+          tn.range(),
+          "Mixed default and named imports"
         );
         return null;
       }

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -1034,12 +1034,7 @@ export class Resolver extends DiagnosticEmitter {
         );
       }
     }
-    if (reportMode == ReportMode.REPORT) {
-      this.error(
-        DiagnosticCode.Not_implemented,
-        node.range
-      );
-    }
+    assert(false);
     return null;
   }
 
@@ -1158,12 +1153,7 @@ export class Resolver extends DiagnosticEmitter {
         );
       }
     }
-    if (reportMode == ReportMode.REPORT) {
-      this.error(
-        DiagnosticCode.Not_implemented,
-        node.range
-      );
-    }
+    assert(false);
     return null;
   }
 
@@ -1658,13 +1648,14 @@ export class Resolver extends DiagnosticEmitter {
         //   return this.resolveClass(this.program.readonlyArrayPrototype, [ elementType ]);
         // }
         this.error(
-          DiagnosticCode.Not_implemented,
-          node.range
+          DiagnosticCode.Not_implemented_0,
+          node.range,
+          "Const assertion"
         );
         return null;
       }
-      default: assert(false);
     }
+    assert(false);
     return null;
   }
 
@@ -1882,12 +1873,7 @@ export class Resolver extends DiagnosticEmitter {
         return type;
       }
     }
-    if (reportMode == ReportMode.REPORT) {
-      this.error(
-        DiagnosticCode.Not_implemented,
-        node.range
-      );
-    }
+    assert(false);
     return null;
   }
 
@@ -2106,12 +2092,7 @@ export class Resolver extends DiagnosticEmitter {
         return this.resolveExpression(left, ctxFlow, ctxType, reportMode);
       }
     }
-    if (reportMode == ReportMode.REPORT) {
-      this.error(
-        DiagnosticCode.Not_implemented,
-        node.range
-      );
-    }
+    assert(false);
     return null;
   }
 
@@ -2316,12 +2297,7 @@ export class Resolver extends DiagnosticEmitter {
         return assert(this.resolveClass(this.program.arrayPrototype, [ elementType ]));
       }
     }
-    if (reportMode == ReportMode.REPORT) {
-      this.error(
-        DiagnosticCode.Not_implemented,
-        node.range
-      );
-    }
+    assert(false);
     return null;
   }
 

--- a/tests/compiler/closure.json
+++ b/tests/compiler/closure.json
@@ -3,8 +3,8 @@
     "--runtime none"
   ],
   "stderr": [
-    "AS100: Not implemented.",
-    "AS100: Not implemented.",
+    "AS100: Not implemented: Closures",
+    "AS100: Not implemented: Closures",
     "Cannot find name '$local0'.",
     "EOF"
   ]

--- a/tests/compiler/wasi/trace.js
+++ b/tests/compiler/wasi/trace.js
@@ -3,11 +3,11 @@ var memory;
 exports.preInstantiate = function(imports, exports) {
   imports["wasi_snapshot_preview1"] = {
     fd_write: function(fd, iov, iov_len, nptr) {
-      if (fd != 1) failed = "unexpected fd: " + fd;
+      if (fd != 2) failed = "unexpected fd: " + fd;
       const messagePtr = new Uint32Array(memory.buffer)[ iov >>> 2     ];
       const messageLen = new Uint32Array(memory.buffer)[(iov >>> 2) + 1];
       const message = Array.from(new Uint8Array(memory.buffer, messagePtr, messageLen)).map(c => String.fromCharCode(c)).join("");
-      process.stdout.write(message);
+      process.stderr.write(message);
     },
     proc_exit: function(code) {
       console.log("exit: " + code);


### PR DESCRIPTION
As a follow-up to https://github.com/AssemblyScript/assemblyscript/pull/1294 this also adds the respective missing feature to `Not implemented` diagnostics, looking like

```
AS100: Not implemented: ref.eq
AS100: Not implemented: Closures
AS100: Not implemented: Exceptions
```

while converting some of the diagnostics back to `assert`s, but only where hitting that code path would indicate a bug that must be fixed anyway and a diagnostic wouldn't be helpful, i.e. "Expression kind X cannot be looked up / resolved / compiled because someone forgot to implement it".

fixes #1294