### PR TITLE
Fix compiler target constants

### DIFF
--- a/std/portable/index.d.ts
+++ b/std/portable/index.d.ts
@@ -33,7 +33,7 @@ declare type valueof<T extends unknown[]> = T[0];
 
 // Compiler hints
 
-/** Compiler target. 0 = JS, 1 = WASM32, 2 = WASM64. */
+/** Compiler target. 0 = WASM32, 1 = WASM64, 2 = JS. */
 declare const ASC_TARGET: i32;
 /** Provided noAssert option. */
 declare const ASC_NO_ASSERT: bool;


### PR DESCRIPTION
From what I can tell the order of the values is wrong in this definition, they are defined [here](https://github.com/AssemblyScript/assemblyscript/blob/0484a6b740b996145f10ad227359be614c190208/std/assembly/shared/target.ts).