### PR TITLE
Fast paths for memset

### DIFF
--- a/std/assembly/util/memory.ts
+++ b/std/assembly/util/memory.ts
@@ -200,7 +200,14 @@ export function memset(dest: usize, c: u8, n: usize): void { // see: musl/src/st
     }
   } else {
     // fill head and tail with minimal branching
-    if (!n) return;
+    switch (n) {
+      case 0: return;
+      case 1: store<u8>(dest, c, 1); return;
+      case 2: store<u16>(dest, <u16>-1 / 255 * c); return;
+      case 4: store<u32>(dest, <u32>-1 / 255 * c); return;
+      case 8: store<u64>(dest, <u64>-1 / 255 * c); return;
+      default: break;
+    }
     let dend = dest + n - 4;
     store<u8>(dest, c);
     store<u8>(dend, c, 3);

--- a/std/assembly/util/memory.ts
+++ b/std/assembly/util/memory.ts
@@ -202,10 +202,10 @@ export function memset(dest: usize, c: u8, n: usize): void { // see: musl/src/st
     // fill head and tail with minimal branching
     switch (n) {
       case 0: return;
-      case 1: store<u8>(dest, c, 1); return;
-      case 2: store<u16>(dest, <u16>-1 / 255 * c); return;
-      case 4: store<u32>(dest, <u32>-1 / 255 * c); return;
-      case 8: store<u64>(dest, <u64>-1 / 255 * c); return;
+      case 1: store<u8>(dest, c); return;
+      case 2: store<u16>(dest, <u16>0x0101 * c); return;
+      case 4: store<u32>(dest, <u32>0x01010101 * c); return;
+      case 8: store<u64>(dest, <u64>0x0101010101010101 * c); return;
       default: break;
     }
     let dend = dest + n - 4;

--- a/tests/compiler/class.untouched.wat
+++ b/tests/compiler/class.untouched.wat
@@ -257,10 +257,81 @@
    i32.const 1
    i32.gt_s
    drop
-   local.get $3
-   i32.eqz
-   if
-    br $~lib/util/memory/memset|inlined.0
+   block $break|0
+    block $case5|0
+     block $case4|0
+      block $case3|0
+       block $case2|0
+        block $case1|0
+         block $case0|0
+          local.get $3
+          local.set $6
+          local.get $6
+          i32.const 0
+          i32.eq
+          br_if $case0|0
+          local.get $6
+          i32.const 1
+          i32.eq
+          br_if $case1|0
+          local.get $6
+          i32.const 2
+          i32.eq
+          br_if $case2|0
+          local.get $6
+          i32.const 4
+          i32.eq
+          br_if $case3|0
+          local.get $6
+          i32.const 8
+          i32.eq
+          br_if $case4|0
+          br $case5|0
+         end
+         br $~lib/util/memory/memset|inlined.0
+        end
+        local.get $5
+        local.get $4
+        i32.store8 offset=1
+        br $~lib/util/memory/memset|inlined.0
+       end
+       local.get $5
+       i32.const -1
+       i32.const 65535
+       i32.and
+       i32.const 255
+       i32.div_u
+       local.get $4
+       i32.const 255
+       i32.and
+       i32.mul
+       i32.store16
+       br $~lib/util/memory/memset|inlined.0
+      end
+      local.get $5
+      i32.const -1
+      i32.const 255
+      i32.div_u
+      local.get $4
+      i32.const 255
+      i32.and
+      i32.mul
+      i32.store
+      br $~lib/util/memory/memset|inlined.0
+     end
+     local.get $5
+     i64.const -1
+     i64.const 255
+     i64.div_u
+     local.get $4
+     i32.const 255
+     i32.and
+     i64.extend_i32_u
+     i64.mul
+     i64.store
+     br $~lib/util/memory/memset|inlined.0
+    end
+    br $break|0
    end
    local.get $5
    local.get $3
@@ -418,7 +489,7 @@
    i64.shl
    i64.or
    local.set $9
-   loop $while-continue|0
+   loop $while-continue|1
     local.get $3
     i32.const 32
     i32.ge_u
@@ -445,7 +516,7 @@
      i32.const 32
      i32.add
      local.set $5
-     br $while-continue|0
+     br $while-continue|1
     end
    end
   end

--- a/tests/compiler/class.untouched.wat
+++ b/tests/compiler/class.untouched.wat
@@ -292,15 +292,11 @@
         end
         local.get $5
         local.get $4
-        i32.store8 offset=1
+        i32.store8
         br $~lib/util/memory/memset|inlined.0
        end
        local.get $5
-       i32.const -1
-       i32.const 65535
-       i32.and
-       i32.const 255
-       i32.div_u
+       i32.const 257
        local.get $4
        i32.const 255
        i32.and
@@ -309,9 +305,7 @@
        br $~lib/util/memory/memset|inlined.0
       end
       local.get $5
-      i32.const -1
-      i32.const 255
-      i32.div_u
+      i32.const 16843009
       local.get $4
       i32.const 255
       i32.and
@@ -320,9 +314,7 @@
       br $~lib/util/memory/memset|inlined.0
      end
      local.get $5
-     i64.const -1
-     i64.const 255
-     i64.div_u
+     i64.const 72340172838076673
      local.get $4
      i32.const 255
      i32.and

--- a/tests/compiler/extends-baseaggregate.optimized.wat
+++ b/tests/compiler/extends-baseaggregate.optimized.wat
@@ -1428,6 +1428,36 @@
    local.get $1
    i32.eqz
    br_if $~lib/util/memory/memset|inlined.0
+   block $break|0
+    block $case4|0
+     block $case3|0
+      block $case2|0
+       block $case1|0
+        local.get $1
+        i32.const 1
+        i32.sub
+        br_table $case1|0 $case2|0 $break|0 $case3|0 $break|0 $break|0 $break|0 $case4|0 $break|0
+       end
+       local.get $0
+       i32.const 0
+       i32.store8 offset=1
+       br $~lib/util/memory/memset|inlined.0
+      end
+      local.get $0
+      i32.const 0
+      i32.store16
+      br $~lib/util/memory/memset|inlined.0
+     end
+     local.get $0
+     i32.const 0
+     i32.store
+     br $~lib/util/memory/memset|inlined.0
+    end
+    local.get $0
+    i64.const 0
+    i64.store
+    br $~lib/util/memory/memset|inlined.0
+   end
    local.get $0
    i32.const 0
    i32.store8
@@ -1550,7 +1580,7 @@
    local.get $1
    i32.sub
    local.set $1
-   loop $while-continue|0
+   loop $while-continue|1
     local.get $1
     i32.const 32
     i32.ge_u
@@ -1575,7 +1605,7 @@
      i32.const 32
      i32.add
      local.set $0
-     br $while-continue|0
+     br $while-continue|1
     end
    end
   end

--- a/tests/compiler/extends-baseaggregate.optimized.wat
+++ b/tests/compiler/extends-baseaggregate.optimized.wat
@@ -1440,7 +1440,7 @@
        end
        local.get $0
        i32.const 0
-       i32.store8 offset=1
+       i32.store8
        br $~lib/util/memory/memset|inlined.0
       end
       local.get $0

--- a/tests/compiler/extends-baseaggregate.untouched.wat
+++ b/tests/compiler/extends-baseaggregate.untouched.wat
@@ -3066,15 +3066,11 @@
         end
         local.get $5
         local.get $4
-        i32.store8 offset=1
+        i32.store8
         br $~lib/util/memory/memset|inlined.0
        end
        local.get $5
-       i32.const -1
-       i32.const 65535
-       i32.and
-       i32.const 255
-       i32.div_u
+       i32.const 257
        local.get $4
        i32.const 255
        i32.and
@@ -3083,9 +3079,7 @@
        br $~lib/util/memory/memset|inlined.0
       end
       local.get $5
-      i32.const -1
-      i32.const 255
-      i32.div_u
+      i32.const 16843009
       local.get $4
       i32.const 255
       i32.and
@@ -3094,9 +3088,7 @@
       br $~lib/util/memory/memset|inlined.0
      end
      local.get $5
-     i64.const -1
-     i64.const 255
-     i64.div_u
+     i64.const 72340172838076673
      local.get $4
      i32.const 255
      i32.and

--- a/tests/compiler/extends-baseaggregate.untouched.wat
+++ b/tests/compiler/extends-baseaggregate.untouched.wat
@@ -3031,10 +3031,81 @@
    i32.const 1
    i32.gt_s
    drop
-   local.get $3
-   i32.eqz
-   if
-    br $~lib/util/memory/memset|inlined.0
+   block $break|0
+    block $case5|0
+     block $case4|0
+      block $case3|0
+       block $case2|0
+        block $case1|0
+         block $case0|0
+          local.get $3
+          local.set $6
+          local.get $6
+          i32.const 0
+          i32.eq
+          br_if $case0|0
+          local.get $6
+          i32.const 1
+          i32.eq
+          br_if $case1|0
+          local.get $6
+          i32.const 2
+          i32.eq
+          br_if $case2|0
+          local.get $6
+          i32.const 4
+          i32.eq
+          br_if $case3|0
+          local.get $6
+          i32.const 8
+          i32.eq
+          br_if $case4|0
+          br $case5|0
+         end
+         br $~lib/util/memory/memset|inlined.0
+        end
+        local.get $5
+        local.get $4
+        i32.store8 offset=1
+        br $~lib/util/memory/memset|inlined.0
+       end
+       local.get $5
+       i32.const -1
+       i32.const 65535
+       i32.and
+       i32.const 255
+       i32.div_u
+       local.get $4
+       i32.const 255
+       i32.and
+       i32.mul
+       i32.store16
+       br $~lib/util/memory/memset|inlined.0
+      end
+      local.get $5
+      i32.const -1
+      i32.const 255
+      i32.div_u
+      local.get $4
+      i32.const 255
+      i32.and
+      i32.mul
+      i32.store
+      br $~lib/util/memory/memset|inlined.0
+     end
+     local.get $5
+     i64.const -1
+     i64.const 255
+     i64.div_u
+     local.get $4
+     i32.const 255
+     i32.and
+     i64.extend_i32_u
+     i64.mul
+     i64.store
+     br $~lib/util/memory/memset|inlined.0
+    end
+    br $break|0
    end
    local.get $5
    local.get $3
@@ -3192,7 +3263,7 @@
    i64.shl
    i64.or
    local.set $9
-   loop $while-continue|0
+   loop $while-continue|1
     local.get $3
     i32.const 32
     i32.ge_u
@@ -3219,7 +3290,7 @@
      i32.const 32
      i32.add
      local.set $5
-     br $while-continue|0
+     br $while-continue|1
     end
    end
   end

--- a/tests/compiler/resolve-elementaccess.optimized.wat
+++ b/tests/compiler/resolve-elementaccess.optimized.wat
@@ -138,6 +138,36 @@
    local.get $1
    i32.eqz
    br_if $~lib/util/memory/memset|inlined.0
+   block $break|0
+    block $case4|0
+     block $case3|0
+      block $case2|0
+       block $case1|0
+        local.get $1
+        i32.const 1
+        i32.sub
+        br_table $case1|0 $case2|0 $break|0 $case3|0 $break|0 $break|0 $break|0 $case4|0 $break|0
+       end
+       local.get $0
+       i32.const 0
+       i32.store8 offset=1
+       br $~lib/util/memory/memset|inlined.0
+      end
+      local.get $0
+      i32.const 0
+      i32.store16
+      br $~lib/util/memory/memset|inlined.0
+     end
+     local.get $0
+     i32.const 0
+     i32.store
+     br $~lib/util/memory/memset|inlined.0
+    end
+    local.get $0
+    i64.const 0
+    i64.store
+    br $~lib/util/memory/memset|inlined.0
+   end
    local.get $0
    i32.const 0
    i32.store8
@@ -260,7 +290,7 @@
    local.get $1
    i32.sub
    local.set $1
-   loop $while-continue|0
+   loop $while-continue|1
     local.get $1
     i32.const 32
     i32.ge_u
@@ -285,7 +315,7 @@
      i32.const 32
      i32.add
      local.set $0
-     br $while-continue|0
+     br $while-continue|1
     end
    end
   end

--- a/tests/compiler/resolve-elementaccess.optimized.wat
+++ b/tests/compiler/resolve-elementaccess.optimized.wat
@@ -150,7 +150,7 @@
        end
        local.get $0
        i32.const 0
-       i32.store8 offset=1
+       i32.store8
        br $~lib/util/memory/memset|inlined.0
       end
       local.get $0

--- a/tests/compiler/resolve-elementaccess.untouched.wat
+++ b/tests/compiler/resolve-elementaccess.untouched.wat
@@ -226,15 +226,11 @@
         end
         local.get $5
         local.get $4
-        i32.store8 offset=1
+        i32.store8
         br $~lib/util/memory/memset|inlined.0
        end
        local.get $5
-       i32.const -1
-       i32.const 65535
-       i32.and
-       i32.const 255
-       i32.div_u
+       i32.const 257
        local.get $4
        i32.const 255
        i32.and
@@ -243,9 +239,7 @@
        br $~lib/util/memory/memset|inlined.0
       end
       local.get $5
-      i32.const -1
-      i32.const 255
-      i32.div_u
+      i32.const 16843009
       local.get $4
       i32.const 255
       i32.and
@@ -254,9 +248,7 @@
       br $~lib/util/memory/memset|inlined.0
      end
      local.get $5
-     i64.const -1
-     i64.const 255
-     i64.div_u
+     i64.const 72340172838076673
      local.get $4
      i32.const 255
      i32.and

--- a/tests/compiler/resolve-elementaccess.untouched.wat
+++ b/tests/compiler/resolve-elementaccess.untouched.wat
@@ -191,10 +191,81 @@
    i32.const 1
    i32.gt_s
    drop
-   local.get $3
-   i32.eqz
-   if
-    br $~lib/util/memory/memset|inlined.0
+   block $break|0
+    block $case5|0
+     block $case4|0
+      block $case3|0
+       block $case2|0
+        block $case1|0
+         block $case0|0
+          local.get $3
+          local.set $6
+          local.get $6
+          i32.const 0
+          i32.eq
+          br_if $case0|0
+          local.get $6
+          i32.const 1
+          i32.eq
+          br_if $case1|0
+          local.get $6
+          i32.const 2
+          i32.eq
+          br_if $case2|0
+          local.get $6
+          i32.const 4
+          i32.eq
+          br_if $case3|0
+          local.get $6
+          i32.const 8
+          i32.eq
+          br_if $case4|0
+          br $case5|0
+         end
+         br $~lib/util/memory/memset|inlined.0
+        end
+        local.get $5
+        local.get $4
+        i32.store8 offset=1
+        br $~lib/util/memory/memset|inlined.0
+       end
+       local.get $5
+       i32.const -1
+       i32.const 65535
+       i32.and
+       i32.const 255
+       i32.div_u
+       local.get $4
+       i32.const 255
+       i32.and
+       i32.mul
+       i32.store16
+       br $~lib/util/memory/memset|inlined.0
+      end
+      local.get $5
+      i32.const -1
+      i32.const 255
+      i32.div_u
+      local.get $4
+      i32.const 255
+      i32.and
+      i32.mul
+      i32.store
+      br $~lib/util/memory/memset|inlined.0
+     end
+     local.get $5
+     i64.const -1
+     i64.const 255
+     i64.div_u
+     local.get $4
+     i32.const 255
+     i32.and
+     i64.extend_i32_u
+     i64.mul
+     i64.store
+     br $~lib/util/memory/memset|inlined.0
+    end
+    br $break|0
    end
    local.get $5
    local.get $3
@@ -352,7 +423,7 @@
    i64.shl
    i64.or
    local.set $9
-   loop $while-continue|0
+   loop $while-continue|1
     local.get $3
     i32.const 32
     i32.ge_u
@@ -379,7 +450,7 @@
      i32.const 32
      i32.add
      local.set $5
-     br $while-continue|0
+     br $while-continue|1
     end
    end
   end

--- a/tests/compiler/retain-release-sanity.optimized.wat
+++ b/tests/compiler/retain-release-sanity.optimized.wat
@@ -1072,6 +1072,36 @@
    local.get $1
    i32.eqz
    br_if $~lib/util/memory/memset|inlined.0
+   block $break|0
+    block $case4|0
+     block $case3|0
+      block $case2|0
+       block $case1|0
+        local.get $1
+        i32.const 1
+        i32.sub
+        br_table $case1|0 $case2|0 $break|0 $case3|0 $break|0 $break|0 $break|0 $case4|0 $break|0
+       end
+       local.get $0
+       i32.const 0
+       i32.store8 offset=1
+       br $~lib/util/memory/memset|inlined.0
+      end
+      local.get $0
+      i32.const 0
+      i32.store16
+      br $~lib/util/memory/memset|inlined.0
+     end
+     local.get $0
+     i32.const 0
+     i32.store
+     br $~lib/util/memory/memset|inlined.0
+    end
+    local.get $0
+    i64.const 0
+    i64.store
+    br $~lib/util/memory/memset|inlined.0
+   end
    local.get $0
    i32.const 0
    i32.store8
@@ -1194,7 +1224,7 @@
    local.get $1
    i32.sub
    local.set $1
-   loop $while-continue|0
+   loop $while-continue|1
     local.get $1
     i32.const 32
     i32.ge_u
@@ -1219,7 +1249,7 @@
      i32.const 32
      i32.add
      local.set $0
-     br $while-continue|0
+     br $while-continue|1
     end
    end
   end

--- a/tests/compiler/retain-release-sanity.optimized.wat
+++ b/tests/compiler/retain-release-sanity.optimized.wat
@@ -1084,7 +1084,7 @@
        end
        local.get $0
        i32.const 0
-       i32.store8 offset=1
+       i32.store8
        br $~lib/util/memory/memset|inlined.0
       end
       local.get $0

--- a/tests/compiler/retain-release-sanity.untouched.wat
+++ b/tests/compiler/retain-release-sanity.untouched.wat
@@ -1536,15 +1536,11 @@
         end
         local.get $5
         local.get $4
-        i32.store8 offset=1
+        i32.store8
         br $~lib/util/memory/memset|inlined.0
        end
        local.get $5
-       i32.const -1
-       i32.const 65535
-       i32.and
-       i32.const 255
-       i32.div_u
+       i32.const 257
        local.get $4
        i32.const 255
        i32.and
@@ -1553,9 +1549,7 @@
        br $~lib/util/memory/memset|inlined.0
       end
       local.get $5
-      i32.const -1
-      i32.const 255
-      i32.div_u
+      i32.const 16843009
       local.get $4
       i32.const 255
       i32.and
@@ -1564,9 +1558,7 @@
       br $~lib/util/memory/memset|inlined.0
      end
      local.get $5
-     i64.const -1
-     i64.const 255
-     i64.div_u
+     i64.const 72340172838076673
      local.get $4
      i32.const 255
      i32.and

--- a/tests/compiler/retain-release-sanity.untouched.wat
+++ b/tests/compiler/retain-release-sanity.untouched.wat
@@ -1501,10 +1501,81 @@
    i32.const 1
    i32.gt_s
    drop
-   local.get $3
-   i32.eqz
-   if
-    br $~lib/util/memory/memset|inlined.0
+   block $break|0
+    block $case5|0
+     block $case4|0
+      block $case3|0
+       block $case2|0
+        block $case1|0
+         block $case0|0
+          local.get $3
+          local.set $6
+          local.get $6
+          i32.const 0
+          i32.eq
+          br_if $case0|0
+          local.get $6
+          i32.const 1
+          i32.eq
+          br_if $case1|0
+          local.get $6
+          i32.const 2
+          i32.eq
+          br_if $case2|0
+          local.get $6
+          i32.const 4
+          i32.eq
+          br_if $case3|0
+          local.get $6
+          i32.const 8
+          i32.eq
+          br_if $case4|0
+          br $case5|0
+         end
+         br $~lib/util/memory/memset|inlined.0
+        end
+        local.get $5
+        local.get $4
+        i32.store8 offset=1
+        br $~lib/util/memory/memset|inlined.0
+       end
+       local.get $5
+       i32.const -1
+       i32.const 65535
+       i32.and
+       i32.const 255
+       i32.div_u
+       local.get $4
+       i32.const 255
+       i32.and
+       i32.mul
+       i32.store16
+       br $~lib/util/memory/memset|inlined.0
+      end
+      local.get $5
+      i32.const -1
+      i32.const 255
+      i32.div_u
+      local.get $4
+      i32.const 255
+      i32.and
+      i32.mul
+      i32.store
+      br $~lib/util/memory/memset|inlined.0
+     end
+     local.get $5
+     i64.const -1
+     i64.const 255
+     i64.div_u
+     local.get $4
+     i32.const 255
+     i32.and
+     i64.extend_i32_u
+     i64.mul
+     i64.store
+     br $~lib/util/memory/memset|inlined.0
+    end
+    br $break|0
    end
    local.get $5
    local.get $3
@@ -1662,7 +1733,7 @@
    i64.shl
    i64.or
    local.set $9
-   loop $while-continue|0
+   loop $while-continue|1
     local.get $3
     i32.const 32
     i32.ge_u
@@ -1689,7 +1760,7 @@
      i32.const 32
      i32.add
      local.set $5
-     br $while-continue|0
+     br $while-continue|1
     end
    end
   end

--- a/tests/compiler/rt/finalize.optimized.wat
+++ b/tests/compiler/rt/finalize.optimized.wat
@@ -1064,6 +1064,36 @@
    local.get $1
    i32.eqz
    br_if $~lib/util/memory/memset|inlined.0
+   block $break|0
+    block $case4|0
+     block $case3|0
+      block $case2|0
+       block $case1|0
+        local.get $1
+        i32.const 1
+        i32.sub
+        br_table $case1|0 $case2|0 $break|0 $case3|0 $break|0 $break|0 $break|0 $case4|0 $break|0
+       end
+       local.get $0
+       i32.const 0
+       i32.store8 offset=1
+       br $~lib/util/memory/memset|inlined.0
+      end
+      local.get $0
+      i32.const 0
+      i32.store16
+      br $~lib/util/memory/memset|inlined.0
+     end
+     local.get $0
+     i32.const 0
+     i32.store
+     br $~lib/util/memory/memset|inlined.0
+    end
+    local.get $0
+    i64.const 0
+    i64.store
+    br $~lib/util/memory/memset|inlined.0
+   end
    local.get $0
    i32.const 0
    i32.store8
@@ -1186,7 +1216,7 @@
    local.get $1
    i32.sub
    local.set $1
-   loop $while-continue|0
+   loop $while-continue|1
     local.get $1
     i32.const 32
     i32.ge_u
@@ -1211,7 +1241,7 @@
      i32.const 32
      i32.add
      local.set $0
-     br $while-continue|0
+     br $while-continue|1
     end
    end
   end

--- a/tests/compiler/rt/finalize.optimized.wat
+++ b/tests/compiler/rt/finalize.optimized.wat
@@ -1076,7 +1076,7 @@
        end
        local.get $0
        i32.const 0
-       i32.store8 offset=1
+       i32.store8
        br $~lib/util/memory/memset|inlined.0
       end
       local.get $0

--- a/tests/compiler/rt/finalize.untouched.wat
+++ b/tests/compiler/rt/finalize.untouched.wat
@@ -1497,10 +1497,81 @@
    i32.const 1
    i32.gt_s
    drop
-   local.get $3
-   i32.eqz
-   if
-    br $~lib/util/memory/memset|inlined.0
+   block $break|0
+    block $case5|0
+     block $case4|0
+      block $case3|0
+       block $case2|0
+        block $case1|0
+         block $case0|0
+          local.get $3
+          local.set $6
+          local.get $6
+          i32.const 0
+          i32.eq
+          br_if $case0|0
+          local.get $6
+          i32.const 1
+          i32.eq
+          br_if $case1|0
+          local.get $6
+          i32.const 2
+          i32.eq
+          br_if $case2|0
+          local.get $6
+          i32.const 4
+          i32.eq
+          br_if $case3|0
+          local.get $6
+          i32.const 8
+          i32.eq
+          br_if $case4|0
+          br $case5|0
+         end
+         br $~lib/util/memory/memset|inlined.0
+        end
+        local.get $5
+        local.get $4
+        i32.store8 offset=1
+        br $~lib/util/memory/memset|inlined.0
+       end
+       local.get $5
+       i32.const -1
+       i32.const 65535
+       i32.and
+       i32.const 255
+       i32.div_u
+       local.get $4
+       i32.const 255
+       i32.and
+       i32.mul
+       i32.store16
+       br $~lib/util/memory/memset|inlined.0
+      end
+      local.get $5
+      i32.const -1
+      i32.const 255
+      i32.div_u
+      local.get $4
+      i32.const 255
+      i32.and
+      i32.mul
+      i32.store
+      br $~lib/util/memory/memset|inlined.0
+     end
+     local.get $5
+     i64.const -1
+     i64.const 255
+     i64.div_u
+     local.get $4
+     i32.const 255
+     i32.and
+     i64.extend_i32_u
+     i64.mul
+     i64.store
+     br $~lib/util/memory/memset|inlined.0
+    end
+    br $break|0
    end
    local.get $5
    local.get $3
@@ -1658,7 +1729,7 @@
    i64.shl
    i64.or
    local.set $9
-   loop $while-continue|0
+   loop $while-continue|1
     local.get $3
     i32.const 32
     i32.ge_u
@@ -1685,7 +1756,7 @@
      i32.const 32
      i32.add
      local.set $5
-     br $while-continue|0
+     br $while-continue|1
     end
    end
   end

--- a/tests/compiler/rt/finalize.untouched.wat
+++ b/tests/compiler/rt/finalize.untouched.wat
@@ -1532,15 +1532,11 @@
         end
         local.get $5
         local.get $4
-        i32.store8 offset=1
+        i32.store8
         br $~lib/util/memory/memset|inlined.0
        end
        local.get $5
-       i32.const -1
-       i32.const 65535
-       i32.and
-       i32.const 255
-       i32.div_u
+       i32.const 257
        local.get $4
        i32.const 255
        i32.and
@@ -1549,9 +1545,7 @@
        br $~lib/util/memory/memset|inlined.0
       end
       local.get $5
-      i32.const -1
-      i32.const 255
-      i32.div_u
+      i32.const 16843009
       local.get $4
       i32.const 255
       i32.and
@@ -1560,9 +1554,7 @@
       br $~lib/util/memory/memset|inlined.0
      end
      local.get $5
-     i64.const -1
-     i64.const 255
-     i64.div_u
+     i64.const 72340172838076673
      local.get $4
      i32.const 255
      i32.and

--- a/tests/compiler/std/array.optimized.wat
+++ b/tests/compiler/std/array.optimized.wat
@@ -1305,7 +1305,7 @@
        end
        local.get $0
        local.get $1
-       i32.store8 offset=1
+       i32.store8
        br $~lib/util/memory/memset|inlined.0
       end
       local.get $0

--- a/tests/compiler/std/array.optimized.wat
+++ b/tests/compiler/std/array.optimized.wat
@@ -1290,8 +1290,52 @@
   (local $5 i32)
   block $~lib/util/memory/memset|inlined.0
    local.get $2
+   local.tee $3
    i32.eqz
    br_if $~lib/util/memory/memset|inlined.0
+   block $break|0
+    block $case4|0
+     block $case3|0
+      block $case2|0
+       block $case1|0
+        local.get $3
+        i32.const 1
+        i32.sub
+        br_table $case1|0 $case2|0 $break|0 $case3|0 $break|0 $break|0 $break|0 $case4|0 $break|0
+       end
+       local.get $0
+       local.get $1
+       i32.store8 offset=1
+       br $~lib/util/memory/memset|inlined.0
+      end
+      local.get $0
+      local.get $1
+      i32.const 255
+      i32.and
+      i32.const 257
+      i32.mul
+      i32.store16
+      br $~lib/util/memory/memset|inlined.0
+     end
+     local.get $0
+     local.get $1
+     i32.const 255
+     i32.and
+     i32.const 16843009
+     i32.mul
+     i32.store
+     br $~lib/util/memory/memset|inlined.0
+    end
+    local.get $0
+    local.get $1
+    i32.const 255
+    i32.and
+    i64.extend_i32_u
+    i64.const 72340172838076673
+    i64.mul
+    i64.store
+    br $~lib/util/memory/memset|inlined.0
+   end
    local.get $0
    local.get $1
    i32.store8
@@ -1427,7 +1471,7 @@
    i64.shl
    i64.or
    local.set $4
-   loop $while-continue|0
+   loop $while-continue|1
     local.get $2
     i32.const 32
     i32.ge_u
@@ -1452,7 +1496,7 @@
      i32.const 32
      i32.add
      local.set $1
-     br $while-continue|0
+     br $while-continue|1
     end
    end
   end

--- a/tests/compiler/std/array.untouched.wat
+++ b/tests/compiler/std/array.untouched.wat
@@ -1760,15 +1760,11 @@
         end
         local.get $5
         local.get $4
-        i32.store8 offset=1
+        i32.store8
         br $~lib/util/memory/memset|inlined.0
        end
        local.get $5
-       i32.const -1
-       i32.const 65535
-       i32.and
-       i32.const 255
-       i32.div_u
+       i32.const 257
        local.get $4
        i32.const 255
        i32.and
@@ -1777,9 +1773,7 @@
        br $~lib/util/memory/memset|inlined.0
       end
       local.get $5
-      i32.const -1
-      i32.const 255
-      i32.div_u
+      i32.const 16843009
       local.get $4
       i32.const 255
       i32.and
@@ -1788,9 +1782,7 @@
       br $~lib/util/memory/memset|inlined.0
      end
      local.get $5
-     i64.const -1
-     i64.const 255
-     i64.div_u
+     i64.const 72340172838076673
      local.get $4
      i32.const 255
      i32.and

--- a/tests/compiler/std/array.untouched.wat
+++ b/tests/compiler/std/array.untouched.wat
@@ -1725,10 +1725,81 @@
    i32.const 1
    i32.gt_s
    drop
-   local.get $3
-   i32.eqz
-   if
-    br $~lib/util/memory/memset|inlined.0
+   block $break|0
+    block $case5|0
+     block $case4|0
+      block $case3|0
+       block $case2|0
+        block $case1|0
+         block $case0|0
+          local.get $3
+          local.set $6
+          local.get $6
+          i32.const 0
+          i32.eq
+          br_if $case0|0
+          local.get $6
+          i32.const 1
+          i32.eq
+          br_if $case1|0
+          local.get $6
+          i32.const 2
+          i32.eq
+          br_if $case2|0
+          local.get $6
+          i32.const 4
+          i32.eq
+          br_if $case3|0
+          local.get $6
+          i32.const 8
+          i32.eq
+          br_if $case4|0
+          br $case5|0
+         end
+         br $~lib/util/memory/memset|inlined.0
+        end
+        local.get $5
+        local.get $4
+        i32.store8 offset=1
+        br $~lib/util/memory/memset|inlined.0
+       end
+       local.get $5
+       i32.const -1
+       i32.const 65535
+       i32.and
+       i32.const 255
+       i32.div_u
+       local.get $4
+       i32.const 255
+       i32.and
+       i32.mul
+       i32.store16
+       br $~lib/util/memory/memset|inlined.0
+      end
+      local.get $5
+      i32.const -1
+      i32.const 255
+      i32.div_u
+      local.get $4
+      i32.const 255
+      i32.and
+      i32.mul
+      i32.store
+      br $~lib/util/memory/memset|inlined.0
+     end
+     local.get $5
+     i64.const -1
+     i64.const 255
+     i64.div_u
+     local.get $4
+     i32.const 255
+     i32.and
+     i64.extend_i32_u
+     i64.mul
+     i64.store
+     br $~lib/util/memory/memset|inlined.0
+    end
+    br $break|0
    end
    local.get $5
    local.get $3
@@ -1886,7 +1957,7 @@
    i64.shl
    i64.or
    local.set $9
-   loop $while-continue|0
+   loop $while-continue|1
     local.get $3
     i32.const 32
     i32.ge_u
@@ -1913,7 +1984,7 @@
      i32.const 32
      i32.add
      local.set $5
-     br $while-continue|0
+     br $while-continue|1
     end
    end
   end

--- a/tests/compiler/std/arraybuffer.optimized.wat
+++ b/tests/compiler/std/arraybuffer.optimized.wat
@@ -1069,7 +1069,7 @@
        end
        local.get $0
        i32.const 0
-       i32.store8 offset=1
+       i32.store8
        br $~lib/util/memory/memset|inlined.0
       end
       local.get $0

--- a/tests/compiler/std/arraybuffer.optimized.wat
+++ b/tests/compiler/std/arraybuffer.optimized.wat
@@ -1057,6 +1057,36 @@
    local.get $1
    i32.eqz
    br_if $~lib/util/memory/memset|inlined.0
+   block $break|0
+    block $case4|0
+     block $case3|0
+      block $case2|0
+       block $case1|0
+        local.get $1
+        i32.const 1
+        i32.sub
+        br_table $case1|0 $case2|0 $break|0 $case3|0 $break|0 $break|0 $break|0 $case4|0 $break|0
+       end
+       local.get $0
+       i32.const 0
+       i32.store8 offset=1
+       br $~lib/util/memory/memset|inlined.0
+      end
+      local.get $0
+      i32.const 0
+      i32.store16
+      br $~lib/util/memory/memset|inlined.0
+     end
+     local.get $0
+     i32.const 0
+     i32.store
+     br $~lib/util/memory/memset|inlined.0
+    end
+    local.get $0
+    i64.const 0
+    i64.store
+    br $~lib/util/memory/memset|inlined.0
+   end
    local.get $0
    i32.const 0
    i32.store8
@@ -1179,7 +1209,7 @@
    local.get $1
    i32.sub
    local.set $1
-   loop $while-continue|0
+   loop $while-continue|1
     local.get $1
     i32.const 32
     i32.ge_u
@@ -1204,7 +1234,7 @@
      i32.const 32
      i32.add
      local.set $0
-     br $while-continue|0
+     br $while-continue|1
     end
    end
   end

--- a/tests/compiler/std/arraybuffer.untouched.wat
+++ b/tests/compiler/std/arraybuffer.untouched.wat
@@ -1527,15 +1527,11 @@
         end
         local.get $5
         local.get $4
-        i32.store8 offset=1
+        i32.store8
         br $~lib/util/memory/memset|inlined.0
        end
        local.get $5
-       i32.const -1
-       i32.const 65535
-       i32.and
-       i32.const 255
-       i32.div_u
+       i32.const 257
        local.get $4
        i32.const 255
        i32.and
@@ -1544,9 +1540,7 @@
        br $~lib/util/memory/memset|inlined.0
       end
       local.get $5
-      i32.const -1
-      i32.const 255
-      i32.div_u
+      i32.const 16843009
       local.get $4
       i32.const 255
       i32.and
@@ -1555,9 +1549,7 @@
       br $~lib/util/memory/memset|inlined.0
      end
      local.get $5
-     i64.const -1
-     i64.const 255
-     i64.div_u
+     i64.const 72340172838076673
      local.get $4
      i32.const 255
      i32.and

--- a/tests/compiler/std/arraybuffer.untouched.wat
+++ b/tests/compiler/std/arraybuffer.untouched.wat
@@ -1492,10 +1492,81 @@
    i32.const 1
    i32.gt_s
    drop
-   local.get $3
-   i32.eqz
-   if
-    br $~lib/util/memory/memset|inlined.0
+   block $break|0
+    block $case5|0
+     block $case4|0
+      block $case3|0
+       block $case2|0
+        block $case1|0
+         block $case0|0
+          local.get $3
+          local.set $6
+          local.get $6
+          i32.const 0
+          i32.eq
+          br_if $case0|0
+          local.get $6
+          i32.const 1
+          i32.eq
+          br_if $case1|0
+          local.get $6
+          i32.const 2
+          i32.eq
+          br_if $case2|0
+          local.get $6
+          i32.const 4
+          i32.eq
+          br_if $case3|0
+          local.get $6
+          i32.const 8
+          i32.eq
+          br_if $case4|0
+          br $case5|0
+         end
+         br $~lib/util/memory/memset|inlined.0
+        end
+        local.get $5
+        local.get $4
+        i32.store8 offset=1
+        br $~lib/util/memory/memset|inlined.0
+       end
+       local.get $5
+       i32.const -1
+       i32.const 65535
+       i32.and
+       i32.const 255
+       i32.div_u
+       local.get $4
+       i32.const 255
+       i32.and
+       i32.mul
+       i32.store16
+       br $~lib/util/memory/memset|inlined.0
+      end
+      local.get $5
+      i32.const -1
+      i32.const 255
+      i32.div_u
+      local.get $4
+      i32.const 255
+      i32.and
+      i32.mul
+      i32.store
+      br $~lib/util/memory/memset|inlined.0
+     end
+     local.get $5
+     i64.const -1
+     i64.const 255
+     i64.div_u
+     local.get $4
+     i32.const 255
+     i32.and
+     i64.extend_i32_u
+     i64.mul
+     i64.store
+     br $~lib/util/memory/memset|inlined.0
+    end
+    br $break|0
    end
    local.get $5
    local.get $3
@@ -1653,7 +1724,7 @@
    i64.shl
    i64.or
    local.set $9
-   loop $while-continue|0
+   loop $while-continue|1
     local.get $3
     i32.const 32
     i32.ge_u
@@ -1680,7 +1751,7 @@
      i32.const 32
      i32.add
      local.set $5
-     br $while-continue|0
+     br $while-continue|1
     end
    end
   end

--- a/tests/compiler/std/dataview.optimized.wat
+++ b/tests/compiler/std/dataview.optimized.wat
@@ -1,8 +1,8 @@
 (module
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
  (type $i32_=>_none (func (param i32)))
- (type $i32_=>_i32 (func (param i32) (result i32)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
+ (type $i32_=>_i32 (func (param i32) (result i32)))
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_none (func))
  (type $i32_i32_=>_none (func (param i32 i32)))
@@ -1110,81 +1110,6 @@
   end
   local.get $0
  )
- (func $~lib/arraybuffer/ArrayBufferView#constructor (param $0 i32) (result i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  local.get $0
-  i32.eqz
-  if
-   i32.const 12
-   i32.const 2
-   call $~lib/rt/tlsf/__alloc
-   call $~lib/rt/pure/__retain
-   local.set $0
-  end
-  local.get $0
-  i32.const 0
-  i32.store
-  local.get $0
-  i32.const 0
-  i32.store offset=4
-  local.get $0
-  i32.const 0
-  i32.store offset=8
-  i32.const 8
-  i32.const 0
-  call $~lib/rt/tlsf/__alloc
-  local.tee $2
-  i32.const 0
-  i32.store8
-  local.get $2
-  local.tee $1
-  i32.const 4
-  i32.add
-  i32.const 0
-  i32.store8 offset=3
-  local.get $1
-  i32.const 0
-  i32.store8 offset=1
-  local.get $1
-  i32.const 0
-  i32.store8 offset=2
-  local.get $1
-  i32.const 0
-  i32.store8 offset=6
-  local.get $1
-  i32.const 0
-  i32.store8 offset=5
-  local.get $1
-  i32.const 0
-  i32.store8 offset=3
-  local.get $1
-  i32.const 0
-  i32.store8 offset=4
-  local.get $1
-  local.get $0
-  i32.load
-  local.tee $3
-  i32.ne
-  if
-   local.get $1
-   call $~lib/rt/pure/__retain
-   local.set $1
-   local.get $3
-   call $~lib/rt/pure/__release
-  end
-  local.get $0
-  local.get $1
-  i32.store
-  local.get $0
-  local.get $2
-  i32.store offset=4
-  local.get $0
-  i32.const 8
-  i32.store offset=8
-  local.get $0
- )
  (func $~lib/typedarray/Uint8Array#__set (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $1
   local.get $0
@@ -1836,47 +1761,93 @@
   i32.const 3
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
-  call $~lib/arraybuffer/ArrayBufferView#constructor
+  local.tee $3
+  i32.eqz
+  if
+   i32.const 12
+   i32.const 2
+   call $~lib/rt/tlsf/__alloc
+   call $~lib/rt/pure/__retain
+   local.set $3
+  end
+  local.get $3
+  i32.const 0
+  i32.store
+  local.get $3
+  i32.const 0
+  i32.store offset=4
+  local.get $3
+  i32.const 0
+  i32.store offset=8
+  i32.const 8
+  i32.const 0
+  call $~lib/rt/tlsf/__alloc
   local.tee $1
+  i64.const 0
+  i64.store
+  local.get $1
+  local.set $0
+  local.get $1
+  local.get $3
+  i32.load
+  local.tee $2
+  i32.ne
+  if
+   local.get $0
+   call $~lib/rt/pure/__retain
+   local.set $0
+   local.get $2
+   call $~lib/rt/pure/__release
+  end
+  local.get $3
+  local.get $0
+  i32.store
+  local.get $3
+  local.get $1
+  i32.store offset=4
+  local.get $3
+  i32.const 8
+  i32.store offset=8
+  local.get $3
   i32.const 0
   i32.const 246
   call $~lib/typedarray/Uint8Array#__set
-  local.get $1
+  local.get $3
   i32.const 1
   i32.const 224
   call $~lib/typedarray/Uint8Array#__set
-  local.get $1
+  local.get $3
   i32.const 2
   i32.const 88
   call $~lib/typedarray/Uint8Array#__set
-  local.get $1
+  local.get $3
   i32.const 3
   i32.const 159
   call $~lib/typedarray/Uint8Array#__set
-  local.get $1
+  local.get $3
   i32.const 4
   i32.const 130
   call $~lib/typedarray/Uint8Array#__set
-  local.get $1
+  local.get $3
   i32.const 5
   i32.const 101
   call $~lib/typedarray/Uint8Array#__set
-  local.get $1
+  local.get $3
   i32.const 6
   i32.const 67
   call $~lib/typedarray/Uint8Array#__set
-  local.get $1
+  local.get $3
   i32.const 7
   i32.const 95
   call $~lib/typedarray/Uint8Array#__set
-  local.get $1
+  local.get $3
   i32.load
-  local.get $1
+  local.get $3
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
-  local.get $1
+  local.get $3
   i32.load offset=8
   call $~lib/dataview/DataView#constructor
-  local.tee $0
+  local.tee $1
   i32.const 0
   i32.const 1
   call $~lib/dataview/DataView#getFloat32
@@ -1890,7 +1861,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 1
   i32.const 1
   call $~lib/dataview/DataView#getFloat32
@@ -1904,7 +1875,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 2
   i32.const 1
   call $~lib/dataview/DataView#getFloat32
@@ -1918,7 +1889,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 3
   i32.const 1
   call $~lib/dataview/DataView#getFloat32
@@ -1932,7 +1903,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 4
   i32.const 1
   call $~lib/dataview/DataView#getFloat32
@@ -1946,7 +1917,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 0
   i32.const 0
   call $~lib/dataview/DataView#getFloat32
@@ -1960,7 +1931,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 1
   i32.const 0
   call $~lib/dataview/DataView#getFloat32
@@ -1974,7 +1945,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 2
   i32.const 0
   call $~lib/dataview/DataView#getFloat32
@@ -1988,7 +1959,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 3
   i32.const 0
   call $~lib/dataview/DataView#getFloat32
@@ -2002,7 +1973,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 4
   i32.const 0
   call $~lib/dataview/DataView#getFloat32
@@ -2016,7 +1987,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 1
   call $~lib/dataview/DataView#getFloat64
   f64.const 7936550095674706383278551e126
@@ -2029,7 +2000,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 0
   call $~lib/dataview/DataView#getFloat64
   f64.const -411777475818852546741639e241
@@ -2042,7 +2013,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 0
   call $~lib/dataview/DataView#getInt8
   i32.const -10
@@ -2055,7 +2026,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 1
   call $~lib/dataview/DataView#getInt8
   i32.const -32
@@ -2068,7 +2039,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 2
   call $~lib/dataview/DataView#getInt8
   i32.const 88
@@ -2081,7 +2052,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 3
   call $~lib/dataview/DataView#getInt8
   i32.const -97
@@ -2094,7 +2065,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 4
   call $~lib/dataview/DataView#getInt8
   i32.const -126
@@ -2107,7 +2078,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 5
   call $~lib/dataview/DataView#getInt8
   i32.const 101
@@ -2120,7 +2091,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 6
   call $~lib/dataview/DataView#getInt8
   i32.const 67
@@ -2133,7 +2104,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 7
   call $~lib/dataview/DataView#getInt8
   i32.const 95
@@ -2146,7 +2117,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 0
   i32.const 1
   call $~lib/dataview/DataView#getInt16
@@ -2162,7 +2133,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 1
   i32.const 1
   call $~lib/dataview/DataView#getInt16
@@ -2178,7 +2149,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 2
   i32.const 1
   call $~lib/dataview/DataView#getInt16
@@ -2194,7 +2165,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 3
   i32.const 1
   call $~lib/dataview/DataView#getInt16
@@ -2210,7 +2181,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 4
   i32.const 1
   call $~lib/dataview/DataView#getInt16
@@ -2226,7 +2197,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 5
   i32.const 1
   call $~lib/dataview/DataView#getInt16
@@ -2242,7 +2213,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 6
   i32.const 1
   call $~lib/dataview/DataView#getInt16
@@ -2258,7 +2229,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 0
   i32.const 0
   call $~lib/dataview/DataView#getInt16
@@ -2274,7 +2245,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 1
   i32.const 0
   call $~lib/dataview/DataView#getInt16
@@ -2290,7 +2261,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 2
   i32.const 0
   call $~lib/dataview/DataView#getInt16
@@ -2306,7 +2277,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 3
   i32.const 0
   call $~lib/dataview/DataView#getInt16
@@ -2322,7 +2293,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 4
   i32.const 0
   call $~lib/dataview/DataView#getInt16
@@ -2338,7 +2309,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 5
   i32.const 0
   call $~lib/dataview/DataView#getInt16
@@ -2354,7 +2325,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 6
   i32.const 0
   call $~lib/dataview/DataView#getInt16
@@ -2370,7 +2341,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 0
   i32.const 1
   call $~lib/dataview/DataView#getInt32
@@ -2384,7 +2355,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 1
   i32.const 1
   call $~lib/dataview/DataView#getInt32
@@ -2398,7 +2369,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 2
   i32.const 1
   call $~lib/dataview/DataView#getInt32
@@ -2412,7 +2383,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 3
   i32.const 1
   call $~lib/dataview/DataView#getInt32
@@ -2426,7 +2397,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 4
   i32.const 1
   call $~lib/dataview/DataView#getInt32
@@ -2440,7 +2411,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 0
   i32.const 0
   call $~lib/dataview/DataView#getInt32
@@ -2454,7 +2425,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 1
   i32.const 0
   call $~lib/dataview/DataView#getInt32
@@ -2468,7 +2439,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 2
   i32.const 0
   call $~lib/dataview/DataView#getInt32
@@ -2482,7 +2453,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 3
   i32.const 0
   call $~lib/dataview/DataView#getInt32
@@ -2496,7 +2467,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 4
   i32.const 0
   call $~lib/dataview/DataView#getInt32
@@ -2510,7 +2481,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 1
   call $~lib/dataview/DataView#getInt64
   i64.const 6864441868736323830
@@ -2523,7 +2494,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 0
   call $~lib/dataview/DataView#getInt64
   i64.const -657428103485373601
@@ -2536,7 +2507,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 0
   call $~lib/dataview/DataView#getUint8
   i32.const 246
@@ -2549,7 +2520,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 1
   call $~lib/dataview/DataView#getUint8
   i32.const 224
@@ -2562,7 +2533,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 2
   call $~lib/dataview/DataView#getUint8
   i32.const 88
@@ -2575,7 +2546,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 3
   call $~lib/dataview/DataView#getUint8
   i32.const 159
@@ -2588,7 +2559,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 4
   call $~lib/dataview/DataView#getUint8
   i32.const 130
@@ -2601,7 +2572,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 5
   call $~lib/dataview/DataView#getUint8
   i32.const 101
@@ -2614,7 +2585,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 6
   call $~lib/dataview/DataView#getUint8
   i32.const 67
@@ -2627,7 +2598,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 7
   call $~lib/dataview/DataView#getUint8
   i32.const 95
@@ -2640,7 +2611,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 0
   i32.const 1
   call $~lib/dataview/DataView#getUint16
@@ -2656,7 +2627,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 1
   i32.const 1
   call $~lib/dataview/DataView#getUint16
@@ -2672,7 +2643,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 2
   i32.const 1
   call $~lib/dataview/DataView#getUint16
@@ -2688,7 +2659,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 3
   i32.const 1
   call $~lib/dataview/DataView#getUint16
@@ -2704,7 +2675,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 4
   i32.const 1
   call $~lib/dataview/DataView#getUint16
@@ -2720,7 +2691,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 5
   i32.const 1
   call $~lib/dataview/DataView#getUint16
@@ -2736,7 +2707,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 6
   i32.const 1
   call $~lib/dataview/DataView#getUint16
@@ -2752,7 +2723,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 0
   i32.const 0
   call $~lib/dataview/DataView#getUint16
@@ -2768,7 +2739,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 1
   i32.const 0
   call $~lib/dataview/DataView#getUint16
@@ -2784,7 +2755,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 2
   i32.const 0
   call $~lib/dataview/DataView#getUint16
@@ -2800,7 +2771,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 3
   i32.const 0
   call $~lib/dataview/DataView#getUint16
@@ -2816,7 +2787,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 4
   i32.const 0
   call $~lib/dataview/DataView#getUint16
@@ -2832,7 +2803,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 5
   i32.const 0
   call $~lib/dataview/DataView#getUint16
@@ -2848,7 +2819,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 6
   i32.const 0
   call $~lib/dataview/DataView#getUint16
@@ -2864,7 +2835,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 0
   i32.const 1
   call $~lib/dataview/DataView#getUint32
@@ -2878,7 +2849,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 1
   i32.const 1
   call $~lib/dataview/DataView#getUint32
@@ -2892,7 +2863,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 2
   i32.const 1
   call $~lib/dataview/DataView#getUint32
@@ -2906,7 +2877,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 3
   i32.const 1
   call $~lib/dataview/DataView#getUint32
@@ -2920,7 +2891,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 4
   i32.const 1
   call $~lib/dataview/DataView#getUint32
@@ -2934,7 +2905,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 0
   i32.const 0
   call $~lib/dataview/DataView#getUint32
@@ -2948,7 +2919,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 1
   i32.const 0
   call $~lib/dataview/DataView#getUint32
@@ -2962,7 +2933,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 2
   i32.const 0
   call $~lib/dataview/DataView#getUint32
@@ -2976,7 +2947,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 3
   i32.const 0
   call $~lib/dataview/DataView#getUint32
@@ -2990,7 +2961,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 4
   i32.const 0
   call $~lib/dataview/DataView#getUint32
@@ -3004,7 +2975,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 1
   call $~lib/dataview/DataView#getUint64
   i64.const 6864441868736323830
@@ -3017,7 +2988,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 0
   call $~lib/dataview/DataView#getUint64
   i64.const -657428103485373601
@@ -3030,11 +3001,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   f32.const 1.5976661625240943e-18
   i32.const 1
   call $~lib/dataview/DataView#setFloat32
-  local.get $0
+  local.get $1
   i32.const 0
   i32.const 1
   call $~lib/dataview/DataView#getFloat32
@@ -3048,11 +3019,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   f32.const 1976281973381696323584
   i32.const 0
   call $~lib/dataview/DataView#setFloat32
-  local.get $0
+  local.get $1
   i32.const 0
   i32.const 0
   call $~lib/dataview/DataView#getFloat32
@@ -3066,11 +3037,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   f64.const -1094252199637739024055454e124
   i32.const 1
   call $~lib/dataview/DataView#setFloat64
-  local.get $0
+  local.get $1
   i32.const 1
   call $~lib/dataview/DataView#getFloat64
   f64.const -1094252199637739024055454e124
@@ -3083,11 +3054,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   f64.const 6.022586634778589e-103
   i32.const 0
   call $~lib/dataview/DataView#setFloat64
-  local.get $0
+  local.get $1
   i32.const 0
   call $~lib/dataview/DataView#getFloat64
   f64.const 6.022586634778589e-103
@@ -3101,7 +3072,7 @@
    unreachable
   end
   i32.const 0
-  local.get $0
+  local.get $1
   i32.load offset=8
   i32.ge_u
   if
@@ -3112,11 +3083,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.load offset=4
   i32.const 108
   i32.store8
-  local.get $0
+  local.get $1
   i32.const 0
   call $~lib/dataview/DataView#getInt8
   i32.const 108
@@ -3129,11 +3100,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const -13360
   i32.const 1
   call $~lib/dataview/DataView#setInt16
-  local.get $0
+  local.get $1
   i32.const 0
   i32.const 1
   call $~lib/dataview/DataView#getInt16
@@ -3149,11 +3120,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 14689
   i32.const 0
   call $~lib/dataview/DataView#setInt16
-  local.get $0
+  local.get $1
   i32.const 0
   i32.const 0
   call $~lib/dataview/DataView#getInt16
@@ -3169,11 +3140,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 1204680201
   i32.const 1
   call $~lib/dataview/DataView#setInt32
-  local.get $0
+  local.get $1
   i32.const 0
   i32.const 1
   call $~lib/dataview/DataView#getInt32
@@ -3187,11 +3158,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 660673230
   i32.const 0
   call $~lib/dataview/DataView#setInt32
-  local.get $0
+  local.get $1
   i32.const 0
   i32.const 0
   call $~lib/dataview/DataView#getInt32
@@ -3205,11 +3176,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i64.const -3290739641816099749
   i32.const 1
   call $~lib/dataview/DataView#setInt64
-  local.get $0
+  local.get $1
   i32.const 1
   call $~lib/dataview/DataView#getInt64
   i64.const -3290739641816099749
@@ -3222,11 +3193,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i64.const 8178932412950708047
   i32.const 0
   call $~lib/dataview/DataView#setInt64
-  local.get $0
+  local.get $1
   i32.const 0
   call $~lib/dataview/DataView#getInt64
   i64.const 8178932412950708047
@@ -3240,7 +3211,7 @@
    unreachable
   end
   i32.const 0
-  local.get $0
+  local.get $1
   i32.load offset=8
   i32.ge_u
   if
@@ -3251,11 +3222,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.load offset=4
   i32.const 238
   i32.store8
-  local.get $0
+  local.get $1
   i32.const 0
   call $~lib/dataview/DataView#getUint8
   i32.const 238
@@ -3268,11 +3239,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 58856
   i32.const 1
   call $~lib/dataview/DataView#setUint16
-  local.get $0
+  local.get $1
   i32.const 0
   i32.const 1
   call $~lib/dataview/DataView#getUint16
@@ -3288,11 +3259,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 60400
   i32.const 0
   call $~lib/dataview/DataView#setUint16
-  local.get $0
+  local.get $1
   i32.const 0
   i32.const 0
   call $~lib/dataview/DataView#getUint16
@@ -3308,11 +3279,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const -846805744
   i32.const 1
   call $~lib/dataview/DataView#setUint32
-  local.get $0
+  local.get $1
   i32.const 0
   i32.const 1
   call $~lib/dataview/DataView#getUint32
@@ -3326,11 +3297,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const -1510791631
   i32.const 0
   call $~lib/dataview/DataView#setUint32
-  local.get $0
+  local.get $1
   i32.const 0
   i32.const 0
   call $~lib/dataview/DataView#getUint32
@@ -3344,11 +3315,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i64.const 2334704782995986958
   i32.const 1
   call $~lib/dataview/DataView#setUint64
-  local.get $0
+  local.get $1
   i32.const 1
   call $~lib/dataview/DataView#getUint64
   i64.const 2334704782995986958
@@ -3361,11 +3332,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i64.const -7123186897289856329
   i32.const 0
   call $~lib/dataview/DataView#setUint64
-  local.get $0
+  local.get $1
   i32.const 0
   call $~lib/dataview/DataView#getUint64
   i64.const -7123186897289856329
@@ -3378,21 +3349,21 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $3
   i32.load
-  local.tee $3
+  local.tee $0
   i32.const 16
   i32.sub
   i32.load offset=12
   local.set $2
-  local.get $3
+  local.get $0
   i32.const 0
   local.get $2
   call $~lib/dataview/DataView#constructor
-  local.set $2
-  local.get $0
+  local.set $0
+  local.get $1
   call $~lib/rt/pure/__release
-  local.get $2
+  local.get $0
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
   if
    i32.const 0
@@ -3402,7 +3373,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $0
   i32.load offset=8
   i32.const 8
   i32.ne
@@ -3414,9 +3385,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $3
   call $~lib/rt/pure/__release
-  local.get $2
+  local.get $0
   call $~lib/rt/pure/__release
  )
  (func $~start

--- a/tests/compiler/std/dataview.untouched.wat
+++ b/tests/compiler/std/dataview.untouched.wat
@@ -1500,10 +1500,81 @@
    i32.const 1
    i32.gt_s
    drop
-   local.get $3
-   i32.eqz
-   if
-    br $~lib/util/memory/memset|inlined.0
+   block $break|0
+    block $case5|0
+     block $case4|0
+      block $case3|0
+       block $case2|0
+        block $case1|0
+         block $case0|0
+          local.get $3
+          local.set $6
+          local.get $6
+          i32.const 0
+          i32.eq
+          br_if $case0|0
+          local.get $6
+          i32.const 1
+          i32.eq
+          br_if $case1|0
+          local.get $6
+          i32.const 2
+          i32.eq
+          br_if $case2|0
+          local.get $6
+          i32.const 4
+          i32.eq
+          br_if $case3|0
+          local.get $6
+          i32.const 8
+          i32.eq
+          br_if $case4|0
+          br $case5|0
+         end
+         br $~lib/util/memory/memset|inlined.0
+        end
+        local.get $5
+        local.get $4
+        i32.store8 offset=1
+        br $~lib/util/memory/memset|inlined.0
+       end
+       local.get $5
+       i32.const -1
+       i32.const 65535
+       i32.and
+       i32.const 255
+       i32.div_u
+       local.get $4
+       i32.const 255
+       i32.and
+       i32.mul
+       i32.store16
+       br $~lib/util/memory/memset|inlined.0
+      end
+      local.get $5
+      i32.const -1
+      i32.const 255
+      i32.div_u
+      local.get $4
+      i32.const 255
+      i32.and
+      i32.mul
+      i32.store
+      br $~lib/util/memory/memset|inlined.0
+     end
+     local.get $5
+     i64.const -1
+     i64.const 255
+     i64.div_u
+     local.get $4
+     i32.const 255
+     i32.and
+     i64.extend_i32_u
+     i64.mul
+     i64.store
+     br $~lib/util/memory/memset|inlined.0
+    end
+    br $break|0
    end
    local.get $5
    local.get $3
@@ -1661,7 +1732,7 @@
    i64.shl
    i64.or
    local.set $9
-   loop $while-continue|0
+   loop $while-continue|1
     local.get $3
     i32.const 32
     i32.ge_u
@@ -1688,7 +1759,7 @@
      i32.const 32
      i32.add
      local.set $5
-     br $while-continue|0
+     br $while-continue|1
     end
    end
   end

--- a/tests/compiler/std/dataview.untouched.wat
+++ b/tests/compiler/std/dataview.untouched.wat
@@ -1535,15 +1535,11 @@
         end
         local.get $5
         local.get $4
-        i32.store8 offset=1
+        i32.store8
         br $~lib/util/memory/memset|inlined.0
        end
        local.get $5
-       i32.const -1
-       i32.const 65535
-       i32.and
-       i32.const 255
-       i32.div_u
+       i32.const 257
        local.get $4
        i32.const 255
        i32.and
@@ -1552,9 +1548,7 @@
        br $~lib/util/memory/memset|inlined.0
       end
       local.get $5
-      i32.const -1
-      i32.const 255
-      i32.div_u
+      i32.const 16843009
       local.get $4
       i32.const 255
       i32.and
@@ -1563,9 +1557,7 @@
       br $~lib/util/memory/memset|inlined.0
      end
      local.get $5
-     i64.const -1
-     i64.const 255
-     i64.div_u
+     i64.const 72340172838076673
      local.get $4
      i32.const 255
      i32.and

--- a/tests/compiler/std/map.optimized.wat
+++ b/tests/compiler/std/map.optimized.wat
@@ -1142,7 +1142,7 @@
        end
        local.get $0
        i32.const 0
-       i32.store8 offset=1
+       i32.store8
        br $~lib/util/memory/memset|inlined.0
       end
       local.get $0

--- a/tests/compiler/std/map.optimized.wat
+++ b/tests/compiler/std/map.optimized.wat
@@ -1130,6 +1130,36 @@
    local.get $1
    i32.eqz
    br_if $~lib/util/memory/memset|inlined.0
+   block $break|0
+    block $case4|0
+     block $case3|0
+      block $case2|0
+       block $case1|0
+        local.get $1
+        i32.const 1
+        i32.sub
+        br_table $case1|0 $case2|0 $break|0 $case3|0 $break|0 $break|0 $break|0 $case4|0 $break|0
+       end
+       local.get $0
+       i32.const 0
+       i32.store8 offset=1
+       br $~lib/util/memory/memset|inlined.0
+      end
+      local.get $0
+      i32.const 0
+      i32.store16
+      br $~lib/util/memory/memset|inlined.0
+     end
+     local.get $0
+     i32.const 0
+     i32.store
+     br $~lib/util/memory/memset|inlined.0
+    end
+    local.get $0
+    i64.const 0
+    i64.store
+    br $~lib/util/memory/memset|inlined.0
+   end
    local.get $0
    i32.const 0
    i32.store8
@@ -1252,7 +1282,7 @@
    local.get $1
    i32.sub
    local.set $1
-   loop $while-continue|0
+   loop $while-continue|1
     local.get $1
     i32.const 32
     i32.ge_u
@@ -1277,7 +1307,7 @@
      i32.const 32
      i32.add
      local.set $0
-     br $while-continue|0
+     br $while-continue|1
     end
    end
   end

--- a/tests/compiler/std/map.untouched.wat
+++ b/tests/compiler/std/map.untouched.wat
@@ -1574,10 +1574,81 @@
    i32.const 1
    i32.gt_s
    drop
-   local.get $3
-   i32.eqz
-   if
-    br $~lib/util/memory/memset|inlined.0
+   block $break|0
+    block $case5|0
+     block $case4|0
+      block $case3|0
+       block $case2|0
+        block $case1|0
+         block $case0|0
+          local.get $3
+          local.set $6
+          local.get $6
+          i32.const 0
+          i32.eq
+          br_if $case0|0
+          local.get $6
+          i32.const 1
+          i32.eq
+          br_if $case1|0
+          local.get $6
+          i32.const 2
+          i32.eq
+          br_if $case2|0
+          local.get $6
+          i32.const 4
+          i32.eq
+          br_if $case3|0
+          local.get $6
+          i32.const 8
+          i32.eq
+          br_if $case4|0
+          br $case5|0
+         end
+         br $~lib/util/memory/memset|inlined.0
+        end
+        local.get $5
+        local.get $4
+        i32.store8 offset=1
+        br $~lib/util/memory/memset|inlined.0
+       end
+       local.get $5
+       i32.const -1
+       i32.const 65535
+       i32.and
+       i32.const 255
+       i32.div_u
+       local.get $4
+       i32.const 255
+       i32.and
+       i32.mul
+       i32.store16
+       br $~lib/util/memory/memset|inlined.0
+      end
+      local.get $5
+      i32.const -1
+      i32.const 255
+      i32.div_u
+      local.get $4
+      i32.const 255
+      i32.and
+      i32.mul
+      i32.store
+      br $~lib/util/memory/memset|inlined.0
+     end
+     local.get $5
+     i64.const -1
+     i64.const 255
+     i64.div_u
+     local.get $4
+     i32.const 255
+     i32.and
+     i64.extend_i32_u
+     i64.mul
+     i64.store
+     br $~lib/util/memory/memset|inlined.0
+    end
+    br $break|0
    end
    local.get $5
    local.get $3
@@ -1735,7 +1806,7 @@
    i64.shl
    i64.or
    local.set $9
-   loop $while-continue|0
+   loop $while-continue|1
     local.get $3
     i32.const 32
     i32.ge_u
@@ -1762,7 +1833,7 @@
      i32.const 32
      i32.add
      local.set $5
-     br $while-continue|0
+     br $while-continue|1
     end
    end
   end

--- a/tests/compiler/std/map.untouched.wat
+++ b/tests/compiler/std/map.untouched.wat
@@ -1609,15 +1609,11 @@
         end
         local.get $5
         local.get $4
-        i32.store8 offset=1
+        i32.store8
         br $~lib/util/memory/memset|inlined.0
        end
        local.get $5
-       i32.const -1
-       i32.const 65535
-       i32.and
-       i32.const 255
-       i32.div_u
+       i32.const 257
        local.get $4
        i32.const 255
        i32.and
@@ -1626,9 +1622,7 @@
        br $~lib/util/memory/memset|inlined.0
       end
       local.get $5
-      i32.const -1
-      i32.const 255
-      i32.div_u
+      i32.const 16843009
       local.get $4
       i32.const 255
       i32.and
@@ -1637,9 +1631,7 @@
       br $~lib/util/memory/memset|inlined.0
      end
      local.get $5
-     i64.const -1
-     i64.const 255
-     i64.div_u
+     i64.const 72340172838076673
      local.get $4
      i32.const 255
      i32.and

--- a/tests/compiler/std/pointer.optimized.wat
+++ b/tests/compiler/std/pointer.optimized.wat
@@ -357,31 +357,8 @@
    call $~lib/memory/memory.copy
   else
    local.get $0
-   i32.const 0
-   i32.store8
-   local.get $0
-   i32.const 4
-   i32.add
-   i32.const 0
-   i32.store8 offset=3
-   local.get $0
-   i32.const 0
-   i32.store8 offset=1
-   local.get $0
-   i32.const 0
-   i32.store8 offset=2
-   local.get $0
-   i32.const 0
-   i32.store8 offset=6
-   local.get $0
-   i32.const 0
-   i32.store8 offset=5
-   local.get $0
-   i32.const 0
-   i32.store8 offset=3
-   local.get $0
-   i32.const 0
-   i32.store8 offset=4
+   i64.const 0
+   i64.store
   end
   global.get $std/pointer/one
   global.get $std/pointer/two

--- a/tests/compiler/std/pointer.untouched.wat
+++ b/tests/compiler/std/pointer.untouched.wat
@@ -74,15 +74,11 @@
         end
         local.get $5
         local.get $4
-        i32.store8 offset=1
+        i32.store8
         br $~lib/util/memory/memset|inlined.0
        end
        local.get $5
-       i32.const -1
-       i32.const 65535
-       i32.and
-       i32.const 255
-       i32.div_u
+       i32.const 257
        local.get $4
        i32.const 255
        i32.and
@@ -91,9 +87,7 @@
        br $~lib/util/memory/memset|inlined.0
       end
       local.get $5
-      i32.const -1
-      i32.const 255
-      i32.div_u
+      i32.const 16843009
       local.get $4
       i32.const 255
       i32.and
@@ -102,9 +96,7 @@
       br $~lib/util/memory/memset|inlined.0
      end
      local.get $5
-     i64.const -1
-     i64.const 255
-     i64.div_u
+     i64.const 72340172838076673
      local.get $4
      i32.const 255
      i32.and

--- a/tests/compiler/std/pointer.untouched.wat
+++ b/tests/compiler/std/pointer.untouched.wat
@@ -39,10 +39,81 @@
    i32.const 1
    i32.gt_s
    drop
-   local.get $3
-   i32.eqz
-   if
-    br $~lib/util/memory/memset|inlined.0
+   block $break|0
+    block $case5|0
+     block $case4|0
+      block $case3|0
+       block $case2|0
+        block $case1|0
+         block $case0|0
+          local.get $3
+          local.set $6
+          local.get $6
+          i32.const 0
+          i32.eq
+          br_if $case0|0
+          local.get $6
+          i32.const 1
+          i32.eq
+          br_if $case1|0
+          local.get $6
+          i32.const 2
+          i32.eq
+          br_if $case2|0
+          local.get $6
+          i32.const 4
+          i32.eq
+          br_if $case3|0
+          local.get $6
+          i32.const 8
+          i32.eq
+          br_if $case4|0
+          br $case5|0
+         end
+         br $~lib/util/memory/memset|inlined.0
+        end
+        local.get $5
+        local.get $4
+        i32.store8 offset=1
+        br $~lib/util/memory/memset|inlined.0
+       end
+       local.get $5
+       i32.const -1
+       i32.const 65535
+       i32.and
+       i32.const 255
+       i32.div_u
+       local.get $4
+       i32.const 255
+       i32.and
+       i32.mul
+       i32.store16
+       br $~lib/util/memory/memset|inlined.0
+      end
+      local.get $5
+      i32.const -1
+      i32.const 255
+      i32.div_u
+      local.get $4
+      i32.const 255
+      i32.and
+      i32.mul
+      i32.store
+      br $~lib/util/memory/memset|inlined.0
+     end
+     local.get $5
+     i64.const -1
+     i64.const 255
+     i64.div_u
+     local.get $4
+     i32.const 255
+     i32.and
+     i64.extend_i32_u
+     i64.mul
+     i64.store
+     br $~lib/util/memory/memset|inlined.0
+    end
+    br $break|0
    end
    local.get $5
    local.get $3
@@ -200,7 +271,7 @@
    i64.shl
    i64.or
    local.set $9
-   loop $while-continue|0
+   loop $while-continue|1
     local.get $3
     i32.const 32
     i32.ge_u
@@ -227,7 +298,7 @@
      i32.const 32
      i32.add
      local.set $5
-     br $while-continue|0
+     br $while-continue|1
     end
    end
   end

--- a/tests/compiler/std/set.optimized.wat
+++ b/tests/compiler/std/set.optimized.wat
@@ -1139,7 +1139,7 @@
        end
        local.get $0
        i32.const 0
-       i32.store8 offset=1
+       i32.store8
        br $~lib/util/memory/memset|inlined.0
       end
       local.get $0

--- a/tests/compiler/std/set.optimized.wat
+++ b/tests/compiler/std/set.optimized.wat
@@ -1127,6 +1127,36 @@
    local.get $1
    i32.eqz
    br_if $~lib/util/memory/memset|inlined.0
+   block $break|0
+    block $case4|0
+     block $case3|0
+      block $case2|0
+       block $case1|0
+        local.get $1
+        i32.const 1
+        i32.sub
+        br_table $case1|0 $case2|0 $break|0 $case3|0 $break|0 $break|0 $break|0 $case4|0 $break|0
+       end
+       local.get $0
+       i32.const 0
+       i32.store8 offset=1
+       br $~lib/util/memory/memset|inlined.0
+      end
+      local.get $0
+      i32.const 0
+      i32.store16
+      br $~lib/util/memory/memset|inlined.0
+     end
+     local.get $0
+     i32.const 0
+     i32.store
+     br $~lib/util/memory/memset|inlined.0
+    end
+    local.get $0
+    i64.const 0
+    i64.store
+    br $~lib/util/memory/memset|inlined.0
+   end
    local.get $0
    i32.const 0
    i32.store8
@@ -1249,7 +1279,7 @@
    local.get $1
    i32.sub
    local.set $1
-   loop $while-continue|0
+   loop $while-continue|1
     local.get $1
     i32.const 32
     i32.ge_u
@@ -1274,7 +1304,7 @@
      i32.const 32
      i32.add
      local.set $0
-     br $while-continue|0
+     br $while-continue|1
     end
    end
   end

--- a/tests/compiler/std/set.untouched.wat
+++ b/tests/compiler/std/set.untouched.wat
@@ -1604,15 +1604,11 @@
         end
         local.get $5
         local.get $4
-        i32.store8 offset=1
+        i32.store8
         br $~lib/util/memory/memset|inlined.0
        end
        local.get $5
-       i32.const -1
-       i32.const 65535
-       i32.and
-       i32.const 255
-       i32.div_u
+       i32.const 257
        local.get $4
        i32.const 255
        i32.and
@@ -1621,9 +1617,7 @@
        br $~lib/util/memory/memset|inlined.0
       end
       local.get $5
-      i32.const -1
-      i32.const 255
-      i32.div_u
+      i32.const 16843009
       local.get $4
       i32.const 255
       i32.and
@@ -1632,9 +1626,7 @@
       br $~lib/util/memory/memset|inlined.0
      end
      local.get $5
-     i64.const -1
-     i64.const 255
-     i64.div_u
+     i64.const 72340172838076673
      local.get $4
      i32.const 255
      i32.and

--- a/tests/compiler/std/set.untouched.wat
+++ b/tests/compiler/std/set.untouched.wat
@@ -1569,10 +1569,81 @@
    i32.const 1
    i32.gt_s
    drop
-   local.get $3
-   i32.eqz
-   if
-    br $~lib/util/memory/memset|inlined.0
+   block $break|0
+    block $case5|0
+     block $case4|0
+      block $case3|0
+       block $case2|0
+        block $case1|0
+         block $case0|0
+          local.get $3
+          local.set $6
+          local.get $6
+          i32.const 0
+          i32.eq
+          br_if $case0|0
+          local.get $6
+          i32.const 1
+          i32.eq
+          br_if $case1|0
+          local.get $6
+          i32.const 2
+          i32.eq
+          br_if $case2|0
+          local.get $6
+          i32.const 4
+          i32.eq
+          br_if $case3|0
+          local.get $6
+          i32.const 8
+          i32.eq
+          br_if $case4|0
+          br $case5|0
+         end
+         br $~lib/util/memory/memset|inlined.0
+        end
+        local.get $5
+        local.get $4
+        i32.store8 offset=1
+        br $~lib/util/memory/memset|inlined.0
+       end
+       local.get $5
+       i32.const -1
+       i32.const 65535
+       i32.and
+       i32.const 255
+       i32.div_u
+       local.get $4
+       i32.const 255
+       i32.and
+       i32.mul
+       i32.store16
+       br $~lib/util/memory/memset|inlined.0
+      end
+      local.get $5
+      i32.const -1
+      i32.const 255
+      i32.div_u
+      local.get $4
+      i32.const 255
+      i32.and
+      i32.mul
+      i32.store
+      br $~lib/util/memory/memset|inlined.0
+     end
+     local.get $5
+     i64.const -1
+     i64.const 255
+     i64.div_u
+     local.get $4
+     i32.const 255
+     i32.and
+     i64.extend_i32_u
+     i64.mul
+     i64.store
+     br $~lib/util/memory/memset|inlined.0
+    end
+    br $break|0
    end
    local.get $5
    local.get $3
@@ -1730,7 +1801,7 @@
    i64.shl
    i64.or
    local.set $9
-   loop $while-continue|0
+   loop $while-continue|1
     local.get $3
     i32.const 32
     i32.ge_u
@@ -1757,7 +1828,7 @@
      i32.const 32
      i32.add
      local.set $5
-     br $while-continue|0
+     br $while-continue|1
     end
    end
   end

--- a/tests/compiler/std/static-array.optimized.wat
+++ b/tests/compiler/std/static-array.optimized.wat
@@ -434,7 +434,7 @@
        end
        local.get $0
        i32.const 0
-       i32.store8 offset=1
+       i32.store8
        br $~lib/util/memory/memset|inlined.0
       end
       local.get $0

--- a/tests/compiler/std/static-array.optimized.wat
+++ b/tests/compiler/std/static-array.optimized.wat
@@ -422,6 +422,36 @@
    local.get $1
    i32.eqz
    br_if $~lib/util/memory/memset|inlined.0
+   block $break|0
+    block $case4|0
+     block $case3|0
+      block $case2|0
+       block $case1|0
+        local.get $1
+        i32.const 1
+        i32.sub
+        br_table $case1|0 $case2|0 $break|0 $case3|0 $break|0 $break|0 $break|0 $case4|0 $break|0
+       end
+       local.get $0
+       i32.const 0
+       i32.store8 offset=1
+       br $~lib/util/memory/memset|inlined.0
+      end
+      local.get $0
+      i32.const 0
+      i32.store16
+      br $~lib/util/memory/memset|inlined.0
+     end
+     local.get $0
+     i32.const 0
+     i32.store
+     br $~lib/util/memory/memset|inlined.0
+    end
+    local.get $0
+    i64.const 0
+    i64.store
+    br $~lib/util/memory/memset|inlined.0
+   end
    local.get $0
    i32.const 0
    i32.store8
@@ -544,7 +574,7 @@
    local.get $1
    i32.sub
    local.set $1
-   loop $while-continue|0
+   loop $while-continue|1
     local.get $1
     i32.const 32
     i32.ge_u
@@ -569,7 +599,7 @@
      i32.const 32
      i32.add
      local.set $0
-     br $while-continue|0
+     br $while-continue|1
     end
    end
   end

--- a/tests/compiler/std/static-array.untouched.wat
+++ b/tests/compiler/std/static-array.untouched.wat
@@ -1582,10 +1582,81 @@
    i32.const 1
    i32.gt_s
    drop
-   local.get $3
-   i32.eqz
-   if
-    br $~lib/util/memory/memset|inlined.0
+   block $break|0
+    block $case5|0
+     block $case4|0
+      block $case3|0
+       block $case2|0
+        block $case1|0
+         block $case0|0
+          local.get $3
+          local.set $6
+          local.get $6
+          i32.const 0
+          i32.eq
+          br_if $case0|0
+          local.get $6
+          i32.const 1
+          i32.eq
+          br_if $case1|0
+          local.get $6
+          i32.const 2
+          i32.eq
+          br_if $case2|0
+          local.get $6
+          i32.const 4
+          i32.eq
+          br_if $case3|0
+          local.get $6
+          i32.const 8
+          i32.eq
+          br_if $case4|0
+          br $case5|0
+         end
+         br $~lib/util/memory/memset|inlined.0
+        end
+        local.get $5
+        local.get $4
+        i32.store8 offset=1
+        br $~lib/util/memory/memset|inlined.0
+       end
+       local.get $5
+       i32.const -1
+       i32.const 65535
+       i32.and
+       i32.const 255
+       i32.div_u
+       local.get $4
+       i32.const 255
+       i32.and
+       i32.mul
+       i32.store16
+       br $~lib/util/memory/memset|inlined.0
+      end
+      local.get $5
+      i32.const -1
+      i32.const 255
+      i32.div_u
+      local.get $4
+      i32.const 255
+      i32.and
+      i32.mul
+      i32.store
+      br $~lib/util/memory/memset|inlined.0
+     end
+     local.get $5
+     i64.const -1
+     i64.const 255
+     i64.div_u
+     local.get $4
+     i32.const 255
+     i32.and
+     i64.extend_i32_u
+     i64.mul
+     i64.store
+     br $~lib/util/memory/memset|inlined.0
+    end
+    br $break|0
    end
    local.get $5
    local.get $3
@@ -1743,7 +1814,7 @@
    i64.shl
    i64.or
    local.set $9
-   loop $while-continue|0
+   loop $while-continue|1
     local.get $3
     i32.const 32
     i32.ge_u
@@ -1770,7 +1841,7 @@
      i32.const 32
      i32.add
      local.set $5
-     br $while-continue|0
+     br $while-continue|1
     end
    end
   end

--- a/tests/compiler/std/static-array.untouched.wat
+++ b/tests/compiler/std/static-array.untouched.wat
@@ -1617,15 +1617,11 @@
         end
         local.get $5
         local.get $4
-        i32.store8 offset=1
+        i32.store8
         br $~lib/util/memory/memset|inlined.0
        end
        local.get $5
-       i32.const -1
-       i32.const 65535
-       i32.and
-       i32.const 255
-       i32.div_u
+       i32.const 257
        local.get $4
        i32.const 255
        i32.and
@@ -1634,9 +1630,7 @@
        br $~lib/util/memory/memset|inlined.0
       end
       local.get $5
-      i32.const -1
-      i32.const 255
-      i32.div_u
+      i32.const 16843009
       local.get $4
       i32.const 255
       i32.and
@@ -1645,9 +1639,7 @@
       br $~lib/util/memory/memset|inlined.0
      end
      local.get $5
-     i64.const -1
-     i64.const 255
-     i64.div_u
+     i64.const 72340172838076673
      local.get $4
      i32.const 255
      i32.and

--- a/tests/compiler/std/string.optimized.wat
+++ b/tests/compiler/std/string.optimized.wat
@@ -5035,6 +5035,36 @@
    local.get $1
    i32.eqz
    br_if $~lib/util/memory/memset|inlined.0
+   block $break|0
+    block $case4|0
+     block $case3|0
+      block $case2|0
+       block $case1|0
+        local.get $1
+        i32.const 1
+        i32.sub
+        br_table $case1|0 $case2|0 $break|0 $case3|0 $break|0 $break|0 $break|0 $case4|0 $break|0
+       end
+       local.get $0
+       i32.const 0
+       i32.store8 offset=1
+       br $~lib/util/memory/memset|inlined.0
+      end
+      local.get $0
+      i32.const 0
+      i32.store16
+      br $~lib/util/memory/memset|inlined.0
+     end
+     local.get $0
+     i32.const 0
+     i32.store
+     br $~lib/util/memory/memset|inlined.0
+    end
+    local.get $0
+    i64.const 0
+    i64.store
+    br $~lib/util/memory/memset|inlined.0
+   end
    local.get $0
    i32.const 0
    i32.store8
@@ -5157,7 +5187,7 @@
    local.get $1
    i32.sub
    local.set $1
-   loop $while-continue|0
+   loop $while-continue|1
     local.get $1
     i32.const 32
     i32.ge_u
@@ -5182,7 +5212,7 @@
      i32.const 32
      i32.add
      local.set $0
-     br $while-continue|0
+     br $while-continue|1
     end
    end
   end

--- a/tests/compiler/std/string.optimized.wat
+++ b/tests/compiler/std/string.optimized.wat
@@ -5047,7 +5047,7 @@
        end
        local.get $0
        i32.const 0
-       i32.store8 offset=1
+       i32.store8
        br $~lib/util/memory/memset|inlined.0
       end
       local.get $0

--- a/tests/compiler/std/string.untouched.wat
+++ b/tests/compiler/std/string.untouched.wat
@@ -8181,10 +8181,81 @@
    i32.const 1
    i32.gt_s
    drop
-   local.get $3
-   i32.eqz
-   if
-    br $~lib/util/memory/memset|inlined.0
+   block $break|0
+    block $case5|0
+     block $case4|0
+      block $case3|0
+       block $case2|0
+        block $case1|0
+         block $case0|0
+          local.get $3
+          local.set $6
+          local.get $6
+          i32.const 0
+          i32.eq
+          br_if $case0|0
+          local.get $6
+          i32.const 1
+          i32.eq
+          br_if $case1|0
+          local.get $6
+          i32.const 2
+          i32.eq
+          br_if $case2|0
+          local.get $6
+          i32.const 4
+          i32.eq
+          br_if $case3|0
+          local.get $6
+          i32.const 8
+          i32.eq
+          br_if $case4|0
+          br $case5|0
+         end
+         br $~lib/util/memory/memset|inlined.0
+        end
+        local.get $5
+        local.get $4
+        i32.store8 offset=1
+        br $~lib/util/memory/memset|inlined.0
+       end
+       local.get $5
+       i32.const -1
+       i32.const 65535
+       i32.and
+       i32.const 255
+       i32.div_u
+       local.get $4
+       i32.const 255
+       i32.and
+       i32.mul
+       i32.store16
+       br $~lib/util/memory/memset|inlined.0
+      end
+      local.get $5
+      i32.const -1
+      i32.const 255
+      i32.div_u
+      local.get $4
+      i32.const 255
+      i32.and
+      i32.mul
+      i32.store
+      br $~lib/util/memory/memset|inlined.0
+     end
+     local.get $5
+     i64.const -1
+     i64.const 255
+     i64.div_u
+     local.get $4
+     i32.const 255
+     i32.and
+     i64.extend_i32_u
+     i64.mul
+     i64.store
+     br $~lib/util/memory/memset|inlined.0
+    end
+    br $break|0
    end
    local.get $5
    local.get $3
@@ -8342,7 +8413,7 @@
    i64.shl
    i64.or
    local.set $9
-   loop $while-continue|0
+   loop $while-continue|1
     local.get $3
     i32.const 32
     i32.ge_u
@@ -8369,7 +8440,7 @@
      i32.const 32
      i32.add
      local.set $5
-     br $while-continue|0
+     br $while-continue|1
     end
    end
   end

--- a/tests/compiler/std/string.untouched.wat
+++ b/tests/compiler/std/string.untouched.wat
@@ -8216,15 +8216,11 @@
         end
         local.get $5
         local.get $4
-        i32.store8 offset=1
+        i32.store8
         br $~lib/util/memory/memset|inlined.0
        end
        local.get $5
-       i32.const -1
-       i32.const 65535
-       i32.and
-       i32.const 255
-       i32.div_u
+       i32.const 257
        local.get $4
        i32.const 255
        i32.and
@@ -8233,9 +8229,7 @@
        br $~lib/util/memory/memset|inlined.0
       end
       local.get $5
-      i32.const -1
-      i32.const 255
-      i32.div_u
+      i32.const 16843009
       local.get $4
       i32.const 255
       i32.and
@@ -8244,9 +8238,7 @@
       br $~lib/util/memory/memset|inlined.0
      end
      local.get $5
-     i64.const -1
-     i64.const 255
-     i64.div_u
+     i64.const 72340172838076673
      local.get $4
      i32.const 255
      i32.and

--- a/tests/compiler/std/symbol.optimized.wat
+++ b/tests/compiler/std/symbol.optimized.wat
@@ -165,7 +165,7 @@
        end
        local.get $0
        i32.const 0
-       i32.store8 offset=1
+       i32.store8
        br $~lib/util/memory/memset|inlined.0
       end
       local.get $0

--- a/tests/compiler/std/symbol.optimized.wat
+++ b/tests/compiler/std/symbol.optimized.wat
@@ -153,6 +153,36 @@
    local.get $1
    i32.eqz
    br_if $~lib/util/memory/memset|inlined.0
+   block $break|0
+    block $case4|0
+     block $case3|0
+      block $case2|0
+       block $case1|0
+        local.get $1
+        i32.const 1
+        i32.sub
+        br_table $case1|0 $case2|0 $break|0 $case3|0 $break|0 $break|0 $break|0 $case4|0 $break|0
+       end
+       local.get $0
+       i32.const 0
+       i32.store8 offset=1
+       br $~lib/util/memory/memset|inlined.0
+      end
+      local.get $0
+      i32.const 0
+      i32.store16
+      br $~lib/util/memory/memset|inlined.0
+     end
+     local.get $0
+     i32.const 0
+     i32.store
+     br $~lib/util/memory/memset|inlined.0
+    end
+    local.get $0
+    i64.const 0
+    i64.store
+    br $~lib/util/memory/memset|inlined.0
+   end
    local.get $0
    i32.const 0
    i32.store8
@@ -275,7 +305,7 @@
    local.get $1
    i32.sub
    local.set $1
-   loop $while-continue|0
+   loop $while-continue|1
     local.get $1
     i32.const 32
     i32.ge_u
@@ -300,7 +330,7 @@
      i32.const 32
      i32.add
      local.set $0
-     br $while-continue|0
+     br $while-continue|1
     end
    end
   end

--- a/tests/compiler/std/symbol.untouched.wat
+++ b/tests/compiler/std/symbol.untouched.wat
@@ -251,15 +251,11 @@
         end
         local.get $5
         local.get $4
-        i32.store8 offset=1
+        i32.store8
         br $~lib/util/memory/memset|inlined.0
        end
        local.get $5
-       i32.const -1
-       i32.const 65535
-       i32.and
-       i32.const 255
-       i32.div_u
+       i32.const 257
        local.get $4
        i32.const 255
        i32.and
@@ -268,9 +264,7 @@
        br $~lib/util/memory/memset|inlined.0
       end
       local.get $5
-      i32.const -1
-      i32.const 255
-      i32.div_u
+      i32.const 16843009
       local.get $4
       i32.const 255
       i32.and
@@ -279,9 +273,7 @@
       br $~lib/util/memory/memset|inlined.0
      end
      local.get $5
-     i64.const -1
-     i64.const 255
-     i64.div_u
+     i64.const 72340172838076673
      local.get $4
      i32.const 255
      i32.and

--- a/tests/compiler/std/symbol.untouched.wat
+++ b/tests/compiler/std/symbol.untouched.wat
@@ -216,10 +216,81 @@
    i32.const 1
    i32.gt_s
    drop
-   local.get $3
-   i32.eqz
-   if
-    br $~lib/util/memory/memset|inlined.0
+   block $break|0
+    block $case5|0
+     block $case4|0
+      block $case3|0
+       block $case2|0
+        block $case1|0
+         block $case0|0
+          local.get $3
+          local.set $6
+          local.get $6
+          i32.const 0
+          i32.eq
+          br_if $case0|0
+          local.get $6
+          i32.const 1
+          i32.eq
+          br_if $case1|0
+          local.get $6
+          i32.const 2
+          i32.eq
+          br_if $case2|0
+          local.get $6
+          i32.const 4
+          i32.eq
+          br_if $case3|0
+          local.get $6
+          i32.const 8
+          i32.eq
+          br_if $case4|0
+          br $case5|0
+         end
+         br $~lib/util/memory/memset|inlined.0
+        end
+        local.get $5
+        local.get $4
+        i32.store8 offset=1
+        br $~lib/util/memory/memset|inlined.0
+       end
+       local.get $5
+       i32.const -1
+       i32.const 65535
+       i32.and
+       i32.const 255
+       i32.div_u
+       local.get $4
+       i32.const 255
+       i32.and
+       i32.mul
+       i32.store16
+       br $~lib/util/memory/memset|inlined.0
+      end
+      local.get $5
+      i32.const -1
+      i32.const 255
+      i32.div_u
+      local.get $4
+      i32.const 255
+      i32.and
+      i32.mul
+      i32.store
+      br $~lib/util/memory/memset|inlined.0
+     end
+     local.get $5
+     i64.const -1
+     i64.const 255
+     i64.div_u
+     local.get $4
+     i32.const 255
+     i32.and
+     i64.extend_i32_u
+     i64.mul
+     i64.store
+     br $~lib/util/memory/memset|inlined.0
+    end
+    br $break|0
    end
    local.get $5
    local.get $3
@@ -377,7 +448,7 @@
    i64.shl
    i64.or
    local.set $9
-   loop $while-continue|0
+   loop $while-continue|1
     local.get $3
     i32.const 32
     i32.ge_u
@@ -404,7 +475,7 @@
      i32.const 32
      i32.add
      local.set $5
-     br $while-continue|0
+     br $while-continue|1
     end
    end
   end

--- a/tests/compiler/std/typedarray.optimized.wat
+++ b/tests/compiler/std/typedarray.optimized.wat
@@ -1244,8 +1244,52 @@
   (local $5 i32)
   block $~lib/util/memory/memset|inlined.0
    local.get $2
+   local.tee $3
    i32.eqz
    br_if $~lib/util/memory/memset|inlined.0
+   block $break|0
+    block $case4|0
+     block $case3|0
+      block $case2|0
+       block $case1|0
+        local.get $3
+        i32.const 1
+        i32.sub
+        br_table $case1|0 $case2|0 $break|0 $case3|0 $break|0 $break|0 $break|0 $case4|0 $break|0
+       end
+       local.get $0
+       local.get $1
+       i32.store8 offset=1
+       br $~lib/util/memory/memset|inlined.0
+      end
+      local.get $0
+      local.get $1
+      i32.const 255
+      i32.and
+      i32.const 257
+      i32.mul
+      i32.store16
+      br $~lib/util/memory/memset|inlined.0
+     end
+     local.get $0
+     local.get $1
+     i32.const 255
+     i32.and
+     i32.const 16843009
+     i32.mul
+     i32.store
+     br $~lib/util/memory/memset|inlined.0
+    end
+    local.get $0
+    local.get $1
+    i32.const 255
+    i32.and
+    i64.extend_i32_u
+    i64.const 72340172838076673
+    i64.mul
+    i64.store
+    br $~lib/util/memory/memset|inlined.0
+   end
    local.get $0
    local.get $1
    i32.store8
@@ -1381,7 +1425,7 @@
    i64.shl
    i64.or
    local.set $4
-   loop $while-continue|0
+   loop $while-continue|1
     local.get $2
     i32.const 32
     i32.ge_u
@@ -1406,7 +1450,7 @@
      i32.const 32
      i32.add
      local.set $1
-     br $while-continue|0
+     br $while-continue|1
     end
    end
   end

--- a/tests/compiler/std/typedarray.optimized.wat
+++ b/tests/compiler/std/typedarray.optimized.wat
@@ -1259,7 +1259,7 @@
        end
        local.get $0
        local.get $1
-       i32.store8 offset=1
+       i32.store8
        br $~lib/util/memory/memset|inlined.0
       end
       local.get $0

--- a/tests/compiler/std/typedarray.untouched.wat
+++ b/tests/compiler/std/typedarray.untouched.wat
@@ -1724,15 +1724,11 @@
         end
         local.get $5
         local.get $4
-        i32.store8 offset=1
+        i32.store8
         br $~lib/util/memory/memset|inlined.0
        end
        local.get $5
-       i32.const -1
-       i32.const 65535
-       i32.and
-       i32.const 255
-       i32.div_u
+       i32.const 257
        local.get $4
        i32.const 255
        i32.and
@@ -1741,9 +1737,7 @@
        br $~lib/util/memory/memset|inlined.0
       end
       local.get $5
-      i32.const -1
-      i32.const 255
-      i32.div_u
+      i32.const 16843009
       local.get $4
       i32.const 255
       i32.and
@@ -1752,9 +1746,7 @@
       br $~lib/util/memory/memset|inlined.0
      end
      local.get $5
-     i64.const -1
-     i64.const 255
-     i64.div_u
+     i64.const 72340172838076673
      local.get $4
      i32.const 255
      i32.and

--- a/tests/compiler/std/typedarray.untouched.wat
+++ b/tests/compiler/std/typedarray.untouched.wat
@@ -1689,10 +1689,81 @@
    i32.const 1
    i32.gt_s
    drop
-   local.get $3
-   i32.eqz
-   if
-    br $~lib/util/memory/memset|inlined.0
+   block $break|0
+    block $case5|0
+     block $case4|0
+      block $case3|0
+       block $case2|0
+        block $case1|0
+         block $case0|0
+          local.get $3
+          local.set $6
+          local.get $6
+          i32.const 0
+          i32.eq
+          br_if $case0|0
+          local.get $6
+          i32.const 1
+          i32.eq
+          br_if $case1|0
+          local.get $6
+          i32.const 2
+          i32.eq
+          br_if $case2|0
+          local.get $6
+          i32.const 4
+          i32.eq
+          br_if $case3|0
+          local.get $6
+          i32.const 8
+          i32.eq
+          br_if $case4|0
+          br $case5|0
+         end
+         br $~lib/util/memory/memset|inlined.0
+        end
+        local.get $5
+        local.get $4
+        i32.store8 offset=1
+        br $~lib/util/memory/memset|inlined.0
+       end
+       local.get $5
+       i32.const -1
+       i32.const 65535
+       i32.and
+       i32.const 255
+       i32.div_u
+       local.get $4
+       i32.const 255
+       i32.and
+       i32.mul
+       i32.store16
+       br $~lib/util/memory/memset|inlined.0
+      end
+      local.get $5
+      i32.const -1
+      i32.const 255
+      i32.div_u
+      local.get $4
+      i32.const 255
+      i32.and
+      i32.mul
+      i32.store
+      br $~lib/util/memory/memset|inlined.0
+     end
+     local.get $5
+     i64.const -1
+     i64.const 255
+     i64.div_u
+     local.get $4
+     i32.const 255
+     i32.and
+     i64.extend_i32_u
+     i64.mul
+     i64.store
+     br $~lib/util/memory/memset|inlined.0
+    end
+    br $break|0
    end
    local.get $5
    local.get $3
@@ -1850,7 +1921,7 @@
    i64.shl
    i64.or
    local.set $9
-   loop $while-continue|0
+   loop $while-continue|1
     local.get $3
     i32.const 32
     i32.ge_u
@@ -1877,7 +1948,7 @@
      i32.const 32
      i32.add
      local.set $5
-     br $while-continue|0
+     br $while-continue|1
     end
    end
   end


### PR DESCRIPTION
Introduce fast pathes for cases such as:
```
memeory.fill(ptr, 0, 4);
memeory.fill(ptr, 0xFF, 8);
memeory.fill(ptr, 1, 2);
```