### PR TITLE
Improve error message if an import cannot be found

### DIFF
--- a/cli/asc.js
+++ b/cli/asc.js
@@ -207,20 +207,20 @@ exports.main = function main(argv, options, callback) {
   // Check for unknown arguments
   if (opts.unknown.length) {
     opts.unknown.forEach(arg => {
-      stderr.write(colorsUtil.stderr.yellow("WARN: ") + "Unknown option '" + arg + "'" + EOL);
+      stderr.write(colorsUtil.stderr.yellow("WARNING ") + "Unknown option '" + arg + "'" + EOL);
     });
   }
 
   // Check for trailing arguments
   if (opts.trailing.length) {
-    stderr.write(colorsUtil.stderr.yellow("WARN: ") + "Unsupported trailing arguments: " + opts.trailing.join(" ") + EOL);
+    stderr.write(colorsUtil.stderr.yellow("WARNING ") + "Unsupported trailing arguments: " + opts.trailing.join(" ") + EOL);
   }
 
   // Use default callback if none is provided
   if (!callback) callback = function defaultCallback(err) {
     var code = 0;
     if (err) {
-      stderr.write(colorsUtil.stderr.red("ERROR: ") + err.stack.replace(/^ERROR: /i, "") + EOL);
+      stderr.write(colorsUtil.stderr.red("FAILURE ") + err.stack.replace(/^ERROR: /i, "") + EOL);
       code = 1;
     }
     return code;
@@ -533,24 +533,21 @@ exports.main = function main(argv, options, callback) {
   function parseBacklog() {
     var internalPath;
     while ((internalPath = assemblyscript.nextFile(program)) != null) {
-      let dependee = assemblyscript.getDependee(program, internalPath);
-      let file = getFile(internalPath, dependee);
-      if (!file) {
-        const searchPaths = [
-          path.resolve(baseDir, internalPath + extension.ext),
-          path.resolve(baseDir, internalPath, "index" + extension.ext),
-          path.resolve(baseDir, internalPath + extension.ext_d)
-        ];
-        return callback(Error("Import path '" + internalPath + "' in '" + dependee + "' not found.\n  No such file '" + searchPaths.join("'\n  No such file '") + "'"));
+      let file = getFile(internalPath, assemblyscript.getDependee(program, internalPath));
+      if (file) {
+        stats.parseCount++;
+        stats.parseTime += measure(() => {
+          assemblyscript.parse(program, file.sourceText, file.sourcePath, false);
+        });
+      } else {
+        assemblyscript.parse(program, null, internalPath + extension.ext, false);
       }
-      stats.parseCount++;
-      stats.parseTime += measure(() => {
-        assemblyscript.parse(program, file.sourceText, file.sourcePath, false);
-      });
     }
     var numErrors = checkDiagnostics(program, stderr);
     if (numErrors) {
-      return callback(Error(numErrors + " parse error(s)"));
+      const err = Error(numErrors + " parse error(s)");
+      err.stack = err.message; // omit stack
+      return callback(err);
     }
   }
 
@@ -585,8 +582,8 @@ exports.main = function main(argv, options, callback) {
     let sourceText = readFile(sourcePath + extension.ext, baseDir);
     if (sourceText == null) {
       sourceText = readFile(sourcePath + "/index" + extension.ext, baseDir);
-      if (sourceText == null) return callback(Error("Entry file '" + sourcePath + extension.ext + "' not found."));
-      sourcePath += "/index" + extension.ext;
+      if (sourceText != null) sourcePath += "/index" + extension.ext;
+      else sourcePath += extension.ext;
     } else {
       sourcePath += extension.ext;
     }
@@ -642,7 +639,9 @@ exports.main = function main(argv, options, callback) {
   var numErrors = checkDiagnostics(program, stderr);
   if (numErrors) {
     if (module) module.dispose();
-    return callback(Error(numErrors + " compile error(s)"));
+    const err = Error(numErrors + " compile error(s)");
+    err.stack = err.message; // omit stack
+    return callback(err);
   }
 
   // Call afterCompile transform hook

--- a/cli/asc.js
+++ b/cli/asc.js
@@ -533,14 +533,15 @@ exports.main = function main(argv, options, callback) {
   function parseBacklog() {
     var internalPath;
     while ((internalPath = assemblyscript.nextFile(program)) != null) {
-      let file = getFile(internalPath, assemblyscript.getDependee(program, internalPath));
+      let dependee = assemblyscript.getDependee(program, internalPath);
+      let file = getFile(internalPath, dependee);
       if (!file) {
         const searchPaths = [
-          path.join(baseDir, internalPath + ".ts"),
-          path.join(baseDir, internalPath, "index.ts"),
-          path.join(baseDir, internalPath + ".d.ts")
+          path.resolve(baseDir, internalPath + extension.ext),
+          path.resolve(baseDir, internalPath, "index" + extension.ext),
+          path.resolve(baseDir, internalPath + extension.ext_d)
         ];
-        return callback(Error("Import '" + internalPath + "' not found.\n  No such file '" + searchPaths.join("'\n  No such file '") + "'"));
+        return callback(Error("Import path '" + internalPath + "' in '" + dependee + "' not found.\n  No such file '" + searchPaths.join("'\n  No such file '") + "'"));
       }
       stats.parseCount++;
       stats.parseTime += measure(() => {

--- a/cli/asc.js
+++ b/cli/asc.js
@@ -534,7 +534,14 @@ exports.main = function main(argv, options, callback) {
     var internalPath;
     while ((internalPath = assemblyscript.nextFile(program)) != null) {
       let file = getFile(internalPath, assemblyscript.getDependee(program, internalPath));
-      if (!file) return callback(Error("Import '" + internalPath + "' not found."));
+      if (!file) {
+        const searchPaths = [
+          path.join(baseDir, internalPath + ".ts"),
+          path.join(baseDir, internalPath, "index.ts"),
+          path.join(baseDir, internalPath + ".d.ts")
+        ];
+        return callback(Error("Import '" + internalPath + "' not found.\n  No such file '" + searchPaths.join("'\n  No such file '") + "'"));
+      }
       stats.parseCount++;
       stats.parseTime += measure(() => {
         assemblyscript.parse(program, file.sourceText, file.sourcePath, false);

--- a/src/index.ts
+++ b/src/index.ts
@@ -214,8 +214,8 @@ export function isError(message: DiagnosticMessage): bool {
 export function parse(
   /** Program reference. */
   program: Program,
-  /** Source text of the file. */
-  text: string,
+  /** Source text of the file, or `null` to indicate not found. */
+  text: string | null,
   /** Normalized path of the file. */
   path: string,
   /** Whether this is an entry file. */

--- a/tests/packages/packages/g/test.js
+++ b/tests/packages/packages/g/test.js
@@ -1,17 +1,16 @@
 #!/usr/bin/env node
-let asc = require("../../../../cli/asc");
+const asc = require("../../../../cli/asc");
 
-let argv = [
+const stderr = asc.createMemoryStream();
+asc.main([
   "assembly/index.ts",
   "--noEmit",
   "--runtime", "stub",
   "--traceResolution"
-];
-
-asc.main(argv, error => {
-  if (/Import .*lib\/a.* not found/g.test(error.message)) {
+], { stderr }, err => {
+  if (stderr.toString().includes("File '~lib/a.ts' not found.")) {
     process.exit(0);
   }
-  console.error("Failed!\n" + error);
+  console.error("Failed!\n" + err);
   process.exit(1);
 });


### PR DESCRIPTION
This PR fixes https://github.com/AssemblyScript/assemblyscript/issues/1282 by adding the paths searched to the error message when an imported file cannot be found, for example when trying to import a file by erroneously specifying a file extension, looking like:

```
ERROR: Import 'tests/compiler/404.ts' not found.
  No such file 'path\to\tests\compiler\404.ts.ts'
  No such file 'path\to\tests\compiler\404.ts\index.ts'
  No such file 'path\to\tests\compiler\404.ts.d.ts'
```

Doesn't implement a `.ts` specific error message because that might be intended, but the problem should be clear from the paths searched. cc @torch2424 