### PR TITLE
Empty use declarations now delete exported elements

### DIFF
--- a/src/program.ts
+++ b/src/program.ts
@@ -1265,7 +1265,10 @@ export class Program extends DiagnosticEmitter {
         let alias = unchecked(_keys[i]);
         let name = changetype<string>(globalAliases.get(alias));
         assert(name != null);
-        if (!name.length) continue; // explicitly disabled
+        if (!name.length) {
+          this.elementsByName.delete(alias);
+          continue;
+        }
         let firstChar = name.charCodeAt(0);
         if (firstChar >= CharCode._0 && firstChar <= CharCode._9) {
           this.registerConstantInteger(alias, Type.i32, i64_new(<i32>parseInt(name, 10)));

--- a/tests/compiler/empty-use.json
+++ b/tests/compiler/empty-use.json
@@ -1,0 +1,10 @@
+{
+  "asc_flags": [
+    "--runtime none",
+    "--use Date="
+  ],
+  "stderr": [
+    "TS2304: Cannot find name 'Date'.",
+    "EOF"
+  ]
+}

--- a/tests/compiler/empty-use.ts
+++ b/tests/compiler/empty-use.ts
@@ -1,0 +1,3 @@
+Date.now();
+
+ERROR("EOF");


### PR DESCRIPTION
Issue:  https://github.com/AssemblyScript/assemblyscript/issues/1296

With this PR, you can now specify an empty use statement to prevent an implementation from being injected with the following syntax: `--use Date=`. When attempting to use date, which is normally globally exported automatically, you will then instead get this error message:

```
ERROR TS2304: Cannot find name 'Date'.

 Date.now();
 ~~~~
 in main.ts(1,1)

ERROR: 1 compile error(s)
```

This is useful when you cannot support the module in question, which in the case of date would be due to the fact that the host will not import it.