### PR TITLE
Warn on unused generic exports

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -695,8 +695,9 @@ export class Compiler extends DiagnosticEmitter {
 
       // traverse instances
       case ElementKind.FUNCTION_PROTOTYPE: {
-        let functionInstances = (<FunctionPrototype>element).instances;
-        if (functionInstances) {
+        let functionPrototype = <FunctionPrototype>element;
+        let functionInstances = functionPrototype.instances;
+        if (functionInstances !== null && functionInstances.size > 0) {
           // TODO: for (let instance of instances.values()) {
           for (let _values = Map_values(functionInstances), i = 0, k = _values.length; i < k; ++i) {
             let instance = unchecked(_values[i]);
@@ -707,12 +708,18 @@ export class Compiler extends DiagnosticEmitter {
             }
             this.ensureModuleExport(instanceName, instance, prefix);
           }
+        } else if (functionPrototype.is(CommonFlags.GENERIC)) {
+          this.warning(
+            DiagnosticCode.Exported_generic_function_or_class_has_no_concrete_instances,
+            functionPrototype.identifierNode.range
+          );
         }
         break;
       }
       case ElementKind.CLASS_PROTOTYPE: {
-        let classInstances = (<ClassPrototype>element).instances;
-        if (classInstances) {
+        let classPrototype = <ClassPrototype>element;
+        let classInstances = classPrototype.instances;
+        if (classInstances !== null && classInstances.size > 0) {
           // TODO: for (let instance of instances.values()) {
           for (let _values = Map_values(classInstances), i = 0, k = _values.length; i < k; ++i) {
             let instance = unchecked(_values[i]);
@@ -723,6 +730,11 @@ export class Compiler extends DiagnosticEmitter {
             }
             this.ensureModuleExport(instanceName, instance, prefix);
           }
+        } else if (classPrototype.is(CommonFlags.GENERIC)) {
+          this.warning(
+            DiagnosticCode.Exported_generic_function_or_class_has_no_concrete_instances,
+            classPrototype.identifierNode.range
+          );
         }
         break;
       }

--- a/src/diagnosticMessages.generated.ts
+++ b/src/diagnosticMessages.generated.ts
@@ -48,6 +48,7 @@ export enum DiagnosticCode {
   Property_0_only_has_a_setter_and_is_missing_a_getter = 229,
   _0_keyword_cannot_be_used_here = 230,
   A_class_with_a_constructor_explicitly_returning_something_else_than_this_must_be_final = 231,
+  Exported_generic_function_or_class_has_no_concrete_instances = 232,
   Type_0_is_cyclic_Module_will_include_deferred_garbage_collection = 900,
   Importing_the_table_disables_some_indirect_call_optimizations = 901,
   Exporting_the_table_disables_some_indirect_call_optimizations = 902,
@@ -221,6 +222,7 @@ export function diagnosticCodeToString(code: DiagnosticCode): string {
     case 229: return "Property '{0}' only has a setter and is missing a getter.";
     case 230: return "'{0}' keyword cannot be used here.";
     case 231: return "A class with a constructor explicitly returning something else than 'this' must be '@final'.";
+    case 232: return "Exported generic function or class has no concrete instances.";
     case 900: return "Type '{0}' is cyclic. Module will include deferred garbage collection.";
     case 901: return "Importing the table disables some indirect call optimizations.";
     case 902: return "Exporting the table disables some indirect call optimizations.";

--- a/src/diagnosticMessages.json
+++ b/src/diagnosticMessages.json
@@ -41,6 +41,7 @@
   "Property '{0}' only has a setter and is missing a getter.": 229,
   "'{0}' keyword cannot be used here.": 230,
   "A class with a constructor explicitly returning something else than 'this' must be '@final'.": 231,
+  "Exported generic function or class has no concrete instances.": 232,
 
   "Type '{0}' is cyclic. Module will include deferred garbage collection.": 900,
   "Importing the table disables some indirect call optimizations.": 901,

--- a/tests/compiler/export-generic.json
+++ b/tests/compiler/export-generic.json
@@ -1,0 +1,17 @@
+{
+  "asc_flags": [
+    "--runtime none"
+  ],
+  "stderr": [
+    "AS232: Exported generic function or class has no concrete instances.",
+    "export function testFunction<T>",
+    "AS232: Exported generic function or class has no concrete instances.",
+    "export class TestClass<T>",
+    "AS232: Exported generic function or class has no concrete instances.",
+    "public testMethod<T>()",
+    "AS232: Exported generic function or class has no concrete instances.",
+    "export function testNamespacedFunction<T>",
+    "AS232: Exported generic function or class has no concrete instances.",
+    "export class TestNamespacedClass<T>"
+  ]
+}

--- a/tests/compiler/export-generic.ts
+++ b/tests/compiler/export-generic.ts
@@ -1,0 +1,14 @@
+export function testFunction<T>(): void {}
+
+export class TestClass<T> {}
+
+export class Foo {
+  public testMethod<T>(): void {}
+}
+
+export namespace test {
+  export function testNamespacedFunction<T>(): void {}
+  export class TestNamespacedClass<T> {}
+}
+
+ERROR("EOF");


### PR DESCRIPTION
A revised implementation of https://github.com/AssemblyScript/assemblyscript/pull/981 that doesn't skip compilation, since it might be intended by the user to export a specific concrete instance when being aware of the limitations. Warns if an exported generic function or class has no instances, since that's most likely unintended.

Fixes https://github.com/AssemblyScript/assemblyscript/issues/570
Fixes https://github.com/AssemblyScript/assemblyscript/pull/981