### PR TITLE
Fixed compiler constant hint in typescript typedefs

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -22,6 +22,7 @@ under the licensing terms detailed in LICENSE:
 * Duncan Uszkay <duncan.uszkay@shopify.com>
 * Surma <surma@surma.dev>
 * Julien Letellier <letellier.julien@gmail.com>
+* Guido Zuidhof <me@guido.io>
 
 Portions of this software are derived from third-party works licensed under
 the following terms:

--- a/std/assembly/index.d.ts
+++ b/std/assembly/index.d.ts
@@ -40,7 +40,7 @@ declare type anyref = object;
 
 // Compiler hints
 
-/** Compiler target. 0 = JS, 1 = WASM32, 2 = WASM64. */
+/** Compiler target. 0 = WASM32, 1 = WASM64, 2 = JS. */
 declare const ASC_TARGET: i32;
 /** Provided noAssert option. */
 declare const ASC_NO_ASSERT: bool;

--- a/std/assembly/shared/target.ts
+++ b/std/assembly/shared/target.ts
@@ -3,9 +3,9 @@
 /** Compilation target. */
 export enum Target {
   /** WebAssembly with 32-bit pointers. */
-  WASM32,
+  WASM32 = 0,
   /** WebAssembly with 64-bit pointers. Experimental and not supported by any runtime yet. */
-  WASM64,
+  WASM64 = 1,
   /** Portable. */
-  JS
+  JS = 2
 }

--- a/std/portable/index.d.ts
+++ b/std/portable/index.d.ts
@@ -33,7 +33,7 @@ declare type valueof<T extends unknown[]> = T[0];
 
 // Compiler hints
 
-/** Compiler target. 0 = JS, 1 = WASM32, 2 = WASM64. */
+/** Compiler target. 0 = WASM32, 1 = WASM64, 2 = JS. */
 declare const ASC_TARGET: i32;
 /** Provided noAssert option. */
 declare const ASC_NO_ASSERT: bool;


### PR DESCRIPTION
From what I can tell, it's 0 for WASM32, not JS. 

- [x] I've read the contributing guidelines