### PR TITLE
Add issue and PR templates, clarify guidelines

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,4 @@
+<!--
+ Thanks for submitting an issue to AssemblyScript!
+ Please follow the contribution guidelines linked below to get off to a good start.
+-->

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,4 +1,4 @@
 <!--
  Thanks for submitting an issue to AssemblyScript!
- Please follow the contribution guidelines linked below to get off to a good start.
+ Please follow the contributing guidelines linked below to get off to a good start.
 -->

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,10 +1,4 @@
 <!--
  Thanks for submitting an issue to AssemblyScript! Please take a moment to
- review the contributing guidelines linked below, and confirm with an [x] 🙂
+ review the contributing guidelines linked below 🙂
 -->
-
-⯈
-⯈
-⯈
-
-- [ ] I've read the contributing guidelines

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,4 +1,4 @@
 <!--
  Thanks for submitting an issue to AssemblyScript! Please take a moment to
- review the contributing guidelines linked below 🙂
+ read the contributing guidelines linked below to get off to a good start 🙂
 -->

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,4 +1,10 @@
 <!--
- Thanks for submitting an issue to AssemblyScript!
- Please follow the contributing guidelines linked below to get off to a good start.
+ Thanks for submitting an issue to AssemblyScript! Please take a moment to
+ review the contributing guidelines linked below, and confirm with an [x] 🙂
 -->
+
+⯈
+⯈
+⯈
+
+- [ ] I've read the contributing guidelines

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
 <!--
  Thanks for submitting a pull request to AssemblyScript!
- Please follow the contribution guidelines linked below to get off to a good start.
+ Please follow the contributing guidelines linked below to get off to a good start.
 -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,10 @@
 <!--
- Thanks for submitting a pull request to AssemblyScript!
- Please follow the contributing guidelines linked below to get off to a good start.
+ Thanks for submitting a pull request to AssemblyScript! Please take a moment to
+ review the contributing guidelines linked below, and confirm with an [x] 🙂
 -->
+
+⯈
+⯈
+⯈
+
+- [ ] I've read the contributing guidelines

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,4 @@
+<!--
+ Thanks for submitting a pull request to AssemblyScript!
+ Please follow the contribution guidelines linked below to get off to a good start.
+-->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,16 +33,16 @@ Instructions are similar to those for bug reports. Please provide the following 
 Submitting Pull Requests
 ------------------------
 
-Instructions are similar to those for bug reports. Please provide the following information:
+Instructions are similar to those for bug reports:
 
 * If this is not a trivial fix, consider **creating an issue to discuss first** and **later link to it from the PR**.
 * Use a **clear and descriptive title** for the pull request.
-* Provide a **description of the suggested changes** in as many details as necessary.
+* Provide a **description of the changes** in as many details as necessary.
 * **Document your new code** where necessary.
 * Please **refrain from refactoring (unrelated code)** as it makes your pull request easier to review.
 * **Create tests for your new code** where necessary. For creating or updating tests, please see the [Test Instructions](./tests).
 
-Before submitting your pull request, please make sure that the following conditions are met:
+Before submitting your pull request, also make sure that the following conditions are met:
 
 * Your new code **adheres to the code style** through running `npm run check`.
 * Your new code **passes all existing and new tests** through running `npm run test`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,7 @@ Submitting Pull Requests
 
 Instructions are similar to those for bug reports. Please provide the following information:
 
+* Consider **creating an issue to discuss first** and **later link to it from the PR** if this is not a trivial fix.
 * Use a **clear and descriptive title** for the pull request.
 * Provide a **description of the suggested changes** in as many details as necessary.
 * **Document your new code** where necessary.
@@ -47,3 +48,7 @@ Before submitting your pull request, please make sure that the following conditi
 * Your new code **passes all existing and new tests** through running `npm run test`.
 * Your PR **excludes distribution files** in `dist/**`.
 * You appended yourself to the **list of contributors** in the [NOTICE](./NOTICE) file.
+
+Please note that if a pull request is rather complicated, i.e. touches lots of internals, or became stale, it is not uncommon that a core contributor performs the final integration to get it done in good conscience while naming you as a co-author.
+
+Thank you!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ Instructions are similar to those for bug reports. Please provide the following 
 Submitting Pull Requests
 ------------------------
 
-Instructions are similar to those for bug reports:
+Instructions are similar to those for bug reports. Please provide the following information:
 
 * If this is not a trivial fix, consider **creating an issue to discuss first** and **later link to it from the PR**.
 * Use a **clear and descriptive title** for the pull request.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ Submitting Pull Requests
 
 Instructions are similar to those for bug reports. Please provide the following information:
 
-* Consider **creating an issue to discuss first** and **later link to it from the PR** if this is not a trivial fix.
+* If this is not a trivial fix, consider **creating an issue to discuss first** and **later link to it from the PR**.
 * Use a **clear and descriptive title** for the pull request.
 * Provide a **description of the suggested changes** in as many details as necessary.
 * **Document your new code** where necessary.


### PR DESCRIPTION
As a follow-up to the respective agenda item at our [12th Working Group meeting](https://github.com/AssemblyScript/working-group/issues/36#issuecomment-631721787), this PR adds relatively light issue and PR templates to the repository and clarifies a few points within the contributing guidelines. Here's the diff:

---
Submitting Pull Requests
------------------------

[...]

* Consider **creating an issue to discuss first** and **later link to it from the PR** if this is not a trivial fix.

[...]

Please note that if a pull request is rather complicated, i.e. touches lots of internals, or became stale, it is not uncommon that a core contributor performs the final integration to get it done in good conscience while naming you as a co-author.

Thank you!

---

Doesn't go overboard with the templates yet, and mostly makes sure that everyone is aware up-front of how complicated PRs may evolve in an attempt to avoid disappointment or conflict. Please let me know if this looks good to you! cc @MaxGraey @torch2424 @jtenner @DuncanUszkay1