### PR TITLE
Remember failed globals so we don't hit assertions

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -62,21 +62,23 @@ export enum CommonFlags {
   RESOLVED = 1 << 21,
   /** Is compiled. */
   COMPILED = 1 << 22,
+  /** Did error. */
+  ERRORED = 1 << 23,
   /** Has a constant value and is therefore inlined. */
-  INLINED = 1 << 23,
+  INLINED = 1 << 24,
   /** Is scoped. */
-  SCOPED = 1 << 24,
+  SCOPED = 1 << 25,
   /** Is a stub. */
-  STUB = 1 << 25,
+  STUB = 1 << 26,
   /** Is a virtual method. */
-  VIRTUAL = 1 << 26,
+  VIRTUAL = 1 << 27,
   /** Is (part of) a closure. */
-  CLOSURE = 1 << 27,
+  CLOSURE = 1 << 28,
 
   // Other
 
   /** Is quoted. */
-  QUOTED = 1 << 28
+  QUOTED = 1 << 29
 }
 
 /** Path delimiter inserted between file system levels. */

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -361,8 +361,8 @@ export class Compiler extends DiagnosticEmitter {
   pendingClassInstanceOf: Set<ClassPrototype> = new Set();
   /** Functions potentially involving a virtual call. */
   virtualCalls: Set<Function> = new Set();
-  /** Set of globals that failed to compile. */
-  failedGlobals: Set<Global> = new Set();
+  /** Elements currently undergoing compilation. */
+  pendingElements: Set<Element> = new Set();
 
   /** Compiles a {@link Program} to a {@link Module} using the specified options. */
   static compile(program: Program): Module {
@@ -995,13 +995,11 @@ export class Compiler extends DiagnosticEmitter {
 
   /** Compiles a global variable. */
   compileGlobal(global: Global): bool {
-    var failedGlobals = this.failedGlobals;
-    if (global.is(CommonFlags.COMPILED)) return !failedGlobals.has(global);
+    if (global.is(CommonFlags.COMPILED)) return !global.is(CommonFlags.ERRORED);
     global.set(CommonFlags.COMPILED);
 
-    // Assume that compilation will fail, and undo once we succeed to compile
-    // it. Means: Referencing a global in its initializer becomes a `false`.
-    failedGlobals.add(global);
+    var pendingElements = this.pendingElements;
+    pendingElements.add(global);
 
     var module = this.module;
     var initExpr: ExpressionRef = 0;
@@ -1013,12 +1011,18 @@ export class Compiler extends DiagnosticEmitter {
       // Resolve type if annotated
       if (typeNode) {
         let resolvedType = this.resolver.resolveType(typeNode, global.parent); // reports
-        if (!resolvedType) return false;
+        if (!resolvedType) {
+          global.set(CommonFlags.ERRORED);
+          pendingElements.delete(global);
+          return false;
+        }
         if (resolvedType == Type.void) {
           this.error(
             DiagnosticCode.Type_expected,
             typeNode.range
           );
+          global.set(CommonFlags.ERRORED);
+          pendingElements.delete(global);
           return false;
         }
         global.setType(resolvedType);
@@ -1039,6 +1043,8 @@ export class Compiler extends DiagnosticEmitter {
             DiagnosticCode.Type_0_is_not_assignable_to_type_1,
             initializerNode.range, this.currentType.toString(), "<auto>"
           );
+          global.set(CommonFlags.ERRORED);
+          pendingElements.delete(global);
           return false;
         }
         global.setType(this.currentType);
@@ -1049,6 +1055,8 @@ export class Compiler extends DiagnosticEmitter {
           DiagnosticCode.Type_expected,
           global.identifierNode.range.atEnd
         );
+        global.set(CommonFlags.ERRORED);
+        pendingElements.delete(global);
         return false;
       }
     }
@@ -1057,7 +1065,7 @@ export class Compiler extends DiagnosticEmitter {
     if (global.is(CommonFlags.AMBIENT) && global.hasDecorator(DecoratorFlags.BUILTIN)) {
       if (global.internalName == BuiltinNames.heap_base) this.runtimeFeatures |= RuntimeFeatures.HEAP;
       else if (global.internalName == BuiltinNames.rtti_base) this.runtimeFeatures |= RuntimeFeatures.RTTI;
-      failedGlobals.delete(global);
+      pendingElements.delete(global);
       return true;
     }
 
@@ -1080,16 +1088,17 @@ export class Compiler extends DiagnosticEmitter {
           nativeType,
           !isDeclaredConstant
         );
-        failedGlobals.delete(global);
+        pendingElements.delete(global);
         return true;
+      }
 
       // Importing mutable globals is not supported in the MVP
-      } else {
-        this.error(
-          DiagnosticCode.Feature_0_is_not_enabled,
-          global.declaration.range, "mutable-globals"
-        );
-      }
+      this.error(
+        DiagnosticCode.Feature_0_is_not_enabled,
+        global.declaration.range, "mutable-globals"
+      );
+      global.set(CommonFlags.ERRORED);
+      pendingElements.delete(global);
       return false;
     }
 
@@ -1175,6 +1184,8 @@ export class Compiler extends DiagnosticEmitter {
             }
             default: {
               assert(false);
+              global.set(CommonFlags.ERRORED);
+              pendingElements.delete(global);
               return false;
             }
           }
@@ -1208,7 +1219,7 @@ export class Compiler extends DiagnosticEmitter {
     } else if (!isDeclaredInline) { // compile normally
       module.addGlobal(internalName, nativeType, !isDeclaredConstant, initExpr);
     }
-    failedGlobals.delete(global);
+    pendingElements.delete(global);
     return true;
   }
 
@@ -1216,8 +1227,11 @@ export class Compiler extends DiagnosticEmitter {
 
   /** Compiles an enum. */
   compileEnum(element: Enum): bool {
-    if (element.is(CommonFlags.COMPILED)) return true;
+    if (element.is(CommonFlags.COMPILED)) return !element.is(CommonFlags.ERRORED);
     element.set(CommonFlags.COMPILED);
+
+    var pendingElements = this.pendingElements;
+    pendingElements.add(element);
 
     var module = this.module;
     var previousParent = this.currentParent;
@@ -1314,6 +1328,7 @@ export class Compiler extends DiagnosticEmitter {
       }
     }
     this.currentParent = previousParent;
+    pendingElements.delete(element);
     return true;
   }
 
@@ -1326,7 +1341,8 @@ export class Compiler extends DiagnosticEmitter {
     /** Force compilation of stdlib alternative if a builtin. */
     forceStdAlternative: bool = false
   ): bool {
-    if (instance.is(CommonFlags.COMPILED)) return true;
+    if (instance.is(CommonFlags.COMPILED)) return !instance.is(CommonFlags.ERRORED);
+
     if (!forceStdAlternative) {
       if (instance.hasDecorator(DecoratorFlags.BUILTIN)) return true;
       if (instance.hasDecorator(DecoratorFlags.LAZY)) {
@@ -1335,9 +1351,11 @@ export class Compiler extends DiagnosticEmitter {
       }
     }
 
-    var previousType = this.currentType;
     instance.set(CommonFlags.COMPILED);
+    var pendingElements = this.pendingElements;
+    pendingElements.add(instance);
 
+    var previousType = this.currentType;
     var module = this.module;
     var signature = instance.signature;
     var bodyNode = instance.prototype.bodyNode;
@@ -1452,10 +1470,12 @@ export class Compiler extends DiagnosticEmitter {
         instance.identifierNode.range
       );
       funcRef = 0; // TODO?
+      instance.set(CommonFlags.ERRORED);
     }
 
     instance.finalize(module, funcRef);
     this.currentType = previousType;
+    pendingElements.delete(instance);
     return true;
   }
 
@@ -2982,18 +3002,29 @@ export class Compiler extends DiagnosticEmitter {
         this.checkTypeSupported(type, typeNode);
 
         if (initializerNode) {
+          let pendingElements = this.pendingElements;
+          let dummy = flow.addScopedDummyLocal(name, type); // pending dummy
+          pendingElements.add(dummy);
           initExpr = this.compileExpression(initializerNode, type, // reports
             Constraints.CONV_IMPLICIT | Constraints.WILL_RETAIN
           );
           initAutoreleaseSkipped = this.skippedAutoreleases.has(initExpr);
+          pendingElements.delete(dummy);
+          flow.freeScopedDummyLocal(name);
         }
 
       // Otherwise infer type from initializer
       } else if (initializerNode) {
+        let pendingElements = this.pendingElements;
+        let temp = flow.addScopedDummyLocal(name, Type.auto); // pending dummy
+        pendingElements.add(temp);
         initExpr = this.compileExpression(initializerNode, Type.auto,
           Constraints.WILL_RETAIN
         ); // reports
         initAutoreleaseSkipped = this.skippedAutoreleases.has(initExpr);
+        pendingElements.delete(temp);
+        flow.freeScopedDummyLocal(name);
+
         if (this.currentType == Type.void) {
           this.error(
             DiagnosticCode.Type_0_is_not_assignable_to_type_1,
@@ -5925,6 +5956,14 @@ export class Compiler extends DiagnosticEmitter {
       }
       case ElementKind.LOCAL:
       case ElementKind.FIELD: {
+        if (this.pendingElements.has(target)) {
+          this.error(
+            DiagnosticCode.Variable_0_used_before_its_declaration,
+            expression.range,
+            target.internalName
+          );
+          return this.module.unreachable();
+        }
         targetType = (<VariableLikeElement>target).type;
         if (target.hasDecorator(DecoratorFlags.UNSAFE)) this.checkUnsafe(expression);
         break;
@@ -8180,6 +8219,15 @@ export class Compiler extends DiagnosticEmitter {
         let local = <Local>target;
         let localType = local.type;
         assert(localType != Type.void);
+        if (this.pendingElements.has(local)) {
+          this.error(
+            DiagnosticCode.Variable_0_used_before_its_declaration,
+            expression.range,
+            local.internalName
+          );
+          this.currentType = localType;
+          return module.unreachable();
+        }
         if (local.is(CommonFlags.INLINED)) {
           return this.compileInlineConstant(local, contextualType, constraints);
         }
@@ -8207,6 +8255,15 @@ export class Compiler extends DiagnosticEmitter {
           return module.unreachable();
         }
         let globalType = global.type;
+        if (this.pendingElements.has(global)) {
+          this.error(
+            DiagnosticCode.Variable_0_used_before_its_declaration,
+            expression.range,
+            global.internalName
+          );
+          this.currentType = globalType;
+          return module.unreachable();
+        }
         assert(globalType != Type.void);
         if (global.is(CommonFlags.INLINED)) {
           return this.compileInlineConstant(global, contextualType, constraints);
@@ -9275,6 +9332,15 @@ export class Compiler extends DiagnosticEmitter {
         if (!this.compileGlobal(global)) return module.unreachable(); // reports
         let globalType = global.type;
         assert(globalType != Type.void);
+        if (this.pendingElements.has(global)) {
+          this.error(
+            DiagnosticCode.Variable_0_used_before_its_declaration,
+            expression.range,
+            global.internalName
+          );
+          this.currentType = globalType;
+          return module.unreachable();
+        }
         if (global.is(CommonFlags.INLINED)) {
           return this.compileInlineConstant(global, ctxType, constraints);
         }

--- a/src/diagnosticMessages.generated.ts
+++ b/src/diagnosticMessages.generated.ts
@@ -147,6 +147,7 @@ export enum DiagnosticCode {
   A_class_can_only_implement_an_interface = 2422,
   A_namespace_declaration_cannot_be_located_prior_to_a_class_or_function_with_which_it_is_merged = 2434,
   Property_0_is_protected_and_only_accessible_within_class_1_and_its_subclasses = 2445,
+  Variable_0_used_before_its_declaration = 2448,
   The_type_argument_for_type_parameter_0_cannot_be_inferred_from_the_usage_Consider_specifying_the_type_arguments_explicitly = 2453,
   Type_0_has_no_property_1 = 2460,
   The_0_operator_cannot_be_applied_to_type_1 = 2469,
@@ -321,6 +322,7 @@ export function diagnosticCodeToString(code: DiagnosticCode): string {
     case 2422: return "A class can only implement an interface.";
     case 2434: return "A namespace declaration cannot be located prior to a class or function with which it is merged.";
     case 2445: return "Property '{0}' is protected and only accessible within class '{1}' and its subclasses.";
+    case 2448: return "Variable '{0}' used before its declaration.";
     case 2453: return "The type argument for type parameter '{0}' cannot be inferred from the usage. Consider specifying the type arguments explicitly.";
     case 2460: return "Type '{0}' has no property '{1}'.";
     case 2469: return "The '{0}' operator cannot be applied to type '{1}'.";

--- a/src/diagnosticMessages.json
+++ b/src/diagnosticMessages.json
@@ -143,6 +143,7 @@
   "A class can only implement an interface.": 2422,
   "A namespace declaration cannot be located prior to a class or function with which it is merged.": 2434,
   "Property '{0}' is protected and only accessible within class '{1}' and its subclasses.": 2445,
+  "Variable '{0}' used before its declaration.": 2448,
   "The type argument for type parameter '{0}' cannot be inferred from the usage. Consider specifying the type arguments explicitly.": 2453,
   "Type '{0}' has no property '{1}'.": 2460,
   "The '{0}' operator cannot be applied to type '{1}'.": 2469,

--- a/src/program.ts
+++ b/src/program.ts
@@ -3267,6 +3267,9 @@ export class Parameter {
 /** A local variable. */
 export class Local extends VariableLikeElement {
 
+  /** Original name of the (temporary) local. */
+  private originalName: string;
+
   /** Constructs a new local variable. */
   constructor(
     /** Simple name. */
@@ -3286,9 +3289,23 @@ export class Local extends VariableLikeElement {
       parent,
       declaration
     );
+    this.originalName = name;
     this.index = index;
     assert(type != Type.void);
     this.setType(type);
+  }
+
+  /** Sets the temporary name of this local. */
+  setTemporaryName(name: string): void {
+    this.name = name;
+    this.internalName = mangleInternalName(name, this.parent, false);
+  }
+
+  /** Resets the temporary name of this local. */
+  resetTemporaryName(): void {
+    var name = this.originalName;
+    this.name = name;
+    this.internalName = mangleInternalName(name, this.parent, false);
   }
 }
 

--- a/tests/compiler/variable-access-in-initializer.json
+++ b/tests/compiler/variable-access-in-initializer.json
@@ -1,0 +1,10 @@
+{
+  "asc_flags": [
+    "--runtime none"
+  ],
+  "stderr": [
+    "TS2448: Variable 'variable-access-in-initializer/a' used before its declaration.",
+    "TS2448: Variable 'variable-access-in-initializer/test~b' used before its declaration.",
+    "EOF"
+  ]
+}

--- a/tests/compiler/variable-access-in-initializer.ts
+++ b/tests/compiler/variable-access-in-initializer.ts
@@ -1,0 +1,8 @@
+var a = (a = 4, 3); // TS2448
+
+function test(): void {
+  let b = (b = 4, 3); // TS2448
+}
+test();
+
+ERROR("EOF");


### PR DESCRIPTION
An alternative to fix https://github.com/AssemblyScript/assemblyscript/pull/1205 by remembering globals that failed to compile so we properly get a `false` upon subsequent `compileGlobal` invocations and don't run into `assert`s in the first place, as per my latest comment on the above PR.

@DuncanUszkay1: Can you confirm that this solves the issue as well?

If so, also fixes https://github.com/AssemblyScript/assemblyscript/issues/1165

Now also: fixes https://github.com/AssemblyScript/assemblyscript/issues/1186, fixes https://github.com/AssemblyScript/assemblyscript/pull/1190

- [x] I've read the contributing guidelines